### PR TITLE
LLVM warnings

### DIFF
--- a/libjlm/include/jlm/common.hpp
+++ b/libjlm/include/jlm/common.hpp
@@ -23,7 +23,7 @@ namespace jlm {
 class error : public std::runtime_error {
 public:
 	virtual
-	~error() noexcept;
+	~error();
 
 	inline
 	error(const std::string & msg)

--- a/libjlm/include/jlm/ir/ipgraph.hpp
+++ b/libjlm/include/jlm/ir/ipgraph.hpp
@@ -138,7 +138,7 @@ class ipgraph_node {
 	typedef std::unordered_set<const ipgraph_node*>::const_iterator const_iterator;
 public:
 	virtual
-	~ipgraph_node() noexcept;
+	~ipgraph_node();
 
 protected:
 	inline
@@ -197,7 +197,7 @@ private:
 class function_node final : public ipgraph_node {
 public:
 	virtual
-	~function_node() noexcept;
+	~function_node();
 
 private:
 	inline
@@ -336,7 +336,7 @@ private:
 class data_node final : public ipgraph_node {
 public:
 	virtual
-	~data_node() noexcept;
+	~data_node();
 
 private:
 	inline
@@ -350,7 +350,7 @@ private:
 	, constant_(constant)
 	, name_(name)
 	, linkage_(linkage)
-	, type_(std::move(type.copy()))
+	, type_(type.copy())
 	{}
 
 public:

--- a/libjlm/include/jlm/ir/operators/call.hpp
+++ b/libjlm/include/jlm/ir/operators/call.hpp
@@ -28,8 +28,8 @@ public:
 	: simple_op(create_srcports(fcttype), create_dstports(fcttype))
 	{}
 
-	virtual bool
-	operator==(const operation & other) const noexcept;
+ 	virtual bool
+ 	operator==(const operation & other) const noexcept override;
 
 	virtual std::string
 	debug_string() const override;

--- a/libjlm/include/jlm/ir/operators/delta.hpp
+++ b/libjlm/include/jlm/ir/operators/delta.hpp
@@ -27,7 +27,7 @@ public:
 	: constant_(constant)
 	, name_(name)
 	, linkage_(linkage)
-	, type_(std::move(type.copy()))
+	, type_(type.copy())
 	{}
 
 	delta_op(const delta_op & other)

--- a/libjlm/include/jlm/ir/operators/load.hpp
+++ b/libjlm/include/jlm/ir/operators/load.hpp
@@ -21,7 +21,7 @@ namespace jlm {
 class load_normal_form final : public jive::simple_normal_form {
 public:
 	virtual
-	~load_normal_form() noexcept;
+	~load_normal_form();
 
 	load_normal_form(
 		const std::type_info & opclass,

--- a/libjlm/include/jlm/ir/operators/operators.hpp
+++ b/libjlm/include/jlm/ir/operators/operators.hpp
@@ -424,7 +424,7 @@ public:
 	copy() const override;
 
 	inline const jive::valuetype &
-	pointee_type() const noexcept
+	pointee_type() const
 	{
 		return static_cast<const jlm::ptrtype*>(&result(0).type())->pointee_type();
 	}
@@ -463,7 +463,7 @@ private:
 class bits2ptr_op final : public jive::unary_op {
 public:
 	virtual
-	~bits2ptr_op() noexcept;
+	~bits2ptr_op();
 
 	inline
 	bits2ptr_op(const jive::bittype & btype, const jlm::ptrtype & ptype)
@@ -508,7 +508,7 @@ public:
 	}
 
 	inline const jive::valuetype &
-	pointee_type() const noexcept
+	pointee_type() const
 	{
 		return static_cast<const jlm::ptrtype*>(&result(0).type())->pointee_type();
 	}
@@ -532,7 +532,7 @@ create_bits2ptr_tac(const variable * argument, jlm::variable * result)
 class ptr2bits_op final : public jive::unary_op {
 public:
 	virtual
-	~ptr2bits_op() noexcept;
+	~ptr2bits_op();
 
 	inline
 	ptr2bits_op(const jlm::ptrtype & ptype, const jive::bittype & btype)
@@ -655,7 +655,7 @@ enum class cmp {eq, ne, gt, ge, lt, le};
 class ptrcmp_op final : public jive::binary_op {
 public:
 	virtual
-	~ptrcmp_op() noexcept;
+	~ptrcmp_op();
 
 	inline
 	ptrcmp_op(const jlm::ptrtype & ptype, const jlm::cmp & cmp)
@@ -718,7 +718,7 @@ create_ptrcmp_tac(
 class zext_op final : public jive::unary_op {
 public:
 	virtual
-	~zext_op() noexcept;
+	~zext_op();
 
 	inline
 	zext_op(size_t nsrcbits, size_t ndstbits)
@@ -846,7 +846,7 @@ enum class fpcmp {
 class fpcmp_op final : public jive::binary_op {
 public:
 	virtual
-	~fpcmp_op() noexcept;
+	~fpcmp_op();
 
 	inline
 	fpcmp_op(const jlm::fpcmp & cmp, const jlm::fpsize & size)
@@ -909,7 +909,7 @@ create_fpcmp_tac(
 class undef_constant_op final : public jive::simple_op {
 public:
 	virtual
-	~undef_constant_op() noexcept;
+	~undef_constant_op();
 
 	inline
 	undef_constant_op(const jive::valuetype & type)
@@ -967,7 +967,7 @@ enum class fpop {add, sub, mul, div, mod};
 class fpbin_op final : public jive::binary_op {
 public:
 	virtual
-	~fpbin_op() noexcept;
+	~fpbin_op();
 
 	inline
 	fpbin_op(const jlm::fpop & op, const jlm::fpsize & size)
@@ -1030,7 +1030,7 @@ create_fpbin_tac(
 class fpext_op final : public jive::unary_op {
 public:
 	virtual
-	~fpext_op() noexcept;
+	~fpext_op();
 
 	inline
 	fpext_op(const jlm::fpsize & srcsize, const jlm::fpsize & dstsize)
@@ -1105,7 +1105,7 @@ create_fpext_tac(const variable * operand, jlm::variable * result)
 class fptrunc_op final : public jive::unary_op {
 public:
 	virtual
-	~fptrunc_op() noexcept;
+	~fptrunc_op();
 
 	inline
 	fptrunc_op(const fpsize & srcsize, const fpsize & dstsize)
@@ -1184,7 +1184,7 @@ create_fptrunc_tac(const variable * operand, jlm::variable * result)
 class valist_op final : public jive::simple_op {
 public:
 	virtual
-	~valist_op() noexcept;
+	~valist_op();
 
 	inline
 	valist_op(std::vector<std::unique_ptr<jive::type>> types)
@@ -1578,7 +1578,7 @@ create_sitofp_tac(const variable * operand, jlm::variable * result)
 class constant_array_op final : public jive::simple_op {
 public:
 	virtual
-	~constant_array_op() noexcept;
+	~constant_array_op();
 
 	inline
 	constant_array_op(const jive::valuetype & type, size_t size)
@@ -1847,7 +1847,7 @@ public:
 		const vectortype & operand,
 		const vectortype & result)
 	: simple_op({operand}, {result})
-	, op_(std::move(op.copy()))
+	, op_(op.copy())
 	{
 		if (operand.type() != op.argument(0).type()) {
 			auto received = operand.type().debug_string();
@@ -1865,7 +1865,7 @@ public:
 	inline
 	vectorunary_op(const vectorunary_op & other)
 	: simple_op(other)
-	, op_(std::move(other.op_->copy()))
+	, op_(other.op_->copy())
 	{}
 
 	inline
@@ -1878,7 +1878,7 @@ public:
 	operator=(const vectorunary_op & other)
 	{
 		if (this != &other)
-			op_ = std::move(other.op_->copy());
+			op_ = other.op_->copy();
 
 		return *this;
 	}
@@ -1939,7 +1939,7 @@ public:
 		const vectortype & op2,
 		const vectortype & result)
 	: simple_op({op1, op2}, {result})
-	, op_(std::move(binop.copy()))
+	, op_(binop.copy())
 	{
 		if (op1 != op2)
 			throw jlm::error("expected the same vector types.");
@@ -1960,7 +1960,7 @@ public:
 	inline
 	vectorbinary_op(const vectorbinary_op & other)
 	: simple_op(other)
-	, op_(std::move(other.op_->copy()))
+	, op_(other.op_->copy())
 	{}
 
 	inline
@@ -1973,7 +1973,7 @@ public:
 	operator=(const vectorbinary_op & other)
 	{
 		if (this != &other)
-			op_ = std::move(other.op_->copy());
+			op_ = other.op_->copy();
 
 		return *this;
 	}
@@ -2027,7 +2027,7 @@ private:
 class constant_data_vector_op final : public jive::simple_op {
 public:
 	virtual
-	~constant_data_vector_op() noexcept;
+	~constant_data_vector_op();
 
 	inline
 	constant_data_vector_op(const jive::valuetype & type, size_t size)
@@ -2080,7 +2080,7 @@ class extractvalue_op final : public jive::simple_op {
 	typedef std::vector<unsigned>::const_iterator const_iterator;
 public:
 	virtual
-	~extractvalue_op() noexcept;
+	~extractvalue_op();
 
 	inline
 	extractvalue_op(
@@ -2157,7 +2157,7 @@ private:
 class loopstatemux_op final : public jive::simple_op {
 public:
 	virtual
-	~loopstatemux_op() noexcept;
+	~loopstatemux_op();
 
 	loopstatemux_op(size_t noperands, size_t nresults)
 	: simple_op(create_portvector(noperands), create_portvector(nresults))
@@ -2216,7 +2216,7 @@ private:
 class memstatemux_op final : public jive::simple_op {
 public:
 	virtual
-	~memstatemux_op() noexcept;
+	~memstatemux_op();
 
 	memstatemux_op(size_t noperands, size_t nresults)
 	: simple_op(create_portvector(noperands), create_portvector(nresults))
@@ -2287,7 +2287,7 @@ private:
 class malloc_op final : public jive::simple_op {
 public:
 	virtual
-	~malloc_op() noexcept;
+	~malloc_op();
 
 	malloc_op(const jive::bittype & btype)
 	: simple_op({btype}, {jlm::ptrtype(jive::bittype(8)), jive::memtype::instance()})

--- a/libjlm/include/jlm/ir/operators/store.hpp
+++ b/libjlm/include/jlm/ir/operators/store.hpp
@@ -21,7 +21,7 @@ namespace jlm {
 class store_normal_form final : public jive::simple_normal_form {
 public:
 	virtual
-	~store_normal_form() noexcept;
+	~store_normal_form();
 
 	store_normal_form(
 		const std::type_info & opclass,

--- a/libjlm/include/jlm/ir/tac.hpp
+++ b/libjlm/include/jlm/ir/tac.hpp
@@ -31,7 +31,7 @@ class tac;
 class tacvariable final : public variable {
 public:
 	virtual
-	~tacvariable() noexcept;
+	~tacvariable();
 
 	inline
 	tacvariable(

--- a/libjlm/include/jlm/ir/types.hpp
+++ b/libjlm/include/jlm/ir/types.hpp
@@ -32,7 +32,7 @@ public:
 	inline
 	ptrtype(const jlm::ptrtype & other)
 	: jive::valuetype(other)
-	, ptype_(std::move(other.ptype_->copy()))
+	, ptype_(other.ptype_->copy())
 	{}
 
 	inline
@@ -93,7 +93,7 @@ public:
 	arraytype(const jlm::arraytype & other)
 	: jive::valuetype(other)
 	, nelements_(other.nelements_)
-	, type_(std::move(other.type_->copy()))
+	, type_(other.type_->copy())
 	{}
 
 	inline

--- a/libjlm/include/jlm/ir/variable.hpp
+++ b/libjlm/include/jlm/ir/variable.hpp
@@ -42,6 +42,8 @@ public:
 
 		name_ = std::move(other.name_);
 		type_ = std::move(other.type_);
+
+		return *this;
 	}
 
 	virtual std::string

--- a/libjlm/include/jlm/util/stats.hpp
+++ b/libjlm/include/jlm/util/stats.hpp
@@ -56,7 +56,7 @@ public:
 	void
 	set_file(const jlm::filepath & path) noexcept
 	{
-		file_ = std::move(jlm::file(path));
+		file_ = jlm::file(path);
 		file_.open("a");
 	}
 

--- a/libjlm/src/ir/operators/call.cpp
+++ b/libjlm/src/ir/operators/call.cpp
@@ -10,7 +10,7 @@ namespace jlm {
 
 /* call operator */
 
-call_op::~call_op() noexcept
+call_op::~call_op()
 {}
 
 bool

--- a/libjlm/src/llvm2jlm/instruction.cpp
+++ b/libjlm/src/llvm2jlm/instruction.cpp
@@ -202,7 +202,7 @@ convert_constantAggregateZero(
 	JLM_DEBUG_ASSERT(c->getValueID() == llvm::Value::ConstantAggregateZeroVal);
 
 	auto r = ctx.module().create_variable(*convert_type(c->getType(), ctx));
-	tacs.push_back(create_constant_aggregate_zero_tac({r}));
+	tacs.push_back(create_constant_aggregate_zero_tac(r));
 	return r;
 }
 


### PR DESCRIPTION
These changes address most warnings from clang but maybe should be solved differently. So this is to start the discussion on how the warnings should be addressed.