### PR TITLE
Jlc opt flags

### DIFF
--- a/libjlc/include/jlc/cmdline.hpp
+++ b/libjlc/include/jlc/cmdline.hpp
@@ -112,7 +112,8 @@ public:
 	std::vector<std::string> libpaths;
 	std::vector<std::string> warnings;
 	std::vector<std::string> includepaths;
-  	std::vector<std::string> flags;
+	std::vector<std::string> flags;
+	std::vector<std::string> jlmopts;
 
 	std::vector<compilation> compilations;
 };

--- a/libjlc/include/jlc/command.hpp
+++ b/libjlc/include/jlc/command.hpp
@@ -76,8 +76,13 @@ public:
 	virtual
 	~optcmd();
 
-	optcmd(const jlm::filepath & ifile)
+	optcmd(
+		const jlm::filepath & ifile,
+		const std::vector<std::string> & jlmopts,
+		const optlvl & ol)
 	: ifile_(ifile)
+	, jlmopts_(jlmopts)
+	, ol_(ol)
 	{}
 
 	virtual std::string
@@ -89,13 +94,17 @@ public:
 	static passgraph_node *
 	create(
 		passgraph * pgraph,
-		const jlm::filepath & ifile)
+		const jlm::filepath & ifile,
+		const std::vector<std::string> & jlmopts,
+		const optlvl & ol)
 	{
-		return passgraph_node::create(pgraph, std::make_unique<optcmd>(ifile));
+		return passgraph_node::create(pgraph, std::make_unique<optcmd>(ifile, jlmopts, ol));
 	}
 
 private:
 	jlm::filepath ifile_;
+	std::vector<std::string> jlmopts_;
+	optlvl ol_;
 };
 
 /* code generator command */

--- a/libjlc/src/cmdline.cpp
+++ b/libjlc/src/cmdline.cpp
@@ -146,6 +146,12 @@ parse_cmdline(int argc, char ** argv, jlm::cmdline_options & options)
 	, cl::desc("Specify flags.")
 	, cl::value_desc("flag"));
 
+	cl::list<std::string> jlmopts(
+	  "J"
+	, cl::Prefix
+	, cl::desc("jlm-opt optimization. Run 'jlm-opt -help' for viable options.")
+	, cl::value_desc("jlmopt"));
+
 	cl::ParseCommandLineOptions(argc, argv);
 
 	if (show_help)
@@ -201,6 +207,7 @@ parse_cmdline(int argc, char ** argv, jlm::cmdline_options & options)
 	options.only_print_commands = print_commands;
 	options.generate_debug_information = generate_debug_information;
 	options.flags = flags;
+	options.jlmopts = jlmopts;
 
 	for (const auto & ifile : ifiles) {
 		if (is_objfile(ifile)) {

--- a/libjlc/src/command.cpp
+++ b/libjlc/src/command.cpp
@@ -33,7 +33,7 @@ generate_commands(const jlm::cmdline_options & opts)
 		}
 
 		if (c.optimize()) {
-			auto optnode = optcmd::create(pgraph.get(), c.ifile());
+			auto optnode = optcmd::create(pgraph.get(), c.ifile(), opts.jlmopts, opts.Olvl);
 			last->add_edge(optnode);
 			last = optnode;
 		}
@@ -145,9 +145,28 @@ optcmd::to_str() const
 {
 	auto f = ifile_.base();
 
+	std::string jlmopts;
+	for (const auto & jlmopt : jlmopts_)
+		jlmopts += "--" + jlmopt + " ";
+
+	/*
+		If a default optimization level has been specified (-O) and no specific jlm-options 
+		have been specified (-J) then use a default set of optimizations.
+	 */
+	if (jlmopts.empty()) {
+		/*
+			Only -O3 sets default optimizations
+		*/
+		if (ol_ == optlvl::O3) {
+			jlmopts  = "--iln --inv --red --dne --ivt --inv --dne --psh --inv --dne ";
+			jlmopts += "--red --cne --dne --pll --inv --dne --url --inv ";
+		}
+	}
+
 	return strfmt(
 	  "jlm-opt "
 	, "--llvm "
+	, jlmopts
 	, "/tmp/", create_prscmd_ofile(f), " > /tmp/", create_optcmd_ofile(f)
 	);
 }


### PR DESCRIPTION
Must have deleted a line by mistake when adding the previous changes as to commits.
The opts.jlmopts was never set in cmdline.cpp so didn't matter if -J was specified for jlc.