### PR TITLE
hls/backend: Removed jive namespace from strfmt

### DIFF
--- a/jlm/hls/backend/rhls2firrtl/mlirgen.cpp
+++ b/jlm/hls/backend/rhls2firrtl/mlirgen.cpp
@@ -2316,7 +2316,7 @@ jlm::hls::MLIRGenImpl::GetModuleName(const jive::node *node) {
             append.append(std::to_string(bytes));
         }
     }
-	auto name = jive::detail::strfmt("op_", node->operation().debug_string() + append);
+	auto name = strfmt("op_", node->operation().debug_string() + append);
 	// Remove characters that are not valid in firrtl module names
 	std::replace_if(name.begin(), name.end(), isForbiddenChar, '_');
 	return name;


### PR DESCRIPTION
Missed update in previous commit.