### PR TITLE
Move jlm-opt logic into JlmOptCommand class

### DIFF
--- a/jlm/tooling/Command.cpp
+++ b/jlm/tooling/Command.cpp
@@ -247,16 +247,30 @@ JlmOptCommand::~JlmOptCommand()
 std::string
 JlmOptCommand::ToString() const
 {
+  /*
+   * There is currently no need to support statistics gathering here.
+   */
+  JLM_ASSERT(CommandLineOptions_.GetStatisticsCollectorSettings().NumDemandedStatistics() == 0);
+
   std::string optimizationArguments;
-  for (auto & optimization : Optimizations_)
+  for (auto & optimization : CommandLineOptions_.GetOptimizationIds())
     optimizationArguments += "--" + std::string(JlmOptCommandLineOptions::ToCommandLineArgument(optimization)) + " ";
+
+  auto outputFormatArgument =
+    "--"
+    + std::string(JlmOptCommandLineOptions::ToCommandLineArgument(CommandLineOptions_.GetOutputFormat()))
+    + " ";
+
+  auto outputFileArgument = !CommandLineOptions_.GetOutputFile().to_str().empty()
+    ? "-o " + CommandLineOptions_.GetOutputFile().to_str() + " "
+    : "";
 
   return util::strfmt(
     "jlm-opt ",
-    "--llvm ",
+    outputFormatArgument,
     optimizationArguments,
-    "-o ", OutputFile_.to_str(), " ",
-    InputFile_.to_str());
+    outputFileArgument,
+    CommandLineOptions_.GetInputFile().to_str());
 }
 
 void

