### PR TITLE
Clean up jlm::hls namespace

### DIFF
--- a/jlm/hls/backend/rhls2firrtl/base-hls.cpp
+++ b/jlm/hls/backend/rhls2firrtl/base-hls.cpp
@@ -9,122 +9,126 @@
 #include <math.h>
 #include <algorithm>
 
+namespace jlm::hls {
+
 bool
-jlm::hls::isForbiddenChar(char c) {
-	if (('A' <= c && c <= 'Z') ||
-		('a' <= c && c <= 'z') ||
-		('0' <= c && c <= '9') ||
-		'_' == c) {
-		return false;
-	}
-	return true;
+isForbiddenChar(char c) {
+  if (('A' <= c && c <= 'Z') ||
+      ('a' <= c && c <= 'z') ||
+      ('0' <= c && c <= '9') ||
+      '_' == c) {
+    return false;
+  }
+  return true;
 }
 
 std::string
-jlm::hls::BaseHLS::get_node_name(const jlm::rvsdg::node *node) {
-	auto found = node_map.find(node);
-	if (found != node_map.end()) {
-		return found->second;
-	}
-	std::string append = "";
-	auto inPorts = node->ninputs();
-	auto outPorts = node->noutputs();
-	if (inPorts) {
-		append.append("_IN");
-		append.append(std::to_string(inPorts));
-		append.append("_W");
-		append.append(std::to_string(JlmSize(&node->input(inPorts-1)->type())));
-	}
-	if (outPorts) {
-		append.append("_OUT");
-		append.append(std::to_string(outPorts));
-		append.append("_W");
-		append.append(std::to_string(JlmSize(&node->output(outPorts-1)->type())));
-	}
-	auto name = util::strfmt("op_", node->operation().debug_string(), append, "_", node_map.size());
-	// remove chars that are not valid in firrtl module names
-	std::replace_if(name.begin(), name.end(), isForbiddenChar, '_');
-	node_map[node] = name;
-	return name;
+BaseHLS::get_node_name(const jlm::rvsdg::node *node) {
+  auto found = node_map.find(node);
+  if (found != node_map.end()) {
+    return found->second;
+  }
+  std::string append = "";
+  auto inPorts = node->ninputs();
+  auto outPorts = node->noutputs();
+  if (inPorts) {
+    append.append("_IN");
+    append.append(std::to_string(inPorts));
+    append.append("_W");
+    append.append(std::to_string(JlmSize(&node->input(inPorts - 1)->type())));
+  }
+  if (outPorts) {
+    append.append("_OUT");
+    append.append(std::to_string(outPorts));
+    append.append("_W");
+    append.append(std::to_string(JlmSize(&node->output(outPorts - 1)->type())));
+  }
+  auto name = util::strfmt("op_", node->operation().debug_string(), append, "_", node_map.size());
+  // remove chars that are not valid in firrtl module names
+  std::replace_if(name.begin(), name.end(), isForbiddenChar, '_');
+  node_map[node] = name;
+  return name;
 }
 
 std::string
-jlm::hls::BaseHLS::get_port_name(jlm::rvsdg::input *port) {
-	std::string result;
-	if (dynamic_cast<const jlm::rvsdg::node_input *>(port)) {
-		result += "i";
-	} else if (dynamic_cast<const jlm::rvsdg::result *>(port)) {
-		result += "r";
-	} else {
-		throw std::logic_error(port->debug_string() + " not implemented!");
-	}
-	result += util::strfmt(port->index());
-	return result;
+BaseHLS::get_port_name(jlm::rvsdg::input *port) {
+  std::string result;
+  if (dynamic_cast<const jlm::rvsdg::node_input *>(port)) {
+    result += "i";
+  } else if (dynamic_cast<const jlm::rvsdg::result *>(port)) {
+    result += "r";
+  } else {
+    throw std::logic_error(port->debug_string() + " not implemented!");
+  }
+  result += util::strfmt(port->index());
+  return result;
 }
 
 std::string
-jlm::hls::BaseHLS::get_port_name(jlm::rvsdg::output *port) {
-	if (port == nullptr) {
-		throw std::logic_error("nullptr!");
-	}
-	std::string result;
-	if (dynamic_cast<const jlm::rvsdg::argument *>(port)) {
-		result += "a";
-	} else if (dynamic_cast<const jlm::rvsdg::node_output *>(port)) {
-		result += "o";
-	} else if (dynamic_cast<const jlm::rvsdg::structural_output *>(port)) {
-		result += "so";
-	} else {
-		throw std::logic_error(port->debug_string() + " not implemented!");
-	}
-	result += util::strfmt(port->index());
-	return result;
+BaseHLS::get_port_name(jlm::rvsdg::output *port) {
+  if (port == nullptr) {
+    throw std::logic_error("nullptr!");
+  }
+  std::string result;
+  if (dynamic_cast<const jlm::rvsdg::argument *>(port)) {
+    result += "a";
+  } else if (dynamic_cast<const jlm::rvsdg::node_output *>(port)) {
+    result += "o";
+  } else if (dynamic_cast<const jlm::rvsdg::structural_output *>(port)) {
+    result += "so";
+  } else {
+    throw std::logic_error(port->debug_string() + " not implemented!");
+  }
+  result += util::strfmt(port->index());
+  return result;
 }
 
 int
-jlm::hls::BaseHLS::JlmSize(const jlm::rvsdg::type *type) {
-	if (auto bt = dynamic_cast<const jlm::rvsdg::bittype *>(type)) {
-		return bt->nbits();
-	} else if (auto at = dynamic_cast<const llvm::arraytype *>(type)) {
-		return JlmSize(&at->element_type()) * at->nelements();
-	} else if (dynamic_cast<const llvm::PointerType *>(type)) {
-		return 64;
-	} else if (auto ct = dynamic_cast<const jlm::rvsdg::ctltype *>(type)) {
-		return ceil(log2(ct->nalternatives()));
-	} else if (dynamic_cast<const jlm::rvsdg::statetype *>(type)) {
-		return 1;
-	} else {
-		throw std::logic_error("Size of '" + type->debug_string() + "' is not implemented!");
-	}
+BaseHLS::JlmSize(const jlm::rvsdg::type *type) {
+  if (auto bt = dynamic_cast<const jlm::rvsdg::bittype *>(type)) {
+    return bt->nbits();
+  } else if (auto at = dynamic_cast<const llvm::arraytype *>(type)) {
+    return JlmSize(&at->element_type()) * at->nelements();
+  } else if (dynamic_cast<const llvm::PointerType *>(type)) {
+    return 64;
+  } else if (auto ct = dynamic_cast<const jlm::rvsdg::ctltype *>(type)) {
+    return ceil(log2(ct->nalternatives()));
+  } else if (dynamic_cast<const jlm::rvsdg::statetype *>(type)) {
+    return 1;
+  } else {
+    throw std::logic_error("Size of '" + type->debug_string() + "' is not implemented!");
+  }
 }
 
 void
-jlm::hls::BaseHLS::create_node_names(jlm::rvsdg::region *r) {
-	for (auto &node : r->nodes) {
-		if (dynamic_cast<jlm::rvsdg::simple_node *>(&node)) {
-			get_node_name(&node);
-		} else if (auto oln = dynamic_cast<jlm::hls::loop_node *>(&node)) {
-			create_node_names(oln->subregion());
-		} else {
-			throw util::error("Unimplemented op (unexpected structural node) : " + node.operation().debug_string());
-		}
-	}
+BaseHLS::create_node_names(jlm::rvsdg::region *r) {
+  for (auto &node: r->nodes) {
+    if (dynamic_cast<jlm::rvsdg::simple_node *>(&node)) {
+      get_node_name(&node);
+    } else if (auto oln = dynamic_cast<loop_node *>(&node)) {
+      create_node_names(oln->subregion());
+    } else {
+      throw util::error("Unimplemented op (unexpected structural node) : " + node.operation().debug_string());
+    }
+  }
 }
 
 const jlm::llvm::lambda::node *
-jlm::hls::BaseHLS::get_hls_lambda(llvm::RvsdgModule &rm) {
-	auto region = rm.Rvsdg().root();
-	auto ln = dynamic_cast<const llvm::lambda::node *>(region->nodes.begin().ptr());
-	if (region->nnodes() == 1 && ln) {
-		return ln;
-	} else {
-		throw util::error("Root should have only one lambda node now");
-	}
+BaseHLS::get_hls_lambda(llvm::RvsdgModule &rm) {
+  auto region = rm.Rvsdg().root();
+  auto ln = dynamic_cast<const llvm::lambda::node *>(region->nodes.begin().ptr());
+  if (region->nnodes() == 1 && ln) {
+    return ln;
+  } else {
+    throw util::error("Root should have only one lambda node now");
+  }
 }
 
 std::string
-jlm::hls::BaseHLS::get_base_file_name(const llvm::RvsdgModule &rm) {
-	auto source_file_name = rm.SourceFileName().name();
-	auto base_file_name = source_file_name.substr(0, source_file_name.find_last_of('.'));
-	return base_file_name;
+BaseHLS::get_base_file_name(const llvm::RvsdgModule &rm) {
+  auto source_file_name = rm.SourceFileName().name();
+  auto base_file_name = source_file_name.substr(0, source_file_name.find_last_of('.'));
+  return base_file_name;
+}
+
 }

--- a/jlm/hls/backend/rhls2firrtl/base-hls.hpp
+++ b/jlm/hls/backend/rhls2firrtl/base-hls.hpp
@@ -12,55 +12,55 @@
 
 #include <fstream>
 
-namespace jlm {
-	namespace hls {
-		bool
-		isForbiddenChar(char c);
+namespace jlm::hls
+{
 
-		class BaseHLS {
-		public:
-			std::string
-			run(llvm::RvsdgModule &rm) {
-				assert(node_map.empty());
-				// ensure consistent naming across runs
-				create_node_names(get_hls_lambda(rm)->subregion());
-				return get_text(rm);
-			}
+bool
+isForbiddenChar(char c);
 
-		private:
-			virtual std::string
-			extension() = 0;
+class BaseHLS {
+public:
+  std::string
+  run(llvm::RvsdgModule &rm) {
+    assert(node_map.empty());
+    // ensure consistent naming across runs
+    create_node_names(get_hls_lambda(rm)->subregion());
+    return get_text(rm);
+  }
 
-		protected:
-			std::unordered_map<const jlm::rvsdg::node *, std::string> node_map;
-			std::unordered_map<jlm::rvsdg::output *, std::string> output_map;
+private:
+  virtual std::string
+  extension() = 0;
 
-			std::string
-			get_node_name(const jlm::rvsdg::node *node);
+protected:
+  std::unordered_map<const jlm::rvsdg::node *, std::string> node_map;
+  std::unordered_map<jlm::rvsdg::output *, std::string> output_map;
 
-			static std::string
-			get_port_name(jlm::rvsdg::input *port);
+  std::string
+  get_node_name(const jlm::rvsdg::node *node);
 
-			static std::string
-			get_port_name(jlm::rvsdg::output *port);
+  static std::string
+  get_port_name(jlm::rvsdg::input *port);
 
-			const llvm::lambda::node *
-			get_hls_lambda(llvm::RvsdgModule &rm);
+  static std::string
+  get_port_name(jlm::rvsdg::output *port);
 
-			int
-			JlmSize(const jlm::rvsdg::type *type);
+  const llvm::lambda::node *
+  get_hls_lambda(llvm::RvsdgModule &rm);
 
-			void
-			create_node_names(jlm::rvsdg::region *r);
+  int
+  JlmSize(const jlm::rvsdg::type *type);
 
-			virtual std::string
-			get_text(llvm::RvsdgModule &rm) = 0;
+  void
+  create_node_names(jlm::rvsdg::region *r);
 
-			static std::string
-			get_base_file_name(const llvm::RvsdgModule &rm);
-		};
-	}
+  virtual std::string
+  get_text(llvm::RvsdgModule &rm) = 0;
+
+  static std::string
+  get_base_file_name(const llvm::RvsdgModule &rm);
+};
+
 }
-
 
 #endif //JLM_HLS_BACKEND_RHLS2FIRRTL_BASE_HLS_HPP

--- a/jlm/hls/backend/rhls2firrtl/dot-hls.cpp
+++ b/jlm/hls/backend/rhls2firrtl/dot-hls.cpp
@@ -10,318 +10,323 @@
 #include <algorithm>
 #include <set>
 
+namespace jlm::hls {
+
 std::string
-jlm::hls::DotHLS::extension() {
-	return ".dot";
+DotHLS::extension() {
+  return ".dot";
 }
 
 std::string
-jlm::hls::DotHLS::get_text(llvm::RvsdgModule &rm) {
-	return subregion_to_dot(get_hls_lambda(rm)->subregion());
+DotHLS::get_text(llvm::RvsdgModule &rm) {
+  return subregion_to_dot(get_hls_lambda(rm)->subregion());
 }
 
 std::string
-jlm::hls::DotHLS::argument_to_dot(jlm::rvsdg::argument *port) {
-	auto name = get_port_name(port);
+DotHLS::argument_to_dot(jlm::rvsdg::argument *port) {
+  auto name = get_port_name(port);
 
-	auto dot = \
+  auto dot = \
         "{rank=source; " +
-		name +
-		" [shape=plaintext label=<\n"
-		"            <TABLE BORDER=\"0\" CELLBORDER=\"0\" CELLSPACING=\"0\" CELLPADDING=\"0\">\n"
-		"                <TR>\n"
-		"                    <TD BORDER=\"1\" CELLPADDING=\"1\"><FONT POINT-SIZE=\"10\">" +
-		name +
-		"</FONT></TD>\n"
-		"                </TR>\n"
-		"            </TABLE>\n"
-		">];}\n";
-	return dot;
-}
-
-std::string
-jlm::hls::DotHLS::result_to_dot(jlm::rvsdg::result *port) {
-	auto name = get_port_name(port);
-
-	auto dot = \
-        "{rank=sink; " +
-		name +
-		" [shape=plaintext label=<\n"
-		"            <TABLE BORDER=\"0\" CELLBORDER=\"0\" CELLSPACING=\"0\" CELLPADDING=\"0\">\n"
-		"                <TR>\n"
-		"                    <TD BORDER=\"1\" CELLPADDING=\"1\"><FONT POINT-SIZE=\"10\">" +
-		name +
-		"</FONT></TD>\n"
-		"                </TR>\n"
-		"            </TABLE>\n"
-		">];}\n";
-	return dot;
-}
-
-std::string
-jlm::hls::DotHLS::node_to_dot(const jlm::rvsdg::node *node) {
-	auto SPACER = "                    <TD WIDTH=\"10\"></TD>\n";
-	auto name = get_node_name(node);
-	auto opname = node->operation().debug_string();
-	std::replace_if(opname.begin(), opname.end(), isForbiddenChar, '_');
-
-	std::string inputs;
-	for (size_t i = 0; i < node->ninputs(); ++i) {
-		if (i != 0) {
-			inputs += SPACER;
-		}
-		auto in = get_port_name(node->input(i));
-		inputs += \
-            "                    <TD PORT=\"" + in + "\" BORDER=\"1\" CELLPADDING=\"1\"><FONT POINT-SIZE=\"10\">" + in +
-			"</FONT></TD>\n";
-	}
-
-	std::string outputs;
-	for (size_t i = 0; i < node->noutputs(); ++i) {
-		if (i != 0) {
-			outputs += SPACER;
-		}
-		auto out = get_port_name(node->output(i));
-		outputs += \
-            "                    <TD PORT=\"" + out + "\" BORDER=\"1\" CELLPADDING=\"1\"><FONT POINT-SIZE=\"10\">" +
-			out + "</FONT></TD>\n";
-	}
-
-	std::string color = "black";
-	if (jlm::rvsdg::is<hls::buffer_op>(node)) {
-		color = "blue";
-	} else if (jlm::rvsdg::is<hls::fork_op>(node)) {
-		color = "grey";
-	} else if (jlm::rvsdg::is<hls::sink_op>(node)) {
-		color = "grey";
-	} else if (jlm::rvsdg::is<hls::branch_op>(node)) {
-		color = "green";
-	} else if (jlm::rvsdg::is<hls::mux_op>(node)) {
-		color = "darkred";
-	} else if (jlm::rvsdg::is<hls::merge_op>(node)) {
-		color = "pink";
-	} else if (
-			jlm::rvsdg::is<hls::trigger_op>(node) ||
-			hls::is_constant(node)
-			) {
-		color = "orange";
-	}
-
-	// dot inspired by https://stackoverflow.com/questions/42157650/moving-graphviz-edge-out-of-the-way
-	auto dot = \
         name +
-		" [shape=plaintext label=<\n"
-		"<TABLE BORDER=\"0\" CELLBORDER=\"0\" CELLSPACING=\"0\" CELLPADDING=\"0\">\n"
-		// inputs
-		"    <TR>\n"
-		"        <TD BORDER=\"0\">\n"
-		"            <TABLE BORDER=\"0\" CELLBORDER=\"0\" CELLSPACING=\"0\" CELLPADDING=\"0\">\n"
-		"                <TR>\n"
-		"                    <TD WIDTH=\"20\"></TD>\n" +
-		inputs +
-		"                    <TD WIDTH=\"20\"></TD>\n"
-		"                </TR>\n"
-		"            </TABLE>\n"
-		"        </TD>\n"
-		"    </TR>\n"
-		"    <TR>\n"
-		"        <TD BORDER=\"3\" STYLE=\"ROUNDED\" CELLPADDING=\"4\">" +
-		opname +
-		"<BR/><FONT POINT-SIZE=\"10\">" +
-		name +
-		"</FONT></TD>\n"
-		"    </TR>\n"
-		"    <TR>\n"
-		"        <TD BORDER=\"0\">\n"
-		"            <TABLE BORDER=\"0\" CELLBORDER=\"0\" CELLSPACING=\"0\" CELLPADDING=\"0\">\n"
-		"                <TR>\n"
-		"                    <TD WIDTH=\"20\"></TD>\n" +
-		outputs +
-		"                    <TD WIDTH=\"20\"></TD>\n"
-		"                </TR>\n"
-		"            </TABLE>\n"
-		"        </TD>\n"
-		"    </TR>\n"
-		"</TABLE>\n"
-		"> fontcolor=" +
-		color + " color=" + color + "];\n";
-	return dot;
+        " [shape=plaintext label=<\n"
+        "            <TABLE BORDER=\"0\" CELLBORDER=\"0\" CELLSPACING=\"0\" CELLPADDING=\"0\">\n"
+        "                <TR>\n"
+        "                    <TD BORDER=\"1\" CELLPADDING=\"1\"><FONT POINT-SIZE=\"10\">" +
+        name +
+        "</FONT></TD>\n"
+        "                </TR>\n"
+        "            </TABLE>\n"
+        ">];}\n";
+  return dot;
 }
 
 std::string
-jlm::hls::DotHLS::edge(std::string src, std::string snk, const jlm::rvsdg::type &type, bool back) {
-	auto color = "black";
-	if (dynamic_cast<const jlm::rvsdg::ctltype *>(&type)) {
-		color = "green";
-	}
-	if (!back) {
-		return src + " -> " + snk + " [style=\"\", arrowhead=\"normal\", color=" + color +
-			   ", headlabel=<>, fontsize=10, labelangle=45, labeldistance=2.0, labelfontcolor=black];\n";
-	}
-	// implement back edges by setting constraint to false
-	return src + " -> " + snk + " [style=\"\", arrowhead=\"normal\", color=" + color +
-		   ", headlabel=<>, fontsize=10, labelangle=45, labeldistance=2.0, labelfontcolor=black, constraint=false];\n";
+DotHLS::result_to_dot(jlm::rvsdg::result *port) {
+  auto name = get_port_name(port);
+
+  auto dot = \
+        "{rank=sink; " +
+        name +
+        " [shape=plaintext label=<\n"
+        "            <TABLE BORDER=\"0\" CELLBORDER=\"0\" CELLSPACING=\"0\" CELLPADDING=\"0\">\n"
+        "                <TR>\n"
+        "                    <TD BORDER=\"1\" CELLPADDING=\"1\"><FONT POINT-SIZE=\"10\">" +
+        name +
+        "</FONT></TD>\n"
+        "                </TR>\n"
+        "            </TABLE>\n"
+        ">];}\n";
+  return dot;
+}
+
+std::string
+DotHLS::node_to_dot(const jlm::rvsdg::node *node) {
+  auto SPACER = "                    <TD WIDTH=\"10\"></TD>\n";
+  auto name = get_node_name(node);
+  auto opname = node->operation().debug_string();
+  std::replace_if(opname.begin(), opname.end(), isForbiddenChar, '_');
+
+  std::string inputs;
+  for (size_t i = 0; i < node->ninputs(); ++i) {
+    if (i != 0) {
+      inputs += SPACER;
+    }
+    auto in = get_port_name(node->input(i));
+    inputs += \
+            "                    <TD PORT=\"" + in + "\" BORDER=\"1\" CELLPADDING=\"1\"><FONT POINT-SIZE=\"10\">" + in +
+            "</FONT></TD>\n";
+  }
+
+  std::string outputs;
+  for (size_t i = 0; i < node->noutputs(); ++i) {
+    if (i != 0) {
+      outputs += SPACER;
+    }
+    auto out = get_port_name(node->output(i));
+    outputs += \
+            "                    <TD PORT=\"" + out + "\" BORDER=\"1\" CELLPADDING=\"1\"><FONT POINT-SIZE=\"10\">" +
+            out + "</FONT></TD>\n";
+  }
+
+  std::string color = "black";
+  if (jlm::rvsdg::is<hls::buffer_op>(node)) {
+    color = "blue";
+  } else if (jlm::rvsdg::is<hls::fork_op>(node)) {
+    color = "grey";
+  } else if (jlm::rvsdg::is<hls::sink_op>(node)) {
+    color = "grey";
+  } else if (jlm::rvsdg::is<hls::branch_op>(node)) {
+    color = "green";
+  } else if (jlm::rvsdg::is<hls::mux_op>(node)) {
+    color = "darkred";
+  } else if (jlm::rvsdg::is<hls::merge_op>(node)) {
+    color = "pink";
+  } else if (
+    jlm::rvsdg::is<hls::trigger_op>(node) ||
+    hls::is_constant(node)
+    ) {
+    color = "orange";
+  }
+
+  // dot inspired by https://stackoverflow.com/questions/42157650/moving-graphviz-edge-out-of-the-way
+  auto dot = \
+        name +
+        " [shape=plaintext label=<\n"
+        "<TABLE BORDER=\"0\" CELLBORDER=\"0\" CELLSPACING=\"0\" CELLPADDING=\"0\">\n"
+        // inputs
+        "    <TR>\n"
+        "        <TD BORDER=\"0\">\n"
+        "            <TABLE BORDER=\"0\" CELLBORDER=\"0\" CELLSPACING=\"0\" CELLPADDING=\"0\">\n"
+        "                <TR>\n"
+        "                    <TD WIDTH=\"20\"></TD>\n" +
+        inputs +
+        "                    <TD WIDTH=\"20\"></TD>\n"
+        "                </TR>\n"
+        "            </TABLE>\n"
+        "        </TD>\n"
+        "    </TR>\n"
+        "    <TR>\n"
+        "        <TD BORDER=\"3\" STYLE=\"ROUNDED\" CELLPADDING=\"4\">" +
+        opname +
+        "<BR/><FONT POINT-SIZE=\"10\">" +
+        name +
+        "</FONT></TD>\n"
+        "    </TR>\n"
+        "    <TR>\n"
+        "        <TD BORDER=\"0\">\n"
+        "            <TABLE BORDER=\"0\" CELLBORDER=\"0\" CELLSPACING=\"0\" CELLPADDING=\"0\">\n"
+        "                <TR>\n"
+        "                    <TD WIDTH=\"20\"></TD>\n" +
+        outputs +
+        "                    <TD WIDTH=\"20\"></TD>\n"
+        "                </TR>\n"
+        "            </TABLE>\n"
+        "        </TD>\n"
+        "    </TR>\n"
+        "</TABLE>\n"
+        "> fontcolor=" +
+        color + " color=" + color + "];\n";
+  return dot;
+}
+
+std::string
+DotHLS::edge(std::string src, std::string snk, const jlm::rvsdg::type &type, bool back) {
+  auto color = "black";
+  if (dynamic_cast<const jlm::rvsdg::ctltype *>(&type)) {
+    color = "green";
+  }
+  if (!back) {
+    return src + " -> " + snk + " [style=\"\", arrowhead=\"normal\", color=" + color +
+           ", headlabel=<>, fontsize=10, labelangle=45, labeldistance=2.0, labelfontcolor=black];\n";
+  }
+  // implement back edges by setting constraint to false
+  return src + " -> " + snk + " [style=\"\", arrowhead=\"normal\", color=" + color +
+         ", headlabel=<>, fontsize=10, labelangle=45, labeldistance=2.0, labelfontcolor=black, constraint=false];\n";
 //	return snk + " -> " + src + " [style=\"\", arrowhead=\"normal\", color=" + color +
 //		   ", headlabel=<>, fontsize=10, labelangle=45, labeldistance=2.0, labelfontcolor=black, dir=back];\n";
 }
 
 std::string
-jlm::hls::DotHLS::loop_to_dot(hls::loop_node *ln) {
-	auto sr = ln->subregion();
-	std::ostringstream dot;
-	dot << "subgraph cluster_loop_" << loop_ctr++ << " {\n";
-	dot << "color=\"#ff8080\"\n";
+DotHLS::loop_to_dot(hls::loop_node *ln) {
+  auto sr = ln->subregion();
+  std::ostringstream dot;
+  dot << "subgraph cluster_loop_" << loop_ctr++ << " {\n";
+  dot << "color=\"#ff8080\"\n";
 
-	std::set<jlm::rvsdg::output *> back_outputs;
-	std::set<jlm::rvsdg::node *> top_nodes; // no artificial top nodes for now
-	for (size_t i = 0; i < sr->narguments(); ++i) {
-		auto arg = sr->argument(i);
-		// arguments without an input produce a cycle
-		if (arg->input() == nullptr) {
-			back_outputs.insert(arg);
-		}
-	}
+  std::set<jlm::rvsdg::output *> back_outputs;
+  std::set<jlm::rvsdg::node *> top_nodes; // no artificial top nodes for now
+  for (size_t i = 0; i < sr->narguments(); ++i) {
+    auto arg = sr->argument(i);
+    // arguments without an input produce a cycle
+    if (arg->input() == nullptr) {
+      back_outputs.insert(arg);
+    }
+  }
 
-	for (auto node: jlm::rvsdg::topdown_traverser(sr)) {
-		if (dynamic_cast<jlm::rvsdg::simple_node *>(node)) {
-			auto node_dot = node_to_dot(node);
-			if (top_nodes.count(node)) {
-				dot << "{rank=source; \n";
-				dot << node_dot;
-				dot << "}\n";
-			} else {
-				dot << node_dot;
-			}
-		} else if (auto ln = dynamic_cast<hls::loop_node *>(node)) {
-			dot << loop_to_dot(ln);
-		} else {
-			throw jlm::util::error("Unimplemented op (unexpected structural node) : " + node->operation().debug_string());
-		}
-	}
+  for (auto node: jlm::rvsdg::topdown_traverser(sr)) {
+    if (dynamic_cast<jlm::rvsdg::simple_node *>(node)) {
+      auto node_dot = node_to_dot(node);
+      if (top_nodes.count(node)) {
+        dot << "{rank=source; \n";
+        dot << node_dot;
+        dot << "}\n";
+      } else {
+        dot << node_dot;
+      }
+    } else if (auto ln = dynamic_cast<hls::loop_node *>(node)) {
+      dot << loop_to_dot(ln);
+    } else {
+      throw jlm::util::error("Unimplemented op (unexpected structural node) : " + node->operation().debug_string());
+    }
+  }
 
-	// all loop muxes at one level
-	dot << "{rank=same ";
-	for (auto node: jlm::rvsdg::topdown_traverser(sr)) {
-		auto mx = dynamic_cast<const hls::mux_op*>(&node->operation());
-		if(mx && !mx->discarding && mx->loop){
-			dot << get_node_name(node) << " ";
-		}
-	}
-	dot << "}\n";
-	// all loop branches at one level
-	dot << "{rank=same ";
-	for (auto node: jlm::rvsdg::topdown_traverser(sr)) {
-		auto br = dynamic_cast<const hls::branch_op*>(&node->operation());
-		if(br && br->loop){
-			dot << get_node_name(node) << " ";
-		}
-	}
-	dot << "}\n";
+  // all loop muxes at one level
+  dot << "{rank=same ";
+  for (auto node: jlm::rvsdg::topdown_traverser(sr)) {
+    auto mx = dynamic_cast<const hls::mux_op *>(&node->operation());
+    if (mx && !mx->discarding && mx->loop) {
+      dot << get_node_name(node) << " ";
+    }
+  }
+  dot << "}\n";
+  // all loop branches at one level
+  dot << "{rank=same ";
+  for (auto node: jlm::rvsdg::topdown_traverser(sr)) {
+    auto br = dynamic_cast<const hls::branch_op *>(&node->operation());
+    if (br && br->loop) {
+      dot << get_node_name(node) << " ";
+    }
+  }
+  dot << "}\n";
 
-	dot << "}\n";
-	// do edges outside in order not to pull other nodes into the cluster
-	for (auto node: jlm::rvsdg::topdown_traverser(sr)) {
-		if (dynamic_cast<jlm::rvsdg::simple_node *>(node)) {
-			auto mx = dynamic_cast<const hls::mux_op*>(&node->operation());
-			auto node_name = get_node_name(node);
-			for (size_t i = 0; i < node->ninputs(); ++i) {
-				auto in_name = node_name + ":" + get_port_name(node->input(i));
-				assert(output_map.count(node->input(i)->origin()));
-				auto origin = output_map[node->input(i)->origin()];
-				// implement edge as back edge when it produces a cycle
-				bool back = mx && !mx->discarding && mx->loop && (i==0||i==2);//back_outputs.count(node->input(i)->origin());
-				dot << edge(origin, in_name, node->input(i)->type(), back);
-			}
-		}
-	}
-	return dot.str();
+  dot << "}\n";
+  // do edges outside in order not to pull other nodes into the cluster
+  for (auto node: jlm::rvsdg::topdown_traverser(sr)) {
+    if (dynamic_cast<jlm::rvsdg::simple_node *>(node)) {
+      auto mx = dynamic_cast<const hls::mux_op *>(&node->operation());
+      auto node_name = get_node_name(node);
+      for (size_t i = 0; i < node->ninputs(); ++i) {
+        auto in_name = node_name + ":" + get_port_name(node->input(i));
+        assert(output_map.count(node->input(i)->origin()));
+        auto origin = output_map[node->input(i)->origin()];
+        // implement edge as back edge when it produces a cycle
+        bool back =
+          mx && !mx->discarding && mx->loop && (i == 0 || i == 2);//back_outputs.count(node->input(i)->origin());
+        dot << edge(origin, in_name, node->input(i)->type(), back);
+      }
+    }
+  }
+  return dot.str();
 }
 
 void
-jlm::hls::DotHLS::prepare_loop_out_port(hls::loop_node *ln) {
-	// make sure all outputs are translated and available (necessary for argument/result cycles)
+DotHLS::prepare_loop_out_port(hls::loop_node *ln) {
+  // make sure all outputs are translated and available (necessary for argument/result cycles)
 
-	auto sr = ln->subregion();
-	// just translate outputs
-	for (auto node: jlm::rvsdg::topdown_traverser(sr)) {
-		if (dynamic_cast<jlm::rvsdg::simple_node *>(node)) {
-			auto node_name = get_node_name(node);
-			for (size_t i = 0; i < node->noutputs(); ++i) {
-				output_map[node->output(i)] = node_name + ":" + get_port_name(node->output(i));
-			}
-		} else if (auto oln = dynamic_cast<hls::loop_node *>(node)) {
-			prepare_loop_out_port(oln);
-		} else {
-			throw jlm::util::error(
-					"Unimplemented op (unexpected structural node) : " + node->operation().debug_string());
-		}
-	}
-	for (size_t i = 0; i < sr->narguments(); ++i) {
-		auto arg = sr->argument(i);
-        auto ba = dynamic_cast<jlm::hls::backedge_argument*>(arg);
-		if (!ba) {
-            assert(arg->input() != nullptr);
-			// map to input of loop
-			output_map[arg] = output_map[arg->input()->origin()];
-		} else {
-			auto result = ba->result();
-			assert(result->type() == arg->type());
-			// map to end of loop (origin of associated result)
-			output_map[arg] = output_map[result->origin()];
-		}
-	}
-	for (size_t i = 0; i < ln->noutputs(); ++i) {
-		auto out = ln->output(i);
-		assert(out->results.size() == 1);
-		output_map[out] = output_map[out->results.begin()->origin()];
-	}
+  auto sr = ln->subregion();
+  // just translate outputs
+  for (auto node: jlm::rvsdg::topdown_traverser(sr)) {
+    if (dynamic_cast<jlm::rvsdg::simple_node *>(node)) {
+      auto node_name = get_node_name(node);
+      for (size_t i = 0; i < node->noutputs(); ++i) {
+        output_map[node->output(i)] = node_name + ":" + get_port_name(node->output(i));
+      }
+    } else if (auto oln = dynamic_cast<hls::loop_node *>(node)) {
+      prepare_loop_out_port(oln);
+    } else {
+      throw jlm::util::error(
+        "Unimplemented op (unexpected structural node) : " + node->operation().debug_string());
+    }
+  }
+  for (size_t i = 0; i < sr->narguments(); ++i) {
+    auto arg = sr->argument(i);
+    auto ba = dynamic_cast<backedge_argument *>(arg);
+    if (!ba) {
+      assert(arg->input() != nullptr);
+      // map to input of loop
+      output_map[arg] = output_map[arg->input()->origin()];
+    } else {
+      auto result = ba->result();
+      assert(result->type() == arg->type());
+      // map to end of loop (origin of associated result)
+      output_map[arg] = output_map[result->origin()];
+    }
+  }
+  for (size_t i = 0; i < ln->noutputs(); ++i) {
+    auto out = ln->output(i);
+    assert(out->results.size() == 1);
+    output_map[out] = output_map[out->results.begin()->origin()];
+  }
 }
 
 std::string
-jlm::hls::DotHLS::subregion_to_dot(jlm::rvsdg::region *sr) {
-	std::ostringstream dot;
-	dot << "digraph G {\n";
-	for (size_t i = 0; i < sr->narguments(); ++i) {
-		dot << argument_to_dot(sr->argument(i));
-	}
-	for (size_t i = 0; i < sr->nresults(); ++i) {
-		dot << result_to_dot(sr->result(i));
-	}
-	dot << "subgraph cluster_sub {\n";
-	dot << "color=\"#80b3ff\"\n";
-	dot << "penwidth=6\n";
+DotHLS::subregion_to_dot(jlm::rvsdg::region *sr) {
+  std::ostringstream dot;
+  dot << "digraph G {\n";
+  for (size_t i = 0; i < sr->narguments(); ++i) {
+    dot << argument_to_dot(sr->argument(i));
+  }
+  for (size_t i = 0; i < sr->nresults(); ++i) {
+    dot << result_to_dot(sr->result(i));
+  }
+  dot << "subgraph cluster_sub {\n";
+  dot << "color=\"#80b3ff\"\n";
+  dot << "penwidth=6\n";
 
-	for (size_t i = 0; i < sr->narguments(); ++i) {
-		output_map[sr->argument(i)] = get_port_name(sr->argument(i));
-	}
-	for (auto node: jlm::rvsdg::topdown_traverser(sr)) {
-		if (dynamic_cast<jlm::rvsdg::simple_node *>(node)) {
-			auto node_dot = node_to_dot(node);
-			dot << node_dot;
-			auto node_name = get_node_name(node);
-			for (size_t i = 0; i < node->ninputs(); ++i) {
-				auto in_name = node_name + ":" + get_port_name(node->input(i));
-				assert(output_map.count(node->input(i)->origin()));
-				auto origin = output_map[node->input(i)->origin()];
-				dot << edge(origin, in_name, node->input(i)->type());
-			}
-			for (size_t i = 0; i < node->noutputs(); ++i) {
-				output_map[node->output(i)] = node_name + ":" + get_port_name(node->output(i));
-			}
-		} else if (auto ln = dynamic_cast<hls::loop_node *>(node)) {
-			prepare_loop_out_port(ln);
-			dot << loop_to_dot(ln);
-		} else {
-			throw jlm::util::error(
-					"Unimplemented op (unexpected structural node) : " + node->operation().debug_string());
-		}
-	}
-	for (size_t i = 0; i < sr->nresults(); ++i) {
-		auto origin = output_map[sr->result(i)->origin()];
-		auto result = get_port_name(sr->result(i));
-		dot << edge(origin, result, sr->result(i)->type());
-	}
-	dot << "}\n";
-	dot << "}\n";
-	return dot.str();
+  for (size_t i = 0; i < sr->narguments(); ++i) {
+    output_map[sr->argument(i)] = get_port_name(sr->argument(i));
+  }
+  for (auto node: jlm::rvsdg::topdown_traverser(sr)) {
+    if (dynamic_cast<jlm::rvsdg::simple_node *>(node)) {
+      auto node_dot = node_to_dot(node);
+      dot << node_dot;
+      auto node_name = get_node_name(node);
+      for (size_t i = 0; i < node->ninputs(); ++i) {
+        auto in_name = node_name + ":" + get_port_name(node->input(i));
+        assert(output_map.count(node->input(i)->origin()));
+        auto origin = output_map[node->input(i)->origin()];
+        dot << edge(origin, in_name, node->input(i)->type());
+      }
+      for (size_t i = 0; i < node->noutputs(); ++i) {
+        output_map[node->output(i)] = node_name + ":" + get_port_name(node->output(i));
+      }
+    } else if (auto ln = dynamic_cast<hls::loop_node *>(node)) {
+      prepare_loop_out_port(ln);
+      dot << loop_to_dot(ln);
+    } else {
+      throw jlm::util::error(
+        "Unimplemented op (unexpected structural node) : " + node->operation().debug_string());
+    }
+  }
+  for (size_t i = 0; i < sr->nresults(); ++i) {
+    auto origin = output_map[sr->result(i)->origin()];
+    auto result = get_port_name(sr->result(i));
+    dot << edge(origin, result, sr->result(i)->type());
+  }
+  dot << "}\n";
+  dot << "}\n";
+  return dot.str();
+}
+
 }

--- a/jlm/hls/backend/rhls2firrtl/dot-hls.hpp
+++ b/jlm/hls/backend/rhls2firrtl/dot-hls.hpp
@@ -10,40 +10,41 @@
 #include <jlm/hls/backend/rhls2firrtl/base-hls.hpp>
 #include <jlm/hls/ir/hls.hpp>
 
-namespace jlm {
-	namespace hls {
-		class DotHLS : public BaseHLS {
-			std::string
-			extension() override;
+namespace jlm::hls
+{
 
-			std::string
-			get_text(llvm::RvsdgModule &rm) override;
+class DotHLS : public BaseHLS {
+  std::string
+  extension() override;
 
-		private:
-			std::string
-			argument_to_dot(jlm::rvsdg::argument *port);
+  std::string
+  get_text(llvm::RvsdgModule &rm) override;
 
-			std::string
-			result_to_dot(jlm::rvsdg::result *port);
+private:
+  std::string
+  argument_to_dot(jlm::rvsdg::argument *port);
 
-			std::string
-			node_to_dot(const jlm::rvsdg::node *node);
+  std::string
+  result_to_dot(jlm::rvsdg::result *port);
 
-			std::string
-			edge(std::string src, std::string snk, const jlm::rvsdg::type &type, bool back = false);
+  std::string
+  node_to_dot(const jlm::rvsdg::node *node);
 
-			std::string
-			loop_to_dot(hls::loop_node *ln);
+  std::string
+  edge(std::string src, std::string snk, const jlm::rvsdg::type &type, bool back = false);
 
-			void
-			prepare_loop_out_port(hls::loop_node *ln);
+  std::string
+  loop_to_dot(hls::loop_node *ln);
 
-			std::string
-			subregion_to_dot(jlm::rvsdg::region *sr);
+  void
+  prepare_loop_out_port(hls::loop_node *ln);
 
-			int loop_ctr = 0;
-		};
-	}
+  std::string
+  subregion_to_dot(jlm::rvsdg::region *sr);
+
+  int loop_ctr = 0;
+};
+
 }
 
 #endif //JLM_HLS_BACKEND_RHLS2FIRRTL_DOT_HLS_HPP

--- a/jlm/hls/backend/rhls2firrtl/firrtl-hls.cpp
+++ b/jlm/hls/backend/rhls2firrtl/firrtl-hls.cpp
@@ -7,915 +7,920 @@
 
 #include <math.h>
 
+namespace jlm::hls {
+
 bool
-jlm::hls::is_identity_mapping(const jlm::rvsdg::match_op &op) {
-	for (const auto &pair : op) {
-		if (pair.first != pair.second)
-			return false;
-	}
+is_identity_mapping(const jlm::rvsdg::match_op &op) {
+  for (const auto &pair: op) {
+    if (pair.first != pair.second)
+      return false;
+  }
 
-	return true;
+  return true;
 }
 
 std::string
-jlm::hls::FirrtlHLS::get_text(llvm::RvsdgModule &rm) {
-	std::ostringstream firrtl;
-	auto module = lambda_node_to_firrtl(get_hls_lambda(rm));
-	firrtl << indent(0) << "circuit " << module.name << ":\n";
-	for (auto module: modules) {
-		firrtl << module.second.firrtl;
-	}
-	return firrtl.str();
+FirrtlHLS::get_text(llvm::RvsdgModule &rm) {
+  std::ostringstream firrtl;
+  auto module = lambda_node_to_firrtl(get_hls_lambda(rm));
+  firrtl << indent(0) << "circuit " << module.name << ":\n";
+  for (auto module: modules) {
+    firrtl << module.second.firrtl;
+  }
+  return firrtl.str();
 }
 
 std::string
-jlm::hls::FirrtlHLS::to_firrtl_type(const jlm::rvsdg::type *type) {
-	return util::strfmt("UInt<", jlm_sizeof(type), ">");
+FirrtlHLS::to_firrtl_type(const jlm::rvsdg::type *type) {
+  return util::strfmt("UInt<", jlm_sizeof(type), ">");
 }
 
 std::string
-jlm::hls::FirrtlHLS::mem_io() {
-	std::ostringstream module;
-	module << indent(2)
-		   << "output mem_req: {flip ready: UInt<1>, valid: UInt<1>, addr: UInt<64>, data: UInt<64>, write: UInt<1>, width: UInt<3>}\n";
-	module << indent(2) << "input mem_res: {valid: UInt<1>, data: UInt<64>}\n";
-	module << indent(2) << "mem_req.valid <= " << UInt(1, 0) << "\n";
-	module << indent(2) << "mem_req.addr is invalid\n";
-	module << indent(2) << "mem_req.write is invalid\n";
-	module << indent(2) << "mem_req.data is invalid\n";
-	module << indent(2) << "mem_req.width is invalid\n";
-	return module.str();
+FirrtlHLS::mem_io() {
+  std::ostringstream module;
+  module << indent(2)
+         << "output mem_req: {flip ready: UInt<1>, valid: UInt<1>, addr: UInt<64>, data: UInt<64>, write: UInt<1>, width: UInt<3>}\n";
+  module << indent(2) << "input mem_res: {valid: UInt<1>, data: UInt<64>}\n";
+  module << indent(2) << "mem_req.valid <= " << UInt(1, 0) << "\n";
+  module << indent(2) << "mem_req.addr is invalid\n";
+  module << indent(2) << "mem_req.write is invalid\n";
+  module << indent(2) << "mem_req.data is invalid\n";
+  module << indent(2) << "mem_req.width is invalid\n";
+  return module.str();
 }
 
 std::string
-jlm::hls::FirrtlHLS::mux_mem(const std::vector<std::string> &mem_nodes) const {
-	std::ostringstream mem;
-	std::string previous_granted = UInt(1, 0);
-	for (auto node_name:mem_nodes) {
-		mem << indent(2) << node_name << ".mem_res.valid <= mem_res.valid\n";
-		mem << indent(2) << node_name << ".mem_res.data <= mem_res.data\n";
-		mem << indent(2) << node_name << ".mem_req.ready <= " << UInt(1, 0) << "\n";
-		mem << indent(2) << "when and(not(" << previous_granted << ")," << node_name
-			<< ".mem_req.valid):\n";
-		mem << indent(3) << node_name << ".mem_req.ready <= " << UInt(1, 1) << "\n";
-		mem << indent(3) << "mem_req.addr <= " << node_name << ".mem_req.addr\n";
-		mem << indent(3) << "mem_req.write <= " << node_name << ".mem_req.write\n";
-		mem << indent(3) << "mem_req.valid <= " << UInt(1, 1) << "\n";
-		mem << indent(3) << "mem_req.data <= " << node_name << ".mem_req.data\n";
-		mem << indent(3) << "mem_req.width <= " << node_name << ".mem_req.width\n";
-		mem << indent(2) << "node previous_granted_" << node_name << " = or(" << previous_granted << ", "
-			<< node_name << ".mem_req.ready)\n";
-		previous_granted = "previous_granted_" + node_name;
-	}
-	return mem.str();
+FirrtlHLS::mux_mem(const std::vector<std::string> &mem_nodes) const {
+  std::ostringstream mem;
+  std::string previous_granted = UInt(1, 0);
+  for (auto node_name: mem_nodes) {
+    mem << indent(2) << node_name << ".mem_res.valid <= mem_res.valid\n";
+    mem << indent(2) << node_name << ".mem_res.data <= mem_res.data\n";
+    mem << indent(2) << node_name << ".mem_req.ready <= " << UInt(1, 0) << "\n";
+    mem << indent(2) << "when and(not(" << previous_granted << ")," << node_name
+        << ".mem_req.valid):\n";
+    mem << indent(3) << node_name << ".mem_req.ready <= " << UInt(1, 1) << "\n";
+    mem << indent(3) << "mem_req.addr <= " << node_name << ".mem_req.addr\n";
+    mem << indent(3) << "mem_req.write <= " << node_name << ".mem_req.write\n";
+    mem << indent(3) << "mem_req.valid <= " << UInt(1, 1) << "\n";
+    mem << indent(3) << "mem_req.data <= " << node_name << ".mem_req.data\n";
+    mem << indent(3) << "mem_req.width <= " << node_name << ".mem_req.width\n";
+    mem << indent(2) << "node previous_granted_" << node_name << " = or(" << previous_granted << ", "
+        << node_name << ".mem_req.ready)\n";
+    previous_granted = "previous_granted_" + node_name;
+  }
+  return mem.str();
 }
 
 std::string
-jlm::hls::FirrtlHLS::module_header(const jlm::rvsdg::node *node, bool has_mem_io) {
-	std::ostringstream module;
+FirrtlHLS::module_header(const jlm::rvsdg::node *node, bool has_mem_io) {
+  std::ostringstream module;
 
-	module << indent(1) << "module " << get_module_name(node) << ":\n";
-	// io
-	module << indent(2) << "; io\n";
-	module << indent(2) << "input clk: Clock\n";
-	module << indent(2) << "input reset: UInt<1>\n";
-	for (size_t i = 0; i < node->ninputs(); ++i) {
-		module << indent(2) << "input i" << (i) << ": {flip ready: UInt<1>, valid: UInt<1>, data: " <<
-			   to_firrtl_type(&node->input(i)->type()) << "}\n";
-	}
-	for (size_t i = 0; i < node->noutputs(); ++i) {
-		module << indent(2) << "output o" << i <<
-			   ": {flip ready: UInt<1>, valid: UInt<1>, data: " <<
-			   to_firrtl_type(&node->output(i)->type()) << "}\n";
-	}
-	if (has_mem_io) {
-		module << mem_io();
-	}
+  module << indent(1) << "module " << get_module_name(node) << ":\n";
+  // io
+  module << indent(2) << "; io\n";
+  module << indent(2) << "input clk: Clock\n";
+  module << indent(2) << "input reset: UInt<1>\n";
+  for (size_t i = 0; i < node->ninputs(); ++i) {
+    module << indent(2) << "input i" << (i) << ": {flip ready: UInt<1>, valid: UInt<1>, data: " <<
+           to_firrtl_type(&node->input(i)->type()) << "}\n";
+  }
+  for (size_t i = 0; i < node->noutputs(); ++i) {
+    module << indent(2) << "output o" << i <<
+           ": {flip ready: UInt<1>, valid: UInt<1>, data: " <<
+           to_firrtl_type(&node->output(i)->type()) << "}\n";
+  }
+  if (has_mem_io) {
+    module << mem_io();
+  }
 
-	return module.str();
+  return module.str();
 }
 
-jlm::hls::FirrtlModule &
-jlm::hls::FirrtlHLS::mem_node_to_firrtl(const jlm::rvsdg::simple_node *n) {
-	std::string module_name = get_module_name(n);
-	std::ostringstream module;
-	module << module_header(n, true);
+FirrtlModule &
+FirrtlHLS::mem_node_to_firrtl(const jlm::rvsdg::simple_node *n) {
+  std::string module_name = get_module_name(n);
+  std::ostringstream module;
+  module << module_header(n, true);
 
-	bool store = dynamic_cast<const llvm::StoreOperation *>(&(n->operation()));
-	// registers
-	module << indent(2) << "; registers\n";
-	for (size_t i = 0; i < n->noutputs(); ++i) {
-		module << indent(2) << "reg o" << i << "_valid_reg: UInt<1>, clk with: (reset => (reset, "
-			   << UInt(1, 0)
-			   << "))\n";
-		module << indent(2) << "reg o" << i << "_data_reg: " << to_firrtl_type(&n->output(i)->type())
-			   << ", clk\n";
-	}
-	module << indent(2) << "reg sent_reg: UInt<1>, clk with: (reset => (reset, " << UInt(1, 0) << "))\n";
-	std::string can_request = "not(sent_reg)"; // only request again once previous request is finished
-	for (size_t i = 0; i < n->ninputs(); ++i) {
-		can_request = "and(" + can_request + ", " + valid(n->input(i)) + ")";
-	}
-	for (size_t i = 0; i < n->noutputs(); ++i) {
-		can_request = "and(" + can_request + ", not(o" + util::strfmt(i) + "_valid_reg))";
-	}
-	// block until all inputs and no outputs are valid
-	module << indent(2) << "node can_request = " << can_request << "\n";
+  bool store = dynamic_cast<const llvm::StoreOperation *>(&(n->operation()));
+  // registers
+  module << indent(2) << "; registers\n";
+  for (size_t i = 0; i < n->noutputs(); ++i) {
+    module << indent(2) << "reg o" << i << "_valid_reg: UInt<1>, clk with: (reset => (reset, "
+           << UInt(1, 0)
+           << "))\n";
+    module << indent(2) << "reg o" << i << "_data_reg: " << to_firrtl_type(&n->output(i)->type())
+           << ", clk\n";
+  }
+  module << indent(2) << "reg sent_reg: UInt<1>, clk with: (reset => (reset, " << UInt(1, 0) << "))\n";
+  std::string can_request = "not(sent_reg)"; // only request again once previous request is finished
+  for (size_t i = 0; i < n->ninputs(); ++i) {
+    can_request = "and(" + can_request + ", " + valid(n->input(i)) + ")";
+  }
+  for (size_t i = 0; i < n->noutputs(); ++i) {
+    can_request = "and(" + can_request + ", not(o" + util::strfmt(i) + "_valid_reg))";
+  }
+  // block until all inputs and no outputs are valid
+  module << indent(2) << "node can_request = " << can_request << "\n";
 
-	module << indent(2) << "; mem request\n";
-	module << indent(2) << "mem_req.valid <= can_request\n";
-	module << indent(2) << "mem_req.addr <= " << data(n->input(0)) << "\n";
-	int bit_width;
-	if (store) {
-		module << indent(2) << "mem_req.write <= " << UInt(1, 1) << "\n";
-		module << indent(2) << "mem_req.data <= " << data(n->input(1)) << "\n";
-		bit_width = dynamic_cast<const jlm::rvsdg::bittype *>(&n->input(1)->type())->nbits();
-	} else {
-		module << indent(2) << "mem_req.write <= " << UInt(1, 0) << "\n";
-		module << indent(2) << "mem_req.data is invalid\n";
-		if (auto bt = dynamic_cast<const jlm::rvsdg::bittype *>(&n->output(0)->type())) {
-			bit_width = bt->nbits();
-		} else if (dynamic_cast<const llvm::PointerType *>(&n->output(0)->type())) {
-			bit_width = 64;
-		} else {
-			throw util::error("unknown width for mem request");
-		}
-	}
-	int log2_bytes = log2(bit_width / 8);
-	module << indent(2) << "mem_req.width <= " << UInt(4, log2_bytes) << "\n";
-	module << indent(2) << "when mem_req.ready:\n";
-	module << indent(3) << "sent_reg <= " << UInt(1, 1) << "\n";
-	// set memstate
-	if (store) {
-		module << indent(3) << "o0_valid_reg <= " << UInt(1, 1) << "\n";
-		module << indent(3) << "o0_data_reg <= " << data(n->input(2)) << "\n";
-	} else {
-		module << indent(3) << "o1_valid_reg <= " << UInt(1, 1) << "\n";
-		module << indent(3) << "o1_data_reg <= " << data(n->input(1)) << "\n";
-	}
-	module << indent(2) << "; mem response\n";
-	module << indent(2) << "when and(sent_reg, mem_res.valid):\n";
-	module << indent(3) << "sent_reg <= " << UInt(1, 0) << "\n";
-	if (!store) {
-		module << indent(3) << "o0_valid_reg <= " << UInt(1, 1) << "\n";
-		module << indent(3) << "o0_data_reg <= mem_res.data\n";
-	}
-	// handshaking
-	module << indent(2) << "; handshaking\n";
-	// inputs are ready when mem interface accepts request (is ready)
-	for (size_t i = 0; i < n->ninputs(); ++i) {
-		module << indent(2) << ready(n->input(i)) << " <= mem_req.ready\n";
-	}
-	for (size_t i = 0; i < n->noutputs(); ++i) {
-		auto out = n->output(i);
-		module << indent(2) << valid(out) << " <= o" << i << "_valid_reg,\n";
-		module << indent(2) << data(out) << " <= o" << i << "_data_reg\n";
-		module << indent(2) << "when " << fire(out) << ":\n";
-		module << indent(3) << "o" << i << "_valid_reg <= " << UInt(1, 0) << "\n";
-	}
+  module << indent(2) << "; mem request\n";
+  module << indent(2) << "mem_req.valid <= can_request\n";
+  module << indent(2) << "mem_req.addr <= " << data(n->input(0)) << "\n";
+  int bit_width;
+  if (store) {
+    module << indent(2) << "mem_req.write <= " << UInt(1, 1) << "\n";
+    module << indent(2) << "mem_req.data <= " << data(n->input(1)) << "\n";
+    bit_width = dynamic_cast<const jlm::rvsdg::bittype *>(&n->input(1)->type())->nbits();
+  } else {
+    module << indent(2) << "mem_req.write <= " << UInt(1, 0) << "\n";
+    module << indent(2) << "mem_req.data is invalid\n";
+    if (auto bt = dynamic_cast<const jlm::rvsdg::bittype *>(&n->output(0)->type())) {
+      bit_width = bt->nbits();
+    } else if (dynamic_cast<const llvm::PointerType *>(&n->output(0)->type())) {
+      bit_width = 64;
+    } else {
+      throw util::error("unknown width for mem request");
+    }
+  }
+  int log2_bytes = log2(bit_width / 8);
+  module << indent(2) << "mem_req.width <= " << UInt(4, log2_bytes) << "\n";
+  module << indent(2) << "when mem_req.ready:\n";
+  module << indent(3) << "sent_reg <= " << UInt(1, 1) << "\n";
+  // set memstate
+  if (store) {
+    module << indent(3) << "o0_valid_reg <= " << UInt(1, 1) << "\n";
+    module << indent(3) << "o0_data_reg <= " << data(n->input(2)) << "\n";
+  } else {
+    module << indent(3) << "o1_valid_reg <= " << UInt(1, 1) << "\n";
+    module << indent(3) << "o1_data_reg <= " << data(n->input(1)) << "\n";
+  }
+  module << indent(2) << "; mem response\n";
+  module << indent(2) << "when and(sent_reg, mem_res.valid):\n";
+  module << indent(3) << "sent_reg <= " << UInt(1, 0) << "\n";
+  if (!store) {
+    module << indent(3) << "o0_valid_reg <= " << UInt(1, 1) << "\n";
+    module << indent(3) << "o0_data_reg <= mem_res.data\n";
+  }
+  // handshaking
+  module << indent(2) << "; handshaking\n";
+  // inputs are ready when mem interface accepts request (is ready)
+  for (size_t i = 0; i < n->ninputs(); ++i) {
+    module << indent(2) << ready(n->input(i)) << " <= mem_req.ready\n";
+  }
+  for (size_t i = 0; i < n->noutputs(); ++i) {
+    auto out = n->output(i);
+    module << indent(2) << valid(out) << " <= o" << i << "_valid_reg,\n";
+    module << indent(2) << data(out) << " <= o" << i << "_data_reg\n";
+    module << indent(2) << "when " << fire(out) << ":\n";
+    module << indent(3) << "o" << i << "_valid_reg <= " << UInt(1, 0) << "\n";
+  }
 
-	modules.emplace_back(&n->operation(), FirrtlModule{module_name, module.str(), true});
-	return modules.back().second;
+  modules.emplace_back(&n->operation(), FirrtlModule{module_name, module.str(), true});
+  return modules.back().second;
 }
 
-jlm::hls::FirrtlModule &
-jlm::hls::FirrtlHLS::pred_buffer_to_firrtl(const jlm::rvsdg::simple_node *n) {
-	std::string module_name = get_module_name(n);
-	std::ostringstream module;
-	module << module_header(n);
-	module << indent(2) << "; registers\n";
-	// start initialized with a valid pred 0
-	module << indent(2) << "reg buf_valid_reg: UInt<1>, clk with: (reset => (reset, " << UInt(1, 1)
-		   << "))\n";
-	module << indent(2) << "reg buf_data_reg: " << to_firrtl_type(&n->output(0)->type())
-		   << ", clk  with: (reset => (reset, " << UInt(1, 0) << "))\n";
-	auto o0 = n->output(0);
-	auto i0 = n->input(0);
-	module << indent(2) << valid(o0) << " <= or(buf_valid_reg, " << valid(i0) << ")\n";
-	module << indent(2) << data(o0) << " <= mux(buf_valid_reg, buf_data_reg, " << data(i0) << ")\n";
-	module << indent(2) << ready(i0) << " <= not(buf_valid_reg)\n";
-	module << indent(2) << "when " << fire(i0) << ":\n";
-	module << indent(3) << "buf_valid_reg <= " << UInt(1, 1) << "\n";
-	module << indent(3) << "buf_data_reg <= " << data(i0) << "\n";
-	module << indent(2) << "when " << fire(o0) << ":\n";
-	module << indent(3) << "buf_valid_reg <= " << UInt(1, 0) << "\n";
-	modules.emplace_back(&n->operation(), FirrtlModule{module_name, module.str(), false});
-	return modules.back().second;
+FirrtlModule &
+FirrtlHLS::pred_buffer_to_firrtl(const jlm::rvsdg::simple_node *n) {
+  std::string module_name = get_module_name(n);
+  std::ostringstream module;
+  module << module_header(n);
+  module << indent(2) << "; registers\n";
+  // start initialized with a valid pred 0
+  module << indent(2) << "reg buf_valid_reg: UInt<1>, clk with: (reset => (reset, " << UInt(1, 1)
+         << "))\n";
+  module << indent(2) << "reg buf_data_reg: " << to_firrtl_type(&n->output(0)->type())
+         << ", clk  with: (reset => (reset, " << UInt(1, 0) << "))\n";
+  auto o0 = n->output(0);
+  auto i0 = n->input(0);
+  module << indent(2) << valid(o0) << " <= or(buf_valid_reg, " << valid(i0) << ")\n";
+  module << indent(2) << data(o0) << " <= mux(buf_valid_reg, buf_data_reg, " << data(i0) << ")\n";
+  module << indent(2) << ready(i0) << " <= not(buf_valid_reg)\n";
+  module << indent(2) << "when " << fire(i0) << ":\n";
+  module << indent(3) << "buf_valid_reg <= " << UInt(1, 1) << "\n";
+  module << indent(3) << "buf_data_reg <= " << data(i0) << "\n";
+  module << indent(2) << "when " << fire(o0) << ":\n";
+  module << indent(3) << "buf_valid_reg <= " << UInt(1, 0) << "\n";
+  modules.emplace_back(&n->operation(), FirrtlModule{module_name, module.str(), false});
+  return modules.back().second;
 }
 
-jlm::hls::FirrtlModule &
-jlm::hls::FirrtlHLS::buffer_to_firrtl(const jlm::rvsdg::simple_node *n) {
-	std::string module_name = get_module_name(n);
-	std::ostringstream module;
-	module << module_header(n);
-	module << indent(2) << "; registers\n";
-	auto o = dynamic_cast<const hls::buffer_op *>(&(n->operation()));
-	auto capacity = o->capacity;
-	for (size_t i = 0; i < capacity; ++i) {
-		module << indent(2) << "reg buf" << i
-			   << "_valid_reg: UInt<1>, clk with: (reset => (reset, " << UInt(1, 0) << "))\n";
-		module << indent(2) << "reg buf" << i << "_data_reg: " << to_firrtl_type(&n->output(0)->type())
-			   << ", clk\n";
-	}
-	for (size_t i = 0; i <= capacity; ++i) {
-		module << indent(2) << "wire in_consumed" << i << ": UInt<1>\n";
-		module << indent(2) << "wire shift_out" << i << ": UInt<1>\n";
-	}
-	auto o0 = n->output(0);
-	// connect out to buf0
-	module << indent(2) << valid(o0) << " <= buf0_valid_reg\n";
-	module << indent(2) << data(o0) << " <= buf0_data_reg\n";
-	auto i0 = n->input(0);
-	// buf is ready if last one is empty
-	module << indent(2) << ready(i0) << " <= not(buf" << capacity - 1 << "_valid_reg)\n";
+FirrtlModule &
+FirrtlHLS::buffer_to_firrtl(const jlm::rvsdg::simple_node *n) {
+  std::string module_name = get_module_name(n);
+  std::ostringstream module;
+  module << module_header(n);
+  module << indent(2) << "; registers\n";
+  auto o = dynamic_cast<const hls::buffer_op *>(&(n->operation()));
+  auto capacity = o->capacity;
+  for (size_t i = 0; i < capacity; ++i) {
+    module << indent(2) << "reg buf" << i
+           << "_valid_reg: UInt<1>, clk with: (reset => (reset, " << UInt(1, 0) << "))\n";
+    module << indent(2) << "reg buf" << i << "_data_reg: " << to_firrtl_type(&n->output(0)->type())
+           << ", clk\n";
+  }
+  for (size_t i = 0; i <= capacity; ++i) {
+    module << indent(2) << "wire in_consumed" << i << ": UInt<1>\n";
+    module << indent(2) << "wire shift_out" << i << ": UInt<1>\n";
+  }
+  auto o0 = n->output(0);
+  // connect out to buf0
+  module << indent(2) << valid(o0) << " <= buf0_valid_reg\n";
+  module << indent(2) << data(o0) << " <= buf0_data_reg\n";
+  auto i0 = n->input(0);
+  // buf is ready if last one is empty
+  module << indent(2) << ready(i0) << " <= not(buf" << capacity - 1 << "_valid_reg)\n";
 
-	// shift register with insertion into earliest free slot
-	module << indent(2) << "shift_out0 <= " << fire(o0) << "\n";
-	module << indent(2) << "in_consumed0 <= " << UInt(1, 0) << "\n";
-	if(o->pass_through){
-		module << indent(2) << valid(o0) << " <= or(" << valid(i0) << ", buf0_valid_reg)\n";
-		module << indent(2) << "in_consumed0 <= and(not(buf0_valid_reg), "<<ready(o0)<<")\n";
-		module << indent(2) << "when not(buf0_valid_reg):\n";
-		module << indent(3) << data(o0) << " <= " << data(i0) << "\n";
-	}
-	// invalid pseudo slot so we can use the same logic for the last slot
-	module << indent(2) << "node buf" << capacity << "_valid_reg = " << UInt(1, 0) << "\n";
-	module << indent(2) << "node buf" << capacity << "_data_reg = " << UInt(1, 0) << "\n";
-	for (size_t i = 0; i < capacity; ++i) {
-		module << indent(2) << "node will_be_empty" << i << " = or(shift_out" << i << ", not(buf" << i
-			   << "_valid_reg))\n";
-		module << indent(2) << "in_consumed" << i + 1 << " <= in_consumed" << i << "\n";
-		module << indent(2) << "node in_available" << i << " = and(" << fire(i0) << ", not(in_consumed" << i
-			   << "))\n";
-		module << indent(2) << "shift_out" << i + 1 << " <= " << UInt(1, 0) << "\n";
-		module << indent(2) << "when shift_out" << i << ":\n";
-		module << indent(3) << "buf" << i << "_valid_reg <= " << UInt(1, 0) << "\n";
-		module << indent(2) << "when will_be_empty" << i << ":\n";
-		module << indent(3) << "when buf" << i + 1 << "_valid_reg:\n";
-		module << indent(4) << "buf" << i << "_valid_reg <= " << UInt(1, 1) << "\n";
-		module << indent(4) << "buf" << i << "_data_reg <= buf" << i + 1 << "_data_reg\n";
-		module << indent(4) << "shift_out" << i + 1 << " <= " << UInt(1, 1) << "\n";
-		module << indent(3) << "else when in_available" << i << ":\n";
-		module << indent(4) << "in_consumed" << i + 1 << " <= " << UInt(1, 1) << "\n";
-		module << indent(4) << "buf" << i << "_valid_reg <= " << UInt(1, 1) << "\n";
-		module << indent(4) << "buf" << i << "_data_reg <= " << data(i0) << "\n";
+  // shift register with insertion into earliest free slot
+  module << indent(2) << "shift_out0 <= " << fire(o0) << "\n";
+  module << indent(2) << "in_consumed0 <= " << UInt(1, 0) << "\n";
+  if (o->pass_through) {
+    module << indent(2) << valid(o0) << " <= or(" << valid(i0) << ", buf0_valid_reg)\n";
+    module << indent(2) << "in_consumed0 <= and(not(buf0_valid_reg), " << ready(o0) << ")\n";
+    module << indent(2) << "when not(buf0_valid_reg):\n";
+    module << indent(3) << data(o0) << " <= " << data(i0) << "\n";
+  }
+  // invalid pseudo slot so we can use the same logic for the last slot
+  module << indent(2) << "node buf" << capacity << "_valid_reg = " << UInt(1, 0) << "\n";
+  module << indent(2) << "node buf" << capacity << "_data_reg = " << UInt(1, 0) << "\n";
+  for (size_t i = 0; i < capacity; ++i) {
+    module << indent(2) << "node will_be_empty" << i << " = or(shift_out" << i << ", not(buf" << i
+           << "_valid_reg))\n";
+    module << indent(2) << "in_consumed" << i + 1 << " <= in_consumed" << i << "\n";
+    module << indent(2) << "node in_available" << i << " = and(" << fire(i0) << ", not(in_consumed" << i
+           << "))\n";
+    module << indent(2) << "shift_out" << i + 1 << " <= " << UInt(1, 0) << "\n";
+    module << indent(2) << "when shift_out" << i << ":\n";
+    module << indent(3) << "buf" << i << "_valid_reg <= " << UInt(1, 0) << "\n";
+    module << indent(2) << "when will_be_empty" << i << ":\n";
+    module << indent(3) << "when buf" << i + 1 << "_valid_reg:\n";
+    module << indent(4) << "buf" << i << "_valid_reg <= " << UInt(1, 1) << "\n";
+    module << indent(4) << "buf" << i << "_data_reg <= buf" << i + 1 << "_data_reg\n";
+    module << indent(4) << "shift_out" << i + 1 << " <= " << UInt(1, 1) << "\n";
+    module << indent(3) << "else when in_available" << i << ":\n";
+    module << indent(4) << "in_consumed" << i + 1 << " <= " << UInt(1, 1) << "\n";
+    module << indent(4) << "buf" << i << "_valid_reg <= " << UInt(1, 1) << "\n";
+    module << indent(4) << "buf" << i << "_data_reg <= " << data(i0) << "\n";
 
-	}
-	modules.emplace_back(&n->operation(), FirrtlModule{module_name, module.str(), false});
-	return modules.back().second;
+  }
+  modules.emplace_back(&n->operation(), FirrtlModule{module_name, module.str(), false});
+  return modules.back().second;
 }
 
-jlm::hls::FirrtlModule &
-jlm::hls::FirrtlHLS::ndmux_to_firrtl(const jlm::rvsdg::simple_node *n) {
-	std::string module_name = get_module_name(n);
-	std::ostringstream module;
-	module << module_header(n);
+FirrtlModule &
+FirrtlHLS::ndmux_to_firrtl(const jlm::rvsdg::simple_node *n) {
+  std::string module_name = get_module_name(n);
+  std::ostringstream module;
+  module << module_header(n);
 
-	auto ipred = n->input(0);
-	auto o0 = n->output(0);
+  auto ipred = n->input(0);
+  auto o0 = n->output(0);
 
-	module << indent(2) << valid(o0) << " <= " << UInt(1, 0) << "\n";
-	module << indent(2) << data(o0) << " is invalid\n";
-	module << indent(2) << ready(ipred) << " <= " << UInt(1, 0) << "\n";
+  module << indent(2) << valid(o0) << " <= " << UInt(1, 0) << "\n";
+  module << indent(2) << data(o0) << " is invalid\n";
+  module << indent(2) << ready(ipred) << " <= " << UInt(1, 0) << "\n";
 
-	for (size_t i = 1; i < n->ninputs(); ++i) {
-		auto in = n->input(i);
-		module << indent(2) << ready(in) << " <= " << UInt(1, 0) << "\n";
-		module << indent(2) << "when and(" << valid(ipred) << ", eq(" << data(ipred) << ", "
-			   << UInt(64, i - 1)
-			   << ")):\n";
-		module << indent(3) << valid(o0) << " <= " << valid(in) << "\n";
-		module << indent(3) << data(o0) << " <= " << data(in) << "\n";
-		module << indent(3) << ready(in) << " <= " << ready(o0) << "\n";
-		module << indent(3) << ready(ipred) << " <= and(" << ready(o0) << "," << valid(in) << ")\n";
-	}
-	modules.emplace_back(&n->operation(), FirrtlModule{module_name, module.str(), false});
-	return modules.back().second;
+  for (size_t i = 1; i < n->ninputs(); ++i) {
+    auto in = n->input(i);
+    module << indent(2) << ready(in) << " <= " << UInt(1, 0) << "\n";
+    module << indent(2) << "when and(" << valid(ipred) << ", eq(" << data(ipred) << ", "
+           << UInt(64, i - 1)
+           << ")):\n";
+    module << indent(3) << valid(o0) << " <= " << valid(in) << "\n";
+    module << indent(3) << data(o0) << " <= " << data(in) << "\n";
+    module << indent(3) << ready(in) << " <= " << ready(o0) << "\n";
+    module << indent(3) << ready(ipred) << " <= and(" << ready(o0) << "," << valid(in) << ")\n";
+  }
+  modules.emplace_back(&n->operation(), FirrtlModule{module_name, module.str(), false});
+  return modules.back().second;
 }
 
-jlm::hls::FirrtlModule &
-jlm::hls::FirrtlHLS::dmux_to_firrtl(const jlm::rvsdg::simple_node *n) {
-	std::string module_name = get_module_name(n);
-	std::ostringstream module;
-	module << module_header(n);
+FirrtlModule &
+FirrtlHLS::dmux_to_firrtl(const jlm::rvsdg::simple_node *n) {
+  std::string module_name = get_module_name(n);
+  std::ostringstream module;
+  module << module_header(n);
 
-	auto ipred = n->input(0);
-	auto o0 = n->output(0);
+  auto ipred = n->input(0);
+  auto o0 = n->output(0);
 
-	std::string any_discard_reg = UInt(1, 0);
-	for (size_t i = 1; i < n->ninputs(); ++i) {
-		// discard and discard_reg are separate in order to allow tokens to be discarded in the same cycle.
-		module << indent(2) << "reg i" << i << "_discard_reg: UInt<1>, clk with: (reset => (reset, " << UInt(1, 0)
-			   << "))\n";
-		module << indent(2) << "wire i" << i << "_discard: UInt<1>\n";
-		module << indent(2) << "i" << i << "_discard <= i" << i << "_discard_reg\n";
-		module << indent(2) << "i" << i << "_discard_reg <= i" << i << "_discard\n";
-		any_discard_reg = util::strfmt("or(", any_discard_reg, ", i", i, "_discard_reg)");
-	}
-	module << indent(2) << "node any_discard_reg = " << any_discard_reg << "\n";
-	module << indent(2) << "reg processed_reg: UInt<1>, clk with: (reset => (reset, " << UInt(1, 0) << "))\n";
-	module << indent(2) << valid(o0) << " <= " << UInt(1, 0) << "\n";
-	module << indent(2) << data(o0) << " is invalid\n";
-	module << indent(2) << ready(ipred) << " <= " << UInt(1, 0) << "\n";
+  std::string any_discard_reg = UInt(1, 0);
+  for (size_t i = 1; i < n->ninputs(); ++i) {
+    // discard and discard_reg are separate in order to allow tokens to be discarded in the same cycle.
+    module << indent(2) << "reg i" << i << "_discard_reg: UInt<1>, clk with: (reset => (reset, " << UInt(1, 0)
+           << "))\n";
+    module << indent(2) << "wire i" << i << "_discard: UInt<1>\n";
+    module << indent(2) << "i" << i << "_discard <= i" << i << "_discard_reg\n";
+    module << indent(2) << "i" << i << "_discard_reg <= i" << i << "_discard\n";
+    any_discard_reg = util::strfmt("or(", any_discard_reg, ", i", i, "_discard_reg)");
+  }
+  module << indent(2) << "node any_discard_reg = " << any_discard_reg << "\n";
+  module << indent(2) << "reg processed_reg: UInt<1>, clk with: (reset => (reset, " << UInt(1, 0) << "))\n";
+  module << indent(2) << valid(o0) << " <= " << UInt(1, 0) << "\n";
+  module << indent(2) << data(o0) << " is invalid\n";
+  module << indent(2) << ready(ipred) << " <= " << UInt(1, 0) << "\n";
 
 
-	for (size_t i = 1; i < n->ninputs(); ++i) {
-		auto in = n->input(i);
-		module << indent(2) << ready(in) << " <= i" << i << "_discard\n";
-		// clear discard reg on fire
-		module << indent(2) << "when " << fire(in) << ":\n";
-		module << indent(3) << "i" << i << "_discard_reg <= " << UInt(1, 0) << "\n";
-		// pred match and no outstanding discards
-		module << indent(2) << "when and(and(" << valid(ipred) << ", eq(" << data(ipred)
-			   << ", "
-			   << UInt(64, i - 1)
-			   << ")), not(any_discard_reg)):\n";
-		module << indent(3) << valid(o0) << " <= " << valid(in) << "\n";
-		module << indent(3) << data(o0) << " <= " << data(in) << "\n";
-		module << indent(3) << ready(in) << " <= " << ready(o0) << "\n";
-		module << indent(3) << ready(ipred) << " <= and(" << ready(o0) << "," << valid(in) << ")\n";
-		module << indent(3) << "when not(processed_reg):\n";
-		for (size_t j = 1; j < n->ninputs(); ++j) {
-			if (i != j) {
-				module << indent(4) << "i" << j << "_discard <= " << UInt(1, 1) << "\n";
-			}
-		}
-		module << indent(4) << "processed_reg <= " << UInt(1, 1) << "\n";
-	}
-	module << indent(2) << "when " << fire(o0) << ":\n";
-	module << indent(3) << "processed_reg <= " << UInt(1, 0) << "\n";
-	modules.emplace_back(&n->operation(), FirrtlModule{module_name, module.str(), false});
-	return modules.back().second;
+  for (size_t i = 1; i < n->ninputs(); ++i) {
+    auto in = n->input(i);
+    module << indent(2) << ready(in) << " <= i" << i << "_discard\n";
+    // clear discard reg on fire
+    module << indent(2) << "when " << fire(in) << ":\n";
+    module << indent(3) << "i" << i << "_discard_reg <= " << UInt(1, 0) << "\n";
+    // pred match and no outstanding discards
+    module << indent(2) << "when and(and(" << valid(ipred) << ", eq(" << data(ipred)
+           << ", "
+           << UInt(64, i - 1)
+           << ")), not(any_discard_reg)):\n";
+    module << indent(3) << valid(o0) << " <= " << valid(in) << "\n";
+    module << indent(3) << data(o0) << " <= " << data(in) << "\n";
+    module << indent(3) << ready(in) << " <= " << ready(o0) << "\n";
+    module << indent(3) << ready(ipred) << " <= and(" << ready(o0) << "," << valid(in) << ")\n";
+    module << indent(3) << "when not(processed_reg):\n";
+    for (size_t j = 1; j < n->ninputs(); ++j) {
+      if (i != j) {
+        module << indent(4) << "i" << j << "_discard <= " << UInt(1, 1) << "\n";
+      }
+    }
+    module << indent(4) << "processed_reg <= " << UInt(1, 1) << "\n";
+  }
+  module << indent(2) << "when " << fire(o0) << ":\n";
+  module << indent(3) << "processed_reg <= " << UInt(1, 0) << "\n";
+  modules.emplace_back(&n->operation(), FirrtlModule{module_name, module.str(), false});
+  return modules.back().second;
 }
 
-jlm::hls::FirrtlModule &
-jlm::hls::FirrtlHLS::merge_to_firrtl(const jlm::rvsdg::simple_node *n) {
-	std::string module_name = get_module_name(n);
-	std::ostringstream module;
-	module << module_header(n);
-	auto o0 = n->output(0);
+FirrtlModule &
+FirrtlHLS::merge_to_firrtl(const jlm::rvsdg::simple_node *n) {
+  std::string module_name = get_module_name(n);
+  std::ostringstream module;
+  module << module_header(n);
+  auto o0 = n->output(0);
 
-	module << indent(2) << valid(o0) << " <= " << UInt(1, 0) << "\n";
-	module << indent(2) << data(o0) << " is invalid\n";
+  module << indent(2) << valid(o0) << " <= " << UInt(1, 0) << "\n";
+  module << indent(2) << data(o0) << " is invalid\n";
 
 
-	for (size_t i = 0; i < n->ninputs(); ++i) {
-		auto in = n->input(i);
-		module << indent(2) << ready(in) << " <= " << ready(o0) << "\n";
-		module << indent(2) << "when " << valid(in) << ":\n";
-		module << indent(3) << valid(o0) << " <= " << valid(in) << "\n";
-		module << indent(3) << data(o0) << " <= " << data(in) << "\n";
-	}
-	modules.emplace_back(&n->operation(), FirrtlModule{module_name, module.str(), false});
-	return modules.back().second;
+  for (size_t i = 0; i < n->ninputs(); ++i) {
+    auto in = n->input(i);
+    module << indent(2) << ready(in) << " <= " << ready(o0) << "\n";
+    module << indent(2) << "when " << valid(in) << ":\n";
+    module << indent(3) << valid(o0) << " <= " << valid(in) << "\n";
+    module << indent(3) << data(o0) << " <= " << data(in) << "\n";
+  }
+  modules.emplace_back(&n->operation(), FirrtlModule{module_name, module.str(), false});
+  return modules.back().second;
 }
 
-jlm::hls::FirrtlModule &
-jlm::hls::FirrtlHLS::fork_to_firrtl(const jlm::rvsdg::simple_node *n) {
-	std::string module_name = get_module_name(n);
-	std::ostringstream module;
-	module << module_header(n);
+FirrtlModule &
+FirrtlHLS::fork_to_firrtl(const jlm::rvsdg::simple_node *n) {
+  std::string module_name = get_module_name(n);
+  std::ostringstream module;
+  module << module_header(n);
 
-	module << indent(2) << "; registers\n";
-	for (size_t i = 0; i < n->noutputs(); ++i) {
-		module << indent(2) << "reg out" << i
-			   << "_fired: UInt<1>, clk with: (reset => (reset, " << UInt(1, 0) << "))\n";
-	}
+  module << indent(2) << "; registers\n";
+  for (size_t i = 0; i < n->noutputs(); ++i) {
+    module << indent(2) << "reg out" << i
+           << "_fired: UInt<1>, clk with: (reset => (reset, " << UInt(1, 0) << "))\n";
+  }
 
-	auto i0 = n->input(0);
-	std::string all_fired = UInt(1, 1); // True by default
-	for (size_t i = 0; i < n->noutputs(); ++i) {
-		auto out = n->output(i);
-		module << indent(2) << valid(out) << " <= and(" << valid(i0) << ", not(out" << i << "_fired))\n";
-		module << indent(2) << data(out) << " <= " << data(i0) << "\n";
-		all_fired =
-				"and(" + all_fired + ", or(" + ready(out) + ", out" + util::strfmt(i) + "_fired))";
-	}
-	module << indent(2) << "node all_fired = " << all_fired << "\n";
-	module << indent(2) << ready(i0) << " <= all_fired\n";
-	module << indent(2) << "when not(all_fired):\n";
-	for (size_t i = 0; i < n->noutputs(); ++i) {
-		module << indent(3) << "when " << fire(n->output(i)) << ":\n";
-		module << indent(4) << "out" << i << "_fired <= " << UInt(1, 1) << "\n";
-	}
-	module << indent(2) << "else:\n";
-	for (size_t i = 0; i < n->noutputs(); ++i) {
-		module << indent(3) << "out" << i << "_fired <= " << UInt(1, 0) << "\n";
-	}
-	modules.emplace_back(&n->operation(), FirrtlModule{module_name, module.str(), false});
-	return modules.back().second;
+  auto i0 = n->input(0);
+  std::string all_fired = UInt(1, 1); // True by default
+  for (size_t i = 0; i < n->noutputs(); ++i) {
+    auto out = n->output(i);
+    module << indent(2) << valid(out) << " <= and(" << valid(i0) << ", not(out" << i << "_fired))\n";
+    module << indent(2) << data(out) << " <= " << data(i0) << "\n";
+    all_fired =
+      "and(" + all_fired + ", or(" + ready(out) + ", out" + util::strfmt(i) + "_fired))";
+  }
+  module << indent(2) << "node all_fired = " << all_fired << "\n";
+  module << indent(2) << ready(i0) << " <= all_fired\n";
+  module << indent(2) << "when not(all_fired):\n";
+  for (size_t i = 0; i < n->noutputs(); ++i) {
+    module << indent(3) << "when " << fire(n->output(i)) << ":\n";
+    module << indent(4) << "out" << i << "_fired <= " << UInt(1, 1) << "\n";
+  }
+  module << indent(2) << "else:\n";
+  for (size_t i = 0; i < n->noutputs(); ++i) {
+    module << indent(3) << "out" << i << "_fired <= " << UInt(1, 0) << "\n";
+  }
+  modules.emplace_back(&n->operation(), FirrtlModule{module_name, module.str(), false});
+  return modules.back().second;
 }
 
-jlm::hls::FirrtlModule &
-jlm::hls::FirrtlHLS::sink_to_firrtl(const jlm::rvsdg::simple_node *n) {
-	std::string module_name = get_module_name(n);
-	std::ostringstream module;
-	module << module_header(n);
-	auto i0 = n->input(0);
-	module << indent(2) << ready(i0) << " <= " << UInt(1, 1) << "\n";
+FirrtlModule &
+FirrtlHLS::sink_to_firrtl(const jlm::rvsdg::simple_node *n) {
+  std::string module_name = get_module_name(n);
+  std::ostringstream module;
+  module << module_header(n);
+  auto i0 = n->input(0);
+  module << indent(2) << ready(i0) << " <= " << UInt(1, 1) << "\n";
 
-	modules.emplace_back(&n->operation(), FirrtlModule{module_name, module.str(), false});
-	return modules.back().second;
+  modules.emplace_back(&n->operation(), FirrtlModule{module_name, module.str(), false});
+  return modules.back().second;
 }
 
 
-jlm::hls::FirrtlModule &
-jlm::hls::FirrtlHLS::print_to_firrtl(const jlm::rvsdg::simple_node *n) {
-	auto pn = dynamic_cast<const jlm::hls::print_op *>(&n->operation());
-	std::string module_name = get_module_name(n);
-	std::ostringstream module;
-	module << module_header(n);
-	auto i0 = n->input(0);
-	auto o0 = n->output(0);
-	module << indent(2) << " ; " << n->operation().debug_string() << "\n";
-	module << indent(2) << data(o0) << " <= " << data(i0);
-	// handshaking
-	module << indent(2) + "; handshaking" + "\n";
+FirrtlModule &
+FirrtlHLS::print_to_firrtl(const jlm::rvsdg::simple_node *n) {
+  auto pn = dynamic_cast<const print_op *>(&n->operation());
+  std::string module_name = get_module_name(n);
+  std::ostringstream module;
+  module << module_header(n);
+  auto i0 = n->input(0);
+  auto o0 = n->output(0);
+  module << indent(2) << " ; " << n->operation().debug_string() << "\n";
+  module << indent(2) << data(o0) << " <= " << data(i0);
+  // handshaking
+  module << indent(2) + "; handshaking" + "\n";
 
-	module << indent(2) << valid(o0) << " <= " << valid(i0) << "\n";
-	module << indent(2) << ready(i0) << " <= " << ready(o0) << "\n";
-	module << indent(2) << "printf(clk, and(" << fire(i0) << ", not(reset)), \"print node " << pn->id() << ": %x\\n\", pad("
-		   << data(i0)
-		   << ", 64))\n";
+  module << indent(2) << valid(o0) << " <= " << valid(i0) << "\n";
+  module << indent(2) << ready(i0) << " <= " << ready(o0) << "\n";
+  module << indent(2) << "printf(clk, and(" << fire(i0) << ", not(reset)), \"print node " << pn->id()
+         << ": %x\\n\", pad("
+         << data(i0)
+         << ", 64))\n";
 
 
-	modules.emplace_back(&n->operation(), FirrtlModule{module_name, module.str(), false});
-	return modules.back().second;
+  modules.emplace_back(&n->operation(), FirrtlModule{module_name, module.str(), false});
+  return modules.back().second;
 }
 
-jlm::hls::FirrtlModule &
-jlm::hls::FirrtlHLS::branch_to_firrtl(const jlm::rvsdg::simple_node *n) {
-	std::string module_name = get_module_name(n);
-	std::ostringstream module;
-	module << module_header(n);
+FirrtlModule &
+FirrtlHLS::branch_to_firrtl(const jlm::rvsdg::simple_node *n) {
+  std::string module_name = get_module_name(n);
+  std::ostringstream module;
+  module << module_header(n);
 
-	auto ipred = n->input(0);
-	auto ival = n->input(1);
+  auto ipred = n->input(0);
+  auto ival = n->input(1);
 
-	module << indent(2) << ready(ival) << " <= " << UInt(1, 0) << "\n";
-	module << indent(2) << ready(ipred) << " <= " << UInt(1, 0) << "\n";
-	for (size_t i = 0; i < n->noutputs(); ++i) {
-		auto out = n->output(i);
-		module << indent(2) << valid(out) << " <= " << UInt(1, 0) << "\n";
-		module << indent(2) << data(out) << " is invalid\n";
-		module << indent(2) << "when and(" << valid(ipred) << ", eq(" << data(ipred) << ", " + UInt(64, i)
-			   << ")):\n";
-		module << indent(3) << ready(ival) << " <= " << ready(out) << "\n";
-		module << indent(3) << ready(ipred) << " <= and(" << ready(out) << "," << valid(ival) << ")\n";
-		module << indent(3) << valid(out) << " <= " << valid(ival) << "\n";
-		module << indent(3) << data(out) << " <= " << data(ival) << "\n";
-	}
-	modules.emplace_back(&n->operation(), FirrtlModule{module_name, module.str(), false});
-	return modules.back().second;
+  module << indent(2) << ready(ival) << " <= " << UInt(1, 0) << "\n";
+  module << indent(2) << ready(ipred) << " <= " << UInt(1, 0) << "\n";
+  for (size_t i = 0; i < n->noutputs(); ++i) {
+    auto out = n->output(i);
+    module << indent(2) << valid(out) << " <= " << UInt(1, 0) << "\n";
+    module << indent(2) << data(out) << " is invalid\n";
+    module << indent(2) << "when and(" << valid(ipred) << ", eq(" << data(ipred) << ", " + UInt(64, i)
+           << ")):\n";
+    module << indent(3) << ready(ival) << " <= " << ready(out) << "\n";
+    module << indent(3) << ready(ipred) << " <= and(" << ready(out) << "," << valid(ival) << ")\n";
+    module << indent(3) << valid(out) << " <= " << valid(ival) << "\n";
+    module << indent(3) << data(out) << " <= " << data(ival) << "\n";
+  }
+  modules.emplace_back(&n->operation(), FirrtlModule{module_name, module.str(), false});
+  return modules.back().second;
 }
 
-jlm::hls::FirrtlModule &
-jlm::hls::FirrtlHLS::trigger_to_firrtl(const jlm::rvsdg::simple_node *n) {
-	std::string module_name = get_module_name(n);
-	std::ostringstream module;
-	module << module_header(n);
+FirrtlModule &
+FirrtlHLS::trigger_to_firrtl(const jlm::rvsdg::simple_node *n) {
+  std::string module_name = get_module_name(n);
+  std::ostringstream module;
+  module << module_header(n);
 
-	auto itrig = n->input(0);
-	auto ival = n->input(1);
-	auto out = n->output(0);
-	// inputs have to both fire at the same time
-	module << indent(2) << ready(itrig) << " <= and(" << ready(out) << "," << valid(ival) << ")\n";
-	module << indent(2) << ready(ival) << " <= and(" << ready(out) << "," << valid(itrig) << ")\n";
-	module << indent(2) << valid(out) << " <= and(" << valid(ival) << "," << valid(itrig) << ")\n";
-	module << indent(2) << data(out) << " <= " << data(ival) << "\n";
-	modules.emplace_back(&n->operation(), FirrtlModule{module_name, module.str(), false});
-	return modules.back().second;
+  auto itrig = n->input(0);
+  auto ival = n->input(1);
+  auto out = n->output(0);
+  // inputs have to both fire at the same time
+  module << indent(2) << ready(itrig) << " <= and(" << ready(out) << "," << valid(ival) << ")\n";
+  module << indent(2) << ready(ival) << " <= and(" << ready(out) << "," << valid(itrig) << ")\n";
+  module << indent(2) << valid(out) << " <= and(" << valid(ival) << "," << valid(itrig) << ")\n";
+  module << indent(2) << data(out) << " <= " << data(ival) << "\n";
+  modules.emplace_back(&n->operation(), FirrtlModule{module_name, module.str(), false});
+  return modules.back().second;
 }
 
 
 int
-jlm::hls::jlm_sizeof(const jlm::rvsdg::type *t) {
-	if (auto bt = dynamic_cast<const jlm::rvsdg::bittype *>(t)) {
-		return bt->nbits();
-	} else if (auto at = dynamic_cast<const llvm::arraytype *>(t)) {
-		return jlm_sizeof(&at->element_type()) * at->nelements();
-	} else if ( dynamic_cast<const llvm::PointerType *>(t)) {
-		return 64;
-	} else if (auto ct = dynamic_cast<const jlm::rvsdg::ctltype *>(t)) {
-		return ceil(log2(ct->nalternatives()));
-	} else if (dynamic_cast<const jlm::rvsdg::statetype *>(t)) {
-		return 1;
-	} else {
-		throw std::logic_error(t->debug_string() + " size of not implemented!");
-	}
+jlm_sizeof(const jlm::rvsdg::type *t) {
+  if (auto bt = dynamic_cast<const jlm::rvsdg::bittype *>(t)) {
+    return bt->nbits();
+  } else if (auto at = dynamic_cast<const llvm::arraytype *>(t)) {
+    return jlm_sizeof(&at->element_type()) * at->nelements();
+  } else if (dynamic_cast<const llvm::PointerType *>(t)) {
+    return 64;
+  } else if (auto ct = dynamic_cast<const jlm::rvsdg::ctltype *>(t)) {
+    return ceil(log2(ct->nalternatives()));
+  } else if (dynamic_cast<const jlm::rvsdg::statetype *>(t)) {
+    return 1;
+  } else {
+    throw std::logic_error(t->debug_string() + " size of not implemented!");
+  }
 }
 
 std::string
-jlm::hls::FirrtlHLS::gep_op_to_firrtl(const jlm::rvsdg::simple_node *n) {
-	auto o = dynamic_cast<const llvm::GetElementPtrOperation *>(&(n->operation()));
-	std::string result = "cvt("+data(n->input(0))+")"; // start of with base pointer
-	//TODO: support structs
-	const jlm::rvsdg::type *pt = &o->GetPointeeType();
-	for (size_t i = 1; i < n->ninputs(); ++i) {
-		int bits = jlm_sizeof(pt);
-		if (dynamic_cast<const jlm::rvsdg::bittype *>(pt)) { ;
-		} else if (auto at = dynamic_cast<const llvm::arraytype *>(pt)) {
-			pt = &at->element_type();
-		} else {
-			throw std::logic_error(pt->debug_string() + " pointer not implemented!");
-		}
-		int bytes = bits / 8;
-		// gep inputs are signed
-		auto offset = "mul(asSInt(" + data(n->input(i)) + "), cvt(" + UInt(64, bytes) + "))";
-		result = "add(" + result + ", " + offset + ")";
-	}
-	return "asUInt("+result+")";
+FirrtlHLS::gep_op_to_firrtl(const jlm::rvsdg::simple_node *n) {
+  auto o = dynamic_cast<const llvm::GetElementPtrOperation *>(&(n->operation()));
+  std::string result = "cvt(" + data(n->input(0)) + ")"; // start of with base pointer
+  //TODO: support structs
+  const jlm::rvsdg::type *pt = &o->GetPointeeType();
+  for (size_t i = 1; i < n->ninputs(); ++i) {
+    int bits = jlm_sizeof(pt);
+    if (dynamic_cast<const jlm::rvsdg::bittype *>(pt)) { ;
+    } else if (auto at = dynamic_cast<const llvm::arraytype *>(pt)) {
+      pt = &at->element_type();
+    } else {
+      throw std::logic_error(pt->debug_string() + " pointer not implemented!");
+    }
+    int bytes = bits / 8;
+    // gep inputs are signed
+    auto offset = "mul(asSInt(" + data(n->input(i)) + "), cvt(" + UInt(64, bytes) + "))";
+    result = "add(" + result + ", " + offset + ")";
+  }
+  return "asUInt(" + result + ")";
 
 }
 
 std::string
-jlm::hls::FirrtlHLS::match_op_to_firrtl(const jlm::rvsdg::simple_node *n) {
-	std::string result;
-	auto o = dynamic_cast<const jlm::rvsdg::match_op *>(&(n->operation()));
-	JLM_ASSERT(o);
-	if (is_identity_mapping(*o)) {
-		return data(n->input(0));
-	} else {
-		result = UInt(64, o->default_alternative());
-		//TODO: optimize?
-		for (auto it = o->begin(); it != o->end(); it++) {
-			result = "mux(eq(" + UInt(64, it->first) + ", " + data(n->input(0)) + "), " + UInt(64, it->second) + ", " +
-					 result + ")";
-		}
-	}
-	return result;
+FirrtlHLS::match_op_to_firrtl(const jlm::rvsdg::simple_node *n) {
+  std::string result;
+  auto o = dynamic_cast<const jlm::rvsdg::match_op *>(&(n->operation()));
+  JLM_ASSERT(o);
+  if (is_identity_mapping(*o)) {
+    return data(n->input(0));
+  } else {
+    result = UInt(64, o->default_alternative());
+    //TODO: optimize?
+    for (auto it = o->begin(); it != o->end(); it++) {
+      result = "mux(eq(" + UInt(64, it->first) + ", " + data(n->input(0)) + "), " + UInt(64, it->second) + ", " +
+               result + ")";
+    }
+  }
+  return result;
 }
 
 std::string
-jlm::hls::FirrtlHLS::simple_op_to_firrtl(const jlm::rvsdg::simple_node *n) {
-	if (dynamic_cast<const jlm::rvsdg::match_op *>(&(n->operation()))) {
-		return match_op_to_firrtl(n);
-	} else if (dynamic_cast<const jlm::rvsdg::bitsgt_op *>(&(n->operation()))) {
-		return "gt(asSInt(" + data(n->input(0)) + "), asSInt(" + data(n->input(1)) + "))";
-	} else if (dynamic_cast<const jlm::rvsdg::bitsge_op *>(&(n->operation()))) {
-		return "geq(asSInt(" + data(n->input(0)) + "), asSInt(" + data(n->input(1)) + "))";
-	} else if (dynamic_cast<const jlm::rvsdg::bitsle_op *>(&(n->operation()))) {
-		return "leq(asSInt(" + data(n->input(0)) + "), asSInt(" + data(n->input(1)) + "))";
-	} else if (auto o = dynamic_cast<const llvm::sext_op *>(&(n->operation()))) {
-		return "asUInt(pad(asSInt(" + data(n->input(0)) + "), " + util::strfmt(o->ndstbits()) +
-			   "))";
-	} else if (dynamic_cast<const llvm::trunc_op *>(&(n->operation()))) {
-		return data(n->input(0));
-	} else if (dynamic_cast<const llvm::bitcast_op *>(&(n->operation()))) {
-		return data(n->input(0));
-	} else if (dynamic_cast<const llvm::zext_op *>(&(n->operation()))) {
-		return data(n->input(0));
-	} else if (dynamic_cast<const jlm::rvsdg::bitugt_op *>(&(n->operation()))) {
-		return "gt(" + data(n->input(0)) + ", " + data(n->input(1)) + ")";
-	} else if (dynamic_cast<const jlm::rvsdg::bitult_op *>(&(n->operation()))) {
-		return "lt(" + data(n->input(0)) + ", " + data(n->input(1)) + ")";
-	} else if (dynamic_cast<const jlm::rvsdg::bitslt_op *>(&(n->operation()))) {
-		return "lt(asSInt(" + data(n->input(0)) + "), asSInt(" + data(n->input(1)) + "))";
-	} else if (dynamic_cast<const jlm::rvsdg::biteq_op *>(&(n->operation()))) {
-		return "eq(" + data(n->input(0)) + ", " + data(n->input(1)) + ")";
-	} else if (dynamic_cast<const jlm::rvsdg::bitadd_op *>(&(n->operation()))) {
-		return "add(" + data(n->input(0)) + ", " + data(n->input(1)) + ")";
-	} else if (dynamic_cast<const jlm::rvsdg::bitmul_op *>(&(n->operation()))) {
-		return "mul(" + data(n->input(0)) + ", " + data(n->input(1)) + ")";
-	} else if (dynamic_cast<const jlm::rvsdg::bitsub_op *>(&(n->operation()))) {
-		return "sub(" + data(n->input(0)) + ", " + data(n->input(1)) + ")";
-	} else if (dynamic_cast<const jlm::rvsdg::bitand_op *>(&(n->operation()))) {
-		return "and(" + data(n->input(0)) + ", " + data(n->input(1)) + ")";
-	} else if (dynamic_cast<const jlm::rvsdg::bitxor_op *>(&(n->operation()))) {
-		return "xor(" + data(n->input(0)) + ", " + data(n->input(1)) + ")";
-	} else if (dynamic_cast<const jlm::rvsdg::bitor_op *>(&(n->operation()))) {
-		return "or(" + data(n->input(0)) + ", " + data(n->input(1)) + ")";
-	} else if (dynamic_cast<const jlm::rvsdg::bitshr_op *>(&(n->operation()))) {
-		//TODO: automatic conversion to static shift?
-		return "dshr(" + data(n->input(0)) + ", " + data(n->input(1)) + ")";
-	} else if (dynamic_cast<const jlm::rvsdg::bitashr_op *>(&(n->operation()))) {
-		//TODO: automatic conversion to static shift?
-		return "asUInt(dshr(asSInt(" + data(n->input(0)) + "), " + data(n->input(1)) + "))";
-	} else if (dynamic_cast<const jlm::rvsdg::bitsdiv_op *>(&(n->operation()))) {
-		return "asUInt(div(asSInt(" + data(n->input(0)) + "), asSInt(" + data(n->input(1)) + ")))";
-	}  else if (dynamic_cast<const jlm::rvsdg::bitsmod_op *>(&(n->operation()))) {
-		return "asUInt(rem(asSInt(" + data(n->input(0)) + "), asSInt(" + data(n->input(1)) + ")))";
-	} else if (dynamic_cast<const jlm::rvsdg::bitshl_op *>(&(n->operation()))) {
-		//TODO: automatic conversion to static shift?
-		// TODO: adjust shift limit (bits)
-		return "dshl(" + data(n->input(0)) + ", bits(" + data(n->input(1)) + ", 7, 0))";
-	} else if (dynamic_cast<const jlm::rvsdg::bitne_op *>(&(n->operation()))) {
-		return "neq(" + data(n->input(0)) + ", " + data(n->input(1)) + ")";
-	} else if (auto o = dynamic_cast<const jlm::rvsdg::bitconstant_op *>(&(n->operation()))) {
-		auto value = o->value();
-		return util::strfmt("UInt<", value.nbits(), ">(", value.to_uint(), ")");
-	} else if (dynamic_cast<const llvm::UndefValueOperation *>(&(n->operation()))) {
-		return UInt(1, 0);  // TODO: Fix?
-	} else if (auto o = dynamic_cast<const jlm::rvsdg::ctlconstant_op *>(&(n->operation()))) {
-		return UInt(ceil(log2(o->value().nalternatives())), o->value().alternative());
-	} else if (dynamic_cast<const llvm::GetElementPtrOperation *>(&(n->operation()))) {
-		return gep_op_to_firrtl(n);
-	} else {
-		throw std::logic_error(n->operation().debug_string() + " not implemented!");
-	}
+FirrtlHLS::simple_op_to_firrtl(const jlm::rvsdg::simple_node *n) {
+  if (dynamic_cast<const jlm::rvsdg::match_op *>(&(n->operation()))) {
+    return match_op_to_firrtl(n);
+  } else if (dynamic_cast<const jlm::rvsdg::bitsgt_op *>(&(n->operation()))) {
+    return "gt(asSInt(" + data(n->input(0)) + "), asSInt(" + data(n->input(1)) + "))";
+  } else if (dynamic_cast<const jlm::rvsdg::bitsge_op *>(&(n->operation()))) {
+    return "geq(asSInt(" + data(n->input(0)) + "), asSInt(" + data(n->input(1)) + "))";
+  } else if (dynamic_cast<const jlm::rvsdg::bitsle_op *>(&(n->operation()))) {
+    return "leq(asSInt(" + data(n->input(0)) + "), asSInt(" + data(n->input(1)) + "))";
+  } else if (auto o = dynamic_cast<const llvm::sext_op *>(&(n->operation()))) {
+    return "asUInt(pad(asSInt(" + data(n->input(0)) + "), " + util::strfmt(o->ndstbits()) +
+           "))";
+  } else if (dynamic_cast<const llvm::trunc_op *>(&(n->operation()))) {
+    return data(n->input(0));
+  } else if (dynamic_cast<const llvm::bitcast_op *>(&(n->operation()))) {
+    return data(n->input(0));
+  } else if (dynamic_cast<const llvm::zext_op *>(&(n->operation()))) {
+    return data(n->input(0));
+  } else if (dynamic_cast<const jlm::rvsdg::bitugt_op *>(&(n->operation()))) {
+    return "gt(" + data(n->input(0)) + ", " + data(n->input(1)) + ")";
+  } else if (dynamic_cast<const jlm::rvsdg::bitult_op *>(&(n->operation()))) {
+    return "lt(" + data(n->input(0)) + ", " + data(n->input(1)) + ")";
+  } else if (dynamic_cast<const jlm::rvsdg::bitslt_op *>(&(n->operation()))) {
+    return "lt(asSInt(" + data(n->input(0)) + "), asSInt(" + data(n->input(1)) + "))";
+  } else if (dynamic_cast<const jlm::rvsdg::biteq_op *>(&(n->operation()))) {
+    return "eq(" + data(n->input(0)) + ", " + data(n->input(1)) + ")";
+  } else if (dynamic_cast<const jlm::rvsdg::bitadd_op *>(&(n->operation()))) {
+    return "add(" + data(n->input(0)) + ", " + data(n->input(1)) + ")";
+  } else if (dynamic_cast<const jlm::rvsdg::bitmul_op *>(&(n->operation()))) {
+    return "mul(" + data(n->input(0)) + ", " + data(n->input(1)) + ")";
+  } else if (dynamic_cast<const jlm::rvsdg::bitsub_op *>(&(n->operation()))) {
+    return "sub(" + data(n->input(0)) + ", " + data(n->input(1)) + ")";
+  } else if (dynamic_cast<const jlm::rvsdg::bitand_op *>(&(n->operation()))) {
+    return "and(" + data(n->input(0)) + ", " + data(n->input(1)) + ")";
+  } else if (dynamic_cast<const jlm::rvsdg::bitxor_op *>(&(n->operation()))) {
+    return "xor(" + data(n->input(0)) + ", " + data(n->input(1)) + ")";
+  } else if (dynamic_cast<const jlm::rvsdg::bitor_op *>(&(n->operation()))) {
+    return "or(" + data(n->input(0)) + ", " + data(n->input(1)) + ")";
+  } else if (dynamic_cast<const jlm::rvsdg::bitshr_op *>(&(n->operation()))) {
+    //TODO: automatic conversion to static shift?
+    return "dshr(" + data(n->input(0)) + ", " + data(n->input(1)) + ")";
+  } else if (dynamic_cast<const jlm::rvsdg::bitashr_op *>(&(n->operation()))) {
+    //TODO: automatic conversion to static shift?
+    return "asUInt(dshr(asSInt(" + data(n->input(0)) + "), " + data(n->input(1)) + "))";
+  } else if (dynamic_cast<const jlm::rvsdg::bitsdiv_op *>(&(n->operation()))) {
+    return "asUInt(div(asSInt(" + data(n->input(0)) + "), asSInt(" + data(n->input(1)) + ")))";
+  } else if (dynamic_cast<const jlm::rvsdg::bitsmod_op *>(&(n->operation()))) {
+    return "asUInt(rem(asSInt(" + data(n->input(0)) + "), asSInt(" + data(n->input(1)) + ")))";
+  } else if (dynamic_cast<const jlm::rvsdg::bitshl_op *>(&(n->operation()))) {
+    //TODO: automatic conversion to static shift?
+    // TODO: adjust shift limit (bits)
+    return "dshl(" + data(n->input(0)) + ", bits(" + data(n->input(1)) + ", 7, 0))";
+  } else if (dynamic_cast<const jlm::rvsdg::bitne_op *>(&(n->operation()))) {
+    return "neq(" + data(n->input(0)) + ", " + data(n->input(1)) + ")";
+  } else if (auto o = dynamic_cast<const jlm::rvsdg::bitconstant_op *>(&(n->operation()))) {
+    auto value = o->value();
+    return util::strfmt("UInt<", value.nbits(), ">(", value.to_uint(), ")");
+  } else if (dynamic_cast<const llvm::UndefValueOperation *>(&(n->operation()))) {
+    return UInt(1, 0);  // TODO: Fix?
+  } else if (auto o = dynamic_cast<const jlm::rvsdg::ctlconstant_op *>(&(n->operation()))) {
+    return UInt(ceil(log2(o->value().nalternatives())), o->value().alternative());
+  } else if (dynamic_cast<const llvm::GetElementPtrOperation *>(&(n->operation()))) {
+    return gep_op_to_firrtl(n);
+  } else {
+    throw std::logic_error(n->operation().debug_string() + " not implemented!");
+  }
 }
 
-jlm::hls::FirrtlModule &
-jlm::hls::FirrtlHLS::single_out_simple_node_to_firrtl(const jlm::rvsdg::simple_node *n) {
-	std::string module_name = get_module_name(n);
-	std::ostringstream module;
+FirrtlModule &
+FirrtlHLS::single_out_simple_node_to_firrtl(const jlm::rvsdg::simple_node *n) {
+  std::string module_name = get_module_name(n);
+  std::ostringstream module;
 
-	module << module_header(n);
+  module << module_header(n);
 
-	if (n->noutputs() != 1) {
-		throw std::logic_error(n->operation().debug_string() + " has more than 1 output");
-	}
-	module << indent(2) << "; logic\n";
-	module << indent(2) << " ; " << n->operation().debug_string() << "\n";
-	auto op = simple_op_to_firrtl(n);
-	module << indent(2) << data(n->output(0)) << " <= " << op;
-	// handshaking
-	module << indent(2) + "; handshaking" + "\n";
+  if (n->noutputs() != 1) {
+    throw std::logic_error(n->operation().debug_string() + " has more than 1 output");
+  }
+  module << indent(2) << "; logic\n";
+  module << indent(2) << " ; " << n->operation().debug_string() << "\n";
+  auto op = simple_op_to_firrtl(n);
+  module << indent(2) << data(n->output(0)) << " <= " << op;
+  // handshaking
+  module << indent(2) + "; handshaking" + "\n";
 
-	auto out = n->output(0);
+  auto out = n->output(0);
 
-	std::string inputs_valids = UInt(1, 1); // True by default
-	for (size_t i = 0; i < n->ninputs(); ++i) {
-		inputs_valids = "and(" + inputs_valids + ", " + valid(n->input(i)) + ")";
-	}
-	module << indent(2) << "node inputs_valid = " << inputs_valids << "\n";
-	for (size_t i = 0; i < n->noutputs(); ++i) {
-		module << indent(2) << valid(out) << " <= inputs_valid\n";
-	}
-	for (size_t i = 0; i < n->ninputs(); ++i) {
-		module << indent(2) + ready(n->input(i)) + "<= and(" << ready(n->output(0)) << ", inputs_valid)\n";
-	}
+  std::string inputs_valids = UInt(1, 1); // True by default
+  for (size_t i = 0; i < n->ninputs(); ++i) {
+    inputs_valids = "and(" + inputs_valids + ", " + valid(n->input(i)) + ")";
+  }
+  module << indent(2) << "node inputs_valid = " << inputs_valids << "\n";
+  for (size_t i = 0; i < n->noutputs(); ++i) {
+    module << indent(2) << valid(out) << " <= inputs_valid\n";
+  }
+  for (size_t i = 0; i < n->ninputs(); ++i) {
+    module << indent(2) + ready(n->input(i)) + "<= and(" << ready(n->output(0)) << ", inputs_valid)\n";
+  }
 
-	modules.emplace_back(&n->operation(), FirrtlModule{module_name, module.str(), false});
-	return modules.back().second;
+  modules.emplace_back(&n->operation(), FirrtlModule{module_name, module.str(), false});
+  return modules.back().second;
 }
 
-jlm::hls::FirrtlModule
-jlm::hls::FirrtlHLS::node_to_firrtl(const jlm::rvsdg::node *node, const int depth) {
-	// check if module for operation was already generated
-	for (auto pair: modules) {
-		if(pair.first != nullptr && *pair.first == node->operation()) {
-			return pair.second;
-		}
-	}
-	if (auto n = dynamic_cast<const jlm::rvsdg::simple_node *>(node)) {
-		if (dynamic_cast<const llvm::LoadOperation *>(&(n->operation()))) {
-			return mem_node_to_firrtl(n);
-		} else if (dynamic_cast<const llvm::StoreOperation *>(&(n->operation()))) {
-			return mem_node_to_firrtl(n);
-		} else if (dynamic_cast<const hls::predicate_buffer_op *>(&(n->operation()))) {
-			return pred_buffer_to_firrtl(n);
-		} else if (dynamic_cast<const hls::buffer_op *>(&(n->operation()))) {
-			return buffer_to_firrtl(n);
-		} else if (dynamic_cast<const hls::branch_op *>(&(n->operation()))) {
-			return branch_to_firrtl(n);
-		} else if (dynamic_cast<const hls::trigger_op *>(&(n->operation()))) {
-			return trigger_to_firrtl(n);
-		} else if (dynamic_cast<const hls::sink_op *>(&(n->operation()))) {
-			return sink_to_firrtl(n);
-		} else if (dynamic_cast<const hls::print_op *>(&(n->operation()))) {
-			return print_to_firrtl(n);
-		} else if (dynamic_cast<const hls::fork_op *>(&(n->operation()))) {
-			return fork_to_firrtl(n);
-		} else if (dynamic_cast<const hls::merge_op *>(&(n->operation()))) {
-			return merge_to_firrtl(n);
-		} else if (auto o = dynamic_cast<const hls::mux_op *>(&(n->operation()))) {
-			if (o->discarding) {
-				return dmux_to_firrtl(n);
-			} else {
-				return ndmux_to_firrtl(n);
-			}
-		}
-		return single_out_simple_node_to_firrtl(n);
-	} else {
-		throw std::logic_error(node->operation().debug_string() + " not implemented!");
-	}
-}
-
-std::string
-jlm::hls::FirrtlHLS::create_loop_instances(jlm::hls::loop_node *ln) {
-	std::ostringstream firrtl;
-	auto sr = ln->subregion();
-	for (const auto node : jlm::rvsdg::topdown_traverser(sr)) {
-		if (dynamic_cast<jlm::rvsdg::simple_node *>(node)) {
-			auto node_module = node_to_firrtl(node, 2);
-			std::string inst_name = get_node_name(node);
-			if (node_module.has_mem) {
-				mem_nodes.push_back(inst_name);
-			}
-			firrtl << indent(2) << "inst " << inst_name << " of " << node_module.name << "\n";
-			for (size_t i = 0; i < node->noutputs(); ++i) {
-				output_map[node->output(i)] = inst_name + "." + get_port_name(node->output(i));
-			}
-		} else if (auto oln = dynamic_cast<hls::loop_node *>(node)) {
-			firrtl << create_loop_instances(oln);
-		} else {
-			throw util::error("Unimplemented op (unexpected structural node) : " + node->operation().debug_string());
-		}
-	}
-	for (size_t i = 0; i < sr->narguments(); ++i) {
-		auto arg = sr->argument(i);
-        auto ba = dynamic_cast<jlm::hls::backedge_argument*>(arg);
-        if (!ba) {
-            assert(arg->input() != nullptr);
-			// map to input of loop
-			output_map[arg] = output_map[arg->input()->origin()];
-		} else {
-			auto result = ba->result();
-			assert(result->type() == arg->type());
-			// map to end of loop (origin of associated result)
-			output_map[arg] = output_map[result->origin()];
-		}
-	}
-	for (size_t i = 0; i < ln->noutputs(); ++i) {
-		auto out = ln->output(i);
-		assert(out->results.size() == 1);
-		output_map[out] = output_map[out->results.begin()->origin()];
-	}
-	return firrtl.str();
+FirrtlModule
+FirrtlHLS::node_to_firrtl(const jlm::rvsdg::node *node, const int depth) {
+  // check if module for operation was already generated
+  for (auto pair: modules) {
+    if (pair.first != nullptr && *pair.first == node->operation()) {
+      return pair.second;
+    }
+  }
+  if (auto n = dynamic_cast<const jlm::rvsdg::simple_node *>(node)) {
+    if (dynamic_cast<const llvm::LoadOperation *>(&(n->operation()))) {
+      return mem_node_to_firrtl(n);
+    } else if (dynamic_cast<const llvm::StoreOperation *>(&(n->operation()))) {
+      return mem_node_to_firrtl(n);
+    } else if (dynamic_cast<const hls::predicate_buffer_op *>(&(n->operation()))) {
+      return pred_buffer_to_firrtl(n);
+    } else if (dynamic_cast<const hls::buffer_op *>(&(n->operation()))) {
+      return buffer_to_firrtl(n);
+    } else if (dynamic_cast<const hls::branch_op *>(&(n->operation()))) {
+      return branch_to_firrtl(n);
+    } else if (dynamic_cast<const hls::trigger_op *>(&(n->operation()))) {
+      return trigger_to_firrtl(n);
+    } else if (dynamic_cast<const hls::sink_op *>(&(n->operation()))) {
+      return sink_to_firrtl(n);
+    } else if (dynamic_cast<const hls::print_op *>(&(n->operation()))) {
+      return print_to_firrtl(n);
+    } else if (dynamic_cast<const hls::fork_op *>(&(n->operation()))) {
+      return fork_to_firrtl(n);
+    } else if (dynamic_cast<const hls::merge_op *>(&(n->operation()))) {
+      return merge_to_firrtl(n);
+    } else if (auto o = dynamic_cast<const hls::mux_op *>(&(n->operation()))) {
+      if (o->discarding) {
+        return dmux_to_firrtl(n);
+      } else {
+        return ndmux_to_firrtl(n);
+      }
+    }
+    return single_out_simple_node_to_firrtl(n);
+  } else {
+    throw std::logic_error(node->operation().debug_string() + " not implemented!");
+  }
 }
 
 std::string
-jlm::hls::FirrtlHLS::connect(jlm::rvsdg::region *sr) {
-	std::ostringstream firrtl;
-	for (const auto &node : jlm::rvsdg::topdown_traverser(sr)) {
-		if (dynamic_cast<jlm::rvsdg::simple_node *>(node)) {
-			auto inst_name = get_node_name(node);
-			firrtl << indent(2) << inst_name << ".clk <= clk\n";
-			firrtl << indent(2) << inst_name << ".reset <= reset\n";
-			for (size_t i = 0; i < node->ninputs(); ++i) {
-				auto in_name = inst_name + "." + get_port_name(node->input(i));
-				assert(output_map.count(node->input(i)->origin()));
-				auto origin = output_map[node->input(i)->origin()];
-				firrtl << indent(2) << origin << ".ready <= " << in_name << ".ready\n";
-				firrtl << indent(2) << in_name << ".data <= " << origin << ".data\n";
-				firrtl << indent(2) << in_name << ".valid <= " << origin << ".valid\n";
-			}
-		} else if (auto oln = dynamic_cast<hls::loop_node *>(node)) {
-			firrtl << connect(oln->subregion());
-		} else {
-			throw util::error("Unimplemented op (unexpected structural node) : " + node->operation().debug_string());
-		}
-	}
-	return firrtl.str();
-}
-
-jlm::hls::FirrtlModule
-jlm::hls::FirrtlHLS::subregion_to_firrtl(jlm::rvsdg::region *sr) {
-	auto module_name = "subregion_mod" + util::strfmt(modules.size());
-	std::ostringstream module;
-	module << indent(1) << "module " << module_name << ":\n";
-	// io
-	module << indent(2) << "; io\n";
-	module << indent(2) << "input clk: Clock\n";
-	module << indent(2) << "input reset: UInt<1>\n";
-	for (size_t i = 0; i < sr->narguments(); ++i) {
-		module << indent(2) << "input " << get_port_name(sr->argument(i)) <<
-			   ": {flip ready: UInt<1>, valid: UInt<1>, data: " <<
-			   to_firrtl_type(&sr->argument(i)->type()) << "}\n";
-	}
-	for (size_t i = 0; i < sr->nresults(); ++i) {
-		module << indent(2) << "output " << get_port_name(sr->result(i)) <<
-			   ": {flip ready: UInt<1>, valid: UInt<1>, data: " <<
-			   to_firrtl_type(&sr->result(i)->type()) << "}\n";
-	}
-	module << mem_io();
-	module << indent(2) << "; instances\n";
-	for (size_t i = 0; i < sr->narguments(); ++i) {
-		output_map[sr->argument(i)] = get_port_name(sr->argument(i));
-	}
-	// create node modules and ios first
-	for (const auto node : jlm::rvsdg::topdown_traverser(sr)) {
-		if (dynamic_cast<jlm::rvsdg::simple_node *>(node)) {
-			auto node_module = node_to_firrtl(node, 2);
-			std::string inst_name = get_node_name(node);
-			if (node_module.has_mem) {
-				mem_nodes.push_back(inst_name);
-			}
-			module << indent(2) << "inst " << inst_name << " of " << node_module.name << "\n";
-			for (size_t i = 0; i < node->noutputs(); ++i) {
-				output_map[node->output(i)] = inst_name + "." + get_port_name(node->output(i));
-			}
-		} else if (auto oln = dynamic_cast<hls::loop_node *>(node)) {
-			module << create_loop_instances(oln);
-		} else {
-			throw util::error("Unimplemented op (unexpected structural node) : " + node->operation().debug_string());
-		}
-	}
-	module << connect(sr);
-	for (size_t i = 0; i < sr->nresults(); ++i) {
-		auto origin = output_map[sr->result(i)->origin()];
-		auto result = get_port_name(sr->result(i));
-		module << indent(2) << origin << ".ready <= " << result << ".ready\n";
-		module << indent(2) << result << ".data <= " << origin << ".data\n";
-		module << indent(2) << result << ".valid <= " << origin << ".valid\n";
-	}
-
-	module << mux_mem(mem_nodes);
-
-	modules.emplace_back(nullptr, FirrtlModule{module_name, module.str(), true});
-	return modules.back().second;
-}
-
-jlm::hls::FirrtlModule
-jlm::hls::FirrtlHLS::lambda_node_to_firrtl(const llvm::lambda::node *ln) {
-	auto module_name = ln->name() + "_lambda_mod";
-	auto sr = ln->subregion();
-	create_node_names(sr);
-	std::ostringstream module;
-	module << indent(1) << "module " << module_name << ":\n";
-	// io
-	module << indent(2) << "; io" << "\n";
-	module << indent(2) << "input clk: Clock" << "\n";
-	module << indent(2) << "input reset: UInt<1>" << "\n";
-	module << indent(2) << "input i: {flip ready: UInt<1>, valid: UInt<1>";
-	for (size_t i = 0; i < sr->narguments(); ++i) {
-		module << ", data" << i << ": " <<
-			   to_firrtl_type(&sr->argument(i)->type());
-	}
-	module << "}\n";
-	module << indent(2) << "output o: {flip ready: UInt<1>, valid: UInt<1>";
-	for (size_t i = 0; i < sr->nresults(); ++i) {
-		module << ", data" << i << ": " <<
-			   to_firrtl_type(&sr->result(i)->type());
-	}
-	module << "}\n";
-	module << mem_io();
-	// registers
-	module << indent(2) << "; registers" << "\n";
-	for (size_t i = 0; i < sr->narguments(); ++i) {
-		module << indent(2) << "reg i" << i <<
-			   "_valid_reg: UInt<1>, clk with: (reset => (reset, " << UInt(1, 0) << "))\n";
-		module << indent(2) << "reg i" << i << "_data_reg: " <<
-			   to_firrtl_type(&sr->argument(i)->type()) + ", clk" + "\n";
-	}
-	for (size_t i = 0; i < sr->nresults(); ++i) {
-		module << indent(2) << "reg o" << i <<
-			   "_valid_reg: UInt<1>, clk with: (reset => (reset, " << UInt(1, 0) << "))\n";
-		module << indent(2) << "reg o" << i << "_data_reg: " <<
-			   to_firrtl_type(&sr->result(i)->type()) + ", clk" + "\n";
-	}
-	module << indent(2) << "; instances" << "\n";
-	auto sr_firrtl = subregion_to_firrtl(sr);
-	module << indent(2) << "inst sr of " << sr_firrtl.name << "\n";
-	module << indent(2) << "sr.clk <= clk\n";
-	module << indent(2) << "sr.reset <= reset\n";
-	for (size_t i = 0; i < sr->narguments(); ++i) {
-		module << indent(2) << "sr." << valid(sr->argument(i)) << " <= i" << i << "_valid_reg\n";
-		module << indent(2) << "sr." << data(sr->argument(i)) << " <= i" << i << "_data_reg\n";
-		module << indent(2) << "when and(sr." << valid(sr->argument(i)) << ", sr." << ready(sr->argument(i))
-			   << "):\n";
-		module << indent(3) << "i" << i << "_valid_reg <= " << UInt(1, 0) << "\n";
-	}
-	// logic
-	module << indent(2) << "; logic" << "\n";
-	for (size_t i = 0; i < sr->nresults(); ++i) {
-		module << indent(2) << "sr." << ready(sr->result(i)) << " <= not(o" << i <<
-			   "_valid_reg)\n";
-	}
-	for (size_t i = 0; i < sr->nresults(); ++i) {
-		module << indent(2) << "when and(sr." << valid(sr->result(i)) << ", sr." << ready(sr->result(i))
-			   << "):\n";
-		module << indent(3) << "o" << i << "_valid_reg <= " << UInt(1, 1) << "\n";
-		module << indent(3) << "o" << i << "_data_reg <= sr." << get_port_name(sr->result(i)) <<
-			   ".data\n";
-	}
-	std::string outputs_valids = UInt(1, 1); // True by default
-	for (size_t i = 0; i < sr->nresults(); ++i) {
-		outputs_valids = "and(" + outputs_valids + ", o" + util::strfmt(i) + "_valid_reg)";
-	}
-	module << indent(2) << "node outputs_valid = " << outputs_valids << "\n";
-	module << indent(2) << "o.valid <= outputs_valid\n";
-	for (size_t i = 0; i < sr->nresults(); ++i) {
-		module << indent(2) << "o.data" << i << " <= o" << i << "_data_reg\n";
-	}
-	module << indent(2) << "when and(o.valid, o.ready):\n";
-	for (size_t i = 0; i < sr->nresults(); ++i) {
-		module << indent(3) << "o" << i << "_valid_reg <= " << UInt(1, 0) << "\n";
-	}
-	std::string inputs_ready = UInt(1, 1); // True by default
-	for (size_t i = 0; i < sr->narguments(); ++i) {
-		inputs_ready = util::strfmt("and(", inputs_ready, ", not(i", i, "_valid_reg))");
-	}
-	module << indent(2) << "node inputs_ready = " << inputs_ready << "\n";
-	module << indent(2) << "i.ready <= inputs_ready\n";
-
-
-	module << indent(2) << "when and(i.ready, i.valid):\n";
-	for (size_t i = 0; i < sr->narguments(); ++i) {
-		module << indent(3) << "i" << i << "_valid_reg <= " << UInt(1, 1) << "\n";
-		module << indent(3) << "i" << i << "_data_reg <= i.data" << i << "\n";
-	}
-
-	module << mux_mem({"sr",});
-	modules.emplace_back(&ln->operation(), FirrtlModule{module_name, module.str(), false});
-	return modules.back().second;
+FirrtlHLS::create_loop_instances(loop_node *ln) {
+  std::ostringstream firrtl;
+  auto sr = ln->subregion();
+  for (const auto node: jlm::rvsdg::topdown_traverser(sr)) {
+    if (dynamic_cast<jlm::rvsdg::simple_node *>(node)) {
+      auto node_module = node_to_firrtl(node, 2);
+      std::string inst_name = get_node_name(node);
+      if (node_module.has_mem) {
+        mem_nodes.push_back(inst_name);
+      }
+      firrtl << indent(2) << "inst " << inst_name << " of " << node_module.name << "\n";
+      for (size_t i = 0; i < node->noutputs(); ++i) {
+        output_map[node->output(i)] = inst_name + "." + get_port_name(node->output(i));
+      }
+    } else if (auto oln = dynamic_cast<hls::loop_node *>(node)) {
+      firrtl << create_loop_instances(oln);
+    } else {
+      throw util::error("Unimplemented op (unexpected structural node) : " + node->operation().debug_string());
+    }
+  }
+  for (size_t i = 0; i < sr->narguments(); ++i) {
+    auto arg = sr->argument(i);
+    auto ba = dynamic_cast<backedge_argument *>(arg);
+    if (!ba) {
+      assert(arg->input() != nullptr);
+      // map to input of loop
+      output_map[arg] = output_map[arg->input()->origin()];
+    } else {
+      auto result = ba->result();
+      assert(result->type() == arg->type());
+      // map to end of loop (origin of associated result)
+      output_map[arg] = output_map[result->origin()];
+    }
+  }
+  for (size_t i = 0; i < ln->noutputs(); ++i) {
+    auto out = ln->output(i);
+    assert(out->results.size() == 1);
+    output_map[out] = output_map[out->results.begin()->origin()];
+  }
+  return firrtl.str();
 }
 
 std::string
-jlm::hls::FirrtlHLS::get_module_name(const jlm::rvsdg::node *node) {
-	auto new_name = util::strfmt("op_", node->operation().debug_string(), "_", modules.size());
-	// remove chars that are not valid in firrtl module names
-	std::replace_if(new_name.begin(), new_name.end(), isForbiddenChar, '_');
-	return new_name;
+FirrtlHLS::connect(jlm::rvsdg::region *sr) {
+  std::ostringstream firrtl;
+  for (const auto &node: jlm::rvsdg::topdown_traverser(sr)) {
+    if (dynamic_cast<jlm::rvsdg::simple_node *>(node)) {
+      auto inst_name = get_node_name(node);
+      firrtl << indent(2) << inst_name << ".clk <= clk\n";
+      firrtl << indent(2) << inst_name << ".reset <= reset\n";
+      for (size_t i = 0; i < node->ninputs(); ++i) {
+        auto in_name = inst_name + "." + get_port_name(node->input(i));
+        assert(output_map.count(node->input(i)->origin()));
+        auto origin = output_map[node->input(i)->origin()];
+        firrtl << indent(2) << origin << ".ready <= " << in_name << ".ready\n";
+        firrtl << indent(2) << in_name << ".data <= " << origin << ".data\n";
+        firrtl << indent(2) << in_name << ".valid <= " << origin << ".valid\n";
+      }
+    } else if (auto oln = dynamic_cast<hls::loop_node *>(node)) {
+      firrtl << connect(oln->subregion());
+    } else {
+      throw util::error("Unimplemented op (unexpected structural node) : " + node->operation().debug_string());
+    }
+  }
+  return firrtl.str();
+}
+
+FirrtlModule
+FirrtlHLS::subregion_to_firrtl(jlm::rvsdg::region *sr) {
+  auto module_name = "subregion_mod" + util::strfmt(modules.size());
+  std::ostringstream module;
+  module << indent(1) << "module " << module_name << ":\n";
+  // io
+  module << indent(2) << "; io\n";
+  module << indent(2) << "input clk: Clock\n";
+  module << indent(2) << "input reset: UInt<1>\n";
+  for (size_t i = 0; i < sr->narguments(); ++i) {
+    module << indent(2) << "input " << get_port_name(sr->argument(i)) <<
+           ": {flip ready: UInt<1>, valid: UInt<1>, data: " <<
+           to_firrtl_type(&sr->argument(i)->type()) << "}\n";
+  }
+  for (size_t i = 0; i < sr->nresults(); ++i) {
+    module << indent(2) << "output " << get_port_name(sr->result(i)) <<
+           ": {flip ready: UInt<1>, valid: UInt<1>, data: " <<
+           to_firrtl_type(&sr->result(i)->type()) << "}\n";
+  }
+  module << mem_io();
+  module << indent(2) << "; instances\n";
+  for (size_t i = 0; i < sr->narguments(); ++i) {
+    output_map[sr->argument(i)] = get_port_name(sr->argument(i));
+  }
+  // create node modules and ios first
+  for (const auto node: jlm::rvsdg::topdown_traverser(sr)) {
+    if (dynamic_cast<jlm::rvsdg::simple_node *>(node)) {
+      auto node_module = node_to_firrtl(node, 2);
+      std::string inst_name = get_node_name(node);
+      if (node_module.has_mem) {
+        mem_nodes.push_back(inst_name);
+      }
+      module << indent(2) << "inst " << inst_name << " of " << node_module.name << "\n";
+      for (size_t i = 0; i < node->noutputs(); ++i) {
+        output_map[node->output(i)] = inst_name + "." + get_port_name(node->output(i));
+      }
+    } else if (auto oln = dynamic_cast<hls::loop_node *>(node)) {
+      module << create_loop_instances(oln);
+    } else {
+      throw util::error("Unimplemented op (unexpected structural node) : " + node->operation().debug_string());
+    }
+  }
+  module << connect(sr);
+  for (size_t i = 0; i < sr->nresults(); ++i) {
+    auto origin = output_map[sr->result(i)->origin()];
+    auto result = get_port_name(sr->result(i));
+    module << indent(2) << origin << ".ready <= " << result << ".ready\n";
+    module << indent(2) << result << ".data <= " << origin << ".data\n";
+    module << indent(2) << result << ".valid <= " << origin << ".valid\n";
+  }
+
+  module << mux_mem(mem_nodes);
+
+  modules.emplace_back(nullptr, FirrtlModule{module_name, module.str(), true});
+  return modules.back().second;
+}
+
+FirrtlModule
+FirrtlHLS::lambda_node_to_firrtl(const llvm::lambda::node *ln) {
+  auto module_name = ln->name() + "_lambda_mod";
+  auto sr = ln->subregion();
+  create_node_names(sr);
+  std::ostringstream module;
+  module << indent(1) << "module " << module_name << ":\n";
+  // io
+  module << indent(2) << "; io" << "\n";
+  module << indent(2) << "input clk: Clock" << "\n";
+  module << indent(2) << "input reset: UInt<1>" << "\n";
+  module << indent(2) << "input i: {flip ready: UInt<1>, valid: UInt<1>";
+  for (size_t i = 0; i < sr->narguments(); ++i) {
+    module << ", data" << i << ": " <<
+           to_firrtl_type(&sr->argument(i)->type());
+  }
+  module << "}\n";
+  module << indent(2) << "output o: {flip ready: UInt<1>, valid: UInt<1>";
+  for (size_t i = 0; i < sr->nresults(); ++i) {
+    module << ", data" << i << ": " <<
+           to_firrtl_type(&sr->result(i)->type());
+  }
+  module << "}\n";
+  module << mem_io();
+  // registers
+  module << indent(2) << "; registers" << "\n";
+  for (size_t i = 0; i < sr->narguments(); ++i) {
+    module << indent(2) << "reg i" << i <<
+           "_valid_reg: UInt<1>, clk with: (reset => (reset, " << UInt(1, 0) << "))\n";
+    module << indent(2) << "reg i" << i << "_data_reg: " <<
+           to_firrtl_type(&sr->argument(i)->type()) + ", clk" + "\n";
+  }
+  for (size_t i = 0; i < sr->nresults(); ++i) {
+    module << indent(2) << "reg o" << i <<
+           "_valid_reg: UInt<1>, clk with: (reset => (reset, " << UInt(1, 0) << "))\n";
+    module << indent(2) << "reg o" << i << "_data_reg: " <<
+           to_firrtl_type(&sr->result(i)->type()) + ", clk" + "\n";
+  }
+  module << indent(2) << "; instances" << "\n";
+  auto sr_firrtl = subregion_to_firrtl(sr);
+  module << indent(2) << "inst sr of " << sr_firrtl.name << "\n";
+  module << indent(2) << "sr.clk <= clk\n";
+  module << indent(2) << "sr.reset <= reset\n";
+  for (size_t i = 0; i < sr->narguments(); ++i) {
+    module << indent(2) << "sr." << valid(sr->argument(i)) << " <= i" << i << "_valid_reg\n";
+    module << indent(2) << "sr." << data(sr->argument(i)) << " <= i" << i << "_data_reg\n";
+    module << indent(2) << "when and(sr." << valid(sr->argument(i)) << ", sr." << ready(sr->argument(i))
+           << "):\n";
+    module << indent(3) << "i" << i << "_valid_reg <= " << UInt(1, 0) << "\n";
+  }
+  // logic
+  module << indent(2) << "; logic" << "\n";
+  for (size_t i = 0; i < sr->nresults(); ++i) {
+    module << indent(2) << "sr." << ready(sr->result(i)) << " <= not(o" << i <<
+           "_valid_reg)\n";
+  }
+  for (size_t i = 0; i < sr->nresults(); ++i) {
+    module << indent(2) << "when and(sr." << valid(sr->result(i)) << ", sr." << ready(sr->result(i))
+           << "):\n";
+    module << indent(3) << "o" << i << "_valid_reg <= " << UInt(1, 1) << "\n";
+    module << indent(3) << "o" << i << "_data_reg <= sr." << get_port_name(sr->result(i)) <<
+           ".data\n";
+  }
+  std::string outputs_valids = UInt(1, 1); // True by default
+  for (size_t i = 0; i < sr->nresults(); ++i) {
+    outputs_valids = "and(" + outputs_valids + ", o" + util::strfmt(i) + "_valid_reg)";
+  }
+  module << indent(2) << "node outputs_valid = " << outputs_valids << "\n";
+  module << indent(2) << "o.valid <= outputs_valid\n";
+  for (size_t i = 0; i < sr->nresults(); ++i) {
+    module << indent(2) << "o.data" << i << " <= o" << i << "_data_reg\n";
+  }
+  module << indent(2) << "when and(o.valid, o.ready):\n";
+  for (size_t i = 0; i < sr->nresults(); ++i) {
+    module << indent(3) << "o" << i << "_valid_reg <= " << UInt(1, 0) << "\n";
+  }
+  std::string inputs_ready = UInt(1, 1); // True by default
+  for (size_t i = 0; i < sr->narguments(); ++i) {
+    inputs_ready = util::strfmt("and(", inputs_ready, ", not(i", i, "_valid_reg))");
+  }
+  module << indent(2) << "node inputs_ready = " << inputs_ready << "\n";
+  module << indent(2) << "i.ready <= inputs_ready\n";
+
+
+  module << indent(2) << "when and(i.ready, i.valid):\n";
+  for (size_t i = 0; i < sr->narguments(); ++i) {
+    module << indent(3) << "i" << i << "_valid_reg <= " << UInt(1, 1) << "\n";
+    module << indent(3) << "i" << i << "_data_reg <= i.data" << i << "\n";
+  }
+
+  module << mux_mem({"sr",});
+  modules.emplace_back(&ln->operation(), FirrtlModule{module_name, module.str(), false});
+  return modules.back().second;
+}
+
+std::string
+FirrtlHLS::get_module_name(const jlm::rvsdg::node *node) {
+  auto new_name = util::strfmt("op_", node->operation().debug_string(), "_", modules.size());
+  // remove chars that are not valid in firrtl module names
+  std::replace_if(new_name.begin(), new_name.end(), isForbiddenChar, '_');
+  return new_name;
+}
+
 }

--- a/jlm/hls/backend/rhls2firrtl/firrtl-hls.hpp
+++ b/jlm/hls/backend/rhls2firrtl/firrtl-hls.hpp
@@ -19,167 +19,173 @@
 
 #include <string>
 
+namespace jlm::hls
+{
 
-namespace jlm {
-	namespace hls {
-		class FirrtlModule {
-		public:
-			FirrtlModule(const std::string &name, const std::string &firrtl, bool hasMem) : has_mem(hasMem), name(name),
-																							firrtl(firrtl) {}
+class FirrtlModule {
+public:
+  FirrtlModule(
+    const std::string &name,
+    const std::string &firrtl,
+    bool hasMem)
+    : has_mem(hasMem),
+      name(name),
+      firrtl(firrtl)
+  {}
 
-		public:
-			bool has_mem;
-			std::string name;
-			std::string firrtl;
-		};
-
-
-		inline bool
-		is_identity_mapping(const jlm::rvsdg::match_op &op);
-
-
-		int jlm_sizeof(const jlm::rvsdg::type * t);
-
-		class FirrtlHLS : public BaseHLS {
-			std::string
-			extension() override {
-				return ".fir";
-			}
-
-			std::string
-			get_text(llvm::RvsdgModule &rm) override;
-
-		private:
-			std::vector<std::pair<const jlm::rvsdg::operation*, FirrtlModule>> modules;
-			std::vector<std::string> mem_nodes;
-
-			std::string
-			get_module_name(const jlm::rvsdg::node *node);
-
-			static inline std::string
-			indent(size_t depth) {
-				return std::string(depth * 4, ' ');
-			}
-
-			static std::string
-			ready(jlm::rvsdg::output *port) {
-				return get_port_name(port) + ".ready";
-			}
-
-			static std::string
-			ready(jlm::rvsdg::input *port) {
-				return get_port_name(port) + ".ready";
-			}
-
-			static std::string
-			valid(jlm::rvsdg::output *port) {
-				return get_port_name(port) + ".valid";
-			}
-
-			static std::string
-			valid(jlm::rvsdg::input *port) {
-				return get_port_name(port) + ".valid";
-			}
-
-			static std::string
-			data(jlm::rvsdg::output *port) {
-				return get_port_name(port) + ".data";
-			}
-
-			static std::string
-			data(jlm::rvsdg::input *port) {
-				return get_port_name(port) + ".data";
-			}
-
-			static std::string
-			fire(jlm::rvsdg::output *port) {
-				return "and(" + valid(port) + ", " + ready(port) + ")";
-			}
-
-			static std::string
-			fire(jlm::rvsdg::input *port) {
-				return "and(" + valid(port) + ", " + ready(port) + ")";
-			}
-
-			static std::string
-			UInt(size_t width, size_t value) {
-				return util::strfmt("UInt<", width, ">(", value, ")");
-			}
-
-			static std::string
-			to_firrtl_type(const jlm::rvsdg::type *type);
-
-			std::string
-			mem_io();
-
-			std::string
-			mux_mem(const std::vector<std::string> &mem_nodes) const;
-
-			std::string
-			module_header(const jlm::rvsdg::node *node, bool has_mem_io = false);
+public:
+  bool has_mem;
+  std::string name;
+  std::string firrtl;
+};
 
 
-			FirrtlModule &
-			mem_node_to_firrtl(const jlm::rvsdg::simple_node *n);
+inline bool
+is_identity_mapping(const jlm::rvsdg::match_op &op);
 
-			FirrtlModule &
-			pred_buffer_to_firrtl(const jlm::rvsdg::simple_node *n);
 
-			FirrtlModule &
-			buffer_to_firrtl(const jlm::rvsdg::simple_node *n);
+int jlm_sizeof(const jlm::rvsdg::type * t);
 
-			FirrtlModule &
-			ndmux_to_firrtl(const jlm::rvsdg::simple_node *n);
+class FirrtlHLS : public BaseHLS {
+  std::string
+  extension() override {
+    return ".fir";
+  }
 
-			FirrtlModule &
-			dmux_to_firrtl(const jlm::rvsdg::simple_node *n);
+  std::string
+  get_text(llvm::RvsdgModule &rm) override;
 
-			FirrtlModule &
-			merge_to_firrtl(const jlm::rvsdg::simple_node *n);
+private:
+  std::vector<std::pair<const jlm::rvsdg::operation*, FirrtlModule>> modules;
+  std::vector<std::string> mem_nodes;
 
-			FirrtlModule &
-			fork_to_firrtl(const jlm::rvsdg::simple_node *n);
+  std::string
+  get_module_name(const jlm::rvsdg::node *node);
 
-			FirrtlModule &
-			sink_to_firrtl(const jlm::rvsdg::simple_node *n);
+  static inline std::string
+  indent(size_t depth) {
+    return std::string(depth * 4, ' ');
+  }
 
-			FirrtlModule &
-			print_to_firrtl(const jlm::rvsdg::simple_node *n);
+  static std::string
+  ready(jlm::rvsdg::output *port) {
+    return get_port_name(port) + ".ready";
+  }
 
-			FirrtlModule &
-			branch_to_firrtl(const jlm::rvsdg::simple_node *n);
+  static std::string
+  ready(jlm::rvsdg::input *port) {
+    return get_port_name(port) + ".ready";
+  }
 
-			FirrtlModule &
-			trigger_to_firrtl(const jlm::rvsdg::simple_node *n);
+  static std::string
+  valid(jlm::rvsdg::output *port) {
+    return get_port_name(port) + ".valid";
+  }
 
-			static std::string
-			gep_op_to_firrtl(const jlm::rvsdg::simple_node *n);
+  static std::string
+  valid(jlm::rvsdg::input *port) {
+    return get_port_name(port) + ".valid";
+  }
 
-			static std::string
-			match_op_to_firrtl(const jlm::rvsdg::simple_node *n);
+  static std::string
+  data(jlm::rvsdg::output *port) {
+    return get_port_name(port) + ".data";
+  }
 
-			static std::string
-			simple_op_to_firrtl(const jlm::rvsdg::simple_node *n);
+  static std::string
+  data(jlm::rvsdg::input *port) {
+    return get_port_name(port) + ".data";
+  }
 
-			FirrtlModule &
-			single_out_simple_node_to_firrtl(const jlm::rvsdg::simple_node *n);
+  static std::string
+  fire(jlm::rvsdg::output *port) {
+    return "and(" + valid(port) + ", " + ready(port) + ")";
+  }
 
-			FirrtlModule
-			node_to_firrtl(const jlm::rvsdg::node *node, const int depth);
+  static std::string
+  fire(jlm::rvsdg::input *port) {
+    return "and(" + valid(port) + ", " + ready(port) + ")";
+  }
 
-			std::string
-			create_loop_instances(hls::loop_node *ln);
+  static std::string
+  UInt(size_t width, size_t value) {
+    return util::strfmt("UInt<", width, ">(", value, ")");
+  }
 
-			std::string
-			connect(jlm::rvsdg::region *sr);
+  static std::string
+  to_firrtl_type(const jlm::rvsdg::type *type);
 
-			FirrtlModule
-			subregion_to_firrtl(jlm::rvsdg::region *sr);
+  std::string
+  mem_io();
 
-			FirrtlModule
-			lambda_node_to_firrtl(const llvm::lambda::node *ln);
-		};
+  std::string
+  mux_mem(const std::vector<std::string> &mem_nodes) const;
 
-	}
+  std::string
+  module_header(const jlm::rvsdg::node *node, bool has_mem_io = false);
+
+
+  FirrtlModule &
+  mem_node_to_firrtl(const jlm::rvsdg::simple_node *n);
+
+  FirrtlModule &
+  pred_buffer_to_firrtl(const jlm::rvsdg::simple_node *n);
+
+  FirrtlModule &
+  buffer_to_firrtl(const jlm::rvsdg::simple_node *n);
+
+  FirrtlModule &
+  ndmux_to_firrtl(const jlm::rvsdg::simple_node *n);
+
+  FirrtlModule &
+  dmux_to_firrtl(const jlm::rvsdg::simple_node *n);
+
+  FirrtlModule &
+  merge_to_firrtl(const jlm::rvsdg::simple_node *n);
+
+  FirrtlModule &
+  fork_to_firrtl(const jlm::rvsdg::simple_node *n);
+
+  FirrtlModule &
+  sink_to_firrtl(const jlm::rvsdg::simple_node *n);
+
+  FirrtlModule &
+  print_to_firrtl(const jlm::rvsdg::simple_node *n);
+
+  FirrtlModule &
+  branch_to_firrtl(const jlm::rvsdg::simple_node *n);
+
+  FirrtlModule &
+  trigger_to_firrtl(const jlm::rvsdg::simple_node *n);
+
+  static std::string
+  gep_op_to_firrtl(const jlm::rvsdg::simple_node *n);
+
+  static std::string
+  match_op_to_firrtl(const jlm::rvsdg::simple_node *n);
+
+  static std::string
+  simple_op_to_firrtl(const jlm::rvsdg::simple_node *n);
+
+  FirrtlModule &
+  single_out_simple_node_to_firrtl(const jlm::rvsdg::simple_node *n);
+
+  FirrtlModule
+  node_to_firrtl(const jlm::rvsdg::node *node, const int depth);
+
+  std::string
+  create_loop_instances(hls::loop_node *ln);
+
+  std::string
+  connect(jlm::rvsdg::region *sr);
+
+  FirrtlModule
+  subregion_to_firrtl(jlm::rvsdg::region *sr);
+
+  FirrtlModule
+  lambda_node_to_firrtl(const llvm::lambda::node *ln);
+};
+
 }
+
 #endif //JLM_HLS_BACKEND_RHLS2FIRRTL_FIRRTL_HLS_HPP

--- a/jlm/hls/backend/rhls2firrtl/mlirgen.cpp
+++ b/jlm/hls/backend/rhls2firrtl/mlirgen.cpp
@@ -8,9 +8,12 @@
 
 #ifdef CIRCT
 
+namespace jlm::hls
+{
+
 // Handles nodes with 2 inputs and 1 output
 circt::firrtl::FModuleOp
-jlm::hls::MLIRGenImpl::MlirGenSimpleNode(const jlm::rvsdg::simple_node *node) {
+MLIRGenImpl::MlirGenSimpleNode(const jlm::rvsdg::simple_node *node) {
 	// Only handles nodes with a single output
 	if (node->noutputs() != 1) {
 		throw std::logic_error(node->operation().debug_string() + " has more than 1 output");
@@ -282,7 +285,7 @@ jlm::hls::MLIRGenImpl::MlirGenSimpleNode(const jlm::rvsdg::simple_node *node) {
 }
 
 circt::firrtl::FModuleOp
-jlm::hls::MLIRGenImpl::MlirGenSink(const jlm::rvsdg::simple_node *node) {
+MLIRGenImpl::MlirGenSink(const jlm::rvsdg::simple_node *node) {
 	// Create the module and its input/output ports
 	auto module = nodeToModule(node);
 	auto body = module.getBodyBlock();
@@ -306,7 +309,7 @@ jlm::hls::MLIRGenImpl::MlirGenSink(const jlm::rvsdg::simple_node *node) {
 }
 
 circt::firrtl::FModuleOp
-jlm::hls::MLIRGenImpl::MlirGenFork(const jlm::rvsdg::simple_node *node) {
+MLIRGenImpl::MlirGenFork(const jlm::rvsdg::simple_node *node) {
 	// Create the module and its input/output ports
 	auto module = nodeToModule(node);
 	auto body = module.getBodyBlock();
@@ -382,7 +385,7 @@ jlm::hls::MLIRGenImpl::MlirGenFork(const jlm::rvsdg::simple_node *node) {
 }
 
 circt::firrtl::FModuleOp
-jlm::hls::MLIRGenImpl::MlirGenMem(const jlm::rvsdg::simple_node *node) {
+MLIRGenImpl::MlirGenMem(const jlm::rvsdg::simple_node *node) {
 	// Create the module and its input/output ports
 	auto module = nodeToModule(node, true);
 	auto body = module.getBodyBlock();
@@ -577,7 +580,7 @@ jlm::hls::MLIRGenImpl::MlirGenMem(const jlm::rvsdg::simple_node *node) {
 }
 
 circt::firrtl::FModuleOp
-jlm::hls::MLIRGenImpl::MlirGenTrigger(const jlm::rvsdg::simple_node *node) {
+MLIRGenImpl::MlirGenTrigger(const jlm::rvsdg::simple_node *node) {
 	// Create the module and its input/output ports
 	auto module = nodeToModule(node);
 	auto body = module.getBodyBlock();
@@ -610,7 +613,7 @@ jlm::hls::MLIRGenImpl::MlirGenTrigger(const jlm::rvsdg::simple_node *node) {
 }
 
 circt::firrtl::FModuleOp
-jlm::hls::MLIRGenImpl::MlirGenPrint(const jlm::rvsdg::simple_node *node) {
+MLIRGenImpl::MlirGenPrint(const jlm::rvsdg::simple_node *node) {
 	// Create the module and its input/output ports
 	auto module = nodeToModule(node);
 	auto body = module.getBodyBlock();
@@ -629,7 +632,7 @@ jlm::hls::MLIRGenImpl::MlirGenPrint(const jlm::rvsdg::simple_node *node) {
 	auto trigger = AddAndOp(body,
 				AddAndOp(body, inReady, inValid),
 				AddNotOp(body, reset));
-	auto pn = dynamic_cast<const jlm::hls::print_op *>(&node->operation());
+	auto pn = dynamic_cast<const print_op *>(&node->operation());
 	auto formatString = "print node " + std::to_string(pn->id()) + ": %x\n";
 	auto name = "print_node_" + std::to_string(pn->id());
 	auto printValue = AddPadOp(body, inData, 64);
@@ -640,7 +643,7 @@ jlm::hls::MLIRGenImpl::MlirGenPrint(const jlm::rvsdg::simple_node *node) {
 }
 
 circt::firrtl::FModuleOp
-jlm::hls::MLIRGenImpl::MlirGenPredicationBuffer(const jlm::rvsdg::simple_node *node) {
+MLIRGenImpl::MlirGenPredicationBuffer(const jlm::rvsdg::simple_node *node) {
 	// Create the module and its input/output ports
 	auto module = nodeToModule(node);
 	auto body = module.getBodyBlock();
@@ -704,7 +707,7 @@ jlm::hls::MLIRGenImpl::MlirGenPredicationBuffer(const jlm::rvsdg::simple_node *n
 }
 
 circt::firrtl::FModuleOp
-jlm::hls::MLIRGenImpl::MlirGenBuffer(const jlm::rvsdg::simple_node *node) {
+MLIRGenImpl::MlirGenBuffer(const jlm::rvsdg::simple_node *node) {
 	// Create the module and its input/output ports
 	auto module = nodeToModule(node);
 	auto body = module.getBodyBlock();
@@ -836,7 +839,7 @@ jlm::hls::MLIRGenImpl::MlirGenBuffer(const jlm::rvsdg::simple_node *node) {
 }
 
 circt::firrtl::FModuleOp
-jlm::hls::MLIRGenImpl::MlirGenDMux(const jlm::rvsdg::simple_node *node) {
+MLIRGenImpl::MlirGenDMux(const jlm::rvsdg::simple_node *node) {
 	// Create the module and its input/output ports
 	auto module = nodeToModule(node);
 	auto body = module.getBodyBlock();
@@ -949,7 +952,7 @@ jlm::hls::MLIRGenImpl::MlirGenDMux(const jlm::rvsdg::simple_node *node) {
 }
 
 circt::firrtl::FModuleOp
-jlm::hls::MLIRGenImpl::MlirGenNDMux(const jlm::rvsdg::simple_node *node) {
+MLIRGenImpl::MlirGenNDMux(const jlm::rvsdg::simple_node *node) {
 	// Create the module and its input/output ports
 	auto module = nodeToModule(node);
 	auto body = module.getBodyBlock();
@@ -994,7 +997,7 @@ jlm::hls::MLIRGenImpl::MlirGenNDMux(const jlm::rvsdg::simple_node *node) {
 }
 
 circt::firrtl::FModuleOp
-jlm::hls::MLIRGenImpl::MlirGenBranch(const jlm::rvsdg::simple_node *node) {
+MLIRGenImpl::MlirGenBranch(const jlm::rvsdg::simple_node *node) {
 	// Create the module and its input/output ports
 	auto module = nodeToModule(node);
 	auto body = module.getBodyBlock();
@@ -1039,7 +1042,7 @@ jlm::hls::MLIRGenImpl::MlirGenBranch(const jlm::rvsdg::simple_node *node) {
 }
 
 circt::firrtl::FModuleOp
-jlm::hls::MLIRGenImpl::MlirGen(const jlm::rvsdg::simple_node *node) {
+MLIRGenImpl::MlirGen(const jlm::rvsdg::simple_node *node) {
 	if (dynamic_cast<const hls::sink_op *>(&(node->operation()))) {
 		return MlirGenSink(node);
 	} else if (dynamic_cast<const hls::fork_op *>(&(node->operation()))) {
@@ -1078,7 +1081,7 @@ jlm::hls::MLIRGenImpl::MlirGen(const jlm::rvsdg::simple_node *node) {
 }
 
 std::unordered_map<jlm::rvsdg::simple_node *, circt::firrtl::InstanceOp>
-jlm::hls::MLIRGenImpl::MlirGen(hls::loop_node *loopNode, mlir::Block *body, mlir::Block *circuitBody) {
+MLIRGenImpl::MlirGen(hls::loop_node *loopNode, mlir::Block *body, mlir::Block *circuitBody) {
 	auto subRegion = loopNode->subregion();
 
 	// First we create and instantiate all the modules and keep them in a dictionary
@@ -1106,12 +1109,12 @@ jlm::hls::MLIRGenImpl::MlirGen(hls::loop_node *loopNode, mlir::Block *body, mlir
 // Returns the output of a node or the argument of a region that has
 // been instantiated as a module
 jlm::rvsdg::output *
-jlm::hls::MLIRGenImpl::TraceArgument(jlm::rvsdg::argument *arg) {
+MLIRGenImpl::TraceArgument(jlm::rvsdg::argument *arg) {
 	// Check if the argument is part of a hls::loop_node
 	auto region = arg->region();
 	auto node = region->node();
 	if (dynamic_cast<hls::loop_node *>(node)) {
-		if (auto ba = dynamic_cast<jlm::hls::backedge_argument*>(arg)) {
+		if (auto ba = dynamic_cast<backedge_argument*>(arg)) {
             return ba->result()->origin();
         } else {
             // Check if the argument is connected to an input,
@@ -1137,7 +1140,7 @@ jlm::hls::MLIRGenImpl::TraceArgument(jlm::rvsdg::argument *arg) {
 }
 
 circt::firrtl::FModuleOp
-jlm::hls::MLIRGenImpl::MlirGen(jlm::rvsdg::region *subRegion, mlir::Block *circuitBody) {
+MLIRGenImpl::MlirGen(jlm::rvsdg::region *subRegion, mlir::Block *circuitBody) {
 	// Generate a vector with all inputs and outputs of the module
 	::llvm::SmallVector<circt::firrtl::PortInfo> ports;
 
@@ -1368,7 +1371,7 @@ jlm::hls::MLIRGenImpl::MlirGen(jlm::rvsdg::region *subRegion, mlir::Block *circu
 // Trace a structural output back to the "node" generating the value
 // Returns the output of the node
 jlm::rvsdg::simple_output *
-jlm::hls::MLIRGenImpl::TraceStructuralOutput(jlm::rvsdg::structural_output *output) {
+MLIRGenImpl::TraceStructuralOutput(jlm::rvsdg::structural_output *output) {
 	auto node = output->node();
 
 	// We are only expecting hls::loop_node to have a structural output
@@ -1391,7 +1394,7 @@ jlm::hls::MLIRGenImpl::TraceStructuralOutput(jlm::rvsdg::structural_output *outp
 
 // Emit a circuit
 circt::firrtl::CircuitOp
-jlm::hls::MLIRGenImpl::MlirGen(const llvm::lambda::node *lambdaNode) {
+MLIRGenImpl::MlirGen(const llvm::lambda::node *lambdaNode) {
 
     // Ensure consistent naming across runs
     create_node_names(lambdaNode->subregion());
@@ -1712,7 +1715,7 @@ jlm::hls::MLIRGenImpl::MlirGen(const llvm::lambda::node *lambdaNode) {
 
 // Returns a PortInfo of ClockType
 void
-jlm::hls::MLIRGenImpl::AddClockPort(::llvm::SmallVector<circt::firrtl::PortInfo> *ports) {
+MLIRGenImpl::AddClockPort(::llvm::SmallVector<circt::firrtl::PortInfo> *ports) {
 	struct circt::firrtl::PortInfo port = {
 		builder.getStringAttr("clk"),
 		circt::firrtl::ClockType::get(builder.getContext()),
@@ -1725,7 +1728,7 @@ jlm::hls::MLIRGenImpl::AddClockPort(::llvm::SmallVector<circt::firrtl::PortInfo>
 
 // Returns a PortInfo of unsigned IntType with width of 1
 void
-jlm::hls::MLIRGenImpl::AddResetPort(::llvm::SmallVector<circt::firrtl::PortInfo> *ports) {
+MLIRGenImpl::AddResetPort(::llvm::SmallVector<circt::firrtl::PortInfo> *ports) {
 	struct circt::firrtl::PortInfo port = {
 		builder.getStringAttr("reset"),
 		circt::firrtl::IntType::get(builder.getContext(), false, 1),
@@ -1737,7 +1740,7 @@ jlm::hls::MLIRGenImpl::AddResetPort(::llvm::SmallVector<circt::firrtl::PortInfo>
 }
 
 void
-jlm::hls::MLIRGenImpl::AddMemReqPort(::llvm::SmallVector<circt::firrtl::PortInfo> *ports) {
+MLIRGenImpl::AddMemReqPort(::llvm::SmallVector<circt::firrtl::PortInfo> *ports) {
 	using BundleElement = circt::firrtl::BundleType::BundleElement;
 
 	::llvm::SmallVector<BundleElement> memReqElements;
@@ -1780,7 +1783,7 @@ jlm::hls::MLIRGenImpl::AddMemReqPort(::llvm::SmallVector<circt::firrtl::PortInfo
 }
 
 void
-jlm::hls::MLIRGenImpl::AddMemResPort(::llvm::SmallVector<circt::firrtl::PortInfo> *ports) {
+MLIRGenImpl::AddMemResPort(::llvm::SmallVector<circt::firrtl::PortInfo> *ports) {
 	using BundleElement = circt::firrtl::BundleType::BundleElement;
 
 	::llvm::SmallVector<BundleElement> memResElements;
@@ -1804,7 +1807,7 @@ jlm::hls::MLIRGenImpl::AddMemResPort(::llvm::SmallVector<circt::firrtl::PortInfo
 }
 
 void
-jlm::hls::MLIRGenImpl::AddBundlePort(
+MLIRGenImpl::AddBundlePort(
 			::llvm::SmallVector<circt::firrtl::PortInfo> *ports,
 			circt::firrtl::Direction direction,
 			std::string name,
@@ -1831,21 +1834,21 @@ jlm::hls::MLIRGenImpl::AddBundlePort(
 }
 
 circt::firrtl::SubfieldOp
-jlm::hls::MLIRGenImpl::GetSubfield(mlir::Block *body, mlir::Value value, int index) {
+MLIRGenImpl::GetSubfield(mlir::Block *body, mlir::Value value, int index) {
 	auto subfield = builder.create<circt::firrtl::SubfieldOp>(location, value, index);
 	body->push_back(subfield);
 	return subfield;
 }
 
 circt::firrtl::SubfieldOp
-jlm::hls::MLIRGenImpl::GetSubfield(mlir::Block *body, mlir::Value value, ::llvm::StringRef fieldName) {
+MLIRGenImpl::GetSubfield(mlir::Block *body, mlir::Value value, ::llvm::StringRef fieldName) {
 	auto subfield = builder.create<circt::firrtl::SubfieldOp>(location, value, fieldName);
 	body->push_back(subfield);
 	return subfield;
 }
 
 mlir::BlockArgument
-jlm::hls::MLIRGenImpl::GetPort(circt::firrtl::FModuleOp& module, std::string portName) {
+MLIRGenImpl::GetPort(circt::firrtl::FModuleOp& module, std::string portName) {
     for (size_t i = 0; i < module.getNumPorts(); ++i) {
         if(module.getPortName(i) == portName){
             return module.getArgument(i);
@@ -1855,17 +1858,17 @@ jlm::hls::MLIRGenImpl::GetPort(circt::firrtl::FModuleOp& module, std::string por
 }
 
 mlir::BlockArgument
-jlm::hls::MLIRGenImpl::GetInPort(circt::firrtl::FModuleOp& module, size_t portNr) {
+MLIRGenImpl::GetInPort(circt::firrtl::FModuleOp& module, size_t portNr) {
     return GetPort(module, "i"+std::to_string(portNr));
 }
 
 mlir::BlockArgument
-jlm::hls::MLIRGenImpl::GetOutPort(circt::firrtl::FModuleOp& module, size_t portNr) {
+MLIRGenImpl::GetOutPort(circt::firrtl::FModuleOp& module, size_t portNr) {
     return GetPort(module, "o"+std::to_string(portNr));
 }
 
 void
-jlm::hls::MLIRGenImpl::Connect(mlir::Block *body, mlir::Value sink, mlir::Value source) {
+MLIRGenImpl::Connect(mlir::Block *body, mlir::Value sink, mlir::Value source) {
 	body->push_back(builder.create<circt::firrtl::ConnectOp>(
 				location,
 				sink,
@@ -1873,7 +1876,7 @@ jlm::hls::MLIRGenImpl::Connect(mlir::Block *body, mlir::Value sink, mlir::Value 
 }
 
 circt::firrtl::BitsPrimOp
-jlm::hls::MLIRGenImpl::AddBitsOp(mlir::Block *body, mlir::Value value, int high, int low) {
+MLIRGenImpl::AddBitsOp(mlir::Block *body, mlir::Value value, int high, int low) {
 	auto intType = builder.getIntegerType(32);
 	auto op = builder.create<circt::firrtl::BitsPrimOp>(
 				location,
@@ -1885,7 +1888,7 @@ jlm::hls::MLIRGenImpl::AddBitsOp(mlir::Block *body, mlir::Value value, int high,
 }
 
 circt::firrtl::AndPrimOp
-jlm::hls::MLIRGenImpl::AddAndOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
+MLIRGenImpl::AddAndOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
 	auto op = builder.create<circt::firrtl::AndPrimOp>(
 				location,
 				first,
@@ -1895,7 +1898,7 @@ jlm::hls::MLIRGenImpl::AddAndOp(mlir::Block *body, mlir::Value first, mlir::Valu
 }
 
 circt::firrtl::XorPrimOp
-jlm::hls::MLIRGenImpl::AddXorOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
+MLIRGenImpl::AddXorOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
 	auto op = builder.create<circt::firrtl::XorPrimOp>(
 				location,
 				first,
@@ -1905,7 +1908,7 @@ jlm::hls::MLIRGenImpl::AddXorOp(mlir::Block *body, mlir::Value first, mlir::Valu
 }
 
 circt::firrtl::OrPrimOp
-jlm::hls::MLIRGenImpl::AddOrOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
+MLIRGenImpl::AddOrOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
 	auto op = builder.create<circt::firrtl::OrPrimOp>(
 				location,
 				first,
@@ -1915,7 +1918,7 @@ jlm::hls::MLIRGenImpl::AddOrOp(mlir::Block *body, mlir::Value first, mlir::Value
 }
 
 circt::firrtl::NotPrimOp
-jlm::hls::MLIRGenImpl::AddNotOp(mlir::Block *body, mlir::Value first) {
+MLIRGenImpl::AddNotOp(mlir::Block *body, mlir::Value first) {
 	auto op = builder.create<circt::firrtl::NotPrimOp>(
 				location,
 				first);
@@ -1924,7 +1927,7 @@ jlm::hls::MLIRGenImpl::AddNotOp(mlir::Block *body, mlir::Value first) {
 }
 
 circt::firrtl::AddPrimOp
-jlm::hls::MLIRGenImpl::AddAddOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
+MLIRGenImpl::AddAddOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
 	auto op = builder.create<circt::firrtl::AddPrimOp>(
 				location,
 				first,
@@ -1934,7 +1937,7 @@ jlm::hls::MLIRGenImpl::AddAddOp(mlir::Block *body, mlir::Value first, mlir::Valu
 }
 
 circt::firrtl::SubPrimOp
-jlm::hls::MLIRGenImpl::AddSubOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
+MLIRGenImpl::AddSubOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
 	auto op = builder.create<circt::firrtl::SubPrimOp>(
 				location,
 				first,
@@ -1944,7 +1947,7 @@ jlm::hls::MLIRGenImpl::AddSubOp(mlir::Block *body, mlir::Value first, mlir::Valu
 }
 
 circt::firrtl::MulPrimOp
-jlm::hls::MLIRGenImpl::AddMulOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
+MLIRGenImpl::AddMulOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
 	auto op = builder.create<circt::firrtl::MulPrimOp>(
 				location,
 				first,
@@ -1954,7 +1957,7 @@ jlm::hls::MLIRGenImpl::AddMulOp(mlir::Block *body, mlir::Value first, mlir::Valu
 }
 
 circt::firrtl::DivPrimOp
-jlm::hls::MLIRGenImpl::AddDivOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
+MLIRGenImpl::AddDivOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
 	auto op = builder.create<circt::firrtl::DivPrimOp>(
 				location,
 				first,
@@ -1964,7 +1967,7 @@ jlm::hls::MLIRGenImpl::AddDivOp(mlir::Block *body, mlir::Value first, mlir::Valu
 }
 
 circt::firrtl::DShrPrimOp
-jlm::hls::MLIRGenImpl::AddDShrOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
+MLIRGenImpl::AddDShrOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
 	auto op = builder.create<circt::firrtl::DShrPrimOp>(
 				location,
 				first,
@@ -1974,7 +1977,7 @@ jlm::hls::MLIRGenImpl::AddDShrOp(mlir::Block *body, mlir::Value first, mlir::Val
 }
 
 circt::firrtl::DShlPrimOp
-jlm::hls::MLIRGenImpl::AddDShlOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
+MLIRGenImpl::AddDShlOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
 	auto op = builder.create<circt::firrtl::DShlPrimOp>(
 				location,
 				first,
@@ -1984,7 +1987,7 @@ jlm::hls::MLIRGenImpl::AddDShlOp(mlir::Block *body, mlir::Value first, mlir::Val
 }
 
 circt::firrtl::RemPrimOp
-jlm::hls::MLIRGenImpl::AddRemOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
+MLIRGenImpl::AddRemOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
 	auto op = builder.create<circt::firrtl::RemPrimOp>(
 				location,
 				first,
@@ -1994,7 +1997,7 @@ jlm::hls::MLIRGenImpl::AddRemOp(mlir::Block *body, mlir::Value first, mlir::Valu
 }
 
 circt::firrtl::EQPrimOp
-jlm::hls::MLIRGenImpl::AddEqOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
+MLIRGenImpl::AddEqOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
 	auto op = builder.create<circt::firrtl::EQPrimOp>(
 				location,
 				first,
@@ -2004,7 +2007,7 @@ jlm::hls::MLIRGenImpl::AddEqOp(mlir::Block *body, mlir::Value first, mlir::Value
 }
 
 circt::firrtl::NEQPrimOp
-jlm::hls::MLIRGenImpl::AddNeqOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
+MLIRGenImpl::AddNeqOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
 	auto op = builder.create<circt::firrtl::NEQPrimOp>(
 				location,
 				first,
@@ -2014,7 +2017,7 @@ jlm::hls::MLIRGenImpl::AddNeqOp(mlir::Block *body, mlir::Value first, mlir::Valu
 }
 
 circt::firrtl::GTPrimOp
-jlm::hls::MLIRGenImpl::AddGtOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
+MLIRGenImpl::AddGtOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
 	auto op = builder.create<circt::firrtl::GTPrimOp>(
 				location,
 				first,
@@ -2024,7 +2027,7 @@ jlm::hls::MLIRGenImpl::AddGtOp(mlir::Block *body, mlir::Value first, mlir::Value
 }
 
 circt::firrtl::GEQPrimOp
-jlm::hls::MLIRGenImpl::AddGeqOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
+MLIRGenImpl::AddGeqOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
 	auto op = builder.create<circt::firrtl::GEQPrimOp>(
 				location,
 				first,
@@ -2034,7 +2037,7 @@ jlm::hls::MLIRGenImpl::AddGeqOp(mlir::Block *body, mlir::Value first, mlir::Valu
 }
 
 circt::firrtl::LTPrimOp
-jlm::hls::MLIRGenImpl::AddLtOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
+MLIRGenImpl::AddLtOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
 	auto op = builder.create<circt::firrtl::LTPrimOp>(
 				location,
 				first,
@@ -2044,7 +2047,7 @@ jlm::hls::MLIRGenImpl::AddLtOp(mlir::Block *body, mlir::Value first, mlir::Value
 }
 
 circt::firrtl::LEQPrimOp
-jlm::hls::MLIRGenImpl::AddLeqOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
+MLIRGenImpl::AddLeqOp(mlir::Block *body, mlir::Value first, mlir::Value second) {
 	auto op = builder.create<circt::firrtl::LEQPrimOp>(
 				location,
 				first,
@@ -2054,7 +2057,7 @@ jlm::hls::MLIRGenImpl::AddLeqOp(mlir::Block *body, mlir::Value first, mlir::Valu
 }
 
 circt::firrtl::MuxPrimOp
-jlm::hls::MLIRGenImpl::AddMuxOp(mlir::Block *body, mlir::Value select, mlir::Value high, mlir::Value low) {
+MLIRGenImpl::AddMuxOp(mlir::Block *body, mlir::Value select, mlir::Value high, mlir::Value low) {
 	auto op = builder.create<circt::firrtl::MuxPrimOp>(
 				location,
 				select,
@@ -2065,7 +2068,7 @@ jlm::hls::MLIRGenImpl::AddMuxOp(mlir::Block *body, mlir::Value select, mlir::Val
 }
 
 circt::firrtl::AsSIntPrimOp
-jlm::hls::MLIRGenImpl::AddAsSIntOp(mlir::Block *body, mlir::Value value) {
+MLIRGenImpl::AddAsSIntOp(mlir::Block *body, mlir::Value value) {
 	auto op = builder.create<circt::firrtl::AsSIntPrimOp>(
 				location,
 				value);
@@ -2074,7 +2077,7 @@ jlm::hls::MLIRGenImpl::AddAsSIntOp(mlir::Block *body, mlir::Value value) {
 }
 
 circt::firrtl::AsUIntPrimOp
-jlm::hls::MLIRGenImpl::AddAsUIntOp(mlir::Block *body, mlir::Value value) {
+MLIRGenImpl::AddAsUIntOp(mlir::Block *body, mlir::Value value) {
 	auto op = builder.create<circt::firrtl::AsUIntPrimOp>(
 				location,
 				value);
@@ -2083,7 +2086,7 @@ jlm::hls::MLIRGenImpl::AddAsUIntOp(mlir::Block *body, mlir::Value value) {
 }
 
 circt::firrtl::PadPrimOp
-jlm::hls::MLIRGenImpl::AddPadOp(mlir::Block *body, mlir::Value value, int amount) {
+MLIRGenImpl::AddPadOp(mlir::Block *body, mlir::Value value, int amount) {
 	auto op = builder.create<circt::firrtl::PadPrimOp>(
 				location,
 				value,
@@ -2093,7 +2096,7 @@ jlm::hls::MLIRGenImpl::AddPadOp(mlir::Block *body, mlir::Value value, int amount
 }
 
 circt::firrtl::CvtPrimOp
-jlm::hls::MLIRGenImpl::AddCvtOp(mlir::Block *body, mlir::Value value) {
+MLIRGenImpl::AddCvtOp(mlir::Block *body, mlir::Value value) {
 	auto op = builder.create<circt::firrtl::CvtPrimOp>(
 				location,
 				value);
@@ -2102,7 +2105,7 @@ jlm::hls::MLIRGenImpl::AddCvtOp(mlir::Block *body, mlir::Value value) {
 }
 
 circt::firrtl::WireOp
-jlm::hls::MLIRGenImpl::AddWireOp(mlir::Block *body, std::string name, int size) {
+MLIRGenImpl::AddWireOp(mlir::Block *body, std::string name, int size) {
 	auto op = builder.create<circt::firrtl::WireOp>(
 				location,
 				GetIntType(size),
@@ -2112,7 +2115,7 @@ jlm::hls::MLIRGenImpl::AddWireOp(mlir::Block *body, std::string name, int size) 
 }
 
 circt::firrtl::WhenOp
-jlm::hls::MLIRGenImpl::AddWhenOp(mlir::Block *body, mlir::Value condition, bool elseStatement) {
+MLIRGenImpl::AddWhenOp(mlir::Block *body, mlir::Value condition, bool elseStatement) {
 	auto op = builder.create<circt::firrtl::WhenOp>(
 				location,
 				condition,
@@ -2122,7 +2125,7 @@ jlm::hls::MLIRGenImpl::AddWhenOp(mlir::Block *body, mlir::Value condition, bool 
 }
 
 circt::firrtl::InstanceOp
-jlm::hls::MLIRGenImpl::AddInstanceOp(mlir::Block *body, jlm::rvsdg::simple_node *node) {
+MLIRGenImpl::AddInstanceOp(mlir::Block *body, jlm::rvsdg::simple_node *node) {
 	auto name = GetModuleName(node);
 	// Check if the module has already been instantiated else we need to generate it
 	if (!modules[name]) {
@@ -2138,7 +2141,7 @@ jlm::hls::MLIRGenImpl::AddInstanceOp(mlir::Block *body, jlm::rvsdg::simple_node 
 }
 
 circt::firrtl::ConstantOp
-jlm::hls::MLIRGenImpl::GetConstant(mlir::Block *body, int size, int value) {
+MLIRGenImpl::GetConstant(mlir::Block *body, int size, int value) {
 	auto intType= GetIntType(size);
 	auto constant = builder.create<circt::firrtl::ConstantOp>(
 			location,
@@ -2149,7 +2152,7 @@ jlm::hls::MLIRGenImpl::GetConstant(mlir::Block *body, int size, int value) {
 }
 
 circt::firrtl::InvalidValueOp
-jlm::hls::MLIRGenImpl::GetInvalid(mlir::Block *body, int size) {
+MLIRGenImpl::GetInvalid(mlir::Block *body, int size) {
 
 	auto invalid = builder.create<circt::firrtl::InvalidValueOp>(
 				location,
@@ -2160,7 +2163,7 @@ jlm::hls::MLIRGenImpl::GetInvalid(mlir::Block *body, int size) {
 
 // Get the clock signal in the module
 mlir::BlockArgument
-jlm::hls::MLIRGenImpl::GetClockSignal(circt::firrtl::FModuleOp module) {
+MLIRGenImpl::GetClockSignal(circt::firrtl::FModuleOp module) {
 	auto clock = module.getArgument(0);
 	auto ctype = clock.getType().cast<circt::firrtl::FIRRTLType>();
 	if (!ctype.isa<circt::firrtl::ClockType>()) {
@@ -2172,7 +2175,7 @@ jlm::hls::MLIRGenImpl::GetClockSignal(circt::firrtl::FModuleOp module) {
 
 // Get the reset signal in the module
 mlir::BlockArgument
-jlm::hls::MLIRGenImpl::GetResetSignal(circt::firrtl::FModuleOp module) {
+MLIRGenImpl::GetResetSignal(circt::firrtl::FModuleOp module) {
 	auto reset = module.getArgument(1);
 	auto rtype = reset.getType().cast<circt::firrtl::FIRRTLType>();
 	if (!rtype.isa<circt::firrtl::ResetType>()) {
@@ -2182,7 +2185,7 @@ jlm::hls::MLIRGenImpl::GetResetSignal(circt::firrtl::FModuleOp module) {
 }
 
 circt::firrtl::BundleType::BundleElement
-jlm::hls::MLIRGenImpl::GetReadyElement() {
+MLIRGenImpl::GetReadyElement() {
 	using BundleElement = circt::firrtl::BundleType::BundleElement;
 
 	return BundleElement(
@@ -2192,7 +2195,7 @@ jlm::hls::MLIRGenImpl::GetReadyElement() {
 }
 
 circt::firrtl::BundleType::BundleElement
-jlm::hls::MLIRGenImpl::GetValidElement() {
+MLIRGenImpl::GetValidElement() {
 	using BundleElement = circt::firrtl::BundleType::BundleElement;
 
 	return BundleElement(
@@ -2202,7 +2205,7 @@ jlm::hls::MLIRGenImpl::GetValidElement() {
 }
 
 void
-jlm::hls::MLIRGenImpl::InitializeMemReq(circt::firrtl::FModuleOp module) {
+MLIRGenImpl::InitializeMemReq(circt::firrtl::FModuleOp module) {
 	mlir::BlockArgument mem = GetPort(module, "mem_req");
 	mlir::Block *body = module.getBodyBlock();
 
@@ -2228,7 +2231,7 @@ jlm::hls::MLIRGenImpl::InitializeMemReq(circt::firrtl::FModuleOp module) {
 // bundle for each node input and output bundle for each node output
 // Returns a circt::firrtl::FModuleOp with an empty body
 circt::firrtl::FModuleOp
-jlm::hls::MLIRGenImpl::nodeToModule(const jlm::rvsdg::simple_node *node, bool mem) {
+MLIRGenImpl::nodeToModule(const jlm::rvsdg::simple_node *node, bool mem) {
 	// Generate a vector with all inputs and outputs of the module
 	::llvm::SmallVector<circt::firrtl::PortInfo> ports;
 
@@ -2273,7 +2276,7 @@ jlm::hls::MLIRGenImpl::nodeToModule(const jlm::rvsdg::simple_node *node, bool me
 
 // Returns IntType of the specified width
 circt::firrtl::IntType
-jlm::hls::MLIRGenImpl::GetIntType(int size) {
+MLIRGenImpl::GetIntType(int size) {
 	return circt::firrtl::IntType::get(builder.getContext(), false, size);
 }
 
@@ -2282,12 +2285,12 @@ jlm::hls::MLIRGenImpl::GetIntType(int size) {
 // which is usefull for, e.g., additions where the result has to be 1
 // larger than the operands to accomodate for the carry.
 circt::firrtl::IntType
-jlm::hls::MLIRGenImpl::GetIntType(const jlm::rvsdg::type *type, int extend) {
+MLIRGenImpl::GetIntType(const jlm::rvsdg::type *type, int extend) {
 	return circt::firrtl::IntType::get(builder.getContext(), false, JlmSize(type)+extend);
 }
 
 std::string
-jlm::hls::MLIRGenImpl::GetModuleName(const jlm::rvsdg::node *node) {
+MLIRGenImpl::GetModuleName(const jlm::rvsdg::node *node) {
 
 	std::string append = "";
 	for (size_t i = 0; i < node->ninputs(); ++i) {
@@ -2324,7 +2327,7 @@ jlm::hls::MLIRGenImpl::GetModuleName(const jlm::rvsdg::node *node) {
 }
 
 bool
-jlm::hls::MLIRGenImpl::IsIdentityMapping(const jlm::rvsdg::match_op &op) {
+MLIRGenImpl::IsIdentityMapping(const jlm::rvsdg::match_op &op) {
 	for (const auto &pair : op) {
 		if (pair.first != pair.second)
 			return false;
@@ -2336,7 +2339,7 @@ jlm::hls::MLIRGenImpl::IsIdentityMapping(const jlm::rvsdg::match_op &op) {
 // Used for debugging a module by wrapping it in a circuit and writing it to a file
 // Node is simply a convenience for generating the circuit name
 void
-jlm::hls::MLIRGenImpl::WriteModuleToFile(const circt::firrtl::FModuleOp fModuleOp, const jlm::rvsdg::node *node) {
+MLIRGenImpl::WriteModuleToFile(const circt::firrtl::FModuleOp fModuleOp, const jlm::rvsdg::node *node) {
 	if (!fModuleOp)
 		return;
 
@@ -2353,7 +2356,7 @@ jlm::hls::MLIRGenImpl::WriteModuleToFile(const circt::firrtl::FModuleOp fModuleO
 
 // Verifies the circuit and writes the FIRRTL to a file
 void
-jlm::hls::MLIRGenImpl::WriteCircuitToFile(const circt::firrtl::CircuitOp circuit, std::string name) {
+MLIRGenImpl::WriteCircuitToFile(const circt::firrtl::CircuitOp circuit, std::string name) {
 	// Add the circuit to a top module
 	auto module = mlir::ModuleOp::create(location);
 	module.push_back(circuit);
@@ -2379,7 +2382,7 @@ jlm::hls::MLIRGenImpl::WriteCircuitToFile(const circt::firrtl::CircuitOp circuit
 }
 
 std::string
-jlm::hls::MLIRGenImpl::toString(const circt::firrtl::CircuitOp circuit) {
+MLIRGenImpl::toString(const circt::firrtl::CircuitOp circuit) {
 	// Add the circuit to a top module
 	auto module = mlir::ModuleOp::create(location);
 	module.push_back(circuit);
@@ -2398,6 +2401,8 @@ jlm::hls::MLIRGenImpl::toString(const circt::firrtl::CircuitOp circuit) {
 		throw std::logic_error("Exporting of firrtl failed");
 
 	return outputString;
+}
+
 }
 
 #endif //CIRCT

--- a/jlm/hls/backend/rhls2firrtl/mlirgen.hpp
+++ b/jlm/hls/backend/rhls2firrtl/mlirgen.hpp
@@ -31,209 +31,210 @@
 #include "circt/Dialect/FIRRTL/Namespace.h"
 #include "circt/Support/LLVM.h"
 
-namespace jlm {
-	namespace hls{
-		class MLIRGenImpl : public BaseHLS {
-			std::string
-			extension() override {
-				return ".fir";
-				}
-		public:
-			std::string get_text(llvm::RvsdgModule &rvsdgModule) override {return "MLIR/FIRRTL generator";}
-			MLIRGenImpl(mlir::MLIRContext &context) : builder(&context) {}
-			circt::firrtl::CircuitOp MlirGen(const llvm::lambda::node *lamdaNode);
-			void WriteModuleToFile(const circt::firrtl::FModuleOp fModuleOp, const jlm::rvsdg::node *node);
-			void WriteCircuitToFile(const circt::firrtl::CircuitOp circuit, std::string name);
-			std::string toString(const circt::firrtl::CircuitOp circuit);
-		private:
-			// Variables
-			mlir::OpBuilder builder;
-			// We don't have any locations (i.e., the originating line in the
-			// source file) in RVSDG, so we set all operations to unkown
-			mlir::Location location = builder.getUnknownLoc();
-			circt::firrtl::ConventionAttr conventionAttr = circt::firrtl::ConventionAttr::get(builder.getContext(), Convention::Internal);
-			std::unordered_map<std::string, circt::firrtl::FModuleOp> modules;
-			// FIRRTL generating functions
-			std::unordered_map<jlm::rvsdg::simple_node *, circt::firrtl::InstanceOp>
-			MlirGen(hls::loop_node *loopNode, mlir::Block *body, mlir::Block *circuitBody);
-			circt::firrtl::FModuleOp MlirGen(jlm::rvsdg::region *subRegion, mlir::Block *circuitBody);
-			circt::firrtl::FModuleOp MlirGen(const jlm::rvsdg::simple_node *node);
-			// Operations
-			circt::firrtl::FModuleOp MlirGenSink(const jlm::rvsdg::simple_node *node);
-			circt::firrtl::FModuleOp MlirGenFork(const jlm::rvsdg::simple_node *node);
-			circt::firrtl::FModuleOp MlirGenMem(const jlm::rvsdg::simple_node *node);
-			circt::firrtl::FModuleOp MlirGenTrigger(const jlm::rvsdg::simple_node *node);
-			circt::firrtl::FModuleOp MlirGenPrint(const jlm::rvsdg::simple_node *node);
-			circt::firrtl::FModuleOp MlirGenPredicationBuffer(const jlm::rvsdg::simple_node *node);
-			circt::firrtl::FModuleOp MlirGenBuffer(const jlm::rvsdg::simple_node *node);
-			circt::firrtl::FModuleOp MlirGenDMux(const jlm::rvsdg::simple_node *node);
-			circt::firrtl::FModuleOp MlirGenNDMux(const jlm::rvsdg::simple_node *node);
-			circt::firrtl::FModuleOp MlirGenBranch(const jlm::rvsdg::simple_node *node);
-			circt::firrtl::FModuleOp MlirGenSimpleNode(const jlm::rvsdg::simple_node *node);
+namespace jlm::hls
+{
 
-			// Helper functions
-			void AddClockPort(::llvm::SmallVector<circt::firrtl::PortInfo> *ports);
-			void AddResetPort(::llvm::SmallVector<circt::firrtl::PortInfo> *ports);
-			void AddMemReqPort(::llvm::SmallVector<circt::firrtl::PortInfo> *ports);
-			void AddMemResPort(::llvm::SmallVector<circt::firrtl::PortInfo> *ports);
-			void AddBundlePort(
-					::llvm::SmallVector<circt::firrtl::PortInfo> *ports,
-					circt::firrtl::Direction direction,
-					std::string name,
-					circt::firrtl::FIRRTLBaseType type);
-			circt::firrtl::SubfieldOp GetSubfield(
-					mlir::Block *body,
-					mlir::Value value,
-					int index);
-			circt::firrtl::SubfieldOp GetSubfield(
-					mlir::Block *body,
-					mlir::Value value,
-					::llvm::StringRef fieldName);
-			mlir::BlockArgument GetPort(circt::firrtl::FModuleOp &module, std::string portName);
-			mlir::BlockArgument GetInPort(circt::firrtl::FModuleOp &module, size_t portNr);
-			mlir::BlockArgument GetOutPort(circt::firrtl::FModuleOp &module, size_t portNr);
-			void Connect(mlir::Block *body, mlir::Value sink, mlir::Value source);
-			// Primary operations
-			circt::firrtl::BitsPrimOp AddBitsOp(mlir::Block *body,
-							mlir::Value value,
-							int high,
-							int low);
-			circt::firrtl::AndPrimOp AddAndOp(mlir::Block *body,
-							mlir::Value first,
-							mlir::Value second);
-			circt::firrtl::XorPrimOp AddXorOp(mlir::Block *body,
-							mlir::Value first,
-							mlir::Value second);
-			circt::firrtl::OrPrimOp AddOrOp(mlir::Block *body,
-							mlir::Value first,
-							mlir::Value second);
-			circt::firrtl::NotPrimOp AddNotOp(mlir::Block *body,
-							mlir::Value first);
-			circt::firrtl::AddPrimOp AddAddOp(mlir::Block *body,
-							mlir::Value first,
-							mlir::Value second);
-			circt::firrtl::SubPrimOp AddSubOp(mlir::Block *body,
-							mlir::Value first,
-							mlir::Value second);
-			circt::firrtl::MulPrimOp AddMulOp(mlir::Block *body,
-							mlir::Value first,
-							mlir::Value second);
-			circt::firrtl::DivPrimOp AddDivOp(mlir::Block *body,
-							mlir::Value first,
-							mlir::Value second);
-			circt::firrtl::DShrPrimOp AddDShrOp(mlir::Block *body,
-							mlir::Value first,
-							mlir::Value second);
-			circt::firrtl::DShlPrimOp AddDShlOp(mlir::Block *body,
-							mlir::Value first,
-							mlir::Value second);
-			circt::firrtl::RemPrimOp AddRemOp(mlir::Block *body,
-							mlir::Value first,
-							mlir::Value second);
-			circt::firrtl::EQPrimOp AddEqOp(mlir::Block *body,
-							mlir::Value first,
-							mlir::Value second);
-			circt::firrtl::NEQPrimOp AddNeqOp(mlir::Block *body,
-							mlir::Value first,
-							mlir::Value second);
-			circt::firrtl::GTPrimOp AddGtOp(mlir::Block *body,
-							mlir::Value first,
-							mlir::Value second);
-			circt::firrtl::GEQPrimOp AddGeqOp(mlir::Block *body,
-							mlir::Value first,
-							mlir::Value second);
-			circt::firrtl::LTPrimOp AddLtOp(mlir::Block *body,
-							mlir::Value first,
-							mlir::Value second);
-			circt::firrtl::LEQPrimOp AddLeqOp(mlir::Block *body,
-							mlir::Value first,
-							mlir::Value second);
-			circt::firrtl::MuxPrimOp AddMuxOp(mlir::Block *body,
-							mlir::Value select,
-							mlir::Value high,
-							mlir::Value low);
-			circt::firrtl::AsSIntPrimOp AddAsSIntOp(mlir::Block *body,
-							mlir::Value value);
-			circt::firrtl::AsUIntPrimOp AddAsUIntOp(mlir::Block *body,
-							mlir::Value value);
-			circt::firrtl::PadPrimOp AddPadOp(mlir::Block *body,
-							mlir::Value value,
-							int amount);
-			circt::firrtl::CvtPrimOp AddCvtOp(mlir::Block *body,
-							mlir::Value value);
-			circt::firrtl::WireOp AddWireOp(mlir::Block *body,
-							std::string name,
-							int size);
-			circt::firrtl::WhenOp AddWhenOp(mlir::Block *body,
-							mlir::Value condition,
-							bool elseStatment);
-			circt::firrtl::InstanceOp AddInstanceOp(mlir::Block *body,
-							jlm::rvsdg::simple_node *node);
-			circt::firrtl::ConstantOp GetConstant(mlir::Block *body, int size, int value);
-			circt::firrtl::InvalidValueOp GetInvalid(mlir::Block *body, int size);
+class MLIRGenImpl : public BaseHLS {
+  std::string
+  extension() override {
+    return ".fir";
+  }
+public:
+  std::string get_text(llvm::RvsdgModule &rvsdgModule) override {return "MLIR/FIRRTL generator";}
+  MLIRGenImpl(mlir::MLIRContext &context) : builder(&context) {}
+  circt::firrtl::CircuitOp MlirGen(const llvm::lambda::node *lamdaNode);
+  void WriteModuleToFile(const circt::firrtl::FModuleOp fModuleOp, const jlm::rvsdg::node *node);
+  void WriteCircuitToFile(const circt::firrtl::CircuitOp circuit, std::string name);
+  std::string toString(const circt::firrtl::CircuitOp circuit);
+private:
+  // Variables
+  mlir::OpBuilder builder;
+  // We don't have any locations (i.e., the originating line in the
+  // source file) in RVSDG, so we set all operations to unkown
+  mlir::Location location = builder.getUnknownLoc();
+  circt::firrtl::ConventionAttr conventionAttr = circt::firrtl::ConventionAttr::get(builder.getContext(), Convention::Internal);
+  std::unordered_map<std::string, circt::firrtl::FModuleOp> modules;
+  // FIRRTL generating functions
+  std::unordered_map<jlm::rvsdg::simple_node *, circt::firrtl::InstanceOp>
+  MlirGen(hls::loop_node *loopNode, mlir::Block *body, mlir::Block *circuitBody);
+  circt::firrtl::FModuleOp MlirGen(jlm::rvsdg::region *subRegion, mlir::Block *circuitBody);
+  circt::firrtl::FModuleOp MlirGen(const jlm::rvsdg::simple_node *node);
+  // Operations
+  circt::firrtl::FModuleOp MlirGenSink(const jlm::rvsdg::simple_node *node);
+  circt::firrtl::FModuleOp MlirGenFork(const jlm::rvsdg::simple_node *node);
+  circt::firrtl::FModuleOp MlirGenMem(const jlm::rvsdg::simple_node *node);
+  circt::firrtl::FModuleOp MlirGenTrigger(const jlm::rvsdg::simple_node *node);
+  circt::firrtl::FModuleOp MlirGenPrint(const jlm::rvsdg::simple_node *node);
+  circt::firrtl::FModuleOp MlirGenPredicationBuffer(const jlm::rvsdg::simple_node *node);
+  circt::firrtl::FModuleOp MlirGenBuffer(const jlm::rvsdg::simple_node *node);
+  circt::firrtl::FModuleOp MlirGenDMux(const jlm::rvsdg::simple_node *node);
+  circt::firrtl::FModuleOp MlirGenNDMux(const jlm::rvsdg::simple_node *node);
+  circt::firrtl::FModuleOp MlirGenBranch(const jlm::rvsdg::simple_node *node);
+  circt::firrtl::FModuleOp MlirGenSimpleNode(const jlm::rvsdg::simple_node *node);
 
-			jlm::rvsdg::output *TraceArgument(jlm::rvsdg::argument *arg);
-			jlm::rvsdg::simple_output *TraceStructuralOutput(jlm::rvsdg::structural_output *out);
+  // Helper functions
+  void AddClockPort(::llvm::SmallVector<circt::firrtl::PortInfo> *ports);
+  void AddResetPort(::llvm::SmallVector<circt::firrtl::PortInfo> *ports);
+  void AddMemReqPort(::llvm::SmallVector<circt::firrtl::PortInfo> *ports);
+  void AddMemResPort(::llvm::SmallVector<circt::firrtl::PortInfo> *ports);
+  void AddBundlePort(
+    ::llvm::SmallVector<circt::firrtl::PortInfo> *ports,
+    circt::firrtl::Direction direction,
+    std::string name,
+    circt::firrtl::FIRRTLBaseType type);
+  circt::firrtl::SubfieldOp GetSubfield(
+    mlir::Block *body,
+    mlir::Value value,
+    int index);
+  circt::firrtl::SubfieldOp GetSubfield(
+    mlir::Block *body,
+    mlir::Value value,
+    ::llvm::StringRef fieldName);
+  mlir::BlockArgument GetPort(circt::firrtl::FModuleOp &module, std::string portName);
+  mlir::BlockArgument GetInPort(circt::firrtl::FModuleOp &module, size_t portNr);
+  mlir::BlockArgument GetOutPort(circt::firrtl::FModuleOp &module, size_t portNr);
+  void Connect(mlir::Block *body, mlir::Value sink, mlir::Value source);
+  // Primary operations
+  circt::firrtl::BitsPrimOp AddBitsOp(mlir::Block *body,
+                                      mlir::Value value,
+                                      int high,
+                                      int low);
+  circt::firrtl::AndPrimOp AddAndOp(mlir::Block *body,
+                                    mlir::Value first,
+                                    mlir::Value second);
+  circt::firrtl::XorPrimOp AddXorOp(mlir::Block *body,
+                                    mlir::Value first,
+                                    mlir::Value second);
+  circt::firrtl::OrPrimOp AddOrOp(mlir::Block *body,
+                                  mlir::Value first,
+                                  mlir::Value second);
+  circt::firrtl::NotPrimOp AddNotOp(mlir::Block *body,
+                                    mlir::Value first);
+  circt::firrtl::AddPrimOp AddAddOp(mlir::Block *body,
+                                    mlir::Value first,
+                                    mlir::Value second);
+  circt::firrtl::SubPrimOp AddSubOp(mlir::Block *body,
+                                    mlir::Value first,
+                                    mlir::Value second);
+  circt::firrtl::MulPrimOp AddMulOp(mlir::Block *body,
+                                    mlir::Value first,
+                                    mlir::Value second);
+  circt::firrtl::DivPrimOp AddDivOp(mlir::Block *body,
+                                    mlir::Value first,
+                                    mlir::Value second);
+  circt::firrtl::DShrPrimOp AddDShrOp(mlir::Block *body,
+                                      mlir::Value first,
+                                      mlir::Value second);
+  circt::firrtl::DShlPrimOp AddDShlOp(mlir::Block *body,
+                                      mlir::Value first,
+                                      mlir::Value second);
+  circt::firrtl::RemPrimOp AddRemOp(mlir::Block *body,
+                                    mlir::Value first,
+                                    mlir::Value second);
+  circt::firrtl::EQPrimOp AddEqOp(mlir::Block *body,
+                                  mlir::Value first,
+                                  mlir::Value second);
+  circt::firrtl::NEQPrimOp AddNeqOp(mlir::Block *body,
+                                    mlir::Value first,
+                                    mlir::Value second);
+  circt::firrtl::GTPrimOp AddGtOp(mlir::Block *body,
+                                  mlir::Value first,
+                                  mlir::Value second);
+  circt::firrtl::GEQPrimOp AddGeqOp(mlir::Block *body,
+                                    mlir::Value first,
+                                    mlir::Value second);
+  circt::firrtl::LTPrimOp AddLtOp(mlir::Block *body,
+                                  mlir::Value first,
+                                  mlir::Value second);
+  circt::firrtl::LEQPrimOp AddLeqOp(mlir::Block *body,
+                                    mlir::Value first,
+                                    mlir::Value second);
+  circt::firrtl::MuxPrimOp AddMuxOp(mlir::Block *body,
+                                    mlir::Value select,
+                                    mlir::Value high,
+                                    mlir::Value low);
+  circt::firrtl::AsSIntPrimOp AddAsSIntOp(mlir::Block *body,
+                                          mlir::Value value);
+  circt::firrtl::AsUIntPrimOp AddAsUIntOp(mlir::Block *body,
+                                          mlir::Value value);
+  circt::firrtl::PadPrimOp AddPadOp(mlir::Block *body,
+                                    mlir::Value value,
+                                    int amount);
+  circt::firrtl::CvtPrimOp AddCvtOp(mlir::Block *body,
+                                    mlir::Value value);
+  circt::firrtl::WireOp AddWireOp(mlir::Block *body,
+                                  std::string name,
+                                  int size);
+  circt::firrtl::WhenOp AddWhenOp(mlir::Block *body,
+                                  mlir::Value condition,
+                                  bool elseStatment);
+  circt::firrtl::InstanceOp AddInstanceOp(mlir::Block *body,
+                                          jlm::rvsdg::simple_node *node);
+  circt::firrtl::ConstantOp GetConstant(mlir::Block *body, int size, int value);
+  circt::firrtl::InvalidValueOp GetInvalid(mlir::Block *body, int size);
 
-			void InitializeMemReq(circt::firrtl::FModuleOp module);
-			circt::firrtl::BundleType::BundleElement GetReadyElement();
-			circt::firrtl::BundleType::BundleElement GetValidElement();
-			mlir::BlockArgument GetClockSignal(circt::firrtl::FModuleOp module);
-			mlir::BlockArgument GetResetSignal(circt::firrtl::FModuleOp module);
-			circt::firrtl::FModuleOp nodeToModule(const jlm::rvsdg::simple_node *node, bool mem=false);
-			circt::firrtl::IntType GetIntType(int size);
-			circt::firrtl::IntType GetIntType(const jlm::rvsdg::type *type, int extend = 0);
-			std::string GetModuleName(const jlm::rvsdg::node *node);
-			bool IsIdentityMapping(const jlm::rvsdg::match_op &op);
-		};
+  jlm::rvsdg::output *TraceArgument(jlm::rvsdg::argument *arg);
+  jlm::rvsdg::simple_output *TraceStructuralOutput(jlm::rvsdg::structural_output *out);
 
-		class MLIRGen : public BaseHLS {
-			std::string
-			extension() override {
-				return ".fir";
-			}
+  void InitializeMemReq(circt::firrtl::FModuleOp module);
+  circt::firrtl::BundleType::BundleElement GetReadyElement();
+  circt::firrtl::BundleType::BundleElement GetValidElement();
+  mlir::BlockArgument GetClockSignal(circt::firrtl::FModuleOp module);
+  mlir::BlockArgument GetResetSignal(circt::firrtl::FModuleOp module);
+  circt::firrtl::FModuleOp nodeToModule(const jlm::rvsdg::simple_node *node, bool mem=false);
+  circt::firrtl::IntType GetIntType(int size);
+  circt::firrtl::IntType GetIntType(const jlm::rvsdg::type *type, int extend = 0);
+  std::string GetModuleName(const jlm::rvsdg::node *node);
+  bool IsIdentityMapping(const jlm::rvsdg::match_op &op);
+};
 
-			std::string get_text(llvm::RvsdgModule &rm) override {return "";}
-		public:
-			std::string
-			run(llvm::RvsdgModule &rvsdgModule) {
-				// Load the FIRRTLDialect
-				mlir::MLIRContext context;
-				context.getOrLoadDialect<circt::firrtl::FIRRTLDialect>();
+class MLIRGen : public BaseHLS {
+  std::string
+  extension() override {
+    return ".fir";
+  }
 
-				// Generate a FIRRTL circuit of the rvsdgModule
-				auto lambdaNode = get_hls_lambda(rvsdgModule);
-				auto mlirGen = MLIRGenImpl(context);
-				auto circuit = mlirGen.MlirGen(lambdaNode);
-				// Write the FIRRTL to a file
-				return mlirGen.toString(circuit);
-			}
-			private:
-		};
+  std::string get_text(llvm::RvsdgModule &rm) override {return "";}
+public:
+  std::string
+  run(llvm::RvsdgModule &rvsdgModule) {
+    // Load the FIRRTLDialect
+    mlir::MLIRContext context;
+    context.getOrLoadDialect<circt::firrtl::FIRRTLDialect>();
 
-	} // namespace hls
+    // Generate a FIRRTL circuit of the rvsdgModule
+    auto lambdaNode = get_hls_lambda(rvsdgModule);
+    auto mlirGen = MLIRGenImpl(context);
+    auto circuit = mlirGen.MlirGen(lambdaNode);
+    // Write the FIRRTL to a file
+    return mlirGen.toString(circuit);
+  }
+private:
+};
+
 } // namespace jlm
 
 #else
 
-namespace jlm {
-        namespace hls{
-                class MLIRGen : public BaseHLS {
-                        std::string
-                        extension() override {
-                                return ".fir";
-                        }
-                        std::string get_text(llvm::RvsdgModule &rm) override {return "";}
-                public:
-			std::string
-                        run(llvm::RvsdgModule &rvsdgModule) {
-				throw util::error("This version of jlm-hls has not been compiled with support for the CIRCT backend\n");
-                        }
-                        private:
-                };
-        } // namespace hls
+namespace jlm::hls
+{
+
+class MLIRGen : public BaseHLS {
+  std::string
+  extension() override {
+    return ".fir";
+  }
+  std::string get_text(llvm::RvsdgModule &rm) override {return "";}
+public:
+  std::string
+  run(llvm::RvsdgModule &rvsdgModule) {
+    throw util::error("This version of jlm-hls has not been compiled with support for the CIRCT backend\n");
+  }
+private:
+};
+
 } // namespace jlm
- 
+
 #endif //CIRCT
 
 #endif // JLM_HLS_BACKEND_RHLS2FIRRTL_MLIRGEN_HPP

--- a/jlm/hls/backend/rhls2firrtl/verilator-harness-hls.cpp
+++ b/jlm/hls/backend/rhls2firrtl/verilator-harness-hls.cpp
@@ -6,313 +6,315 @@
 #include <jlm/hls/backend/rhls2firrtl/verilator-harness-hls.hpp>
 #include <jlm/llvm/ir/operators/delta.hpp>
 
+namespace jlm::hls {
+
 std::string
-jlm::hls::VerilatorHarnessHLS::get_text(llvm::RvsdgModule &rm) {
-	std::ostringstream cpp;
-	auto ln = get_hls_lambda(rm);
-	auto function_name = ln->name();
-	auto file_name = get_base_file_name(rm);
-	cpp <<
-		"#define TRACE_CHUNK_SIZE 100000\n"
-#ifndef HLS_USE_VCD
-		"#define FST 1\n"
-#endif
-//		"#define HLS_MEM_DEBUG 1\n"
-		"\n"
-		"#include <verilated.h>\n"
-		"#include <cassert>\n"
-		"#include <iostream>\n"
-		"#include <signal.h>\n"
-		"#include <stdio.h>\n"
-		"#include <stdlib.h>\n"
-		"#include <string.h>\n"
-		"#include <unistd.h>\n"
-		"#include <sstream>\n"
-		"#include <iomanip>\n"
-		"#ifdef FST\n"
-		"#include \"verilated_fst_c.h\"\n"
-		"#else\n"
-		"#include \"verilated_vcd_c.h\"\n"
-		"#endif\n"
-		"#include \"V" << file_name << ".h\"\n" <<
-		"#define V_NAME V" << file_name << "\n" <<
-		"#define TIMEOUT 10000000\n"
-		"#define xstr(s) str(s)\n"
-		"#define str(s) #s\n"
-		"void clock_cycle();\n"
-		"\n"
-		"// Current simulation time (64-bit unsigned)\n"
-		"vluint64_t main_time = 0;\n"
-		"// Called by $time in Verilog\n"
-		"double sc_time_stamp() {\n"
-		"    return main_time;  // Note does conversion to real, to match SystemC\n"
-		"}\n"
-		"V_NAME *top;\n"
-		"#ifdef FST\n"
-		"VerilatedFstC *tfp;\n"
-		"#else\n"
-		"VerilatedVcdC *tfp;\n"
-		"#endif\n"
-		"bool terminate = false;\n"
-		"\n"
-		"void term(int signum) {\n"
-		"    terminate = true;\n"
-		"}\n"
-		"\n"
-		"void verilator_finish() {\n"
-		"    // Final model cleanup\n"
-		"    tfp->dump(main_time * 2);\n"
-		"    top->final();\n"
-		"\n"
-		"    //  Coverage analysis (since test passed)\n"
-		"#if VM_COVERAGE\n"
-		"    Verilated::mkdir(\"logs\");\n"
-		"    VerilatedCov::write(\"logs/coverage.dat\");\n"
-		"#endif\n"
-		"    tfp->close();\n"
-		"    // Destroy model\n"
-		"    delete top;\n"
-		"    top = NULL;\n"
-		"}\n"
-		"\n"
-		"void verilator_init(int argc, char **argv) {\n"
-		"    // set up signaling so we can kill the program and still get waveforms\n"
-		"    struct sigaction action;\n"
-		"    memset(&action, 0, sizeof(struct sigaction));\n"
-		"    action.sa_handler = term;\n"
-		"    sigaction(SIGTERM, &action, NULL);\n"
-		"    sigaction(SIGKILL, &action, NULL);\n"
-		"    sigaction(SIGINT, &action, NULL);\n"
-		"\n"
-		"	atexit(verilator_finish);\n"
-		"\n"
-		"    // Set debug level, 0 is off, 9 is highest presently used\n"
-		"    // May be overridden by commandArgs\n"
-		"    Verilated::debug(0);\n"
-		"\n"
-		"    // Randomization reset policy\n"
-		"    // May be overridden by commandArgs\n"
-		"    Verilated::randReset(2);\n"
-		"\n"
-		"    // Verilator must compute traced signals\n"
-		"    Verilated::traceEverOn(true);\n"
-		"\n"
-		"    // Pass arguments so Verilated code can see them, e.g. $value$plusargs\n"
-		"    // This needs to be called before you create any model\n"
-		"    Verilated::commandArgs(argc, argv);\n"
-		"\n"
-		"    // Construct the Verilated model, from Vtop.h generated from Verilating \"top.v\"\n"
-		"    top = new V_NAME;  // Or use a const unique_ptr, or the VL_UNIQUE_PTR wrapper\n"
-		"#ifdef FST\n"
-		"    tfp = new VerilatedFstC;\n"
-		"    top->trace(tfp, 99);   // Trace 99 levels of hierarchy\n"
-		"    tfp->open(xstr(V_NAME)\".fst\");\n"
-		"#else\n"
-		"    tfp = new VerilatedVcdC;\n"
-		"    top->trace(tfp, 99);   // Trace 99 levels of hierarchy\n"
-		"    tfp->open(xstr(V_NAME)\".vcd\");\n"
-		"#endif\n"
-		"\n"
-		"    top->i_valid = 0;\n";
-	// reset all data inputs to zero
-	for (size_t i = 0; i < ln->ninputs(); ++i) {
-		cpp << "    top->i_data" << i << " = 0;\n";
-	}
-	cpp <<
-		"    top->reset = 1;\n"
-		"\n"
-		"    top->mem_req_ready = true;\n"
-		"    top->mem_res_valid = false;\n"
-		"    top->mem_res_data = 1111111;\n"
-		"    clock_cycle();\n"
-		"    clock_cycle();\n"
-		"    top->reset = 0;\n"
-		"    clock_cycle();\n"
-		"}\n"
-		"\n"
-		"bool mem_resp_valid;\n"
-		"uint64_t mem_resp_data;\n"
-		"\n"
-		"void clock_cycle() {\n"
-		"    if (terminate) {\n"
-		"        std::cout << \"terminating\\n\";\n"
-		"        verilator_finish();\n"
-		"        exit(-1);\n"
-		"    }\n"
-		"    assert(!Verilated::gotFinish());\n"
-		"    top->clk = 1;\n"
-		"    top->eval();\n"
-		"    top->mem_res_valid = mem_resp_valid;\n"
-		"    top->mem_res_data = mem_resp_data;\n"
-		"    // dump before trying to access memory\n"
-        "    tfp->dump(main_time * 2);\n"
-		"    if (!top->reset && top->mem_req_valid) {\n"
-		"        mem_resp_valid = true;\n"
-		"        void *addr = (void *) top->mem_req_addr;\n"
-		"        uint64_t data = top->mem_req_data;\n"
-		"        if (top->mem_req_write) {\n"
-		"#ifdef HLS_MEM_DEBUG\n"
-		"            std::cout << \"writing \" << data << \" to \" << addr << \"\\n\";\n"
-		"#endif\n"
-		"            switch (top->mem_req_width) {\n"
-		"                case 0:\n"
-		"                    *(uint8_t *) addr = data;\n"
-		"                    break;\n"
-		"                case 1:\n"
-		"                    *(uint16_t *) addr = data;\n"
-		"                    break;\n"
-		"                case 2:\n"
-		"                    *(uint32_t *) addr = data;\n"
-		"                    break;\n"
-		"                case 3:\n"
-		"                    *(uint64_t *) addr = data;\n"
-		"                    break;\n"
-		"                default:\n"
-		"                    assert(false);\n"
-		"            }\n"
-		"        } else {\n"
-		"#ifdef HLS_MEM_DEBUG\n"
-		"            std::cout << \"reading from \" << addr << \"\\n\";\n"
-		"#endif\n"
-		"        }\n"
-		"        switch (top->mem_req_width) {\n"
-		"            case 0:\n"
-		"                mem_resp_data = *(uint8_t *) addr;\n"
-		"                break;\n"
-		"            case 1:\n"
-		"                mem_resp_data = *(uint16_t *) addr;\n"
-		"                break;\n"
-		"            case 2:\n"
-		"                mem_resp_data = *(uint32_t *) addr;\n"
-		"                break;\n"
-		"            case 3:\n"
-		"                mem_resp_data = *(uint64_t *) addr;\n"
-		"                break;\n"
-		"            default:\n"
-		"                assert(false);\n"
-		"        }\n"
-		"    } else {\n"
-		"        mem_resp_valid = false;\n"
-		"    }\n"
-		"    assert(!Verilated::gotFinish());\n"
-		"    top->clk = 0;\n"
-		"    top->eval();\n"
-		"    tfp->dump(main_time * 2 + 1);\n"
-		"    main_time++;\n"
-		"}\n"
-		"extern \"C\"\n"// TODO: parameter for linkage type here
-		"{\n";
-	// imports
-	auto root = rm.Rvsdg().root();
-	for (size_t i = 0; i < root->narguments(); ++i)
-  {
-    if (auto rvsdgImport = dynamic_cast<const llvm::impport*>(&root->argument(i)->port()))
-    {
+VerilatorHarnessHLS::get_text(llvm::RvsdgModule &rm) {
+  std::ostringstream cpp;
+  auto ln = get_hls_lambda(rm);
+  auto function_name = ln->name();
+  auto file_name = get_base_file_name(rm);
+  cpp <<
+      "#define TRACE_CHUNK_SIZE 100000\n"
+      #ifndef HLS_USE_VCD
+      "#define FST 1\n"
+      #endif
+      //		"#define HLS_MEM_DEBUG 1\n"
+      "\n"
+      "#include <verilated.h>\n"
+      "#include <cassert>\n"
+      "#include <iostream>\n"
+      "#include <signal.h>\n"
+      "#include <stdio.h>\n"
+      "#include <stdlib.h>\n"
+      "#include <string.h>\n"
+      "#include <unistd.h>\n"
+      "#include <sstream>\n"
+      "#include <iomanip>\n"
+      "#ifdef FST\n"
+      "#include \"verilated_fst_c.h\"\n"
+      "#else\n"
+      "#include \"verilated_vcd_c.h\"\n"
+      "#endif\n"
+      "#include \"V" << file_name << ".h\"\n" <<
+      "#define V_NAME V" << file_name << "\n" <<
+      "#define TIMEOUT 10000000\n"
+      "#define xstr(s) str(s)\n"
+      "#define str(s) #s\n"
+      "void clock_cycle();\n"
+      "\n"
+      "// Current simulation time (64-bit unsigned)\n"
+      "vluint64_t main_time = 0;\n"
+      "// Called by $time in Verilog\n"
+      "double sc_time_stamp() {\n"
+      "    return main_time;  // Note does conversion to real, to match SystemC\n"
+      "}\n"
+      "V_NAME *top;\n"
+      "#ifdef FST\n"
+      "VerilatedFstC *tfp;\n"
+      "#else\n"
+      "VerilatedVcdC *tfp;\n"
+      "#endif\n"
+      "bool terminate = false;\n"
+      "\n"
+      "void term(int signum) {\n"
+      "    terminate = true;\n"
+      "}\n"
+      "\n"
+      "void verilator_finish() {\n"
+      "    // Final model cleanup\n"
+      "    tfp->dump(main_time * 2);\n"
+      "    top->final();\n"
+      "\n"
+      "    //  Coverage analysis (since test passed)\n"
+      "#if VM_COVERAGE\n"
+      "    Verilated::mkdir(\"logs\");\n"
+      "    VerilatedCov::write(\"logs/coverage.dat\");\n"
+      "#endif\n"
+      "    tfp->close();\n"
+      "    // Destroy model\n"
+      "    delete top;\n"
+      "    top = NULL;\n"
+      "}\n"
+      "\n"
+      "void verilator_init(int argc, char **argv) {\n"
+      "    // set up signaling so we can kill the program and still get waveforms\n"
+      "    struct sigaction action;\n"
+      "    memset(&action, 0, sizeof(struct sigaction));\n"
+      "    action.sa_handler = term;\n"
+      "    sigaction(SIGTERM, &action, NULL);\n"
+      "    sigaction(SIGKILL, &action, NULL);\n"
+      "    sigaction(SIGINT, &action, NULL);\n"
+      "\n"
+      "	atexit(verilator_finish);\n"
+      "\n"
+      "    // Set debug level, 0 is off, 9 is highest presently used\n"
+      "    // May be overridden by commandArgs\n"
+      "    Verilated::debug(0);\n"
+      "\n"
+      "    // Randomization reset policy\n"
+      "    // May be overridden by commandArgs\n"
+      "    Verilated::randReset(2);\n"
+      "\n"
+      "    // Verilator must compute traced signals\n"
+      "    Verilated::traceEverOn(true);\n"
+      "\n"
+      "    // Pass arguments so Verilated code can see them, e.g. $value$plusargs\n"
+      "    // This needs to be called before you create any model\n"
+      "    Verilated::commandArgs(argc, argv);\n"
+      "\n"
+      "    // Construct the Verilated model, from Vtop.h generated from Verilating \"top.v\"\n"
+      "    top = new V_NAME;  // Or use a const unique_ptr, or the VL_UNIQUE_PTR wrapper\n"
+      "#ifdef FST\n"
+      "    tfp = new VerilatedFstC;\n"
+      "    top->trace(tfp, 99);   // Trace 99 levels of hierarchy\n"
+      "    tfp->open(xstr(V_NAME)\".fst\");\n"
+      "#else\n"
+      "    tfp = new VerilatedVcdC;\n"
+      "    top->trace(tfp, 99);   // Trace 99 levels of hierarchy\n"
+      "    tfp->open(xstr(V_NAME)\".vcd\");\n"
+      "#endif\n"
+      "\n"
+      "    top->i_valid = 0;\n";
+  // reset all data inputs to zero
+  for (size_t i = 0; i < ln->ninputs(); ++i) {
+    cpp << "    top->i_data" << i << " = 0;\n";
+  }
+  cpp <<
+      "    top->reset = 1;\n"
+      "\n"
+      "    top->mem_req_ready = true;\n"
+      "    top->mem_res_valid = false;\n"
+      "    top->mem_res_data = 1111111;\n"
+      "    clock_cycle();\n"
+      "    clock_cycle();\n"
+      "    top->reset = 0;\n"
+      "    clock_cycle();\n"
+      "}\n"
+      "\n"
+      "bool mem_resp_valid;\n"
+      "uint64_t mem_resp_data;\n"
+      "\n"
+      "void clock_cycle() {\n"
+      "    if (terminate) {\n"
+      "        std::cout << \"terminating\\n\";\n"
+      "        verilator_finish();\n"
+      "        exit(-1);\n"
+      "    }\n"
+      "    assert(!Verilated::gotFinish());\n"
+      "    top->clk = 1;\n"
+      "    top->eval();\n"
+      "    top->mem_res_valid = mem_resp_valid;\n"
+      "    top->mem_res_data = mem_resp_data;\n"
+      "    // dump before trying to access memory\n"
+      "    tfp->dump(main_time * 2);\n"
+      "    if (!top->reset && top->mem_req_valid) {\n"
+      "        mem_resp_valid = true;\n"
+      "        void *addr = (void *) top->mem_req_addr;\n"
+      "        uint64_t data = top->mem_req_data;\n"
+      "        if (top->mem_req_write) {\n"
+      "#ifdef HLS_MEM_DEBUG\n"
+      "            std::cout << \"writing \" << data << \" to \" << addr << \"\\n\";\n"
+      "#endif\n"
+      "            switch (top->mem_req_width) {\n"
+      "                case 0:\n"
+      "                    *(uint8_t *) addr = data;\n"
+      "                    break;\n"
+      "                case 1:\n"
+      "                    *(uint16_t *) addr = data;\n"
+      "                    break;\n"
+      "                case 2:\n"
+      "                    *(uint32_t *) addr = data;\n"
+      "                    break;\n"
+      "                case 3:\n"
+      "                    *(uint64_t *) addr = data;\n"
+      "                    break;\n"
+      "                default:\n"
+      "                    assert(false);\n"
+      "            }\n"
+      "        } else {\n"
+      "#ifdef HLS_MEM_DEBUG\n"
+      "            std::cout << \"reading from \" << addr << \"\\n\";\n"
+      "#endif\n"
+      "        }\n"
+      "        switch (top->mem_req_width) {\n"
+      "            case 0:\n"
+      "                mem_resp_data = *(uint8_t *) addr;\n"
+      "                break;\n"
+      "            case 1:\n"
+      "                mem_resp_data = *(uint16_t *) addr;\n"
+      "                break;\n"
+      "            case 2:\n"
+      "                mem_resp_data = *(uint32_t *) addr;\n"
+      "                break;\n"
+      "            case 3:\n"
+      "                mem_resp_data = *(uint64_t *) addr;\n"
+      "                break;\n"
+      "            default:\n"
+      "                assert(false);\n"
+      "        }\n"
+      "    } else {\n"
+      "        mem_resp_valid = false;\n"
+      "    }\n"
+      "    assert(!Verilated::gotFinish());\n"
+      "    top->clk = 0;\n"
+      "    top->eval();\n"
+      "    tfp->dump(main_time * 2 + 1);\n"
+      "    main_time++;\n"
+      "}\n"
+      "extern \"C\"\n"// TODO: parameter for linkage type here
+      "{\n";
+  // imports
+  auto root = rm.Rvsdg().root();
+  for (size_t i = 0; i < root->narguments(); ++i) {
+    if (auto rvsdgImport = dynamic_cast<const llvm::impport *>(&root->argument(i)->port())) {
       JLM_ASSERT(jlm::rvsdg::is<llvm::PointerType>(rvsdgImport->type()));
       cpp << "extern " << convert_to_c_type(&rvsdgImport->GetValueType()) << " " << rvsdgImport->name() << ";\n";
     }
-	}
-	std::string return_type;
-	if (ln->type().NumResults() == 0) {
-		return_type = "void";
-	} else {
-		auto type = &ln->type().ResultType(0);
-		if (dynamic_cast<const jlm::rvsdg::statetype *>(type)) {
-			return_type = "void";
-		} else {
-			return_type = convert_to_c_type(type);
-		}
-	}
-	cpp << return_type << " " << function_name << "(\n";
-	for (size_t i = 0; i < ln->type().NumArguments(); ++i) {
-		if (dynamic_cast<const jlm::rvsdg::statetype *>(&ln->type().ArgumentType(i))) {
-			continue;
-		}
-		if (i != 0) {
-			cpp << ",\n";
-		}
-		cpp << "    " << convert_to_c_type(&ln->type().ArgumentType(i)) << " a" << i
-			<< convert_to_c_type_postfix(&ln->type().ArgumentType(i));
-	}
+  }
+  std::string return_type;
+  if (ln->type().NumResults() == 0) {
+    return_type = "void";
+  } else {
+    auto type = &ln->type().ResultType(0);
+    if (dynamic_cast<const jlm::rvsdg::statetype *>(type)) {
+      return_type = "void";
+    } else {
+      return_type = convert_to_c_type(type);
+    }
+  }
+  cpp << return_type << " " << function_name << "(\n";
+  for (size_t i = 0; i < ln->type().NumArguments(); ++i) {
+    if (dynamic_cast<const jlm::rvsdg::statetype *>(&ln->type().ArgumentType(i))) {
+      continue;
+    }
+    if (i != 0) {
+      cpp << ",\n";
+    }
+    cpp << "    " << convert_to_c_type(&ln->type().ArgumentType(i)) << " a" << i
+        << convert_to_c_type_postfix(&ln->type().ArgumentType(i));
+  }
 
-	cpp << "\n"
-		   ") {\n"
-		   "	if(!top){\n"
-		   "		verilator_init(0, NULL);\n"
-		   "	}\n";
-	for (size_t i = 0; i < ln->type().NumArguments(); ++i) {
-		if (dynamic_cast<const jlm::rvsdg::statetype *>(&ln->type().ArgumentType(i))) {
-			continue;
-		}
-		cpp << "    top->i_data" << i << " = (uint64_t) a" << i << ";\n";
-	}
-	for (size_t i = 0; i < ln->ncvarguments(); ++i) {
-		size_t ix = ln->cvargument(i)->input()->argument()->index();
-		std::string name;
-		if(auto a = dynamic_cast<jlm::rvsdg::argument *>(ln->input(i)->origin())){
-			if(auto ip = dynamic_cast<const llvm::impport*>(&a->port())){
-				name = ip->name();
-			}
-		} else{
-			throw util::error("Unsupported cvarg origin type type");
-		}
-		cpp << "    top->i_data" << ix << " = (uint64_t) &" << name << ";\n";
-		cpp << "#ifdef HLS_MEM_DEBUG\n";
-		cpp << "    std::cout << \"" << name << ": \" << &" << name << " << \"\\n\";\n";
-		cpp << "#endif\n";
-	}
-	cpp <<
-		"    int start = main_time;\n"
-		"    for (int i = 0; i < TIMEOUT && !top->i_ready; i++) {\n"
-		"        clock_cycle();\n"
-		"    }\n"
-		"    if (!top->i_ready) {\n"
-		"        std::cout << \"i_ready not set\\n\";\n"
-		"        verilator_finish();\n"
-		"        exit(-1);\n"
-		"    }\n"
-		"    top->i_valid = 1;\n"
-		"    top->o_ready = 1;\n"
-		"    clock_cycle();\n"
-		"    top->i_valid = 0;\n";
-	for (size_t i = 0; i < ln->type().NumArguments(); ++i) {
-		cpp << "    top->i_data" << i << " = 0;\n";
-	}
-	cpp <<
-		"    for (int i = 0; i < TIMEOUT && !top->o_valid; i++) {\n"
-		"        clock_cycle();\n"
-		"    }\n"
-		"    if (!top->o_valid) {\n"
-		"        std::cout << \"o_valid not set\\n\";\n"
-		"        verilator_finish();\n"
-		"        exit(-1);\n"
-		"    }\n"
-		"    std::cout << \"finished - took \" << (main_time - start) << \"cycles\\n\";\n";
-	if (ln->type().NumResults() && !dynamic_cast<const jlm::rvsdg::statetype *>(&ln->type().ResultType(0))) {
-		cpp << "    return top->o_data0;\n";
-	}
-	cpp << "}\n}\n";
-	return cpp.str();
+  cpp << "\n"
+         ") {\n"
+         "	if(!top){\n"
+         "		verilator_init(0, NULL);\n"
+         "	}\n";
+  for (size_t i = 0; i < ln->type().NumArguments(); ++i) {
+    if (dynamic_cast<const jlm::rvsdg::statetype *>(&ln->type().ArgumentType(i))) {
+      continue;
+    }
+    cpp << "    top->i_data" << i << " = (uint64_t) a" << i << ";\n";
+  }
+  for (size_t i = 0; i < ln->ncvarguments(); ++i) {
+    size_t ix = ln->cvargument(i)->input()->argument()->index();
+    std::string name;
+    if (auto a = dynamic_cast<jlm::rvsdg::argument *>(ln->input(i)->origin())) {
+      if (auto ip = dynamic_cast<const llvm::impport *>(&a->port())) {
+        name = ip->name();
+      }
+    } else {
+      throw util::error("Unsupported cvarg origin type type");
+    }
+    cpp << "    top->i_data" << ix << " = (uint64_t) &" << name << ";\n";
+    cpp << "#ifdef HLS_MEM_DEBUG\n";
+    cpp << "    std::cout << \"" << name << ": \" << &" << name << " << \"\\n\";\n";
+    cpp << "#endif\n";
+  }
+  cpp <<
+      "    int start = main_time;\n"
+      "    for (int i = 0; i < TIMEOUT && !top->i_ready; i++) {\n"
+      "        clock_cycle();\n"
+      "    }\n"
+      "    if (!top->i_ready) {\n"
+      "        std::cout << \"i_ready not set\\n\";\n"
+      "        verilator_finish();\n"
+      "        exit(-1);\n"
+      "    }\n"
+      "    top->i_valid = 1;\n"
+      "    top->o_ready = 1;\n"
+      "    clock_cycle();\n"
+      "    top->i_valid = 0;\n";
+  for (size_t i = 0; i < ln->type().NumArguments(); ++i) {
+    cpp << "    top->i_data" << i << " = 0;\n";
+  }
+  cpp <<
+      "    for (int i = 0; i < TIMEOUT && !top->o_valid; i++) {\n"
+      "        clock_cycle();\n"
+      "    }\n"
+      "    if (!top->o_valid) {\n"
+      "        std::cout << \"o_valid not set\\n\";\n"
+      "        verilator_finish();\n"
+      "        exit(-1);\n"
+      "    }\n"
+      "    std::cout << \"finished - took \" << (main_time - start) << \"cycles\\n\";\n";
+  if (ln->type().NumResults() && !dynamic_cast<const jlm::rvsdg::statetype *>(&ln->type().ResultType(0))) {
+    cpp << "    return top->o_data0;\n";
+  }
+  cpp << "}\n}\n";
+  return cpp.str();
 }
 
 std::string
-jlm::hls::VerilatorHarnessHLS::convert_to_c_type(const jlm::rvsdg::type *type) {
-	if (auto t = dynamic_cast<const jlm::rvsdg::bittype *>(type)) {
-		return "int" + util::strfmt(t->nbits()) + "_t";
-	} else if (jlm::rvsdg::is<llvm::PointerType>(*type)) {
-		return "void*";
-	} else if (auto t = dynamic_cast<const llvm::arraytype *>(type)) {
-		return convert_to_c_type(&t->element_type());
-	} else {
-		throw std::logic_error(type->debug_string() + " not implemented!");
-	}
+VerilatorHarnessHLS::convert_to_c_type(const jlm::rvsdg::type *type) {
+  if (auto t = dynamic_cast<const jlm::rvsdg::bittype *>(type)) {
+    return "int" + util::strfmt(t->nbits()) + "_t";
+  } else if (jlm::rvsdg::is<llvm::PointerType>(*type)) {
+    return "void*";
+  } else if (auto t = dynamic_cast<const llvm::arraytype *>(type)) {
+    return convert_to_c_type(&t->element_type());
+  } else {
+    throw std::logic_error(type->debug_string() + " not implemented!");
+  }
 }
 
 std::string
-jlm::hls::VerilatorHarnessHLS::convert_to_c_type_postfix(const jlm::rvsdg::type *type) {
-	if (auto t = dynamic_cast<const llvm::arraytype *>(type)) {
-		return util::strfmt("[", t->nelements(), "]", convert_to_c_type(&t->element_type()));
-	} else {
-		return "";
-	}
+VerilatorHarnessHLS::convert_to_c_type_postfix(const jlm::rvsdg::type *type) {
+  if (auto t = dynamic_cast<const llvm::arraytype *>(type)) {
+    return util::strfmt("[", t->nelements(), "]", convert_to_c_type(&t->element_type()));
+  } else {
+    return "";
+  }
+}
+
 }

--- a/jlm/hls/backend/rhls2firrtl/verilator-harness-hls.hpp
+++ b/jlm/hls/backend/rhls2firrtl/verilator-harness-hls.hpp
@@ -9,25 +9,26 @@
 #include <jlm/hls/backend/rhls2firrtl/base-hls.hpp>
 #include <jlm/rvsdg/bitstring/type.hpp>
 
-namespace jlm {
-	namespace hls {
-		class VerilatorHarnessHLS : public BaseHLS {
-			std::string
-			extension() override {
-				return "_harness.cpp";
-			}
+namespace jlm::hls
+{
 
-			std::string
-			get_text(llvm::RvsdgModule &rm) override;
+class VerilatorHarnessHLS : public BaseHLS {
+  std::string
+  extension() override {
+    return "_harness.cpp";
+  }
 
-		private:
-			std::string
-			convert_to_c_type(const jlm::rvsdg::type* type);
+  std::string
+  get_text(llvm::RvsdgModule &rm) override;
 
-			std::string
-			convert_to_c_type_postfix(const jlm::rvsdg::type* type);
-		};
-	}
+private:
+  std::string
+  convert_to_c_type(const jlm::rvsdg::type* type);
+
+  std::string
+  convert_to_c_type_postfix(const jlm::rvsdg::type* type);
+};
+
 }
 
 #endif //JLM_HLS_BACKEND_RHLS2FIRRTL_VERILATOR_HARNESS_HLS_HPP

--- a/jlm/hls/backend/rvsdg2rhls/add-buffers.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-buffers.cpp
@@ -8,48 +8,52 @@
 #include <jlm/hls/ir/hls.hpp>
 #include <jlm/rvsdg/traverser.hpp>
 
+namespace jlm::hls {
+
 void
-jlm::hls::add_buffers(jlm::rvsdg::region *region, bool pass_through) {
-	for (auto &node : jlm::rvsdg::topdown_traverser(region)) {
-		if (auto structnode = dynamic_cast<jlm::rvsdg::structural_node *>(node)) {
-			for (size_t n = 0; n < structnode->nsubregions(); n++) {
-				add_buffers(structnode->subregion(n), pass_through);
-			}
-		} else if (dynamic_cast<jlm::rvsdg::simple_node *>(node)) {
-			if (jlm::rvsdg::is<hls::buffer_op>(node)) {
-				continue;
-			} else if (is_constant(node)) {
-				continue;
-			} else if (jlm::rvsdg::is<hls::print_op>(node)) {
-				continue;
-			}
-			for (size_t i = 0; i < node->noutputs(); ++i) {
-				auto out = node->output(i);
-				JLM_ASSERT(out->nusers() == 1);
-				if (auto ni = dynamic_cast<jlm::rvsdg::node_input *>(*out->begin())) {
-					auto buf = dynamic_cast<const hls::buffer_op*>(&ni->node()->operation());
-					if (buf && (buf->pass_through||!pass_through)) {
-						continue;
-					}
-				}
-				std::vector<jlm::rvsdg::input *> old_users(out->begin(), out->end());
-				jlm::rvsdg::output* new_out;
-				if(pass_through){
-					new_out = buffer_op::create(*out, 10, true)[0];
-				} else{
-					new_out = buffer_op::create(*out, 1, false)[0];
-				}
-				for (auto user: old_users) {
-					user->divert_to(new_out);
-				}
-			}
-		}
-	}
+add_buffers(jlm::rvsdg::region *region, bool pass_through) {
+  for (auto &node: jlm::rvsdg::topdown_traverser(region)) {
+    if (auto structnode = dynamic_cast<jlm::rvsdg::structural_node *>(node)) {
+      for (size_t n = 0; n < structnode->nsubregions(); n++) {
+        add_buffers(structnode->subregion(n), pass_through);
+      }
+    } else if (dynamic_cast<jlm::rvsdg::simple_node *>(node)) {
+      if (jlm::rvsdg::is<hls::buffer_op>(node)) {
+        continue;
+      } else if (is_constant(node)) {
+        continue;
+      } else if (jlm::rvsdg::is<hls::print_op>(node)) {
+        continue;
+      }
+      for (size_t i = 0; i < node->noutputs(); ++i) {
+        auto out = node->output(i);
+        JLM_ASSERT(out->nusers() == 1);
+        if (auto ni = dynamic_cast<jlm::rvsdg::node_input *>(*out->begin())) {
+          auto buf = dynamic_cast<const hls::buffer_op *>(&ni->node()->operation());
+          if (buf && (buf->pass_through || !pass_through)) {
+            continue;
+          }
+        }
+        std::vector<jlm::rvsdg::input *> old_users(out->begin(), out->end());
+        jlm::rvsdg::output *new_out;
+        if (pass_through) {
+          new_out = buffer_op::create(*out, 10, true)[0];
+        } else {
+          new_out = buffer_op::create(*out, 1, false)[0];
+        }
+        for (auto user: old_users) {
+          user->divert_to(new_out);
+        }
+      }
+    }
+  }
 }
 
 void
-jlm::hls::add_buffers(llvm::RvsdgModule &rm, bool pass_through) {
-	auto &graph = rm.Rvsdg();
-	auto root = graph.root();
-	add_buffers(root, pass_through);
+add_buffers(llvm::RvsdgModule &rm, bool pass_through) {
+  auto &graph = rm.Rvsdg();
+  auto root = graph.root();
+  add_buffers(root, pass_through);
+}
+
 }

--- a/jlm/hls/backend/rvsdg2rhls/add-buffers.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-buffers.hpp
@@ -9,13 +9,15 @@
 #include <jlm/llvm/ir/RvsdgModule.hpp>
 #include <jlm/rvsdg/region.hpp>
 
-namespace jlm{
-	namespace hls{
-		void
-		add_buffers(rvsdg::region *region, bool pass_through);
+namespace jlm::hls
+{
 
-		void
-		add_buffers(llvm::RvsdgModule &rm, bool pass_through);
-	}
+void
+add_buffers(rvsdg::region *region, bool pass_through);
+
+void
+add_buffers(llvm::RvsdgModule &rm, bool pass_through);
+
 }
+
 #endif //JLM_HLS_BACKEND_RVSDG2RHLS_ADD_BUFFERS_HPP

--- a/jlm/hls/backend/rvsdg2rhls/add-forks.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-forks.cpp
@@ -7,42 +7,46 @@
 #include <jlm/hls/ir/hls.hpp>
 #include <jlm/rvsdg/traverser.hpp>
 
+namespace jlm::hls {
+
 void
-jlm::hls::add_forks(jlm::rvsdg::region *region) {
-	for (size_t i = 0; i < region->narguments(); ++i) {
-		auto arg = region->argument(i);
-		if (arg->nusers() > 1) {
-			std::vector<jlm::rvsdg::input *> users;
-			users.insert(users.begin(), arg->begin(), arg->end());
-			auto fork = hls::fork_op::create(arg->nusers(), *arg);
-			for (size_t j = 0; j < users.size(); j++) {
-				users[j]->divert_to(fork[j]);
-			}
-		}
-	}
-	for (auto &node : jlm::rvsdg::topdown_traverser(region)) {
-		if (auto structnode = dynamic_cast<jlm::rvsdg::structural_node *>(node)) {
-			for (size_t n = 0; n < structnode->nsubregions(); n++) {
-				add_forks(structnode->subregion(n));
-			}
-		}
-		for (size_t i = 0; i < node->noutputs(); ++i) {
-			auto out = node->output(i);
-			if (out->nusers() > 1) {
-				std::vector<jlm::rvsdg::input *> users;
-				users.insert(users.begin(), out->begin(), out->end());
-				auto fork = hls::fork_op::create(out->nusers(), *out);
-				for (size_t j = 0; j < users.size(); j++) {
-					users[j]->divert_to(fork[j]);
-				}
-			}
-		}
-	}
+add_forks(jlm::rvsdg::region *region) {
+  for (size_t i = 0; i < region->narguments(); ++i) {
+    auto arg = region->argument(i);
+    if (arg->nusers() > 1) {
+      std::vector<jlm::rvsdg::input *> users;
+      users.insert(users.begin(), arg->begin(), arg->end());
+      auto fork = hls::fork_op::create(arg->nusers(), *arg);
+      for (size_t j = 0; j < users.size(); j++) {
+        users[j]->divert_to(fork[j]);
+      }
+    }
+  }
+  for (auto &node: jlm::rvsdg::topdown_traverser(region)) {
+    if (auto structnode = dynamic_cast<jlm::rvsdg::structural_node *>(node)) {
+      for (size_t n = 0; n < structnode->nsubregions(); n++) {
+        add_forks(structnode->subregion(n));
+      }
+    }
+    for (size_t i = 0; i < node->noutputs(); ++i) {
+      auto out = node->output(i);
+      if (out->nusers() > 1) {
+        std::vector<jlm::rvsdg::input *> users;
+        users.insert(users.begin(), out->begin(), out->end());
+        auto fork = hls::fork_op::create(out->nusers(), *out);
+        for (size_t j = 0; j < users.size(); j++) {
+          users[j]->divert_to(fork[j]);
+        }
+      }
+    }
+  }
 }
 
 void
-jlm::hls::add_forks(llvm::RvsdgModule &rm) {
-	auto &graph = rm.Rvsdg();
-	auto root = graph.root();
-	add_forks(root);
+add_forks(llvm::RvsdgModule &rm) {
+  auto &graph = rm.Rvsdg();
+  auto root = graph.root();
+  add_forks(root);
+}
+
 }

--- a/jlm/hls/backend/rvsdg2rhls/add-forks.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-forks.hpp
@@ -9,13 +9,14 @@
 #include <jlm/llvm/ir/RvsdgModule.hpp>
 #include <jlm/rvsdg/region.hpp>
 
-namespace jlm{
-	namespace hls{
-		void
-		add_forks(rvsdg::region *region);
+namespace jlm::hls
+{
 
-		void
-		add_forks(llvm::RvsdgModule &rm);
-	}
+void
+add_forks(rvsdg::region *region);
+
+void
+add_forks(llvm::RvsdgModule &rm);
+
 }
 #endif //JLM_HLS_BACKEND_RVSDG2RHLS_ADD_FORKS_HPP

--- a/jlm/hls/backend/rvsdg2rhls/add-prints.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-prints.cpp
@@ -8,103 +8,105 @@
 #include <jlm/llvm/ir/operators.hpp>
 #include <jlm/rvsdg/traverser.hpp>
 
+namespace jlm::hls {
+
 void
-jlm::hls::add_prints(jlm::rvsdg::region *region) {
-	for (auto &node : jlm::rvsdg::topdown_traverser(region)) {
-		if (auto structnode = dynamic_cast<jlm::rvsdg::structural_node *>(node)) {
-			for (size_t n = 0; n < structnode->nsubregions(); n++) {
-				add_prints(structnode->subregion(n));
-			}
-		}
+add_prints(jlm::rvsdg::region *region) {
+  for (auto &node: jlm::rvsdg::topdown_traverser(region)) {
+    if (auto structnode = dynamic_cast<jlm::rvsdg::structural_node *>(node)) {
+      for (size_t n = 0; n < structnode->nsubregions(); n++) {
+        add_prints(structnode->subregion(n));
+      }
+    }
 //		if (auto lo = dynamic_cast<const jlm::load_op *>(&(node->operation()))) {
 //
 //		} else if (auto so = dynamic_cast<const jlm::store_op *>(&(node->operation()))) {
 //			auto po = hls::print_op::create(*node->input(1)->origin())[0];
 //			node->input(1)->divert_to(po);
 //		}
-		if( dynamic_cast<jlm::rvsdg::simple_node *>(node)
-				&& node->noutputs()==1
-				&& jlm::rvsdg::is<jlm::rvsdg::bittype>(node->output(0)->type())
-				&& !jlm::rvsdg::is<llvm::UndefValueOperation>(node)){
-			auto out = node->output(0);
-			std::vector<jlm::rvsdg::input *> old_users(out->begin(), out->end());
-			auto new_out = hls::print_op::create(*out)[0];
-			for (auto user: old_users) {
-				user->divert_to(new_out);
-			}
-		}
-	}
+    if (dynamic_cast<jlm::rvsdg::simple_node *>(node)
+        && node->noutputs() == 1
+        && jlm::rvsdg::is<jlm::rvsdg::bittype>(node->output(0)->type())
+        && !jlm::rvsdg::is<llvm::UndefValueOperation>(node)) {
+      auto out = node->output(0);
+      std::vector<jlm::rvsdg::input *> old_users(out->begin(), out->end());
+      auto new_out = hls::print_op::create(*out)[0];
+      for (auto user: old_users) {
+        user->divert_to(new_out);
+      }
+    }
+  }
 }
 
 void
-jlm::hls::add_prints(llvm::RvsdgModule &rm) {
-	auto &graph = rm.Rvsdg();
-	auto root = graph.root();
-	add_prints(root);
+add_prints(llvm::RvsdgModule &rm) {
+  auto &graph = rm.Rvsdg();
+  auto root = graph.root();
+  add_prints(root);
 }
 
 void
-jlm::hls::convert_prints(llvm::RvsdgModule &rm) {
-	auto &graph = rm.Rvsdg();
-	auto root = graph.root();
-	//TODO: make this less hacky by using the correct state types
-	llvm::FunctionType fct({&jlm::rvsdg::bit64, &jlm::rvsdg::bit64}, {llvm::loopstatetype::create().get()});
-	llvm::impport imp(fct, "printnode", llvm::linkage::external_linkage);
-	auto printf = graph.add_import(imp);
-	convert_prints(
+convert_prints(llvm::RvsdgModule &rm) {
+  auto &graph = rm.Rvsdg();
+  auto root = graph.root();
+  //TODO: make this less hacky by using the correct state types
+  llvm::FunctionType fct({&jlm::rvsdg::bit64, &jlm::rvsdg::bit64}, {llvm::loopstatetype::create().get()});
+  llvm::impport imp(fct, "printnode", llvm::linkage::external_linkage);
+  auto printf = graph.add_import(imp);
+  convert_prints(
     root,
     printf,
     fct);
 }
 
 jlm::rvsdg::output *
-jlm::hls::route_to_region(jlm::rvsdg::output * output, jlm::rvsdg::region * region)
-{
-	JLM_ASSERT(region != nullptr);
+route_to_region(jlm::rvsdg::output *output, jlm::rvsdg::region *region) {
+  JLM_ASSERT(region != nullptr);
 
-	if (region == output->region())
-		return output;
+  if (region == output->region())
+    return output;
 
-	output = route_to_region(output, region->node()->region());
+  output = route_to_region(output, region->node()->region());
 
-	if (auto gamma = dynamic_cast<jlm::rvsdg::gamma_node*>(region->node())) {
-		gamma->add_entryvar(output);
-		output = region->argument(region->narguments()-1);
-	}	else if (auto theta = dynamic_cast<jlm::rvsdg::theta_node*>(region->node())) {
-		output = theta->add_loopvar(output)->argument();
-	} else if (auto lambda = dynamic_cast<llvm::lambda::node*>(region->node())) {
-		output = lambda->add_ctxvar(output);
-	} else {
-		JLM_ASSERT(0);
-	}
+  if (auto gamma = dynamic_cast<jlm::rvsdg::gamma_node *>(region->node())) {
+    gamma->add_entryvar(output);
+    output = region->argument(region->narguments() - 1);
+  } else if (auto theta = dynamic_cast<jlm::rvsdg::theta_node *>(region->node())) {
+    output = theta->add_loopvar(output)->argument();
+  } else if (auto lambda = dynamic_cast<llvm::lambda::node *>(region->node())) {
+    output = lambda->add_ctxvar(output);
+  } else {
+    JLM_ASSERT(0);
+  }
 
-	return output;
+  return output;
 }
 
 void
-jlm::hls::convert_prints(
+convert_prints(
   jlm::rvsdg::region *region,
-  jlm::rvsdg::output * printf,
-  const llvm::FunctionType & functionType)
-{
-	for (auto &node : jlm::rvsdg::topdown_traverser(region)) {
-		if (auto structnode = dynamic_cast<jlm::rvsdg::structural_node *>(node)) {
-			for (size_t n = 0; n < structnode->nsubregions(); n++) {
-				convert_prints(structnode->subregion(n), printf, functionType);
-			}
-		} else if (auto po = dynamic_cast<const jlm::hls::print_op *>(&(node->operation()))) {
-			auto printf_local = route_to_region(printf, region); //TODO: prevent repetition?
-			auto bc = jlm::rvsdg::create_bitconstant(region, 64, po->id());
-			jlm::rvsdg::output * val = node->input(0)->origin();
-			if(val->type()!=jlm::rvsdg::bit64){
-				auto bt = dynamic_cast<const jlm::rvsdg::bittype*>(&val->type());
-				JLM_ASSERT(bt);
-				auto op = llvm::zext_op(bt->nbits(), 64);
-				val = jlm::rvsdg::simple_node::create_normalized(region, op, {val})[0];
-			}
-			llvm::CallNode::Create(printf_local, functionType, {bc, val});
-			node->output(0)->divert_users(node->input(0)->origin());
-			jlm::rvsdg::remove(node);
-		}
-	}
+  jlm::rvsdg::output *printf,
+  const llvm::FunctionType &functionType) {
+  for (auto &node: jlm::rvsdg::topdown_traverser(region)) {
+    if (auto structnode = dynamic_cast<jlm::rvsdg::structural_node *>(node)) {
+      for (size_t n = 0; n < structnode->nsubregions(); n++) {
+        convert_prints(structnode->subregion(n), printf, functionType);
+      }
+    } else if (auto po = dynamic_cast<const print_op *>(&(node->operation()))) {
+      auto printf_local = route_to_region(printf, region); //TODO: prevent repetition?
+      auto bc = jlm::rvsdg::create_bitconstant(region, 64, po->id());
+      jlm::rvsdg::output *val = node->input(0)->origin();
+      if (val->type() != jlm::rvsdg::bit64) {
+        auto bt = dynamic_cast<const jlm::rvsdg::bittype *>(&val->type());
+        JLM_ASSERT(bt);
+        auto op = llvm::zext_op(bt->nbits(), 64);
+        val = jlm::rvsdg::simple_node::create_normalized(region, op, {val})[0];
+      }
+      llvm::CallNode::Create(printf_local, functionType, {bc, val});
+      node->output(0)->divert_users(node->input(0)->origin());
+      jlm::rvsdg::remove(node);
+    }
+  }
+}
+
 }

--- a/jlm/hls/backend/rvsdg2rhls/add-prints.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-prints.hpp
@@ -9,26 +9,27 @@
 #include <jlm/llvm/ir/RvsdgModule.hpp>
 #include <jlm/rvsdg/region.hpp>
 
-namespace jlm{
-	namespace hls{
-		void
-		add_prints(rvsdg::region *region);
+namespace jlm::hls
+{
 
-		void
-		add_prints(llvm::RvsdgModule &rm);
+void
+add_prints(rvsdg::region *region);
 
-		void
-		convert_prints(llvm::RvsdgModule &rm);
+void
+add_prints(llvm::RvsdgModule &rm);
 
-		void
-		convert_prints(
-      rvsdg::region *region,
-      rvsdg::output * printf,
-      const llvm::FunctionType & functionType);
+void
+convert_prints(llvm::RvsdgModule &rm);
 
-		rvsdg::output *
-		route_to_region(rvsdg::output * output, rvsdg::region * region);
-	}
+void
+convert_prints(
+  rvsdg::region *region,
+  rvsdg::output * printf,
+  const llvm::FunctionType & functionType);
+
+rvsdg::output *
+route_to_region(rvsdg::output * output, rvsdg::region * region);
+
 }
 
 #endif //JLM_HLS_BACKEND_RVSDG2RHLS_ADD_PRINTS_HPP

--- a/jlm/hls/backend/rvsdg2rhls/add-sinks.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-sinks.cpp
@@ -7,33 +7,37 @@
 #include <jlm/hls/ir/hls.hpp>
 #include <jlm/rvsdg/traverser.hpp>
 
-void
-jlm::hls::add_sinks(jlm::rvsdg::region *region) {
-	for (size_t i = 0; i < region->narguments(); ++i) {
-		auto arg = region->argument(i);
-		if (!arg->nusers()) {
-			hls::sink_op::create(*arg);
-		}
-	}
-	for (auto &node : jlm::rvsdg::topdown_traverser(region)) {
-		if (auto structnode = dynamic_cast<jlm::rvsdg::structural_node *>(node)) {
-			for (size_t n = 0; n < structnode->nsubregions(); n++) {
-				add_sinks(structnode->subregion(n));
-			}
-		}
+namespace jlm::hls {
 
-		for (size_t i = 0; i < node->noutputs(); ++i) {
-			auto out = node->output(i);
-			if (!out->nusers()) {
-				hls::sink_op::create(*out);
-			}
-		}
-	}
+void
+add_sinks(jlm::rvsdg::region *region) {
+  for (size_t i = 0; i < region->narguments(); ++i) {
+    auto arg = region->argument(i);
+    if (!arg->nusers()) {
+      hls::sink_op::create(*arg);
+    }
+  }
+  for (auto &node: jlm::rvsdg::topdown_traverser(region)) {
+    if (auto structnode = dynamic_cast<jlm::rvsdg::structural_node *>(node)) {
+      for (size_t n = 0; n < structnode->nsubregions(); n++) {
+        add_sinks(structnode->subregion(n));
+      }
+    }
+
+    for (size_t i = 0; i < node->noutputs(); ++i) {
+      auto out = node->output(i);
+      if (!out->nusers()) {
+        hls::sink_op::create(*out);
+      }
+    }
+  }
 }
 
 void
-jlm::hls::add_sinks(llvm::RvsdgModule &rm) {
-	auto &graph = rm.Rvsdg();
-	auto root = graph.root();
-	add_sinks(root);
+add_sinks(llvm::RvsdgModule &rm) {
+  auto &graph = rm.Rvsdg();
+  auto root = graph.root();
+  add_sinks(root);
+}
+
 }

--- a/jlm/hls/backend/rvsdg2rhls/add-sinks.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-sinks.hpp
@@ -9,13 +9,15 @@
 #include <jlm/llvm/ir/RvsdgModule.hpp>
 #include <jlm/rvsdg/region.hpp>
 
-namespace jlm{
-	namespace hls{
-		void
-		add_sinks(rvsdg::region *region);
+namespace jlm::hls
+{
 
-		void
-		add_sinks(jlm::llvm::RvsdgModule &rm);
-	}
+void
+add_sinks(rvsdg::region *region);
+
+void
+add_sinks(jlm::llvm::RvsdgModule &rm);
+
 }
+
 #endif //JLM_HLS_BACKEND_RVSDG2RHLS_ADD_SINKS_HPP

--- a/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
@@ -11,106 +11,110 @@
 #include <jlm/rvsdg/traverser.hpp>
 #include <jlm/rvsdg/view.hpp>
 
+namespace jlm::hls {
+
 jlm::rvsdg::output *
-jlm::hls::get_trigger(jlm::rvsdg::region *region) {
-	for (size_t i = 0; i < region->narguments(); ++i) {
-		if (region->argument(i)->type() == hls::trigger) {
-			return region->argument(i);
-		}
-	}
-	return nullptr;
+get_trigger(jlm::rvsdg::region *region) {
+  for (size_t i = 0; i < region->narguments(); ++i) {
+    if (region->argument(i)->type() == hls::trigger) {
+      return region->argument(i);
+    }
+  }
+  return nullptr;
 }
 
 jlm::llvm::lambda::node *
-jlm::hls::add_lambda_argument(llvm::lambda::node *ln, const jlm::rvsdg::type *type) {
-	auto old_fcttype = ln->type();
-	std::vector<const jlm::rvsdg::type *> new_argument_types;
-	for (size_t i = 0; i < old_fcttype.NumArguments(); ++i) {
-		new_argument_types.push_back(&old_fcttype.ArgumentType(i));
-	}
-	new_argument_types.push_back(type);
-	std::vector<const jlm::rvsdg::type *> new_result_types;
-	for (size_t i = 0; i < old_fcttype.NumResults(); ++i) {
-		new_result_types.push_back(&old_fcttype.ResultType(i));
-	}
-	llvm::FunctionType new_fcttype(new_argument_types, new_result_types);
-	auto new_lambda = llvm::lambda::node::create(ln->region(), new_fcttype, ln->name(), ln->linkage(),
-												ln->attributes());
+add_lambda_argument(llvm::lambda::node *ln, const jlm::rvsdg::type *type) {
+  auto old_fcttype = ln->type();
+  std::vector<const jlm::rvsdg::type *> new_argument_types;
+  for (size_t i = 0; i < old_fcttype.NumArguments(); ++i) {
+    new_argument_types.push_back(&old_fcttype.ArgumentType(i));
+  }
+  new_argument_types.push_back(type);
+  std::vector<const jlm::rvsdg::type *> new_result_types;
+  for (size_t i = 0; i < old_fcttype.NumResults(); ++i) {
+    new_result_types.push_back(&old_fcttype.ResultType(i));
+  }
+  llvm::FunctionType new_fcttype(new_argument_types, new_result_types);
+  auto new_lambda = llvm::lambda::node::create(ln->region(), new_fcttype, ln->name(), ln->linkage(),
+                                               ln->attributes());
 
-	jlm::rvsdg::substitution_map smap;
-	for (size_t i = 0; i < ln->ncvarguments(); ++i) {
-		// copy over cvarguments
-		smap.insert(ln->cvargument(i), new_lambda->add_ctxvar(ln->cvargument(i)->input()->origin()));
-	}
-	for (size_t i = 0; i < ln->nfctarguments(); ++i) {
-		smap.insert(ln->fctargument(i), new_lambda->fctargument(i));
-	}
+  jlm::rvsdg::substitution_map smap;
+  for (size_t i = 0; i < ln->ncvarguments(); ++i) {
+    // copy over cvarguments
+    smap.insert(ln->cvargument(i), new_lambda->add_ctxvar(ln->cvargument(i)->input()->origin()));
+  }
+  for (size_t i = 0; i < ln->nfctarguments(); ++i) {
+    smap.insert(ln->fctargument(i), new_lambda->fctargument(i));
+  }
 //	jlm::rvsdg::view(ln->subregion(), stdout);
 //	jlm::rvsdg::view(new_lambda->subregion(), stdout);
-	ln->subregion()->copy(new_lambda->subregion(), smap, false, false);
+  ln->subregion()->copy(new_lambda->subregion(), smap, false, false);
 
-	std::vector<jlm::rvsdg::output *> new_results;
-	for (size_t i = 0; i < ln->nfctresults(); ++i) {
-		new_results.push_back(smap.lookup(ln->fctresult(i)->origin()));
-	}
-	auto new_out = new_lambda->finalize(new_results);
+  std::vector<jlm::rvsdg::output *> new_results;
+  for (size_t i = 0; i < ln->nfctresults(); ++i) {
+    new_results.push_back(smap.lookup(ln->fctresult(i)->origin()));
+  }
+  auto new_out = new_lambda->finalize(new_results);
 
-	// TODO handle functions at other levels?
-	assert(ln->region() == ln->region()->graph()->root());
-	assert((*ln->output()->begin())->region() == ln->region()->graph()->root());
+  // TODO handle functions at other levels?
+  assert(ln->region() == ln->region()->graph()->root());
+  assert((*ln->output()->begin())->region() == ln->region()->graph()->root());
 
 //            ln->output()->divert_users(new_out);
-	ln->region()->remove_result((*ln->output()->begin())->index());
-	remove(ln);
-	jlm::rvsdg::result::create(new_lambda->region(), new_out, nullptr, new_out->type());
-	return new_lambda;
+  ln->region()->remove_result((*ln->output()->begin())->index());
+  remove(ln);
+  jlm::rvsdg::result::create(new_lambda->region(), new_out, nullptr, new_out->type());
+  return new_lambda;
 }
 
 void
-jlm::hls::add_triggers(jlm::rvsdg::region *region) {
-	auto trigger = get_trigger(region);
-	for (auto &node : jlm::rvsdg::topdown_traverser(region)) {
-		if (dynamic_cast<jlm::rvsdg::structural_node *>(node)) {
-			if (auto ln = dynamic_cast<llvm::lambda::node *>(node)) {
-				// check here in order not to process removed and re-added node twice
-				if (!get_trigger(ln->subregion())) {
-					auto new_lambda = add_lambda_argument(ln, &(hls::trigger));
-					add_triggers(new_lambda->subregion());
-				}
-			} else if (auto t = dynamic_cast<jlm::rvsdg::theta_node *>(node)) {
-				assert(trigger != nullptr);
-				assert(get_trigger(t->subregion()) == nullptr);
-				t->add_loopvar(trigger);
-				add_triggers(t->subregion());
-			} else if (auto gn = dynamic_cast<jlm::rvsdg::gamma_node *>(node)) {
-				assert(trigger != nullptr);
-				assert(get_trigger(gn->subregion(0)) == nullptr);
-				gn->add_entryvar(trigger);
-				for (size_t i = 0; i < gn->nsubregions(); ++i) {
-					add_triggers(gn->subregion(i));
-				}
-			} else {
-				throw jlm::util::error("Unexpected node type: " + node->operation().debug_string());
-			}
-		} else if (auto sn = dynamic_cast<jlm::rvsdg::simple_node *>(node)) {
-			assert(trigger != nullptr);
-			if (is_constant(node)) {
-				auto orig_out = sn->output(0);
-				std::vector<jlm::rvsdg::input *> previous_users(orig_out->begin(), orig_out->end());
-				auto gated = hls::trigger_op::create(*trigger, *orig_out)[0];
-				for (auto user: previous_users) {
-					user->divert_to(gated);
-				}
-			}
-		} else {
-			throw jlm::util::error("Unexpected node type: " + node->operation().debug_string());
-		}
-	}
+add_triggers(jlm::rvsdg::region *region) {
+  auto trigger = get_trigger(region);
+  for (auto &node: jlm::rvsdg::topdown_traverser(region)) {
+    if (dynamic_cast<jlm::rvsdg::structural_node *>(node)) {
+      if (auto ln = dynamic_cast<llvm::lambda::node *>(node)) {
+        // check here in order not to process removed and re-added node twice
+        if (!get_trigger(ln->subregion())) {
+          auto new_lambda = add_lambda_argument(ln, &(hls::trigger));
+          add_triggers(new_lambda->subregion());
+        }
+      } else if (auto t = dynamic_cast<jlm::rvsdg::theta_node *>(node)) {
+        assert(trigger != nullptr);
+        assert(get_trigger(t->subregion()) == nullptr);
+        t->add_loopvar(trigger);
+        add_triggers(t->subregion());
+      } else if (auto gn = dynamic_cast<jlm::rvsdg::gamma_node *>(node)) {
+        assert(trigger != nullptr);
+        assert(get_trigger(gn->subregion(0)) == nullptr);
+        gn->add_entryvar(trigger);
+        for (size_t i = 0; i < gn->nsubregions(); ++i) {
+          add_triggers(gn->subregion(i));
+        }
+      } else {
+        throw jlm::util::error("Unexpected node type: " + node->operation().debug_string());
+      }
+    } else if (auto sn = dynamic_cast<jlm::rvsdg::simple_node *>(node)) {
+      assert(trigger != nullptr);
+      if (is_constant(node)) {
+        auto orig_out = sn->output(0);
+        std::vector<jlm::rvsdg::input *> previous_users(orig_out->begin(), orig_out->end());
+        auto gated = hls::trigger_op::create(*trigger, *orig_out)[0];
+        for (auto user: previous_users) {
+          user->divert_to(gated);
+        }
+      }
+    } else {
+      throw jlm::util::error("Unexpected node type: " + node->operation().debug_string());
+    }
+  }
 }
 
 void
-jlm::hls::add_triggers(llvm::RvsdgModule &rm) {
-	auto &graph = rm.Rvsdg();
-	auto root = graph.root();
-	add_triggers(root);
+add_triggers(llvm::RvsdgModule &rm) {
+  auto &graph = rm.Rvsdg();
+  auto root = graph.root();
+  add_triggers(root);
+}
+
 }

--- a/jlm/hls/backend/rvsdg2rhls/add-triggers.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-triggers.hpp
@@ -10,20 +10,21 @@
 #include <jlm/llvm/ir/RvsdgModule.hpp>
 #include <jlm/rvsdg/region.hpp>
 
-namespace jlm {
-	namespace hls {
+namespace jlm::hls
+{
 
-		rvsdg::output *
-		get_trigger(rvsdg::region *region);
+rvsdg::output *
+get_trigger(rvsdg::region *region);
 
-		llvm::lambda::node *
-		add_lambda_argument(llvm::lambda::node *ln, const rvsdg::type *type);
+llvm::lambda::node *
+add_lambda_argument(llvm::lambda::node *ln, const rvsdg::type *type);
 
-		void
-		add_triggers(rvsdg::region *region);
+void
+add_triggers(rvsdg::region *region);
 
-		void
-		add_triggers(llvm::RvsdgModule &rm);
-	}
+void
+add_triggers(llvm::RvsdgModule &rm);
+
 }
+
 #endif //JLM_HLS_BACKEND_RVSDG2RHLS_ADD_TRIGGERS_HPP

--- a/jlm/hls/backend/rvsdg2rhls/check-rhls.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/check-rhls.hpp
@@ -8,13 +8,15 @@
 
 #include <jlm/llvm/ir/RvsdgModule.hpp>
 
-namespace jlm {
-	namespace hls {
-		void
-		check_rhls(jlm::rvsdg::region *sr);
+namespace jlm::hls
+{
 
-		void
-		check_rhls(llvm::RvsdgModule &rm);
-	}
+void
+check_rhls(jlm::rvsdg::region *sr);
+
+void
+check_rhls(llvm::RvsdgModule &rm);
+
 }
+
 #endif //JLM_HLS_BACKEND_RVSDG2RHLS_CHECK_RHLS_HPP

--- a/jlm/hls/backend/rvsdg2rhls/gamma-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/gamma-conv.cpp
@@ -8,115 +8,119 @@
 #include <jlm/rvsdg/theta.hpp>
 #include <jlm/rvsdg/traverser.hpp>
 
+namespace jlm::hls {
+
 void
-jlm::hls::gamma_conv(llvm::RvsdgModule &rm, bool allow_speculation) {
-	auto &graph = rm.Rvsdg();
-	auto root = graph.root();
-	gamma_conv(root, allow_speculation);
+gamma_conv(llvm::RvsdgModule &rm, bool allow_speculation) {
+  auto &graph = rm.Rvsdg();
+  auto root = graph.root();
+  gamma_conv(root, allow_speculation);
 }
 
 void
-jlm::hls::gamma_conv(jlm::rvsdg::region *region, bool allow_speculation) {
-	for (auto &node : jlm::rvsdg::topdown_traverser(region)) {
-		if (auto structnode = dynamic_cast<jlm::rvsdg::structural_node *>(node)) {
-			for (size_t n = 0; n < structnode->nsubregions(); n++)
-				gamma_conv(structnode->subregion(n), allow_speculation);
-			if (auto gamma = dynamic_cast<jlm::rvsdg::gamma_node *>(node)) {
-				if (allow_speculation && gamma_can_be_spec(gamma)) {
-					gamma_conv_spec(gamma);
-				} else {
-					gamma_conv_nonspec(gamma);
-				}
-			}
-		}
-	}
+gamma_conv(jlm::rvsdg::region *region, bool allow_speculation) {
+  for (auto &node: jlm::rvsdg::topdown_traverser(region)) {
+    if (auto structnode = dynamic_cast<jlm::rvsdg::structural_node *>(node)) {
+      for (size_t n = 0; n < structnode->nsubregions(); n++)
+        gamma_conv(structnode->subregion(n), allow_speculation);
+      if (auto gamma = dynamic_cast<jlm::rvsdg::gamma_node *>(node)) {
+        if (allow_speculation && gamma_can_be_spec(gamma)) {
+          gamma_conv_spec(gamma);
+        } else {
+          gamma_conv_nonspec(gamma);
+        }
+      }
+    }
+  }
 }
 
 void
-jlm::hls::gamma_conv_spec(jlm::rvsdg::gamma_node *gamma) {
-	jlm::rvsdg::substitution_map smap;
-	// connect arguments to origins of inputs. Forks will automatically be created later
-	auto pro = gamma->predicate()->origin();
-	for (size_t i = 0; i < gamma->nentryvars(); i++) {
-		auto envo = gamma->entryvar(i)->origin();
-		for (size_t s = 0; s < gamma->nsubregions(); s++) {
-			smap.insert(gamma->subregion(s)->argument(i), envo);
-		}
-	}
-	// copy each of the subregions
-	for (size_t s = 0; s < gamma->nsubregions(); s++) {
-		gamma->subregion(s)->copy(gamma->region(), smap, false, false);
-	}
-	for (size_t i = 0; i < gamma->nexitvars(); i++) {
-		std::vector<jlm::rvsdg::output *> alternatives;
-		for (size_t s = 0; s < gamma->nsubregions(); s++) {
-			alternatives.push_back(smap.lookup(gamma->subregion(s)->result(i)->origin()));
-		}
-		// create discarding mux for each exitvar
-		auto merge = hls::mux_op::create(*pro, alternatives, true);
-		// divert users of exitvars to merge instead
-		gamma->exitvar(i)->divert_users(merge[0]);
-	}
-	remove(gamma);
+gamma_conv_spec(jlm::rvsdg::gamma_node *gamma) {
+  jlm::rvsdg::substitution_map smap;
+  // connect arguments to origins of inputs. Forks will automatically be created later
+  auto pro = gamma->predicate()->origin();
+  for (size_t i = 0; i < gamma->nentryvars(); i++) {
+    auto envo = gamma->entryvar(i)->origin();
+    for (size_t s = 0; s < gamma->nsubregions(); s++) {
+      smap.insert(gamma->subregion(s)->argument(i), envo);
+    }
+  }
+  // copy each of the subregions
+  for (size_t s = 0; s < gamma->nsubregions(); s++) {
+    gamma->subregion(s)->copy(gamma->region(), smap, false, false);
+  }
+  for (size_t i = 0; i < gamma->nexitvars(); i++) {
+    std::vector<jlm::rvsdg::output *> alternatives;
+    for (size_t s = 0; s < gamma->nsubregions(); s++) {
+      alternatives.push_back(smap.lookup(gamma->subregion(s)->result(i)->origin()));
+    }
+    // create discarding mux for each exitvar
+    auto merge = hls::mux_op::create(*pro, alternatives, true);
+    // divert users of exitvars to merge instead
+    gamma->exitvar(i)->divert_users(merge[0]);
+  }
+  remove(gamma);
 }
 
 void
-jlm::hls::gamma_conv_nonspec(jlm::rvsdg::gamma_node *gamma) {
-	jlm::rvsdg::substitution_map smap;
-	// create a branch for each entryvar and map the corresponding argument of each subregion to an output of the branch
-	auto pro = gamma->predicate()->origin();
-	for (size_t i = 0; i < gamma->nentryvars(); i++) {
-		auto envo = gamma->entryvar(i)->origin();
-		auto bros = hls::branch_op::create(*pro, *envo);
-		for (size_t s = 0; s < gamma->nsubregions(); s++) {
-			smap.insert(gamma->subregion(s)->argument(i), bros[s]);
-		}
-	}
-	// copy each of the subregions
-	for (size_t s = 0; s < gamma->nsubregions(); s++) {
+gamma_conv_nonspec(jlm::rvsdg::gamma_node *gamma) {
+  jlm::rvsdg::substitution_map smap;
+  // create a branch for each entryvar and map the corresponding argument of each subregion to an output of the branch
+  auto pro = gamma->predicate()->origin();
+  for (size_t i = 0; i < gamma->nentryvars(); i++) {
+    auto envo = gamma->entryvar(i)->origin();
+    auto bros = hls::branch_op::create(*pro, *envo);
+    for (size_t s = 0; s < gamma->nsubregions(); s++) {
+      smap.insert(gamma->subregion(s)->argument(i), bros[s]);
+    }
+  }
+  // copy each of the subregions
+  for (size_t s = 0; s < gamma->nsubregions(); s++) {
 //                std::cout << "copying gamma subregion:\n";
 //                jlm::rvsdg::view(gamma->subregion(s), stdout);
-		gamma->subregion(s)->copy(gamma->region(), smap, false, false);
-	}
-	for (size_t i = 0; i < gamma->nexitvars(); i++) {
-		std::vector<jlm::rvsdg::output *> alternatives;
-		for (size_t s = 0; s < gamma->nsubregions(); s++) {
-			alternatives.push_back(smap.lookup(gamma->subregion(s)->result(i)->origin()));
-		}
-		// create mux nodes for each exitvar
-		// use mux instead of merge in case of paths with different delay - otherwise one could overtake the other
-		// see https://ieeexplore.ieee.org/abstract/document/9515491
-		auto mux = hls::mux_op::create(*pro, alternatives, false);
-		// divert users of exitvars to mux instead
-		gamma->exitvar(i)->divert_users(mux[0]);
-	}
-	remove(gamma);
+    gamma->subregion(s)->copy(gamma->region(), smap, false, false);
+  }
+  for (size_t i = 0; i < gamma->nexitvars(); i++) {
+    std::vector<jlm::rvsdg::output *> alternatives;
+    for (size_t s = 0; s < gamma->nsubregions(); s++) {
+      alternatives.push_back(smap.lookup(gamma->subregion(s)->result(i)->origin()));
+    }
+    // create mux nodes for each exitvar
+    // use mux instead of merge in case of paths with different delay - otherwise one could overtake the other
+    // see https://ieeexplore.ieee.org/abstract/document/9515491
+    auto mux = hls::mux_op::create(*pro, alternatives, false);
+    // divert users of exitvars to mux instead
+    gamma->exitvar(i)->divert_users(mux[0]);
+  }
+  remove(gamma);
 }
 
 bool
-jlm::hls::gamma_can_be_spec(jlm::rvsdg::gamma_node *gamma) {
-	for (size_t i = 0; i < gamma->noutputs(); ++i) {
-		auto out = gamma->output(i);
-		if (jlm::rvsdg::is<jlm::rvsdg::statetype>(out->type())) {
-			// don't allow state outputs since they imply operations with side effects
-			return false;
-		}
-	}
-	for (size_t i = 0; i < gamma->nsubregions(); ++i) {
-		auto sr = gamma->subregion(i);
-		for (auto &node : jlm::rvsdg::topdown_traverser(sr)) {
-			if (jlm::rvsdg::is<jlm::rvsdg::theta_op>(node) || jlm::rvsdg::is<hls::loop_op>(node)) {
-				// don't allow thetas or loops since they could potentially block forever
-				return false;
-			} else if (auto g = dynamic_cast<jlm::rvsdg::gamma_node *>(node)) {
-				if (!gamma_can_be_spec(g)) {
-					// only allow gammas that can also be speculated on
-					return false;
-				}
-			} else if (dynamic_cast<jlm::rvsdg::structural_node *>(node)) {
-				throw util::error("Unexpected structural node: " + node->operation().debug_string());
-			}
-		}
-	}
-	return true;
+gamma_can_be_spec(jlm::rvsdg::gamma_node *gamma) {
+  for (size_t i = 0; i < gamma->noutputs(); ++i) {
+    auto out = gamma->output(i);
+    if (jlm::rvsdg::is<jlm::rvsdg::statetype>(out->type())) {
+      // don't allow state outputs since they imply operations with side effects
+      return false;
+    }
+  }
+  for (size_t i = 0; i < gamma->nsubregions(); ++i) {
+    auto sr = gamma->subregion(i);
+    for (auto &node: jlm::rvsdg::topdown_traverser(sr)) {
+      if (jlm::rvsdg::is<jlm::rvsdg::theta_op>(node) || jlm::rvsdg::is<hls::loop_op>(node)) {
+        // don't allow thetas or loops since they could potentially block forever
+        return false;
+      } else if (auto g = dynamic_cast<jlm::rvsdg::gamma_node *>(node)) {
+        if (!gamma_can_be_spec(g)) {
+          // only allow gammas that can also be speculated on
+          return false;
+        }
+      } else if (dynamic_cast<jlm::rvsdg::structural_node *>(node)) {
+        throw util::error("Unexpected structural node: " + node->operation().debug_string());
+      }
+    }
+  }
+  return true;
+}
+
 }

--- a/jlm/hls/backend/rvsdg2rhls/gamma-conv.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/gamma-conv.hpp
@@ -9,20 +9,24 @@
 #include <jlm/llvm/ir/RvsdgModule.hpp>
 #include <jlm/rvsdg/gamma.hpp>
 
-namespace jlm{
-	namespace hls{
+namespace jlm::hls
+{
 
-		bool gamma_can_be_spec(jlm::rvsdg::gamma_node *gamma);
+bool
+gamma_can_be_spec(jlm::rvsdg::gamma_node *gamma);
 
-		void gamma_conv_nonspec(jlm::rvsdg::gamma_node *gamma);
+void
+gamma_conv_nonspec(jlm::rvsdg::gamma_node *gamma);
 
-		void gamma_conv_spec(jlm::rvsdg::gamma_node *gamma);
+void
+gamma_conv_spec(jlm::rvsdg::gamma_node *gamma);
 
-		void
-		gamma_conv(jlm::rvsdg::region *region, bool allow_speculation=true);
+void
+gamma_conv(jlm::rvsdg::region *region, bool allow_speculation=true);
 
-		void
-		gamma_conv(llvm::RvsdgModule &rm, bool allow_speculation=true);
-	}
+void
+gamma_conv(llvm::RvsdgModule &rm, bool allow_speculation=true);
+
 }
+
 #endif //JLM_HLS_BACKEND_RVSDG2RHLS_GAMMA_CONV_HPP

--- a/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
@@ -6,172 +6,176 @@
 #include <jlm/hls/backend/rvsdg2rhls/remove-unused-state.hpp>
 #include <jlm/rvsdg/traverser.hpp>
 
+namespace jlm::hls {
+
 void
-jlm::hls::remove_unused_state(jlm::rvsdg::region *region, bool can_remove_arguments) {
-	// process children first so that unnecessary users get removed
-	for (auto &node : jlm::rvsdg::topdown_traverser(region)) {
-		if (auto structnode = dynamic_cast<jlm::rvsdg::structural_node *>(node)) {
-			if (auto gn = dynamic_cast<jlm::rvsdg::gamma_node *>(node)) {
-				// process subnodes first
-				for (size_t n = 0; n < gn->nsubregions(); n++) {
-					remove_unused_state(gn->subregion(n), false);
-				}
-				remove_gamma_passthrough(gn);
-			} else if (auto ln = dynamic_cast<llvm::lambda::node *>(node)) {
-				remove_unused_state(structnode->subregion(0), false);
-				remove_lambda_passthrough(ln);
-			} else {
-				assert(structnode->nsubregions() == 1);
-				remove_unused_state(structnode->subregion(0));
-			}
-		}
-	}
-	if (can_remove_arguments) {
-		// check if an input is passed through unnecessarily
-		for (int i = region->narguments() - 1; i >= 0; --i) {
-			auto arg = region->argument(i);
-			if (is_passthrough(arg)) {
-				remove_region_passthrough(arg);
-			}
-		}
-	}
+remove_unused_state(jlm::rvsdg::region *region, bool can_remove_arguments) {
+  // process children first so that unnecessary users get removed
+  for (auto &node: jlm::rvsdg::topdown_traverser(region)) {
+    if (auto structnode = dynamic_cast<jlm::rvsdg::structural_node *>(node)) {
+      if (auto gn = dynamic_cast<jlm::rvsdg::gamma_node *>(node)) {
+        // process subnodes first
+        for (size_t n = 0; n < gn->nsubregions(); n++) {
+          remove_unused_state(gn->subregion(n), false);
+        }
+        remove_gamma_passthrough(gn);
+      } else if (auto ln = dynamic_cast<llvm::lambda::node *>(node)) {
+        remove_unused_state(structnode->subregion(0), false);
+        remove_lambda_passthrough(ln);
+      } else {
+        assert(structnode->nsubregions() == 1);
+        remove_unused_state(structnode->subregion(0));
+      }
+    }
+  }
+  if (can_remove_arguments) {
+    // check if an input is passed through unnecessarily
+    for (int i = region->narguments() - 1; i >= 0; --i) {
+      auto arg = region->argument(i);
+      if (is_passthrough(arg)) {
+        remove_region_passthrough(arg);
+      }
+    }
+  }
 }
 
 void
-jlm::hls::remove_unused_state(llvm::RvsdgModule &rm) {
-	auto &graph = rm.Rvsdg();
-	auto root = graph.root();
-	remove_unused_state(root);
+remove_unused_state(llvm::RvsdgModule &rm) {
+  auto &graph = rm.Rvsdg();
+  auto root = graph.root();
+  remove_unused_state(root);
 }
 
 void
-jlm::hls::remove_gamma_passthrough(jlm::rvsdg::gamma_node *gn) {// remove inputs in reverse
-	for (int i = gn->nentryvars() - 1; i >= 0; --i) {
-		bool can_remove = true;
-		size_t res_index = 0;
-		auto arg = gn->subregion(0)->argument(i);
-		if(arg->nusers()==1){
-			auto res = dynamic_cast<jlm::rvsdg::result *>(*arg->begin());
-			res_index = res?res->index():res_index;
-		}
-		for (size_t n = 0; n < gn->nsubregions(); n++) {
-			auto sr = gn->subregion(n);
-			can_remove &= is_passthrough(sr->argument(i)) &&
-			// check that all subregions pass through to the same result
-			dynamic_cast<jlm::rvsdg::result *>(*sr->argument(i)->begin())->index() == res_index;
-		}
-		if (can_remove) {
-			auto origin = gn->entryvar(i)->origin();
-			// divert users of output to origin of input
+remove_gamma_passthrough(jlm::rvsdg::gamma_node *gn) {// remove inputs in reverse
+  for (int i = gn->nentryvars() - 1; i >= 0; --i) {
+    bool can_remove = true;
+    size_t res_index = 0;
+    auto arg = gn->subregion(0)->argument(i);
+    if (arg->nusers() == 1) {
+      auto res = dynamic_cast<jlm::rvsdg::result *>(*arg->begin());
+      res_index = res ? res->index() : res_index;
+    }
+    for (size_t n = 0; n < gn->nsubregions(); n++) {
+      auto sr = gn->subregion(n);
+      can_remove &= is_passthrough(sr->argument(i)) &&
+                    // check that all subregions pass through to the same result
+                    dynamic_cast<jlm::rvsdg::result *>(*sr->argument(i)->begin())->index() == res_index;
+    }
+    if (can_remove) {
+      auto origin = gn->entryvar(i)->origin();
+      // divert users of output to origin of input
 
-			gn->output(res_index)->divert_users(origin);
-			gn->output(res_index)->results.clear();
-			gn->remove_output(res_index);
-			// remove input
-			gn->input(i+1)->arguments.clear();
-			gn->remove_input(i + 1);
-			for (size_t j = 0; j < gn->nsubregions(); ++j) {
-				JLM_ASSERT(gn->subregion(j)->result(res_index)->origin() == gn->subregion(j)->argument(i));
-				JLM_ASSERT(gn->subregion(j)->argument(i)->nusers() == 1);
-				gn->subregion(j)->remove_result(res_index);
-				JLM_ASSERT(gn->subregion(j)->argument(i)->nusers() == 0);
-				gn->subregion(j)->remove_argument(i);
-			}
-		}
-	}
+      gn->output(res_index)->divert_users(origin);
+      gn->output(res_index)->results.clear();
+      gn->remove_output(res_index);
+      // remove input
+      gn->input(i + 1)->arguments.clear();
+      gn->remove_input(i + 1);
+      for (size_t j = 0; j < gn->nsubregions(); ++j) {
+        JLM_ASSERT(gn->subregion(j)->result(res_index)->origin() == gn->subregion(j)->argument(i));
+        JLM_ASSERT(gn->subregion(j)->argument(i)->nusers() == 1);
+        gn->subregion(j)->remove_result(res_index);
+        JLM_ASSERT(gn->subregion(j)->argument(i)->nusers() == 0);
+        gn->subregion(j)->remove_argument(i);
+      }
+    }
+  }
 }
 
 jlm::llvm::lambda::node *
-jlm::hls::remove_lambda_passthrough(llvm::lambda::node *ln) {
-	auto old_fcttype = ln->type();
-	std::vector<const jlm::rvsdg::type *> new_argument_types;
-	for (size_t i = 0; i < old_fcttype.NumArguments(); ++i) {
-		auto arg = ln->subregion()->argument(i);
-		auto argtype = &old_fcttype.ArgumentType(i);
-		assert(*argtype == arg->type());
-		if (!is_passthrough(arg)) {
-			new_argument_types.push_back(argtype);
-		}
-	}
-	std::vector<const jlm::rvsdg::type *> new_result_types;
-	for (size_t i = 0; i < old_fcttype.NumResults(); ++i) {
-		auto res = ln->subregion()->result(i);
-		auto restype = &old_fcttype.ResultType(i);
-		assert(*restype == res->type());
-		if (!is_passthrough(res)) {
-			new_result_types.push_back(&old_fcttype.ResultType(i));
-		}
-	}
-	llvm::FunctionType new_fcttype(new_argument_types, new_result_types);
-	auto new_lambda = llvm::lambda::node::create(ln->region(), new_fcttype, ln->name(), ln->linkage(),
-												ln->attributes());
+remove_lambda_passthrough(llvm::lambda::node *ln) {
+  auto old_fcttype = ln->type();
+  std::vector<const jlm::rvsdg::type *> new_argument_types;
+  for (size_t i = 0; i < old_fcttype.NumArguments(); ++i) {
+    auto arg = ln->subregion()->argument(i);
+    auto argtype = &old_fcttype.ArgumentType(i);
+    assert(*argtype == arg->type());
+    if (!is_passthrough(arg)) {
+      new_argument_types.push_back(argtype);
+    }
+  }
+  std::vector<const jlm::rvsdg::type *> new_result_types;
+  for (size_t i = 0; i < old_fcttype.NumResults(); ++i) {
+    auto res = ln->subregion()->result(i);
+    auto restype = &old_fcttype.ResultType(i);
+    assert(*restype == res->type());
+    if (!is_passthrough(res)) {
+      new_result_types.push_back(&old_fcttype.ResultType(i));
+    }
+  }
+  llvm::FunctionType new_fcttype(new_argument_types, new_result_types);
+  auto new_lambda = llvm::lambda::node::create(ln->region(), new_fcttype, ln->name(), ln->linkage(),
+                                               ln->attributes());
 
-	jlm::rvsdg::substitution_map smap;
-	for (size_t i = 0; i < ln->ncvarguments(); ++i) {
-		// copy over cvarguments
-		smap.insert(ln->cvargument(i), new_lambda->add_ctxvar(ln->cvargument(i)->input()->origin()));
-	}
-	size_t new_i = 0;
-	for (size_t i = 0; i < ln->nfctarguments(); ++i) {
-		auto arg = ln->fctargument(i);
-		if (!is_passthrough(arg)) {
-			smap.insert(arg, new_lambda->fctargument(new_i));
-			new_i++;
-		}
-	}
-	ln->subregion()->copy(new_lambda->subregion(), smap, false, false);
+  jlm::rvsdg::substitution_map smap;
+  for (size_t i = 0; i < ln->ncvarguments(); ++i) {
+    // copy over cvarguments
+    smap.insert(ln->cvargument(i), new_lambda->add_ctxvar(ln->cvargument(i)->input()->origin()));
+  }
+  size_t new_i = 0;
+  for (size_t i = 0; i < ln->nfctarguments(); ++i) {
+    auto arg = ln->fctargument(i);
+    if (!is_passthrough(arg)) {
+      smap.insert(arg, new_lambda->fctargument(new_i));
+      new_i++;
+    }
+  }
+  ln->subregion()->copy(new_lambda->subregion(), smap, false, false);
 
-	std::vector<jlm::rvsdg::output *> new_results;
-	for (size_t i = 0; i < ln->nfctresults(); ++i) {
-		auto res = ln->fctresult(i);
-		if (!is_passthrough(res)) {
-			new_results.push_back(smap.lookup(res->origin()));
-		}
-	}
-	auto new_out = new_lambda->finalize(new_results);
+  std::vector<jlm::rvsdg::output *> new_results;
+  for (size_t i = 0; i < ln->nfctresults(); ++i) {
+    auto res = ln->fctresult(i);
+    if (!is_passthrough(res)) {
+      new_results.push_back(smap.lookup(res->origin()));
+    }
+  }
+  auto new_out = new_lambda->finalize(new_results);
 
-	// TODO handle functions at other levels?
-	assert(ln->region() == ln->region()->graph()->root());
-	assert((*ln->output()->begin())->region() == ln->region()->graph()->root());
+  // TODO handle functions at other levels?
+  assert(ln->region() == ln->region()->graph()->root());
+  assert((*ln->output()->begin())->region() == ln->region()->graph()->root());
 
 //	ln->output()->divert_users(new_out); // can't divert since the type changed
-	JLM_ASSERT(ln->output()->nusers()==1);
-	ln->region()->remove_result((*ln->output()->begin())->index());
-	remove(ln);
-	jlm::rvsdg::result::create(new_lambda->region(), new_out, nullptr, new_out->type());
-	return new_lambda;
+  JLM_ASSERT(ln->output()->nusers() == 1);
+  ln->region()->remove_result((*ln->output()->begin())->index());
+  remove(ln);
+  jlm::rvsdg::result::create(new_lambda->region(), new_out, nullptr, new_out->type());
+  return new_lambda;
 }
 
 void
-jlm::hls::remove_region_passthrough(const jlm::rvsdg::argument *arg) {
-	auto res = dynamic_cast<jlm::rvsdg::result *>(*arg->begin());
-	auto origin = arg->input()->origin();
-	// divert users of output to origin of input
-	arg->region()->node()->output(res->output()->index())->divert_users(origin);
-	// remove result first so argument has no users
-	arg->region()->remove_result(res->index());
-	arg->region()->remove_argument(arg->index());
-	arg->region()->node()->remove_input(arg->input()->index());
-	arg->region()->node()->remove_output(res->output()->index());
+remove_region_passthrough(const jlm::rvsdg::argument *arg) {
+  auto res = dynamic_cast<jlm::rvsdg::result *>(*arg->begin());
+  auto origin = arg->input()->origin();
+  // divert users of output to origin of input
+  arg->region()->node()->output(res->output()->index())->divert_users(origin);
+  // remove result first so argument has no users
+  arg->region()->remove_result(res->index());
+  arg->region()->remove_argument(arg->index());
+  arg->region()->node()->remove_input(arg->input()->index());
+  arg->region()->node()->remove_output(res->output()->index());
 }
 
 bool
-jlm::hls::is_passthrough(const jlm::rvsdg::result *res) {
-	auto arg = dynamic_cast<jlm::rvsdg::argument *>(res->origin());
-	if (arg) {
-		return true;
-	}
-	return false;
+is_passthrough(const jlm::rvsdg::result *res) {
+  auto arg = dynamic_cast<jlm::rvsdg::argument *>(res->origin());
+  if (arg) {
+    return true;
+  }
+  return false;
 }
 
 bool
-jlm::hls::is_passthrough(const jlm::rvsdg::argument *arg) {
-	if (arg->nusers() == 1) {
-		auto res = dynamic_cast<jlm::rvsdg::result *>(*arg->begin());
-		// used only by a result
-		if (res) {
-			return true;
-		}
-	}
-	return false;
+is_passthrough(const jlm::rvsdg::argument *arg) {
+  if (arg->nusers() == 1) {
+    auto res = dynamic_cast<jlm::rvsdg::result *>(*arg->begin());
+    // used only by a result
+    if (res) {
+      return true;
+    }
+  }
+  return false;
+}
+
 }

--- a/jlm/hls/backend/rvsdg2rhls/remove-unused-state.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/remove-unused-state.hpp
@@ -11,29 +11,30 @@
 #include <jlm/rvsdg/region.hpp>
 #include <jlm/rvsdg/gamma.hpp>
 
-namespace jlm {
-	namespace hls {
+namespace jlm::hls
+{
 
-		bool
-		is_passthrough(const jlm::rvsdg::argument *arg);
+bool
+is_passthrough(const jlm::rvsdg::argument *arg);
 
-		bool
-		is_passthrough(const jlm::rvsdg::result *res);
+bool
+is_passthrough(const jlm::rvsdg::result *res);
 
-		llvm::lambda::node *
-		remove_lambda_passthrough(llvm::lambda::node *ln);
+llvm::lambda::node *
+remove_lambda_passthrough(llvm::lambda::node *ln);
 
-		void
-		remove_region_passthrough(const jlm::rvsdg::argument *arg);
+void
+remove_region_passthrough(const jlm::rvsdg::argument *arg);
 
-		void
-		remove_gamma_passthrough(jlm::rvsdg::gamma_node *gn);
+void
+remove_gamma_passthrough(jlm::rvsdg::gamma_node *gn);
 
-		void
-		remove_unused_state(llvm::RvsdgModule &rm);
+void
+remove_unused_state(llvm::RvsdgModule &rm);
 
-		void
-		remove_unused_state(jlm::rvsdg::region *region, bool can_remove_arguments = true);
-	}
+void
+remove_unused_state(jlm::rvsdg::region *region, bool can_remove_arguments = true);
+
 }
+
 #endif //JLM_HLS_BACKEND_RVSDG2RHLS_REMOVE_UNUSED_STATE_HPP

--- a/jlm/hls/backend/rvsdg2rhls/rhls-dne.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rhls-dne.cpp
@@ -7,89 +7,93 @@
 #include <jlm/llvm/ir/operators/lambda.hpp>
 #include <jlm/rvsdg/traverser.hpp>
 
+namespace jlm::hls {
+
 bool
-jlm::hls::remove_unused_loop_outputs(hls::loop_node *ln) {
-	bool any_changed = false;
-	auto sr = ln->subregion();
-	// go through in reverse because we remove some
-	for (int i = ln->noutputs() - 1; i >= 0; --i) {
-		auto out = ln->output(i);
-		if (out->nusers() == 0) {
-			assert(out->results.size() == 1);
-			auto result = out->results.begin();
-			sr->remove_result(result->index());
-			ln->remove_output(out->index());
-			any_changed = true;
-		}
-	}
-	return any_changed;
+remove_unused_loop_outputs(hls::loop_node *ln) {
+  bool any_changed = false;
+  auto sr = ln->subregion();
+  // go through in reverse because we remove some
+  for (int i = ln->noutputs() - 1; i >= 0; --i) {
+    auto out = ln->output(i);
+    if (out->nusers() == 0) {
+      assert(out->results.size() == 1);
+      auto result = out->results.begin();
+      sr->remove_result(result->index());
+      ln->remove_output(out->index());
+      any_changed = true;
+    }
+  }
+  return any_changed;
 }
 
 bool
-jlm::hls::remove_unused_loop_inputs(hls::loop_node *ln) {
-	bool any_changed = false;
-	auto sr = ln->subregion();
-	// go through in reverse because we remove some
-	for (int i = ln->ninputs() - 1; i >= 0; --i) {
-		auto in = ln->input(i);
-		assert(in->arguments.size() == 1);
-		auto arg = in->arguments.begin();
-		if (arg->nusers() == 0) {
-			sr->remove_argument(arg->index());
-			ln->remove_input(in->index());
-			any_changed = true;
-		}
-	}
-	// clean up unused arguments - only ones without an input should be left
-	// go through in reverse because we remove some
-	for (int i = sr->narguments() - 1; i >= 0; --i) {
-		auto arg = sr->argument(i);
-		if (auto ba = dynamic_cast<jlm::hls::backedge_argument*>(arg)){
-			auto result = ba->result();
-			assert(result->type() == arg->type());
-			if (arg->nusers() == 0 || (arg->nusers()==1 && result->origin() == arg)) {
-                sr->remove_result(result->index());
-                sr->remove_argument(arg->index());
-			}
-		} else{
-            assert(arg->nusers() != 0);
-        }
-	}
-	return any_changed;
+remove_unused_loop_inputs(hls::loop_node *ln) {
+  bool any_changed = false;
+  auto sr = ln->subregion();
+  // go through in reverse because we remove some
+  for (int i = ln->ninputs() - 1; i >= 0; --i) {
+    auto in = ln->input(i);
+    assert(in->arguments.size() == 1);
+    auto arg = in->arguments.begin();
+    if (arg->nusers() == 0) {
+      sr->remove_argument(arg->index());
+      ln->remove_input(in->index());
+      any_changed = true;
+    }
+  }
+  // clean up unused arguments - only ones without an input should be left
+  // go through in reverse because we remove some
+  for (int i = sr->narguments() - 1; i >= 0; --i) {
+    auto arg = sr->argument(i);
+    if (auto ba = dynamic_cast<backedge_argument *>(arg)) {
+      auto result = ba->result();
+      assert(result->type() == arg->type());
+      if (arg->nusers() == 0 || (arg->nusers() == 1 && result->origin() == arg)) {
+        sr->remove_result(result->index());
+        sr->remove_argument(arg->index());
+      }
+    } else {
+      assert(arg->nusers() != 0);
+    }
+  }
+  return any_changed;
 }
 
 bool
-jlm::hls::dne(jlm::rvsdg::region *sr) {
-	bool any_changed = false;
-	bool changed;
-	do {
-		changed = false;
-		for (auto &node : jlm::rvsdg::bottomup_traverser(sr)) {
-			if (!node->has_users()) {
-				remove(node);
-				changed = true;
-			} else if (auto ln = dynamic_cast<hls::loop_node *>(node)) {
-				changed |= remove_unused_loop_outputs(ln);
-				changed |= remove_unused_loop_inputs(ln);
-				changed |= dne(ln->subregion());
-			}
-		}
-		any_changed |= changed;
-	} while (changed);
-	assert(sr->bottom_nodes.empty());
-	return any_changed;
+dne(jlm::rvsdg::region *sr) {
+  bool any_changed = false;
+  bool changed;
+  do {
+    changed = false;
+    for (auto &node: jlm::rvsdg::bottomup_traverser(sr)) {
+      if (!node->has_users()) {
+        remove(node);
+        changed = true;
+      } else if (auto ln = dynamic_cast<hls::loop_node *>(node)) {
+        changed |= remove_unused_loop_outputs(ln);
+        changed |= remove_unused_loop_inputs(ln);
+        changed |= dne(ln->subregion());
+      }
+    }
+    any_changed |= changed;
+  } while (changed);
+  assert(sr->bottom_nodes.empty());
+  return any_changed;
 }
 
 void
-jlm::hls::dne(llvm::RvsdgModule &rm) {
-	auto &graph = rm.Rvsdg();
-	auto root = graph.root();
-	if (root->nodes.size() != 1) {
-		throw util::error("Root should have only one node now");
-	}
-	auto ln = dynamic_cast<const llvm::lambda::node *>(root->nodes.begin().ptr());
-	if (!ln) {
-		throw util::error("Node needs to be a lambda");
-	}
-	dne(ln->subregion());
+dne(llvm::RvsdgModule &rm) {
+  auto &graph = rm.Rvsdg();
+  auto root = graph.root();
+  if (root->nodes.size() != 1) {
+    throw util::error("Root should have only one node now");
+  }
+  auto ln = dynamic_cast<const llvm::lambda::node *>(root->nodes.begin().ptr());
+  if (!ln) {
+    throw util::error("Node needs to be a lambda");
+  }
+  dne(ln->subregion());
+}
+
 }

--- a/jlm/hls/backend/rvsdg2rhls/rhls-dne.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/rhls-dne.hpp
@@ -9,20 +9,22 @@
 #include <jlm/hls/ir/hls.hpp>
 #include <jlm/llvm/ir/RvsdgModule.hpp>
 
-namespace jlm {
-	namespace hls {
-		bool
-		remove_unused_loop_outputs(hls::loop_node *ln);
+namespace jlm::hls
+{
 
-		bool
-		remove_unused_loop_inputs(hls::loop_node *ln);
+bool
+remove_unused_loop_outputs(hls::loop_node *ln);
+
+bool
+remove_unused_loop_inputs(hls::loop_node *ln);
 
 
-		bool
-		dne(jlm::rvsdg::region *sr);
+bool
+dne(jlm::rvsdg::region *sr);
 
-		void
-		dne(llvm::RvsdgModule &rm);
-	}
+void
+dne(llvm::RvsdgModule &rm);
+
 }
+
 #endif //JLM_HLS_BACKEND_RVSDG2RHLS_RHLS_DNE_HPP

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -33,273 +33,275 @@
 
 #include <regex>
 
+namespace jlm::hls {
+
 void
 pre_opt(jlm::llvm::RvsdgModule &rm) {
-	// TODO: figure out which optimizations to use here
-	jlm::llvm::DeadNodeElimination dne;
-	jlm::llvm::cne cne;
-	jlm::llvm::InvariantValueRedirection ivr;
-	jlm::llvm::tginversion tgi;
-	jlm::util::StatisticsCollector statisticsCollector;
-	tgi.run(rm, statisticsCollector);
-	dne.run(rm, statisticsCollector);
-	cne.run(rm, statisticsCollector);
-	ivr.run(rm, statisticsCollector);
+  // TODO: figure out which optimizations to use here
+  jlm::llvm::DeadNodeElimination dne;
+  jlm::llvm::cne cne;
+  jlm::llvm::InvariantValueRedirection ivr;
+  jlm::llvm::tginversion tgi;
+  jlm::util::StatisticsCollector statisticsCollector;
+  tgi.run(rm, statisticsCollector);
+  dne.run(rm, statisticsCollector);
+  cne.run(rm, statisticsCollector);
+  ivr.run(rm, statisticsCollector);
 }
 
-namespace jlm {
+bool
+function_match(llvm::lambda::node *ln, const std::string &function_name) {
+  const std::regex fn_regex(function_name);
+  if (std::regex_match(ln->name(), fn_regex)) {// TODO: handle C++ name mangling
+    return true;
+  }
+  return false;
+}
 
-	bool
-	function_match(llvm::lambda::node *ln, const std::string &function_name) {
-		const std::regex fn_regex(function_name);
-		if (std::regex_match(ln->name(), fn_regex)) {// TODO: handle C++ name mangling
-			return true;
-		}
-		return false;
-	}
+const jlm::rvsdg::output *
+trace_call(jlm::rvsdg::input *input) {
+  auto graph = input->region()->graph();
 
-	const jlm::rvsdg::output *
-	trace_call(jlm::rvsdg::input *input) {
-		auto graph = input->region()->graph();
-
-		auto argument = dynamic_cast<const jlm::rvsdg::argument *>(input->origin());
-		const jlm::rvsdg::output * result;
-		if (auto to = dynamic_cast<const jlm::rvsdg::theta_output*>(input->origin())){
-			result = trace_call(to->input());
-		} else if (argument == nullptr) {
-			result = input->origin();
-		} else if (argument->region() == graph->root()){
-			result = argument;
-		} else{
-			JLM_ASSERT(argument->input() != nullptr);
-			result = trace_call(argument->input());
-		}
-		auto so = dynamic_cast<const jlm::rvsdg::structural_output *>(result);
-		if(!so){
-			auto arg = dynamic_cast<const jlm::rvsdg::argument *>(result);
-			auto ip = dynamic_cast<const llvm::impport*>(&arg->port());
-			if(ip){
-				throw jlm::util::error("can not inline external function " + ip->name());
-			}
-		}
-		JLM_ASSERT(so);
-		JLM_ASSERT(jlm::rvsdg::is<llvm::lambda::operation>(so->node()));
-		return result;
-	}
-
-	void
-	inline_calls(jlm::rvsdg::region *region) {
-		for (auto &node : jlm::rvsdg::topdown_traverser(region)) {
-			if (auto structnode = dynamic_cast<jlm::rvsdg::structural_node *>(node)) {
-				for (size_t n = 0; n < structnode->nsubregions(); n++) {
-					inline_calls(structnode->subregion(n));
-				}
-			} else if (dynamic_cast<const llvm::CallOperation *>(&(node->operation()))) {
-				auto func = trace_call(node->input(0));
-				auto ln = dynamic_cast<const jlm::rvsdg::structural_output *>(func)->node();
-				llvm::inlineCall(dynamic_cast<jlm::rvsdg::simple_node *>(node), dynamic_cast<const llvm::lambda::node *>(ln));
-				// restart for this region
-				inline_calls(region);
-				return;
-			}
-		}
-	}
-
-	size_t alloca_cnt = 0;
-
-	void
-	convert_alloca(jlm::rvsdg::region *region) {
-		for (auto &node : jlm::rvsdg::topdown_traverser(region)) {
-			if (auto structnode = dynamic_cast<jlm::rvsdg::structural_node *>(node)) {
-				for (size_t n = 0; n < structnode->nsubregions(); n++) {
-					convert_alloca(structnode->subregion(n));
-				}
-			} else if (auto po = dynamic_cast<const llvm::alloca_op *>(&(node->operation()))) {
-				auto rr = region->graph()->root();
-				auto delta_name = jlm::util::strfmt("hls_alloca_", alloca_cnt++);
-        llvm::PointerType delta_type;
-        std::cout << "alloca " << delta_name << ": " << po->value_type().debug_string() << "\n";
-				auto db = llvm::delta::node::Create(rr, po->value_type(), delta_name, llvm::linkage::external_linkage, "", false);
-				// create zero constant of allocated type
-				jlm::rvsdg::output *cout;
-				if (auto bt = dynamic_cast<const jlm::rvsdg::bittype *>(&po->value_type())) {
-					cout = jlm::rvsdg::create_bitconstant(db->subregion(), bt->nbits(), 0);
-				} else {
-					llvm::ConstantAggregateZero cop(po->value_type());
-					cout = jlm::rvsdg::simple_node::create_normalized(db->subregion(), cop, {})[0];
-				}
-				auto delta = db->finalize(cout);
-				region->graph()->add_export(delta, {delta_type, delta_name});
-				auto delta_local = jlm::hls::route_to_region(delta, region);
-				node->output(0)->divert_users(delta_local);
-				// TODO: check that the input to alloca is a bitconst 1
-				JLM_ASSERT(node->output(1)->nusers() == 1);
-				auto mux_in = *node->output(1)->begin();
-				auto mux_node = llvm::input_node(mux_in);
-				JLM_ASSERT(dynamic_cast<const llvm::MemStateMergeOperator *>(&mux_node->operation()));
-				JLM_ASSERT(mux_node->ninputs() == 2);
-				auto other_index = mux_in->index() ? 0 : 1;
-				mux_node->output(0)->divert_users(mux_node->input(other_index)->origin());
-				jlm::rvsdg::remove(mux_node);
-				jlm::rvsdg::remove(node);
-			}
-		}
-	}
-
-	llvm::delta::node *
-	rename_delta(llvm::delta::node *odn) {
-		auto name = odn->name();
-		std::replace_if(name.begin(), name.end(), [](char c) { return c == '.'; }, '_');
-		std::cout << "renaming delta node " << odn->name() << " to " << name << "\n";
-		auto db = llvm::delta::node::Create(odn->region(), odn->type(), name, llvm::linkage::external_linkage, "", odn->constant());
-		/* add dependencies */
-		jlm::rvsdg::substitution_map rmap;
-		for (size_t i=0; i<odn->ncvarguments(); i++) {
-			auto input = odn->input(i);
-			auto nd = db->add_ctxvar(input->origin());
-			rmap.insert(input->argument(), nd);
-		}
-
-		/* copy subregion */
-		odn->subregion()->copy(db->subregion(), rmap, false, false);
-
-		auto result = rmap.lookup(odn->subregion()->result(0)->origin());
-		auto data = db->finalize(result);
-
-		odn->output()->divert_users(data);
-		jlm::rvsdg::remove(odn);
-		return static_cast<llvm::delta::node *>(jlm::rvsdg::node_output::node(data));
-	}
-
-    llvm::lambda::node * change_linkage(llvm::lambda::node * ln, llvm::linkage link){
-        auto lambda = llvm::lambda::node::create(ln->region(), ln->type(), ln->name(), link, ln->attributes());
-
-        /* add context variables */
-        jlm::rvsdg::substitution_map subregionmap;
-        for (auto & cv : ln->ctxvars()) {
-            auto origin = cv.origin();
-            auto newcv = lambda->add_ctxvar(origin);
-            subregionmap.insert(cv.argument(), newcv);
-        }
-
-        /* collect function arguments */
-        for (size_t n = 0; n < ln->nfctarguments(); n++)
-            subregionmap.insert(ln->fctargument(n), lambda->fctargument(n));
-
-        /* copy subregion */
-        ln->subregion()->copy(lambda->subregion(), subregionmap, false, false);
-
-        /* collect function results */
-        std::vector<jlm::rvsdg::output*> results;
-        for (auto & result : ln->fctresults())
-            results.push_back(subregionmap.lookup(result.origin()));
-
-        /* finalize lambda */
-        lambda->finalize(results);
-
-        divert_users(ln,outputs(lambda));
-        jlm::rvsdg::remove(ln);
-
-        return lambda;
+  auto argument = dynamic_cast<const jlm::rvsdg::argument *>(input->origin());
+  const jlm::rvsdg::output *result;
+  if (auto to = dynamic_cast<const jlm::rvsdg::theta_output *>(input->origin())) {
+    result = trace_call(to->input());
+  } else if (argument == nullptr) {
+    result = input->origin();
+  } else if (argument->region() == graph->root()) {
+    result = argument;
+  } else {
+    JLM_ASSERT(argument->input() != nullptr);
+    result = trace_call(argument->input());
+  }
+  auto so = dynamic_cast<const jlm::rvsdg::structural_output *>(result);
+  if (!so) {
+    auto arg = dynamic_cast<const jlm::rvsdg::argument *>(result);
+    auto ip = dynamic_cast<const llvm::impport *>(&arg->port());
+    if (ip) {
+      throw jlm::util::error("can not inline external function " + ip->name());
     }
+  }
+  JLM_ASSERT(so);
+  JLM_ASSERT(jlm::rvsdg::is<llvm::lambda::operation>(so->node()));
+  return result;
+}
+
+void
+inline_calls(jlm::rvsdg::region *region) {
+  for (auto &node: jlm::rvsdg::topdown_traverser(region)) {
+    if (auto structnode = dynamic_cast<jlm::rvsdg::structural_node *>(node)) {
+      for (size_t n = 0; n < structnode->nsubregions(); n++) {
+        inline_calls(structnode->subregion(n));
+      }
+    } else if (dynamic_cast<const llvm::CallOperation *>(&(node->operation()))) {
+      auto func = trace_call(node->input(0));
+      auto ln = dynamic_cast<const jlm::rvsdg::structural_output *>(func)->node();
+      llvm::inlineCall(dynamic_cast<jlm::rvsdg::simple_node *>(node), dynamic_cast<const llvm::lambda::node *>(ln));
+      // restart for this region
+      inline_calls(region);
+      return;
+    }
+  }
+}
+
+size_t alloca_cnt = 0;
+
+void
+convert_alloca(jlm::rvsdg::region *region) {
+  for (auto &node: jlm::rvsdg::topdown_traverser(region)) {
+    if (auto structnode = dynamic_cast<jlm::rvsdg::structural_node *>(node)) {
+      for (size_t n = 0; n < structnode->nsubregions(); n++) {
+        convert_alloca(structnode->subregion(n));
+      }
+    } else if (auto po = dynamic_cast<const llvm::alloca_op *>(&(node->operation()))) {
+      auto rr = region->graph()->root();
+      auto delta_name = jlm::util::strfmt("hls_alloca_", alloca_cnt++);
+      llvm::PointerType delta_type;
+      std::cout << "alloca " << delta_name << ": " << po->value_type().debug_string() << "\n";
+      auto db = llvm::delta::node::Create(rr, po->value_type(), delta_name, llvm::linkage::external_linkage, "", false);
+      // create zero constant of allocated type
+      jlm::rvsdg::output *cout;
+      if (auto bt = dynamic_cast<const jlm::rvsdg::bittype *>(&po->value_type())) {
+        cout = jlm::rvsdg::create_bitconstant(db->subregion(), bt->nbits(), 0);
+      } else {
+        llvm::ConstantAggregateZero cop(po->value_type());
+        cout = jlm::rvsdg::simple_node::create_normalized(db->subregion(), cop, {})[0];
+      }
+      auto delta = db->finalize(cout);
+      region->graph()->add_export(delta, {delta_type, delta_name});
+      auto delta_local = route_to_region(delta, region);
+      node->output(0)->divert_users(delta_local);
+      // TODO: check that the input to alloca is a bitconst 1
+      JLM_ASSERT(node->output(1)->nusers() == 1);
+      auto mux_in = *node->output(1)->begin();
+      auto mux_node = llvm::input_node(mux_in);
+      JLM_ASSERT(dynamic_cast<const llvm::MemStateMergeOperator *>(&mux_node->operation()));
+      JLM_ASSERT(mux_node->ninputs() == 2);
+      auto other_index = mux_in->index() ? 0 : 1;
+      mux_node->output(0)->divert_users(mux_node->input(other_index)->origin());
+      jlm::rvsdg::remove(mux_node);
+      jlm::rvsdg::remove(node);
+    }
+  }
+}
+
+llvm::delta::node *
+rename_delta(llvm::delta::node *odn) {
+  auto name = odn->name();
+  std::replace_if(name.begin(), name.end(), [](char c) { return c == '.'; }, '_');
+  std::cout << "renaming delta node " << odn->name() << " to " << name << "\n";
+  auto db = llvm::delta::node::Create(odn->region(), odn->type(), name, llvm::linkage::external_linkage, "",
+                                      odn->constant());
+  /* add dependencies */
+  jlm::rvsdg::substitution_map rmap;
+  for (size_t i = 0; i < odn->ncvarguments(); i++) {
+    auto input = odn->input(i);
+    auto nd = db->add_ctxvar(input->origin());
+    rmap.insert(input->argument(), nd);
+  }
+
+  /* copy subregion */
+  odn->subregion()->copy(db->subregion(), rmap, false, false);
+
+  auto result = rmap.lookup(odn->subregion()->result(0)->origin());
+  auto data = db->finalize(result);
+
+  odn->output()->divert_users(data);
+  jlm::rvsdg::remove(odn);
+  return static_cast<llvm::delta::node *>(jlm::rvsdg::node_output::node(data));
+}
+
+llvm::lambda::node *change_linkage(llvm::lambda::node *ln, llvm::linkage link) {
+  auto lambda = llvm::lambda::node::create(ln->region(), ln->type(), ln->name(), link, ln->attributes());
+
+  /* add context variables */
+  jlm::rvsdg::substitution_map subregionmap;
+  for (auto &cv: ln->ctxvars()) {
+    auto origin = cv.origin();
+    auto newcv = lambda->add_ctxvar(origin);
+    subregionmap.insert(cv.argument(), newcv);
+  }
+
+  /* collect function arguments */
+  for (size_t n = 0; n < ln->nfctarguments(); n++)
+    subregionmap.insert(ln->fctargument(n), lambda->fctargument(n));
+
+  /* copy subregion */
+  ln->subregion()->copy(lambda->subregion(), subregionmap, false, false);
+
+  /* collect function results */
+  std::vector<jlm::rvsdg::output *> results;
+  for (auto &result: ln->fctresults())
+    results.push_back(subregionmap.lookup(result.origin()));
+
+  /* finalize lambda */
+  lambda->finalize(results);
+
+  divert_users(ln, outputs(lambda));
+  jlm::rvsdg::remove(ln);
+
+  return lambda;
 }
 
 std::unique_ptr<jlm::llvm::RvsdgModule>
-jlm::hls::split_hls_function(llvm::RvsdgModule &rm, const std::string &function_name) {
-    // TODO: use a different datastructure for rhls?
-    // create a copy of rm
-    auto rhls = llvm::RvsdgModule::Create(rm.SourceFileName(), rm.TargetTriple(), rm.DataLayout());
-    std::cout << "processing " << rm.SourceFileName().name() << "\n";
-    auto root = rm.Rvsdg().root();
-    for (auto node : jlm::rvsdg::topdown_traverser(root)) {
-        if (auto ln = dynamic_cast<llvm::lambda::node *>(node)) {
-            if (!function_match(ln, function_name)) {
-                continue;
-            }
-            inline_calls(ln->subregion());
-            // TODO: have a seperate set of optimizations here
-            pre_opt(rm);
-            convert_alloca(ln->subregion());
-            jlm::rvsdg::substitution_map smap;
-            for (size_t i = 0; i < ln->ninputs(); ++i) {
-                auto orig_node = dynamic_cast<jlm::rvsdg::node_output *>(ln->input(i)->origin())->node();
-                if (auto oln = dynamic_cast<llvm::lambda::node *>(orig_node)) {
-                    throw jlm::util::error("Inlining of function " + oln->name() + " not supported");
-                } else if (auto odn = dynamic_cast<llvm::delta::node *>(orig_node)) {
-                    // modify name to not contain .
-                    if (odn->name().find('.') != std::string::npos) {
-                        odn = rename_delta(odn);
-                    }
-                    std::cout << "delta node " << odn->name() << ": " << odn->type().debug_string() << "\n";
-                    // add import for delta to rhls
-                    llvm::impport im(odn->type(), odn->name(), llvm::linkage::external_linkage);
+split_hls_function(llvm::RvsdgModule &rm, const std::string &function_name) {
+  // TODO: use a different datastructure for rhls?
+  // create a copy of rm
+  auto rhls = llvm::RvsdgModule::Create(rm.SourceFileName(), rm.TargetTriple(), rm.DataLayout());
+  std::cout << "processing " << rm.SourceFileName().name() << "\n";
+  auto root = rm.Rvsdg().root();
+  for (auto node: jlm::rvsdg::topdown_traverser(root)) {
+    if (auto ln = dynamic_cast<llvm::lambda::node *>(node)) {
+      if (!function_match(ln, function_name)) {
+        continue;
+      }
+      inline_calls(ln->subregion());
+      // TODO: have a seperate set of optimizations here
+      pre_opt(rm);
+      convert_alloca(ln->subregion());
+      jlm::rvsdg::substitution_map smap;
+      for (size_t i = 0; i < ln->ninputs(); ++i) {
+        auto orig_node = dynamic_cast<jlm::rvsdg::node_output *>(ln->input(i)->origin())->node();
+        if (auto oln = dynamic_cast<llvm::lambda::node *>(orig_node)) {
+          throw jlm::util::error("Inlining of function " + oln->name() + " not supported");
+        } else if (auto odn = dynamic_cast<llvm::delta::node *>(orig_node)) {
+          // modify name to not contain .
+          if (odn->name().find('.') != std::string::npos) {
+            odn = rename_delta(odn);
+          }
+          std::cout << "delta node " << odn->name() << ": " << odn->type().debug_string() << "\n";
+          // add import for delta to rhls
+          llvm::impport im(odn->type(), odn->name(), llvm::linkage::external_linkage);
 //						JLM_ASSERT(im.name()==odn->name());
-                    auto arg = rhls->Rvsdg().add_import(im);
-                    auto tmp = dynamic_cast<const llvm::impport*>(&arg->port());
-                    assert(tmp && tmp->name() == odn->name());
-                    smap.insert(ln->input(i)->origin(), arg);
-                    // add export for delta to rm
-                    // TODO: check if not already exported and maybe adjust linkage?
-                    rm.Rvsdg().add_export(odn->output(), {odn->output()->type(), odn->name()});
-                } else {
-                    throw jlm::util::error("Unsupported node type: " + orig_node->operation().debug_string());
-                }
-            }
-            // copy function into rhls
-            auto new_ln = ln->copy(rhls->Rvsdg().root(), smap);
-            new_ln = change_linkage(new_ln, llvm::linkage::external_linkage);
-            jlm::rvsdg::result::create(rhls->Rvsdg().root(), new_ln->output(), nullptr, new_ln->output()->type());
-            // add function as input to rm and remove it
-            llvm::impport im(ln->type(), ln->name(), llvm::linkage::external_linkage); //TODO: change linkage?
-            auto arg = rm.Rvsdg().add_import(im);
-            ln->output()->divert_users(arg);
-            remove(ln);
-            std::cout << "function " << new_ln->name() << " extracted for HLS\n";
-            return rhls;
+          auto arg = rhls->Rvsdg().add_import(im);
+          auto tmp = dynamic_cast<const llvm::impport *>(&arg->port());
+          assert(tmp && tmp->name() == odn->name());
+          smap.insert(ln->input(i)->origin(), arg);
+          // add export for delta to rm
+          // TODO: check if not already exported and maybe adjust linkage?
+          rm.Rvsdg().add_export(odn->output(), {odn->output()->type(), odn->name()});
+        } else {
+          throw jlm::util::error("Unsupported node type: " + orig_node->operation().debug_string());
         }
+      }
+      // copy function into rhls
+      auto new_ln = ln->copy(rhls->Rvsdg().root(), smap);
+      new_ln = change_linkage(new_ln, llvm::linkage::external_linkage);
+      jlm::rvsdg::result::create(rhls->Rvsdg().root(), new_ln->output(), nullptr, new_ln->output()->type());
+      // add function as input to rm and remove it
+      llvm::impport im(ln->type(), ln->name(), llvm::linkage::external_linkage); //TODO: change linkage?
+      auto arg = rm.Rvsdg().add_import(im);
+      ln->output()->divert_users(arg);
+      remove(ln);
+      std::cout << "function " << new_ln->name() << " extracted for HLS\n";
+      return rhls;
     }
-    throw jlm::util::error("HLS function " + function_name + " not found");
+  }
+  throw jlm::util::error("HLS function " + function_name + " not found");
 }
 
 void
-jlm::hls::rvsdg2rhls(llvm::RvsdgModule &rhls) {
-	pre_opt(rhls);
+rvsdg2rhls(llvm::RvsdgModule &rhls) {
+  pre_opt(rhls);
 
-//	jlm::hls::add_prints(rhls);
+//	add_prints(rhls);
 //	dump_ref(rhls);
 
-	// run conversion on copy
-	jlm::hls::remove_unused_state(rhls);
-	// main conversion steps
-	jlm::hls::add_triggers(rhls); // TODO: make compatible with loop nodes?
-	jlm::hls::gamma_conv(rhls, true);
-	jlm::hls::theta_conv(rhls);
-	// rhls optimization
-	jlm::hls::dne(rhls);
-	// enforce 1:1 input output relationship
-	jlm::hls::add_sinks(rhls);
-	jlm::hls::add_forks(rhls);
-//	jlm::hls::add_buffers(*rhls, true);
-	// ensure that all rhls rules are met
-	jlm::hls::check_rhls(rhls);
+  // run conversion on copy
+  remove_unused_state(rhls);
+  // main conversion steps
+  add_triggers(rhls); // TODO: make compatible with loop nodes?
+  gamma_conv(rhls, true);
+  theta_conv(rhls);
+  // rhls optimization
+  dne(rhls);
+  // enforce 1:1 input output relationship
+  add_sinks(rhls);
+  add_forks(rhls);
+//	add_buffers(*rhls, true);
+  // ensure that all rhls rules are met
+  check_rhls(rhls);
 }
 
 void
-jlm::hls::dump_ref(llvm::RvsdgModule &rhls) {
-	auto reference = llvm::RvsdgModule::Create(rhls.SourceFileName(), rhls.TargetTriple(), rhls.DataLayout());
-	jlm::rvsdg::substitution_map smap;
-	rhls.Rvsdg().root()->copy(reference->Rvsdg().root(), smap, true, true);
-	convert_prints(*reference);
-	for (size_t i = 0; i < reference->Rvsdg().root()->narguments(); ++i) {
-		auto arg = reference->Rvsdg().root()->argument(i);
-		auto imp = dynamic_cast<const llvm::impport*>(&arg->port());
-		std::cout << "impport " << imp->name() << ": " << imp->type().debug_string() << "\n";
-	}
-	::llvm::LLVMContext ctx;
-	jlm::util::StatisticsCollector statisticsCollector;
-	auto jm2 = llvm::rvsdg2jlm::rvsdg2jlm(*reference, statisticsCollector);
-	auto lm2 = llvm::jlm2llvm::convert(*jm2, ctx);
-	std::error_code EC;
-	::llvm::raw_fd_ostream os(reference->SourceFileName().base() + ".ref.ll", EC);
-	lm2->print(os, nullptr);
+dump_ref(llvm::RvsdgModule &rhls) {
+  auto reference = llvm::RvsdgModule::Create(rhls.SourceFileName(), rhls.TargetTriple(), rhls.DataLayout());
+  jlm::rvsdg::substitution_map smap;
+  rhls.Rvsdg().root()->copy(reference->Rvsdg().root(), smap, true, true);
+  convert_prints(*reference);
+  for (size_t i = 0; i < reference->Rvsdg().root()->narguments(); ++i) {
+    auto arg = reference->Rvsdg().root()->argument(i);
+    auto imp = dynamic_cast<const llvm::impport *>(&arg->port());
+    std::cout << "impport " << imp->name() << ": " << imp->type().debug_string() << "\n";
+  }
+  ::llvm::LLVMContext ctx;
+  jlm::util::StatisticsCollector statisticsCollector;
+  auto jm2 = llvm::rvsdg2jlm::rvsdg2jlm(*reference, statisticsCollector);
+  auto lm2 = llvm::jlm2llvm::convert(*jm2, ctx);
+  std::error_code EC;
+  ::llvm::raw_fd_ostream os(reference->SourceFileName().base() + ".ref.ll", EC);
+  lm2->print(os, nullptr);
+}
+
 }

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.hpp
@@ -11,22 +11,24 @@
 #include <jlm/rvsdg/bitstring/constant.hpp>
 #include <jlm/rvsdg/node.hpp>
 
-namespace jlm{
-	namespace hls{
-		static inline bool is_constant(const jlm::rvsdg::node *node) {
-			return jlm::rvsdg::is<jlm::rvsdg::bitconstant_op>(node) ||
-				   jlm::rvsdg::is<llvm::UndefValueOperation>(node) ||
-				   jlm::rvsdg::is<jlm::rvsdg::ctlconstant_op>(node);
-		}
+namespace jlm::hls
+{
 
-		void
-		rvsdg2rhls(llvm::RvsdgModule &rm);
-
-		void
-		dump_ref(llvm::RvsdgModule &rhls);
-
-        std::unique_ptr<llvm::RvsdgModule>
-        split_hls_function(llvm::RvsdgModule &rm, const std::string &function_name);
-    }
+static inline bool is_constant(const jlm::rvsdg::node *node) {
+  return jlm::rvsdg::is<jlm::rvsdg::bitconstant_op>(node) ||
+         jlm::rvsdg::is<llvm::UndefValueOperation>(node) ||
+         jlm::rvsdg::is<jlm::rvsdg::ctlconstant_op>(node);
 }
+
+void
+rvsdg2rhls(llvm::RvsdgModule &rm);
+
+void
+dump_ref(llvm::RvsdgModule &rhls);
+
+std::unique_ptr<llvm::RvsdgModule>
+split_hls_function(llvm::RvsdgModule &rm, const std::string &function_name);
+
+}
+
 #endif //JLM_HLS_BACKEND_RVSDG2RHLS_RVSDG2RHLS_HPP

--- a/jlm/hls/backend/rvsdg2rhls/theta-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/theta-conv.cpp
@@ -7,56 +7,60 @@
 #include <jlm/hls/ir/hls.hpp>
 #include <jlm/rvsdg/traverser.hpp>
 
+namespace jlm::hls {
+
 void
-jlm::hls::theta_conv(jlm::rvsdg::theta_node *theta) {
-	jlm::rvsdg::substitution_map smap;
+theta_conv(jlm::rvsdg::theta_node *theta) {
+  jlm::rvsdg::substitution_map smap;
 
-	auto loop = hls::loop_node::create(theta->region());
-	std::vector<jlm::rvsdg::input *> branches;
+  auto loop = hls::loop_node::create(theta->region());
+  std::vector<jlm::rvsdg::input *> branches;
 
-	// add loopvars and populate the smap
-	for (size_t i = 0; i < theta->ninputs(); i++) {
-		jlm::rvsdg::output *buffer;
-		loop->add_loopvar(theta->input(i)->origin(), &buffer);
-		smap.insert(theta->input(i)->argument(), buffer);
-		// buffer out is only used by branch
-		branches.push_back(*buffer->begin());
-		// divert theta outputs
-		theta->output(i)->divert_users(loop->output(i));
-	}
+  // add loopvars and populate the smap
+  for (size_t i = 0; i < theta->ninputs(); i++) {
+    jlm::rvsdg::output *buffer;
+    loop->add_loopvar(theta->input(i)->origin(), &buffer);
+    smap.insert(theta->input(i)->argument(), buffer);
+    // buffer out is only used by branch
+    branches.push_back(*buffer->begin());
+    // divert theta outputs
+    theta->output(i)->divert_users(loop->output(i));
+  }
 
 
-	// copy contents of theta
-	theta->subregion()->copy(loop->subregion(), smap, false, false);
+  // copy contents of theta
+  theta->subregion()->copy(loop->subregion(), smap, false, false);
 
-	// connect predicate/branches in loop to results
-	loop->set_predicate(smap.lookup(theta->predicate()->origin()));
-	for (size_t i = 0; i < theta->ninputs(); i++) {
-		branches[i]->divert_to(smap.lookup(theta->input(i)->result()->origin()));
-	}
+  // connect predicate/branches in loop to results
+  loop->set_predicate(smap.lookup(theta->predicate()->origin()));
+  for (size_t i = 0; i < theta->ninputs(); i++) {
+    branches[i]->divert_to(smap.lookup(theta->input(i)->result()->origin()));
+  }
 
-	remove(theta);
+  remove(theta);
 }
 
 void
-jlm::hls::theta_conv(jlm::rvsdg::region *region) {
-	for (auto &node : jlm::rvsdg::topdown_traverser(region)) {
-		if (auto structnode = dynamic_cast<jlm::rvsdg::structural_node *>(node)) {
-			if (auto theta = dynamic_cast<jlm::rvsdg::theta_node *>(node)) {
-				theta_conv(theta->subregion());
-				theta_conv(theta);
+theta_conv(jlm::rvsdg::region *region) {
+  for (auto &node: jlm::rvsdg::topdown_traverser(region)) {
+    if (auto structnode = dynamic_cast<jlm::rvsdg::structural_node *>(node)) {
+      if (auto theta = dynamic_cast<jlm::rvsdg::theta_node *>(node)) {
+        theta_conv(theta->subregion());
+        theta_conv(theta);
 //                        theta_conv(region);
-			} else {
-				for (size_t n = 0; n < structnode->nsubregions(); n++)
-					theta_conv(structnode->subregion(n));
-			}
-		}
-	}
+      } else {
+        for (size_t n = 0; n < structnode->nsubregions(); n++)
+          theta_conv(structnode->subregion(n));
+      }
+    }
+  }
 }
 
 void
-jlm::hls::theta_conv(jlm::llvm::RvsdgModule &rm) {
-	auto &graph = rm.Rvsdg();
-	auto root = graph.root();
-	theta_conv(root);
+theta_conv(jlm::llvm::RvsdgModule &rm) {
+  auto &graph = rm.Rvsdg();
+  auto root = graph.root();
+  theta_conv(root);
+}
+
 }

--- a/jlm/hls/backend/rvsdg2rhls/theta-conv.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/theta-conv.hpp
@@ -9,15 +9,18 @@
 #include <jlm/llvm/ir/RvsdgModule.hpp>
 #include <jlm/rvsdg/theta.hpp>
 
-namespace jlm{
-	namespace hls{
-		void theta_conv(jlm::rvsdg::theta_node *theta);
+namespace jlm::hls
+{
 
-		void
-		theta_conv(jlm::rvsdg::region *region);
+void
+theta_conv(jlm::rvsdg::theta_node *theta);
 
-		void
-		theta_conv(jlm::llvm::RvsdgModule &rm);
-	}
+void
+theta_conv(jlm::rvsdg::region *region);
+
+void
+theta_conv(jlm::llvm::RvsdgModule &rm);
+
 }
+
 #endif //JLM_HLS_BACKEND_RVSDG2RHLS_THETA_CONV_HPP

--- a/jlm/hls/ir/hls.cpp
+++ b/jlm/hls/ir/hls.cpp
@@ -5,95 +5,100 @@
 
 #include <jlm/hls/ir/hls.hpp>
 
-jlm::rvsdg::structural_output *jlm::hls::loop_node::add_loopvar(jlm::rvsdg::output *origin, jlm::rvsdg::output **buffer) {
-    auto input = jlm::rvsdg::structural_input::create(this, origin, origin->type());
-    auto output = jlm::rvsdg::structural_output::create(this, origin->type());
+namespace jlm::hls {
 
-    auto argument_in = jlm::rvsdg::argument::create(subregion(), input, origin->type());
-    auto argument_loop = add_backedge(origin->type());
+jlm::rvsdg::structural_output *
+loop_node::add_loopvar(jlm::rvsdg::output *origin, jlm::rvsdg::output **buffer) {
+  auto input = jlm::rvsdg::structural_input::create(this, origin, origin->type());
+  auto output = jlm::rvsdg::structural_output::create(this, origin->type());
 
-    auto mux = hls::mux_op::create(*predicate_buffer(), {argument_in, argument_loop}, false, true)[0];
-    auto buf = hls::buffer_op::create(*mux, 2)[0];
-    auto branch = hls::branch_op::create(*predicate()->origin(), *buf, true);
-    if (buffer != nullptr) {
-        *buffer = buf;
-    }
-    jlm::rvsdg::result::create(subregion(), branch[0], output, origin->type());
-    auto result_loop = argument_loop->result();
-    result_loop->divert_to(branch[1]);
-    return output;
+  auto argument_in = jlm::rvsdg::argument::create(subregion(), input, origin->type());
+  auto argument_loop = add_backedge(origin->type());
+
+  auto mux = hls::mux_op::create(*predicate_buffer(), {argument_in, argument_loop}, false, true)[0];
+  auto buf = hls::buffer_op::create(*mux, 2)[0];
+  auto branch = hls::branch_op::create(*predicate()->origin(), *buf, true);
+  if (buffer != nullptr) {
+    *buffer = buf;
+  }
+  jlm::rvsdg::result::create(subregion(), branch[0], output, origin->type());
+  auto result_loop = argument_loop->result();
+  result_loop->divert_to(branch[1]);
+  return output;
 }
 
-jlm::hls::loop_node *jlm::hls::loop_node::copy(jlm::rvsdg::region *region, jlm::rvsdg::substitution_map &smap) const {
-    auto nf = graph()->node_normal_form(typeid(jlm::rvsdg::operation));
-    nf->set_mutable(false);
+loop_node *loop_node::copy(jlm::rvsdg::region *region, jlm::rvsdg::substitution_map &smap) const {
+  auto nf = graph()->node_normal_form(typeid(jlm::rvsdg::operation));
+  nf->set_mutable(false);
 
-    jlm::rvsdg::substitution_map rmap;
-    auto loop = create(region, false);
+  jlm::rvsdg::substitution_map rmap;
+  auto loop = create(region, false);
 
-    for (size_t i = 0; i < ninputs(); ++i) {
-        auto in_origin = smap.lookup(input(i)->origin());
-        auto inp = jlm::rvsdg::structural_input::create(loop, in_origin, in_origin->type());
-        rmap.insert(input(i), loop->input(i));
-        auto oarg = input(i)->arguments.begin().ptr();
-        auto narg = jlm::rvsdg::argument::create(loop->subregion(), inp, oarg->port());
-        rmap.insert(oarg, narg);
+  for (size_t i = 0; i < ninputs(); ++i) {
+    auto in_origin = smap.lookup(input(i)->origin());
+    auto inp = jlm::rvsdg::structural_input::create(loop, in_origin, in_origin->type());
+    rmap.insert(input(i), loop->input(i));
+    auto oarg = input(i)->arguments.begin().ptr();
+    auto narg = jlm::rvsdg::argument::create(loop->subregion(), inp, oarg->port());
+    rmap.insert(oarg, narg);
+  }
+  for (size_t i = 0; i < noutputs(); ++i) {
+    auto out = jlm::rvsdg::structural_output::create(loop, output(i)->type());
+    rmap.insert(output(i), out);
+    smap.insert(output(i), out);
+  }
+  for (size_t i = 0; i < subregion()->narguments(); ++i) {
+    auto arg = subregion()->argument(i);
+    if (auto ba = dynamic_cast<backedge_argument *>(arg)) {
+      auto na = loop->add_backedge(arg->type());
+      rmap.insert(ba, na);
     }
-    for (size_t i = 0; i < noutputs(); ++i) {
-        auto out = jlm::rvsdg::structural_output::create(loop, output(i)->type());
-        rmap.insert(output(i), out);
-        smap.insert(output(i), out);
-    }
-    for (size_t i = 0; i < subregion()->narguments(); ++i) {
-        auto arg = subregion()->argument(i);
-        if (auto ba = dynamic_cast<jlm::hls::backedge_argument*>(arg)) {
-            auto na = loop->add_backedge(arg->type());
-            rmap.insert(ba, na);
-        }
-    }
+  }
 
-    subregion()->copy(loop->subregion(), rmap, false, false);
-    loop->_predicate_buffer = rmap.lookup(_predicate_buffer);
-    // redirect backedges
-    for (size_t i = 0; i < subregion()->narguments(); ++i) {
-        auto arg = subregion()->argument(i);
-        if (auto ba = dynamic_cast<jlm::hls::backedge_argument*>(arg)) {
-            auto na = dynamic_cast<jlm::hls::backedge_argument*>(rmap.lookup(ba));
-            na->result()->divert_to(rmap.lookup(ba->result()->origin()));
-        }
+  subregion()->copy(loop->subregion(), rmap, false, false);
+  loop->_predicate_buffer = rmap.lookup(_predicate_buffer);
+  // redirect backedges
+  for (size_t i = 0; i < subregion()->narguments(); ++i) {
+    auto arg = subregion()->argument(i);
+    if (auto ba = dynamic_cast<backedge_argument *>(arg)) {
+      auto na = dynamic_cast<backedge_argument *>(rmap.lookup(ba));
+      na->result()->divert_to(rmap.lookup(ba->result()->origin()));
     }
-    for (size_t i = 0; i < noutputs(); ++i) {
-        auto outp = output(i);
-        auto res = outp->results.begin().ptr();
-        auto origin = rmap.lookup(res->origin());
-        jlm::rvsdg::result::create(loop->subregion(), origin, loop->output(i), res->port());
-    }
-    nf->set_mutable(true);
-    return loop;
+  }
+  for (size_t i = 0; i < noutputs(); ++i) {
+    auto outp = output(i);
+    auto res = outp->results.begin().ptr();
+    auto origin = rmap.lookup(res->origin());
+    jlm::rvsdg::result::create(loop->subregion(), origin, loop->output(i), res->port());
+  }
+  nf->set_mutable(true);
+  return loop;
 }
 
-jlm::hls::backedge_argument *jlm::hls::loop_node::add_backedge(const jlm::rvsdg::type &type) {
-    auto argument_loop = backedge_argument::create(subregion(), type);
-    auto result_loop = backedge_result::create(argument_loop);
-    argument_loop->result_ = result_loop;
-    result_loop->argument_ = argument_loop;
-    return argument_loop;
+backedge_argument *loop_node::add_backedge(const jlm::rvsdg::type &type) {
+  auto argument_loop = backedge_argument::create(subregion(), type);
+  auto result_loop = backedge_result::create(argument_loop);
+  argument_loop->result_ = result_loop;
+  result_loop->argument_ = argument_loop;
+  return argument_loop;
 }
 
-jlm::hls::loop_node *jlm::hls::loop_node::create(jlm::rvsdg::region *parent, bool init) {
-    auto ln = new loop_node(parent);
-    if (init) {
-        auto predicate = jlm::rvsdg::control_false(ln->subregion());
-        auto pred_arg = ln->add_backedge(jlm::rvsdg::ctltype(2));
-        pred_arg->result()->divert_to(predicate);
-        ln->_predicate_buffer = hls::predicate_buffer_op::create(*pred_arg)[0];
-    }
-    return ln;
+loop_node *loop_node::create(jlm::rvsdg::region *parent, bool init) {
+  auto ln = new loop_node(parent);
+  if (init) {
+    auto predicate = jlm::rvsdg::control_false(ln->subregion());
+    auto pred_arg = ln->add_backedge(jlm::rvsdg::ctltype(2));
+    pred_arg->result()->divert_to(predicate);
+    ln->_predicate_buffer = hls::predicate_buffer_op::create(*pred_arg)[0];
+  }
+  return ln;
 }
 
-void jlm::hls::loop_node::set_predicate(jlm::rvsdg::output *p) {
-    auto node = jlm::rvsdg::node_output::node(predicate()->origin());
-    predicate()->origin()->divert_users(p);
-    if (node && !node->has_users())
-        remove(node);
+void loop_node::set_predicate(jlm::rvsdg::output *p) {
+  auto node = jlm::rvsdg::node_output::node(predicate()->origin());
+  predicate()->origin()->divert_users(p);
+  if (node && !node->has_users())
+    remove(node);
+}
+
 }

--- a/jlm/hls/ir/hls.hpp
+++ b/jlm/hls/ir/hls.hpp
@@ -12,550 +12,552 @@
 #include <jlm/rvsdg/substitution.hpp>
 #include <jlm/util/common.hpp>
 
-namespace jlm {
-	namespace hls {
-		class branch_op final : public jlm::rvsdg::simple_op {
-		private:
-			branch_op(size_t nalternatives, const jlm::rvsdg::type &type, bool loop)
-					: jlm::rvsdg::simple_op({jlm::rvsdg::ctltype(nalternatives), type}, std::vector<jlm::rvsdg::port>(nalternatives, type)), loop(loop){}
-
-		public:
-			virtual
-			~branch_op() {}
-
-			bool
-			operator==(const jlm::rvsdg::operation &other) const noexcept override {
-				auto ot = dynamic_cast<const branch_op *>(&other);
-				// check predicate and value
-				return ot
-					   && ot->argument(0).type() == argument(0).type()
-					   && ot->result(0).type() == result(0).type();
-			}
-
-			std::string
-			debug_string() const override {
-				return "HLS_BRANCH";
-			}
-
-			std::unique_ptr<jlm::rvsdg::operation>
-			copy() const override {
-				return std::unique_ptr<jlm::rvsdg::operation>(new branch_op(*this));
-			}
-
-			static std::vector<jlm::rvsdg::output *>
-			create(
-					jlm::rvsdg::output &predicate,
-					jlm::rvsdg::output &value,
-					bool loop=false
-			) {
-				auto ctl = dynamic_cast<const jlm::rvsdg::ctltype *>(&predicate.type());
-				if (!ctl)
-					throw util::error("Predicate needs to be a ctltype.");
-
-				auto region = predicate.region();
-				branch_op op(ctl->nalternatives(), value.type(), loop);
-				return jlm::rvsdg::simple_node::create_normalized(region, op, {&predicate, &value});
-			}
-
-			bool loop;//only used for dot output
-		};
-
-		class fork_op final : public jlm::rvsdg::simple_op {
-		public:
-			virtual
-			~fork_op() {}
-
-			fork_op(size_t nalternatives, const jlm::rvsdg::type &type)
-					: jlm::rvsdg::simple_op({type}, std::vector<jlm::rvsdg::port>(nalternatives, type)) {}
-
-			bool
-			operator==(const jlm::rvsdg::operation &other) const noexcept override {
-				auto ot = dynamic_cast<const fork_op *>(&other);
-				// check predicate and value
-				return ot
-					   && ot->argument(0).type() == argument(0).type()
-					   && ot->nresults() == nresults();
-			}
-
-			std::string
-			debug_string() const override {
-				return "HLS_FORK";
-			}
-
-			std::unique_ptr<jlm::rvsdg::operation>
-			copy() const override {
-				return std::unique_ptr<jlm::rvsdg::operation>(new fork_op(*this));
-			}
-
-			static std::vector<jlm::rvsdg::output *>
-			create(
-					size_t nalternatives,
-					jlm::rvsdg::output &value
-			) {
-
-				auto region = value.region();
-				fork_op op(nalternatives, value.type());
-				return jlm::rvsdg::simple_node::create_normalized(region, op, {&value});
-			}
-		};
-
-		class merge_op final : public jlm::rvsdg::simple_op {
-		public:
-			virtual
-			~merge_op() {}
-
-			merge_op(size_t nalternatives, const jlm::rvsdg::type &type)
-					: jlm::rvsdg::simple_op(std::vector<jlm::rvsdg::port>(nalternatives, type), {type}) {}
-
-			bool
-			operator==(const jlm::rvsdg::operation &other) const noexcept override {
-				auto ot = dynamic_cast<const merge_op *>(&other);
-				return ot
-					   && ot->narguments() == narguments()
-					   && ot->argument(0).type() == argument(0).type();
-			}
-
-			std::string
-			debug_string() const override {
-				return "HLS_MERGE";
-			}
-
-			std::unique_ptr<jlm::rvsdg::operation>
-			copy() const override {
-				return std::unique_ptr<jlm::rvsdg::operation>(new merge_op(*this));
-			}
-
-			static std::vector<jlm::rvsdg::output *>
-			create(
-					const std::vector<jlm::rvsdg::output *> &alternatives
-			) {
-				if (alternatives.empty())
-					throw util::error("Insufficient number of operands.");
-
-
-				auto region = alternatives.front()->region();
-				merge_op op(alternatives.size(), alternatives.front()->type());
-				return jlm::rvsdg::simple_node::create_normalized(region, op, alternatives);
-			}
-		};
-
-		class mux_op final : public jlm::rvsdg::simple_op {
-		public:
-			virtual
-			~mux_op() {}
-
-			mux_op(size_t nalternatives, const jlm::rvsdg::type &type, bool discarding, bool loop)
-					: jlm::rvsdg::simple_op(create_portvector(nalternatives, type), {type}), discarding(discarding), loop(loop) {}
-
-			bool
-			operator==(const jlm::rvsdg::operation &other) const noexcept override {
-				auto ot = dynamic_cast<const mux_op *>(&other);
-				// check predicate and value
-				return ot
-					   && ot->argument(0).type() == argument(0).type()
-					   && ot->result(0).type() == result(0).type()
-					   && ot->discarding == discarding;
-			}
-
-			std::string
-			debug_string() const override {
-				return discarding ? "HLS_DMUX" : "HLS_NDMUX";
-			}
-
-			std::unique_ptr<jlm::rvsdg::operation>
-			copy() const override {
-				return std::unique_ptr<jlm::rvsdg::operation>(new mux_op(*this));
-			}
-
-			static std::vector<jlm::rvsdg::output *>
-			create(
-					jlm::rvsdg::output &predicate,
-					const std::vector<jlm::rvsdg::output *> &alternatives,
-					bool discarding,
-					bool loop=false
-			) {
-				if (alternatives.empty())
-					throw util::error("Insufficient number of operands.");
-				auto ctl = dynamic_cast<const jlm::rvsdg::ctltype *>(&predicate.type());
-				if (!ctl)
-					throw util::error("Predicate needs to be a ctltype.");
-				if (alternatives.size() != ctl->nalternatives())
-					throw util::error("Alternatives and predicate do not match.");
-
-
-				auto region = predicate.region();
-				auto operands = std::vector<jlm::rvsdg::output *>();
-				operands.push_back(&predicate);
-				operands.insert(operands.end(), alternatives.begin(), alternatives.end());
-				mux_op op(alternatives.size(), alternatives.front()->type(), discarding, loop);
-				return jlm::rvsdg::simple_node::create_normalized(region, op, operands);
-			}
-
-
-			bool discarding;
-			bool loop; // used only for dot output
-		private:
-
-			static std::vector<jlm::rvsdg::port>
-			create_portvector(size_t nalternatives, const jlm::rvsdg::type &type) {
-				auto vec = std::vector<jlm::rvsdg::port>(nalternatives + 1, type);
-				vec[0] = jlm::rvsdg::ctltype(nalternatives);
-				return vec;
-			}
-		};
-
-		class sink_op final : public jlm::rvsdg::simple_op {
-		public:
-			virtual
-			~sink_op() {}
-
-			sink_op(const jlm::rvsdg::type &type)
-					: jlm::rvsdg::simple_op({type}, {}) {}
-
-			bool
-			operator==(const jlm::rvsdg::operation &other) const noexcept override {
-				auto ot = dynamic_cast<const sink_op *>(&other);
-				return ot && ot->argument(0).type() == argument(0).type();
-			}
-
-			std::string
-			debug_string() const override {
-				return "HLS_SINK";
-			}
-
-			std::unique_ptr<jlm::rvsdg::operation>
-			copy() const override {
-				return std::unique_ptr<jlm::rvsdg::operation>(new sink_op(*this));
-			}
-
-			static std::vector<jlm::rvsdg::output *>
-			create(
-					jlm::rvsdg::output &value
-			) {
-				auto region = value.region();
-				sink_op op(value.type());
-				return jlm::rvsdg::simple_node::create_normalized(region, op, {&value});
-			}
-		};
-
-		class predicate_buffer_op final : public jlm::rvsdg::simple_op {
-		public:
-			virtual
-			~predicate_buffer_op() {}
-
-			predicate_buffer_op(const jlm::rvsdg::ctltype &type)
-					: jlm::rvsdg::simple_op({type}, {type}) {}
-
-			bool
-			operator==(const jlm::rvsdg::operation &other) const noexcept override {
-				auto ot = dynamic_cast<const predicate_buffer_op *>(&other);
-				return ot && ot->result(0).type() == result(0).type();
-			}
-
-			std::string
-			debug_string() const override {
-				return "HLS_PRED_BUF";
-			}
-
-			std::unique_ptr<jlm::rvsdg::operation>
-			copy() const override {
-				return std::unique_ptr<jlm::rvsdg::operation>(new predicate_buffer_op(*this));
-			}
-
-			static std::vector<jlm::rvsdg::output *>
-			create(
-					jlm::rvsdg::output &predicate
-			) {
-				auto region = predicate.region();
-				auto ctl = dynamic_cast<const jlm::rvsdg::ctltype *>(&predicate.type());
-				if (!ctl)
-					throw util::error("Predicate needs to be a ctltype.");
-				predicate_buffer_op op(*ctl);
-				return jlm::rvsdg::simple_node::create_normalized(region, op, {&predicate});
-			}
-		};
-
-		class buffer_op final : public jlm::rvsdg::simple_op {
-		public:
-			virtual
-			~buffer_op() {}
-
-			buffer_op(const jlm::rvsdg::type &type, size_t capacity, bool pass_through)
-			: jlm::rvsdg::simple_op({type}, {type}), capacity(capacity), pass_through(pass_through) {}
-
-			bool
-			operator==(const jlm::rvsdg::operation &other) const noexcept override {
-				auto ot = dynamic_cast<const buffer_op *>(&other);
-				return ot
-				&& ot->capacity == capacity
-				&& ot->pass_through == pass_through
-				&& ot->result(0).type() == result(0).type();
-			}
-
-			std::string
-			debug_string() const override {
-				return util::strfmt("HLS_BUF_",(pass_through ? "P_": ""),capacity);
-			}
-
-			std::unique_ptr<jlm::rvsdg::operation>
-			copy() const override {
-				return std::unique_ptr<jlm::rvsdg::operation>(new buffer_op(*this));
-			}
-
-			static std::vector<jlm::rvsdg::output *>
-			create(
-					jlm::rvsdg::output &value,
-					size_t capacity,
-					bool pass_through = false
-			) {
-				auto region = value.region();
-				buffer_op op(value.type(), capacity, pass_through);
-				return jlm::rvsdg::simple_node::create_normalized(region, op, {&value});
-			}
-
-			size_t capacity;
-			bool pass_through;
-		private:
-		};
-
-		class triggertype final : public jlm::rvsdg::statetype {
-		public:
-			virtual
-			~triggertype() {}
-
-			triggertype() : jlm::rvsdg::statetype() {}
-
-			std::string
-			debug_string() const override {
-				return "trigger";
-			};
-
-			bool
-			operator==(const jlm::rvsdg::type &other) const noexcept override {
-				auto type = dynamic_cast<const triggertype *>(&other);
-				return type;
-			};
-
-			virtual std::unique_ptr<jlm::rvsdg::type>
-			copy() const override {
-				return std::unique_ptr<jlm::rvsdg::type>(new triggertype(*this));
-			}
-
-		private:
-		};
-
-		const triggertype trigger;
-
-
-		class trigger_op final : public jlm::rvsdg::simple_op {
-		public:
-			virtual
-			~trigger_op() {}
-
-			trigger_op(const jlm::rvsdg::type &type)
-					: jlm::rvsdg::simple_op({trigger, type}, {type}) {}
-
-			bool
-			operator==(const jlm::rvsdg::operation &other) const noexcept override {
-				auto ot = dynamic_cast<const trigger_op *>(&other);
-				// check predicate and value
-				return ot
-					   && ot->argument(1).type() == argument(1).type()
-					   && ot->result(0).type() == result(0).type();
-			}
-
-			std::string
-			debug_string() const override {
-				return "HLS_TRIGGER";
-			}
-
-			std::unique_ptr<jlm::rvsdg::operation>
-			copy() const override {
-				return std::unique_ptr<jlm::rvsdg::operation>(new trigger_op(*this));
-			}
-
-			static std::vector<jlm::rvsdg::output *>
-			create(
-					jlm::rvsdg::output &tg,
-					jlm::rvsdg::output &value
-			) {
-				if (tg.type() != trigger)
-					throw util::error("Trigger needs to be a triggertype.");
-
-				auto region = value.region();
-				trigger_op op(value.type());
-				return jlm::rvsdg::simple_node::create_normalized(region, op, {&tg, &value});
-			}
-		};
-
-		class print_op final : public jlm::rvsdg::simple_op {
-		private:
-			size_t _id;
-		public:
-			virtual
-			~print_op() {}
-
-			print_op(const jlm::rvsdg::type &type)
-			: jlm::rvsdg::simple_op({type}, {type}) {
-				static size_t common_id{0};
-				_id = common_id++;
-			}
-
-			bool
-			operator==(const jlm::rvsdg::operation &other) const noexcept override {
+namespace jlm::hls
+{
+
+class branch_op final : public jlm::rvsdg::simple_op {
+private:
+  branch_op(size_t nalternatives, const jlm::rvsdg::type &type, bool loop)
+    : jlm::rvsdg::simple_op({jlm::rvsdg::ctltype(nalternatives), type}, std::vector<jlm::rvsdg::port>(nalternatives, type)), loop(loop){}
+
+public:
+  virtual
+  ~branch_op() {}
+
+  bool
+  operator==(const jlm::rvsdg::operation &other) const noexcept override {
+    auto ot = dynamic_cast<const branch_op *>(&other);
+    // check predicate and value
+    return ot
+           && ot->argument(0).type() == argument(0).type()
+           && ot->result(0).type() == result(0).type();
+  }
+
+  std::string
+  debug_string() const override {
+    return "HLS_BRANCH";
+  }
+
+  std::unique_ptr<jlm::rvsdg::operation>
+  copy() const override {
+    return std::unique_ptr<jlm::rvsdg::operation>(new branch_op(*this));
+  }
+
+  static std::vector<jlm::rvsdg::output *>
+  create(
+    jlm::rvsdg::output &predicate,
+    jlm::rvsdg::output &value,
+    bool loop=false
+  ) {
+    auto ctl = dynamic_cast<const jlm::rvsdg::ctltype *>(&predicate.type());
+    if (!ctl)
+      throw util::error("Predicate needs to be a ctltype.");
+
+    auto region = predicate.region();
+    branch_op op(ctl->nalternatives(), value.type(), loop);
+    return jlm::rvsdg::simple_node::create_normalized(region, op, {&predicate, &value});
+  }
+
+  bool loop;//only used for dot output
+};
+
+class fork_op final : public jlm::rvsdg::simple_op {
+public:
+  virtual
+  ~fork_op() {}
+
+  fork_op(size_t nalternatives, const jlm::rvsdg::type &type)
+    : jlm::rvsdg::simple_op({type}, std::vector<jlm::rvsdg::port>(nalternatives, type)) {}
+
+  bool
+  operator==(const jlm::rvsdg::operation &other) const noexcept override {
+    auto ot = dynamic_cast<const fork_op *>(&other);
+    // check predicate and value
+    return ot
+           && ot->argument(0).type() == argument(0).type()
+           && ot->nresults() == nresults();
+  }
+
+  std::string
+  debug_string() const override {
+    return "HLS_FORK";
+  }
+
+  std::unique_ptr<jlm::rvsdg::operation>
+  copy() const override {
+    return std::unique_ptr<jlm::rvsdg::operation>(new fork_op(*this));
+  }
+
+  static std::vector<jlm::rvsdg::output *>
+  create(
+    size_t nalternatives,
+    jlm::rvsdg::output &value
+  ) {
+
+    auto region = value.region();
+    fork_op op(nalternatives, value.type());
+    return jlm::rvsdg::simple_node::create_normalized(region, op, {&value});
+  }
+};
+
+class merge_op final : public jlm::rvsdg::simple_op {
+public:
+  virtual
+  ~merge_op() {}
+
+  merge_op(size_t nalternatives, const jlm::rvsdg::type &type)
+    : jlm::rvsdg::simple_op(std::vector<jlm::rvsdg::port>(nalternatives, type), {type}) {}
+
+  bool
+  operator==(const jlm::rvsdg::operation &other) const noexcept override {
+    auto ot = dynamic_cast<const merge_op *>(&other);
+    return ot
+           && ot->narguments() == narguments()
+           && ot->argument(0).type() == argument(0).type();
+  }
+
+  std::string
+  debug_string() const override {
+    return "HLS_MERGE";
+  }
+
+  std::unique_ptr<jlm::rvsdg::operation>
+  copy() const override {
+    return std::unique_ptr<jlm::rvsdg::operation>(new merge_op(*this));
+  }
+
+  static std::vector<jlm::rvsdg::output *>
+  create(
+    const std::vector<jlm::rvsdg::output *> &alternatives
+  ) {
+    if (alternatives.empty())
+      throw util::error("Insufficient number of operands.");
+
+
+    auto region = alternatives.front()->region();
+    merge_op op(alternatives.size(), alternatives.front()->type());
+    return jlm::rvsdg::simple_node::create_normalized(region, op, alternatives);
+  }
+};
+
+class mux_op final : public jlm::rvsdg::simple_op {
+public:
+  virtual
+  ~mux_op() {}
+
+  mux_op(size_t nalternatives, const jlm::rvsdg::type &type, bool discarding, bool loop)
+    : jlm::rvsdg::simple_op(create_portvector(nalternatives, type), {type}), discarding(discarding), loop(loop) {}
+
+  bool
+  operator==(const jlm::rvsdg::operation &other) const noexcept override {
+    auto ot = dynamic_cast<const mux_op *>(&other);
+    // check predicate and value
+    return ot
+           && ot->argument(0).type() == argument(0).type()
+           && ot->result(0).type() == result(0).type()
+           && ot->discarding == discarding;
+  }
+
+  std::string
+  debug_string() const override {
+    return discarding ? "HLS_DMUX" : "HLS_NDMUX";
+  }
+
+  std::unique_ptr<jlm::rvsdg::operation>
+  copy() const override {
+    return std::unique_ptr<jlm::rvsdg::operation>(new mux_op(*this));
+  }
+
+  static std::vector<jlm::rvsdg::output *>
+  create(
+    jlm::rvsdg::output &predicate,
+    const std::vector<jlm::rvsdg::output *> &alternatives,
+    bool discarding,
+    bool loop=false
+  ) {
+    if (alternatives.empty())
+      throw util::error("Insufficient number of operands.");
+    auto ctl = dynamic_cast<const jlm::rvsdg::ctltype *>(&predicate.type());
+    if (!ctl)
+      throw util::error("Predicate needs to be a ctltype.");
+    if (alternatives.size() != ctl->nalternatives())
+      throw util::error("Alternatives and predicate do not match.");
+
+
+    auto region = predicate.region();
+    auto operands = std::vector<jlm::rvsdg::output *>();
+    operands.push_back(&predicate);
+    operands.insert(operands.end(), alternatives.begin(), alternatives.end());
+    mux_op op(alternatives.size(), alternatives.front()->type(), discarding, loop);
+    return jlm::rvsdg::simple_node::create_normalized(region, op, operands);
+  }
+
+
+  bool discarding;
+  bool loop; // used only for dot output
+private:
+
+  static std::vector<jlm::rvsdg::port>
+  create_portvector(size_t nalternatives, const jlm::rvsdg::type &type) {
+    auto vec = std::vector<jlm::rvsdg::port>(nalternatives + 1, type);
+    vec[0] = jlm::rvsdg::ctltype(nalternatives);
+    return vec;
+  }
+};
+
+class sink_op final : public jlm::rvsdg::simple_op {
+public:
+  virtual
+  ~sink_op() {}
+
+  sink_op(const jlm::rvsdg::type &type)
+    : jlm::rvsdg::simple_op({type}, {}) {}
+
+  bool
+  operator==(const jlm::rvsdg::operation &other) const noexcept override {
+    auto ot = dynamic_cast<const sink_op *>(&other);
+    return ot && ot->argument(0).type() == argument(0).type();
+  }
+
+  std::string
+  debug_string() const override {
+    return "HLS_SINK";
+  }
+
+  std::unique_ptr<jlm::rvsdg::operation>
+  copy() const override {
+    return std::unique_ptr<jlm::rvsdg::operation>(new sink_op(*this));
+  }
+
+  static std::vector<jlm::rvsdg::output *>
+  create(
+    jlm::rvsdg::output &value
+  ) {
+    auto region = value.region();
+    sink_op op(value.type());
+    return jlm::rvsdg::simple_node::create_normalized(region, op, {&value});
+  }
+};
+
+class predicate_buffer_op final : public jlm::rvsdg::simple_op {
+public:
+  virtual
+  ~predicate_buffer_op() {}
+
+  predicate_buffer_op(const jlm::rvsdg::ctltype &type)
+    : jlm::rvsdg::simple_op({type}, {type}) {}
+
+  bool
+  operator==(const jlm::rvsdg::operation &other) const noexcept override {
+    auto ot = dynamic_cast<const predicate_buffer_op *>(&other);
+    return ot && ot->result(0).type() == result(0).type();
+  }
+
+  std::string
+  debug_string() const override {
+    return "HLS_PRED_BUF";
+  }
+
+  std::unique_ptr<jlm::rvsdg::operation>
+  copy() const override {
+    return std::unique_ptr<jlm::rvsdg::operation>(new predicate_buffer_op(*this));
+  }
+
+  static std::vector<jlm::rvsdg::output *>
+  create(
+    jlm::rvsdg::output &predicate
+  ) {
+    auto region = predicate.region();
+    auto ctl = dynamic_cast<const jlm::rvsdg::ctltype *>(&predicate.type());
+    if (!ctl)
+      throw util::error("Predicate needs to be a ctltype.");
+    predicate_buffer_op op(*ctl);
+    return jlm::rvsdg::simple_node::create_normalized(region, op, {&predicate});
+  }
+};
+
+class buffer_op final : public jlm::rvsdg::simple_op {
+public:
+  virtual
+  ~buffer_op() {}
+
+  buffer_op(const jlm::rvsdg::type &type, size_t capacity, bool pass_through)
+    : jlm::rvsdg::simple_op({type}, {type}), capacity(capacity), pass_through(pass_through) {}
+
+  bool
+  operator==(const jlm::rvsdg::operation &other) const noexcept override {
+    auto ot = dynamic_cast<const buffer_op *>(&other);
+    return ot
+           && ot->capacity == capacity
+           && ot->pass_through == pass_through
+           && ot->result(0).type() == result(0).type();
+  }
+
+  std::string
+  debug_string() const override {
+    return util::strfmt("HLS_BUF_",(pass_through ? "P_": ""),capacity);
+  }
+
+  std::unique_ptr<jlm::rvsdg::operation>
+  copy() const override {
+    return std::unique_ptr<jlm::rvsdg::operation>(new buffer_op(*this));
+  }
+
+  static std::vector<jlm::rvsdg::output *>
+  create(
+    jlm::rvsdg::output &value,
+    size_t capacity,
+    bool pass_through = false
+  ) {
+    auto region = value.region();
+    buffer_op op(value.type(), capacity, pass_through);
+    return jlm::rvsdg::simple_node::create_normalized(region, op, {&value});
+  }
+
+  size_t capacity;
+  bool pass_through;
+private:
+};
+
+class triggertype final : public jlm::rvsdg::statetype {
+public:
+  virtual
+  ~triggertype() {}
+
+  triggertype() : jlm::rvsdg::statetype() {}
+
+  std::string
+  debug_string() const override {
+    return "trigger";
+  };
+
+  bool
+  operator==(const jlm::rvsdg::type &other) const noexcept override {
+    auto type = dynamic_cast<const triggertype *>(&other);
+    return type;
+  };
+
+  virtual std::unique_ptr<jlm::rvsdg::type>
+  copy() const override {
+    return std::unique_ptr<jlm::rvsdg::type>(new triggertype(*this));
+  }
+
+private:
+};
+
+const triggertype trigger;
+
+
+class trigger_op final : public jlm::rvsdg::simple_op {
+public:
+  virtual
+  ~trigger_op() {}
+
+  trigger_op(const jlm::rvsdg::type &type)
+    : jlm::rvsdg::simple_op({trigger, type}, {type}) {}
+
+  bool
+  operator==(const jlm::rvsdg::operation &other) const noexcept override {
+    auto ot = dynamic_cast<const trigger_op *>(&other);
+    // check predicate and value
+    return ot
+           && ot->argument(1).type() == argument(1).type()
+           && ot->result(0).type() == result(0).type();
+  }
+
+  std::string
+  debug_string() const override {
+    return "HLS_TRIGGER";
+  }
+
+  std::unique_ptr<jlm::rvsdg::operation>
+  copy() const override {
+    return std::unique_ptr<jlm::rvsdg::operation>(new trigger_op(*this));
+  }
+
+  static std::vector<jlm::rvsdg::output *>
+  create(
+    jlm::rvsdg::output &tg,
+    jlm::rvsdg::output &value
+  ) {
+    if (tg.type() != trigger)
+      throw util::error("Trigger needs to be a triggertype.");
+
+    auto region = value.region();
+    trigger_op op(value.type());
+    return jlm::rvsdg::simple_node::create_normalized(region, op, {&tg, &value});
+  }
+};
+
+class print_op final : public jlm::rvsdg::simple_op {
+private:
+  size_t _id;
+public:
+  virtual
+  ~print_op() {}
+
+  print_op(const jlm::rvsdg::type &type)
+    : jlm::rvsdg::simple_op({type}, {type}) {
+    static size_t common_id{0};
+    _id = common_id++;
+  }
+
+  bool
+  operator==(const jlm::rvsdg::operation &other) const noexcept override {
 //				auto ot = dynamic_cast<const print_op *>(&other);
-				// check predicate and value
+    // check predicate and value
 //				return ot
 //					   && ot->argument(0).type() == argument(0).type()
 //					   && ot->result(0).type() == result(0).type();
-				return false; // print nodes are intentionally distinct
-			}
+    return false; // print nodes are intentionally distinct
+  }
 
-			std::string
-			debug_string() const override {
-				return util::strfmt("HLS_PRINT_", _id);
-			}
+  std::string
+  debug_string() const override {
+    return util::strfmt("HLS_PRINT_", _id);
+  }
 
-			size_t
-			id() const {
-				return _id;
-			}
+  size_t
+  id() const {
+    return _id;
+  }
 
-			std::unique_ptr<jlm::rvsdg::operation>
-			copy() const override {
-				return std::unique_ptr<jlm::rvsdg::operation>(new print_op(*this));
-			}
+  std::unique_ptr<jlm::rvsdg::operation>
+  copy() const override {
+    return std::unique_ptr<jlm::rvsdg::operation>(new print_op(*this));
+  }
 
-			static std::vector<jlm::rvsdg::output *>
-			create(
-					jlm::rvsdg::output &value
-			) {
+  static std::vector<jlm::rvsdg::output *>
+  create(
+    jlm::rvsdg::output &value
+  ) {
 
-				auto region = value.region();
-				print_op op(value.type());
-				return jlm::rvsdg::simple_node::create_normalized(region, op, {&value});
-			}
-		};
+    auto region = value.region();
+    print_op op(value.type());
+    return jlm::rvsdg::simple_node::create_normalized(region, op, {&value});
+  }
+};
 
-		class loop_op final : public jlm::rvsdg::structural_op {
-		public:
-			virtual
-			~loop_op() noexcept {}
+class loop_op final : public jlm::rvsdg::structural_op {
+public:
+  virtual
+  ~loop_op() noexcept {}
 
-			std::string
-			debug_string() const override {
-				return "HLS_LOOP";
-			}
+  std::string
+  debug_string() const override {
+    return "HLS_LOOP";
+  }
 
-			std::unique_ptr<jlm::rvsdg::operation>
-			copy() const override {
-				return std::unique_ptr<jlm::rvsdg::operation>(new loop_op(*this));
-			}
-		};
+  std::unique_ptr<jlm::rvsdg::operation>
+  copy() const override {
+    return std::unique_ptr<jlm::rvsdg::operation>(new loop_op(*this));
+  }
+};
 
-        class backedge_argument;
-        class backedge_result;
-        class loop_node;
+class backedge_argument;
+class backedge_result;
+class loop_node;
 
-        class backedge_argument : public jlm::rvsdg::argument {
-            friend loop_node;
-            friend backedge_result;
-        public:
-            ~backedge_argument() override= default;
+class backedge_argument : public jlm::rvsdg::argument {
+  friend loop_node;
+  friend backedge_result;
+public:
+  ~backedge_argument() override= default;
 
-            backedge_result * result(){
-                return result_;
-            }
+  backedge_result * result(){
+    return result_;
+  }
 
-        private:
-            backedge_argument(
-                    jlm::rvsdg::region * region,
-                    const jlm::rvsdg::type & type)
-                    : jlm::rvsdg::argument(region, nullptr, type), result_(nullptr)
-            {}
+private:
+  backedge_argument(
+    jlm::rvsdg::region * region,
+    const jlm::rvsdg::type & type)
+    : jlm::rvsdg::argument(region, nullptr, type), result_(nullptr)
+  {}
 
-            static backedge_argument *
-            create(
-                    jlm::rvsdg::region * region,
-                    const jlm::rvsdg::type & type)
-            {
-                auto argument = new backedge_argument(region, type);
-                region->append_argument(argument);
-                return argument;
-            }
-            backedge_result * result_;
-        };
+  static backedge_argument *
+  create(
+    jlm::rvsdg::region * region,
+    const jlm::rvsdg::type & type)
+  {
+    auto argument = new backedge_argument(region, type);
+    region->append_argument(argument);
+    return argument;
+  }
+  backedge_result * result_;
+};
 
-        class backedge_result : public jlm::rvsdg::result {
-            friend loop_node;
-            friend backedge_argument;
-        public:
-            ~backedge_result() override= default;
+class backedge_result : public jlm::rvsdg::result {
+  friend loop_node;
+  friend backedge_argument;
+public:
+  ~backedge_result() override= default;
 
-            backedge_argument * argument(){
-                return argument_;
-            }
+  backedge_argument * argument(){
+    return argument_;
+  }
 
-        private:
-            backedge_result(jlm::rvsdg::output * origin)
-                    : jlm::rvsdg::result(origin->region(), origin, nullptr, origin->port()), argument_(nullptr)
-            {}
+private:
+  backedge_result(jlm::rvsdg::output * origin)
+    : jlm::rvsdg::result(origin->region(), origin, nullptr, origin->port()), argument_(nullptr)
+  {}
 
-            static backedge_result *
-            create(jlm::rvsdg::output * origin)
-            {
-                auto result = new backedge_result(origin);
-                origin->region()->append_result(result);
-                return result;
-            }
-            backedge_argument * argument_;
-        };
+  static backedge_result *
+  create(jlm::rvsdg::output * origin)
+  {
+    auto result = new backedge_result(origin);
+    origin->region()->append_result(result);
+    return result;
+  }
+  backedge_argument * argument_;
+};
 
-		class loop_node final : public jlm::rvsdg::structural_node {
-		public:
+class loop_node final : public jlm::rvsdg::structural_node {
+public:
 
-			virtual
-			~loop_node() {}
+  virtual
+  ~loop_node() {}
 
-		private:
-			inline
-			loop_node(jlm::rvsdg::region *parent)
-					: structural_node(loop_op(), parent, 1) {
-			}
+private:
+  inline
+  loop_node(jlm::rvsdg::region *parent)
+    : structural_node(loop_op(), parent, 1) {
+  }
 
-			jlm::rvsdg::output *_predicate_buffer;
+  jlm::rvsdg::output *_predicate_buffer;
 
-		public:
-			static loop_node *
-			create(jlm::rvsdg::region *parent, bool init = true);
+public:
+  static loop_node *
+  create(jlm::rvsdg::region *parent, bool init = true);
 
-			inline jlm::rvsdg::region *
-			subregion() const noexcept {
-				return structural_node::subregion(0);
-			}
+  inline jlm::rvsdg::region *
+  subregion() const noexcept {
+    return structural_node::subregion(0);
+  }
 
-			inline jlm::rvsdg::result *
-			predicate() const noexcept {
-				auto result = subregion()->result(0);
-				JLM_ASSERT(dynamic_cast<const jlm::rvsdg::ctltype *>(&result->type()));
-				return result;
-			}
+  inline jlm::rvsdg::result *
+  predicate() const noexcept {
+    auto result = subregion()->result(0);
+    JLM_ASSERT(dynamic_cast<const jlm::rvsdg::ctltype *>(&result->type()));
+    return result;
+  }
 
-			inline jlm::rvsdg::output *
-			predicate_buffer() const noexcept {
-				return _predicate_buffer;
-			}
+  inline jlm::rvsdg::output *
+  predicate_buffer() const noexcept {
+    return _predicate_buffer;
+  }
 
-			void set_predicate(jlm::rvsdg::output *p);
+  void set_predicate(jlm::rvsdg::output *p);
 
-            backedge_argument * add_backedge(const jlm::rvsdg::type & type);
+  backedge_argument * add_backedge(const jlm::rvsdg::type & type);
 
-			jlm::rvsdg::structural_output *
-			add_loopvar(jlm::rvsdg::output *origin, jlm::rvsdg::output **buffer = nullptr);
+  jlm::rvsdg::structural_output *
+  add_loopvar(jlm::rvsdg::output *origin, jlm::rvsdg::output **buffer = nullptr);
 
-			virtual loop_node *
-			copy(jlm::rvsdg::region *region, jlm::rvsdg::substitution_map &smap) const override;
-		};
-	}
+  virtual loop_node *
+  copy(jlm::rvsdg::region *region, jlm::rvsdg::substitution_map &smap) const override;
+};
+
 }
+
 #endif //JLM_HLS_IR_HLS_HPP


### PR DESCRIPTION
1. Merged namespace names in header files
2. Used relative namespace in source files
3. Properly aligned code in files