### PR TITLE
jlm-hls: Tool for interacting with the libljm HLS backend

### DIFF
--- a/Makefile.sub
+++ b/Makefile.sub
@@ -58,14 +58,15 @@ include $(JLM_ROOT)/libjlm/Makefile.sub
 include $(JLM_ROOT)/libjlc/Makefile.sub
 include $(JLM_ROOT)/jlm-print/Makefile.sub
 include $(JLM_ROOT)/jlm-opt/Makefile.sub
+include $(JLM_ROOT)/jlm-hls/Makefile.sub
 include $(JLM_ROOT)/docs/Makefile.sub
 include $(JLM_ROOT)/tests/Makefile.sub
 
 .PHONY: jlm-debug
-jlm-debug: libjlm-debug libjlc-debug jlm-print-debug jlm-opt-debug jlc-debug
+jlm-debug: libjlm-debug libjlc-debug jlm-print-debug jlm-opt-debug jlm-hls-debug jlc-debug
 
 .PHONY: jlm-release
-jlm-release: libjlm-release libjlc-release jlm-print-release jlm-opt-release jlc-release
+jlm-release: libjlm-release libjlc-release jlm-print-release jlm-opt-release jlm-hls-release jlc-release
 
 .PHONY: jlm-clean
 jlm-clean:

--- a/jlm-hls/Makefile.sub
+++ b/jlm-hls/Makefile.sub
@@ -1,0 +1,26 @@
+# Copyright 2019 Nico Reißmann <nico.reissmann@gmail.com>
+# See COPYING for terms of redistribution.
+
+JLM_HLS_SRC = \
+	jlm-hls/src/cmdline.cpp \
+	jlm-hls/src/jlm-hls.cpp \
+
+.PHONY: jlm-hls-debug
+jlm-hls-debug: CXXFLAGS += -g -DJIVE_DEBUG -DJLM_DEBUG -DJLM_ENABLE_ASSERTS
+jlm-hls-debug: $(JLM_BUILD)/libjive.a $(JLM_BUILD)/libjlm.a $(JLM_BIN)/jlm-hls
+
+.PHONY: jlm-hls-release
+jlm-hls-release: CXXFLAGS += -O3
+jlm-hls-release: $(JLM_BUILD)/libjive.a $(JLM_BUILD)/libjlm.a $(JLM_BIN)/jlm-hls
+
+$(JLM_BIN)/jlm-hls: CPPFLAGS += -I$(JLM_ROOT)/libjlm/include -I$(JLM_ROOT)/jlm-hls/include -I$(JLM_ROOT)/libjive/include -I$(shell $(LLVMCONFIG) --includedir)
+$(JLM_BIN)/jlm-hls: CXXFLAGS += --std=c++17 -Wall -Wpedantic -Wextra -Wno-unused-parameter -Wfatal-errors
+$(JLM_BIN)/jlm-hls: LDFLAGS += $(shell $(LLVMCONFIG) --libs core irReader) $(shell $(LLVMCONFIG) --ldflags) $(shell $(LLVMCONFIG) --system-libs) -L$(JLM_BUILD)/ -ljlm -ljive
+$(JLM_BIN)/jlm-hls: $(patsubst %.cpp, $(JLM_BUILD)/%.o, $(JLM_HLS_SRC)) $(JLM_BUILD)/libjive.a $(JLM_BUILD)/libjlm.a
+	@mkdir -p $(JLM_BIN)
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -o $@ $^ $(LDFLAGS)
+
+.PHONY: jlm-hls-clean
+jlm-hls-clean:
+	@rm -rf $(JLM_BUILD)/jlm-hls
+	@rm -rf $(JLM_BIN)/jlm-hls

--- a/jlm-hls/include/jlm-hls/cmdline.hpp
+++ b/jlm-hls/include/jlm-hls/cmdline.hpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 Magnus Sjalander <work@sjalander.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#ifndef JLM_JLMHLS_CMDLINE_HPP
+#define JLM_JLMHLS_CMDLINE_HPP
+
+#include <jlm/util/file.hpp>
+
+namespace jlm {
+
+enum class OutputFormat {firrtl, dot};
+
+class cmdline_options {
+public:
+	cmdline_options()
+	: inputFile("")
+	, outputFolder("")
+	, format(OutputFormat::firrtl)
+	{}
+
+	jlm::filepath inputFile;
+	jlm::filepath outputFolder;
+	OutputFormat format;
+	std::string hlsFunction;
+	bool extractHlsFunction = false;
+	bool useCirct = false;
+};
+
+void
+parse_cmdline(int argc, char ** argv, cmdline_options & options);
+
+}
+
+#endif

