### PR TITLE
Fix wrong traversal in memory state encoder

### DIFF
--- a/libjive/include/jive/rvsdg/traverser.hpp
+++ b/libjive/include/jive/rvsdg/traverser.hpp
@@ -91,6 +91,35 @@ private:
 	tracker tracker_;
 };
 
+/** \brief TopDown Traverser
+ *
+ * The topdown traverser visits a regions' nodes starting at the nodes with the lowest depth to the nodes with the
+ * highest depth, i.e. from the topmost nodes to the nodes at the bottom. The traverser guarantees that newly created
+ * nodes are never visited iff the created nodes replace already traversed nodes, including the current node under
+ * inspection, and iff the edges of the inputs of the newly created nodes originate from already traversed nodes.
+ * Otherwise, newly created nodes might also be traversed. The main usage of the topdown traverser is for
+ * replacing subgraphs in the already visited part of a region.
+ *
+ * The topdown traverser associates three distinct states with any node in the region throughout traversal:
+ *
+ * 1. <b>ahead</b>: Nodes that have not been visited yet and are not yet marked for visitation.
+ * 2. <b>frontier</b>: Nodes that are marked for visitation.
+ * 3. <b>behind</b>: Nodes that were already visited.
+ *
+ * All nodes are by default in state <em>ahead</em>. The topdown_traverser() constructor associates the
+ * <em>frontier</em> state with the top-most nodes in the region, <em>i.e.</em>, all nodes that have no inputs or
+ * only region arguments as origins. The next() method can then be used to traverse these <em>frontier</em> nodes.
+ * Before a <em>frontier</em> node is returned by next(), it is marked as <em>behind</em> and all nodes that depend on
+ * its outputs are transferred from the <em>ahead</em> state to state <em>frontier</em>. The repeated invocation of
+ * next() traverses all nodes in the region.
+ *
+ * A newly created node is marked as <em>behind</em> iff all the nodes' predecessors are marked as behind. Otherwise,
+ * it is marked as <em>frontier</em>.
+ *
+ * An alternative to traversing all nodes using next() is the utilization of begin() and end().
+ *
+ * @see node::depth()
+ */
 class topdown_traverser final {
 public:
 	~topdown_traverser() noexcept;

--- a/tests/libjlm/opt/alias-analyses/AliasAnalysesTests.hpp
+++ b/tests/libjlm/opt/alias-analyses/AliasAnalysesTests.hpp
@@ -884,6 +884,77 @@ private:
 	jlm::CallNode * CallF1_;
 };
 
