### PR TITLE
Add descriptive optimization flags to jlm-opt

### DIFF
--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -273,23 +273,23 @@ JlcCommandLineParser::ParseCommandLineArguments(int argc, char **argv)
     {
       return std::vector<JlmOptCommandLineOptions::OptimizationId>
         ({
-           JlmOptCommandLineOptions::OptimizationId::iln,
+           JlmOptCommandLineOptions::OptimizationId::FunctionInlining,
            JlmOptCommandLineOptions::OptimizationId::InvariantValueRedirection,
-           JlmOptCommandLineOptions::OptimizationId::red,
-           JlmOptCommandLineOptions::OptimizationId::dne,
-           JlmOptCommandLineOptions::OptimizationId::ivt,
+           JlmOptCommandLineOptions::OptimizationId::NodeReduction,
+           JlmOptCommandLineOptions::OptimizationId::DeadNodeElimination,
+           JlmOptCommandLineOptions::OptimizationId::ThetaGammaInversion,
            JlmOptCommandLineOptions::OptimizationId::InvariantValueRedirection,
-           JlmOptCommandLineOptions::OptimizationId::dne,
-           JlmOptCommandLineOptions::OptimizationId::psh,
+           JlmOptCommandLineOptions::OptimizationId::DeadNodeElimination,
+           JlmOptCommandLineOptions::OptimizationId::NodePushOut,
            JlmOptCommandLineOptions::OptimizationId::InvariantValueRedirection,
-           JlmOptCommandLineOptions::OptimizationId::dne,
-           JlmOptCommandLineOptions::OptimizationId::red,
-           JlmOptCommandLineOptions::OptimizationId::cne,
-           JlmOptCommandLineOptions::OptimizationId::dne,
-           JlmOptCommandLineOptions::OptimizationId::pll,
+           JlmOptCommandLineOptions::OptimizationId::DeadNodeElimination,
+           JlmOptCommandLineOptions::OptimizationId::NodeReduction,
+           JlmOptCommandLineOptions::OptimizationId::CommonNodeElimination,
+           JlmOptCommandLineOptions::OptimizationId::DeadNodeElimination,
+           JlmOptCommandLineOptions::OptimizationId::NodePullIn,
            JlmOptCommandLineOptions::OptimizationId::InvariantValueRedirection,
-           JlmOptCommandLineOptions::OptimizationId::dne,
-           JlmOptCommandLineOptions::OptimizationId::url,
+           JlmOptCommandLineOptions::OptimizationId::DeadNodeElimination,
+           JlmOptCommandLineOptions::OptimizationId::LoopUnrolling,
            JlmOptCommandLineOptions::OptimizationId::InvariantValueRedirection
          });
     }

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -117,17 +117,25 @@ JlmOptCommandLineOptions::FromCommandLineArgument(const std::string& commandLine
 {
   static std::unordered_map<std::string, OptimizationId> map(
     {
-      {AaSteensgaardAgnosticCommandLineArgument_,     OptimizationId::AASteensgaardAgnostic},
-      {AaSteensgaardRegionAwareCommandLineArgument_,  OptimizationId::AASteensgaardRegionAware},
-      {CommonNodeEliminationCommandLineArgument_,     OptimizationId::cne},
-      {DeadNodeEliminationCommandLineArgument_,       OptimizationId::dne},
-      {FunctionInliningCommandLineArgument_,          OptimizationId::iln},
-      {InvariantValueRedirectionCommandLineArgument_, OptimizationId::InvariantValueRedirection},
-      {NodePushOutCommandLineArgument_,               OptimizationId::psh},
-      {NodePullInCommandLineArgument_,                OptimizationId::pll},
-      {NodeReductionCommandLineArgument_,             OptimizationId::red},
-      {ThetaGammaInversionCommandLineArgument_,       OptimizationId::ivt},
-      {LoopUnrollingCommandLineArgument_,             OptimizationId::url}
+      {AaSteensgaardAgnosticCommandLineArgument_,           OptimizationId::AASteensgaardAgnostic},
+      {AaSteensgaardRegionAwareCommandLineArgument_,        OptimizationId::AASteensgaardRegionAware},
+      {CommonNodeEliminationCommandLineArgument_,           OptimizationId::CommonNodeElimination},
+      {CommonNodeEliminationDeprecatedCommandLineArgument_, OptimizationId::cne},
+      {DeadNodeEliminationCommandLineArgument_,             OptimizationId::DeadNodeElimination},
+      {DeadNodeEliminationDeprecatedCommandLineArgument_,   OptimizationId::dne},
+      {FunctionInliningCommandLineArgument_,                OptimizationId::FunctionInlining},
+      {FunctionInliningDeprecatedCommandLineArgument_,      OptimizationId::iln},
+      {InvariantValueRedirectionCommandLineArgument_,       OptimizationId::InvariantValueRedirection},
+      {NodePushOutCommandLineArgument_,                     OptimizationId::NodePushOut},
+      {NodePushOutDeprecatedCommandLineArgument_,           OptimizationId::psh},
+      {NodePullInCommandLineArgument_,                      OptimizationId::NodePullIn},
+      {NodePullInDeprecatedCommandLineArgument_,            OptimizationId::pll},
+      {NodeReductionCommandLineArgument_,                   OptimizationId::NodeReduction},
+      {NodeReductionDeprecatedCommandLineArgument_,         OptimizationId::red},
+      {ThetaGammaInversionCommandLineArgument_,             OptimizationId::ThetaGammaInversion},
+      {ThetaGammaInversionDeprecatedCommandLineArgument_,   OptimizationId::ivt},
+      {LoopUnrollingCommandLineArgument_,                   OptimizationId::LoopUnrolling},
+      {LoopUnrollingDeprecatedCommandLineArgument_,         OptimizationId::url}
     });
 
   if (map.find(commandLineArgument) != map.end())
@@ -143,15 +151,23 @@ JlmOptCommandLineOptions::ToCommandLineArgument(OptimizationId optimizationId)
     {
       {OptimizationId::AASteensgaardAgnostic,     AaSteensgaardAgnosticCommandLineArgument_},
       {OptimizationId::AASteensgaardRegionAware,  AaSteensgaardRegionAwareCommandLineArgument_},
-      {OptimizationId::cne,                       CommonNodeEliminationCommandLineArgument_},
-      {OptimizationId::dne,                       DeadNodeEliminationCommandLineArgument_},
-      {OptimizationId::iln,                       FunctionInliningCommandLineArgument_},
+      {OptimizationId::cne,                       CommonNodeEliminationDeprecatedCommandLineArgument_},
+      {OptimizationId::CommonNodeElimination,     CommonNodeEliminationCommandLineArgument_},
+      {OptimizationId::DeadNodeElimination,       DeadNodeEliminationCommandLineArgument_},
+      {OptimizationId::dne,                       DeadNodeEliminationDeprecatedCommandLineArgument_},
+      {OptimizationId::FunctionInlining,          FunctionInliningCommandLineArgument_},
+      {OptimizationId::iln,                       FunctionInliningDeprecatedCommandLineArgument_},
       {OptimizationId::InvariantValueRedirection, InvariantValueRedirectionCommandLineArgument_},
-      {OptimizationId::psh,                       NodePushOutCommandLineArgument_},
-      {OptimizationId::pll,                       NodePullInCommandLineArgument_},
-      {OptimizationId::red,                       NodeReductionCommandLineArgument_},
-      {OptimizationId::ivt,                       ThetaGammaInversionCommandLineArgument_},
-      {OptimizationId::url,                       LoopUnrollingCommandLineArgument_}
+      {OptimizationId::LoopUnrolling,             LoopUnrollingCommandLineArgument_},
+      {OptimizationId::NodePullIn,                NodePullInCommandLineArgument_},
+      {OptimizationId::NodePushOut,               NodePushOutCommandLineArgument_},
+      {OptimizationId::NodeReduction,             NodeReductionCommandLineArgument_},
+      {OptimizationId::psh,                       NodePushOutDeprecatedCommandLineArgument_},
+      {OptimizationId::pll,                       NodePullInDeprecatedCommandLineArgument_},
+      {OptimizationId::red,                       NodeReductionDeprecatedCommandLineArgument_},
+      {OptimizationId::ivt,                       ThetaGammaInversionDeprecatedCommandLineArgument_},
+      {OptimizationId::url,                       LoopUnrollingDeprecatedCommandLineArgument_},
+      {OptimizationId::ThetaGammaInversion,       ThetaGammaInversionCommandLineArgument_}
     });
 
   if (map.find(optimizationId) != map.end())
@@ -185,7 +201,7 @@ JlmOptCommandLineOptions::GetOptimization(enum OptimizationId id)
   static llvm::fctinline functionInlining;
   static llvm::InvariantValueRedirection invariantValueRedirection;
   static llvm::pullin nodePullIn;
-  static llvm::pushout nodePushOt;
+  static llvm::pushout nodePushOut;
   static llvm::tginversion thetaGammaInversion;
   static llvm::loopunroll loopUnrolling(4);
   static llvm::nodereduction nodeReduction;
@@ -195,14 +211,22 @@ JlmOptCommandLineOptions::GetOptimization(enum OptimizationId id)
       {OptimizationId::AASteensgaardAgnostic,     &steensgaardAgnostic},
       {OptimizationId::AASteensgaardRegionAware,  &steensgaardRegionAware},
       {OptimizationId::cne,                       &commonNodeElimination},
+      {OptimizationId::CommonNodeElimination,     &commonNodeElimination},
+      {OptimizationId::DeadNodeElimination,       &deadNodeElimination},
       {OptimizationId::dne,                       &deadNodeElimination},
+      {OptimizationId::FunctionInlining,          &functionInlining},
       {OptimizationId::iln,                       &functionInlining},
       {OptimizationId::InvariantValueRedirection, &invariantValueRedirection},
+      {OptimizationId::LoopUnrolling,             &loopUnrolling},
+      {OptimizationId::NodePullIn,                &nodePullIn},
+      {OptimizationId::NodePushOut,               &nodePushOut},
+      {OptimizationId::NodeReduction,             &nodeReduction},
       {OptimizationId::pll,                       &nodePullIn},
-      {OptimizationId::psh,                       &nodePushOt},
+      {OptimizationId::psh,                       &nodePushOut},
       {OptimizationId::ivt,                       &thetaGammaInversion},
       {OptimizationId::url,                       &loopUnrolling},
-      {OptimizationId::red,                       &nodeReduction}
+      {OptimizationId::red,                       &nodeReduction},
+      {OptimizationId::ThetaGammaInversion,       &thetaGammaInversion}
     });
 
   if (map.find(id) != map.end())