--- a/jlm/tooling/Command.cpp
+++ b/jlm/tooling/Command.cpp
@@ -249,7 +249,7 @@ JlmOptCommand::ToString() const
 {
   std::string optimizationArguments;
   for (auto & optimization : Optimizations_)
-    optimizationArguments += ToString(optimization) + " ";
+    optimizationArguments += "--" + std::string(JlmOptCommandLineOptions::ToCommandLineArgument(optimization)) + " ";
 
   return util::strfmt(
     "jlm-opt ",
@@ -264,28 +264,6 @@ JlmOptCommand::Run() const
 {
   if (system(ToString().c_str()))
     exit(EXIT_FAILURE);
-}
-
-std::string
-JlmOptCommand::ToString(const Optimization & optimization)
-{
-  static std::unordered_map<Optimization, const char*>
-    map({
-          {Optimization::AASteensgaardAgnostic,     "--AASteensgaardAgnostic"},
-          {Optimization::AASteensgaardRegionAware,  "--AASteensgaardRegionAware"},
-          {Optimization::CommonNodeElimination,     "--cne"},
-          {Optimization::DeadNodeElimination,       "--dne"},
-          {Optimization::FunctionInlining,          "--iln"},
-          {Optimization::InvariantValueRedirection, "--InvariantValueRedirection"},
-          {Optimization::LoopUnrolling,             "--url"},
-          {Optimization::NodePullIn,                "--pll"},
-          {Optimization::NodePushOut,               "--psh"},
-          {Optimization::NodeReduction,             "--red"},
-          {Optimization::ThetaGammaInversion,       "--ivt"}
-        });
-
-  JLM_ASSERT(map.find(optimization) != map.end());
-  return map[optimization];
 }
 
 MkdirCommand::~MkdirCommand() noexcept

--- a/jlm/tooling/Command.cpp
+++ b/jlm/tooling/Command.cpp
@@ -3,9 +3,22 @@
  * See COPYING for terms of redistribution.
  */
 
+#include <jlm/llvm/backend/rvsdg2jlm/rvsdg2jlm.hpp>
+#include <jlm/llvm/backend/jlm2llvm/jlm2llvm.hpp>
+#include <jlm/llvm/frontend/InterProceduralGraphConversion.hpp>
+#include <jlm/llvm/frontend/LlvmModuleConversion.hpp>
+#include <jlm/llvm/ir/ipgraph-module.hpp>
+#include <jlm/llvm/ir/RvsdgModule.hpp>
+#include <jlm/llvm/opt/OptimizationSequence.hpp>
 #include <jlm/tooling/Command.hpp>
 #include <jlm/tooling/CommandPaths.hpp>
-#include <jlm/util/strfmt.hpp>
+#include <jlm/rvsdg/view.hpp>
+
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IRReader/IRReader.h>
+#include <llvm/Support/raw_os_ostream.h>
+#include <llvm/Support/SourceMgr.h>
 
 #include <sys/stat.h>
 
@@ -266,7 +279,7 @@ JlmOptCommand::ToString() const
     : "";
 
   return util::strfmt(
-    "jlm-opt ",
+    ProgramName_ + " ",
     outputFormatArgument,
     optimizationArguments,
     outputFileArgument,
@@ -276,8 +289,106 @@ JlmOptCommand::ToString() const
 void
 JlmOptCommand::Run() const
 {
-  if (system(ToString().c_str()))
-    exit(EXIT_FAILURE);
+  ::llvm::LLVMContext llvmContext;
+  auto llvmModule = ParseLlvmIrFile(
+    CommandLineOptions_.GetInputFile(),
+    llvmContext);
+
+  auto interProceduralGraphModule = llvm::ConvertLlvmModule(*llvmModule);
+
+  /*
+   * Dispose of Llvm module. It is no longer needed.
+   */
+  llvmModule.reset();
+
+  jlm::util::StatisticsCollector statisticsCollector(CommandLineOptions_.GetStatisticsCollectorSettings());
+
+  auto rvsdgModule = llvm::ConvertInterProceduralGraphModule(
+    *interProceduralGraphModule,
+    statisticsCollector);
+
+  llvm::OptimizationSequence::CreateAndRun(
+    *rvsdgModule,
+    statisticsCollector,
+    CommandLineOptions_.GetOptimizations());
+
+  PrintRvsdgModule(
+    *rvsdgModule,
+    CommandLineOptions_.GetOutputFile(),
+    CommandLineOptions_.GetOutputFormat(),
+    statisticsCollector);
+
+  statisticsCollector.PrintStatistics();
+}
+
+std::unique_ptr<::llvm::Module>
+JlmOptCommand::ParseLlvmIrFile(
+  const util::filepath & llvmIrFile,
+  ::llvm::LLVMContext & llvmContext) const
+{
+  ::llvm::SMDiagnostic diagnostic;
+  if (auto module = ::llvm::parseIRFile(llvmIrFile.to_str(), diagnostic, llvmContext))
+  {
+    return module;
+  }
+
+  std::string errors;
+  ::llvm::raw_string_ostream os(errors);
+  diagnostic.print(ProgramName_.c_str(), os);
+  throw util::error(errors);
+}
+
+void
+JlmOptCommand::PrintRvsdgModule(
+  const llvm::RvsdgModule & rvsdgModule,
+  const util::filepath & outputFile,
+  const JlmOptCommandLineOptions::OutputFormat & outputFormat,
+  util::StatisticsCollector & statisticsCollector)
+{
+  auto printAsXml = [](
+    const llvm::RvsdgModule & rvsdgModule,
+    const util::filepath & outputFile,
+    util::StatisticsCollector&)
+  {
+    auto fd = outputFile == "" ? stdout : fopen(outputFile.to_str().c_str(), "w");
+
+    jlm::rvsdg::view_xml(rvsdgModule.Rvsdg().root(), fd);
+
+    if (fd != stdout)
+      fclose(fd);
+  };
+
+  auto printAsLlvm = [](
+    const llvm::RvsdgModule & rvsdgModule,
+    const util::filepath & outputFile,
+    util::StatisticsCollector & statisticsCollector)
+  {
+    auto jlm_module = llvm::rvsdg2jlm::rvsdg2jlm(rvsdgModule, statisticsCollector);
+
+    ::llvm::LLVMContext ctx;
+    auto llvm_module = jlm::llvm::jlm2llvm::convert(*jlm_module, ctx);
+
+    if (outputFile == "") {
+      ::llvm::raw_os_ostream os(std::cout);
+      llvm_module->print(os, nullptr);
+    } else {
+      std::error_code ec;
+      ::llvm::raw_fd_ostream os(outputFile.to_str(), ec);
+      llvm_module->print(os, nullptr);
+    }
+  };
+
+  static std::unordered_map<
+    JlmOptCommandLineOptions::OutputFormat,
+    std::function<void(const llvm::RvsdgModule&, const util::filepath&, util::StatisticsCollector&)>
+  > printers(
+    {
+      {tooling::JlmOptCommandLineOptions::OutputFormat::Xml,  printAsXml},
+      {tooling::JlmOptCommandLineOptions::OutputFormat::Llvm, printAsLlvm}
+    });
+
+  JLM_ASSERT(printers.find(outputFormat) != printers.end());
+  printers[outputFormat](rvsdgModule, outputFile, statisticsCollector);
 }
 
 MkdirCommand::~MkdirCommand() noexcept

--- a/jlm/tooling/Command.hpp
+++ b/jlm/tooling/Command.hpp
@@ -10,6 +10,8 @@
 #include <jlm/tooling/CommandLine.hpp>
 #include <jlm/util/file.hpp>
 
+#include <llvm/IR/Module.h>
+
 #include <memory>
 #include <string>
 
@@ -341,9 +343,11 @@ class JlmOptCommand final : public Command {
 public:
   ~JlmOptCommand() override;
 
-  explicit
-  JlmOptCommand(JlmOptCommandLineOptions commandLineOptions)
-    : CommandLineOptions_(std::move(commandLineOptions))
+  JlmOptCommand(
+    std::string programName,
+    JlmOptCommandLineOptions commandLineOptions)
+    : ProgramName_(std::move(programName)),
+      CommandLineOptions_(std::move(commandLineOptions))
   {}
 
   [[nodiscard]] std::string
@@ -355,9 +359,12 @@ public:
   static CommandGraph::Node &
   Create(
     CommandGraph & commandGraph,
+    std::string programName,
     JlmOptCommandLineOptions commandLineOptions)
   {
-    auto command = std::make_unique<JlmOptCommand>(std::move(commandLineOptions));
+    auto command = std::make_unique<JlmOptCommand>(
+      std::move(programName),
+      std::move(commandLineOptions));
     return CommandGraph::Node::Create(commandGraph, std::move(command));
   }
 
@@ -368,6 +375,19 @@ public:
   }
 
 private:
+  std::unique_ptr<::llvm::Module>
+  ParseLlvmIrFile(
+    const util::filepath & llvmIrFile,
+    ::llvm::LLVMContext & llvmContext) const;
+
+  static void
+  PrintRvsdgModule(
+    const llvm::RvsdgModule & rvsdgModule,
+    const util::filepath & outputFile,
+    const JlmOptCommandLineOptions::OutputFormat & outputFormat,
+    util::StatisticsCollector & statisticsCollector);
+
+  std::string ProgramName_;
   JlmOptCommandLineOptions CommandLineOptions_;
 };
 

--- a/jlm/tooling/Command.hpp
+++ b/jlm/tooling/Command.hpp
@@ -7,6 +7,7 @@
 #define JLM_TOOLING_COMMAND_HPP
 
 #include <jlm/tooling/CommandGraph.hpp>
+#include <jlm/tooling/CommandLine.hpp>
 #include <jlm/util/file.hpp>
 
 #include <memory>
@@ -338,26 +339,12 @@ private:
  */
 class JlmOptCommand final : public Command {
 public:
-  enum class Optimization {
-    AASteensgaardAgnostic,
-    AASteensgaardRegionAware,
-    CommonNodeElimination,
-    DeadNodeElimination,
-    FunctionInlining,
-    InvariantValueRedirection,
-    LoopUnrolling,
-    NodePullIn,
-    NodePushOut,
-    NodeReduction,
-    ThetaGammaInversion
-  };
-
   ~JlmOptCommand() override;
 
   JlmOptCommand(
     util::filepath inputFile,
     util::filepath outputFile,
-    std::vector<Optimization> optimizations)
+    std::vector<JlmOptCommandLineOptions::OptimizationId> optimizations)
     : InputFile_(std::move(inputFile))
     , OutputFile_(std::move(outputFile))
     , Optimizations_(std::move(optimizations))
@@ -372,23 +359,27 @@ public:
   static CommandGraph::Node &
   Create(
     CommandGraph & commandGraph,
-    const util::filepath & inputFile,
-    const util::filepath & outputFile,
-    const std::vector<Optimization> & optimizations)
+    util::filepath inputFile,
+    util::filepath outputFile,
+    std::vector<JlmOptCommandLineOptions::OptimizationId> optimizations)
   {
-    std::unique_ptr<JlmOptCommand> command(new JlmOptCommand(inputFile, outputFile, optimizations));
+    auto command = std::make_unique<JlmOptCommand>(
+      std::move(inputFile),
+      std::move(outputFile),
+      std::move(optimizations));
     return CommandGraph::Node::Create(commandGraph, std::move(command));
   }
 
-  const std::vector<Optimization> &Optimizations() const noexcept { return Optimizations_; }
+  [[nodiscard]] const std::vector<JlmOptCommandLineOptions::OptimizationId>&
+  Optimizations() const noexcept
+  {
+    return Optimizations_;
+  }
 
 private:
-  static std::string
-  ToString(const Optimization & optimization);
-
   util::filepath InputFile_;
   util::filepath OutputFile_;
-  std::vector<Optimization> Optimizations_;
+  std::vector<JlmOptCommandLineOptions::OptimizationId> Optimizations_;
 };
 
 /**

--- a/jlm/tooling/Command.hpp
+++ b/jlm/tooling/Command.hpp
@@ -341,13 +341,9 @@ class JlmOptCommand final : public Command {
 public:
   ~JlmOptCommand() override;
 
-  JlmOptCommand(
-    util::filepath inputFile,
-    util::filepath outputFile,
-    std::vector<JlmOptCommandLineOptions::OptimizationId> optimizations)
-    : InputFile_(std::move(inputFile))
-    , OutputFile_(std::move(outputFile))
-    , Optimizations_(std::move(optimizations))
+  explicit
+  JlmOptCommand(JlmOptCommandLineOptions commandLineOptions)
+    : CommandLineOptions_(std::move(commandLineOptions))
   {}
 
   [[nodiscard]] std::string
@@ -359,27 +355,20 @@ public:
   static CommandGraph::Node &
   Create(
     CommandGraph & commandGraph,
-    util::filepath inputFile,
-    util::filepath outputFile,
-    std::vector<JlmOptCommandLineOptions::OptimizationId> optimizations)
+    JlmOptCommandLineOptions commandLineOptions)
   {
-    auto command = std::make_unique<JlmOptCommand>(
-      std::move(inputFile),
-      std::move(outputFile),
-      std::move(optimizations));
+    auto command = std::make_unique<JlmOptCommand>(std::move(commandLineOptions));
     return CommandGraph::Node::Create(commandGraph, std::move(command));
   }
 
-  [[nodiscard]] const std::vector<JlmOptCommandLineOptions::OptimizationId>&
-  Optimizations() const noexcept
+  [[nodiscard]] const JlmOptCommandLineOptions&
+  GetCommandLineOptions() const noexcept
   {
-    return Optimizations_;
+    return CommandLineOptions_;
   }
 
 private:
-  util::filepath InputFile_;
-  util::filepath OutputFile_;
-  std::vector<JlmOptCommandLineOptions::OptimizationId> Optimizations_;
+  JlmOptCommandLineOptions CommandLineOptions_;
 };
 
 /**

--- a/jlm/tooling/CommandGraphGenerator.cpp
+++ b/jlm/tooling/CommandGraphGenerator.cpp
@@ -114,11 +114,16 @@ JlcCommandGraphGenerator::GenerateCommandGraph(const JlcCommandLineOptions & com
 
     if (compilation.RequiresOptimization())
     {
-      auto & jlmOptCommandNode = JlmOptCommand::Create(
-        *commandGraph,
+      JlmOptCommandLineOptions jlmOptCommandLineOptions(
         CreateParserCommandOutputFile(compilation.InputFile()),
         CreateJlmOptCommandOutputFile(compilation.InputFile()),
+        JlmOptCommandLineOptions::OutputFormat::Llvm,
+        util::StatisticsCollectorSettings(),
         commandLineOptions.JlmOptOptimizations_);
+
+      auto & jlmOptCommandNode = JlmOptCommand::Create(
+        *commandGraph,
+        std::move(jlmOptCommandLineOptions));
       lastNode->AddEdge(jlmOptCommandNode);
       lastNode = &jlmOptCommandNode;
     }

--- a/jlm/tooling/CommandGraphGenerator.cpp
+++ b/jlm/tooling/CommandGraphGenerator.cpp
@@ -123,6 +123,7 @@ JlcCommandGraphGenerator::GenerateCommandGraph(const JlcCommandLineOptions & com
 
       auto & jlmOptCommandNode = JlmOptCommand::Create(
         *commandGraph,
+        "jlm-opt",
         std::move(jlmOptCommandLineOptions));
       lastNode->AddEdge(jlmOptCommandNode);
       lastNode = &jlmOptCommandNode;

--- a/jlm/tooling/CommandGraphGenerator.cpp
+++ b/jlm/tooling/CommandGraphGenerator.cpp
@@ -114,48 +114,11 @@ JlcCommandGraphGenerator::GenerateCommandGraph(const JlcCommandLineOptions & com
 
     if (compilation.RequiresOptimization())
     {
-      std::vector<JlmOptCommandLineOptions::OptimizationId> optimizations;
-      if (!commandLineOptions.JlmOptOptimizations_.empty())
-      {
-        optimizations = commandLineOptions.JlmOptOptimizations_;
-        /*
-         * If a default optimization level has been specified (-O) and no specific jlm options
-         * have been specified (-J) then use a default set of optimizations.
-         */
-      }
-      else if (commandLineOptions.JlmOptOptimizations_.empty()
-          && commandLineOptions.OptimizationLevel_ == JlcCommandLineOptions::OptimizationLevel::O3)
-      {
-        /*
-         * Only -O3 sets default optimizations
-         */
-        optimizations = {
-          JlmOptCommandLineOptions::OptimizationId::iln,
-          JlmOptCommandLineOptions::OptimizationId::InvariantValueRedirection,
-          JlmOptCommandLineOptions::OptimizationId::red,
-          JlmOptCommandLineOptions::OptimizationId::dne,
-          JlmOptCommandLineOptions::OptimizationId::ivt,
-          JlmOptCommandLineOptions::OptimizationId::InvariantValueRedirection,
-          JlmOptCommandLineOptions::OptimizationId::dne,
-          JlmOptCommandLineOptions::OptimizationId::psh,
-          JlmOptCommandLineOptions::OptimizationId::InvariantValueRedirection,
-          JlmOptCommandLineOptions::OptimizationId::dne,
-          JlmOptCommandLineOptions::OptimizationId::red,
-          JlmOptCommandLineOptions::OptimizationId::cne,
-          JlmOptCommandLineOptions::OptimizationId::dne,
-          JlmOptCommandLineOptions::OptimizationId::pll,
-          JlmOptCommandLineOptions::OptimizationId::InvariantValueRedirection,
-          JlmOptCommandLineOptions::OptimizationId::dne,
-          JlmOptCommandLineOptions::OptimizationId::url,
-          JlmOptCommandLineOptions::OptimizationId::InvariantValueRedirection
-        };
-      }
-
       auto & jlmOptCommandNode = JlmOptCommand::Create(
         *commandGraph,
         CreateParserCommandOutputFile(compilation.InputFile()),
         CreateJlmOptCommandOutputFile(compilation.InputFile()),
-        optimizations);
+        commandLineOptions.JlmOptOptimizations_);
       lastNode->AddEdge(jlmOptCommandNode);
       lastNode = &jlmOptCommandNode;
     }