--- a/jlm-hls/src/cmdline.cpp
+++ b/jlm-hls/src/cmdline.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 Magnus Sjalander <work@sjalander.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <jlm-hls/cmdline.hpp>
+
+#include <llvm/Support/CommandLine.h>
+
+namespace jlm {
+
+void
+parse_cmdline(int argc, char ** argv, jlm::cmdline_options & options)
+{
+	using namespace llvm;
+
+	/*
+		FIXME: The command line parser setup is currently redone
+		for every invocation of parse_cmdline. We should be able
+		to do it only once and then reset the parser on every
+		invocation of parse_cmdline.
+	*/
+
+	cl::TopLevelSubCommand->reset();
+
+	cl::opt<std::string> inputFile(
+	  cl::Positional
+	, cl::desc("<input>"));
+
+	cl::opt<std::string> outputFolder(
+	  "o"
+	, cl::desc("Write output to <folder>")
+	, cl::value_desc("folder"));
+
+	cl::opt<std::string> hlsFunction(
+	  "hls-function"
+	, cl::Prefix
+	, cl::desc("Function that should be accelerated")
+	, cl::value_desc("hls-function"));
+
+	cl::opt<bool> extractHlsFunction(
+	  "extract"
+	, cl::Prefix
+	, cl::desc("Extracts function specified by hls-function"));
+
+	cl::opt<bool> useCirct(
+	  "circt"
+	, cl::Prefix
+	, cl::desc("Use CIRCT to generate FIRRTL"));
+
+	cl::opt<OutputFormat> format(
+		cl::values(
+		  clEnumValN(OutputFormat::firrtl, "fir", "Output FIRRTL [default]")
+		, clEnumValN(OutputFormat::dot, "dot", "Output DOT graph"))
+	, cl::desc("Select output format"));
+
+	cl::ParseCommandLineOptions(argc, argv);
+
+	if (outputFolder.empty()) {
+		throw jlm::error("jlm-hls no output directory provided, i.e, -o.\n");
+	}
+
+	if (extractHlsFunction && hlsFunction.empty()) {
+		throw jlm::error("jlm-hls: --hls-function is not specifided.\n         which is required for --extract\n");
+	}
+
+	options.inputFile = inputFile;
+	options.hlsFunction = hlsFunction;
+	options.outputFolder = outputFolder;
+	options.extractHlsFunction = extractHlsFunction;
+	options.useCirct = useCirct;
+	options.format = format;
+}
+
+} // jlm

--- a/jlm-hls/src/jlm-hls.cpp
+++ b/jlm-hls/src/jlm-hls.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2022 Magnus Sjalander <work@sjalander.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <jive/view.hpp>
+
+#include <jlm/backend/llvm/jlm2llvm/jlm2llvm.hpp>
+#include <jlm/backend/llvm/rvsdg2jlm/rvsdg2jlm.hpp>
+#include <jlm/backend/hls/rvsdg2rhls/rvsdg2rhls.hpp>
+#include <jlm/backend/hls/rhls2firrtl/dot-hls.hpp>
+#include <jlm/backend/hls/rhls2firrtl/firrtl-hls.hpp>
+#include <jlm/backend/hls/rhls2firrtl/mlirgen.hpp>
+#include <jlm/backend/hls/rhls2firrtl/verilator-harness-hls.hpp>
+#include <jlm/frontend/llvm/InterProceduralGraphConversion.hpp>
+#include <jlm/frontend/llvm/LlvmModuleConversion.hpp>
+#include <jlm/ir/RvsdgModule.hpp>
+#include <jlm/util/Statistics.hpp>
+
+#include <jlm-hls/cmdline.hpp>
+
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IRReader/IRReader.h>
+#include <llvm/Support/raw_os_ostream.h>
+#include <llvm/Support/SourceMgr.h>
+
+
+static void
+stringToFile(
+	std::string output,
+	std::string fileName)
+{
+	std::ofstream outputFile;
+	outputFile.open(fileName);
+	outputFile << output;
+	outputFile.close();
+}
+
+static void
+llvmToFile(
+	jlm::RvsdgModule &module,
+	std::string fileName)
+{
+	llvm::LLVMContext ctx;
+	jlm::StatisticsDescriptor sd;
+	auto jm = jlm::rvsdg2jlm::rvsdg2jlm(module, sd);
+	auto lm = jlm::jlm2llvm::convert(*jm, ctx);
+	std::error_code EC;
+	llvm::raw_fd_ostream os(fileName, EC);
+	lm->print(os, nullptr);
+}
+
+int
+main(int argc, char ** argv)
+{
+	jlm::cmdline_options flags;
+	parse_cmdline(argc, argv, flags);
+
+	llvm::LLVMContext ctx;
+	llvm::SMDiagnostic err;
+	auto llvmModule = llvm::parseIRFile(flags.inputFile.to_str(), err, ctx);
+	llvmModule->setSourceFileName(flags.outputFolder.path() + "/jlm_hls");
+	if (!llvmModule) {
+		err.print(argv[0], llvm::errs());
+		exit(1);
+	}
+
+	/* LLVM to JLM pass */
+	auto jlmModule = jlm::ConvertLlvmModule(*llvmModule);
+	jlm::StatisticsDescriptor sd;
+	auto rvsdgModule = jlm::ConvertInterProceduralGraphModule(
+					*jlmModule,
+					sd);
+
+	if (flags.extractHlsFunction) {
+		auto hlsFunction = jlm::hls::split_hls_function(
+					*rvsdgModule,
+					flags.hlsFunction);
+
+		llvmToFile(
+			*rvsdgModule,
+			flags.outputFolder.path() + "/jlm_hls_rest.ll");
+		llvmToFile(
+			*hlsFunction,
+			flags.outputFolder.path() + "/jlm_hls_function.ll");
+		return 0;
+	}
+
+	if (flags.format == jlm::OutputFormat::firrtl) {
+		jlm::hls::rvsdg2rhls(*rvsdgModule);
+
+		std::string output;
+		if (flags.useCirct) {
+			jlm::hls::MLIRGen hls;
+			output = hls.run(*rvsdgModule);
+		} else {
+			jlm::hls::FirrtlHLS hls;
+			output = hls.run(*rvsdgModule);
+		}
+		stringToFile(
+			output,
+			flags.outputFolder.path() + "/jlm_hls.fir");
+
+		jlm::hls::VerilatorHarnessHLS vhls;
+		stringToFile(
+			vhls.run(*rvsdgModule),
+			flags.outputFolder.path() + "/jlm_hls_harness.cpp");
+	} else if (flags.format == jlm::OutputFormat::dot) {
+		jlm::hls::rvsdg2rhls(*rvsdgModule);
+
+		jlm::hls::DotHLS dhls;
+		stringToFile(
+			dhls.run(*rvsdgModule),
+			flags.outputFolder.path() + "/jlm_hls.dot");
+	} else {
+		JLM_UNREACHABLE("Format not supported.\n");
+	}
+	return 0;
+}

