### PR TITLE
jive: Bumped jive to version that use .hpp and .cpp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,6 @@ submodule:
 %.la: %.cpp
 	$(CXX) -c $(CXXFLAGS) $(CPPFLAGS) -o $@ $<
 
-%.la: %.c
-	$(CXX) -c $(CFLAGS) $(CPPFLAGS) -o $@ $<
-
 %.o: %.cpp
 	$(CXX) -c $(CXXFLAGS) $(CPPFLAGS) -o $@ $<
 

--- a/jlm-opt/src/jlm-opt.cpp
+++ b/jlm-opt/src/jlm-opt.cpp
@@ -3,7 +3,7 @@
  * See COPYING for terms of redistribution.
  */
 
-#include <jive/view.h>
+#include <jive/view.hpp>
 
 #include <jlm/ir/ipgraph-module.hpp>
 #include <jlm/ir/operators.hpp>

--- a/jlm-print/jlm-print.cpp
+++ b/jlm-print/jlm-print.cpp
@@ -12,8 +12,8 @@
 #include <jlm/rvsdg2jlm/rvsdg2jlm.hpp>
 #include <jlm/util/stats.hpp>
 
-#include <jive/rvsdg/graph.h>
-#include <jive/view.h>
+#include <jive/rvsdg/graph.hpp>
+#include <jive/view.hpp>
 
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>

--- a/libjlm/include/jlm/ir/cfg.hpp
+++ b/libjlm/include/jlm/ir/cfg.hpp
@@ -10,8 +10,8 @@
 #include <jlm/ir/cfg-node.hpp>
 #include <jlm/ir/variable.hpp>
 