--- a/jlm/tooling/CommandGraphGenerator.cpp
+++ b/jlm/tooling/CommandGraphGenerator.cpp
@@ -114,91 +114,40 @@ JlcCommandGraphGenerator::GenerateCommandGraph(const JlcCommandLineOptions & com
 
     if (compilation.RequiresOptimization())
     {
-      std::vector<JlmOptCommand::Optimization> optimizations;
+      std::vector<JlmOptCommandLineOptions::OptimizationId> optimizations;
       if (!commandLineOptions.JlmOptOptimizations_.empty())
       {
-        static std::unordered_map<JlmOptCommandLineOptions::OptimizationId, JlmOptCommand::Optimization> map(
-          {
-            {
-              JlmOptCommandLineOptions::OptimizationId::AASteensgaardAgnostic,
-              JlmOptCommand::Optimization::AASteensgaardAgnostic
-            },
-            {
-              JlmOptCommandLineOptions::OptimizationId::AASteensgaardRegionAware,
-              JlmOptCommand::Optimization::AASteensgaardRegionAware
-            },
-            {
-              JlmOptCommandLineOptions::OptimizationId::cne,
-              JlmOptCommand::Optimization::CommonNodeElimination
-            },
-            {
-              JlmOptCommandLineOptions::OptimizationId::dne,
-              JlmOptCommand::Optimization::DeadNodeElimination
-            },
-            {
-              JlmOptCommandLineOptions::OptimizationId::iln,
-              JlmOptCommand::Optimization::FunctionInlining
-            },
-            {
-              JlmOptCommandLineOptions::OptimizationId::InvariantValueRedirection,
-              JlmOptCommand::Optimization::InvariantValueRedirection
-            },
-            {
-              JlmOptCommandLineOptions::OptimizationId::psh,
-              JlmOptCommand::Optimization::NodePushOut
-            },
-            {
-              JlmOptCommandLineOptions::OptimizationId::pll,
-              JlmOptCommand::Optimization::NodePullIn
-            },
-            {
-              JlmOptCommandLineOptions::OptimizationId::red,
-              JlmOptCommand::Optimization::NodeReduction
-            },
-            {
-              JlmOptCommandLineOptions::OptimizationId::ivt,
-              JlmOptCommand::Optimization::ThetaGammaInversion
-            },
-            {
-              JlmOptCommandLineOptions::OptimizationId::url,
-              JlmOptCommand::Optimization::LoopUnrolling},
-          });
-
-        for (const auto & jlmOpt : commandLineOptions.JlmOptOptimizations_)
-        {
-          JLM_ASSERT(map.find(jlmOpt) != map.end());
-          optimizations.push_back(map[jlmOpt]);
-        }
-
+        optimizations = commandLineOptions.JlmOptOptimizations_;
         /*
          * If a default optimization level has been specified (-O) and no specific jlm options
          * have been specified (-J) then use a default set of optimizations.
          */
-      } else if (commandLineOptions.JlmOptOptimizations_.empty()
+      }
+      else if (commandLineOptions.JlmOptOptimizations_.empty()
           && commandLineOptions.OptimizationLevel_ == JlcCommandLineOptions::OptimizationLevel::O3)
       {
         /*
          * Only -O3 sets default optimizations
          */
         optimizations = {
-          JlmOptCommand::Optimization::FunctionInlining,
-          JlmOptCommand::Optimization::InvariantValueRedirection,
-          JlmOptCommand::Optimization::NodeReduction,
-          JlmOptCommand::Optimization::DeadNodeElimination,
-          JlmOptCommand::Optimization::ThetaGammaInversion,
-          JlmOptCommand::Optimization::InvariantValueRedirection,
-          JlmOptCommand::Optimization::DeadNodeElimination,
-          JlmOptCommand::Optimization::NodePushOut,
-          JlmOptCommand::Optimization::InvariantValueRedirection,
-          JlmOptCommand::Optimization::DeadNodeElimination,
-          JlmOptCommand::Optimization::NodeReduction,
-          JlmOptCommand::Optimization::CommonNodeElimination,
-          JlmOptCommand::Optimization::DeadNodeElimination,
-          JlmOptCommand::Optimization::NodePullIn,
-          JlmOptCommand::Optimization::InvariantValueRedirection,
-          JlmOptCommand::Optimization::DeadNodeElimination,
-          JlmOptCommand::Optimization::LoopUnrolling,
-          JlmOptCommand::Optimization::InvariantValueRedirection
+          JlmOptCommandLineOptions::OptimizationId::iln,
+          JlmOptCommandLineOptions::OptimizationId::InvariantValueRedirection,
+          JlmOptCommandLineOptions::OptimizationId::red,
+          JlmOptCommandLineOptions::OptimizationId::dne,
+          JlmOptCommandLineOptions::OptimizationId::ivt,
+          JlmOptCommandLineOptions::OptimizationId::InvariantValueRedirection,
+          JlmOptCommandLineOptions::OptimizationId::dne,
+          JlmOptCommandLineOptions::OptimizationId::psh,
+          JlmOptCommandLineOptions::OptimizationId::InvariantValueRedirection,
+          JlmOptCommandLineOptions::OptimizationId::dne,
+          JlmOptCommandLineOptions::OptimizationId::red,
+          JlmOptCommandLineOptions::OptimizationId::cne,
+          JlmOptCommandLineOptions::OptimizationId::dne,
+          JlmOptCommandLineOptions::OptimizationId::pll,
+          JlmOptCommandLineOptions::OptimizationId::InvariantValueRedirection,
+          JlmOptCommandLineOptions::OptimizationId::dne,
+          JlmOptCommandLineOptions::OptimizationId::url,
+          JlmOptCommandLineOptions::OptimizationId::InvariantValueRedirection
         };
       }
 

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -95,7 +95,21 @@ JlmOptCommandLineOptions::Reset() noexcept
   OutputFile_ = util::filepath("");
   OutputFormat_ = OutputFormat::Llvm;
   StatisticsCollectorSettings_ = util::StatisticsCollectorSettings();
-  Optimizations_.clear();
+  OptimizationIds_.clear();
+}
+
+std::vector<llvm::optimization*>
+JlmOptCommandLineOptions::GetOptimizations() const noexcept
+{
+  std::vector<llvm::optimization*> optimizations;
+  optimizations.reserve(OptimizationIds_.size());
+
+  for (auto & optimizationId: OptimizationIds_)
+  {
+    optimizations.emplace_back(GetOptimization(optimizationId));
+  }
+
+  return optimizations;
 }
 
 JlmOptCommandLineOptions::OptimizationId
@@ -671,16 +685,12 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, char **argv)
   util::HashSet<util::Statistics::Id> demandedStatistics({printStatistics.begin(), printStatistics.end()});
   statisticsCollectorSettings.SetDemandedStatistics(std::move(demandedStatistics));
 