@@ -670,38 +694,58 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, char **argv)
 
   auto aASteensgaardAgnostic = JlmOptCommandLineOptions::OptimizationId::AASteensgaardAgnostic;
   auto aASteensgaardRegionAware = JlmOptCommandLineOptions::OptimizationId::AASteensgaardRegionAware;
-  auto commonNodeElimination = JlmOptCommandLineOptions::OptimizationId::cne;
-  auto deadNodeElimination = JlmOptCommandLineOptions::OptimizationId::dne;
-  auto functionInlining = JlmOptCommandLineOptions::OptimizationId::iln;
+  auto commonNodeElimination = JlmOptCommandLineOptions::OptimizationId::CommonNodeElimination;
+  auto commonNodeEliminationDeprecated = JlmOptCommandLineOptions::OptimizationId::cne;
+  auto deadNodeElimination = JlmOptCommandLineOptions::OptimizationId::DeadNodeElimination;
+  auto deadNodeEliminationDeprecated = JlmOptCommandLineOptions::OptimizationId::dne;
+  auto functionInlining = JlmOptCommandLineOptions::OptimizationId::FunctionInlining;
+  auto functionInliningDeprecated = JlmOptCommandLineOptions::OptimizationId::iln;
   auto invariantValueRedirection = JlmOptCommandLineOptions::OptimizationId::InvariantValueRedirection;
