### PR TITLE
all: Modified makefiles to use JLM_ROOT and JIVE_ROOT

### DIFF
--- a/jlm-opt/Makefile.sub
+++ b/jlm-opt/Makefile.sub
@@ -4,7 +4,18 @@
 JLMOPT_SRC = \
 	jlm-opt/jlm-opt.cpp \
 
-jlm-opt: CPPFLAGS += -Ilibjlm/include
-jlm-opt: LDFLAGS += -L. -ljlm -ljive
-jlm-opt: $(patsubst %.cpp, %.o, $(JLMOPT_SRC)) libjlm.a
-	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -o bin/$@ $^ $(LDFLAGS)
+.PHONY: jlm-opt
+jlm-opt: $(JLM_ROOT)/bin/jlm-opt
+
+$(JLM_ROOT)/bin/jlm-opt: $(JIVE_ROOT)/libjive.a
+$(JLM_ROOT)/bin/jlm-opt: CPPFLAGS += -I$(JLM_ROOT)/libjlm/include -I$(JIVE_ROOT)/include -I$(shell $(LLVMCONFIG) --includedir)
+$(JLM_ROOT)/bin/jlm-opt: CXXFLAGS += -Wall -Wpedantic -Wextra -Wno-unused-parameter --std=c++14 -Wfatal-errors
+$(JLM_ROOT)/bin/jlm-opt: LDFLAGS += -L$(JLM_ROOT)/ -ljlm -ljive
+$(JLM_ROOT)/bin/jlm-opt: $(patsubst %.cpp, $(JLM_ROOT)/%.o, $(JLMOPT_SRC)) $(JLM_ROOT)/libjlm.a
+	@mkdir -p $(JLM_ROOT)/bin
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -o $@ $^ $(LDFLAGS)
+
+.PHONY: jlmopt-clean
+jlmopt-clean:
+	@find  $(JLM_ROOT)/jlm-opt/ -name "*.o" -o -name "*.la" -o -name "*.a" | grep -v external | xargs rm -rf
+	@rm -rf $(JLM_ROOT)/bin/jlm-opt

--- a/jlm-print/Makefile.sub
+++ b/jlm-print/Makefile.sub
@@ -3,8 +3,20 @@
 
 JLMPRINT_SRC = \
 	jlm-print/jlm-print.cpp \
+ 
+.PHONY: jlm-print
+jlm-print: $(JLM_ROOT)/bin/jlm-print
 
-jlm-print: CPPFLAGS += -Ilibjlm/include
-jlm-print: LDFLAGS+=-L. -ljlm -ljive
-jlm-print: $(patsubst %.cpp, %.o, $(JLMPRINT_SRC)) libjlm.a
-	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -o bin/$@ $^ $(LDFLAGS)
+$(JLM_ROOT)/bin/jlm-print: $(JIVE_ROOT)/libjive.a
+$(JLM_ROOT)/bin/jlm-print: CPPFLAGS += -I$(JLM_ROOT)/libjlm/include -I$(JIVE_ROOT)/include -I$(shell $(LLVMCONFIG) --includedir)
+$(JLM_ROOT)/bin/jlm-print: CXXFLAGS += -Wall -Wpedantic -Wextra -Wno-unused-parameter --std=c++14 -Wfatal-errors
+$(JLM_ROOT)/bin/jlm-print: LDFLAGS+=-L$(JLM_ROOT)/ -ljlm -ljive
+$(JLM_ROOT)/bin/jlm-print: $(patsubst %.cpp, $(JLM_ROOT)/%.o, $(JLMPRINT_SRC)) $(JLM_ROOT)/libjlm.a
+	@mkdir -p $(JLM_ROOT)/bin
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -o $@ $^ $(LDFLAGS)
+
+.PHONY: jlmprint-clean
+jlmprint-clean:
+	@find  $(JLM_ROOT)/jlm-print/ -name "*.o" -o -name "*.la" -o -name "*.a" | grep -v external | xargs rm -rf
+	@rm -rf $(JLM_ROOT)/bin/jlm-print
+

--- a/libjlc/Makefile.sub
+++ b/libjlc/Makefile.sub
@@ -8,11 +8,27 @@ LIBJLC_SRC = \
 JLC_SRC = \
 	libjlc/src/jlc.cpp \
 
-libjlc.a: CPPFLAGS += -Ilibjlc/include -Ilibjlm/include
-libjlc.a: LDFLAGS += -L. -ljlm
-libjlc.a: $(patsubst %.cpp, %.la, $(LIBJLC_SRC)) libjlm.a
+.PHONY: libjlc
+libjlc: $(JLM_ROOT)/libjlc.a
 
