### PR TITLE
CI: Optimized runtime of CIRCT build

### DIFF
--- a/.github/workflows/hls.yml
+++ b/.github/workflows/hls.yml
@@ -22,21 +22,6 @@ jobs:
         fetch-depth: '0'
 
     # --------
-    # Install dependencies
-    # --------
-
-    - name: Get LLVM apt key
-      run: wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-    - name: Update apt sources
-      run: sudo add-apt-repository deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main
-    - name: Install dependencies (LLVM-16, MLIR-16, Clang-16, and ninja)
-      run: sudo apt-get install llvm-16-dev libmlir-16-dev mlir-16-tools clang-16 ninja-build
-    - name: Place MLIRlib in system folder
-      run: sudo ln -s /usr/lib/llvm-16/lib/libMLIR.so.16 /usr/lib/x86_64-linux-gnu/ && sudo ln -s /usr/lib/llvm-16/lib/libMLIR.so.16 /usr/lib/x86_64-linux-gnu/libMLIR.so
-    - name: Instal llvm-lit
-      run: sudo python3 /usr/lib/llvm-16/build/utils/lit/setup.py install
-
-    # --------
     # Restore CIRCT from cache and build if it's not in there
     # --------
 
@@ -45,10 +30,6 @@ jobs:
       run: git clone https://github.com/EECS-NTNU/jlm-eval-suite.git
 
     # Extract the CIRCT submodule hash for use in the cache key
-    - name: Checkout CIRCT
-      run: |
-        cd jlm-eval-suite
-        make submodule-circt
     - name: Get CIRCT hash
       id: get-circt-hash
       run: |
@@ -64,11 +45,22 @@ jobs:
           jlm-eval-suite/circt/local
         key: ${{ runner.os }}-circt-${{ steps.get-circt-hash.outputs.hash }}
 
+    # Install dependencies if we didn't hit in the cache
+    - name: Install dependencies
+      if: steps.cache-circt.outputs.cache-hit != 'true'
+      run: |
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+        sudo add-apt-repository deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main
+        sudo apt-get install llvm-16-dev libmlir-16-dev mlir-16-tools clang-16 ninja-build
+        sudo ln -s /usr/lib/llvm-16/lib/libMLIR.so.16 /usr/lib/x86_64-linux-gnu/ && sudo ln -s /usr/lib/llvm-16/lib/libMLIR.so.16 /usr/lib/x86_64-linux-gnu/libMLIR.so
+        sudo python3 /usr/lib/llvm-16/build/utils/lit/setup.py install
+
     # Build CIRCT if we didn't hit in the cache
     - name: Rebuild and Install CIRCT
       if: steps.cache-circt.outputs.cache-hit != 'true'
       run: |
         cd jlm-eval-suite
+        make submodule-circt
         make circt-build
 
   hls-test-suite:
@@ -103,10 +95,6 @@ jobs:
       run: git clone https://github.com/EECS-NTNU/jlm-eval-suite.git
 
     # Extract the CIRCT submodule hash for use in the cache key
-    - name: Checkout CIRCT
-      run: |
-        cd jlm-eval-suite
-        make submodule-circt
     - name: Get CIRCT hash
       id: get-circt-hash
       run: |
@@ -127,6 +115,7 @@ jobs:
       if: steps.cache-circt.outputs.cache-hit != 'true'
       run: |
         cd jlm-eval-suite
+        make submodule-circt
         make circt-build
 
     # --------


### PR DESCRIPTION
Dependencies are now only installed if CIRCT is to be rebuilt. Also avoid cloning CIRCT if not rebuilt.