### PR TITLE
Fix jlc command line parsing bug

### DIFF
--- a/jlm/tooling/CommandGraphGenerator.cpp
+++ b/jlm/tooling/CommandGraphGenerator.cpp
@@ -115,30 +115,65 @@ JlcCommandGraphGenerator::GenerateCommandGraph(const JlcCommandLineOptions & com
     if (compilation.RequiresOptimization())
     {
       std::vector<JlmOptCommand::Optimization> optimizations;
-      if (!commandLineOptions.JlmOptOptimizations_.empty()) {
-        static std::unordered_map<std::string, JlmOptCommand::Optimization>map(
-        {
-          {"AASteensgaardAgnostic", JlmOptCommand::Optimization::AASteensgaardAgnostic},
-          {"AASteensgaardRegionAware", JlmOptCommand::Optimization::AASteensgaardRegionAware},
-          {"cne", JlmOptCommand::Optimization::CommonNodeElimination},
-          {"dne", JlmOptCommand::Optimization::DeadNodeElimination},
-          {"iln", JlmOptCommand::Optimization::FunctionInlining},
-          {"InvariantValueRedirection", JlmOptCommand::Optimization::InvariantValueRedirection},
-          {"psh", JlmOptCommand::Optimization::NodePushOut},
-          {"pll", JlmOptCommand::Optimization::NodePullIn},
-          {"red", JlmOptCommand::Optimization::NodeReduction},
-          {"ivt", JlmOptCommand::Optimization::ThetaGammaInversion},
-          {"url", JlmOptCommand::Optimization::LoopUnrolling},
-        });
+      if (!commandLineOptions.JlmOptOptimizations_.empty())
+      {
+        static std::unordered_map<JlmOptCommandLineOptions::OptimizationId, JlmOptCommand::Optimization> map(
+          {
+            {
+              JlmOptCommandLineOptions::OptimizationId::AASteensgaardAgnostic,
+              JlmOptCommand::Optimization::AASteensgaardAgnostic
+            },
+            {
+              JlmOptCommandLineOptions::OptimizationId::AASteensgaardRegionAware,
+              JlmOptCommand::Optimization::AASteensgaardRegionAware
+            },
+            {
+              JlmOptCommandLineOptions::OptimizationId::cne,
+              JlmOptCommand::Optimization::CommonNodeElimination
+            },
+            {
+              JlmOptCommandLineOptions::OptimizationId::dne,
+              JlmOptCommand::Optimization::DeadNodeElimination
+            },
+            {
+              JlmOptCommandLineOptions::OptimizationId::iln,
+              JlmOptCommand::Optimization::FunctionInlining
+            },
+            {
+              JlmOptCommandLineOptions::OptimizationId::InvariantValueRedirection,
+              JlmOptCommand::Optimization::InvariantValueRedirection
+            },
+            {
+              JlmOptCommandLineOptions::OptimizationId::psh,
+              JlmOptCommand::Optimization::NodePushOut
+            },
+            {
+              JlmOptCommandLineOptions::OptimizationId::pll,
+              JlmOptCommand::Optimization::NodePullIn
+            },
+            {
+              JlmOptCommandLineOptions::OptimizationId::red,
+              JlmOptCommand::Optimization::NodeReduction
+            },
+            {
+              JlmOptCommandLineOptions::OptimizationId::ivt,
+              JlmOptCommand::Optimization::ThetaGammaInversion
+            },
+            {
+              JlmOptCommandLineOptions::OptimizationId::url,
+              JlmOptCommand::Optimization::LoopUnrolling},
+          });
+
         for (const auto & jlmOpt : commandLineOptions.JlmOptOptimizations_)
-	{
+        {
           JLM_ASSERT(map.find(jlmOpt) != map.end());
           optimizations.push_back(map[jlmOpt]);
-	}
-      /*
-       * If a default optimization level has been specified (-O) and no specific jlm options
-       * have been specified (-J) then use a default set of optimizations.
-       */
+        }
+
+        /*
+         * If a default optimization level has been specified (-O) and no specific jlm options
+         * have been specified (-J) then use a default set of optimizations.
+         */
       } else if (commandLineOptions.JlmOptOptimizations_.empty()
           && commandLineOptions.OptimizationLevel_ == JlcCommandLineOptions::OptimizationLevel::O3)
       {

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -103,17 +103,17 @@ JlmOptCommandLineOptions::FromCommandLineArgument(const std::string& commandLine
 {
   static std::unordered_map<std::string, OptimizationId> map(
     {
-      {"AASteensgaardAgnostic",     OptimizationId::AASteensgaardAgnostic},
-      {"AASteensgaardRegionAware",  OptimizationId::AASteensgaardRegionAware},
-      {"cne",                       OptimizationId::cne},
-      {"dne",                       OptimizationId::dne},
-      {"iln",                       OptimizationId::iln},
-      {"InvariantValueRedirection", OptimizationId::InvariantValueRedirection},
-      {"psh",                       OptimizationId::psh},
-      {"pll",                       OptimizationId::pll},
-      {"red",                       OptimizationId::red},
-      {"ivt",                       OptimizationId::ivt},
-      {"url",                       OptimizationId::url}
+      {AaSteensgaardAgnosticCommandLineArgument_,     OptimizationId::AASteensgaardAgnostic},
+      {AaSteensgaardRegionAwareCommandLineArgument_,  OptimizationId::AASteensgaardRegionAware},
+      {CommonNodeEliminationCommandLineArgument_,     OptimizationId::cne},
+      {DeadNodeEliminationCommandLineArgument_,       OptimizationId::dne},
+      {FunctionInliningCommandLineArgument_,          OptimizationId::iln},
+      {InvariantValueRedirectionCommandLineArgument_, OptimizationId::InvariantValueRedirection},
+      {NodePushOutCommandLineArgument_,               OptimizationId::psh},
+      {NodePullInCommandLineArgument_,                OptimizationId::pll},
+      {NodeReductionCommandLineArgument_,             OptimizationId::red},
+      {ThetaGammaInversionCommandLineArgument_,       OptimizationId::ivt},
+      {LoopUnrollingCommandLineArgument_,             OptimizationId::url}
     });
 
   if (map.find(commandLineArgument) != map.end())
@@ -127,17 +127,17 @@ JlmOptCommandLineOptions::ToCommandLineArgument(OptimizationId optimizationId)
 {
   static std::unordered_map<OptimizationId, const char*> map(
     {
-      {OptimizationId::AASteensgaardAgnostic,     "AASteensgaardAgnostic"},
-      {OptimizationId::AASteensgaardRegionAware,  "AASteensgaardRegionAware"},
-      {OptimizationId::cne,                       "cne"},
-      {OptimizationId::dne,                       "dne"},
-      {OptimizationId::iln,                       "iln"},
-      {OptimizationId::InvariantValueRedirection, "InvariantValueRedirection"},
-      {OptimizationId::psh,                       "psh"},
-      {OptimizationId::pll,                       "pll"},
-      {OptimizationId::red,                       "red"},
-      {OptimizationId::ivt,                       "ivt"},
-      {OptimizationId::url,                       "url"}
+      {OptimizationId::AASteensgaardAgnostic,     AaSteensgaardAgnosticCommandLineArgument_},
+      {OptimizationId::AASteensgaardRegionAware,  AaSteensgaardRegionAwareCommandLineArgument_},
+      {OptimizationId::cne,                       CommonNodeEliminationCommandLineArgument_},
+      {OptimizationId::dne,                       DeadNodeEliminationCommandLineArgument_},
+      {OptimizationId::iln,                       FunctionInliningCommandLineArgument_},
+      {OptimizationId::InvariantValueRedirection, InvariantValueRedirectionCommandLineArgument_},
+      {OptimizationId::psh,                       NodePushOutCommandLineArgument_},
+      {OptimizationId::pll,                       NodePullInCommandLineArgument_},
+      {OptimizationId::red,                       NodeReductionCommandLineArgument_},
+      {OptimizationId::ivt,                       ThetaGammaInversionCommandLineArgument_},
+      {OptimizationId::url,                       LoopUnrollingCommandLineArgument_}
     });
 
   if (map.find(optimizationId) != map.end())

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -98,6 +98,90 @@ JlmOptCommandLineOptions::Reset() noexcept
   Optimizations_.clear();
 }
 
+JlmOptCommandLineOptions::OptimizationId
+JlmOptCommandLineOptions::FromCommandLineArgument(const std::string& commandLineArgument)
+{
+  static std::unordered_map<std::string, OptimizationId> map(
+    {
+      {"AASteensgaardAgnostic",     OptimizationId::AASteensgaardAgnostic},
+      {"AASteensgaardRegionAware",  OptimizationId::AASteensgaardRegionAware},
+      {"cne",                       OptimizationId::cne},
+      {"dne",                       OptimizationId::dne},
+      {"iln",                       OptimizationId::iln},
+      {"InvariantValueRedirection", OptimizationId::InvariantValueRedirection},
+      {"psh",                       OptimizationId::psh},
+      {"pll",                       OptimizationId::pll},
+      {"red",                       OptimizationId::red},
+      {"ivt",                       OptimizationId::ivt},
+      {"url",                       OptimizationId::url}
+    });
+
+  if (map.find(commandLineArgument) != map.end())
+    return map[commandLineArgument];
+
+  throw util::error("Unknown command line argument: " + commandLineArgument);
+}
+
+const char*
+JlmOptCommandLineOptions::ToCommandLineArgument(OptimizationId optimizationId)
+{
+  static std::unordered_map<OptimizationId, const char*> map(
+    {
+      {OptimizationId::AASteensgaardAgnostic,     "AASteensgaardAgnostic"},
+      {OptimizationId::AASteensgaardRegionAware,  "AASteensgaardRegionAware"},
+      {OptimizationId::cne,                       "cne"},
+      {OptimizationId::dne,                       "dne"},
+      {OptimizationId::iln,                       "iln"},
+      {OptimizationId::InvariantValueRedirection, "InvariantValueRedirection"},
+      {OptimizationId::psh,                       "psh"},
+      {OptimizationId::pll,                       "pll"},
+      {OptimizationId::red,                       "red"},
+      {OptimizationId::ivt,                       "ivt"},
+      {OptimizationId::url,                       "url"}
+    });
+
+  if (map.find(optimizationId) != map.end())
+    return map[optimizationId];
+
+  throw util::error("Unknown optimization identifier");
+}
+
+llvm::optimization *
+JlmOptCommandLineOptions::GetOptimization(enum OptimizationId id)
+{
+  static llvm::aa::SteensgaardAgnostic steensgaardAgnostic;
+  static llvm::aa::SteensgaardRegionAware steensgaardRegionAware;
+  static llvm::cne commonNodeElimination;
+  static llvm::DeadNodeElimination deadNodeElimination;
+  static llvm::fctinline functionInlining;
+  static llvm::InvariantValueRedirection invariantValueRedirection;
+  static llvm::pullin nodePullIn;
+  static llvm::pushout nodePushOt;
+  static llvm::tginversion thetaGammaInversion;
+  static llvm::loopunroll loopUnrolling(4);
+  static llvm::nodereduction nodeReduction;
+
+  static std::unordered_map<OptimizationId, llvm::optimization*> map(
+    {
+      {OptimizationId::AASteensgaardAgnostic,     &steensgaardAgnostic},
+      {OptimizationId::AASteensgaardRegionAware,  &steensgaardRegionAware},
+      {OptimizationId::cne,                       &commonNodeElimination},
+      {OptimizationId::dne,                       &deadNodeElimination},
+      {OptimizationId::iln,                       &functionInlining},
+      {OptimizationId::InvariantValueRedirection, &invariantValueRedirection},
+      {OptimizationId::pll,                       &nodePullIn},
+      {OptimizationId::psh,                       &nodePushOt},
+      {OptimizationId::ivt,                       &thetaGammaInversion},
+      {OptimizationId::url,                       &loopUnrolling},
+      {OptimizationId::red,                       &nodeReduction}
+    });
+
+  if (map.find(id) != map.end())
+    return map[id];
+
+  throw util::error("Unknown optimization identifier");
+}
+
 void
 JlmHlsCommandLineOptions::Reset() noexcept
 {
@@ -118,12 +202,36 @@ JhlsCommandLineOptions::Reset() noexcept
 CommandLineParser::~CommandLineParser() noexcept
 = default;
 
+CommandLineParser::Exception::~Exception() noexcept
+= default;
+
 JlcCommandLineParser::~JlcCommandLineParser() noexcept
 = default;
 
 const JlcCommandLineOptions &
 JlcCommandLineParser::ParseCommandLineArguments(int argc, char **argv)
 {
+  auto checkAndConvertJlmOptOptimizations = [](const ::llvm::cl::list<std::string>& optimizations)
+  {
+    std::vector<JlmOptCommandLineOptions::OptimizationId> optimizationIds;
+    for (auto & optimization : optimizations)
+    {
+      JlmOptCommandLineOptions::OptimizationId optimizationId;
+      try
+      {
+        optimizationId = JlmOptCommandLineOptions::FromCommandLineArgument(optimization);
+      }
+      catch (util::error&)
+      {
+        throw CommandLineParser::Exception("Unknown jlm-opt optimization: " + optimization);
+      }
+
+      optimizationIds.emplace_back(optimizationId);
+    }
+
+    return optimizationIds;
+  };
+
   CommandLineOptions_.Reset();
 
   using namespace ::llvm;
@@ -312,7 +420,7 @@ JlcCommandLineParser::ParseCommandLineArguments(int argc, char **argv)
   CommandLineOptions_.OnlyPrintCommands_ = onlyPrintCommands;
   CommandLineOptions_.GenerateDebugInformation_ = generateDebugInformation;
   CommandLineOptions_.Flags_ = flags;
-  CommandLineOptions_.JlmOptOptimizations_ = jlmOptimizations;
+  CommandLineOptions_.JlmOptOptimizations_ = checkAndConvertJlmOptOptimizations(jlmOptimizations);
   CommandLineOptions_.Verbose_ = verbose;
   CommandLineOptions_.Rdynamic_ = rDynamic;
   CommandLineOptions_.Suppress_ = suppress;
@@ -360,40 +468,6 @@ JlcCommandLineParser::ParseCommandLineArguments(int argc, char **argv)
 
 JlmOptCommandLineParser::~JlmOptCommandLineParser() noexcept
 = default;
-
-llvm::optimization *
-JlmOptCommandLineParser::GetOptimization(enum OptimizationId id)
-{
-  static llvm::aa::SteensgaardAgnostic steensgaardAgnostic;
-  static llvm::aa::SteensgaardRegionAware steensgaardRegionAware;
-  static llvm::cne commonNodeElimination;
-  static llvm::DeadNodeElimination deadNodeElimination;
-  static llvm::fctinline functionInlining;
-  static llvm::InvariantValueRedirection invariantValueRedirection;
-  static llvm::pullin nodePullIn;
-  static llvm::pushout nodePushOt;
-  static llvm::tginversion thetaGammaInversion;
-  static llvm::loopunroll loopUnrolling(4);
-  static llvm::nodereduction nodeReduction;
-
-  static std::unordered_map<OptimizationId, llvm::optimization*> map(
-    {
-      {OptimizationId::AASteensgaardAgnostic,     &steensgaardAgnostic},
-      {OptimizationId::AASteensgaardRegionAware,  &steensgaardRegionAware},
-      {OptimizationId::cne,                       &commonNodeElimination},
-      {OptimizationId::dne,                       &deadNodeElimination},
-      {OptimizationId::iln,                       &functionInlining},
-      {OptimizationId::InvariantValueRedirection, &invariantValueRedirection},
-      {OptimizationId::pll,                       &nodePullIn},
-      {OptimizationId::psh,                       &nodePushOt},
-      {OptimizationId::ivt,                       &thetaGammaInversion},
-      {OptimizationId::url,                       &loopUnrolling},
-      {OptimizationId::red,                       &nodeReduction}
-    });
-
-  JLM_ASSERT(map.find(id) != map.end());
-  return map[id];
-}
 
 const JlmOptCommandLineOptions &
 JlmOptCommandLineParser::ParseCommandLineArguments(int argc, char **argv)
@@ -527,51 +601,63 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, char **argv)
         "Output XML")),
     cl::desc("Select output format"));
 
-  cl::list<OptimizationId> optimizationIds(
+  auto aASteensgaardAgnostic = JlmOptCommandLineOptions::OptimizationId::AASteensgaardAgnostic;
+  auto aASteensgaardRegionAware = JlmOptCommandLineOptions::OptimizationId::AASteensgaardRegionAware;
+  auto commonNodeElimination = JlmOptCommandLineOptions::OptimizationId::cne;
+  auto deadNodeElimination = JlmOptCommandLineOptions::OptimizationId::dne;
+  auto functionInlining = JlmOptCommandLineOptions::OptimizationId::iln;
+  auto invariantValueRedirection = JlmOptCommandLineOptions::OptimizationId::InvariantValueRedirection;
+  auto nodePushOut = JlmOptCommandLineOptions::OptimizationId::psh;
+  auto nodePullIn = JlmOptCommandLineOptions::OptimizationId::pll;
+  auto nodeReduction = JlmOptCommandLineOptions::OptimizationId::red;
+  auto thetaGammaInversion = JlmOptCommandLineOptions::OptimizationId::ivt;
+  auto loopUnrolling = JlmOptCommandLineOptions::OptimizationId::url;
+
+  cl::list<JlmOptCommandLineOptions::OptimizationId> optimizationIds(
     cl::values(
       ::clEnumValN(
-        OptimizationId::AASteensgaardAgnostic,
-        "AASteensgaardAgnostic",
+        aASteensgaardAgnostic,
+        JlmOptCommandLineOptions::ToCommandLineArgument(aASteensgaardAgnostic),
         "Steensgaard alias analysis with agnostic memory state encoding."),
       ::clEnumValN(
-        OptimizationId::AASteensgaardRegionAware,
-        "AASteensgaardRegionAware",
+        aASteensgaardRegionAware,
+        JlmOptCommandLineOptions::ToCommandLineArgument(aASteensgaardRegionAware),
         "Steensgaard alias analysis with region-aware memory state encoding."),
       ::clEnumValN(
-        OptimizationId::cne,
-        "cne",
+        commonNodeElimination,
+        JlmOptCommandLineOptions::ToCommandLineArgument(commonNodeElimination),
         "Common node elimination"),
       ::clEnumValN(
-        OptimizationId::dne,
-        "dne",
+        deadNodeElimination,
+        JlmOptCommandLineOptions::ToCommandLineArgument(deadNodeElimination),
         "Dead node elimination"),
       ::clEnumValN(
-        OptimizationId::iln,
-        "iln",
+        functionInlining,
+        JlmOptCommandLineOptions::ToCommandLineArgument(functionInlining),
         "Function inlining"),
       ::clEnumValN(
-        OptimizationId::InvariantValueRedirection,
-        "InvariantValueRedirection",
+        invariantValueRedirection,
+        JlmOptCommandLineOptions::ToCommandLineArgument(invariantValueRedirection),
         "Invariant Value Redirection"),
       ::clEnumValN(
-        OptimizationId::psh,
-        "psh",
+        nodePushOut,
+        JlmOptCommandLineOptions::ToCommandLineArgument(nodePushOut),
         "Node push out"),
       ::clEnumValN(
-        OptimizationId::pll,
-        "pll",
+        nodePullIn,
+        JlmOptCommandLineOptions::ToCommandLineArgument(nodePullIn),
         "Node pull in"),
       ::clEnumValN(
-        OptimizationId::red,
-        "red",
+        nodeReduction,
+        JlmOptCommandLineOptions::ToCommandLineArgument(nodeReduction),
         "Node reductions"),
       ::clEnumValN(
-        OptimizationId::ivt,
-        "ivt",
+        thetaGammaInversion,
+        JlmOptCommandLineOptions::ToCommandLineArgument(thetaGammaInversion),
         "Theta-gamma inversion"),
       ::clEnumValN(
-        OptimizationId::url,
-        "url",
+        loopUnrolling,
+        JlmOptCommandLineOptions::ToCommandLineArgument(loopUnrolling),
         "Loop unrolling")),
     cl::desc("Perform optimization"));
 
@@ -584,8 +670,9 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, char **argv)
     CommandLineOptions_.StatisticsCollectorSettings_.SetFilePath(statisticFile);
 
   std::vector<llvm::optimization*> optimizations;
-  for (auto & optimizationId : optimizationIds)
-    optimizations.push_back(GetOptimization(optimizationId));
+  for (auto &optimizationId: optimizationIds)
+    optimizations.push_back(JlmOptCommandLineOptions::GetOptimization(optimizationId));
+
 
   util::HashSet<util::Statistics::Id> printStatisticsIds({printStatistics.begin(), printStatistics.end()});
 

--- a/jlm/tooling/CommandLine.hpp
+++ b/jlm/tooling/CommandLine.hpp
@@ -33,6 +33,65 @@ public:
   Reset() noexcept = 0;
 };
 
+class optimization;
+
+/**
+ * Command line options for the \a jlm-opt command line tool.
+ */
+class JlmOptCommandLineOptions final : public CommandLineOptions {
+public:
+  enum class OutputFormat {
+    Llvm,
+    Xml
+  };
+
+  enum class OptimizationId
+  {
+    FirstEnumValue, // must always be the first enum value, used for iteration
+
+    AASteensgaardAgnostic,
+    AASteensgaardRegionAware,
+    cne,
+    dne,
+    iln,
+    InvariantValueRedirection,
+    psh,
+    red,
+    ivt,
+    url,
+    pll,
+
+    LastEnumValue // must always be the last enum value, used for iteration
+  };
+
+  JlmOptCommandLineOptions()
+    : InputFile_("")
+    , OutputFile_("")
+    , OutputFormat_(OutputFormat::Llvm)
+  {}
+
+  void
+  Reset() noexcept override;
+
+  static OptimizationId
+  FromCommandLineArgument(const std::string& commandLineArgument);
+
+  static const char*
+  ToCommandLineArgument(OptimizationId optimizationId);
+
+  static llvm::optimization *
+  GetOptimization(enum OptimizationId optimizationId);
+
+  util::filepath InputFile_;
+  util::filepath OutputFile_;
+  OutputFormat OutputFormat_;
+  util::StatisticsCollectorSettings StatisticsCollectorSettings_;
+  std::vector<jlm::llvm::optimization*> Optimizations_;
+
+private:
+  inline static const char* AaSteensgaardAgnosticCommandLineArgument_ = "AASteensgaardAgnostic";
+};
+
 class JlcCommandLineOptions final : public CommandLineOptions {
 public:
   class Compilation;
@@ -98,7 +157,7 @@ public:
   std::vector<std::string> Warnings_;
   std::vector<std::string> IncludePaths_;
   std::vector<std::string> Flags_;
-  std::vector<std::string> JlmOptOptimizations_;
+  std::vector<JlmOptCommandLineOptions::OptimizationId> JlmOptOptimizations_;
 
   std::vector<Compilation> Compilations_;
 };
@@ -187,34 +246,6 @@ private:
   util::filepath OutputFile_;
   util::filepath DependencyFile_;
   const std::string Mt_;
-};
-
-class optimization;
-
-/**
- * Command line options for the \a jlm-opt command line tool.
- */
-class JlmOptCommandLineOptions final : public CommandLineOptions {
-public:
-  enum class OutputFormat {
-    Llvm,
-    Xml
-  };
-
-  JlmOptCommandLineOptions()
-    : InputFile_("")
-    , OutputFile_("")
-    , OutputFormat_(OutputFormat::Llvm)
-  {}
-
-  void
-  Reset() noexcept override;
-
-  util::filepath InputFile_;
-  util::filepath OutputFile_;
-  OutputFormat OutputFormat_;
-  util::StatisticsCollectorSettings StatisticsCollectorSettings_;
-  std::vector<jlm::llvm::optimization*> Optimizations_;
 };
 
 /**
@@ -410,6 +441,20 @@ private:
  */
 class CommandLineParser {
 public:
+  /**
+   * Exception thrown in case of command line parsing errors.
+   */
+  class Exception : util::error
+  {
+  public:
+    ~Exception() noexcept override;
+
+    explicit
+    Exception(const std::string & message)
+    : util::error(message)
+    {}
+  };
+
   virtual
   ~CommandLineParser() noexcept;
 
@@ -457,20 +502,6 @@ private:
  */
 class JlmOptCommandLineParser final : public CommandLineParser {
 public:
-  enum class OptimizationId {
-    AASteensgaardAgnostic,
-    AASteensgaardRegionAware,
-    cne,
-    dne,
-    iln,
-    InvariantValueRedirection,
-    psh,
-    red,
-    ivt,
-    url,
-    pll,
-  };
-
   ~JlmOptCommandLineParser() noexcept override;
 
   const JlmOptCommandLineOptions &
@@ -480,9 +511,6 @@ public:
   Parse(int argc, char ** argv);
 
 private:
-  static llvm::optimization *
-  GetOptimization(enum OptimizationId optimizationId);
-
   JlmOptCommandLineOptions CommandLineOptions_;
 };
 

--- a/jlm/tooling/CommandLine.hpp
+++ b/jlm/tooling/CommandLine.hpp
@@ -90,6 +90,16 @@ public:
 
 private:
   inline static const char* AaSteensgaardAgnosticCommandLineArgument_ = "AASteensgaardAgnostic";
+  inline static const char* AaSteensgaardRegionAwareCommandLineArgument_ = "AASteensgaardRegionAware";
+  inline static const char* CommonNodeEliminationCommandLineArgument_ = "cne";
+  inline static const char* DeadNodeEliminationCommandLineArgument_ = "dne";
+  inline static const char* FunctionInliningCommandLineArgument_ = "iln";
+  inline static const char* InvariantValueRedirectionCommandLineArgument_ = "InvariantValueRedirection";
+  inline static const char* NodePullInCommandLineArgument_ = "pll";
+  inline static const char* NodePushOutCommandLineArgument_ = "psh";
+  inline static const char* ThetaGammaInversionCommandLineArgument_ = "ivt";
+  inline static const char* LoopUnrollingCommandLineArgument_ = "url";
+  inline static const char* NodeReductionCommandLineArgument_ = "red";
 };
 
 class JlcCommandLineOptions final : public CommandLineOptions {

--- a/jlm/tooling/CommandLine.hpp
+++ b/jlm/tooling/CommandLine.hpp
@@ -444,7 +444,7 @@ public:
   /**
    * Exception thrown in case of command line parsing errors.
    */
-  class Exception : util::error
+  class Exception : public util::error
   {
   public:
     ~Exception() noexcept override;

--- a/tests/jlm/tooling/Makefile.sub
+++ b/tests/jlm/tooling/Makefile.sub
@@ -1,3 +1,4 @@
 TESTS += \
 	jlm/tooling/TestJlcCommandGraphGenerator \
 	jlm/tooling/TestJlcCommandLineParser \
+	jlm/tooling/TestJlmOptCommandLineParser \

--- a/tests/jlm/tooling/TestJlcCommandGraphGenerator.cpp
+++ b/tests/jlm/tooling/TestJlcCommandGraphGenerator.cpp
@@ -97,8 +97,8 @@ TestJlmOptOptimizations()
                                                true,
                                                true});
   commandLineOptions.OutputFile_ = {"foobar"};
-  commandLineOptions.JlmOptOptimizations_.push_back("cne");
-  commandLineOptions.JlmOptOptimizations_.push_back("dne");
+  commandLineOptions.JlmOptOptimizations_.push_back(JlmOptCommandLineOptions::OptimizationId::cne);
+  commandLineOptions.JlmOptOptimizations_.push_back(JlmOptCommandLineOptions::OptimizationId::dne);
 
   /*
    * Act

--- a/tests/jlm/tooling/TestJlcCommandLineParser.cpp
+++ b/tests/jlm/tooling/TestJlcCommandLineParser.cpp
@@ -13,6 +13,14 @@
 static const jlm::tooling::JlcCommandLineOptions &
 ParseCommandLineArguments(const std::vector<std::string> & commandLineArguments)
 {
+  auto cleanUp = [](const std::vector<char*>& array)
+  {
+    for (const auto& ptr : array)
+    {
+      delete[] ptr;
+    }
+  };
+
   std::vector<char*> array;
   for (const auto & commandLineArgument : commandLineArguments) {
     array.push_back(new char[commandLineArgument.size() + 1]);
@@ -21,14 +29,22 @@ ParseCommandLineArguments(const std::vector<std::string> & commandLineArguments)
   }
 
   static jlm::tooling::JlcCommandLineParser commandLineParser;
-  auto & commandLineOptions = commandLineParser.ParseCommandLineArguments(
-    static_cast<int>(array.size()),
-    &array[0]);
+  const jlm::tooling::JlcCommandLineOptions* commandLineOptions;
+  try
+  {
+    commandLineOptions = &commandLineParser.ParseCommandLineArguments(
+      static_cast<int>(array.size()),
+      &array[0]);
+  }
+  catch (...)
+  {
+    cleanUp(array);
+    throw;
+  }
 
-  for (const auto & ptr : array)
-    delete[] ptr;
+  cleanUp(array);
 
-  return commandLineOptions;
+  return *commandLineOptions;
 }
 
 static void

--- a/tests/jlm/tooling/TestJlcCommandLineParser.cpp
+++ b/tests/jlm/tooling/TestJlcCommandLineParser.cpp
@@ -127,21 +127,40 @@ Test4()
 static void
 TestJlmOptOptimizations()
 {
-  /*
-   * Arrange
-   */
+  using namespace jlm::tooling;
+
+  // Arrange
   std::vector<std::string> commandLineArguments({"jlc", "foobar.c", "-Jcne", "-Jdne"});
 
-  /*
-   * Act
-   */
+  // Act
   auto & commandLineOptions = ParseCommandLineArguments(commandLineArguments);
 
-  /*
-   * Assert
-   */
-  assert(commandLineOptions.JlmOptOptimizations_[0].compare("cne") == 0 && \
-         commandLineOptions.JlmOptOptimizations_[1].compare("dne") == 0);
+  // Assert
+  assert(commandLineOptions.JlmOptOptimizations_.size() == 2);
+  assert(commandLineOptions.JlmOptOptimizations_[0] == JlmOptCommandLineOptions::OptimizationId::cne);
+  assert(commandLineOptions.JlmOptOptimizations_[1] == JlmOptCommandLineOptions::OptimizationId::dne);
+}
+
+static void
+TestFalseJlmOptOptimization()
+{
+  using namespace jlm::tooling;
+
+  // Arrange
+  std::vector<std::string> commandLineArguments({"jlc", "-JFoobar", "foobar.c"});
+
+  // Act & Assert
+  bool exceptionThrown = false;
+  try
+  {
+    ParseCommandLineArguments(commandLineArguments);
+  }
+  catch (CommandLineParser::Exception&)
+  {
+    exceptionThrown = true;
+  }
+
+  assert(exceptionThrown);
 }
 
 static int
@@ -152,6 +171,7 @@ Test()
   Test3();
   Test4();
   TestJlmOptOptimizations();
+  TestFalseJlmOptOptimization();
 
   return 0;
 }