-  auto nodePushOut = JlmOptCommandLineOptions::OptimizationId::psh;
-  auto nodePullIn = JlmOptCommandLineOptions::OptimizationId::pll;
-  auto nodeReduction = JlmOptCommandLineOptions::OptimizationId::red;
-  auto thetaGammaInversion = JlmOptCommandLineOptions::OptimizationId::ivt;
-  auto loopUnrolling = JlmOptCommandLineOptions::OptimizationId::url;
+  auto nodePushOut = JlmOptCommandLineOptions::OptimizationId::NodePushOut;
+  auto nodePushOutDeprecated = JlmOptCommandLineOptions::OptimizationId::psh;
+  auto nodePullIn = JlmOptCommandLineOptions::OptimizationId::NodePullIn;
+  auto nodePullInDeprecated = JlmOptCommandLineOptions::OptimizationId::pll;
+  auto nodeReduction = JlmOptCommandLineOptions::OptimizationId::NodeReduction;
+  auto nodeReductionDeprecated = JlmOptCommandLineOptions::OptimizationId::red;
+  auto thetaGammaInversion = JlmOptCommandLineOptions::OptimizationId::ThetaGammaInversion;
+  auto thetaGammaInversionDeprecated = JlmOptCommandLineOptions::OptimizationId::ivt;
+  auto loopUnrolling = JlmOptCommandLineOptions::OptimizationId::LoopUnrolling;
+  auto loopUnrollingDeprecated = JlmOptCommandLineOptions::OptimizationId::url;
 
   cl::list<JlmOptCommandLineOptions::OptimizationId> optimizationIds(
     cl::values(
       ::clEnumValN(
         aASteensgaardAgnostic,
         JlmOptCommandLineOptions::ToCommandLineArgument(aASteensgaardAgnostic),
-        "Steensgaard alias analysis with agnostic memory state encoding."),
+        "Steensgaard alias analysis with agnostic memory state encoding"),
       ::clEnumValN(
         aASteensgaardRegionAware,
         JlmOptCommandLineOptions::ToCommandLineArgument(aASteensgaardRegionAware),
-        "Steensgaard alias analysis with region-aware memory state encoding."),
+        "Steensgaard alias analysis with region-aware memory state encoding"),
       ::clEnumValN(
         commonNodeElimination,
         JlmOptCommandLineOptions::ToCommandLineArgument(commonNodeElimination),
-        "Common node elimination"),
+        "Common Node Elimination"),
+      ::clEnumValN(
+        commonNodeEliminationDeprecated,
+        JlmOptCommandLineOptions::ToCommandLineArgument(commonNodeEliminationDeprecated),
+        "[Deprecated] Use --CommonNodeElimination flag instead"),
       ::clEnumValN(
         deadNodeElimination,
         JlmOptCommandLineOptions::ToCommandLineArgument(deadNodeElimination),
-        "Dead node elimination"),
+        "Dead Node Elimination"),
+      ::clEnumValN(
+        deadNodeEliminationDeprecated,
+        JlmOptCommandLineOptions::ToCommandLineArgument(deadNodeEliminationDeprecated),
+        "[Deprecated] Use --DeadNodeElimination flag instead"),
       ::clEnumValN(
         functionInlining,
         JlmOptCommandLineOptions::ToCommandLineArgument(functionInlining),
-        "Function inlining"),
+        "Function Inlining"),
+      ::clEnumValN(
+        functionInliningDeprecated,
+        JlmOptCommandLineOptions::ToCommandLineArgument(functionInliningDeprecated),
+        "[Deprecated] Use --FunctionInlining flag instead"),
       ::clEnumValN(
         invariantValueRedirection,
         JlmOptCommandLineOptions::ToCommandLineArgument(invariantValueRedirection),
@@ -709,23 +753,43 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, char **argv)
       ::clEnumValN(
         nodePushOut,
         JlmOptCommandLineOptions::ToCommandLineArgument(nodePushOut),
-        "Node push out"),
+        "Node Push Out"),
+      ::clEnumValN(
+        nodePushOutDeprecated,
+        JlmOptCommandLineOptions::ToCommandLineArgument(nodePushOutDeprecated),
+        "[Deprecated] Use --NodePushOut flag instead"),
       ::clEnumValN(
         nodePullIn,
         JlmOptCommandLineOptions::ToCommandLineArgument(nodePullIn),
-        "Node pull in"),
+        "Node Pull In"),
+      ::clEnumValN(
+        nodePullInDeprecated,
+        JlmOptCommandLineOptions::ToCommandLineArgument(nodePullInDeprecated),
+        "[Deprecated] Use --NodePullIn flag instead"),
       ::clEnumValN(
         nodeReduction,
         JlmOptCommandLineOptions::ToCommandLineArgument(nodeReduction),
-        "Node reductions"),
+        "Node Reduction"),
+      ::clEnumValN(
+        nodeReductionDeprecated,
+        JlmOptCommandLineOptions::ToCommandLineArgument(nodeReductionDeprecated),
+        "[Deprecated] Use --NodeReduction flag instead"),
       ::clEnumValN(
         thetaGammaInversion,
         JlmOptCommandLineOptions::ToCommandLineArgument(thetaGammaInversion),
-        "Theta-gamma inversion"),
+        "Theta-Gamma Inversion"),
+      ::clEnumValN(
+        thetaGammaInversionDeprecated,
+        JlmOptCommandLineOptions::ToCommandLineArgument(thetaGammaInversionDeprecated),
+        "[Deprecated] Use --ThetaGammaInversion flag instead"),
       ::clEnumValN(
         loopUnrolling,
         JlmOptCommandLineOptions::ToCommandLineArgument(loopUnrolling),
-        "Loop unrolling")),
+        "Loop Unrolling"),
+      ::clEnumValN(
+        loopUnrollingDeprecated,
+        JlmOptCommandLineOptions::ToCommandLineArgument(loopUnrollingDeprecated),
+        "[Deprecated] Use --LoopUnrolling flag instead")),
     cl::desc("Perform optimization"));
 
   cl::ParseCommandLineOptions(argc, argv);

