### PR TITLE
Avoid test runs for pushing to master

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,6 @@
 name: Tests
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
We currently run the tests twice: once a PR is created and once after the PR is merged to master. This is wasteful and we can avoid the second test run.