-  std::vector<llvm::optimization*> optimizations;
-  for (auto &optimizationId: optimizationIds)
-    optimizations.push_back(JlmOptCommandLineOptions::GetOptimization(optimizationId));
-
   CommandLineOptions_ = JlmOptCommandLineOptions::Create(
     inputFile,
     outputFile,
     outputFormat,
     std::move(statisticsCollectorSettings),
-    std::move(optimizations));
+    std::move(optimizationIds));
 
   return *CommandLineOptions_;
 }

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -225,8 +225,36 @@ JlcCommandLineParser::~JlcCommandLineParser() noexcept
 const JlcCommandLineOptions &
 JlcCommandLineParser::ParseCommandLineArguments(int argc, char **argv)
 {
-  auto checkAndConvertJlmOptOptimizations = [](const ::llvm::cl::list<std::string>& optimizations)
+  auto checkAndConvertJlmOptOptimizations = [](
+    const ::llvm::cl::list<std::string>& optimizations,
+    JlcCommandLineOptions::OptimizationLevel optimizationLevel)
   {
+    if (optimizations.empty()
+        && optimizationLevel == JlcCommandLineOptions::OptimizationLevel::O3)
+    {
+      return std::vector<JlmOptCommandLineOptions::OptimizationId>
+        ({
+           JlmOptCommandLineOptions::OptimizationId::iln,
+           JlmOptCommandLineOptions::OptimizationId::InvariantValueRedirection,
+           JlmOptCommandLineOptions::OptimizationId::red,
+           JlmOptCommandLineOptions::OptimizationId::dne,
+           JlmOptCommandLineOptions::OptimizationId::ivt,
+           JlmOptCommandLineOptions::OptimizationId::InvariantValueRedirection,
+           JlmOptCommandLineOptions::OptimizationId::dne,
+           JlmOptCommandLineOptions::OptimizationId::psh,
+           JlmOptCommandLineOptions::OptimizationId::InvariantValueRedirection,
+           JlmOptCommandLineOptions::OptimizationId::dne,
+           JlmOptCommandLineOptions::OptimizationId::red,
+           JlmOptCommandLineOptions::OptimizationId::cne,
+           JlmOptCommandLineOptions::OptimizationId::dne,
+           JlmOptCommandLineOptions::OptimizationId::pll,
+           JlmOptCommandLineOptions::OptimizationId::InvariantValueRedirection,
+           JlmOptCommandLineOptions::OptimizationId::dne,
+           JlmOptCommandLineOptions::OptimizationId::url,
+           JlmOptCommandLineOptions::OptimizationId::InvariantValueRedirection
+         });
+    }
+
     std::vector<JlmOptCommandLineOptions::OptimizationId> optimizationIds;
     for (auto & optimization : optimizations)
     {
@@ -426,6 +454,10 @@ JlcCommandLineParser::ParseCommandLineArguments(int argc, char **argv)
     exit(EXIT_FAILURE);
   }
 
+  auto jlmOptOptimizations = checkAndConvertJlmOptOptimizations(
+    jlmOptimizations,
+    CommandLineOptions_.OptimizationLevel_);
+
   CommandLineOptions_.Libraries_ = libraries;
   CommandLineOptions_.MacroDefinitions_ = macroDefinitions;
   CommandLineOptions_.LibraryPaths_ = libraryPaths;
@@ -434,7 +466,7 @@ JlcCommandLineParser::ParseCommandLineArguments(int argc, char **argv)
   CommandLineOptions_.OnlyPrintCommands_ = onlyPrintCommands;
   CommandLineOptions_.GenerateDebugInformation_ = generateDebugInformation;
   CommandLineOptions_.Flags_ = flags;
-  CommandLineOptions_.JlmOptOptimizations_ = checkAndConvertJlmOptOptimizations(jlmOptimizations);
+  CommandLineOptions_.JlmOptOptimizations_ = jlmOptOptimizations;
   CommandLineOptions_.Verbose_ = verbose;
   CommandLineOptions_.Rdynamic_ = rDynamic;
   CommandLineOptions_.Suppress_ = suppress;

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -160,6 +160,21 @@ JlmOptCommandLineOptions::ToCommandLineArgument(OptimizationId optimizationId)
   throw util::error("Unknown optimization identifier");
 }
 
+const char*
+JlmOptCommandLineOptions::ToCommandLineArgument(OutputFormat outputFormat)
+{
+  static std::unordered_map<OutputFormat, const char*> map(
+    {
+      {OutputFormat::Llvm, "llvm"},
+      {OutputFormat::Xml,  "xml"}
+    });
+
+  if (map.find(outputFormat) != map.end())
+    return map[outputFormat];
+
+  throw util::error("Unknown output format");
+}
+
 llvm::optimization *
 JlmOptCommandLineOptions::GetOptimization(enum OptimizationId id)
 {
@@ -637,17 +652,20 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, char **argv)
         "Write theta-gamma inversion statistics to file.")),
     cl::desc("Write statistics"));
 