--- a/jlm/tooling/CommandLine.hpp
+++ b/jlm/tooling/CommandLine.hpp
@@ -51,15 +51,56 @@ public:
 
     AASteensgaardAgnostic,
     AASteensgaardRegionAware,
+
+    /**
+     * \deprecated This flag is going to be removed in the future. Use \ref OptimizationId::CommonNodeElimination
+     * instead.
+     */
     cne,
+    CommonNodeElimination,
+    DeadNodeElimination,
+
+    /**
+     * \deprecated This flag is going to be removed in the future. Use \ref OptimizationId::DeadNodeElimination instead.
+     */
     dne,
+    FunctionInlining,
+
+    /**
+     * \deprecated This flag is going to be removed in the future. Use \ref OptimizationId::FunctionInlining instead.
+     */
     iln,
     InvariantValueRedirection,
+    LoopUnrolling,
+    NodePullIn,
+    NodePushOut,
+    NodeReduction,
+
+    /**
+     * \deprecated This flag is going to be removed in the future. Use \ref OptimizationId::NodePushOut instead.
+     */
     psh,
+
+    /**
+     * \deprecated This flag is going to be removed in the future. Use \ref OptimizationId::NodeReduction instead.
+     */
     red,
+
+    /**
+     * \deprecated This flag is going to be removed in the future. Use \ref OptimizationId::ThetaGammaInversion instead.
+     */
     ivt,
