### PR TITLE
Simplify Steensgaard alias analysis statistics

### DIFF
--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -19,7 +19,7 @@
 namespace jlm::llvm::aa
 {
 
-/** \brief Steensgaard analysis statistics class
+/** \brief Collect statistics about Steensgaard alias analysis pass
  *
  */
 class Steensgaard::Statistics final : public jlm::util::Statistics {

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -46,14 +46,14 @@ public:
   {}
 
   void
-  StartAliasAnalysisStatistics(const jlm::rvsdg::graph & graph) noexcept
+  StartSteensgaardStatistics(const jlm::rvsdg::graph & graph) noexcept
   {
     NumRvsdgNodes_ = jlm::rvsdg::nnodes(graph.root());
     AnalysisTimer_.start();
   }
 
   void
-  StopAliasAnalysisStatistics() noexcept
+  StopSteensgaardStatistics() noexcept
   {
     AnalysisTimer_.stop();
   }
@@ -1529,10 +1529,10 @@ Steensgaard::Analyze(
   auto statistics = Statistics::Create(module.SourceFileName());
 
   // Perform Steensgaard analysis
-  statistics->StartAliasAnalysisStatistics(module.Rvsdg());
+  statistics->StartSteensgaardStatistics(module.Rvsdg());
   Analyze(module.Rvsdg());
 	// std::cout << LocationSet_.ToDot() << std::flush;
-  statistics->StopAliasAnalysisStatistics();
+  statistics->StopSteensgaardStatistics();
 
   // Construct PointsTo graph
   statistics->StartPointsToGraphConstructionStatistics(LocationSet_);

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -22,13 +22,14 @@ namespace jlm::llvm::aa
 /** \brief Steensgaard analysis statistics class
  *
  */
-class SteensgaardAnalysisStatistics final : public jlm::util::Statistics {
+class Steensgaard::Statistics final : public jlm::util::Statistics {
 public:
-  ~SteensgaardAnalysisStatistics() override = default;
+  ~Statistics() override
+  = default;
 
   explicit
-  SteensgaardAnalysisStatistics(jlm::util::filepath sourceFile)
-    : Statistics(Statistics::Id::SteensgaardAnalysis)
+  Statistics(jlm::util::filepath sourceFile)
+    : jlm::util::Statistics(Statistics::Id::SteensgaardAnalysis)
     , NumRvsdgNodes_(0)
     , SourceFile_(std::move(sourceFile))
     , NumDisjointSets_(0)
@@ -101,10 +102,10 @@ public:
                              "PointsToGraphConstructionTime[ns]:", PointsToGraphConstructionTimer_.ns());
   }
 
-  static std::unique_ptr<SteensgaardAnalysisStatistics>
+  static std::unique_ptr<Statistics>
   Create(const jlm::util::filepath & sourceFile)
   {
-    return std::make_unique<SteensgaardAnalysisStatistics>(sourceFile);
+    return std::make_unique<Statistics>(sourceFile);
   }
 
 private:
@@ -1525,7 +1526,7 @@ Steensgaard::Analyze(
   jlm::util::StatisticsCollector & statisticsCollector)
 {
   ResetState();
-  auto statistics = SteensgaardAnalysisStatistics::Create(module.SourceFileName());
+  auto statistics = Statistics::Create(module.SourceFileName());
 
   // Perform Steensgaard analysis
   statistics->StartAliasAnalysisStatistics(module.Rvsdg());

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -29,59 +29,11 @@ public:
   explicit
   SteensgaardAnalysisStatistics(jlm::util::filepath sourceFile)
     : Statistics(Statistics::Id::SteensgaardAnalysis)
-    , NumNodesBefore_(0)
-    , SourceFile_(std::move(sourceFile))
-  {}
-
-  void
-  Start(const jlm::rvsdg::graph & graph) noexcept
-  {
-    NumNodesBefore_ = jlm::rvsdg::nnodes(graph.root());
-    Timer_.start();
-  }
-
-  void
-  Stop() noexcept
-  {
-    Timer_.stop();
-  }
-
-  [[nodiscard]] std::string
-  ToString() const override
-  {
-    return jlm::util::strfmt("SteensgaardAnalysis ",
-                  SourceFile_.to_str(), " ",
-                  "#RvsdgNodes:", NumNodesBefore_, " ",
-                  "Time[ns]:", Timer_.ns());
-  }
-
-  static std::unique_ptr<SteensgaardAnalysisStatistics>
-  Create(const jlm::util::filepath & sourceFile)
-  {
-    return std::make_unique<SteensgaardAnalysisStatistics>(sourceFile);
-  }
-
-private:
-  size_t NumNodesBefore_;
-  jlm::util::filepath SourceFile_;
-
-  jlm::util::timer Timer_;
-};
-
-/** \brief Steensgaard PointsTo graph construction statistics class
- *
- */
-class SteensgaardPointsToGraphConstructionStatistics final : public jlm::util::Statistics {
-public:
-  ~SteensgaardPointsToGraphConstructionStatistics() override = default;
-
-  explicit
-  SteensgaardPointsToGraphConstructionStatistics(jlm::util::filepath sourceFile)
-    : Statistics(jlm::util::Statistics::Id::SteensgaardPointsToGraphConstruction)
+    , NumRvsdgNodes_(0)
     , SourceFile_(std::move(sourceFile))
     , NumDisjointSets_(0)
     , NumLocations_(0)
-    , NumNodes_(0)
+    , NumPointsToGraphNodes_(0)
     , NumAllocaNodes_(0)
     , NumDeltaNodes_(0)
     , NumImportNodes_(0)
@@ -93,18 +45,31 @@ public:
   {}
 
   void
-  Start(const LocationSet & locationSet)
+  StartAliasAnalysisStatistics(const jlm::rvsdg::graph & graph) noexcept
   {
-    NumDisjointSets_ = locationSet.NumDisjointSets();
-    NumLocations_ = locationSet.NumLocations();
-    Timer_.start();
+    NumRvsdgNodes_ = jlm::rvsdg::nnodes(graph.root());
+    AnalysisTimer_.start();
   }
 
   void
-  Stop(const PointsToGraph & pointsToGraph)
+  StopAliasAnalysisStatistics() noexcept
   {
-    Timer_.stop();
-    NumNodes_ = pointsToGraph.NumNodes();
+    AnalysisTimer_.stop();
+  }
+
+  void
+  StartPointsToGraphConstructionStatistics(const LocationSet & locationSet)
+  {
+    NumDisjointSets_ = locationSet.NumDisjointSets();
+    NumLocations_ = locationSet.NumLocations();
+    PointsToGraphConstructionTimer_.start();
+  }
+
+  void
+  StopPointsToGraphConstructionStatistics(const PointsToGraph & pointsToGraph)
+  {
+    PointsToGraphConstructionTimer_.stop();
+    NumPointsToGraphNodes_ = pointsToGraph.NumNodes();
     NumAllocaNodes_ = pointsToGraph.NumAllocaNodes();
     NumDeltaNodes_ = pointsToGraph.NumDeltaNodes();
     NumImportNodes_ = pointsToGraph.NumImportNodes();
@@ -118,35 +83,38 @@ public:
   [[nodiscard]] std::string
   ToString() const override
   {
-    return jlm::util::strfmt("SteensgaardPointsToGraphConstruction ",
-                  SourceFile_.to_str(), " ",
-                  "#DisjointSets:", NumDisjointSets_, " ",
-                  "#Locations:", NumLocations_, " ",
-                  "#Nodes:", NumNodes_, " ",
-                  "#AllocaNodes:", NumAllocaNodes_, " ",
-                  "#DeltaNodes:", NumDeltaNodes_, " ",
-                  "#ImportNodes:", NumImportNodes_, " ",
-                  "#LambdaNodes:", NumLambdaNodes_, " ",
-                  "#MallocNodes:", NumMallocNodes_, " ",
-                  "#MemoryNodes:", NumMemoryNodes_, " ",
-                  "#RegisterNodes:", NumRegisterNodes_, " ",
-                  "#UnknownMemorySources:", NumUnknownMemorySources_, " ",
-                  "Time[ns]:", Timer_.ns());
+    return jlm::util::strfmt("SteensgaardAnalysis ",
+                             SourceFile_.to_str(), " ",
+                             "#RvsdgNodes:", NumRvsdgNodes_, " ",
+                             "AliasAnalysisTime[ns]:", AnalysisTimer_.ns(), " ",
+                             "#DisjointSets:", NumDisjointSets_, " ",
+                             "#Locations:", NumLocations_, " ",
+                             "#PointsToGraphNodes:", NumPointsToGraphNodes_, " ",
+                             "#AllocaNodes:", NumAllocaNodes_, " ",
+                             "#DeltaNodes:", NumDeltaNodes_, " ",
+                             "#ImportNodes:", NumImportNodes_, " ",
+                             "#LambdaNodes:", NumLambdaNodes_, " ",
+                             "#MallocNodes:", NumMallocNodes_, " ",
+                             "#MemoryNodes:", NumMemoryNodes_, " ",
+                             "#RegisterNodes:", NumRegisterNodes_, " ",
+                             "#UnknownMemorySources:", NumUnknownMemorySources_, " ",
+                             "PointsToGraphConstructionTime[ns]:", PointsToGraphConstructionTimer_.ns());
   }
 
-  static std::unique_ptr<SteensgaardPointsToGraphConstructionStatistics>
+  static std::unique_ptr<SteensgaardAnalysisStatistics>
   Create(const jlm::util::filepath & sourceFile)
   {
-    return std::make_unique<SteensgaardPointsToGraphConstructionStatistics>(sourceFile);
+    return std::make_unique<SteensgaardAnalysisStatistics>(sourceFile);
   }
 
 private:
+  size_t NumRvsdgNodes_;
   jlm::util::filepath SourceFile_;
 
   size_t NumDisjointSets_;
   size_t NumLocations_;
 
-  size_t NumNodes_;
+  size_t NumPointsToGraphNodes_;
   size_t NumAllocaNodes_;
   size_t NumDeltaNodes_;
   size_t NumImportNodes_;
@@ -155,7 +123,9 @@ private:
   size_t NumMemoryNodes_;
   size_t NumRegisterNodes_;
   size_t NumUnknownMemorySources_;
-  jlm::util::timer Timer_;
+
+  jlm::util::timer AnalysisTimer_;
+  jlm::util::timer PointsToGraphConstructionTimer_;
 };
 
 /** \brief Location class
@@ -1555,27 +1525,21 @@ Steensgaard::Analyze(
   jlm::util::StatisticsCollector & statisticsCollector)
 {
   ResetState();
-  auto steensgaardStatistics = SteensgaardAnalysisStatistics::Create(module.SourceFileName());
-  auto ptgConstructionStatistics = SteensgaardPointsToGraphConstructionStatistics::Create(module.SourceFileName());
+  auto statistics = SteensgaardAnalysisStatistics::Create(module.SourceFileName());
 
-  /**
-   * Perform Steensgaard analysis
-   */
-  steensgaardStatistics->Start(module.Rvsdg());
+  // Perform Steensgaard analysis
+  statistics->StartAliasAnalysisStatistics(module.Rvsdg());
   Analyze(module.Rvsdg());
 	// std::cout << LocationSet_.ToDot() << std::flush;
-  steensgaardStatistics->Stop();
+  statistics->StopAliasAnalysisStatistics();
 
-  /**
-   * Construct PointsTo graph
-   */
-  ptgConstructionStatistics->Start(LocationSet_);
+  // Construct PointsTo graph
+  statistics->StartPointsToGraphConstructionStatistics(LocationSet_);
   auto pointsToGraph = ConstructPointsToGraph(LocationSet_);
-//	std::cout << PointsToGraph::ToDot(*pointsToGraph) << std::flush;
-  ptgConstructionStatistics->Stop(*pointsToGraph);
+  // std::cout << PointsToGraph::ToDot(*pointsToGraph) << std::flush;
+  statistics->StopPointsToGraphConstructionStatistics(*pointsToGraph);
 
-  statisticsCollector.CollectDemandedStatistics(std::move(steensgaardStatistics));
-  statisticsCollector.CollectDemandedStatistics(std::move(ptgConstructionStatistics));
+  statisticsCollector.CollectDemandedStatistics(std::move(statistics));
 
   return pointsToGraph;
 }

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
@@ -165,7 +165,9 @@ private:
  * context-insensitive, flow-insensitive, and uses a static heap model. It is an implementation corresponding to the
  * algorithm presented in Bjarne Steensgaard - Points-to Analysis in Almost Linear Time.
  */
-class Steensgaard final : public AliasAnalysis {
+class Steensgaard final : public AliasAnalysis
+{
+  class Statistics;
 public:
 	~Steensgaard() override;
 

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -668,10 +668,6 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, char **argv)
         "print-steensgaard-analysis",
         "Write Steensgaard analysis statistics to file."),
       ::clEnumValN(
-        util::Statistics::Id::SteensgaardPointsToGraphConstruction,
-        "print-steensgaard-pointstograph-construction",
-        "Write Steensgaard PointsTo Graph construction statistics to file."),
-      ::clEnumValN(
         util::Statistics::Id::ThetaGammaInversion,
         "print-ivt-stat",
         "Write theta-gamma inversion statistics to file.")),

--- a/jlm/util/Statistics.hpp
+++ b/jlm/util/Statistics.hpp
@@ -39,7 +39,6 @@ public:
     RvsdgDestruction,
     RvsdgOptimization,
     SteensgaardAnalysis,
-    SteensgaardPointsToGraphConstruction,
     ThetaGammaInversion
   };
 

--- a/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
@@ -1114,8 +1114,29 @@ TestLinkedList()
   validatePointsToGraph(*pointsToGraph, test);
 }
 