+  auto llvmOutputFormat = JlmOptCommandLineOptions::OutputFormat::Llvm;
+  auto xmlOutputFormat = JlmOptCommandLineOptions::OutputFormat::Xml;
+
   cl::opt<JlmOptCommandLineOptions::OutputFormat> outputFormat(
     cl::values(
       ::clEnumValN(
-        JlmOptCommandLineOptions::OutputFormat::Llvm,
-        "llvm",
+        llvmOutputFormat,
+        JlmOptCommandLineOptions::ToCommandLineArgument(llvmOutputFormat),
         "Output LLVM IR [default]"),
       ::clEnumValN(
-        JlmOptCommandLineOptions::OutputFormat::Xml,
-        "xml",
+        xmlOutputFormat,
+        JlmOptCommandLineOptions::ToCommandLineArgument(xmlOutputFormat),
         "Output XML")),
-    cl::init(JlmOptCommandLineOptions::OutputFormat::Llvm),
+    cl::init(llvmOutputFormat),
     cl::desc("Select output format"));
 
   auto aASteensgaardAgnostic = JlmOptCommandLineOptions::OptimizationId::AASteensgaardAgnostic;

--- a/jlm/tooling/CommandLine.hpp
+++ b/jlm/tooling/CommandLine.hpp
@@ -64,14 +64,51 @@ public:
     LastEnumValue // must always be the last enum value, used for iteration
   };
 
