### PR TITLE
libjlm/ir: Copy argument attributes in lambda copy

### DIFF
--- a/libjlm/src/ir/operators/lambda.cpp
+++ b/libjlm/src/ir/operators/lambda.cpp
@@ -224,9 +224,11 @@ node::copy(jive::region * region, jive::substitution_map & smap) const
 		subregionmap.insert(cv.argument(), newcv);
 	}
 
-	/* collect function arguments */
-	for (size_t n = 0; n < nfctarguments(); n++)
-		subregionmap.insert(fctargument(n), lambda->fctargument(n));
+    /* collect function arguments */
+    for (size_t n = 0; n < nfctarguments(); n++){
+        lambda->fctargument(n)->set_attributes(fctargument(n)->attributes());
+        subregionmap.insert(fctargument(n), lambda->fctargument(n));
+    }
 
 	/* copy subregion */
 	subregion()->copy(lambda->subregion(), subregionmap, false, false);


### PR DESCRIPTION
Attributes of fctarguments are currently discarded when a lambda is copied.