-jlc: CPPFLAGS += -Ilibjlc/include -Ilibjlm/include
-jlc: LDFLAGS += -L. -ljlc -ljlm -ljive
-jlc: $(patsubst %.cpp, %.o, $(JLC_SRC)) libjlc.a
-	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -o bin/$@ $^ $(LDFLAGS)
+$(JLM_ROOT)/libjlc.a: CPPFLAGS += -I$(JLM_ROOT)/libjlc/include -I$(JLM_ROOT)/libjlm/include -I$(shell $(LLVMCONFIG) --includedir)
+$(JLM_ROOT)/libjlc.a: CXXFLAGS += -Wall -Wpedantic -Wextra -Wno-unused-parameter --std=c++14 -Wfatal-errors
+$(JLM_ROOT)/libjlc.a: LDFLAGS += -L$(JLM_ROOT)/ -ljlm
+$(JLM_ROOT)/libjlc.a: $(patsubst %.cpp, $(JLM_ROOT)/%.la, $(LIBJLC_SRC)) $(JLM_ROOT)/libjlm.a
+
+.PHONY: jlc
+jlc: $(JLM_ROOT)/bin/jlc
+
+$(JLM_ROOT)/bin/jlc: $(JIVE_ROOT)/libjive.a
+$(JLM_ROOT)/bin/jlc: CPPFLAGS += -I$(JIVE_ROOT)/include -I$(JLM_ROOT)/libjlc/include -I$(JLM_ROOT)/libjlm/include -I$(shell $(LLVMCONFIG) --includedir)
+$(JLM_ROOT)/bin/jlc: CXXFLAGS += -Wall -Wpedantic -Wextra -Wno-unused-parameter --std=c++14 -Wfatal-errors
+$(JLM_ROOT)/bin/jlc: LDFLAGS += -L$(JLM_ROOT)/ -ljlc -ljlm -ljive
+$(JLM_ROOT)/bin/jlc: $(patsubst %.cpp, $(JLM_ROOT)/%.o, $(JLC_SRC)) $(JLM_ROOT)/libjlc.a
+	@mkdir -p $(JLM_ROOT)/bin
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -o $@ $^ $(LDFLAGS)
+
+.PHONY: libjlc-clean
+libjlc-clean:
+	@find  $(JLM_ROOT)/libjlc/ -name "*.o" -o -name "*.la" -o -name "*.a" | grep -v external | xargs rm -rf
+	@rm -rf $(JLM_ROOT)/libjlc.a
+	@rm -rf $(JLM_ROOT)/bin/jlc

--- a/libjlm/Makefile.sub
+++ b/libjlm/Makefile.sub
@@ -57,5 +57,14 @@ LIBJLM_SRC = \
 	libjlm/src/opt/reduction.cpp \
 	libjlm/src/opt/unroll.cpp \
 
-libjlm.a: CPPFLAGS += -Ilibjlm/include
-libjlm.a: $(patsubst %.cpp, %.la, $(LIBJLM_SRC))
+.PHONY: libjlm
+libjlm: $(JLM_ROOT)/libjlm.a
+
+$(JLM_ROOT)/libjlm.a: CPPFLAGS += -I$(JIVE_ROOT)/include -I$(shell $(LLVMCONFIG) --includedir) -I$(JLM_ROOT)/libjlm/include
+$(JLM_ROOT)/libjlm.a: CXXFLAGS += -Wall -Wpedantic -Wextra -Wno-unused-parameter --std=c++14 -Wfatal-errors
+$(JLM_ROOT)/libjlm.a: $(patsubst %.cpp, $(JLM_ROOT)/%.la, $(LIBJLM_SRC))
+
+.PHONY: libjlm-clean
+libjlm-clean:
+	@find $(JLM_ROOT)/libjlm/ -name "*.o" -o -name "*.la" -o -name "*.a" | grep -v external | xargs rm -rf
+	@rm -rf $(JLM_ROOT)/libjlm.a

--- a/tests/Makefile.sub
+++ b/tests/Makefile.sub
@@ -4,6 +4,12 @@ include tests/util/Makefile.sub
 include tests/libjlm/Makefile.sub
 include tests/libjlc/Makefile.sub
 
+# Font colors for terminal
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+
 TEST_SOURCES = \
 	tests/test-operation.cpp \
 	tests/test-registry.cpp \
