### PR TITLE
Llvm13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   docs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.10
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
@@ -17,7 +17,7 @@ jobs:
       run: make docs
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.10
     steps:
     - uses: actions/checkout@v2
     - name: Cache build
@@ -33,29 +33,29 @@ jobs:
         path: ${{ github.workspace }}/*
         key: ${{ runner.os }}-${{ github.sha }}-jlm
     - name: Install dependencies (LLVM)
-      run: sudo apt-get install llvm-11-dev clang-11
+      run: sudo apt-get install llvm-13-dev clang-13
     - name: Set LLVMCONFIG
-      run: echo "LLVMCONFIG=llvm-config-11" >> $GITHUB_ENV
+      run: echo "LLVMCONFIG=llvm-config-13" >> $GITHUB_ENV
     - name: Compile jlm
       run: make jlm-release -j `nproc`
     - name: Run unit and C tests
       run: make check -j `nproc`
 
-  ubuntu-latest-gcc:
-    runs-on: ubuntu-latest
+  gcc:
+    runs-on: ubuntu-20.10
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies (LLVM)
-      run: sudo apt-get install llvm-11-dev clang-11
+      run: sudo apt-get install llvm-13-dev clang-13
     - name: Set LLVMCONFIG
-      run: echo "LLVMCONFIG=llvm-config-11" >> $GITHUB_ENV
+      run: echo "LLVMCONFIG=llvm-config-13" >> $GITHUB_ENV
     - name: Compile jlm
       run: make CXX=g++ jlm-release -j `nproc`
     - name: Run unit and C tests
       run: make check -j `nproc`
 
   valgrind:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.10
     needs: build
     steps:
     - name: Cache
@@ -66,16 +66,16 @@ jobs:
     - name: Add jlc to PATH
       run: echo '${{ github.workspace }}/bin' >> $GITHUB_PATH
     - name: Install dependencies (LLVM)
-      run: sudo apt-get install llvm-11-dev clang-11
+      run: sudo apt-get install llvm-13-dev clang-13
     - name: Install valgrind
       run: sudo apt-get install valgrind
     - name: Set LLVMCONFIG
-      run: echo "LLVMCONFIG=llvm-config-11" >> $GITHUB_ENV
+      run: echo "LLVMCONFIG=llvm-config-13" >> $GITHUB_ENV
     - name: Valgrind Check 
       run: make -C ${{ github.workspace }} valgrind-check
 
   polybench:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.10
     needs: build
     steps:
     - name: Cache
@@ -86,16 +86,16 @@ jobs:
     - name: Add jlc to PATH
       run: echo '${{ github.workspace }}/bin' >> $GITHUB_PATH
     - name: Install dependencies (LLVM)
-      run: sudo apt-get install llvm-11-dev clang-11
+      run: sudo apt-get install llvm-13-dev clang-13
     - name: Set LLVMCONFIG
-      run: echo "LLVMCONFIG=llvm-config-11" >> $GITHUB_ENV
+      run: echo "LLVMCONFIG=llvm-config-13" >> $GITHUB_ENV
     - name: Clone polybench
       run: git clone https://github.com/phate/polybench-jlm.git
     - name: Check polybench
       run: make -C polybench-jlm check
 
   llvm-test-suite:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.10
     needs: build
     steps:
     - name: Cache
@@ -106,9 +106,9 @@ jobs:
     - name: Add jlc to PATH
       run: echo '${{ github.workspace }}/bin' >> $GITHUB_PATH
     - name: Install dependencies (LLVM)
-      run: sudo apt-get install llvm-11-dev clang-11
+      run: sudo apt-get install llvm-13-dev clang-13
     - name: Set LLVMCONFIG
-      run: echo "LLVMCONFIG=llvm-config-11" >> $GITHUB_ENV
+      run: echo "LLVMCONFIG=llvm-config-13" >> $GITHUB_ENV
     - name: Clone jlm-test-suite
       run: git clone https://github.com/phate/jlm-eval-suite.git
     - name: Update submodules

--- a/jlm-opt/src/cmdline.cpp
+++ b/jlm-opt/src/cmdline.cpp
@@ -69,11 +69,6 @@ parse_cmdline(int argc, char ** argv, jlm::cmdline_options & options)
 
 	cl::TopLevelSubCommand->reset();
 
-	cl::opt<bool> show_help(
-	  "help"
-	, cl::ValueDisallowed
-	, cl::desc("Display available options."));
-
 	cl::opt<std::string> ifile(
 	  cl::Positional
 	, cl::desc("<input>"));
@@ -178,11 +173,6 @@ parse_cmdline(int argc, char ** argv, jlm::cmdline_options & options)
 	, cl::desc("Perform optimization"));
 
 	cl::ParseCommandLineOptions(argc, argv);
-
-	if (show_help) {
-		cl::PrintHelpMessage();
-		exit(EXIT_SUCCESS);
-	}
 
 	if (!ofile.empty())
 		options.ofile = ofile;

--- a/libjlc/src/cmdline.cpp
+++ b/libjlc/src/cmdline.cpp
@@ -76,11 +76,6 @@ parse_cmdline(int argc, char ** argv, jlm::cmdline_options & options)
 
 	cl::TopLevelSubCommand->reset();
 
-	cl::opt<bool> show_help(
-	  "help"
-	, cl::ValueDisallowed
-	, cl::desc("Display available options."));
-
 	cl::opt<bool> print_commands(
 	  "###"
 	, cl::ValueDisallowed
@@ -195,9 +190,6 @@ parse_cmdline(int argc, char ** argv, jlm::cmdline_options & options)
 	, cl::value_desc("value"));
 
 	cl::ParseCommandLineOptions(argc, argv);
-
-	if (show_help)
-		cl::PrintHelpMessage();
 
 	/* Process parsed options */
 

