### PR TITLE
LLVM12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,9 +33,9 @@ jobs:
         path: ${{ github.workspace }}/*
         key: ${{ runner.os }}-${{ github.sha }}-jlm
     - name: Install dependencies (LLVM)
-      run: sudo apt-get install llvm-11-dev clang-11
+      run: sudo apt-get install llvm-12-dev clang-12
     - name: Set LLVMCONFIG
-      run: echo "LLVMCONFIG=llvm-config-11" >> $GITHUB_ENV
+      run: echo "LLVMCONFIG=llvm-config-12" >> $GITHUB_ENV
     - name: Compile jlm
       run: make jlm-release -j `nproc`
     - name: Run unit and C tests
@@ -46,9 +46,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies (LLVM)
-      run: sudo apt-get install llvm-11-dev clang-11
+      run: sudo apt-get install llvm-12dev clang-12
     - name: Set LLVMCONFIG
-      run: echo "LLVMCONFIG=llvm-config-11" >> $GITHUB_ENV
+      run: echo "LLVMCONFIG=llvm-config-12" >> $GITHUB_ENV
     - name: Compile jlm
       run: make CXX=g++ jlm-release -j `nproc`
     - name: Run unit and C tests
@@ -66,11 +66,11 @@ jobs:
     - name: Add jlc to PATH
       run: echo '${{ github.workspace }}/bin' >> $GITHUB_PATH
     - name: Install dependencies (LLVM)
-      run: sudo apt-get install llvm-11-dev clang-11
+      run: sudo apt-get install llvm-12-dev clang-12
     - name: Install valgrind
       run: sudo apt-get install valgrind
     - name: Set LLVMCONFIG
-      run: echo "LLVMCONFIG=llvm-config-11" >> $GITHUB_ENV
+      run: echo "LLVMCONFIG=llvm-config-12" >> $GITHUB_ENV
     - name: Valgrind Check 
       run: make -C ${{ github.workspace }} valgrind-check
 
@@ -86,9 +86,9 @@ jobs:
     - name: Add jlc to PATH
       run: echo '${{ github.workspace }}/bin' >> $GITHUB_PATH
     - name: Install dependencies (LLVM)
-      run: sudo apt-get install llvm-11-dev clang-11
+      run: sudo apt-get install llvm-12-dev clang-12
     - name: Set LLVMCONFIG
-      run: echo "LLVMCONFIG=llvm-config-11" >> $GITHUB_ENV
+      run: echo "LLVMCONFIG=llvm-config-12" >> $GITHUB_ENV
     - name: Clone polybench
       run: git clone https://github.com/phate/polybench-jlm.git
     - name: Check polybench
@@ -106,9 +106,9 @@ jobs:
     - name: Add jlc to PATH
       run: echo '${{ github.workspace }}/bin' >> $GITHUB_PATH
     - name: Install dependencies (LLVM)
-      run: sudo apt-get install llvm-11-dev clang-11
+      run: sudo apt-get install llvm-12-dev clang-12
     - name: Set LLVMCONFIG
-      run: echo "LLVMCONFIG=llvm-config-11" >> $GITHUB_ENV
+      run: echo "LLVMCONFIG=llvm-config-12" >> $GITHUB_ENV
     - name: Clone jlm-test-suite
       run: git clone https://github.com/phate/jlm-eval-suite.git
     - name: Update submodules

--- a/libjlm/include/jlm/ir/attribute.hpp
+++ b/libjlm/include/jlm/ir/attribute.hpp
@@ -39,6 +39,7 @@ public:
 	, inline_hint
 	, jump_table
 	, min_size
+	, MustProgress
 	, naked
 	, nest
 	, no_alias

--- a/libjlm/src/frontend/llvm/llvm2jlm/module.cpp
+++ b/libjlm/src/frontend/llvm/llvm2jlm/module.cpp
@@ -105,6 +105,7 @@ convert_attribute_kind(const llvm::Attribute::AttrKind & kind)
 	, {ak::InlineHint,                  attribute::kind::inline_hint}
 	, {ak::JumpTable,                   attribute::kind::jump_table}
 	, {ak::MinSize,                     attribute::kind::min_size}
+	, {ak::MustProgress,                attribute::kind::MustProgress}
 	, {ak::Naked,                       attribute::kind::naked}
 	, {ak::Nest,                        attribute::kind::nest}
 	, {ak::NoAlias,                     attribute::kind::no_alias}
@@ -165,6 +166,9 @@ convert_attribute(const llvm::Attribute & attribute, context & ctx)
 		JLM_ASSERT(attribute.isTypeAttribute());
 
 		if (attribute.getKindAsEnum() == llvm::Attribute::AttrKind::ByVal) {
+			auto type = convert_type(attribute.getValueAsType(), ctx);
+			return type_attribute::create_byval(std::move(type));
+		} else if (attribute.getKindAsEnum() == llvm::Attribute::StructRet) {
 			auto type = convert_type(attribute.getValueAsType(), ctx);
 			return type_attribute::create_byval(std::move(type));
 		}

--- a/tests/c-tests/test-constant-array.c
+++ b/tests/c-tests/test-constant-array.c
@@ -1,9 +1,10 @@
 #include <stdio.h>
 
+#define n 3
+
 int
 main()
 {
-	const unsigned int n = 3;
 	static const char * strings[n] = {"1", "2", "3"};
 
 	for (unsigned int i = 0; i < n; i++)


### PR DESCRIPTION
Still not completed.

jlm-opt generates incorrect use of optforfuzzing.

llc: error: /usr/lib/llvm-12/bin/llc: tmp-conditional-gnu-ext-cxx-jlm-opt-out.ll:15:28: error: invalid use of function-only attribute
define void @_Z3fooRi(i32* optforfuzzing align 4 dereferenceable(4) %0) #0 {
