### PR TITLE
Porting jlm to LLLVM 15 part 1

### DIFF
--- a/libjlm/include/jlm/ir/ipgraph.hpp
+++ b/libjlm/include/jlm/ir/ipgraph.hpp
@@ -210,6 +210,7 @@ private:
 		const attributeset & attributes)
 	: ipgraph_node(clg)
 	, type_(type)
+  , FunctionType_(type)
 	, name_(name)
 	, linkage_(linkage)
 	, attributes_(attributes)
@@ -228,7 +229,7 @@ public:
 	const FunctionType &
 	fcttype() const noexcept
 	{
-		return *static_cast<const FunctionType*>(&type_.GetElementType());
+		return FunctionType_;
 	}
 
 	virtual const jlm::linkage &
@@ -279,6 +280,7 @@ public:
 
 private:
 	PointerType type_;
+  FunctionType FunctionType_;
 	std::string name_;
 	jlm::linkage linkage_;
 	attributeset attributes_;

--- a/libjlm/include/jlm/ir/operators/operators.hpp
+++ b/libjlm/include/jlm/ir/operators/operators.hpp
@@ -727,12 +727,6 @@ public:
 		return cmp_;
 	}
 
-	const jive::type &
-	pointee_type() const noexcept
-	{
-		return static_cast<const PointerType *>(&argument(0).type())->GetElementType();
-	}
-
 	static std::unique_ptr<jlm::tac>
 	create(
 		const jlm::cmp & cmp,

--- a/libjlm/include/jlm/ir/operators/operators.hpp
+++ b/libjlm/include/jlm/ir/operators/operators.hpp
@@ -605,12 +605,6 @@ public:
 		return static_cast<const jive::bittype*>(&result(0).type())->nbits();
 	}
 
-	inline const jive::valuetype &
-	pointee_type() const noexcept
-	{
-		return static_cast<const PointerType *>(&argument(0).type())->GetElementType();
-	}
-
 	static std::unique_ptr<jlm::tac>
 	create(
 		const variable * argument,

--- a/libjlm/include/jlm/ir/operators/operators.hpp
+++ b/libjlm/include/jlm/ir/operators/operators.hpp
@@ -525,12 +525,6 @@ public:
 		return static_cast<const jive::bittype*>(&argument(0).type())->nbits();
 	}
 
