### PR TITLE
Steensgaard bug

### DIFF
--- a/libjlm/src/opt/alias-analyses/Steensgaard.cpp
+++ b/libjlm/src/opt/alias-analyses/Steensgaard.cpp
@@ -1023,17 +1023,15 @@ Steensgaard::AnalyzeCall(const CallNode & callNode)
     /*
       FIXME: What about varargs
     */
-    for (size_t n = 1; n < callNode.NumArguments(); n++) {
+    for (size_t n = 1; n < callNode.NumArguments(); n++)
+    {
       auto & callArgument = *callNode.input(n)->origin();
 
-      if (!is<PointerType>(callArgument.type()))
-        continue;
-
-      auto & callArgumentLocation = LocationSet_.FindOrInsertRegisterLocation(
-        callArgument,
-        PointsToFlags::PointsToNone);
-      auto & registerLocation = Location::CastTo<RegisterLocation>(callArgumentLocation);
-      registerLocation.SetIsEscapingModule(true);
+      if (is<PointerType>(callArgument.type()))
+      {
+        auto registerLocation = LocationSet_.LookupRegisterLocation(callArgument);
+        registerLocation->SetIsEscapingModule(true);
+      }
     }
 
     for (size_t n = 0; n < callNode.NumResults(); n++) {

--- a/tests/TestRvsdgs.hpp
+++ b/tests/TestRvsdgs.hpp
@@ -754,6 +754,46 @@ private:
   jive::simple_node * AllocaPz_;
 };
 
+/** \brief ExternalCallTest
+ *
+ * This function sets up an RVSDG representing the following program:
+ *
+ * \code{.c}
+ *   int*
+ *   g(const char * path, const char * mode);
+ *
+ *   int*
+ *   f(const char * path, const char * mode)
+ *   {
+ *     return g(path, mode);
+ *   }
+ * \endcode
+ *
+ * It uses a single memory state to sequentialize the respective memory operations within each function.
+ */
+class ExternalCallTest final : public RvsdgTest
+{
+public:
+  [[nodiscard]] const jlm::lambda::node &
+  LambdaF() const noexcept
+  {
+    return *LambdaF_;
+  }
+
+  [[nodiscard]] const jlm::CallNode &
+  CallG() const noexcept
+  {
+    return *CallG_;
+  }
+private:
+  std::unique_ptr<jlm::RvsdgModule>
+  SetupRvsdg() override;
+
+  jlm::lambda::node * LambdaF_;
+
+  jlm::CallNode * CallG_;
+};
+
 /** \brief GammaTest class
 *
 * This function sets up an RVSDG representing the following function:


### PR DESCRIPTION
We got a segmentation fault when analyzing the pointer arguments of external calls with the Steensgaard alias analysis. This PR adds a unit test exposing the problem and fixes it.