### PR TITLE
LLVM 11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,9 +24,9 @@ jobs:
         path: ${{ github.workspace }}/*
         key: ${{ runner.os }}-${{ github.sha }}-jlm
     - name: Install dependencies (LLVM)
-      run: sudo apt-get install llvm-10-dev clang-10
+      run: sudo apt-get install llvm-11-dev clang-11
     - name: Set LLVMCONFIG
-      run: echo "LLVMCONFIG=llvm-config-10" >> $GITHUB_ENV
+      run: echo "LLVMCONFIG=llvm-config-11" >> $GITHUB_ENV
     - name: Initialize submodules
       run: make submodule
     - name: Compile jive and jlm
@@ -39,9 +39,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies (LLVM)
-      run: sudo apt-get install llvm-10-dev clang-10
+      run: sudo apt-get install llvm-11-dev clang-11
     - name: Set LLVMCONFIG
-      run: echo "LLVMCONFIG=llvm-config-10" >> $GITHUB_ENV
+      run: echo "LLVMCONFIG=llvm-config-11" >> $GITHUB_ENV
     - name: Initialize submodules
       run: make submodule
     - name: Compile jive and jlm
@@ -61,11 +61,11 @@ jobs:
     - name: Add jlc to PATH
       run: echo '${{ github.workspace }}/bin' >> $GITHUB_PATH
     - name: Install dependencies (LLVM)
-      run: sudo apt-get install llvm-10-dev clang-10
+      run: sudo apt-get install llvm-11-dev clang-11
     - name: Install valgrind
       run: sudo apt-get install valgrind
     - name: Set LLVMCONFIG
-      run: echo "LLVMCONFIG=llvm-config-10" >> $GITHUB_ENV
+      run: echo "LLVMCONFIG=llvm-config-11" >> $GITHUB_ENV
     - name: Valgrind Check 
       run: make -C ${{ github.workspace }} valgrind-check
 
@@ -81,9 +81,9 @@ jobs:
     - name: Add jlc to PATH
       run: echo '${{ github.workspace }}/bin' >> $GITHUB_PATH
     - name: Install dependencies (LLVM)
-      run: sudo apt-get install llvm-10-dev clang-10
+      run: sudo apt-get install llvm-11-dev clang-11
     - name: Set LLVMCONFIG
-      run: echo "LLVMCONFIG=llvm-config-10" >> $GITHUB_ENV
+      run: echo "LLVMCONFIG=llvm-config-11" >> $GITHUB_ENV
     - name: Clone polybench
       run: git clone https://github.com/phate/polybench-jlm.git
     - name: Check polybench
@@ -101,9 +101,9 @@ jobs:
     - name: Add jlc to PATH
       run: echo '${{ github.workspace }}/bin' >> $GITHUB_PATH
     - name: Install dependencies (LLVM)
-      run: sudo apt-get install llvm-10-dev clang-10
+      run: sudo apt-get install llvm-11-dev clang-11
     - name: Set LLVMCONFIG
-      run: echo "LLVMCONFIG=llvm-config-10" >> $GITHUB_ENV
+      run: echo "LLVMCONFIG=llvm-config-11" >> $GITHUB_ENV
     - name: Clone jlm-test-suite
       run: git clone https://github.com/phate/jlm-eval-suite.git
     - name: Update submodules

--- a/libjlm/include/jlm/ir/types.hpp
+++ b/libjlm/include/jlm/ir/types.hpp
@@ -290,12 +290,8 @@ private:
 
 /* vector type */
 