--- a/libjlm/include/jlm/ir/attribute.hpp
+++ b/libjlm/include/jlm/ir/attribute.hpp
@@ -26,11 +26,15 @@ public:
 	, always_inline
 	, arg_mem_only
 	, builtin
+	, ByRef
 	, by_val
 	, cold
 	, convergent
 	, dereferenceable
 	, dereferenceable_or_null
+	, DisableSanitizerInstrumentation
+	, ElementType
+	, Hot
 	, imm_arg
 	, in_alloca
 	, in_reg
@@ -39,26 +43,34 @@ public:
 	, inline_hint
 	, jump_table
 	, min_size
+	, MustProgress
 	, naked
 	, nest
 	, no_alias
 	, no_builtin
+	, NoCallback
 	, no_capture
 	, no_cf_check
 	, no_duplicate
 	, no_free
 	, no_implicit_float
 	, no_inline
+	, NoMerge
+	, NoProfile
 	, no_recurse
 	, no_red_zone
 	, no_return
+	, NoSanitizeCoverage
 	, no_sync
+	, NoUndef
 	, no_unwind
 	, non_lazy_bind
 	, non_null
+	, NullPointerIsValid
 	, opt_for_fuzzing
 	, optimize_for_size
 	, optimize_none
+	, Preallocated
 	, read_none
 	, read_only
 	, returned
@@ -79,9 +91,11 @@ public:
 	, stack_protect_strong
 	, strict_fp
 	, struct_ret
+	, SwiftAsync
 	, swift_error
 	, swift_self
 	, uwtable
+	, VScaleRange
 	, will_return
 	, write_only
 	, zext

--- a/libjlm/src/backend/llvm/jlm2llvm/jlm2llvm.cpp
+++ b/libjlm/src/backend/llvm/jlm2llvm/jlm2llvm.cpp
@@ -166,11 +166,14 @@ convert_attribute_kind(const jlm::attribute::kind & kind)
 	, {attribute::kind::always_inline,                    ak::AlwaysInline}
 	, {attribute::kind::arg_mem_only,                     ak::ArgMemOnly}
 	, {attribute::kind::builtin,                          ak::Builtin}
+	, {attribute::kind::ByRef,                            ak::ByRef}
 	, {attribute::kind::by_val,                           ak::ByVal}
 	, {attribute::kind::cold,                             ak::Cold}
 	, {attribute::kind::convergent,                       ak::Convergent}
 	, {attribute::kind::dereferenceable,                  ak::Dereferenceable}
 	, {attribute::kind::dereferenceable_or_null,          ak::DereferenceableOrNull}
+	, {attribute::kind::ElementType,                      ak::ElementType}
+	, {attribute::kind::Hot,                              ak::Hot}
 	, {attribute::kind::imm_arg,                          ak::ImmArg}
 	, {attribute::kind::in_alloca,                        ak::InAlloca}
 	, {attribute::kind::in_reg,                           ak::InReg}
@@ -179,26 +182,34 @@ convert_attribute_kind(const jlm::attribute::kind & kind)
 	, {attribute::kind::inline_hint,                      ak::InlineHint}
 	, {attribute::kind::jump_table,                       ak::JumpTable}
 	, {attribute::kind::min_size,                         ak::MinSize}
+	, {attribute::kind::MustProgress,                     ak::MustProgress}
 	, {attribute::kind::naked,                            ak::Naked}
 	, {attribute::kind::nest,                             ak::Nest}
 	, {attribute::kind::no_alias,                         ak::NoAlias}
 	, {attribute::kind::no_builtin,                       ak::NoBuiltin}
