### PR TITLE
make: Removed the 'l' option for the ar command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ submodule:
 
 %.a:
 	rm -f $@
-	ar clqv $@ $^
+	ar cqv $@ $^
 	ranlib $@
 
 .PHONY: clean


### PR DESCRIPTION
ar was using clqv as arguments, which cause an error when trying
to create libjlm.a on Ubuntu 21.10
Error message
  ar: libdeps specified more than once

The l argument has been removed, i.e., ar is now usig cqv.
The change has also been tested to work with Ubuntu 20.04.3