-  JlmOptCommandLineOptions()
-    : InputFile_("")
-    , OutputFile_("")
-    , OutputFormat_(OutputFormat::Llvm)
+  JlmOptCommandLineOptions(
+    util::filepath inputFile,
+    util::filepath outputFile,
+    OutputFormat outputFormat,
+    util::StatisticsCollectorSettings statisticsCollectorSettings,
+    std::vector<jlm::llvm::optimization*> optimizations)
+    : InputFile_(std::move(inputFile))
+    , OutputFile_(std::move(outputFile))
+    , OutputFormat_(outputFormat)
+    , StatisticsCollectorSettings_(std::move(statisticsCollectorSettings))
+    , Optimizations_(std::move(optimizations))
   {}
 
   void
   Reset() noexcept override;
+
+  [[nodiscard]] const util::filepath&
+  GetInputFile() const noexcept
+  {
+    return InputFile_;
+  }
+
+  [[nodiscard]] const util::filepath&
+  GetOutputFile() const noexcept
+  {
+    return OutputFile_;
+  }
+
+  [[nodiscard]] OutputFormat
+  GetOutputFormat() const noexcept
+  {
+    return OutputFormat_;
+  }
+
+  [[nodiscard]] const util::StatisticsCollectorSettings &
+  GetStatisticsCollectorSettings() const noexcept
+  {
+    return StatisticsCollectorSettings_;
+  }
+
+  [[nodiscard]] const std::vector<jlm::llvm::optimization*> &
+  GetOptimizations() const noexcept
+  {
+    return Optimizations_;
+  }
 
   static OptimizationId
   FromCommandLineArgument(const std::string& commandLineArgument);