@@ -11,38 +17,45 @@ TEST_SOURCES = \
 	tests/test-types.cpp \
 	$(patsubst %, tests/%.cpp, $(TESTS))
 
-tests/test-runner: libjlc.a libjlm.a
-tests/test-runner: CPPFLAGS += -Ilibjlm/include -Ilibjlc/include
+tests/test-runner: libjlc.a libjlm.a $(JIVE_ROOT)/libjive.a
+tests/test-runner: CPPFLAGS += -I$(JLM_ROOT)/libjlm/include -I$(JLM_ROOT)/libjlc/include -I$(JIVE_ROOT)/include
 tests/test-runner: LDFLAGS=-L. -Lexternal/jive -ljlc -ljlm $(shell $(LLVMCONFIG) --ldflags --libs) -ljive
 tests/test-runner: %: $(patsubst %.cpp, %.la, $(TEST_SOURCES)) libjlm.a
 	$(CXX) -o $@ $(filter %.la, $^) $(LDFLAGS)
 
-$(patsubst %, tests/%.la, $(TESTS)): CPPFLAGS += -Itests
+$(patsubst %, tests/%.la, $(TESTS)): CPPFLAGS += -Itests -I$(shell $(LLVMCONFIG) --includedir)
 
 TESTLOG = true
 
 check: check-utests check-ctests
 
 check-ctests: jlc jlm-opt
-	rm -rf ctests.log
+	@rm -rf ctests.log
 	@FAILED_TESTS="" ; \
 	for TEST in `ls tests/c-tests`; do \
 		$(TESTLOG) -n "$$TEST: " ; if tests/test-jlc.sh tests/c-tests/$$TEST >>ctests.log 2>&1 ; then $(TESTLOG) pass ; else $(TESTLOG) FAIL ; FAILED_TESTS="$$FAILED_TESTS $$TEST" ; fi ; \
 	done ; \
-	if [ "x$$FAILED_TESTS" != x ] ; then echo "Failed tests:$$FAILED_TESTS" ; else echo "All tests passed" ; fi ; \
+	if [ "x$$FAILED_TESTS" != x ] ; then echo $(RED)Failed c-tests:$(NC)$$FAILED_TESTS ; else echo $(GREEN)All c-tests passed$(NC) ; fi ; \
 
 check-utests: tests/test-runner
-	rm -rf utests.log
+	@rm -rf utests.log
 	@FAILED_TESTS="" ; \
 	for TEST in $(TESTS); do \
 		$(TESTLOG) -n "$$TEST: " ; if tests/test-runner $$TEST >>utests.log 2>&1 ; then $(TESTLOG) pass ; else $(TESTLOG) FAIL ; FAILED_TESTS="$$FAILED_TESTS $$TEST" ; fi ; \
 	done ; \
-	if [ "x$$FAILED_TESTS" != x ] ; then echo "Failed tests:$$FAILED_TESTS" ; else echo "All tests passed" ; fi ; \
+	if [ "x$$FAILED_TESTS" != x ] ; then echo $(RED)Failed u-tests:$(NC)$$FAILED_TESTS ; else echo $(GREEN)All u-tests passed$(NC) ; fi ; \
 
 valgrind-check: tests/test-runner
-	rm -rf check.log
+	@rm -rf check.log
 	@FAILED_TESTS="" ; \
 	for TEST in $(TESTS); do \
 		$(TESTLOG) -n "$$TEST: " ; if valgrind --leak-check=full --error-exitcode=1 tests/test-runner $$TEST >>check.log 2>&1 ; then $(TESTLOG) pass ; else $(TESTLOG) FAIL ; FAILED_TESTS="$$UNEXPECTED_FAILED_TESTS $$TEST" ; fi ; \
 	done ; \
-	if [ "x$$FAILED_TESTS" != x ] ; then echo "Failed tests:$$FAILED_TESTS" ; else echo "All tests passed" ; fi ; \
+	if [ "x$$FAILED_TESTS" != x ] ; then echo $(RED)Failed valgrind-tests:$(NC)$$FAILED_TESTS ; else echo $(GREEN)All valgrind-tests passed$(NC) ; fi ; \
+
+.PHONY: jlmtest-clean
+jlmtest-clean:
+	@rm -rf $(JLM_ROOT)/tests/test-runner
+	@rm -rf $(JLM_ROOT)/utests.log
+	@rm -rf $(JLM_ROOT)/ctests.log
+	@rm -rf $(JLM_ROOT)/check.log


### PR DESCRIPTION
There are two %.la: targets in the root Makefile since one is needed for the %.c files from jive and the other for the %.cpp files in jlm.

