### PR TITLE
LLVM 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Jlm is an experimental compiler/optimizer that consumes and produces LLVM IR. It
 Regionalized Value State Dependence Graph (RVSDG) as intermediate representation for optimizations.
 
 ## Dependencies:
-* Clang/LLVM 7
+* Clang/LLVM 10
 
 ## Bootstrap:
 ```

--- a/libjlm/include/jlm/ir/operators/operators.hpp
+++ b/libjlm/include/jlm/ir/operators/operators.hpp
@@ -1100,6 +1100,58 @@ create_fpext_tac(const variable * operand, jlm::variable * result)
 	return tac::create(op, {operand}, {result});
 }
 
+/* fpneg operator */
+
+class fpneg_op final : public jive::unary_op {
+public:
+	~fpneg_op() override;
+
+	fpneg_op(const jlm::fpsize & size)
+	: unary_op(fptype(size), fptype(size))
+	{}
+
+	fpneg_op(const jive::type & type)
+	: unary_op(type, type)
+	{
+		auto st = dynamic_cast<const jlm::fptype*>(&type);
+		if (!st) throw jlm::error("expected floating point type.");
+	}
+
+	virtual bool
+	operator==(const operation & other) const noexcept override;
+
+	virtual std::string
+	debug_string() const override;
+
+	virtual std::unique_ptr<jive::operation>
+	copy() const override;
+
+	jive_unop_reduction_path_t
+	can_reduce_operand(
+		const jive::output * output) const noexcept override;
+
+	jive::output *
+	reduce_operand(
+		jive_unop_reduction_path_t path,
+		jive::output * output) const override;
+
+	const jlm::fpsize &
+	size() const noexcept
+	{
+		return static_cast<const jlm::fptype*>(&argument(0).type())->size();
+	}
+
+	static std::unique_ptr<jlm::tac>
+	create(const variable * operand, jlm::variable * result)
+        {
+		auto type = dynamic_cast<const jlm::fptype*>(&operand->type());
+		if (!type) throw jlm::error("expected floating point type.");
+
+		jlm::fpneg_op op(type->size());
+		return tac::create(op, {operand}, {result});
+	}
+};
+
 /* fptrunc operator */
 
 class fptrunc_op final : public jive::unary_op {

--- a/libjlm/src/ir/operators/operators.cpp
+++ b/libjlm/src/ir/operators/operators.cpp
@@ -665,6 +665,44 @@ fpext_op::reduce_operand(
 	JLM_ASSERT(0);
 }
 
+/* fpneg operator */
+
+fpneg_op::~fpneg_op()
+{}
+
+bool
+fpneg_op::operator==(const operation & other) const noexcept
+{
+	auto op = dynamic_cast<const jlm::fpneg_op*>(&other);
+	return op && op->size() == size();
+}
+
+std::string
+fpneg_op::debug_string() const
+{
+	return "fpneg";
+}
+
+std::unique_ptr<jive::operation>
+fpneg_op::copy() const
+{
+	return std::unique_ptr<jive::operation>(new jlm::fpneg_op(*this));
+}
+
+jive_unop_reduction_path_t
+fpneg_op::can_reduce_operand(const jive::output * operand) const noexcept
+{
+	return jive_unop_reduction_none;
+}
+
+jive::output *
+fpneg_op::reduce_operand(
+	jive_unop_reduction_path_t path,
+	jive::output * operand) const
+{
+	JLM_ASSERT(0);
+}
+
 /* fptrunc operator */
 
 fptrunc_op::~fptrunc_op()

--- a/libjlm/src/jlm2llvm/instruction.cpp
+++ b/libjlm/src/jlm2llvm/instruction.cpp
@@ -283,7 +283,7 @@ convert_load(
 	auto load = static_cast<const load_op*>(&op);
 
 	auto i = builder.CreateLoad(ctx.value(args[0]));
-	i->setAlignment(load->alignment());
+	i->setAlignment(llvm::MaybeAlign(load->alignment()));
 	return i;
 }
 
@@ -298,7 +298,7 @@ convert_store(
 	auto store = static_cast<const store_op*>(&op);
 
 	auto i = builder.CreateStore(ctx.value(args[1]), ctx.value(args[0]));
-	i->setAlignment(store->alignment());
+	i->setAlignment(llvm::MaybeAlign(store->alignment()));
 	return nullptr;
 }
 
@@ -314,7 +314,7 @@ convert_alloca(
 
 	auto t = convert_type(aop.value_type(), ctx);
 	auto i = builder.CreateAlloca(t, ctx.value(args[0]));
-	i->setAlignment(aop.alignment());
+	i->setAlignment(llvm::MaybeAlign(aop.alignment()));
 	return i;
 }
 

--- a/libjlm/src/jlm2llvm/instruction.cpp
+++ b/libjlm/src/jlm2llvm/instruction.cpp
@@ -514,6 +514,18 @@ convert_fpbin(
 	return builder.CreateBinOp(map[fpbin.fpop()], op1, op2);
 }
 
+static llvm::Value *
+convert_fpneg(
+	const jive::simple_op & op,
+	const std::vector<const variable*> & args,
+	llvm::IRBuilder<> & builder,
+	context & ctx)
+{
+	JLM_DEBUG_ASSERT(is<fpneg_op>(op));
+	auto operand = ctx.value(args[0]);
+	return builder.CreateUnOp(llvm::Instruction::FNeg, operand);
+}
+
 static inline llvm::Value *
 convert_valist(
 	const jive::simple_op & op,
@@ -848,6 +860,8 @@ convert_operation(
 
 	, {typeid(call_op), convert_call}
 	, {typeid(malloc_op), convert<malloc_op>}
+
+	, {typeid(fpneg_op), convert_fpneg}
 
 	/* LLVM Cast Instructions */
 	/* FIXME: AddrSpaceCast instruction is not supported */


### PR DESCRIPTION
Port of jlm to work with LLVM 10.
Added MaybeAlign to memory operations.
Added llvm fneg support to libjlm's ir operators.

All checks pass and the complete polyench.

Based on the make-targets branch.