+/** \brief DeltaTest3 class
+*
+*	This function sets up an RVSDG representing the following function:
+*
+* \code{.c}
+*   static int32_t g1 = 1L;
+*   static int32_t *g2 = &g1;
+*
+*   static int16_t
+*   f()
+*   {
+*     g2 = g2;
+*     return g1;
+*   }
+*
+*   int16_t
+*   test()
+*   {
+*     return f();
+*   }
+* \endcode
+*
+* It uses a single memory state to sequentialize the respective memory
+* operations.
+*/
+class DeltaTest3 final : public AliasAnalysisTest
+{
+public:
+  [[nodiscard]] const jlm::lambda::node &
+  LambdaF() const noexcept
+  {
+    return *LambdaF_;
+  }
+
+  [[nodiscard]] const jlm::lambda::node &
+  LambdaTest() const noexcept
+  {
+    return *LambdaTest_;
+  }
+
+  [[nodiscard]] const jlm::delta::node &
+  DeltaG1() const noexcept
+  {
+    return *DeltaG1_;
+  }
+
+  [[nodiscard]] const jlm::delta::node &
+  DeltaG2() const noexcept
+  {
+    return *DeltaG2_;
+  }
+
+  [[nodiscard]] const jlm::CallNode &
+  CallF() const noexcept
+  {
+    return *CallF_;
+  }
+
+private:
+  std::unique_ptr<jlm::RvsdgModule>
+  SetupRvsdg() override;
+
+  jlm::lambda::node * LambdaF_;
+  jlm::lambda::node * LambdaTest_;
+
+  jlm::delta::node * DeltaG1_;
+  jlm::delta::node * DeltaG2_;
+
+  jlm::CallNode * CallF_;
+};
+
 /** \brief ImportTest class
 *
 *	This function sets up an RVSDG representing the following function:

--- a/tests/libjlm/opt/alias-analyses/TestMemoryStateEncoder.cpp
+++ b/tests/libjlm/opt/alias-analyses/TestMemoryStateEncoder.cpp
@@ -902,6 +902,90 @@ ValidateDeltaTest2SteensgaardRegionAware(const DeltaTest2 & test)
 }
 
 static void
+ValidateDeltaTest3SteensgaardAgnostic(const DeltaTest3 & test)
+{
+  using namespace jlm;
+
+  /* validate f() */
+  {
+    assert(test.LambdaF().subregion()->nnodes() == 6);
+
+    auto lambdaExitMerge = jive::node_output::node(test.LambdaF().fctresult(2)->origin());
+    assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 5, 1));
+
+    auto truncNode = jive::node_output::node(test.LambdaF().fctresult(0)->origin());
+    assert(is<trunc_op>(*truncNode, 1, 1));
+
+    auto loadG1Node = jive::node_output::node(truncNode->input(0)->origin());
+    assert(is<LoadOperation>(*loadG1Node, 2, 2));
+
+    auto lambdaEntrySplit = jive::node_output::node(loadG1Node->input(1)->origin());
+    assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 5));
+
+    jive::node * storeG2Node = nullptr;
+    for (size_t n = 0; n < lambdaExitMerge->ninputs(); n++)
+    {
+      auto input = lambdaExitMerge->input(n);
+      auto node = jive::node_output::node(input->origin());
+      if (is<StoreOperation>(node))
+      {
+        storeG2Node = node;
+        break;
+      }
+    }
+    assert(storeG2Node != nullptr);
+
+    auto loadG2Node = jive::node_output::node(storeG2Node->input(2)->origin());
+    assert(is<LoadOperation>(*loadG2Node, 2, 2));
+
+    auto node = jive::node_output::node(loadG2Node->input(1)->origin());
+    assert(node == lambdaEntrySplit);
+  }
+}
+
+static void
+ValidateDeltaTest3SteensgaardRegionAware(const DeltaTest3 & test)
+{
+  using namespace jlm;
+
+  /* validate f() */
+  {
+    assert(test.LambdaF().subregion()->nnodes() == 6);
+
+    auto lambdaExitMerge = jive::node_output::node(test.LambdaF().fctresult(2)->origin());
+    assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
+
+    auto truncNode = jive::node_output::node(test.LambdaF().fctresult(0)->origin());
+    assert(is<trunc_op>(*truncNode, 1, 1));
+
+    auto loadG1Node = jive::node_output::node(truncNode->input(0)->origin());
+    assert(is<LoadOperation>(*loadG1Node, 2, 2));
+
+    auto lambdaEntrySplit = jive::node_output::node(loadG1Node->input(1)->origin());
+    assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 2));
+
+    jive::node * storeG2Node = nullptr;
+    for (size_t n = 0; n < lambdaExitMerge->ninputs(); n++)
+    {
+      auto input = lambdaExitMerge->input(n);
+      auto node = jive::node_output::node(input->origin());
+      if (is<StoreOperation>(node))
+      {
+        storeG2Node = node;
+        break;
+      }
+    }
+    assert(storeG2Node != nullptr);
+
+    auto loadG2Node = jive::node_output::node(storeG2Node->input(2)->origin());
+    assert(is<LoadOperation>(*loadG2Node, 2, 2));
+
+    auto node = jive::node_output::node(loadG2Node->input(1)->origin());
+    assert(node == lambdaEntrySplit);
+  }
+}
+
+static void
 ValidateImportTestSteensgaardAgnostic(const ImportTest & test)
 {
   using namespace jlm;
@@ -1188,6 +1272,9 @@ test()
 
   ValidateTest<DeltaTest2, Steensgaard, AgnosticMemoryNodeProvider>(ValidateDeltaTest2SteensgaardAgnostic);
   ValidateTest<DeltaTest2, Steensgaard, RegionAwareMemoryNodeProvider>(ValidateDeltaTest2SteensgaardRegionAware);
+
+  ValidateTest<DeltaTest3, Steensgaard, AgnosticMemoryNodeProvider>(ValidateDeltaTest3SteensgaardAgnostic);
+  ValidateTest<DeltaTest3, Steensgaard, RegionAwareMemoryNodeProvider>(ValidateDeltaTest3SteensgaardRegionAware);
 
   ValidateTest<ImportTest, Steensgaard, AgnosticMemoryNodeProvider>(ValidateImportTestSteensgaardAgnostic);
   ValidateTest<ImportTest, Steensgaard, RegionAwareMemoryNodeProvider>(ValidateImportTestSteensgaardRegionAware);


### PR DESCRIPTION
We had a bug in the memory state encoder where traverser visited newly created nodes. This should never happen in the memory state encoder. The PR contains the following:

1. Added documentation to topdown_traverser class
2. Added DeltaTest3 alias analysis test
3. Fixed bug in memory state encoder