-class vectortype final : public jive::valuetype {
+class vectortype : public jive::valuetype {
 public:
-	virtual
-	~vectortype();
-
-	inline
 	vectortype(
 		const jive::valuetype & type,
 		size_t size)
@@ -303,14 +299,12 @@ public:
 	, type_(type.copy())
 	{}
 
-	inline
 	vectortype(const vectortype & other)
 	: valuetype(other)
 	, size_(other.size_)
 	, type_(other.type_->copy())
 	{}
 
-	inline
 	vectortype(vectortype && other)
 	: valuetype(other)
 	, size_(other.size_)
@@ -339,17 +333,49 @@ public:
 		return *this;
 	}
 
-	inline size_t
+	virtual bool
+	operator==(const jive::type & other) const noexcept override;
+
+  /*
+	virtual std::unique_ptr<jive::type>
+	copy() const override;
+
+	virtual std::string
+	debug_string() const override;
+  */
+
+	size_t
 	size() const noexcept
 	{
 		return size_;
 	}
 
-	inline const jive::valuetype &
+	const jive::valuetype &
 	type() const noexcept
 	{
 		return *static_cast<const jive::valuetype*>(type_.get());
 	}
+
+	bool
+	isScalable() const noexcept
+	{
+		return false;
+	}
+
+private:
+	size_t size_;
+	std::unique_ptr<jive::type> type_;
+};
+
+class fixedvectortype final : public vectortype {
+public:
+	~fixedvectortype() override;
+
+	fixedvectortype(
+		const jive::valuetype & type,
+		size_t size)
+	: vectortype(type, size)
+	{}
 
 	virtual bool
 	operator==(const jive::type & other) const noexcept override;
@@ -360,9 +386,32 @@ public:
 	virtual std::string
 	debug_string() const override;
 
-private:
-	size_t size_;
-	std::unique_ptr<jive::type> type_;
+};
+
+class scalablevectortype final : public vectortype {
+public:
+	~scalablevectortype() override;
+
+	scalablevectortype(
+		const jive::valuetype & type,
+		size_t size)
+	: vectortype(type, size)
+	{}
+
+	virtual bool
+	operator==(const jive::type & other) const noexcept override;
+
+	virtual std::unique_ptr<jive::type>
+	copy() const override;
+
+	virtual std::string
+	debug_string() const override;
+
+	bool
+	isScalable() const noexcept
+	{
+		return true;
+	}
 };
 
 /* loop state type */

--- a/libjlm/src/backend/llvm/jlm2llvm/instruction.cpp
+++ b/libjlm/src/backend/llvm/jlm2llvm/instruction.cpp
@@ -281,7 +281,7 @@ convert_load(
 	auto load = static_cast<const load_op*>(&op);
 
 	auto i = builder.CreateLoad(ctx.value(args[0]));
-	i->setAlignment(llvm::MaybeAlign(load->alignment()));
+	i->setAlignment(llvm::Align(load->alignment()));
 	return i;
 }
 
@@ -296,7 +296,7 @@ convert_store(
 	auto store = static_cast<const store_op*>(&op);
 
 	auto i = builder.CreateStore(ctx.value(args[1]), ctx.value(args[0]));
-	i->setAlignment(llvm::MaybeAlign(store->alignment()));
+	i->setAlignment(llvm::Align(store->alignment()));
 	return nullptr;
 }
 
@@ -312,7 +312,7 @@ convert_alloca(
 
 	auto t = convert_type(aop.value_type(), ctx);
 	auto i = builder.CreateAlloca(t, ctx.value(args[0]));
-	i->setAlignment(llvm::MaybeAlign(aop.alignment()));
+	i->setAlignment(llvm::Align(aop.alignment()));
 	return i;
 }
 