+	, {attribute::kind::NoCallback,                       ak::NoCallback}
 	, {attribute::kind::no_capture,                       ak::NoCapture}
 	, {attribute::kind::no_cf_check,                      ak::NoCfCheck}
 	, {attribute::kind::no_duplicate,                     ak::NoDuplicate}
 	, {attribute::kind::no_free,                          ak::NoFree}
 	, {attribute::kind::no_implicit_float,                ak::NoImplicitFloat}
 	, {attribute::kind::no_inline,                        ak::NoInline}
+	, {attribute::kind::NoMerge,                          ak::NoMerge}
+	, {attribute::kind::NoProfile,                        ak::NoProfile}
 	, {attribute::kind::no_recurse,                       ak::NoRecurse}
 	, {attribute::kind::no_red_zone,                      ak::NoRedZone}
 	, {attribute::kind::no_return,                        ak::NoReturn}
+	, {attribute::kind::NoSanitizeCoverage,               ak::NoSanitizeCoverage}
 	, {attribute::kind::no_sync,                          ak::NoSync}
+	, {attribute::kind::NoUndef,                          ak::NoUndef}
 	, {attribute::kind::no_unwind,                        ak::NoUnwind}
 	, {attribute::kind::non_lazy_bind,                    ak::NonLazyBind}
 	, {attribute::kind::non_null,                         ak::NonNull}
+	, {attribute::kind::NullPointerIsValid,               ak::NullPointerIsValid}
 	, {attribute::kind::opt_for_fuzzing,                  ak::OptForFuzzing}
 	, {attribute::kind::optimize_for_size,                ak::OptimizeForSize}
 	, {attribute::kind::optimize_none,                    ak::OptimizeNone}
+	, {attribute::kind::Preallocated,                     ak::Preallocated}
 	, {attribute::kind::read_none,                        ak::ReadNone}
 	, {attribute::kind::read_only,                        ak::ReadOnly}
 	, {attribute::kind::returned,                         ak::Returned}
@@ -219,9 +230,11 @@ convert_attribute_kind(const jlm::attribute::kind & kind)
 	, {attribute::kind::stack_protect_strong,             ak::StackProtectStrong}
 	, {attribute::kind::strict_fp,                        ak::StrictFP}
 	, {attribute::kind::struct_ret,                       ak::StructRet}
+	, {attribute::kind::SwiftAsync,                       ak::SwiftAsync}
 	, {attribute::kind::swift_error,                      ak::SwiftError}
 	, {attribute::kind::swift_self,                       ak::SwiftSelf}
 	, {attribute::kind::uwtable,                          ak::UWTable}
+	, {attribute::kind::VScaleRange,                      ak::VScaleRange}
 	, {attribute::kind::will_return,                      ak::WillReturn}
 	, {attribute::kind::write_only,                       ak::WriteOnly}
 	, {attribute::kind::zext,                             ak::ZExt}

--- a/libjlm/src/frontend/llvm/llvm2jlm/instruction.cpp
+++ b/libjlm/src/frontend/llvm/llvm2jlm/instruction.cpp
@@ -59,7 +59,9 @@ convert_apint(const llvm::APInt & value)
 	if (value.isNegative())
 		v = -value;
 
-	std::string str = value.toString(2, false);
+	llvm::SmallString<256> small_str;
+	value.toString(small_str, 2, false);
+	std::string str = small_str.str().str();
 	std::reverse(str.begin(), str.end());
 
 	jive::bitvalue_repr vr(str.c_str());

--- a/libjlm/src/frontend/llvm/llvm2jlm/module.cpp
+++ b/libjlm/src/frontend/llvm/llvm2jlm/module.cpp
@@ -93,10 +93,14 @@ convert_attribute_kind(const llvm::Attribute::AttrKind & kind)
 	, {ak::AlwaysInline,                attribute::kind::always_inline}
 	, {ak::ArgMemOnly,                  attribute::kind::arg_mem_only}
 	, {ak::Builtin,                     attribute::kind::builtin}
+	, {ak::ByRef,                       attribute::kind::ByRef}
+	, {ak::ByVal,                       attribute::kind::by_val}
 	, {ak::Cold,                        attribute::kind::cold}
 	, {ak::Convergent,                  attribute::kind::convergent}
 	, {ak::Dereferenceable,             attribute::kind::dereferenceable}
 	, {ak::DereferenceableOrNull,       attribute::kind::dereferenceable_or_null}
+	, {ak::ElementType,                 attribute::kind::ElementType}
+	, {ak::Hot,                         attribute::kind::Hot}
 	, {ak::ImmArg,                      attribute::kind::imm_arg}
 	, {ak::InAlloca,                    attribute::kind::in_alloca}
 	, {ak::InReg,                       attribute::kind::in_reg}