+
+    /**
+     * \deprecated This flag is going to be removed in the future. Use \ref OptimizationId::LoopUnrolling instead.
+     */
     url,
+
+    /**
+     * \deprecated This flag is going to be removed in the future. Use \ref OptimizationId::NodePullIn instead.
+     */
     pll,
+    ThetaGammaInversion,
 
     LastEnumValue // must always be the last enum value, used for iteration
   };
@@ -150,15 +191,23 @@ private:
 
   inline static const char* AaSteensgaardAgnosticCommandLineArgument_ = "AASteensgaardAgnostic";
   inline static const char* AaSteensgaardRegionAwareCommandLineArgument_ = "AASteensgaardRegionAware";
-  inline static const char* CommonNodeEliminationCommandLineArgument_ = "cne";
-  inline static const char* DeadNodeEliminationCommandLineArgument_ = "dne";
-  inline static const char* FunctionInliningCommandLineArgument_ = "iln";
+  inline static const char* CommonNodeEliminationCommandLineArgument_ = "CommonNodeElimination";
+  inline static const char* CommonNodeEliminationDeprecatedCommandLineArgument_ = "cne";
+  inline static const char* DeadNodeEliminationCommandLineArgument_ = "DeadNodeElimination";
+  inline static const char* DeadNodeEliminationDeprecatedCommandLineArgument_ = "dne";
+  inline static const char* FunctionInliningCommandLineArgument_ = "FunctionInlining";
+  inline static const char* FunctionInliningDeprecatedCommandLineArgument_ = "iln";
   inline static const char* InvariantValueRedirectionCommandLineArgument_ = "InvariantValueRedirection";