--- a/libjlm/src/backend/llvm/jlm2llvm/instruction.cpp
+++ b/libjlm/src/backend/llvm/jlm2llvm/instruction.cpp
@@ -743,8 +743,13 @@ convert_cast(
 	auto operand = operands[0];
 
 	if (auto vtype = dynamic_cast<const vectortype*>(&operand->type())) {
-		auto type = convert_type(vectortype(dsttype, vtype->size()), ctx);
-		return builder.CreateCast(OPCODE, ctx.value(operand), type);
+		if (vtype->isScalable()) {
+			auto type = convert_type(scalablevectortype(dsttype, vtype->size()), ctx);
+			return builder.CreateCast(OPCODE, ctx.value(operand), type);
+		} else {
+			auto type = convert_type(scalablevectortype(dsttype, vtype->size()), ctx);
+			return builder.CreateCast(OPCODE, ctx.value(operand), type);
+		}
 	}
 
 	auto type = convert_type(dsttype, ctx);

--- a/libjlm/src/backend/llvm/jlm2llvm/instruction.cpp
+++ b/libjlm/src/backend/llvm/jlm2llvm/instruction.cpp
@@ -392,13 +392,16 @@ convert(
 	if (auto ft = dynamic_cast<const fptype*>(&op.type())) {
 		if (ft->size() == fpsize::half) {
 			auto data = get_fpdata<uint16_t>(operands, ctx);
-			return llvm::ConstantDataArray::getFP(builder.getContext(), data);
+			auto type = llvm::Type::getBFloatTy(builder.getContext());
+			return llvm::ConstantDataArray::getFP(type, data);
 		} else if (ft->size() == fpsize::flt) {
 			auto data = get_fpdata<uint32_t>(operands, ctx);
-			return llvm::ConstantDataArray::getFP(builder.getContext(), data);
+			auto type = llvm::Type::getFloatTy(builder.getContext());
+			return llvm::ConstantDataArray::getFP(type, data);
 		} else if (ft->size() == fpsize::dbl) {
 			auto data = get_fpdata<uint64_t>(operands, ctx);
-			return llvm::ConstantDataArray::getFP(builder.getContext(), data);
+			auto type = llvm::Type::getDoubleTy(builder.getContext());
+			return llvm::ConstantDataArray::getFP(type, data);
 		}
 	}
 
@@ -634,13 +637,16 @@ convert_constantdatavector(
 	if (auto ft = dynamic_cast<const fptype*>(&cop.type())) {
 		if (ft->size() == fpsize::half) {
 			auto data = get_fpdata<uint16_t>(operands, ctx);
-			return llvm::ConstantDataVector::getFP(builder.getContext(), data);
+			auto type = llvm::Type::getBFloatTy(builder.getContext());
+			return llvm::ConstantDataVector::getFP(type, data);
 		} else if (ft->size() == fpsize::flt) {
 			auto data = get_fpdata<uint32_t>(operands, ctx);
-			return llvm::ConstantDataVector::getFP(builder.getContext(), data);
+			auto type = llvm::Type::getFloatTy(builder.getContext());
+			return llvm::ConstantDataVector::getFP(type, data);
 		} else if (ft->size() == fpsize::dbl) {
 			auto data = get_fpdata<uint64_t>(operands, ctx);
-			return llvm::ConstantDataVector::getFP(builder.getContext(), data);
+			auto type = llvm::Type::getDoubleTy(builder.getContext());
+			return llvm::ConstantDataVector::getFP(type, data);
 		}
 	}
 

--- a/libjlm/src/backend/llvm/jlm2llvm/instruction.cpp
+++ b/libjlm/src/backend/llvm/jlm2llvm/instruction.cpp
@@ -167,15 +167,13 @@ convert_undef(
 	return llvm::UndefValue::get(convert_type(op.result(0).type(), ctx));
 }
 
-static inline llvm::Value *
-convert_call(
-	const jive::simple_op & op,
+static llvm::Value *
+convert(
+	const call_op & op,
 	const std::vector<const variable*> & args,
 	llvm::IRBuilder<> & builder,
 	context & ctx)
 {
-	JLM_ASSERT(is<call_op>(op));
-
 	auto function = ctx.value(args[0]);
 
 	std::vector<llvm::Value*> operands;
@@ -201,7 +199,8 @@ convert_call(
 		operands.push_back(ctx.value(argument));
 	}
 
-	return builder.CreateCall(function, operands);
+	auto ftype = convert_type(op.fcttype(), ctx);
+	return builder.CreateCall(ftype, function, operands);
 }
 
 static inline bool
@@ -914,7 +913,7 @@ convert_operation(
 	, {typeid(vectorselect_op), convert<vectorselect_op>}
 	, {typeid(ExtractValue), convert<ExtractValue>}
 
-	, {typeid(call_op), convert_call}
+	, {typeid(call_op), convert<call_op>}
 	, {typeid(malloc_op), convert<malloc_op>}
 	, {typeid(free_op), convert<free_op>}
 	, {typeid(Memcpy), convert<Memcpy>}

--- a/libjlm/src/backend/llvm/jlm2llvm/type.cpp
+++ b/libjlm/src/backend/llvm/jlm2llvm/type.cpp
@@ -150,7 +150,8 @@ convert_type(const jive::type & type, context & ctx)
 	, {typeid(jive::ctltype), convert<jive::ctltype>}
 	, {typeid(fptype),        convert<fptype>}
 	, {typeid(structtype),    convert<structtype>}
-	, {typeid(vectortype),    convert<vectortype>}
+	, {typeid(fixedvectortype),    convert<fixedvectortype>}
+	, {typeid(scalablevectortype),    convert<scalablevectortype>}
 	});
 
 	JLM_ASSERT(map.find(typeid(type)) != map.end());

--- a/libjlm/src/frontend/llvm/llvm2jlm/instruction.cpp
+++ b/libjlm/src/frontend/llvm/llvm2jlm/instruction.cpp
@@ -591,7 +591,7 @@ convert_getelementptr_instruction(llvm::Instruction * inst, tacsvector_t & tacs,
 static const llvm::FunctionType *
 function_type(const llvm::CallInst * i)
 {
-	auto f = i->getCalledValue();
+	auto f = i->getCalledOperand();
 	JLM_ASSERT(f->getType()->isPointerTy());
 	JLM_ASSERT(f->getType()->getContainedType(0)->isFunctionTy());
 	return llvm::cast<const llvm::FunctionType>(f->getType()->getContainedType(0));
@@ -711,7 +711,7 @@ convert_call_instruction(llvm::Instruction * instruction, tacsvector_t & tacs, c
 	arguments.push_back(ctx.memory_state());
 	arguments.push_back(ctx.loop_state());
 
-	auto fctvar = convert_value(i->getCalledValue(), tacs, ctx);
+	auto fctvar = convert_value(i->getCalledOperand(), tacs, ctx);
 	auto call = call_op::create(fctvar, arguments);
 
 	auto result = call->result(0);

--- a/libjlm/src/frontend/llvm/llvm2jlm/module.cpp
+++ b/libjlm/src/frontend/llvm/llvm2jlm/module.cpp
@@ -176,7 +176,7 @@ convert_attribute(const llvm::Attribute & attribute, context & ctx)
 	auto convert_string_attribute = [](const llvm::Attribute & attribute)
 	{
 		JLM_ASSERT(attribute.isStringAttribute());
-		return string_attribute::create(attribute.getKindAsString(), attribute.getValueAsString());
+		return string_attribute::create(attribute.getKindAsString().str(), attribute.getValueAsString().str());
 	};
 
 	auto convert_enum_attribute = [](const llvm::Attribute & attribute)

--- a/libjlm/src/frontend/llvm/llvm2jlm/type.cpp
+++ b/libjlm/src/frontend/llvm/llvm2jlm/type.cpp
@@ -104,7 +104,7 @@ convert_struct_type(const llvm::Type * t, context & ctx)
 	auto packed = type->isPacked();
 	auto dcl = ctx.lookup_declaration(type);
 	if (type->hasName())
-		return std::unique_ptr<jive::valuetype>(new structtype(type->getName(), packed, dcl));
+		return std::unique_ptr<jive::valuetype>(new structtype(type->getName().str(), packed, dcl));
 
 	return std::unique_ptr<jive::valuetype>(new structtype(packed, dcl));
 }

--- a/libjlm/src/frontend/llvm/llvm2jlm/type.cpp
+++ b/libjlm/src/frontend/llvm/llvm2jlm/type.cpp
@@ -118,11 +118,19 @@ convert_array_type(const llvm::Type * t, context & ctx)
 }
 
 static std::unique_ptr<jive::valuetype>
-convert_vector_type(const llvm::Type * t, context & ctx)
+convert_fixed_vector_type(const llvm::Type * t, context & ctx)
 {
-	JLM_ASSERT(t->isVectorTy());
-	auto type = convert_type(t->getVectorElementType(), ctx);
-	return std::unique_ptr<jive::valuetype>(new jlm::vectortype(*type, t->getVectorNumElements()));
+	JLM_ASSERT(t->getTypeID() == llvm::Type::FixedVectorTyID);
+	auto type = convert_type(t->getScalarType(), ctx);
+	return std::unique_ptr<jive::valuetype>(new jlm::fixedvectortype(*type, llvm::cast<llvm::FixedVectorType>(t)->getNumElements()));
+}
+
+static std::unique_ptr<jive::valuetype>
+convert_scalable_vector_type(const llvm::Type * t, context & ctx)
+{
+	JLM_ASSERT(t->getTypeID() == llvm::Type::ScalableVectorTyID);
+	auto type = convert_type(t->getScalarType(), ctx);
+	return std::unique_ptr<jive::valuetype>(new jlm::scalablevectortype(*type, llvm::cast<llvm::ScalableVectorType>(t)->getMinNumElements()));
 }
 
 std::unique_ptr<jive::valuetype>
@@ -141,7 +149,8 @@ convert_type(const llvm::Type * t, context & ctx)
 	, {llvm::Type::X86_FP80TyID, convert_fp_type}
 	, {llvm::Type::StructTyID, convert_struct_type}
 	, {llvm::Type::ArrayTyID, convert_array_type}
-	, {llvm::Type::VectorTyID, convert_vector_type}
+	, {llvm::Type::FixedVectorTyID, convert_fixed_vector_type}
+	, {llvm::Type::ScalableVectorTyID, convert_scalable_vector_type}
 	});
 
 	JLM_ASSERT(map.find(t->getTypeID()) != map.end());

--- a/libjlm/src/ir/types.cpp
+++ b/libjlm/src/ir/types.cpp
@@ -143,9 +143,6 @@ structtype::copy() const
 
 /* vectortype */
 
-vectortype::~vectortype()
-{}
-
 bool
 vectortype::operator==(const jive::type & other) const noexcept
 {
@@ -155,16 +152,51 @@ vectortype::operator==(const jive::type & other) const noexcept
 	    && *type->type_ == *type_;
 }
 
-std::string
-vectortype::debug_string() const
+/* fixedvectortype */
+
+fixedvectortype::~fixedvectortype()
+{}
+
+bool
+fixedvectortype::operator==(const jive::type & other) const noexcept
 {
-	return strfmt("vector[", type().debug_string(), ":", size(), "]");
+	return vectortype::operator==(other);
+}
+
+std::string
+fixedvectortype::debug_string() const
+{
+	return strfmt("fixedvector[", type().debug_string(), ":", size(), "]");
 }
 
 std::unique_ptr<jive::type>
-vectortype::copy() const
+fixedvectortype::copy() const
 {
-	return std::unique_ptr<jive::type>(new vectortype(*this));
+	return std::unique_ptr<jive::type>(new fixedvectortype(*this));
+}
+
+
+/* scalablevectortype */
+
+scalablevectortype::~scalablevectortype()
+{}
+
+bool
+scalablevectortype::operator==(const jive::type & other) const noexcept
+{
+	return vectortype::operator==(other);
+}
+
+std::string
+scalablevectortype::debug_string() const
+{
+	return strfmt("scalablevector[", type().debug_string(), ":", size(), "]");
+}
+
+std::unique_ptr<jive::type>
+scalablevectortype::copy() const
+{
+	return std::unique_ptr<jive::type>(new scalablevectortype(*this));
 }
 
 /* loop state type */


### PR DESCRIPTION
Search for FIXME to see two places where the derived vector types (maybe) should be used.

Passes polybench and 28% of the LLVM test suite but throws an error at runtime.