### PR TITLE
JLC: Fixed problem with extensions

### DIFF
--- a/libjlc/src/cmdline.cpp
+++ b/libjlc/src/cmdline.cpp
@@ -46,7 +46,7 @@ to_str(const standard & std)
 static bool
 is_objfile(const jlm::filepath & file)
 {
-	return file.complete_suffix() == "o";
+	return file.last_suffix() == "o";
 }
 
 static jlm::filepath

--- a/libjlm/include/jlm/util/file.hpp
+++ b/libjlm/include/jlm/util/file.hpp
@@ -103,6 +103,24 @@ public:
 	}
 
 	/**
+	* \brief Returns the last suffix (extension) of the file.
+	*
+	* Example:
+	*    jlm::file f("/tmp/archive.tar.gz");
+	*    auto ext = f.complete_suffix(); // ext = "gz"
+	*/
+	inline std::string
+	last_suffix() const noexcept
+	{
+		auto fn = name();
+		auto pos = fn.find_last_of(".");
+		if (pos == std::string::npos)
+			return fn;
+
+		return fn.substr(pos+1, fn.size()-pos);
+	}
+
+	/**
 	* \brief Returns a file's path, excluding the file name.
 	*
 	* Example:


### PR DESCRIPTION
The check for object files used the first occuring '.' in the file
thus names such as test.c.o was not detected as an object file name..
This fix instead looks for the last occuring '.' in the file name.