### PR TITLE
[backend][hls] Removed use of GetElementType()

### DIFF
--- a/libjlm/src/backend/hls/rhls2firrtl/verilator-harness-hls.cpp
+++ b/libjlm/src/backend/hls/rhls2firrtl/verilator-harness-hls.cpp
@@ -300,8 +300,8 @@ std::string
 jlm::hls::VerilatorHarnessHLS::convert_to_c_type(const jive::type *type) {
 	if (auto t = dynamic_cast<const jive::bittype *>(type)) {
 		return "int" + jive::detail::strfmt(t->nbits()) + "_t";
-	} else if (auto t = dynamic_cast<const jlm::PointerType *>(type)) {
-		return convert_to_c_type(&t->GetElementType()) + "*";
+	} else if (is<PointerType>(*type)) {
+		return "void*";
 	} else if (auto t = dynamic_cast<const jlm::arraytype *>(type)) {
 		return convert_to_c_type(&t->element_type());
 	} else {


### PR DESCRIPTION
LLVM-15 use opaque pointers, so to avoid using GetElementType() we simply use void*, as the function is external and correctly links anyway.