### PR TITLE
make: Improved jlm-clean

### DIFF
--- a/Makefile.sub
+++ b/Makefile.sub
@@ -71,6 +71,7 @@ jlm-release: libjlm-release libjlc-release jlm-print-release jlm-opt-release jlc
 jlm-clean:
 	@rm -rf $(JLM_BUILD)
 	@rm -rf $(JLM_BIN)
-	@rm -rf $(JLM_ROOT)/utests.log
-	@rm -rf $(JLM_ROOT)/ctests.log
-	@rm -rf $(JLM_ROOT)/check.log
+	@rm -f $(JLM_ROOT)/utests.log
+	@rm -f $(JLM_ROOT)/ctests.log
+	@rm -f $(JLM_ROOT)/check.log
+	@rm -f $(LLVMPATHSFILE)


### PR DESCRIPTION
Removed -r from 'rm' command when only deleting files.
Now also deletes the llvmpaths.hpp that is autogenerated for libjlc.