### PR TITLE
libjlm/tooling: Added missing support for -J in jlc

### DIFF
--- a/libjlm/include/jlm/tooling/Command.hpp
+++ b/libjlm/include/jlm/tooling/Command.hpp
@@ -378,6 +378,8 @@ public:
     return CommandGraph::Node::Create(commandGraph, std::move(command));
   }
 
+  const std::vector<Optimization> &Optimizations() const noexcept { return Optimizations_; }
+
 private:
   static std::string
   ToString(const Optimization & optimization);

--- a/libjlm/src/tooling/CommandGraphGenerator.cpp
+++ b/libjlm/src/tooling/CommandGraphGenerator.cpp
@@ -114,12 +114,31 @@ JlcCommandGraphGenerator::GenerateCommandGraph(const JlcCommandLineOptions & com
 
     if (compilation.RequiresOptimization())
     {
+      std::vector<JlmOptCommand::Optimization> optimizations;
+      if (!commandLineOptions.JlmOptOptimizations_.empty()) {
+        static std::unordered_map<std::string, JlmOptCommand::Optimization>map(
+        {
+          {"AASteensgaardBasic", JlmOptCommand::Optimization::AASteensgaardBasic},
+          {"cne", JlmOptCommand::Optimization::CommonNodeElimination},
+          {"dne", JlmOptCommand::Optimization::DeadNodeElimination},
+          {"iln", JlmOptCommand::Optimization::FunctionInlining},
+          {"InvariantValueRedirection", JlmOptCommand::Optimization::InvariantValueRedirection},
+          {"psh", JlmOptCommand::Optimization::NodePushOut},
+          {"pll", JlmOptCommand::Optimization::NodePullIn},
+          {"red", JlmOptCommand::Optimization::NodeReduction},
+          {"ivt", JlmOptCommand::Optimization::ThetaGammaInversion},
+          {"url", JlmOptCommand::Optimization::LoopUnrolling},
+        });
+        for (const auto & jlmOpt : commandLineOptions.JlmOptOptimizations_)
+	{
+          JLM_ASSERT(map.find(jlmOpt) != map.end());
+          optimizations.push_back(map[jlmOpt]);
+	}
       /*
        * If a default optimization level has been specified (-O) and no specific jlm options
        * have been specified (-J) then use a default set of optimizations.
        */
-      std::vector<JlmOptCommand::Optimization> optimizations;
-      if (commandLineOptions.JlmOptOptimizations_.empty()
+      } else if (commandLineOptions.JlmOptOptimizations_.empty()
           && commandLineOptions.OptimizationLevel_ == JlcCommandLineOptions::OptimizationLevel::O3)
       {
         /*

--- a/tests/libjlm/tooling/TestJlcCommandLineParser.cpp
+++ b/tests/libjlm/tooling/TestJlcCommandLineParser.cpp
@@ -122,6 +122,26 @@ Test4()
   assert(compilation.OutputFile() == "foobar.o");
 }
 
+static void
+TestJlmOptOptimizations()
+{
+  /*
+   * Arrange
+   */
+  std::vector<std::string> commandLineArguments({"jlc", "foobar.c", "-Jcne", "-Jdne"});
+
+  /*
+   * Act
+   */
+  auto & commandLineOptions = ParseCommandLineArguments(commandLineArguments);
+
+  /*
+   * Assert
+   */
+  assert(commandLineOptions.JlmOptOptimizations_[0].compare("cne") == 0 && \
+         commandLineOptions.JlmOptOptimizations_[1].compare("dne") == 0);
+}
+
 static int
 Test()
 {
@@ -129,6 +149,7 @@ Test()
   Test2();
   Test3();
   Test4();
+  TestJlmOptOptimizations();
 
   return 0;
 }


### PR DESCRIPTION
jlc accepted the -J argument but didn't pass on the optimizations to jlm-opt