@@ -82,13 +119,29 @@ public:
   static llvm::optimization *
   GetOptimization(enum OptimizationId optimizationId);
 
+  static std::unique_ptr<JlmOptCommandLineOptions>
+  Create(
+    util::filepath inputFile,
+    util::filepath outputFile,
+    OutputFormat outputFormat,
+    util::StatisticsCollectorSettings statisticsCollectorSettings,
+    std::vector<jlm::llvm::optimization*> optimizations)
+  {
+    return std::make_unique<JlmOptCommandLineOptions>(
+      std::move(inputFile),
+      std::move(outputFile),
+      outputFormat,
+      std::move(statisticsCollectorSettings),
+      std::move(optimizations));
+  }
+
+private:
   util::filepath InputFile_;
   util::filepath OutputFile_;
   OutputFormat OutputFormat_;
   util::StatisticsCollectorSettings StatisticsCollectorSettings_;
   std::vector<jlm::llvm::optimization*> Optimizations_;
 
-private:
   inline static const char* AaSteensgaardAgnosticCommandLineArgument_ = "AASteensgaardAgnostic";
   inline static const char* AaSteensgaardRegionAwareCommandLineArgument_ = "AASteensgaardRegionAware";
   inline static const char* CommonNodeEliminationCommandLineArgument_ = "cne";
@@ -521,7 +574,7 @@ public:
   Parse(int argc, char ** argv);
 
 private:
-  JlmOptCommandLineOptions CommandLineOptions_;
+  std::unique_ptr<JlmOptCommandLineOptions> CommandLineOptions_;
 };
 
 /**

--- a/jlm/tooling/CommandLine.hpp
+++ b/jlm/tooling/CommandLine.hpp
@@ -119,6 +119,9 @@ public:
   static const char*
   ToCommandLineArgument(OptimizationId optimizationId);
 
+  static const char*
+  ToCommandLineArgument(OutputFormat outputFormat);
+
   static llvm::optimization *
   GetOptimization(enum OptimizationId optimizationId);
 

--- a/jlm/tooling/CommandLine.hpp
+++ b/jlm/tooling/CommandLine.hpp
@@ -69,12 +69,12 @@ public:
     util::filepath outputFile,
     OutputFormat outputFormat,
     util::StatisticsCollectorSettings statisticsCollectorSettings,
-    std::vector<jlm::llvm::optimization*> optimizations)
+    std::vector<OptimizationId> optimizations)
     : InputFile_(std::move(inputFile))
     , OutputFile_(std::move(outputFile))
     , OutputFormat_(outputFormat)
     , StatisticsCollectorSettings_(std::move(statisticsCollectorSettings))
-    , Optimizations_(std::move(optimizations))
+    , OptimizationIds_(std::move(optimizations))
   {}
 
   void
@@ -104,11 +104,14 @@ public:
     return StatisticsCollectorSettings_;
   }
 
-  [[nodiscard]] const std::vector<jlm::llvm::optimization*> &
-  GetOptimizations() const noexcept
+  [[nodiscard]] const std::vector<OptimizationId> &
+  GetOptimizationIds() const noexcept
   {
-    return Optimizations_;
+    return OptimizationIds_;
   }
+
+  [[nodiscard]] std::vector<llvm::optimization*>
+  GetOptimizations() const noexcept;
 
   static OptimizationId
   FromCommandLineArgument(const std::string& commandLineArgument);
@@ -125,7 +128,7 @@ public:
     util::filepath outputFile,
     OutputFormat outputFormat,
     util::StatisticsCollectorSettings statisticsCollectorSettings,
-    std::vector<jlm::llvm::optimization*> optimizations)
+    std::vector<OptimizationId> optimizations)
   {
     return std::make_unique<JlmOptCommandLineOptions>(
       std::move(inputFile),
@@ -140,7 +143,7 @@ private:
   util::filepath OutputFile_;
   OutputFormat OutputFormat_;
   util::StatisticsCollectorSettings StatisticsCollectorSettings_;
-  std::vector<jlm::llvm::optimization*> Optimizations_;
+  std::vector<OptimizationId> OptimizationIds_;
 
   inline static const char* AaSteensgaardAgnosticCommandLineArgument_ = "AASteensgaardAgnostic";
   inline static const char* AaSteensgaardRegionAwareCommandLineArgument_ = "AASteensgaardRegionAware";

--- a/jlm/util/Statistics.hpp
+++ b/jlm/util/Statistics.hpp
@@ -109,6 +109,12 @@ public:
     DemandedStatistics_ = std::move(demandedStatistics);
   }
 
+  [[nodiscard]] size_t
+  NumDemandedStatistics() const noexcept
+  {
+    return DemandedStatistics_.Size();
+  }
+
 private:
   filepath FilePath_;
   HashSet<Statistics::Id> DemandedStatistics_;

--- a/tests/jlm/tooling/TestJlcCommandGraphGenerator.cpp
+++ b/tests/jlm/tooling/TestJlcCommandGraphGenerator.cpp
@@ -110,7 +110,8 @@ TestJlmOptOptimizations()
    */
   auto & clangCommandNode = (*commandGraph->GetEntryNode().OutgoingEdges().begin()).GetSink();
   auto & jlmOptCommandNode = (clangCommandNode.OutgoingEdges().begin())->GetSink();