--- a/tests/jlm/tooling/TestJlmOptCommandLineParser.cpp
+++ b/tests/jlm/tooling/TestJlmOptCommandLineParser.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <test-registry.hpp>
+
+#include <jlm/tooling/CommandLine.hpp>
+
+static void
+TestOptimizationCommandLineArgumentConversion()
+{
+  using namespace jlm::tooling;
+
+  for (
+    size_t n = static_cast<std::size_t>(JlmOptCommandLineOptions::OptimizationId::FirstEnumValue)+1;
+    n != static_cast<std::size_t>(JlmOptCommandLineOptions::OptimizationId::LastEnumValue);
+    n++)
+  {
+    auto expectedOptimizationId = static_cast<JlmOptCommandLineOptions::OptimizationId>(n);
+    auto commandLineArgument = JlmOptCommandLineOptions::ToCommandLineArgument(expectedOptimizationId);
+    auto receivedOptimizationId = JlmOptCommandLineOptions::FromCommandLineArgument(commandLineArgument);
+
+    assert(receivedOptimizationId == expectedOptimizationId);
+  }
+}
+
+static void
+TestOptimizationIdToOptimizationTranslation()
+{
+  using namespace jlm::tooling;
+
+  for (
+    size_t n = static_cast<std::size_t>(JlmOptCommandLineOptions::OptimizationId::FirstEnumValue)+1;
+    n != static_cast<std::size_t>(JlmOptCommandLineOptions::OptimizationId::LastEnumValue);
+    n++)
+  {
+    auto optimizationId = static_cast<JlmOptCommandLineOptions::OptimizationId>(n);
+
+    // throws exception on failure
+    JlmOptCommandLineOptions::GetOptimization(optimizationId);
+  }
+
+}
+
+static int
+Test()
+{
+  TestOptimizationCommandLineArgumentConversion();
+  TestOptimizationIdToOptimizationTranslation();
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER("jlm/tooling/TestJlmOptCommandLineParser", Test)

--- a/tools/jlc/jlc.cpp
+++ b/tools/jlc/jlc.cpp
@@ -12,9 +12,18 @@ main(int argc, char ** argv)
   using namespace jlm::tooling;
 
   JlcCommandLineParser commandLineParser;
-  auto & commandLineOptions = commandLineParser.ParseCommandLineArguments(argc, argv);
+  const JlcCommandLineOptions* commandLineOptions;
+  try
+  {
+    commandLineOptions = &commandLineParser.ParseCommandLineArguments(argc, argv);
+  }
+  catch(const CommandLineParser::Exception& e)
+  {
+    std::cerr << e.what() << std::endl;
+    exit(EXIT_FAILURE);
+  }
 
-  auto commandGraph = JlcCommandGraphGenerator::Generate(commandLineOptions);
+  auto commandGraph = JlcCommandGraphGenerator::Generate(*commandLineOptions);
   commandGraph->Run();
 
   return 0;


### PR DESCRIPTION
This fixes a jlc command line parsing bug where an invalid jlm-opt optimization did not lead to a command line parsing error.