-	inline const jive::valuetype &
-	pointee_type() const
-	{
-		return static_cast<const PointerType *>(&result(0).type())->GetElementType();
-	}
-
 	static std::unique_ptr<jlm::tac>
 	create(
 		const variable * argument,

--- a/libjlm/src/frontend/llvm/LlvmInstructionConversion.cpp
+++ b/libjlm/src/frontend/llvm/LlvmInstructionConversion.cpp
@@ -546,8 +546,9 @@ convert_load_instruction(llvm::Instruction * i, tacsvector_t & tacs, context & c
 	/* FIXME: volatile */
 	auto alignment = instruction->getAlignment();
 	auto address = ConvertValue(instruction->getPointerOperand(), tacs, ctx);
+  auto loadedType = ConvertType(instruction->getType(), ctx);
 
-	tacs.push_back(LoadOperation::Create(address, ctx.memory_state(), alignment));
+	tacs.push_back(LoadOperation::Create(address, ctx.memory_state(), *loadedType, alignment));
 	auto value = tacs.back()->result(0);
 	auto state = tacs.back()->result(1);
 

--- a/libjlm/src/ir/operators/load.cpp
+++ b/libjlm/src/ir/operators/load.cpp
@@ -253,7 +253,11 @@ perform_load_mux_reduction(
 {
 	auto memStateMergeNode = jive::node_output::node(operands[1]);
 
-	auto ld = LoadNode::Create(operands[0], jive::operands(memStateMergeNode), op.GetAlignment());
+	auto ld = LoadNode::Create(
+    operands[0],
+    jive::operands(memStateMergeNode),
+    op.GetLoadedType(),
+    op.GetAlignment());
 
 	std::vector<jive::output*> states = {std::next(ld.begin()), ld.end()};
 	auto mx = MemStateMergeOperator::Create(states);
@@ -278,7 +282,11 @@ perform_load_alloca_reduction(
 			otherstates.push_back(operands[n]);
 	}
 
-	auto ld = LoadNode::Create(operands[0], loadstates, op.GetAlignment());
+	auto ld = LoadNode::Create(
+    operands[0],
+    loadstates,
+    op.GetLoadedType(),
+    op.GetAlignment());
 
 	std::vector<jive::output*> results(1, ld[0]);
 	results.insert(results.end(), std::next(ld.begin()), ld.end());
@@ -303,7 +311,11 @@ perform_load_store_state_reduction(
 		else new_loadstates.push_back(state);
 	}
 
-	auto ld = LoadNode::Create(operands[0], new_loadstates, op.GetAlignment());
+	auto ld = LoadNode::Create(
+    operands[0],
+    new_loadstates,
+    op.GetLoadedType(),
+    op.GetAlignment());
 
 	results[0] = ld[0];
 	for (size_t n = 1, s = 1; n < results.size(); n++) {
@@ -332,7 +344,11 @@ perform_multiple_origin_reduction(
 		seen_state.insert(state);
 	}
 
-	auto ld = LoadNode::Create(operands[0], new_loadstates, op.GetAlignment());
+	auto ld = LoadNode::Create(
+    operands[0],
+    new_loadstates,
+    op.GetLoadedType(),
+    op.GetAlignment());
 
 	results[0] = ld[0];
 	for (size_t n = 1, s = 1; n < results.size(); n++) {
@@ -406,7 +422,11 @@ perform_load_load_state_reduction(
 	for (size_t n = 1; n < operands.size(); n++)
 		ldstates.push_back(reduce_state(n-1, operands[n], mxstates));
 
-	auto ld = LoadNode::Create(operands[0], ldstates, op.GetAlignment());
+	auto ld = LoadNode::Create(
+    operands[0],
+    ldstates,
+    op.GetLoadedType(),
+    op.GetAlignment());
 	for (size_t n = 0; n < mxstates.size(); n++) {
 		auto & states = mxstates[n];
 		if (!states.empty()) {

--- a/libjlm/src/opt/alias-analyses/MemoryStateEncoder.cpp
+++ b/libjlm/src/opt/alias-analyses/MemoryStateEncoder.cpp
@@ -598,7 +598,11 @@ MemoryStateEncoder::EncodeLoad(const LoadNode & loadNode)
   auto oldResult = loadNode.GetValueOutput();
   auto inStates = StateMap::MemoryNodeStatePair::States(memoryNodeStatePairs);
 
-  auto outputs = LoadNode::Create(address, inStates, loadOperation.GetAlignment());
+  auto outputs = LoadNode::Create(
+    address,
+    inStates,
+    loadOperation.GetLoadedType(),
+    loadOperation.GetAlignment());
   oldResult->divert_users(outputs[0]);
 
   StateMap::MemoryNodeStatePair::ReplaceStates(

--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -132,8 +132,8 @@ LoadTest1::SetupRvsdg()
 
   auto fct = lambda::node::create(graph->root(), fcttype, "f", linkage::external_linkage);
 
-  auto ld1 = LoadNode::Create(fct->fctargument(0), {fct->fctargument(1)}, 4);
-  auto ld2 = LoadNode::Create(ld1[0], {ld1[1]}, 4);
+  auto ld1 = LoadNode::Create(fct->fctargument(0), {fct->fctargument(1)}, *pt, 4);
+  auto ld2 = LoadNode::Create(ld1[0], {ld1[1]}, jive::bit32, 4);
 
   fct->finalize(ld2);
 
@@ -185,8 +185,8 @@ LoadTest2::SetupRvsdg()
   auto y_amp_b = StoreNode::Create(y[0], b[0], x_amp_a, 4);
   auto p_amp_x = StoreNode::Create(p[0], x[0], y_amp_b, 4);
 
-  auto ld1 = LoadNode::Create(p[0], p_amp_x, 4);
-  auto ld2 = LoadNode::Create(ld1[0], {ld1[1]}, 4);
+  auto ld1 = LoadNode::Create(p[0], p_amp_x, *ppt, 4);
+  auto ld2 = LoadNode::Create(ld1[0], {ld1[1]}, *pt, 4);
   auto y_star_p = StoreNode::Create(y[0], ld2[0], {ld2[1]}, 4);
 
   fct->finalize({y_star_p[0]});
@@ -235,7 +235,7 @@ LoadFromUndefTest::SetupRvsdg()
     linkage::external_linkage);
 
   auto undefValue = UndefValueOperation::Create(*Lambda_->subregion(), pointerType);
-  auto loadResults = LoadNode::Create(undefValue, {Lambda_->fctargument(0)}, 4);
+  auto loadResults = LoadNode::Create(undefValue, {Lambda_->fctargument(0)}, jive::bit32, 4);
 
   Lambda_->finalize(loadResults);
   rvsdg.add_export(Lambda_->output(), {PointerType(functionType), "f"});
@@ -273,10 +273,10 @@ GetElementPtrTest::SetupRvsdg()
   auto one = jive::create_bitconstant(fct->subregion(), 32, 1);
 
   auto gepx = getelementptr_op::create(fct->fctargument(0), {zero, zero}, *pbt);
-  auto ldx = LoadNode::Create(gepx, {fct->fctargument(1)}, 4);
+  auto ldx = LoadNode::Create(gepx, {fct->fctargument(1)}, jive::bit32, 4);
 
   auto gepy = getelementptr_op::create(fct->fctargument(0), {zero, one}, *pbt);
-  auto ldy = LoadNode::Create(gepy, {ldx[1]}, 4);
+  auto ldy = LoadNode::Create(gepy, {ldx[1]}, jive::bit32, 4);
 
   auto sum = jive::bitadd_op::create(32, ldx[0], ldy[0]);
 
@@ -483,8 +483,8 @@ CallTest1::SetupRvsdg()
     auto memoryStateArgument = lambda->fctargument(3);
     auto loopStateArgument = lambda->fctargument(4);
 
-    auto ld1 = LoadNode::Create(pointerArgument1, {memoryStateArgument}, 4);
-    auto ld2 = LoadNode::Create(pointerArgument2, {ld1[1]}, 4);
+    auto ld1 = LoadNode::Create(pointerArgument1, {memoryStateArgument}, jive::bit32, 4);
+    auto ld2 = LoadNode::Create(pointerArgument2, {ld1[1]}, jive::bit32, 4);
 
     auto sum = jive::bitadd_op::create(32, ld1[0], ld2[0]);
 
@@ -514,8 +514,8 @@ CallTest1::SetupRvsdg()
     auto memoryStateArgument = lambda->fctargument(3);
     auto loopStateArgument = lambda->fctargument(4);
 
-    auto ld1 = LoadNode::Create(pointerArgument1, {memoryStateArgument}, 4);
-    auto ld2 = LoadNode::Create(pointerArgument2, {ld1[1]}, 4);
+    auto ld1 = LoadNode::Create(pointerArgument1, {memoryStateArgument}, jive::bit32, 4);
+    auto ld2 = LoadNode::Create(pointerArgument2, {ld1[1]}, jive::bit32, 4);
 
     auto diff = jive::bitsub_op::create(32, ld1[0], ld2[0]);
 
@@ -1051,8 +1051,8 @@ IndirectCallTest2::SetupRvsdg()
       functionYCv,
       {pyAlloca[0], iOStateArgument, callX[2], loopStateArgument});
 
-    auto loadG1 = LoadNode::Create(globalG1Cv, {callY[2]}, 4);
-    auto loadG2 = LoadNode::Create(globalG2Cv, {loadG1[1]}, 4);
+    auto loadG1 = LoadNode::Create(globalG1Cv, {callY[2]}, jive::bit32, 4);
+    auto loadG2 = LoadNode::Create(globalG2Cv, {loadG1[1]}, jive::bit32, 4);
 
     auto sum = jive::bitadd_op::create(32, callX[0], callY[0]);
     sum = jive::bitadd_op::create(32, sum, loadG1[0]);
@@ -1205,8 +1205,8 @@ ExternalCallTest::SetupRvsdg()
     auto storePath = StoreNode::Create(allocaPath[0], pathArgument, {mergeMode}, 4);
     auto storeMode = StoreNode::Create(allocaMode[0], modeArgument, {storePath[0]}, 4);
 
-    auto loadPath = LoadNode::Create(allocaPath[0], storeMode, 4);
-    auto loadMode = LoadNode::Create(allocaMode[0], {loadPath[1]}, 4);
+    auto loadPath = LoadNode::Create(allocaPath[0], storeMode, p8, 4);
+    auto loadMode = LoadNode::Create(allocaMode[0], {loadPath[1]}, p8, 4);
 
     auto callGResults = CallNode::Create(
       functionGCv,
@@ -1261,8 +1261,8 @@ GammaTest::SetupRvsdg()
   auto tmp1 = gammanode->add_exitvar({p1ev->argument(0), p3ev->argument(1)});
   auto tmp2 = gammanode->add_exitvar({p2ev->argument(0), p4ev->argument(1)});
 
-  auto ld1 = LoadNode::Create(tmp1, {fct->fctargument(5)}, 4);
-  auto ld2 = LoadNode::Create(tmp2, {ld1[1]}, 4);
+  auto ld1 = LoadNode::Create(tmp1, {fct->fctargument(5)}, jive::bit32, 4);
+  auto ld2 = LoadNode::Create(tmp2, {ld1[1]}, jive::bit32, 4);
   auto sum = jive::bitadd_op::create(32, ld1[0], ld2[0]);
 
   fct->finalize({sum, ld2[1]});
@@ -1377,7 +1377,7 @@ DeltaTest1::SetupRvsdg()
     auto memoryStateArgument = lambda->fctargument(2);
     auto loopStateArgument = lambda->fctargument(3);
 
-    auto ld = LoadNode::Create(pointerArgument, {memoryStateArgument}, 4);
+    auto ld = LoadNode::Create(pointerArgument, {memoryStateArgument}, jive::bit32, 4);
 
     return lambda->finalize({ld[0], iOStateArgument, ld[1], loopStateArgument});
   };
@@ -1624,10 +1624,10 @@ DeltaTest3::SetupRvsdg()
     auto g1CtxVar = lambda->add_ctxvar(&g1);
     auto g2CtxVar = lambda->add_ctxvar(&g2);
 
-    auto loadResults = LoadNode::Create(g2CtxVar, {memoryStateArgument}, 8);
+    auto loadResults = LoadNode::Create(g2CtxVar, {memoryStateArgument}, PointerType(jive::bit32), 8);
     auto storeResults = StoreNode::Create(g2CtxVar, loadResults[0], {loadResults[1]}, 8);
 
-    loadResults = LoadNode::Create(g1CtxVar, storeResults, 8);
+    loadResults = LoadNode::Create(g1CtxVar, storeResults, jive::bit32, 8);
     auto truncResult = trunc_op::create(16, loadResults[0]);
 
     return lambda->finalize({truncResult, iOStateArgument, loadResults[1], loopStateArgument});
@@ -1842,10 +1842,10 @@ PhiTest1::SetupRvsdg()
       {nm2, resultev->argument(0), callfibm1Results[0], callfibm1Results[1], callfibm1Results[2]});
 
     auto gepnm1 = getelementptr_op::create(resultev->argument(0), {nm1}, pbit64);
-    auto ldnm1 = LoadNode::Create(gepnm1, {callfibm2Results[1]}, 8);
+    auto ldnm1 = LoadNode::Create(gepnm1, {callfibm2Results[1]}, jive::bit64, 8);
 
     auto gepnm2 = getelementptr_op::create(resultev->argument(0), {nm2}, pbit64);
-    auto ldnm2 = LoadNode::Create(gepnm2, {ldnm1[1]}, 8);
+    auto ldnm2 = LoadNode::Create(gepnm2, {ldnm1[1]}, jive::bit64, 8);
 
     auto sum = jive::bitadd_op::create(64, ldnm1[0], ldnm2[0]);
 
@@ -2145,7 +2145,7 @@ PhiTest2::SetupRvsdg()
       functionACv,
       {pcAlloca[0], iOStateArgument, pcMerge, loopStateArgument});
 
-    auto loadX = LoadNode::Create(xArgument, {callA[2]}, 4);
+    auto loadX = LoadNode::Create(xArgument, {callA[2]}, jive::bit32, 4);
 
     auto sum = jive::bitadd_op::create(32, callA[0], loadX[0]);
 
@@ -2481,8 +2481,8 @@ EscapedMemoryTest1::SetupRvsdg()
 
     auto contextVariableB = lambda->add_ctxvar(&deltaB);
 
-    auto loadResults1 = LoadNode::Create(pointerArgument, {memoryStateArgument}, 4);
-    auto loadResults2 = LoadNode::Create(loadResults1[0], {loadResults1[1]}, 4);
+    auto loadResults1 = LoadNode::Create(pointerArgument, {memoryStateArgument}, p32, 4);
+    auto loadResults2 = LoadNode::Create(loadResults1[0], {loadResults1[1]}, jive::bit32, 4);
 
     auto five = jive::create_bitconstant(lambda->subregion(), 32, 5);
     auto storeResults = StoreNode::Create(contextVariableB, five, {loadResults2[1]}, 4);
@@ -2656,7 +2656,7 @@ EscapedMemoryTest2::SetupRvsdg()
       externalFunction2,
       {iOStateArgument, memoryStateArgument, loopStateArgument});
 
-    auto loadResults = LoadNode::Create(callResults[0], {callResults[2]}, 4);
+    auto loadResults = LoadNode::Create(callResults[0], {callResults[2]}, jive::bit32, 4);
 
     auto lambdaOutput = lambda->finalize({loadResults[0], callResults[1], loadResults[1], callResults[3]});
 
@@ -2765,7 +2765,7 @@ EscapedMemoryTest3::SetupRvsdg()
       externalFunction,
       {iOStateArgument, memoryStateArgument, loopStateArgument});
 
-    auto loadResults = LoadNode::Create(callResults[0], {callResults[2]}, 4);
+    auto loadResults = LoadNode::Create(callResults[0], {callResults[2]}, jive::bit32, 4);
 
     auto lambdaOutput = lambda->finalize({loadResults[0], callResults[1], loadResults[1], callResults[3]});
 
@@ -2883,7 +2883,7 @@ MemcpyTest::SetupRvsdg()
 
     auto storeResults = StoreNode::Create(gep, six, {memoryStateArgument}, 8);
 
-    auto loadResults = LoadNode::Create(gep, {storeResults[0]}, 8);
+    auto loadResults = LoadNode::Create(gep, {storeResults[0]}, jive::bit32, 8);
 
     auto lambdaOutput = lambda->finalize({loadResults[0], iOStateArgument, loadResults[1], loopStateArgument});
 
@@ -3022,19 +3022,19 @@ LinkedListTest::SetupRvsdg()
     auto alloca = alloca_op::create(*pointerType, size, 4);
     auto mergedMemoryState = MemStateMergeOperator::Create({alloca[1], memoryStateArgument});
 
-    auto load1 = LoadNode::Create(myListArgument, {mergedMemoryState}, 4);
+    auto load1 = LoadNode::Create(myListArgument, {mergedMemoryState}, *pointerType, 4);
     auto store1 = StoreNode::Create(alloca[0], load1[0], {load1[1]}, 4);
 
-    auto load2 = LoadNode::Create(alloca[0], {store1[0]}, 4);
+    auto load2 = LoadNode::Create(alloca[0], {store1[0]}, *pointerType, 4);
     auto gep = getelementptr_op::create(
       load2[0],
       {zero, zero},
       PointerType(*static_cast<jive::valuetype*>(pointerType.get())));
 
-    auto load3 = LoadNode::Create(gep, {load2[1]}, 4);
+    auto load3 = LoadNode::Create(gep, {load2[1]}, *pointerType, 4);
     auto store2 = StoreNode::Create(alloca[0], load3[0], {load3[1]}, 4);
 
-    auto load4 = LoadNode::Create(alloca[0], {store2[0]}, 4);
+    auto load4 = LoadNode::Create(alloca[0], {store2[0]}, *pointerType, 4);
 
     auto lambdaOutput = lambda->finalize({load4[0], iOStateArgument, load4[1], loopStateArgument});
     rvsdg.add_export(lambdaOutput, {PointerType(lambda->type()), "next"});

--- a/tests/libjlm/ir/operators/TestCall.cpp
+++ b/tests/libjlm/ir/operators/TestCall.cpp
@@ -51,7 +51,7 @@ TestCallTypeClassifierIndirectCall()
 
     auto store = StoreNode::Create(alloca[0], lambda->fctargument(0), {alloca[1]}, 8);
 
-    auto load = LoadNode::Create(alloca[0], store, 8);
+    auto load = LoadNode::Create(alloca[0], store, PointerType(fcttype1), 8);
 
     auto callResults = CallNode::Create(
       load[0],
@@ -400,10 +400,10 @@ TestCallTypeClassifierRecursiveDirectCall()
       {nm2, resultev->argument(0), callfibm1Results[0], callfibm1Results[1], callfibm1Results[2]});
 
     auto gepnm1 = getelementptr_op::create(resultev->argument(0), {nm1}, pbit64);
-    auto ldnm1 = LoadNode::Create(gepnm1, {callfibm2Results[1]}, 8);
+    auto ldnm1 = LoadNode::Create(gepnm1, {callfibm2Results[1]}, jive::bit64, 8);
 
     auto gepnm2 = getelementptr_op::create(resultev->argument(0), {nm2}, pbit64);
-    auto ldnm2 = LoadNode::Create(gepnm2, {ldnm1[1]}, 8);
+    auto ldnm2 = LoadNode::Create(gepnm2, {ldnm1[1]}, jive::bit64, 8);
 
     auto sum = jive::bitadd_op::create(64, ldnm1[0], ldnm2[0]);
 

--- a/tests/libjlm/opt/TestLoadMuxReduction.cpp
+++ b/tests/libjlm/opt/TestLoadMuxReduction.cpp
@@ -31,7 +31,7 @@ test_load_mux_reduction()
   auto s3 = graph.add_import({mt, "s3"});
 
   auto mux = MemStateMergeOperator::Create({s1, s2, s3});
-  auto ld = LoadNode::Create(a, {mux}, 4);
+  auto ld = LoadNode::Create(a, {mux}, vt, 4);
 
   auto ex1 = graph.add_export(ld[0], {ld[0]->type(), "v"});
   auto ex2 = graph.add_export(ld[1], {ld[1]->type(), "s"});
@@ -83,7 +83,7 @@ test_load_mux_reduction2()
   auto s2 = graph.add_import({mt, "s2"});
 
   auto merge = MemStateMergeOperator::Create(std::vector<jive::output*>{s1, s2});
-  auto ld = LoadNode::Create(a, {merge, merge}, 4);
+  auto ld = LoadNode::Create(a, {merge, merge}, vt, 4);
 
   auto ex1 = graph.add_export(ld[0], {ld[0]->type(), "v"});
   auto ex2 = graph.add_export(ld[1], {ld[1]->type(), "s1"});

--- a/tests/libjlm/test-load.cpp
+++ b/tests/libjlm/test-load.cpp
@@ -32,7 +32,7 @@ test_load_alloca_reduction()
 	auto alloca1 = alloca_op::create(bt, size, 4);
 	auto alloca2 = alloca_op::create(bt, size, 4);
 	auto mux = jive::create_state_mux(mt, {alloca1[1]}, 1);
-	auto value = LoadNode::Create(alloca1[0], {alloca1[1], alloca2[1], mux[0]}, 4)[0];
+	auto value = LoadNode::Create(alloca1[0], {alloca1[1], alloca2[1], mux[0]}, bt, 4)[0];
 
 	auto ex = graph.add_export(value, {value->type(), "l"});
 
@@ -69,7 +69,7 @@ test_multiple_origin_reduction()
 	auto a = graph.add_import({pt, "a"});
 	auto s = graph.add_import({mt, "s"});
 
-	auto load = LoadNode::Create(a, {s, s, s, s}, 4)[0];
+	auto load = LoadNode::Create(a, {s, s, s, s}, vt, 4)[0];
 
 	auto ex = graph.add_export(load, {load->type(), "l"});
 
@@ -105,8 +105,8 @@ test_load_store_state_reduction()
 	auto store1 = StoreNode::Create(alloca1[0], size, {alloca1[1]}, 4);
 	auto store2 = StoreNode::Create(alloca2[0], size, {alloca2[1]}, 4);
 
-	auto value1 = LoadNode::Create(alloca1[0], {store1[0], store2[0]}, 4)[0];
-	auto value2 = LoadNode::Create(alloca1[0], {store1[0]}, 8)[0];
+	auto value1 = LoadNode::Create(alloca1[0], {store1[0], store2[0]}, bt, 4)[0];
+	auto value2 = LoadNode::Create(alloca1[0], {store1[0]}, bt, 8)[0];
 
 	auto ex1 = graph.add_export(value1, {value1->type(), "l1"});
 	auto ex2 = graph.add_export(value2, {value2->type(), "l2"});
@@ -146,7 +146,7 @@ test_load_store_alloca_reduction()
 
 	auto alloca = alloca_op::create(bt, size, 4);
 	auto store = StoreNode::Create(alloca[0], size, {alloca[1]}, 4);
-	auto load = LoadNode::Create(alloca[0], store, 4);
+	auto load = LoadNode::Create(alloca[0], store, bt, 4);
 
 	auto value = graph.add_export(load[0], {load[0]->type(), "l"});
 	auto rstate = graph.add_export(load[1], {mt, "s"});
@@ -182,7 +182,7 @@ test_load_store_reduction()
   auto s = graph.add_import({mt, "state"});
 
   auto s1 = StoreNode::Create(a, v, {s}, 4)[0];
-  auto load = LoadNode::Create(a, {s1}, 4);
+  auto load = LoadNode::Create(a, {s1}, vt, 4);
 
   auto x1 = graph.add_export(load[0], {load[0]->type(), "value"});
   auto x2 = graph.add_export(load[1], {load[1]->type(), "state"});
@@ -222,10 +222,10 @@ test_load_load_reduction()
 	auto s2 = graph.add_import({mt, "s2"});
 
 	auto st1 = StoreNode::Create(a1, v1, {s1}, 4);
-	auto ld1 = LoadNode::Create(a2, {s1}, 4);
-	auto ld2 = LoadNode::Create(a3, {s2}, 4);
+	auto ld1 = LoadNode::Create(a2, {s1}, vt, 4);
+	auto ld2 = LoadNode::Create(a3, {s2}, vt, 4);
 
-	auto ld3 = LoadNode::Create(a4, {st1[0], ld1[1], ld2[1]}, 4);
+	auto ld3 = LoadNode::Create(a4, {st1[0], ld1[1], ld2[1]}, vt, 4);
 
 	auto x1 = graph.add_export(ld3[1], {mt, "s"});
 	auto x2 = graph.add_export(ld3[2], {mt, "s"});


### PR DESCRIPTION
The biggest change when porting to LLVM 15 is the transition to [opaque pointers](https://releases.llvm.org/14.0.0/docs/OpaquePointers.html). This means that we have to get rid off the element type in the PointerType class. A prerequisite for this is to eliminate all usages of the GetElementType() method, which in turn means that we have to add types explicitly to certain operations.

This PR removes some usages of the GetElementType() method of the PointerType class. These were the low hanging fruits. The other usages will be removed in a later PR.