-  inline static const char* NodePullInCommandLineArgument_ = "pll";
-  inline static const char* NodePushOutCommandLineArgument_ = "psh";
-  inline static const char* ThetaGammaInversionCommandLineArgument_ = "ivt";
-  inline static const char* LoopUnrollingCommandLineArgument_ = "url";
-  inline static const char* NodeReductionCommandLineArgument_ = "red";
+  inline static const char* NodePullInCommandLineArgument_ = "NodePullIn";
+  inline static const char* NodePullInDeprecatedCommandLineArgument_ = "pll";
+  inline static const char* NodePushOutCommandLineArgument_ = "NodePushOut";
+  inline static const char* NodePushOutDeprecatedCommandLineArgument_ = "psh";
+  inline static const char* ThetaGammaInversionCommandLineArgument_ = "ThetaGammaInversion";
+  inline static const char* ThetaGammaInversionDeprecatedCommandLineArgument_ = "ivt";
+  inline static const char* LoopUnrollingCommandLineArgument_ = "LoopUnrolling";
+  inline static const char* LoopUnrollingDeprecatedCommandLineArgument_ = "url";
+  inline static const char* NodeReductionCommandLineArgument_ = "NodeReduction";
+  inline static const char* NodeReductionDeprecatedCommandLineArgument_ = "red";
 };
 
 class JlcCommandLineOptions final : public CommandLineOptions {

--- a/tests/jlm/tooling/TestJlcCommandGraphGenerator.cpp
+++ b/tests/jlm/tooling/TestJlcCommandGraphGenerator.cpp
@@ -97,8 +97,8 @@ TestJlmOptOptimizations()
                                                true,
                                                true});
   commandLineOptions.OutputFile_ = {"foobar"};
-  commandLineOptions.JlmOptOptimizations_.push_back(JlmOptCommandLineOptions::OptimizationId::cne);
-  commandLineOptions.JlmOptOptimizations_.push_back(JlmOptCommandLineOptions::OptimizationId::dne);
+  commandLineOptions.JlmOptOptimizations_.push_back(JlmOptCommandLineOptions::OptimizationId::CommonNodeElimination);
+  commandLineOptions.JlmOptOptimizations_.push_back(JlmOptCommandLineOptions::OptimizationId::DeadNodeElimination);
 
   /*
    * Act
@@ -114,8 +114,8 @@ TestJlmOptOptimizations()
   auto & optimizations = jlmOptCommand.GetCommandLineOptions().GetOptimizationIds();
 
   assert(optimizations.size() == 2);
-  assert(optimizations[0] == JlmOptCommandLineOptions::OptimizationId::cne);
-  assert(optimizations[1] == JlmOptCommandLineOptions::OptimizationId::dne);
+  assert(optimizations[0] == JlmOptCommandLineOptions::OptimizationId::CommonNodeElimination);
+  assert(optimizations[1] == JlmOptCommandLineOptions::OptimizationId::DeadNodeElimination);
 }
 
 static int

--- a/tests/jlm/tooling/TestJlcCommandLineParser.cpp
+++ b/tests/jlm/tooling/TestJlcCommandLineParser.cpp
@@ -146,15 +146,15 @@ TestJlmOptOptimizations()
   using namespace jlm::tooling;
 
   // Arrange
-  std::vector<std::string> commandLineArguments({"jlc", "foobar.c", "-Jcne", "-Jdne"});
+  std::vector<std::string> commandLineArguments({"jlc", "foobar.c", "-JCommonNodeElimination", "-JDeadNodeElimination"});
 
   // Act
   auto & commandLineOptions = ParseCommandLineArguments(commandLineArguments);
 
   // Assert
   assert(commandLineOptions.JlmOptOptimizations_.size() == 2);
-  assert(commandLineOptions.JlmOptOptimizations_[0] == JlmOptCommandLineOptions::OptimizationId::cne);
-  assert(commandLineOptions.JlmOptOptimizations_[1] == JlmOptCommandLineOptions::OptimizationId::dne);
+  assert(commandLineOptions.JlmOptOptimizations_[0] == JlmOptCommandLineOptions::OptimizationId::CommonNodeElimination);
+  assert(commandLineOptions.JlmOptOptimizations_[1] == JlmOptCommandLineOptions::OptimizationId::DeadNodeElimination);
 }
 
 static void


### PR DESCRIPTION
This PR does the following:

1. Adds more descriptive optimization flags to jlm-opt
3. Marks the non-descriptive optimization flags as deprecated
4. Replaces all internal usages of the non-descriptive optimizations with the corresponding descriptive optimization

The non-descriptive optimization flags will be removed in a future PR after all external usages have been converted to the descriptive optimization flags.