-#include <jive/types/function.h>
-#include <jive/rvsdg/operation.h>
+#include <jive/types/function.hpp>
+#include <jive/rvsdg/operation.hpp>
 
 namespace jive {
 namespace base {

--- a/libjlm/include/jlm/ir/ipgraph.hpp
+++ b/libjlm/include/jlm/ir/ipgraph.hpp
@@ -11,7 +11,7 @@
 #include <jlm/ir/types.hpp>
 #include <jlm/ir/variable.hpp>
 
-#include <jive/types/function.h>
+#include <jive/types/function.hpp>
 
 #include <unordered_map>
 #include <unordered_set>

--- a/libjlm/include/jlm/ir/operators/alloca.hpp
+++ b/libjlm/include/jlm/ir/operators/alloca.hpp
@@ -6,11 +6,11 @@
 #ifndef JLM_IR_OPERATORS_ALLOCA_HPP
 #define JLM_IR_OPERATORS_ALLOCA_HPP
 
-#include <jive/arch/addresstype.h>
-#include <jive/types/bitstring/type.h>
-#include <jive/rvsdg/graph.h>
-#include <jive/rvsdg/simple-normal-form.h>
-#include <jive/rvsdg/simple-node.h>
+#include <jive/arch/addresstype.hpp>
+#include <jive/types/bitstring/type.hpp>
+#include <jive/rvsdg/graph.hpp>
+#include <jive/rvsdg/simple-normal-form.hpp>
+#include <jive/rvsdg/simple-node.hpp>
 
 #include <jlm/ir/tac.hpp>
 #include <jlm/ir/types.hpp>

--- a/libjlm/include/jlm/ir/operators/call.hpp
+++ b/libjlm/include/jlm/ir/operators/call.hpp
@@ -6,8 +6,8 @@
 #ifndef JLM_IR_OPERATORS_CALL_HPP
 #define JLM_IR_OPERATORS_CALL_HPP
 
-#include <jive/rvsdg/simple-node.h>
-#include <jive/types/function.h>
+#include <jive/rvsdg/simple-node.hpp>
+#include <jive/types/function.hpp>
 
 #include <jlm/ir/tac.hpp>
 #include <jlm/ir/types.hpp>

--- a/libjlm/include/jlm/ir/operators/delta.hpp
+++ b/libjlm/include/jlm/ir/operators/delta.hpp
@@ -6,8 +6,8 @@
 #ifndef JLM_IR_OPERATORS_DELTA_HPP
 #define JLM_IR_OPERATORS_DELTA_HPP
 
-#include <jive/rvsdg/region.h>
-#include <jive/rvsdg/structural-node.h>
+#include <jive/rvsdg/region.hpp>
+#include <jive/rvsdg/structural-node.hpp>
 
 #include <jlm/ir/types.hpp>
 #include <jlm/ir/variable.hpp>

--- a/libjlm/include/jlm/ir/operators/gamma.hpp
+++ b/libjlm/include/jlm/ir/operators/gamma.hpp
@@ -6,7 +6,7 @@
 #ifndef JLM_IR_OPERATORS_GAMMA_HPP
 #define JLM_IR_OPERATORS_GAMMA_HPP
 
-#include <jive/rvsdg/gamma.h>
+#include <jive/rvsdg/gamma.hpp>
 
 namespace jlm {
 

--- a/libjlm/include/jlm/ir/operators/getelementptr.hpp
+++ b/libjlm/include/jlm/ir/operators/getelementptr.hpp
@@ -6,8 +6,8 @@
 #ifndef JLM_IR_OPERATORS_GETELEMENTPTR_HPP
 #define JLM_IR_OPERATORS_GETELEMENTPTR_HPP
 
-#include <jive/types/bitstring/type.h>
-#include <jive/rvsdg/simple-node.h>
+#include <jive/types/bitstring/type.hpp>
+#include <jive/rvsdg/simple-node.hpp>
 
 #include <jlm/ir/tac.hpp>
 #include <jlm/ir/types.hpp>

--- a/libjlm/include/jlm/ir/operators/lambda.hpp
+++ b/libjlm/include/jlm/ir/operators/lambda.hpp
@@ -6,9 +6,9 @@
 #ifndef JLM_IR_OPERATORS_LAMBDA_HPP
 #define JLM_IR_OPERATORS_LAMBDA_HPP
 
-#include <jive/rvsdg/region.h>
-#include <jive/rvsdg/structural-node.h>
-#include <jive/types/function.h>
+#include <jive/rvsdg/region.hpp>
+#include <jive/rvsdg/structural-node.hpp>
+#include <jive/types/function.hpp>
 
 #include <jlm/ir/types.hpp>
 #include <jlm/ir/variable.hpp>

--- a/libjlm/include/jlm/ir/operators/load.hpp
+++ b/libjlm/include/jlm/ir/operators/load.hpp
@@ -6,10 +6,10 @@
 #ifndef JLM_IR_OPERATORS_LOAD_HPP
 #define JLM_IR_OPERATORS_LOAD_HPP
 
-#include <jive/arch/addresstype.h>
-#include <jive/rvsdg/graph.h>
-#include <jive/rvsdg/simple-normal-form.h>
-#include <jive/rvsdg/simple-node.h>
+#include <jive/arch/addresstype.hpp>
+#include <jive/rvsdg/graph.hpp>
+#include <jive/rvsdg/simple-normal-form.hpp>
+#include <jive/rvsdg/simple-node.hpp>
 
 #include <jlm/ir/tac.hpp>
 #include <jlm/ir/types.hpp>

--- a/libjlm/include/jlm/ir/operators/operators.hpp
+++ b/libjlm/include/jlm/ir/operators/operators.hpp
@@ -6,16 +6,16 @@
 #ifndef JLM_IR_OPERATORS_OPERATORS_HPP
 #define JLM_IR_OPERATORS_OPERATORS_HPP
 
-#include <jive/arch/addresstype.h>
-#include <jive/types/bitstring/type.h>
-#include <jive/types/function.h>
-#include <jive/types/record.h>
-#include <jive/rvsdg/binary.h>
-#include <jive/rvsdg/control.h>
-#include <jive/rvsdg/nullary.h>
-#include <jive/rvsdg/simple-node.h>
-#include <jive/rvsdg/type.h>
-#include <jive/rvsdg/unary.h>
+#include <jive/arch/addresstype.hpp>
+#include <jive/types/bitstring/type.hpp>
+#include <jive/types/function.hpp>
+#include <jive/types/record.hpp>
+#include <jive/rvsdg/binary.hpp>
+#include <jive/rvsdg/control.hpp>
+#include <jive/rvsdg/nullary.hpp>
+#include <jive/rvsdg/simple-node.hpp>
+#include <jive/rvsdg/type.hpp>
+#include <jive/rvsdg/unary.hpp>
 
 #include <jlm/ir/ipgraph-module.hpp>
 #include <jlm/ir/tac.hpp>

--- a/libjlm/include/jlm/ir/operators/phi.hpp
+++ b/libjlm/include/jlm/ir/operators/phi.hpp
@@ -6,7 +6,7 @@
 #ifndef JLM_IR_OPERATORS_PHI_HPP
 #define JLM_IR_OPERATORS_PHI_HPP
 
-#include <jive/rvsdg/phi.h>
+#include <jive/rvsdg/phi.hpp>
 
 /*
 	FIXME: This should be defined in jive.

--- a/libjlm/include/jlm/ir/operators/sext.hpp
+++ b/libjlm/include/jlm/ir/operators/sext.hpp
@@ -6,8 +6,8 @@
 #ifndef JLM_IR_OPERATORS_SEXT_HPP
 #define JLM_IR_OPERATORS_SEXT_HPP
 
-#include <jive/types/bitstring.h>
-#include <jive/rvsdg/unary.h>
+#include <jive/types/bitstring.hpp>
+#include <jive/rvsdg/unary.hpp>
 
 #include <jlm/ir/tac.hpp>
 

--- a/libjlm/include/jlm/ir/operators/store.hpp
+++ b/libjlm/include/jlm/ir/operators/store.hpp
@@ -6,10 +6,10 @@
 #ifndef JLM_IR_OPERATORS_STORE_HPP
 #define JLM_IR_OPERATORS_STORE_HPP
 
-#include <jive/arch/addresstype.h>
-#include <jive/rvsdg/graph.h>
-#include <jive/rvsdg/simple-normal-form.h>
-#include <jive/rvsdg/simple-node.h>
+#include <jive/arch/addresstype.hpp>
+#include <jive/rvsdg/graph.hpp>
+#include <jive/rvsdg/simple-normal-form.hpp>
+#include <jive/rvsdg/simple-node.hpp>
 
 #include <jlm/ir/tac.hpp>
 #include <jlm/ir/types.hpp>

--- a/libjlm/include/jlm/ir/operators/theta.hpp
+++ b/libjlm/include/jlm/ir/operators/theta.hpp
@@ -6,7 +6,7 @@
 #ifndef JLM_IR_OPERATORS_THETA_HPP
 #define JLM_IR_OPERATORS_THETA_HPP
 
-#include <jive/rvsdg/theta.h>
+#include <jive/rvsdg/theta.hpp>
 
 namespace jlm {
 

--- a/libjlm/include/jlm/ir/rvsdg-module.hpp
+++ b/libjlm/include/jlm/ir/rvsdg-module.hpp
@@ -6,7 +6,7 @@
 #ifndef JLM_IR_RVSDG_MODULE_HPP
 #define JLM_IR_RVSDG_MODULE_HPP
 
-#include <jive/rvsdg/graph.h>
+#include <jive/rvsdg/graph.hpp>
 
 #include <jlm/ir/linkage.hpp>
 #include <jlm/util/file.hpp>

--- a/libjlm/include/jlm/ir/tac.hpp
+++ b/libjlm/include/jlm/ir/tac.hpp
@@ -9,7 +9,7 @@
 #include <jlm/common.hpp>
 #include <jlm/ir/variable.hpp>
 
-#include <jive/rvsdg/operation.h>
+#include <jive/rvsdg/operation.hpp>
 
 #include <list>
 #include <memory>

--- a/libjlm/include/jlm/ir/types.hpp
+++ b/libjlm/include/jlm/ir/types.hpp
@@ -6,9 +6,9 @@
 #ifndef JLM_IR_TYPES_HPP
 #define JLM_IR_TYPES_HPP
 
-#include <jive/types/function.h>
-#include <jive/types/record.h>
-#include <jive/rvsdg/type.h>
+#include <jive/types/function.hpp>
+#include <jive/types/record.hpp>
+#include <jive/rvsdg/type.hpp>
 
 #include <jlm/common.hpp>
 

--- a/libjlm/include/jlm/ir/variable.hpp
+++ b/libjlm/include/jlm/ir/variable.hpp
@@ -6,7 +6,7 @@
 #ifndef JLM_IR_VARIABLE_HPP
 #define JLM_IR_VARIABLE_HPP
 
-#include <jive/rvsdg/type.h>
+#include <jive/rvsdg/type.hpp>
 
 #include <jlm/ir/linkage.hpp>
 #include <jlm/util/strfmt.hpp>

--- a/libjlm/include/jlm/jlm2llvm/context.hpp
+++ b/libjlm/include/jlm/jlm2llvm/context.hpp
@@ -8,7 +8,7 @@
 
 #include <jlm/common.hpp>
 
-#include <jive/types/record.h>
+#include <jive/types/record.hpp>
 
 #include <memory>
 #include <unordered_map>

--- a/libjlm/include/jlm/jlm2llvm/type.hpp
+++ b/libjlm/include/jlm/jlm2llvm/type.hpp
@@ -6,10 +6,10 @@
 #ifndef JLM_JLM2LLVM_TYPE_HPP
 #define JLM_JLM2LLVM_TYPE_HPP
 
-#include <jive/types/bitstring/type.h>
-#include <jive/types/function.h>
-#include <jive/types/record.h>
-#include <jive/rvsdg/control.h>
+#include <jive/types/bitstring/type.hpp>
+#include <jive/types/function.hpp>
+#include <jive/types/record.hpp>
+#include <jive/rvsdg/control.hpp>
 
 #include <jlm/common.hpp>
 #include <jlm/ir/types.hpp>

--- a/libjlm/include/jlm/llvm2jlm/context.hpp
+++ b/libjlm/include/jlm/llvm2jlm/context.hpp
@@ -11,7 +11,7 @@
 #include <jlm/ir/tac.hpp>
 #include <jlm/llvm2jlm/type.hpp>
 
-#include <jive/types/record.h>
+#include <jive/types/record.hpp>
 #include <llvm/IR/DerivedTypes.h>
 
 #include <unordered_map>

--- a/libjlm/include/jlm/llvm2jlm/type.hpp
+++ b/libjlm/include/jlm/llvm2jlm/type.hpp
@@ -6,7 +6,7 @@
 #ifndef JLM_LLVM2JLM_TYPE_HPP
 #define JLM_LLVM2JLM_TYPE_HPP
 
-#include <jive/types/record.h>
+#include <jive/types/record.hpp>
 
 #include <jlm/ir/types.hpp>
 

--- a/libjlm/include/jlm/opt/pull.hpp
+++ b/libjlm/include/jlm/opt/pull.hpp
@@ -6,7 +6,7 @@
 #ifndef JLM_OPT_PULL_HPP
 #define JLM_OPT_PULL_HPP
 
-#include <jive/rvsdg/graph.h>
+#include <jive/rvsdg/graph.hpp>
 
 #include <jlm/opt/optimization.hpp>
 

--- a/libjlm/include/jlm/opt/unroll.hpp
+++ b/libjlm/include/jlm/opt/unroll.hpp
@@ -6,8 +6,8 @@
 #ifndef JLM_OPT_UNROLL_HPP
 #define JLM_OPT_UNROLL_HPP
 
-#include <jive/rvsdg/theta.h>
-#include <jive/types/bitstring.h>
+#include <jive/rvsdg/theta.hpp>
+#include <jive/types/bitstring.hpp>
 
 #include <jlm/common.hpp>
 #include <jlm/opt/optimization.hpp>

--- a/libjlm/src/ir/ipgraph.cpp
+++ b/libjlm/src/ir/ipgraph.cpp
@@ -7,7 +7,7 @@
 #include <jlm/ir/cfg.hpp>
 #include <jlm/ir/tac.hpp>
 
-#include <jive/common.h>
+#include <jive/common.hpp>
 
 #include <stdio.h>
 

--- a/libjlm/src/ir/operators/alloca.cpp
+++ b/libjlm/src/ir/operators/alloca.cpp
@@ -3,8 +3,8 @@
  * See COPYING for terms of redistribution.
  */
 
-#include <jive/rvsdg/graph.h>
-#include <jive/rvsdg/statemux.h>
+#include <jive/rvsdg/graph.hpp>
+#include <jive/rvsdg/statemux.hpp>
 
 #include <jlm/ir/operators/alloca.hpp>
 

--- a/libjlm/src/ir/operators/delta.cpp
+++ b/libjlm/src/ir/operators/delta.cpp
@@ -5,7 +5,7 @@
 
 #include <jlm/ir/operators/delta.hpp>
 
-#include <jive/rvsdg/substitution.h>
+#include <jive/rvsdg/substitution.hpp>
 
 namespace jlm {
 

--- a/libjlm/src/ir/operators/lambda.cpp
+++ b/libjlm/src/ir/operators/lambda.cpp
@@ -5,7 +5,7 @@
 
 #include <jlm/ir/operators/lambda.hpp>
 
-#include <jive/rvsdg/substitution.h>
+#include <jive/rvsdg/substitution.hpp>
 
 namespace jlm {
 

--- a/libjlm/src/ir/operators/load.cpp
+++ b/libjlm/src/ir/operators/load.cpp
@@ -3,8 +3,8 @@
  * See COPYING for terms of redistribution.
  */
 
-#include <jive/arch/addresstype.h>
-#include <jive/rvsdg/statemux.h>
+#include <jive/arch/addresstype.hpp>
+#include <jive/rvsdg/statemux.hpp>
 
 #include <jlm/ir/operators/alloca.hpp>
 #include <jlm/ir/operators/load.hpp>

--- a/libjlm/src/ir/operators/operators.cpp
+++ b/libjlm/src/ir/operators/operators.cpp
@@ -5,9 +5,9 @@
 
 #include <jlm/ir/operators/operators.hpp>
 
-#include <jive/arch/addresstype.h>
-#include <jive/types/bitstring/constant.h>
-#include <jive/types/float/flttype.h>
+#include <jive/arch/addresstype.hpp>
+#include <jive/types/bitstring/constant.hpp>
+#include <jive/types/float/flttype.hpp>
 
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/Support/raw_ostream.h>

--- a/libjlm/src/ir/operators/store.cpp
+++ b/libjlm/src/ir/operators/store.cpp
@@ -3,8 +3,8 @@
  * See COPYING for terms of redistribution.
  */
 
-#include <jive/rvsdg/graph.h>
-#include <jive/rvsdg/statemux.h>
+#include <jive/rvsdg/graph.hpp>
+#include <jive/rvsdg/statemux.hpp>
 
 #include <jlm/ir/operators/alloca.hpp>
 #include <jlm/ir/operators/operators.hpp>

--- a/libjlm/src/ir/tac.cpp
+++ b/libjlm/src/ir/tac.cpp
@@ -5,7 +5,7 @@
 
 #include <jlm/ir/tac.hpp>
 
-#include <jive/rvsdg/type.h>
+#include <jive/rvsdg/type.hpp>
 
 #include <sstream>
 

--- a/libjlm/src/jlm2llvm/instruction.cpp
+++ b/libjlm/src/jlm2llvm/instruction.cpp
@@ -3,10 +3,10 @@
  * See COPYING for terms of redistribution.
  */
 
-#include <jive/arch/addresstype.h>
-#include <jive/types/bitstring.h>
-#include <jive/rvsdg/control.h>
-#include <jive/rvsdg/statemux.h>
+#include <jive/arch/addresstype.hpp>
+#include <jive/types/bitstring.hpp>
+#include <jive/rvsdg/control.hpp>
+#include <jive/rvsdg/statemux.hpp>
 
 #include <jlm/ir/cfg-node.hpp>
 #include <jlm/ir/ipgraph-module.hpp>

--- a/libjlm/src/jlm2llvm/jlm2llvm.cpp
+++ b/libjlm/src/jlm2llvm/jlm2llvm.cpp
@@ -3,8 +3,8 @@
  * See COPYING for terms of redistribution.
  */
 
-#include <jive/arch/addresstype.h>
-#include <jive/rvsdg/control.h>
+#include <jive/arch/addresstype.hpp>
+#include <jive/rvsdg/control.hpp>
 
 #include <jlm/ir/basic-block.hpp>
 #include <jlm/ir/cfg.hpp>

--- a/libjlm/src/jlm2llvm/type.cpp
+++ b/libjlm/src/jlm2llvm/type.cpp
@@ -6,7 +6,7 @@
 #include <jlm/jlm2llvm/context.hpp>
 #include <jlm/jlm2llvm/type.hpp>
 
-#include <jive/arch/addresstype.h>
+#include <jive/arch/addresstype.hpp>
 
 #include <llvm/IR/Module.h>
 

--- a/libjlm/src/jlm2rvsdg/module.cpp
+++ b/libjlm/src/jlm2rvsdg/module.cpp
@@ -20,21 +20,21 @@
 #include <jlm/util/stats.hpp>
 #include <jlm/util/time.hpp>
 
-#include <jive/arch/address.h>
-#include <jive/arch/addresstype.h>
-#include <jive/arch/dataobject.h>
-#include <jive/arch/memlayout-simple.h>
-#include <jive/types/bitstring/constant.h>
-#include <jive/types/bitstring/type.h>
-#include <jive/types/float.h>
-#include <jive/types/function.h>
-#include <jive/rvsdg/binary.h>
-#include <jive/rvsdg/control.h>
-#include <jive/rvsdg/gamma.h>
-#include <jive/rvsdg/phi.h>
-#include <jive/rvsdg/region.h>
-#include <jive/rvsdg/theta.h>
-#include <jive/rvsdg/type.h>
+#include <jive/arch/address.hpp>
+#include <jive/arch/addresstype.hpp>
+#include <jive/arch/dataobject.hpp>
+#include <jive/arch/memlayout-simple.hpp>
+#include <jive/types/bitstring/constant.hpp>
+#include <jive/types/bitstring/type.hpp>
+#include <jive/types/float.hpp>
+#include <jive/types/function.hpp>
+#include <jive/rvsdg/binary.hpp>
+#include <jive/rvsdg/control.hpp>
+#include <jive/rvsdg/gamma.hpp>
+#include <jive/rvsdg/phi.hpp>
+#include <jive/rvsdg/region.hpp>
+#include <jive/rvsdg/theta.hpp>
+#include <jive/rvsdg/type.hpp>
 
 #include <cmath>
 #include <stack>

--- a/libjlm/src/jlm2rvsdg/restructuring.cpp
+++ b/libjlm/src/jlm2rvsdg/restructuring.cpp
@@ -10,7 +10,7 @@
 #include <jlm/ir/ipgraph-module.hpp>
 #include <jlm/ir/operators/operators.hpp>
 
-#include <jive/rvsdg/control.h>
+#include <jive/rvsdg/control.hpp>
 
 #include <algorithm>
 #include <cmath>

--- a/libjlm/src/llvm2jlm/instruction.cpp
+++ b/libjlm/src/llvm2jlm/instruction.cpp
@@ -13,15 +13,15 @@
 #include <jlm/ir/operators.hpp>
 #include <jlm/ir/tac.hpp>
 
-#include <jive/arch/address.h>
-#include <jive/arch/address-transform.h>
-#include <jive/arch/load.h>
-#include <jive/arch/addresstype.h>
-#include <jive/arch/store.h>
-#include <jive/types/bitstring.h>
-#include <jive/types/float.h>
-#include <jive/types/record.h>
-#include <jive/rvsdg/control.h>
+#include <jive/arch/address.hpp>
+#include <jive/arch/address-transform.hpp>
+#include <jive/arch/load.hpp>
+#include <jive/arch/addresstype.hpp>
+#include <jive/arch/store.hpp>
+#include <jive/types/bitstring.hpp>
+#include <jive/types/float.hpp>
+#include <jive/types/record.hpp>
+#include <jive/rvsdg/control.hpp>
 
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Instructions.h>

--- a/libjlm/src/llvm2jlm/module.cpp
+++ b/libjlm/src/llvm2jlm/module.cpp
@@ -16,8 +16,8 @@
 #include <jlm/llvm2jlm/module.hpp>
 #include <jlm/llvm2jlm/type.hpp>
 
-#include <jive/arch/addresstype.h>
-#include <jive/rvsdg/type.h>
+#include <jive/arch/addresstype.hpp>
+#include <jive/rvsdg/type.hpp>
 
 #include <llvm/ADT/PostOrderIterator.h>
 #include <llvm/IR/BasicBlock.h>

--- a/libjlm/src/llvm2jlm/type.cpp
+++ b/libjlm/src/llvm2jlm/type.cpp
@@ -8,10 +8,10 @@
 #include <jlm/llvm2jlm/context.hpp>
 #include <jlm/llvm2jlm/type.hpp>
 
-#include <jive/arch/addresstype.h>
-#include <jive/types/bitstring/type.h>
-#include <jive/types/float/flttype.h>
-#include <jive/types/function.h>
+#include <jive/arch/addresstype.hpp>
+#include <jive/types/bitstring/type.hpp>
+#include <jive/types/float/flttype.hpp>
+#include <jive/types/function.hpp>
 
 #include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/Type.h>

--- a/libjlm/src/opt/cne.cpp
+++ b/libjlm/src/opt/cne.cpp
@@ -10,11 +10,11 @@
 #include <jlm/util/stats.hpp>
 #include <jlm/util/time.hpp>
 
-#include <jive/rvsdg/gamma.h>
-#include <jive/rvsdg/phi.h>
-#include <jive/rvsdg/simple-node.h>
-#include <jive/rvsdg/theta.h>
-#include <jive/rvsdg/traverser.h>
+#include <jive/rvsdg/gamma.hpp>
+#include <jive/rvsdg/phi.hpp>
+#include <jive/rvsdg/simple-node.hpp>
+#include <jive/rvsdg/theta.hpp>
+#include <jive/rvsdg/traverser.hpp>
 
 namespace jlm {
 

--- a/libjlm/src/opt/dne.cpp
+++ b/libjlm/src/opt/dne.cpp
@@ -10,12 +10,12 @@
 #include <jlm/util/stats.hpp>
 #include <jlm/util/time.hpp>
 
-#include <jive/rvsdg/gamma.h>
-#include <jive/rvsdg/phi.h>
-#include <jive/rvsdg/simple-node.h>
-#include <jive/rvsdg/structural-node.h>
-#include <jive/rvsdg/theta.h>
-#include <jive/rvsdg/traverser.h>
+#include <jive/rvsdg/gamma.hpp>
+#include <jive/rvsdg/phi.hpp>
+#include <jive/rvsdg/simple-node.hpp>
+#include <jive/rvsdg/structural-node.hpp>
+#include <jive/rvsdg/theta.hpp>
+#include <jive/rvsdg/traverser.hpp>
 
 namespace jlm {
 

--- a/libjlm/src/opt/inlining.cpp
+++ b/libjlm/src/opt/inlining.cpp
@@ -10,10 +10,10 @@
 #include <jlm/util/stats.hpp>
 #include <jlm/util/time.hpp>
 
-#include <jive/rvsdg/gamma.h>
-#include <jive/rvsdg/substitution.h>
-#include <jive/rvsdg/theta.h>
-#include <jive/rvsdg/traverser.h>
+#include <jive/rvsdg/gamma.hpp>
+#include <jive/rvsdg/substitution.hpp>
+#include <jive/rvsdg/theta.hpp>
+#include <jive/rvsdg/traverser.hpp>
 
 namespace jlm {
 

--- a/libjlm/src/opt/invariance.cpp
+++ b/libjlm/src/opt/invariance.cpp
@@ -12,9 +12,9 @@
 #include <jlm/util/strfmt.hpp>
 #include <jlm/util/time.hpp>
 
-#include <jive/rvsdg/gamma.h>
-#include <jive/rvsdg/theta.h>
-#include <jive/rvsdg/traverser.h>
+#include <jive/rvsdg/gamma.hpp>
+#include <jive/rvsdg/theta.hpp>
+#include <jive/rvsdg/traverser.hpp>
 
 namespace jlm {
 

--- a/libjlm/src/opt/inversion.cpp
+++ b/libjlm/src/opt/inversion.cpp
@@ -11,10 +11,10 @@
 #include <jlm/util/strfmt.hpp>
 #include <jlm/util/time.hpp>
 
-#include <jive/rvsdg/gamma.h>
-#include <jive/rvsdg/substitution.h>
-#include <jive/rvsdg/theta.h>
-#include <jive/rvsdg/traverser.h>
+#include <jive/rvsdg/gamma.hpp>
+#include <jive/rvsdg/substitution.hpp>
+#include <jive/rvsdg/theta.hpp>
+#include <jive/rvsdg/traverser.hpp>
 
 namespace jlm {
 

--- a/libjlm/src/opt/pull.cpp
+++ b/libjlm/src/opt/pull.cpp
@@ -3,8 +3,8 @@
  * See COPYING for terms of redistribution.
  */
 
-#include <jive/rvsdg/gamma.h>
-#include <jive/rvsdg/traverser.h>
+#include <jive/rvsdg/gamma.hpp>
+#include <jive/rvsdg/traverser.hpp>
 
 #include <jlm/common.hpp>
 #include <jlm/ir/rvsdg-module.hpp>

--- a/libjlm/src/opt/push.cpp
+++ b/libjlm/src/opt/push.cpp
@@ -11,9 +11,9 @@
 #include <jlm/util/strfmt.hpp>
 #include <jlm/util/time.hpp>
 
-#include <jive/rvsdg/gamma.h>
-#include <jive/rvsdg/theta.h>
-#include <jive/rvsdg/traverser.h>
+#include <jive/rvsdg/gamma.hpp>
+#include <jive/rvsdg/theta.hpp>
+#include <jive/rvsdg/traverser.hpp>
 
 #include <deque>
 

--- a/libjlm/src/opt/reduction.cpp
+++ b/libjlm/src/opt/reduction.cpp
@@ -3,9 +3,9 @@
  * See COPYING for terms of redistribution.
  */
 
-#include <jive/rvsdg/binary.h>
-#include <jive/rvsdg/gamma.h>
-#include <jive/rvsdg/statemux.h>
+#include <jive/rvsdg/binary.hpp>
+#include <jive/rvsdg/gamma.hpp>
+#include <jive/rvsdg/statemux.hpp>
 
 #include <jlm/ir/operators.hpp>
 #include <jlm/ir/rvsdg-module.hpp>

--- a/libjlm/src/opt/unroll.cpp
+++ b/libjlm/src/opt/unroll.cpp
@@ -3,16 +3,16 @@
  * See COPYING for terms of redistribution.
  */
 
-#include <jive/arch/addresstype.h>
-#include <jive/types/bitstring/arithmetic.h>
-#include <jive/types/bitstring/comparison.h>
-#include <jive/types/bitstring/constant.h>
-#include <jive/rvsdg/binary.h>
-#include <jive/rvsdg/gamma.h>
-#include <jive/rvsdg/structural-node.h>
-#include <jive/rvsdg/substitution.h>
-#include <jive/rvsdg/theta.h>
-#include <jive/rvsdg/traverser.h>
+#include <jive/arch/addresstype.hpp>
+#include <jive/types/bitstring/arithmetic.hpp>
+#include <jive/types/bitstring/comparison.hpp>
+#include <jive/types/bitstring/constant.hpp>
+#include <jive/rvsdg/binary.hpp>
+#include <jive/rvsdg/gamma.hpp>
+#include <jive/rvsdg/structural-node.hpp>
+#include <jive/rvsdg/substitution.hpp>
+#include <jive/rvsdg/theta.hpp>
+#include <jive/rvsdg/traverser.hpp>
 
 #include <jlm/common.hpp>
 #include <jlm/ir/rvsdg-module.hpp>

--- a/libjlm/src/rvsdg2jlm/rvsdg2jlm.cpp
+++ b/libjlm/src/rvsdg2jlm/rvsdg2jlm.cpp
@@ -3,11 +3,11 @@
  * See COPYING for terms of redistribution.
  */
 
-#include <jive/rvsdg/gamma.h>
-#include <jive/rvsdg/graph.h>
-#include <jive/rvsdg/phi.h>
-#include <jive/rvsdg/theta.h>
-#include <jive/rvsdg/traverser.h>
+#include <jive/rvsdg/gamma.hpp>
+#include <jive/rvsdg/graph.hpp>
+#include <jive/rvsdg/phi.hpp>
+#include <jive/rvsdg/theta.hpp>
+#include <jive/rvsdg/traverser.hpp>
 
 #include <jlm/common.hpp>
 #include <jlm/ir/basic-block.hpp>

--- a/tests/libjlm/ir/operators/test-delta.cpp
+++ b/tests/libjlm/ir/operators/test-delta.cpp
@@ -7,7 +7,7 @@
 #include <test-types.hpp>
 #include <test-registry.hpp>
 
-#include <jive/view.h>
+#include <jive/view.hpp>
 
 #include <jlm/ir/rvsdg-module.hpp>
 #include <jlm/ir/operators/delta.hpp>

--- a/tests/libjlm/j2r/test-recursive-data.cpp
+++ b/tests/libjlm/j2r/test-recursive-data.cpp
@@ -7,7 +7,7 @@
 #include "test-operation.hpp"
 #include "test-types.hpp"
 
-#include <jive/view.h>
+#include <jive/view.hpp>
 
 #include <jlm/ir/ipgraph-module.hpp>
 #include <jlm/ir/print.hpp>

--- a/tests/libjlm/opt/test-cne.cpp
+++ b/tests/libjlm/opt/test-cne.cpp
@@ -7,13 +7,13 @@
 #include "test-registry.hpp"
 #include "test-types.hpp"
 
-#include <jive/view.h>
-#include <jive/rvsdg/control.h>
-#include <jive/rvsdg/gamma.h>
-#include <jive/rvsdg/graph.h>
-#include <jive/rvsdg/phi.h>
-#include <jive/rvsdg/simple-node.h>
-#include <jive/rvsdg/theta.h>
+#include <jive/view.hpp>
+#include <jive/rvsdg/control.hpp>
+#include <jive/rvsdg/gamma.hpp>
+#include <jive/rvsdg/graph.hpp>
+#include <jive/rvsdg/phi.hpp>
+#include <jive/rvsdg/simple-node.hpp>
+#include <jive/rvsdg/theta.hpp>
 
 #include <jlm/ir/operators/lambda.hpp>
 #include <jlm/ir/rvsdg-module.hpp>

--- a/tests/libjlm/opt/test-dne.cpp
+++ b/tests/libjlm/opt/test-dne.cpp
@@ -7,13 +7,13 @@
 #include "test-registry.hpp"
 #include "test-types.hpp"
 
-#include <jive/view.h>
-#include <jive/rvsdg/control.h>
-#include <jive/rvsdg/gamma.h>
-#include <jive/rvsdg/graph.h>
-#include <jive/rvsdg/phi.h>
-#include <jive/rvsdg/simple-node.h>
-#include <jive/rvsdg/theta.h>
+#include <jive/view.hpp>
+#include <jive/rvsdg/control.hpp>
+#include <jive/rvsdg/gamma.hpp>
+#include <jive/rvsdg/graph.hpp>
+#include <jive/rvsdg/phi.hpp>
+#include <jive/rvsdg/simple-node.hpp>
+#include <jive/rvsdg/theta.hpp>
 
 #include <jlm/ir/operators/lambda.hpp>
 #include <jlm/ir/rvsdg-module.hpp>

--- a/tests/libjlm/opt/test-inlining.cpp
+++ b/tests/libjlm/opt/test-inlining.cpp
@@ -7,9 +7,9 @@
 #include "test-registry.hpp"
 #include "test-types.hpp"
 
-#include <jive/view.h>
-#include <jive/rvsdg/control.h>
-#include <jive/rvsdg/gamma.h>
+#include <jive/view.hpp>
+#include <jive/rvsdg/control.hpp>
+#include <jive/rvsdg/gamma.hpp>
 
 #include <jlm/ir/operators.hpp>
 #include <jlm/ir/rvsdg-module.hpp>

--- a/tests/libjlm/opt/test-invariance.cpp
+++ b/tests/libjlm/opt/test-invariance.cpp
@@ -6,11 +6,11 @@
 #include "test-registry.hpp"
 #include "test-types.hpp"
 
-#include <jive/view.h>
-#include <jive/rvsdg/control.h>
-#include <jive/rvsdg/gamma.h>
-#include <jive/rvsdg/graph.h>
-#include <jive/rvsdg/theta.h>
+#include <jive/view.hpp>
+#include <jive/rvsdg/control.hpp>
+#include <jive/rvsdg/gamma.hpp>
+#include <jive/rvsdg/graph.hpp>
+#include <jive/rvsdg/theta.hpp>
 
 #include <jlm/ir/rvsdg-module.hpp>
 #include <jlm/ir/types.hpp>

--- a/tests/libjlm/opt/test-inversion.cpp
+++ b/tests/libjlm/opt/test-inversion.cpp
@@ -7,10 +7,10 @@
 #include "test-registry.hpp"
 #include "test-types.hpp"
 
-#include <jive/view.h>
-#include <jive/rvsdg/gamma.h>
-#include <jive/rvsdg/simple-node.h>
-#include <jive/rvsdg/theta.h>
+#include <jive/view.hpp>
+#include <jive/rvsdg/gamma.hpp>
+#include <jive/rvsdg/simple-node.hpp>
+#include <jive/rvsdg/theta.hpp>
 
 #include <jlm/ir/rvsdg-module.hpp>
 #include <jlm/opt/inversion.hpp>

--- a/tests/libjlm/opt/test-pull.cpp
+++ b/tests/libjlm/opt/test-pull.cpp
@@ -7,9 +7,9 @@
 #include "test-registry.hpp"
 #include "test-types.hpp"
 
-#include <jive/view.h>
-#include <jive/rvsdg/gamma.h>
-#include <jive/rvsdg/simple-node.h>
+#include <jive/view.hpp>
+#include <jive/rvsdg/gamma.hpp>
+#include <jive/rvsdg/simple-node.hpp>
 
 #include <jlm/ir/rvsdg-module.hpp>
 #include <jlm/opt/pull.hpp>

--- a/tests/libjlm/opt/test-push.cpp
+++ b/tests/libjlm/opt/test-push.cpp
@@ -7,11 +7,11 @@
 #include "test-registry.hpp"
 #include "test-types.hpp"
 
-#include <jive/arch/addresstype.h>
-#include <jive/view.h>
-#include <jive/rvsdg/gamma.h>
-#include <jive/rvsdg/simple-node.h>
-#include <jive/rvsdg/theta.h>
+#include <jive/arch/addresstype.hpp>
+#include <jive/view.hpp>
+#include <jive/rvsdg/gamma.hpp>
+#include <jive/rvsdg/simple-node.hpp>
+#include <jive/rvsdg/theta.hpp>
 
 #include <jlm/ir/operators/store.hpp>
 #include <jlm/ir/rvsdg-module.hpp>

--- a/tests/libjlm/opt/test-unroll.cpp
+++ b/tests/libjlm/opt/test-unroll.cpp
@@ -6,16 +6,16 @@
 #include "test-operation.hpp"
 #include "test-registry.hpp"
 
-#include <jive/evaluator/eval.h>
-#include <jive/evaluator/literal.h>
-#include <jive/types/bitstring/arithmetic.h>
-#include <jive/types/bitstring/constant.h>
-#include <jive/types/bitstring/comparison.h>
-#include <jive/view.h>
-#include <jive/rvsdg/gamma.h>
-#include <jive/rvsdg/graph.h>
-#include <jive/rvsdg/simple-node.h>
-#include <jive/rvsdg/theta.h>
+#include <jive/evaluator/eval.hpp>
+#include <jive/evaluator/literal.hpp>
+#include <jive/types/bitstring/arithmetic.hpp>
+#include <jive/types/bitstring/constant.hpp>
+#include <jive/types/bitstring/comparison.hpp>
+#include <jive/view.hpp>
+#include <jive/rvsdg/gamma.hpp>
+#include <jive/rvsdg/graph.hpp>
+#include <jive/rvsdg/simple-node.hpp>
+#include <jive/rvsdg/theta.hpp>
 
 #include <jlm/ir/rvsdg-module.hpp>
 #include <jlm/opt/dne.hpp>

--- a/tests/libjlm/r2j/test-empty-gamma.cpp
+++ b/tests/libjlm/r2j/test-empty-gamma.cpp
@@ -6,9 +6,9 @@
 #include "test-registry.hpp"
 #include "test-types.hpp"
 
-#include <jive/rvsdg/control.h>
-#include <jive/rvsdg/gamma.h>
-#include <jive/view.h>
+#include <jive/rvsdg/control.hpp>
+#include <jive/rvsdg/gamma.hpp>
+#include <jive/view.hpp>
 
 #include <jlm/ir/cfg-structure.hpp>
 #include <jlm/ir/ipgraph-module.hpp>

--- a/tests/libjlm/r2j/test-partial-gamma.cpp
+++ b/tests/libjlm/r2j/test-partial-gamma.cpp
@@ -7,9 +7,9 @@
 #include "test-registry.hpp"
 #include "test-types.hpp"
 
-#include <jive/rvsdg/control.h>
-#include <jive/rvsdg/gamma.h>
-#include <jive/view.h>
+#include <jive/rvsdg/control.hpp>
+#include <jive/rvsdg/gamma.hpp>
+#include <jive/view.hpp>
 
 #include <jlm/ir/cfg-structure.hpp>
 #include <jlm/ir/ipgraph-module.hpp>

--- a/tests/libjlm/r2j/test-recursive-data.cpp
+++ b/tests/libjlm/r2j/test-recursive-data.cpp
@@ -7,8 +7,8 @@
 #include "test-operation.hpp"
 #include "test-types.hpp"
 
-#include <jive/rvsdg/phi.h>
-#include <jive/view.h>
+#include <jive/rvsdg/phi.hpp>
+#include <jive/view.hpp>
 
 #include <jlm/ir/ipgraph-module.hpp>
 #include <jlm/ir/operators/delta.hpp>

--- a/tests/libjlm/test-load.cpp
+++ b/tests/libjlm/test-load.cpp
@@ -6,9 +6,9 @@
 #include <test-registry.hpp>
 #include <test-types.hpp>
 
-#include <jive/arch/addresstype.h>
-#include <jive/view.h>
-#include <jive/rvsdg/statemux.h>
+#include <jive/arch/addresstype.hpp>
+#include <jive/view.hpp>
+#include <jive/rvsdg/statemux.hpp>
 
 #include <jlm/ir/operators/alloca.hpp>
 #include <jlm/ir/operators/load.hpp>

--- a/tests/libjlm/test-sext.cpp
+++ b/tests/libjlm/test-sext.cpp
@@ -5,8 +5,8 @@
 
 #include <test-registry.hpp>
 
-#include <jive/types/bitstring/arithmetic.h>
-#include <jive/view.h>
+#include <jive/types/bitstring/arithmetic.hpp>
+#include <jive/view.hpp>
 
 #include <jlm/ir/operators/operators.hpp>
 #include <jlm/ir/operators/sext.hpp>

--- a/tests/libjlm/test-store.cpp
+++ b/tests/libjlm/test-store.cpp
@@ -6,11 +6,11 @@
 #include <test-registry.hpp>
 #include <test-types.hpp>
 
-#include <jive/arch/addresstype.h>
-#include <jive/types/bitstring/type.h>
-#include <jive/view.h>
-#include <jive/rvsdg/graph.h>
-#include <jive/rvsdg/statemux.h>
+#include <jive/arch/addresstype.hpp>
+#include <jive/types/bitstring/type.hpp>
+#include <jive/view.hpp>
+#include <jive/rvsdg/graph.hpp>
+#include <jive/rvsdg/statemux.hpp>
 
 #include <jlm/ir/operators/alloca.hpp>
 #include <jlm/ir/operators/operators.hpp>

--- a/tests/test-operation.hpp
+++ b/tests/test-operation.hpp
@@ -6,9 +6,9 @@
 #ifndef TESTS_TEST_OPERATION_HPP
 #define TESTS_TEST_OPERATION_HPP
 
-#include <jive/rvsdg/operation.h>
-#include <jive/rvsdg/simple-node.h>
-#include <jive/rvsdg/type.h>
+#include <jive/rvsdg/operation.hpp>
+#include <jive/rvsdg/simple-node.hpp>
+#include <jive/rvsdg/type.hpp>
 
 #include <jlm/ir/tac.hpp>
 

--- a/tests/test-types.hpp
+++ b/tests/test-types.hpp
@@ -6,7 +6,7 @@
 #ifndef TEST_TEST_TYPES_HPP
 #define TEST_TEST_TYPES_HPP
 
-#include <jive/rvsdg/type.h>
+#include <jive/rvsdg/type.hpp>
 
 namespace jlm {
 


### PR DESCRIPTION
The file endings in jive has been renamed to .hpp and .cpp from
.h and .c, which required all includes in jlm to be updated and a
make target for %.c to be changed to %.cpp