### PR TITLE
libjlm: Changed variable to high_resolution_clock

### DIFF
--- a/libjlm/include/jlm/util/time.hpp
+++ b/libjlm/include/jlm/util/time.hpp
@@ -34,8 +34,8 @@ public:
 	}
 
 private:
-	std::chrono::time_point<std::chrono::system_clock> start_;
-	std::chrono::time_point<std::chrono::system_clock> end_;
+	std::chrono::time_point<std::chrono::high_resolution_clock> start_;
+	std::chrono::time_point<std::chrono::high_resolution_clock> end_;
 };
 
 }


### PR DESCRIPTION
The result from the high_resolution_clock was stored as a
system_clock variable, which causes an error when compiling
on Mac.