--- a/libjlm/include/jlm/backend/hls/rhls2firrtl/base-hls.hpp
+++ b/libjlm/include/jlm/backend/hls/rhls2firrtl/base-hls.hpp
@@ -18,19 +18,12 @@ namespace jlm {
 
 		class BaseHLS {
 		public:
-			void
+			std::string
 			run(jlm::RvsdgModule &rm) {
 				assert(node_map.empty());
 				// ensure consistent naming across runs
 				create_node_names(get_hls_lambda(rm)->subregion());
-				auto text = get_text(rm);
-				std::basic_string<char, std::char_traits<char>, std::allocator<char>> base_file_name = get_base_file_name(
-						rm);
-				std::string file_name = base_file_name + extension();
-				std::ofstream out_file;
-				out_file.open(file_name);
-				out_file << text;
-				out_file.close();
+				return get_text(rm);
 			}
 
 		private:

--- a/libjlm/include/jlm/backend/hls/rhls2firrtl/mlirgen.hpp
+++ b/libjlm/include/jlm/backend/hls/rhls2firrtl/mlirgen.hpp
@@ -46,6 +46,7 @@ namespace jlm {
 			circt::firrtl::CircuitOp MlirGen(const jlm::lambda::node *lamdaNode);
 			void WriteModuleToFile(const circt::firrtl::FModuleOp fModuleOp, const jive::node *node);
 			void WriteCircuitToFile(const circt::firrtl::CircuitOp circuit, std::string name);
+			std::string toString(const circt::firrtl::CircuitOp circuit);
 		private:
 			// Variables
 			mlir::OpBuilder builder;
@@ -197,7 +198,7 @@ namespace jlm {
 
 			std::string get_text(jlm::RvsdgModule &rm) override {return "";}
 		public:
-			void
+			std::string
 			run(jlm::RvsdgModule &rvsdgModule) {
 				// Load the FIRRTLDialect
 				mlir::MLIRContext context;
@@ -208,7 +209,7 @@ namespace jlm {
 				auto mlirGen = MLIRGenImpl(context);
 				auto circuit = mlirGen.MlirGen(lambdaNode);
 				// Write the FIRRTL to a file
-				mlirGen.WriteCircuitToFile(circuit, "jlm_hls");
+				return mlirGen.toString(circuit);
 			}
 			private:
 		};
@@ -227,9 +228,9 @@ namespace jlm {
                         }
                         std::string get_text(jlm::RvsdgModule &rm) override {return "";}
                 public:
-                        void
+			std::string
                         run(jlm::RvsdgModule &rvsdgModule) {
-                                std::cout << "This version of jlm-hls has not been compiled with support for the CIRCT backend\n";
+				throw jlm::error("This version of jlm-hls has not been compiled with support for the CIRCT backend\n");
                         }
                         private:
                 };


### PR DESCRIPTION
The tool has support extracting specified function for synthesis.
Inlining is performed such that the extracted function does not
contain any function calls. Thus, the LLVM IR used as input has
to contain all functions that's called by the extracted function.

The tool also has support for generating FIRRTL or a DOT graph of
the provided input function after the RVSDG has been created and
lowered to RHLS.