### PR TITLE
Fix use-after-free-bug in jlm-opt --help due to implicit StringRef

### DIFF
--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -580,12 +580,13 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, char **argv)
     cl::desc("Write output to <file>"),
     cl::value_desc("file"));
 
+  const auto statisticFileDesc = "Write stats to <file>. Default is "
+                                 + statisticsCollectorSettings.GetFilePath().to_str()
+                                 + ".";
   cl::opt<std::string> statisticFile(
     "s",
     cl::init(statisticsCollectorSettings.GetFilePath().to_str()),
-    cl::desc("Write stats to <file>. Default is "
-             + statisticsCollectorSettings.GetFilePath().to_str()
-             + "."),
+    cl::desc(statisticFileDesc),
     cl::value_desc("file"));
 
   cl::list<util::Statistics::Id> printStatistics(


### PR DESCRIPTION
This PR stores the runtime string description of the `-s` option in a `std::string` on stack,
which keeps the string alive long enough for the `StringRef` passed to `cl::desc()` to stay valid.

Constructing the string could also be done using `std::stringstream`, the current fix just moves the `+` result to stack frame ownership.

Fixes issue #245