@@ -105,26 +109,33 @@ convert_attribute_kind(const llvm::Attribute::AttrKind & kind)
 	, {ak::InlineHint,                  attribute::kind::inline_hint}
 	, {ak::JumpTable,                   attribute::kind::jump_table}
 	, {ak::MinSize,                     attribute::kind::min_size}
+	, {ak::MustProgress,                attribute::kind::MustProgress}
 	, {ak::Naked,                       attribute::kind::naked}
 	, {ak::Nest,                        attribute::kind::nest}
 	, {ak::NoAlias,                     attribute::kind::no_alias}
 	, {ak::NoBuiltin,                   attribute::kind::no_builtin}
+	, {ak::NoCallback,                  attribute::kind::NoCallback}
 	, {ak::NoCapture,                   attribute::kind::no_capture}
 	, {ak::NoCfCheck,                   attribute::kind::no_cf_check}
 	, {ak::NoDuplicate,                 attribute::kind::no_duplicate}
 	, {ak::NoFree,                      attribute::kind::no_free}
 	, {ak::NoImplicitFloat,             attribute::kind::no_implicit_float}
 	, {ak::NoInline,                    attribute::kind::no_inline}
+	, {ak::NoMerge,                     attribute::kind::NoMerge}
+	, {ak::NoProfile,                   attribute::kind::NoProfile}
 	, {ak::NoRecurse,                   attribute::kind::no_recurse}
 	, {ak::NoRedZone,                   attribute::kind::no_red_zone}
 	, {ak::NoReturn,                    attribute::kind::no_return}
+	, {ak::NoSanitizeCoverage,          attribute::kind::NoSanitizeCoverage}
 	, {ak::NoSync,                      attribute::kind::no_sync}
 	, {ak::NoUnwind,                    attribute::kind::no_unwind}
 	, {ak::NonLazyBind,                 attribute::kind::non_lazy_bind}
 	, {ak::NonNull,                     attribute::kind::non_null}
+	, {ak::NullPointerIsValid,          attribute::kind::NullPointerIsValid}
 	, {ak::OptForFuzzing,               attribute::kind::opt_for_fuzzing}
 	, {ak::OptimizeForSize,             attribute::kind::optimize_for_size}
 	, {ak::OptimizeNone,                attribute::kind::optimize_none}
+	, {ak::Preallocated,                attribute::kind::Preallocated}
 	, {ak::ReadNone,                    attribute::kind::read_none}
 	, {ak::ReadOnly,                    attribute::kind::read_only}
 	, {ak::Returned,                    attribute::kind::returned}
@@ -145,6 +156,7 @@ convert_attribute_kind(const llvm::Attribute::AttrKind & kind)
 	, {ak::StackProtectStrong,          attribute::kind::stack_protect_strong}
 	, {ak::StrictFP,                    attribute::kind::strict_fp}
 	, {ak::StructRet,                   attribute::kind::struct_ret}
+	, {ak::SwiftAsync,                  attribute::kind::SwiftAsync}
 	, {ak::SwiftError,                  attribute::kind::swift_error}
 	, {ak::SwiftSelf,                   attribute::kind::swift_self}
 	, {ak::UWTable,                     attribute::kind::uwtable}
@@ -165,6 +177,9 @@ convert_attribute(const llvm::Attribute & attribute, context & ctx)
 		JLM_ASSERT(attribute.isTypeAttribute());
 
 		if (attribute.getKindAsEnum() == llvm::Attribute::AttrKind::ByVal) {
+			auto type = convert_type(attribute.getValueAsType(), ctx);
+			return type_attribute::create_byval(std::move(type));
+		} else if (attribute.getKindAsEnum() == llvm::Attribute::StructRet) {
 			auto type = convert_type(attribute.getValueAsType(), ctx);
 			return type_attribute::create_byval(std::move(type));
 		}

--- a/tests/c-tests/test-constant-array.c
+++ b/tests/c-tests/test-constant-array.c
@@ -1,9 +1,10 @@
 #include <stdio.h>
 
+#define n 3
+
 int
 main()
 {
-	const unsigned int n = 3;
 	static const char * strings[n] = {"1", "2", "3"};
 
 	for (unsigned int i = 0; i < n; i++)


### PR DESCRIPTION
Especially check the "jlm-opt: Removed help argument from command line parsing" commit and the code added for llvm::Attribute::StructRet, as I don't know if it is correct.
The llvm-test-suite test that caused and assert before handling this case compiles.


There are still issues with the llvm-test-suite though
pr78791 of llvm-test-suite fails due to incorrectly handled global

jlm-opt output:
@llvm.compiler.used = appending global [1 x i8*] [i8* bitcast (i64 (i64, i64, i64)* @foo to i8*)]

clang output:
@llvm.compiler.used = appending global [1 x i8*] [i8* bitcast (i64 (i64, i64, i64)* @foo to i8*)], section "llvm.metadata"