+static void
+TestStatistics()
+{
+  // Arrange
+  jlm::tests::LoadTest1 test;
+  jlm::util::filepath filePath("/tmp/TestDisabledStatistics");
+  std::remove(filePath.to_str().c_str());
+
+  jlm::util::StatisticsCollectorSettings statisticsCollectorSettings(
+    filePath,
+    {jlm::util::Statistics::Id::SteensgaardAnalysis});
+  jlm::util::StatisticsCollector statisticsCollector(statisticsCollectorSettings);
+
+  // Act
+  jlm::llvm::aa::Steensgaard steensgaard;
+  steensgaard.Analyze(test.module(), statisticsCollector);
+
+  // Assert
+  assert(statisticsCollector.NumCollectedStatistics() == 1);
+}
+
 static int
-test()
+TestSteensgaardAnalysis()
 {
   TestStore1();
   TestStore2();
@@ -1158,7 +1179,11 @@ test()
 
   TestLinkedList();
 
+  TestStatistics();
+
   return 0;
 }
 
-JLM_UNIT_TEST_REGISTER("jlm/llvm/opt/alias-analyses/TestSteensgaard", test)
+JLM_UNIT_TEST_REGISTER(
+  "jlm/llvm/opt/alias-analyses/TestSteensgaard",
+  TestSteensgaardAnalysis)


### PR DESCRIPTION
Simplifies the Steensgaard alias analysis statistics. The PR makes the following changes:

1. Merge the alias analysis and points-to graph construction statistics into a single statistics
2. Remove the dead steensgaard points-to graph construction statistics option from jlm-opt command line interface
3. Add a simple unit test to ensure the statistics is actually gathered