-  auto optimizations = dynamic_cast<const JlmOptCommand*>(&jlmOptCommandNode.GetCommand())->Optimizations();
+  auto & jlmOptCommand = *dynamic_cast<const JlmOptCommand*>(&jlmOptCommandNode.GetCommand());
+  auto & optimizations = jlmOptCommand.GetCommandLineOptions().GetOptimizationIds();
 
   assert(optimizations.size() == 2);
   assert(optimizations[0] == JlmOptCommandLineOptions::OptimizationId::cne);

--- a/tests/jlm/tooling/TestJlcCommandGraphGenerator.cpp
+++ b/tests/jlm/tooling/TestJlcCommandGraphGenerator.cpp
@@ -110,11 +110,11 @@ TestJlmOptOptimizations()
    */
   auto & clangCommandNode = (*commandGraph->GetEntryNode().OutgoingEdges().begin()).GetSink();
   auto & jlmOptCommandNode = (clangCommandNode.OutgoingEdges().begin())->GetSink();
-  auto command = dynamic_cast<const JlmOptCommand*>(&jlmOptCommandNode.GetCommand());
-  auto optimizations = command->Optimizations();
+  auto optimizations = dynamic_cast<const JlmOptCommand*>(&jlmOptCommandNode.GetCommand())->Optimizations();
+
   assert(optimizations.size() == 2);
-  assert(optimizations[0] == JlmOptCommand::Optimization::CommonNodeElimination && \
-         optimizations[1] == JlmOptCommand::Optimization::DeadNodeElimination);
+  assert(optimizations[0] == JlmOptCommandLineOptions::OptimizationId::cne);
+  assert(optimizations[1] == JlmOptCommandLineOptions::OptimizationId::dne);
 }
 
 static int

--- a/tools/jlm-opt/jlm-opt.cpp
+++ b/tools/jlm-opt/jlm-opt.cpp
@@ -107,12 +107,12 @@ main(int argc, char ** argv)
 {
   auto & commandLineOptions = jlm::tooling::JlmOptCommandLineParser::Parse(argc, argv);
 
-  jlm::util::StatisticsCollector statisticsCollector(commandLineOptions.StatisticsCollectorSettings_);
+  jlm::util::StatisticsCollector statisticsCollector(commandLineOptions.GetStatisticsCollectorSettings());
 
   llvm::LLVMContext llvmContext;
   auto llvmModule = parse_llvm_file(
     argv[0],
-    commandLineOptions.InputFile_,
+    commandLineOptions.GetInputFile(),
     llvmContext);
 
   auto interProceduralGraphModule = construct_jlm_module(*llvmModule);
@@ -125,12 +125,12 @@ main(int argc, char ** argv)
   jlm::llvm::OptimizationSequence::CreateAndRun(
     *rvsdgModule,
     statisticsCollector,
-    commandLineOptions.Optimizations_);
+    commandLineOptions.GetOptimizations());
 
   print(
     *rvsdgModule,
-    commandLineOptions.OutputFile_,
-    commandLineOptions.OutputFormat_,
+    commandLineOptions.GetOutputFile(),
+    commandLineOptions.GetOutputFormat(),
     statisticsCollector);
 
   statisticsCollector.PrintStatistics();

--- a/tools/jlm-opt/jlm-opt.cpp
+++ b/tools/jlm-opt/jlm-opt.cpp
@@ -122,10 +122,12 @@ main(int argc, char ** argv)
     *interProceduralGraphModule,
     statisticsCollector);
 
+  auto optimizations = commandLineOptions.GetOptimizations();
+
   jlm::llvm::OptimizationSequence::CreateAndRun(
     *rvsdgModule,
     statisticsCollector,
-    commandLineOptions.GetOptimizations());
+    std::move(optimizations));
 
   print(
     *rvsdgModule,


### PR DESCRIPTION
The JlmOptCommand class represents the jlm-opt command line tool. This PR moves the entire logic of the jlm-opt command line tool from the jlm-opt.c file into the JlmOptCommand class. This permits for better testing in the future and cleans up quite a few code smells. Specifically, this PR makes the following changes:

1. It privatizes all attributes of the JlmOptCommandLineOptions class.
2. Establishes the JlmOptCommandLineOptions::OptimizationIds as the sole truth for jlm-opt optimizations.
3. Ensures that the jlm-opt optimizations performed under the hood by jlc are set in the command line parser and not later in the pipeline.
4. Moves the jlm-opt logic into the JlmOptCommand class