### PR TITLE
Add statistics collection support to jlc

### DIFF
--- a/jlm/tooling/Command.cpp
+++ b/jlm/tooling/Command.cpp
@@ -260,11 +260,6 @@ JlmOptCommand::~JlmOptCommand()
 std::string
 JlmOptCommand::ToString() const
 {
-  /*
-   * There is currently no need to support statistics gathering here.
-   */
-  JLM_ASSERT(CommandLineOptions_.GetStatisticsCollectorSettings().NumDemandedStatistics() == 0);
-
   std::string optimizationArguments;
   for (auto & optimization : CommandLineOptions_.GetOptimizationIds())
     optimizationArguments += "--" + std::string(JlmOptCommandLineOptions::ToCommandLineArgument(optimization)) + " ";
@@ -278,10 +273,18 @@ JlmOptCommand::ToString() const
     ? "-o " + CommandLineOptions_.GetOutputFile().to_str() + " "
     : "";
 
+  std::string statisticsArguments;
+  auto & demandedStatistics = CommandLineOptions_.GetStatisticsCollectorSettings().GetDemandedStatistics();
+  for (auto & statisticsId : demandedStatistics.Items())
+  {
+    statisticsArguments += "--" + std::string(JlmOptCommandLineOptions::ToCommandLineArgument(statisticsId)) + " ";
+  }
+
   return util::strfmt(
     ProgramName_ + " ",
     outputFormatArgument,
     optimizationArguments,
+    statisticsArguments,
     outputFileArgument,
     CommandLineOptions_.GetInputFile().to_str());
 }

--- a/jlm/tooling/CommandGraphGenerator.cpp
+++ b/jlm/tooling/CommandGraphGenerator.cpp
@@ -118,7 +118,7 @@ JlcCommandGraphGenerator::GenerateCommandGraph(const JlcCommandLineOptions & com
         CreateParserCommandOutputFile(compilation.InputFile()),
         CreateJlmOptCommandOutputFile(compilation.InputFile()),
         JlmOptCommandLineOptions::OutputFormat::Llvm,
-        util::StatisticsCollectorSettings(),
+        util::StatisticsCollectorSettings(commandLineOptions.JlmOptPassStatistics_),
         commandLineOptions.JlmOptOptimizations_);
 
       auto & jlmOptCommandNode = JlmOptCommand::Create(

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -113,7 +113,7 @@ JlmOptCommandLineOptions::GetOptimizations() const noexcept
 }
 
 JlmOptCommandLineOptions::OptimizationId
-JlmOptCommandLineOptions::FromCommandLineArgument(const std::string& commandLineArgument)
+JlmOptCommandLineOptions::FromCommandLineArgumentToOptimizationId(const std::string& commandLineArgument)
 {
   static std::unordered_map<std::string, OptimizationId> map(
     {
@@ -300,7 +300,7 @@ JlcCommandLineParser::ParseCommandLineArguments(int argc, char **argv)
       JlmOptCommandLineOptions::OptimizationId optimizationId;
       try
       {
-        optimizationId = JlmOptCommandLineOptions::FromCommandLineArgument(optimization);
+        optimizationId = JlmOptCommandLineOptions::FromCommandLineArgumentToOptimizationId(optimization);
       }
       catch (util::error&)
       {

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -181,27 +181,26 @@ JlmOptCommandLineOptions::FromCommandLineArgumentToStatisticsId(const std::strin
 {
   static std::unordered_map<std::string, util::Statistics::Id> map(
     {
-      {StatisticsCommandLineArgument::Aggregation_,                          util::Statistics::Id::Aggregation},
-      {StatisticsCommandLineArgument::BasicEncoderEncoding_,                 util::Statistics::Id::BasicEncoderEncoding},
-      {StatisticsCommandLineArgument::Annotation_,                           util::Statistics::Id::Annotation},
-      {StatisticsCommandLineArgument::CommonNodeElimination_,                util::Statistics::Id::CommonNodeElimination},
-      {StatisticsCommandLineArgument::ControlFlowRecovery_,                  util::Statistics::Id::ControlFlowRecovery},
-      {StatisticsCommandLineArgument::DataNodeToDelta_,                      util::Statistics::Id::DataNodeToDelta},
-      {StatisticsCommandLineArgument::DeadNodeElimination_,                  util::Statistics::Id::DeadNodeElimination},
-      {StatisticsCommandLineArgument::FunctionInlining_,                     util::Statistics::Id::FunctionInlining},
-      {StatisticsCommandLineArgument::InvariantValueRedirection_,            util::Statistics::Id::InvariantValueRedirection},
-      {StatisticsCommandLineArgument::JlmToRvsdgConversion_,                 util::Statistics::Id::JlmToRvsdgConversion},
-      {StatisticsCommandLineArgument::LoopUnrolling_,                        util::Statistics::Id::LoopUnrolling},
-      {StatisticsCommandLineArgument::MemoryNodeProvisioning_,               util::Statistics::Id::MemoryNodeProvisioning},
-      {StatisticsCommandLineArgument::PullNodes_,                            util::Statistics::Id::PullNodes},
-      {StatisticsCommandLineArgument::PushNodes_,                            util::Statistics::Id::PushNodes},
-      {StatisticsCommandLineArgument::ReduceNodes_,                          util::Statistics::Id::ReduceNodes},
-      {StatisticsCommandLineArgument::RvsdgConstruction_,                    util::Statistics::Id::RvsdgConstruction},
-      {StatisticsCommandLineArgument::RvsdgDestruction_,                     util::Statistics::Id::RvsdgDestruction},
-      {StatisticsCommandLineArgument::RvsdgOptimization_,                    util::Statistics::Id::RvsdgOptimization},
-      {StatisticsCommandLineArgument::SteensgaardAnalysis_,                  util::Statistics::Id::SteensgaardAnalysis},
-      {StatisticsCommandLineArgument::SteensgaardPointsToGraphConstruction_, util::Statistics::Id::SteensgaardPointsToGraphConstruction},
-      {StatisticsCommandLineArgument::ThetaGammaInversion_,                  util::Statistics::Id::ThetaGammaInversion}
+      {StatisticsCommandLineArgument::Aggregation_,               util::Statistics::Id::Aggregation},
+      {StatisticsCommandLineArgument::BasicEncoderEncoding_,      util::Statistics::Id::BasicEncoderEncoding},
+      {StatisticsCommandLineArgument::Annotation_,                util::Statistics::Id::Annotation},
+      {StatisticsCommandLineArgument::CommonNodeElimination_,     util::Statistics::Id::CommonNodeElimination},
+      {StatisticsCommandLineArgument::ControlFlowRecovery_,       util::Statistics::Id::ControlFlowRecovery},
+      {StatisticsCommandLineArgument::DataNodeToDelta_,           util::Statistics::Id::DataNodeToDelta},
+      {StatisticsCommandLineArgument::DeadNodeElimination_,       util::Statistics::Id::DeadNodeElimination},
+      {StatisticsCommandLineArgument::FunctionInlining_,          util::Statistics::Id::FunctionInlining},
+      {StatisticsCommandLineArgument::InvariantValueRedirection_, util::Statistics::Id::InvariantValueRedirection},
+      {StatisticsCommandLineArgument::JlmToRvsdgConversion_,      util::Statistics::Id::JlmToRvsdgConversion},
+      {StatisticsCommandLineArgument::LoopUnrolling_,             util::Statistics::Id::LoopUnrolling},
+      {StatisticsCommandLineArgument::MemoryNodeProvisioning_,    util::Statistics::Id::MemoryNodeProvisioning},
+      {StatisticsCommandLineArgument::PullNodes_,                 util::Statistics::Id::PullNodes},
+      {StatisticsCommandLineArgument::PushNodes_,                 util::Statistics::Id::PushNodes},
+      {StatisticsCommandLineArgument::ReduceNodes_,               util::Statistics::Id::ReduceNodes},
+      {StatisticsCommandLineArgument::RvsdgConstruction_,         util::Statistics::Id::RvsdgConstruction},
+      {StatisticsCommandLineArgument::RvsdgDestruction_,          util::Statistics::Id::RvsdgDestruction},
+      {StatisticsCommandLineArgument::RvsdgOptimization_,         util::Statistics::Id::RvsdgOptimization},
+      {StatisticsCommandLineArgument::SteensgaardAnalysis_,       util::Statistics::Id::SteensgaardAnalysis},
+      {StatisticsCommandLineArgument::ThetaGammaInversion_,       util::Statistics::Id::ThetaGammaInversion}
     });
 
   if (map.find(commandLineArgument) != map.end())
@@ -215,27 +214,26 @@ JlmOptCommandLineOptions::ToCommandLineArgument(jlm::util::Statistics::Id statis
 {
   static std::unordered_map<util::Statistics::Id, const char*> map(
     {
-      {util::Statistics::Id::Aggregation,                          StatisticsCommandLineArgument::Aggregation_},
-      {util::Statistics::Id::BasicEncoderEncoding,                 StatisticsCommandLineArgument::BasicEncoderEncoding_},
-      {util::Statistics::Id::Annotation,                           StatisticsCommandLineArgument::Annotation_},
-      {util::Statistics::Id::CommonNodeElimination,                StatisticsCommandLineArgument::CommonNodeElimination_},
-      {util::Statistics::Id::ControlFlowRecovery,                  StatisticsCommandLineArgument::ControlFlowRecovery_},
-      {util::Statistics::Id::DataNodeToDelta,                      StatisticsCommandLineArgument::DataNodeToDelta_},
-      {util::Statistics::Id::DeadNodeElimination,                  StatisticsCommandLineArgument::DeadNodeElimination_},
-      {util::Statistics::Id::FunctionInlining,                     StatisticsCommandLineArgument::FunctionInlining_},
-      {util::Statistics::Id::InvariantValueRedirection,            StatisticsCommandLineArgument::InvariantValueRedirection_},
-      {util::Statistics::Id::JlmToRvsdgConversion,                 StatisticsCommandLineArgument::JlmToRvsdgConversion_},
-      {util::Statistics::Id::LoopUnrolling,                        StatisticsCommandLineArgument::LoopUnrolling_},
-      {util::Statistics::Id::MemoryNodeProvisioning,               StatisticsCommandLineArgument::MemoryNodeProvisioning_},
-      {util::Statistics::Id::PullNodes,                            StatisticsCommandLineArgument::PullNodes_},
-      {util::Statistics::Id::PushNodes,                            StatisticsCommandLineArgument::PushNodes_},
-      {util::Statistics::Id::ReduceNodes,                          StatisticsCommandLineArgument::ReduceNodes_},
-      {util::Statistics::Id::RvsdgConstruction,                    StatisticsCommandLineArgument::RvsdgConstruction_},
-      {util::Statistics::Id::RvsdgDestruction,                     StatisticsCommandLineArgument::RvsdgDestruction_},
-      {util::Statistics::Id::RvsdgOptimization,                    StatisticsCommandLineArgument::RvsdgOptimization_},
-      {util::Statistics::Id::SteensgaardAnalysis,                  StatisticsCommandLineArgument::SteensgaardAnalysis_},
-      {util::Statistics::Id::SteensgaardPointsToGraphConstruction, StatisticsCommandLineArgument::SteensgaardPointsToGraphConstruction_},
-      {util::Statistics::Id::ThetaGammaInversion,                  StatisticsCommandLineArgument::ThetaGammaInversion_}
+      {util::Statistics::Id::Aggregation,               StatisticsCommandLineArgument::Aggregation_},
+      {util::Statistics::Id::BasicEncoderEncoding,      StatisticsCommandLineArgument::BasicEncoderEncoding_},
+      {util::Statistics::Id::Annotation,                StatisticsCommandLineArgument::Annotation_},
+      {util::Statistics::Id::CommonNodeElimination,     StatisticsCommandLineArgument::CommonNodeElimination_},
+      {util::Statistics::Id::ControlFlowRecovery,       StatisticsCommandLineArgument::ControlFlowRecovery_},
+      {util::Statistics::Id::DataNodeToDelta,           StatisticsCommandLineArgument::DataNodeToDelta_},
+      {util::Statistics::Id::DeadNodeElimination,       StatisticsCommandLineArgument::DeadNodeElimination_},
+      {util::Statistics::Id::FunctionInlining,          StatisticsCommandLineArgument::FunctionInlining_},
+      {util::Statistics::Id::InvariantValueRedirection, StatisticsCommandLineArgument::InvariantValueRedirection_},
+      {util::Statistics::Id::JlmToRvsdgConversion,      StatisticsCommandLineArgument::JlmToRvsdgConversion_},
+      {util::Statistics::Id::LoopUnrolling,             StatisticsCommandLineArgument::LoopUnrolling_},
+      {util::Statistics::Id::MemoryNodeProvisioning,    StatisticsCommandLineArgument::MemoryNodeProvisioning_},
+      {util::Statistics::Id::PullNodes,                 StatisticsCommandLineArgument::PullNodes_},
+      {util::Statistics::Id::PushNodes,                 StatisticsCommandLineArgument::PushNodes_},
+      {util::Statistics::Id::ReduceNodes,               StatisticsCommandLineArgument::ReduceNodes_},
+      {util::Statistics::Id::RvsdgConstruction,         StatisticsCommandLineArgument::RvsdgConstruction_},
+      {util::Statistics::Id::RvsdgDestruction,          StatisticsCommandLineArgument::RvsdgDestruction_},
+      {util::Statistics::Id::RvsdgOptimization,         StatisticsCommandLineArgument::RvsdgOptimization_},
+      {util::Statistics::Id::SteensgaardAnalysis,       StatisticsCommandLineArgument::SteensgaardAnalysis_},
+      {util::Statistics::Id::ThetaGammaInversion,       StatisticsCommandLineArgument::ThetaGammaInversion_}
     });
 
   if (map.find(statisticsId) != map.end())
@@ -526,7 +524,6 @@ JlcCommandLineParser::ParseCommandLineArguments(int argc, char **argv)
   auto rvsdgDestructionStatisticsId = util::Statistics::Id::RvsdgDestruction;
   auto rvsdgOptimizationStatisticsId = util::Statistics::Id::RvsdgOptimization;
   auto steensgaardAnalysisStatisticsId = util::Statistics::Id::SteensgaardAnalysis;
-  auto steensgaardPointsToGraphConstructionStatisticsId = util::Statistics::Id::SteensgaardPointsToGraphConstruction;
   auto thetaGammaInversionStatisticsId = util::Statistics::Id::ThetaGammaInversion;
 
   cl::list<util::Statistics::Id> jlmOptPassStatistics(
@@ -608,10 +605,6 @@ JlcCommandLineParser::ParseCommandLineArguments(int argc, char **argv)
         steensgaardAnalysisStatisticsId,
         JlmOptCommandLineOptions::ToCommandLineArgument(steensgaardAnalysisStatisticsId),
         "Collect Steensgaard alias analysis pass statistics."),
-      ::clEnumValN(
-        steensgaardPointsToGraphConstructionStatisticsId,
-        JlmOptCommandLineOptions::ToCommandLineArgument(steensgaardPointsToGraphConstructionStatisticsId),
-        "Collect Steensgaard alias analysis points-to graph construction pass statistics."),
       ::clEnumValN(
         thetaGammaInversionStatisticsId,
         JlmOptCommandLineOptions::ToCommandLineArgument(thetaGammaInversionStatisticsId),
@@ -792,7 +785,6 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, char **argv)
   auto rvsdgDestructionStatisticsId = util::Statistics::Id::RvsdgDestruction;
   auto rvsdgOptimizationStatisticsId = util::Statistics::Id::RvsdgOptimization;
   auto steensgaardAnalysisStatisticsId = util::Statistics::Id::SteensgaardAnalysis;
-  auto steensgaardPointsToGraphConstructionStatisticsId = util::Statistics::Id::SteensgaardPointsToGraphConstruction;
   auto thetaGammaInversionStatisticsId = util::Statistics::Id::ThetaGammaInversion;
 
   cl::list<util::Statistics::Id> printStatistics(

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -117,25 +117,25 @@ JlmOptCommandLineOptions::FromCommandLineArgumentToOptimizationId(const std::str
 {
   static std::unordered_map<std::string, OptimizationId> map(
     {
-      {AaSteensgaardAgnosticCommandLineArgument_,           OptimizationId::AASteensgaardAgnostic},
-      {AaSteensgaardRegionAwareCommandLineArgument_,        OptimizationId::AASteensgaardRegionAware},
-      {CommonNodeEliminationCommandLineArgument_,           OptimizationId::CommonNodeElimination},
-      {CommonNodeEliminationDeprecatedCommandLineArgument_, OptimizationId::cne},
-      {DeadNodeEliminationCommandLineArgument_,             OptimizationId::DeadNodeElimination},
-      {DeadNodeEliminationDeprecatedCommandLineArgument_,   OptimizationId::dne},
-      {FunctionInliningCommandLineArgument_,                OptimizationId::FunctionInlining},
-      {FunctionInliningDeprecatedCommandLineArgument_,      OptimizationId::iln},
-      {InvariantValueRedirectionCommandLineArgument_,       OptimizationId::InvariantValueRedirection},
-      {NodePushOutCommandLineArgument_,                     OptimizationId::NodePushOut},
-      {NodePushOutDeprecatedCommandLineArgument_,           OptimizationId::psh},
-      {NodePullInCommandLineArgument_,                      OptimizationId::NodePullIn},
-      {NodePullInDeprecatedCommandLineArgument_,            OptimizationId::pll},
-      {NodeReductionCommandLineArgument_,                   OptimizationId::NodeReduction},
-      {NodeReductionDeprecatedCommandLineArgument_,         OptimizationId::red},
-      {ThetaGammaInversionCommandLineArgument_,             OptimizationId::ThetaGammaInversion},
-      {ThetaGammaInversionDeprecatedCommandLineArgument_,   OptimizationId::ivt},
-      {LoopUnrollingCommandLineArgument_,                   OptimizationId::LoopUnrolling},
-      {LoopUnrollingDeprecatedCommandLineArgument_,         OptimizationId::url}
+      {OptimizationCommandLineArgument::AaSteensgaardAgnostic_,           OptimizationId::AASteensgaardAgnostic},
+      {OptimizationCommandLineArgument::AaSteensgaardRegionAware_,        OptimizationId::AASteensgaardRegionAware},
+      {OptimizationCommandLineArgument::CommonNodeElimination_,           OptimizationId::CommonNodeElimination},
+      {OptimizationCommandLineArgument::CommonNodeEliminationDeprecated_, OptimizationId::cne},
+      {OptimizationCommandLineArgument::DeadNodeElimination_,             OptimizationId::DeadNodeElimination},
+      {OptimizationCommandLineArgument::DeadNodeEliminationDeprecated_,   OptimizationId::dne},
+      {OptimizationCommandLineArgument::FunctionInlining_,                OptimizationId::FunctionInlining},
+      {OptimizationCommandLineArgument::FunctionInliningDeprecated_,      OptimizationId::iln},
+      {OptimizationCommandLineArgument::InvariantValueRedirection_,       OptimizationId::InvariantValueRedirection},
+      {OptimizationCommandLineArgument::NodePushOut_,                     OptimizationId::NodePushOut},
+      {OptimizationCommandLineArgument::NodePushOutDeprecated_,           OptimizationId::psh},
+      {OptimizationCommandLineArgument::NodePullIn_,                      OptimizationId::NodePullIn},
+      {OptimizationCommandLineArgument::NodePullInDeprecated_,            OptimizationId::pll},
+      {OptimizationCommandLineArgument::NodeReduction_,                   OptimizationId::NodeReduction},
+      {OptimizationCommandLineArgument::NodeReductionDeprecated_,         OptimizationId::red},
+      {OptimizationCommandLineArgument::ThetaGammaInversion_,             OptimizationId::ThetaGammaInversion},
+      {OptimizationCommandLineArgument::ThetaGammaInversionDeprecated_,   OptimizationId::ivt},
+      {OptimizationCommandLineArgument::LoopUnrolling_,                   OptimizationId::LoopUnrolling},
+      {OptimizationCommandLineArgument::LoopUnrollingDeprecated_,         OptimizationId::url}
     });
 
   if (map.find(commandLineArgument) != map.end())
@@ -149,25 +149,25 @@ JlmOptCommandLineOptions::ToCommandLineArgument(OptimizationId optimizationId)
 {
   static std::unordered_map<OptimizationId, const char*> map(
     {
-      {OptimizationId::AASteensgaardAgnostic,     AaSteensgaardAgnosticCommandLineArgument_},
-      {OptimizationId::AASteensgaardRegionAware,  AaSteensgaardRegionAwareCommandLineArgument_},
-      {OptimizationId::cne,                       CommonNodeEliminationDeprecatedCommandLineArgument_},
-      {OptimizationId::CommonNodeElimination,     CommonNodeEliminationCommandLineArgument_},
-      {OptimizationId::DeadNodeElimination,       DeadNodeEliminationCommandLineArgument_},
-      {OptimizationId::dne,                       DeadNodeEliminationDeprecatedCommandLineArgument_},
-      {OptimizationId::FunctionInlining,          FunctionInliningCommandLineArgument_},
-      {OptimizationId::iln,                       FunctionInliningDeprecatedCommandLineArgument_},
-      {OptimizationId::InvariantValueRedirection, InvariantValueRedirectionCommandLineArgument_},
-      {OptimizationId::LoopUnrolling,             LoopUnrollingCommandLineArgument_},
-      {OptimizationId::NodePullIn,                NodePullInCommandLineArgument_},
-      {OptimizationId::NodePushOut,               NodePushOutCommandLineArgument_},
-      {OptimizationId::NodeReduction,             NodeReductionCommandLineArgument_},
-      {OptimizationId::psh,                       NodePushOutDeprecatedCommandLineArgument_},
-      {OptimizationId::pll,                       NodePullInDeprecatedCommandLineArgument_},
-      {OptimizationId::red,                       NodeReductionDeprecatedCommandLineArgument_},
-      {OptimizationId::ivt,                       ThetaGammaInversionDeprecatedCommandLineArgument_},
-      {OptimizationId::url,                       LoopUnrollingDeprecatedCommandLineArgument_},
-      {OptimizationId::ThetaGammaInversion,       ThetaGammaInversionCommandLineArgument_}
+      {OptimizationId::AASteensgaardAgnostic,     OptimizationCommandLineArgument::AaSteensgaardAgnostic_},
+      {OptimizationId::AASteensgaardRegionAware,  OptimizationCommandLineArgument::AaSteensgaardRegionAware_},
+      {OptimizationId::cne,                       OptimizationCommandLineArgument::CommonNodeEliminationDeprecated_},
+      {OptimizationId::CommonNodeElimination,     OptimizationCommandLineArgument::CommonNodeElimination_},
+      {OptimizationId::DeadNodeElimination,       OptimizationCommandLineArgument::DeadNodeElimination_},
+      {OptimizationId::dne,                       OptimizationCommandLineArgument::DeadNodeEliminationDeprecated_},
+      {OptimizationId::FunctionInlining,          OptimizationCommandLineArgument::FunctionInlining_},
+      {OptimizationId::iln,                       OptimizationCommandLineArgument::FunctionInliningDeprecated_},
+      {OptimizationId::InvariantValueRedirection, OptimizationCommandLineArgument::InvariantValueRedirection_},
+      {OptimizationId::LoopUnrolling,             OptimizationCommandLineArgument::LoopUnrolling_},
+      {OptimizationId::NodePullIn,                OptimizationCommandLineArgument::NodePullIn_},
+      {OptimizationId::NodePushOut,               OptimizationCommandLineArgument::NodePushOut_},
+      {OptimizationId::NodeReduction,             OptimizationCommandLineArgument::NodeReduction_},
+      {OptimizationId::psh,                       OptimizationCommandLineArgument::NodePushOutDeprecated_},
+      {OptimizationId::pll,                       OptimizationCommandLineArgument::NodePullInDeprecated_},
+      {OptimizationId::red,                       OptimizationCommandLineArgument::NodeReductionDeprecated_},
+      {OptimizationId::ivt,                       OptimizationCommandLineArgument::ThetaGammaInversionDeprecated_},
+      {OptimizationId::url,                       OptimizationCommandLineArgument::LoopUnrollingDeprecated_},
+      {OptimizationId::ThetaGammaInversion,       OptimizationCommandLineArgument::ThetaGammaInversion_}
     });
 
   if (map.find(optimizationId) != map.end())

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -176,6 +176,74 @@ JlmOptCommandLineOptions::ToCommandLineArgument(OptimizationId optimizationId)
   throw util::error("Unknown optimization identifier");
 }
 
+util::Statistics::Id
+JlmOptCommandLineOptions::FromCommandLineArgumentToStatisticsId(const std::string& commandLineArgument)
+{
+  static std::unordered_map<std::string, util::Statistics::Id> map(
+    {
+      {StatisticsCommandLineArgument::Aggregation_,                          util::Statistics::Id::Aggregation},
+      {StatisticsCommandLineArgument::BasicEncoderEncoding_,                 util::Statistics::Id::BasicEncoderEncoding},
+      {StatisticsCommandLineArgument::Annotation_,                           util::Statistics::Id::Annotation},
+      {StatisticsCommandLineArgument::CommonNodeElimination_,                util::Statistics::Id::CommonNodeElimination},
+      {StatisticsCommandLineArgument::ControlFlowRecovery_,                  util::Statistics::Id::ControlFlowRecovery},
+      {StatisticsCommandLineArgument::DataNodeToDelta_,                      util::Statistics::Id::DataNodeToDelta},
+      {StatisticsCommandLineArgument::DeadNodeElimination_,                  util::Statistics::Id::DeadNodeElimination},
+      {StatisticsCommandLineArgument::FunctionInlining_,                     util::Statistics::Id::FunctionInlining},
+      {StatisticsCommandLineArgument::InvariantValueRedirection_,            util::Statistics::Id::InvariantValueRedirection},
+      {StatisticsCommandLineArgument::JlmToRvsdgConversion_,                 util::Statistics::Id::JlmToRvsdgConversion},
+      {StatisticsCommandLineArgument::LoopUnrolling_,                        util::Statistics::Id::LoopUnrolling},
+      {StatisticsCommandLineArgument::MemoryNodeProvisioning_,               util::Statistics::Id::MemoryNodeProvisioning},
+      {StatisticsCommandLineArgument::PullNodes_,                            util::Statistics::Id::PullNodes},
+      {StatisticsCommandLineArgument::PushNodes_,                            util::Statistics::Id::PushNodes},
+      {StatisticsCommandLineArgument::ReduceNodes_,                          util::Statistics::Id::ReduceNodes},
+      {StatisticsCommandLineArgument::RvsdgConstruction_,                    util::Statistics::Id::RvsdgConstruction},
+      {StatisticsCommandLineArgument::RvsdgDestruction_,                     util::Statistics::Id::RvsdgDestruction},
+      {StatisticsCommandLineArgument::RvsdgOptimization_,                    util::Statistics::Id::RvsdgOptimization},
+      {StatisticsCommandLineArgument::SteensgaardAnalysis_,                  util::Statistics::Id::SteensgaardAnalysis},
+      {StatisticsCommandLineArgument::SteensgaardPointsToGraphConstruction_, util::Statistics::Id::SteensgaardPointsToGraphConstruction},
+      {StatisticsCommandLineArgument::ThetaGammaInversion_,                  util::Statistics::Id::ThetaGammaInversion}
+    });
+
+  if (map.find(commandLineArgument) != map.end())
+    return map[commandLineArgument];
+
+  throw util::error("Unknown command line argument: " + commandLineArgument);
+}
+
+const char*
+JlmOptCommandLineOptions::ToCommandLineArgument(jlm::util::Statistics::Id statisticsId)
+{
+  static std::unordered_map<util::Statistics::Id, const char*> map(
+    {
+      {util::Statistics::Id::Aggregation,                          StatisticsCommandLineArgument::Aggregation_},
+      {util::Statistics::Id::BasicEncoderEncoding,                 StatisticsCommandLineArgument::BasicEncoderEncoding_},
+      {util::Statistics::Id::Annotation,                           StatisticsCommandLineArgument::Annotation_},
+      {util::Statistics::Id::CommonNodeElimination,                StatisticsCommandLineArgument::CommonNodeElimination_},
+      {util::Statistics::Id::ControlFlowRecovery,                  StatisticsCommandLineArgument::ControlFlowRecovery_},
+      {util::Statistics::Id::DataNodeToDelta,                      StatisticsCommandLineArgument::DataNodeToDelta_},
+      {util::Statistics::Id::DeadNodeElimination,                  StatisticsCommandLineArgument::DeadNodeElimination_},
+      {util::Statistics::Id::FunctionInlining,                     StatisticsCommandLineArgument::FunctionInlining_},
+      {util::Statistics::Id::InvariantValueRedirection,            StatisticsCommandLineArgument::InvariantValueRedirection_},
+      {util::Statistics::Id::JlmToRvsdgConversion,                 StatisticsCommandLineArgument::JlmToRvsdgConversion_},
+      {util::Statistics::Id::LoopUnrolling,                        StatisticsCommandLineArgument::LoopUnrolling_},
+      {util::Statistics::Id::MemoryNodeProvisioning,               StatisticsCommandLineArgument::MemoryNodeProvisioning_},
+      {util::Statistics::Id::PullNodes,                            StatisticsCommandLineArgument::PullNodes_},
+      {util::Statistics::Id::PushNodes,                            StatisticsCommandLineArgument::PushNodes_},
+      {util::Statistics::Id::ReduceNodes,                          StatisticsCommandLineArgument::ReduceNodes_},
+      {util::Statistics::Id::RvsdgConstruction,                    StatisticsCommandLineArgument::RvsdgConstruction_},
+      {util::Statistics::Id::RvsdgDestruction,                     StatisticsCommandLineArgument::RvsdgDestruction_},
+      {util::Statistics::Id::RvsdgOptimization,                    StatisticsCommandLineArgument::RvsdgOptimization_},
+      {util::Statistics::Id::SteensgaardAnalysis,                  StatisticsCommandLineArgument::SteensgaardAnalysis_},
+      {util::Statistics::Id::SteensgaardPointsToGraphConstruction, StatisticsCommandLineArgument::SteensgaardPointsToGraphConstruction_},
+      {util::Statistics::Id::ThetaGammaInversion,                  StatisticsCommandLineArgument::ThetaGammaInversion_}
+    });
+
+  if (map.find(statisticsId) != map.end())
+    return map[statisticsId];
+
+  throw util::error("Unknown statistics identifier");
+}
+
 const char*
 JlmOptCommandLineOptions::ToCommandLineArgument(OutputFormat outputFormat)
 {
@@ -589,91 +657,113 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, char **argv)
     cl::desc(statisticFileDesc),
     cl::value_desc("file"));
 
+  auto aggregationStatisticsId = util::Statistics::Id::Aggregation;
+  auto annotationStatisticsId = util::Statistics::Id::Annotation;
+  auto basicEncoderEncodingStatisticsId = util::Statistics::Id::BasicEncoderEncoding;
+  auto commonNodeEliminationStatisticsId = util::Statistics::Id::CommonNodeElimination;
+  auto controlFlowRecoveryStatisticsId = util::Statistics::Id::ControlFlowRecovery;
+  auto dataNodeToDeltaStatisticsId = util::Statistics::Id::DataNodeToDelta;
+  auto deadNodeEliminationStatisticsId = util::Statistics::Id::DeadNodeElimination;
+  auto functionInliningStatisticsId = util::Statistics::Id::FunctionInlining;
+  auto invariantValueRedirectionStatisticsId = util::Statistics::Id::InvariantValueRedirection;
+  auto jlmToRvsdgConversionStatisticsId = util::Statistics::Id::JlmToRvsdgConversion;
+  auto loopUnrollingStatisticsId = util::Statistics::Id::LoopUnrolling;
+  auto memoryNodeProvisioningStatisticsId = util::Statistics::Id::MemoryNodeProvisioning;
+  auto pullNodesStatisticsId = util::Statistics::Id::PullNodes;
+  auto pushNodesStatisticsId = util::Statistics::Id::PushNodes;
+  auto reduceNodesStatisticsId = util::Statistics::Id::ReduceNodes;
+  auto rvsdgConstructionStatisticsId = util::Statistics::Id::RvsdgConstruction;
+  auto rvsdgDestructionStatisticsId = util::Statistics::Id::RvsdgDestruction;
+  auto rvsdgOptimizationStatisticsId = util::Statistics::Id::RvsdgOptimization;
+  auto steensgaardAnalysisStatisticsId = util::Statistics::Id::SteensgaardAnalysis;
+  auto steensgaardPointsToGraphConstructionStatisticsId = util::Statistics::Id::SteensgaardPointsToGraphConstruction;
+  auto thetaGammaInversionStatisticsId = util::Statistics::Id::ThetaGammaInversion;
+
   cl::list<util::Statistics::Id> printStatistics(
     cl::values(
       ::clEnumValN(
-        util::Statistics::Id::Aggregation,
-        "print-aggregation-time",
+        aggregationStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(aggregationStatisticsId),
         "Write aggregation statistics to file."),
       ::clEnumValN(
-        util::Statistics::Id::Annotation,
-        "print-annotation-time",
+        annotationStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(annotationStatisticsId),
         "Write annotation statistics to file."),
       ::clEnumValN(
-        util::Statistics::Id::BasicEncoderEncoding,
-        "print-basicencoder-encoding",
+        basicEncoderEncodingStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(basicEncoderEncodingStatisticsId),
         "Write encoding statistics of basic encoder to file."),
       ::clEnumValN(
-        util::Statistics::Id::CommonNodeElimination,
-        "print-cne-stat",
+        commonNodeEliminationStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(commonNodeEliminationStatisticsId),
         "Write common node elimination statistics to file."),
       ::clEnumValN(
-        util::Statistics::Id::ControlFlowRecovery,
-        "print-cfr-time",
+        controlFlowRecoveryStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(controlFlowRecoveryStatisticsId),
         "Write control flow recovery statistics to file."),
       ::clEnumValN(
-        util::Statistics::Id::DataNodeToDelta,
-        "printDataNodeToDelta",
+        dataNodeToDeltaStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(dataNodeToDeltaStatisticsId),
         "Write data node to delta node conversion statistics to file."),
       ::clEnumValN(
-        util::Statistics::Id::DeadNodeElimination,
-        "print-dne-stat",
+        deadNodeEliminationStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(deadNodeEliminationStatisticsId),
         "Write dead node elimination statistics to file."),
       ::clEnumValN(
-        util::Statistics::Id::FunctionInlining,
-        "print-iln-stat",
+        functionInliningStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(functionInliningStatisticsId),
         "Write function inlining statistics to file."),
       ::clEnumValN(
-        util::Statistics::Id::InvariantValueRedirection,
-        "printInvariantValueRedirection",
+        invariantValueRedirectionStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(invariantValueRedirectionStatisticsId),
         "Write invariant value redirection statistics to file."),
       ::clEnumValN(
-        util::Statistics::Id::JlmToRvsdgConversion,
-        "print-jlm-rvsdg-conversion",
+        jlmToRvsdgConversionStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(jlmToRvsdgConversionStatisticsId),
         "Write Jlm to RVSDG conversion statistics to file."),
       ::clEnumValN(
-        util::Statistics::Id::LoopUnrolling,
-        "print-unroll-stat",
+        loopUnrollingStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(loopUnrollingStatisticsId),
         "Write loop unrolling statistics to file."),
       ::clEnumValN(
-        util::Statistics::Id::MemoryNodeProvisioning,
-        "print-memory-node-provisioning",
+        memoryNodeProvisioningStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(memoryNodeProvisioningStatisticsId),
         "Write memory node provisioning statistics to file."),
       ::clEnumValN(
-        util::Statistics::Id::PullNodes,
-        "print-pull-stat",
+        pullNodesStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(pullNodesStatisticsId),
         "Write node pull statistics to file."),
       ::clEnumValN(
-        util::Statistics::Id::PushNodes,
-        "print-push-stat",
+        pushNodesStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(pushNodesStatisticsId),
         "Write node push statistics to file."),
       ::clEnumValN(
-        util::Statistics::Id::ReduceNodes,
-        "print-reduction-stat",
+        reduceNodesStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(reduceNodesStatisticsId),
         "Write node reduction statistics to file."),
       ::clEnumValN(
-        util::Statistics::Id::RvsdgConstruction,
-        "print-rvsdg-construction",
+        rvsdgConstructionStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(rvsdgConstructionStatisticsId),
         "Write RVSDG construction statistics to file."),
       ::clEnumValN(
-        util::Statistics::Id::RvsdgDestruction,
-        "print-rvsdg-destruction",
+        rvsdgDestructionStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(rvsdgDestructionStatisticsId),
         "Write RVSDG destruction statistics to file."),
       ::clEnumValN(
-        util::Statistics::Id::RvsdgOptimization,
-        "print-rvsdg-optimization",
+        rvsdgOptimizationStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(rvsdgOptimizationStatisticsId),
         "Write RVSDG optimization statistics to file."),
       ::clEnumValN(
-        util::Statistics::Id::SteensgaardAnalysis,
-        "print-steensgaard-analysis",
+        steensgaardAnalysisStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(steensgaardAnalysisStatisticsId),
         "Write Steensgaard analysis statistics to file."),
       ::clEnumValN(
-        util::Statistics::Id::SteensgaardPointsToGraphConstruction,
-        "print-steensgaard-pointstograph-construction",
+        steensgaardPointsToGraphConstructionStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(steensgaardPointsToGraphConstructionStatisticsId),
         "Write Steensgaard PointsTo Graph construction statistics to file."),
       ::clEnumValN(
-        util::Statistics::Id::ThetaGammaInversion,
-        "print-ivt-stat",
+        thetaGammaInversionStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(thetaGammaInversionStatisticsId),
         "Write theta-gamma inversion statistics to file.")),
     cl::desc("Write statistics"));
 

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -507,6 +507,117 @@ JlcCommandLineParser::ParseCommandLineArguments(int argc, char **argv)
     cl::desc("Specify name of main file output in depfile."),
     cl::value_desc("value"));
 
+  auto aggregationStatisticsId = util::Statistics::Id::Aggregation;
+  auto annotationStatisticsId = util::Statistics::Id::Annotation;
+  auto basicEncoderEncodingStatisticsId = util::Statistics::Id::BasicEncoderEncoding;
+  auto commonNodeEliminationStatisticsId = util::Statistics::Id::CommonNodeElimination;
+  auto controlFlowRecoveryStatisticsId = util::Statistics::Id::ControlFlowRecovery;
+  auto dataNodeToDeltaStatisticsId = util::Statistics::Id::DataNodeToDelta;
+  auto deadNodeEliminationStatisticsId = util::Statistics::Id::DeadNodeElimination;
+  auto functionInliningStatisticsId = util::Statistics::Id::FunctionInlining;
+  auto invariantValueRedirectionStatisticsId = util::Statistics::Id::InvariantValueRedirection;
+  auto jlmToRvsdgConversionStatisticsId = util::Statistics::Id::JlmToRvsdgConversion;
+  auto loopUnrollingStatisticsId = util::Statistics::Id::LoopUnrolling;
+  auto memoryNodeProvisioningStatisticsId = util::Statistics::Id::MemoryNodeProvisioning;
+  auto pullNodesStatisticsId = util::Statistics::Id::PullNodes;
+  auto pushNodesStatisticsId = util::Statistics::Id::PushNodes;
+  auto reduceNodesStatisticsId = util::Statistics::Id::ReduceNodes;
+  auto rvsdgConstructionStatisticsId = util::Statistics::Id::RvsdgConstruction;
+  auto rvsdgDestructionStatisticsId = util::Statistics::Id::RvsdgDestruction;
+  auto rvsdgOptimizationStatisticsId = util::Statistics::Id::RvsdgOptimization;
+  auto steensgaardAnalysisStatisticsId = util::Statistics::Id::SteensgaardAnalysis;
+  auto steensgaardPointsToGraphConstructionStatisticsId = util::Statistics::Id::SteensgaardPointsToGraphConstruction;
+  auto thetaGammaInversionStatisticsId = util::Statistics::Id::ThetaGammaInversion;
+
+  cl::list<util::Statistics::Id> jlmOptPassStatistics(
+    "JlmOptPassStatistics",
+    cl::values(
+      ::clEnumValN(
+        aggregationStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(aggregationStatisticsId),
+        "Collect control flow graph aggregation pass statistics."),
+      ::clEnumValN(
+        annotationStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(annotationStatisticsId),
+        "Collect aggregation tree annotation pass statistics."),
+      ::clEnumValN(
+        basicEncoderEncodingStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(basicEncoderEncodingStatisticsId),
+        "Collect memory state encoding pass statistics."),
+      ::clEnumValN(
+        commonNodeEliminationStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(commonNodeEliminationStatisticsId),
+        "Collect common node elimination pass statistics."),
+      ::clEnumValN(
+        controlFlowRecoveryStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(controlFlowRecoveryStatisticsId),
+        "Collect control flow recovery pass statistics."),
+      ::clEnumValN(
+        dataNodeToDeltaStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(dataNodeToDeltaStatisticsId),
+        "Collect data node to delta node conversion pass statistics."),
+      ::clEnumValN(
+        deadNodeEliminationStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(deadNodeEliminationStatisticsId),
+        "Collect dead node elimination pass statistics."),
+      ::clEnumValN(
+        functionInliningStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(functionInliningStatisticsId),
+        "Collect function inlining pass statistics."),
+      ::clEnumValN(
+        invariantValueRedirectionStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(invariantValueRedirectionStatisticsId),
+        "Collect invariant value redirection pass statistics."),
+      ::clEnumValN(
+        jlmToRvsdgConversionStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(jlmToRvsdgConversionStatisticsId),
+        "Collect Jlm to RVSDG conversion pass statistics."),
+      ::clEnumValN(
+        loopUnrollingStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(loopUnrollingStatisticsId),
+        "Collect loop unrolling pass statistics."),
+      ::clEnumValN(
+        memoryNodeProvisioningStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(memoryNodeProvisioningStatisticsId),
+        "Collect memory node provisioning pass statistics."),
+      ::clEnumValN(
+        pullNodesStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(pullNodesStatisticsId),
+        "Collect node pull pass statistics."),
+      ::clEnumValN(
+        pushNodesStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(pushNodesStatisticsId),
+        "Collect node push pass statistics."),
+      ::clEnumValN(
+        reduceNodesStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(reduceNodesStatisticsId),
+        "Collect node reduction pass statistics."),
+      ::clEnumValN(
+        rvsdgConstructionStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(rvsdgConstructionStatisticsId),
+        "Collect RVSDG construction pass statistics."),
+      ::clEnumValN(
+        rvsdgDestructionStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(rvsdgDestructionStatisticsId),
+        "Collect RVSDG destruction pass statistics."),
+      ::clEnumValN(
+        rvsdgOptimizationStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(rvsdgOptimizationStatisticsId),
+        "Collect RVSDG optimization pass statistics."),
+      ::clEnumValN(
+        steensgaardAnalysisStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(steensgaardAnalysisStatisticsId),
+        "Collect Steensgaard alias analysis pass statistics."),
+      ::clEnumValN(
+        steensgaardPointsToGraphConstructionStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(steensgaardPointsToGraphConstructionStatisticsId),
+        "Collect Steensgaard alias analysis points-to graph construction pass statistics."),
+      ::clEnumValN(
+        thetaGammaInversionStatisticsId,
+        JlmOptCommandLineOptions::ToCommandLineArgument(thetaGammaInversionStatisticsId),
+        "Collect theta-gamma inversion pass statistics.")),
+    cl::desc("Collect jlm-opt pass statistics"));
+
   cl::ParseCommandLineOptions(argc, argv);
 
   /* Process parsed options */
@@ -574,6 +685,11 @@ JlcCommandLineParser::ParseCommandLineArguments(int argc, char **argv)
   CommandLineOptions_.GenerateDebugInformation_ = generateDebugInformation;
   CommandLineOptions_.Flags_ = flags;
   CommandLineOptions_.JlmOptOptimizations_ = jlmOptOptimizations;
+  CommandLineOptions_.JlmOptPassStatistics_ = util::HashSet<util::Statistics::Id>(
+    {
+      jlmOptPassStatistics.begin(),
+      jlmOptPassStatistics.end()
+    });
   CommandLineOptions_.Verbose_ = verbose;
   CommandLineOptions_.Rdynamic_ = rDynamic;
   CommandLineOptions_.Suppress_ = suppress;

--- a/jlm/tooling/CommandLine.hpp
+++ b/jlm/tooling/CommandLine.hpp
@@ -239,7 +239,6 @@ private:
     inline static const char* RvsdgDestruction_ = "print-rvsdg-destruction";
     inline static const char* RvsdgOptimization_ = "print-rvsdg-optimization";
     inline static const char* SteensgaardAnalysis_ = "print-steensgaard-analysis";
-    inline static const char* SteensgaardPointsToGraphConstruction_ = "print-steensgaard-pointstograph-construction";
     inline static const char* ThetaGammaInversion_ = "print-ivt-stat";
   };
 };

--- a/jlm/tooling/CommandLine.hpp
+++ b/jlm/tooling/CommandLine.hpp
@@ -155,7 +155,7 @@ public:
   GetOptimizations() const noexcept;
 
   static OptimizationId
-  FromCommandLineArgument(const std::string& commandLineArgument);
+  FromCommandLineArgumentToOptimizationId(const std::string& commandLineArgument);
 
   static const char*
   ToCommandLineArgument(OptimizationId optimizationId);

--- a/jlm/tooling/CommandLine.hpp
+++ b/jlm/tooling/CommandLine.hpp
@@ -310,6 +310,7 @@ public:
   std::vector<std::string> IncludePaths_;
   std::vector<std::string> Flags_;
   std::vector<JlmOptCommandLineOptions::OptimizationId> JlmOptOptimizations_;
+  util::HashSet<util::Statistics::Id> JlmOptPassStatistics_;
 
   std::vector<Compilation> Compilations_;
 };

--- a/jlm/tooling/CommandLine.hpp
+++ b/jlm/tooling/CommandLine.hpp
@@ -157,8 +157,14 @@ public:
   static OptimizationId
   FromCommandLineArgumentToOptimizationId(const std::string& commandLineArgument);
 
+  static util::Statistics::Id
+  FromCommandLineArgumentToStatisticsId(const std::string& commandLineArgument);
+
   static const char*
   ToCommandLineArgument(OptimizationId optimizationId);
+
+  static const char*
+  ToCommandLineArgument(util::Statistics::Id statisticsId);
 
   static const char*
   ToCommandLineArgument(OutputFormat outputFormat);
@@ -215,8 +221,8 @@ private:
   struct StatisticsCommandLineArgument
   {
     inline static const char* Aggregation_ = "print-aggregation-time";
-    inline static const char* AgnosticMemoryNodeProvider_ = "print-basicencoder-encoding";
     inline static const char* Annotation_ = "print-annotation-time";
+    inline static const char* BasicEncoderEncoding_ = "print-basicencoder-encoding";
     inline static const char* CommonNodeElimination_ = "print-cne-stat";
     inline static const char* ControlFlowRecovery_ = "print-cfr-time";
     inline static const char* DataNodeToDelta_ = "printDataNodeToDelta";

--- a/jlm/tooling/CommandLine.hpp
+++ b/jlm/tooling/CommandLine.hpp
@@ -189,25 +189,53 @@ private:
   util::StatisticsCollectorSettings StatisticsCollectorSettings_;
   std::vector<OptimizationId> OptimizationIds_;
 
-  inline static const char* AaSteensgaardAgnosticCommandLineArgument_ = "AASteensgaardAgnostic";
-  inline static const char* AaSteensgaardRegionAwareCommandLineArgument_ = "AASteensgaardRegionAware";
-  inline static const char* CommonNodeEliminationCommandLineArgument_ = "CommonNodeElimination";
-  inline static const char* CommonNodeEliminationDeprecatedCommandLineArgument_ = "cne";
-  inline static const char* DeadNodeEliminationCommandLineArgument_ = "DeadNodeElimination";
-  inline static const char* DeadNodeEliminationDeprecatedCommandLineArgument_ = "dne";
-  inline static const char* FunctionInliningCommandLineArgument_ = "FunctionInlining";
-  inline static const char* FunctionInliningDeprecatedCommandLineArgument_ = "iln";
-  inline static const char* InvariantValueRedirectionCommandLineArgument_ = "InvariantValueRedirection";
-  inline static const char* NodePullInCommandLineArgument_ = "NodePullIn";
-  inline static const char* NodePullInDeprecatedCommandLineArgument_ = "pll";
-  inline static const char* NodePushOutCommandLineArgument_ = "NodePushOut";
-  inline static const char* NodePushOutDeprecatedCommandLineArgument_ = "psh";
-  inline static const char* ThetaGammaInversionCommandLineArgument_ = "ThetaGammaInversion";
-  inline static const char* ThetaGammaInversionDeprecatedCommandLineArgument_ = "ivt";
-  inline static const char* LoopUnrollingCommandLineArgument_ = "LoopUnrolling";
-  inline static const char* LoopUnrollingDeprecatedCommandLineArgument_ = "url";
-  inline static const char* NodeReductionCommandLineArgument_ = "NodeReduction";
-  inline static const char* NodeReductionDeprecatedCommandLineArgument_ = "red";
+  struct OptimizationCommandLineArgument
+  {
+    inline static const char* AaSteensgaardAgnostic_ = "AASteensgaardAgnostic";
+    inline static const char* AaSteensgaardRegionAware_ = "AASteensgaardRegionAware";
+    inline static const char* CommonNodeElimination_ = "CommonNodeElimination";
+    inline static const char* CommonNodeEliminationDeprecated_ = "cne";
+    inline static const char* DeadNodeElimination_ = "DeadNodeElimination";
+    inline static const char* DeadNodeEliminationDeprecated_ = "dne";
+    inline static const char* FunctionInlining_ = "FunctionInlining";
+    inline static const char* FunctionInliningDeprecated_ = "iln";
+    inline static const char* InvariantValueRedirection_ = "InvariantValueRedirection";
+    inline static const char* NodePullIn_ = "NodePullIn";
+    inline static const char* NodePullInDeprecated_ = "pll";
+    inline static const char* NodePushOut_ = "NodePushOut";
+    inline static const char* NodePushOutDeprecated_ = "psh";
+    inline static const char* ThetaGammaInversion_ = "ThetaGammaInversion";
+    inline static const char* ThetaGammaInversionDeprecated_ = "ivt";
+    inline static const char* LoopUnrolling_ = "LoopUnrolling";
+    inline static const char* LoopUnrollingDeprecated_ = "url";
+    inline static const char* NodeReduction_ = "NodeReduction";
+    inline static const char* NodeReductionDeprecated_ = "red";
+  };
+
+  struct StatisticsCommandLineArgument
+  {
+    inline static const char* Aggregation_ = "print-aggregation-time";
+    inline static const char* AgnosticMemoryNodeProvider_ = "print-basicencoder-encoding";
+    inline static const char* Annotation_ = "print-annotation-time";
+    inline static const char* CommonNodeElimination_ = "print-cne-stat";
+    inline static const char* ControlFlowRecovery_ = "print-cfr-time";
+    inline static const char* DataNodeToDelta_ = "printDataNodeToDelta";
+    inline static const char* DeadNodeElimination_ = "print-dne-stat";
+    inline static const char* FunctionInlining_ = "print-iln-stat";
+    inline static const char* InvariantValueRedirection_ = "printInvariantValueRedirection";
+    inline static const char* JlmToRvsdgConversion_ = "print-jlm-rvsdg-conversion";
+    inline static const char* LoopUnrolling_ = "print-unroll-stat";
+    inline static const char* MemoryNodeProvisioning_ = "print-memory-node-provisioning";
+    inline static const char* PullNodes_ = "print-pull-stat";
+    inline static const char* PushNodes_ = "print-push-stat";
+    inline static const char* ReduceNodes_ = "print-reduction-stat";
+    inline static const char* RvsdgConstruction_ = "print-rvsdg-construction";
+    inline static const char* RvsdgDestruction_ = "print-rvsdg-destruction";
+    inline static const char* RvsdgOptimization_ = "print-rvsdg-optimization";
+    inline static const char* SteensgaardAnalysis_ = "print-steensgaard-analysis";
+    inline static const char* SteensgaardPointsToGraphConstruction_ = "print-steensgaard-pointstograph-construction";
+    inline static const char* ThetaGammaInversion_ = "print-ivt-stat";
+  };
 };
 
 class JlcCommandLineOptions final : public CommandLineOptions {

--- a/jlm/util/Statistics.hpp
+++ b/jlm/util/Statistics.hpp
@@ -72,10 +72,19 @@ private:
 /**
  * Determines the settings of a StatisticsCollector.
  */
-class StatisticsCollectorSettings final {
+class StatisticsCollectorSettings final
+{
+  inline static const char* DefaultFilePath_ = "/tmp/jlm-stats.log";
+
 public:
   StatisticsCollectorSettings()
-    : FilePath_("/tmp/jlm-stats.log")
+    : FilePath_(DefaultFilePath_)
+  {}
+
+  explicit
+  StatisticsCollectorSettings(HashSet<Statistics::Id> demandedStatistics)
+    : FilePath_(DefaultFilePath_)
+    , DemandedStatistics_(std::move(demandedStatistics))
   {}
 
   StatisticsCollectorSettings(
@@ -118,6 +127,12 @@ public:
   NumDemandedStatistics() const noexcept
   {
     return DemandedStatistics_.Size();
+  }
+
+  [[nodiscard]] const HashSet<Statistics::Id>&
+  GetDemandedStatistics() const noexcept
+  {
+    return DemandedStatistics_;
   }
 
 private:

--- a/jlm/util/Statistics.hpp
+++ b/jlm/util/Statistics.hpp
@@ -19,7 +19,10 @@ namespace jlm::util
  */
 class Statistics {
 public:
-  enum class Id {
+  enum class Id
+  {
+    FirstEnumValue, // must always be the first enum value, used for iteration
+
     Aggregation,
     Annotation,
     BasicEncoderEncoding,
@@ -40,7 +43,9 @@ public:
     RvsdgOptimization,
     SteensgaardAnalysis,
     SteensgaardPointsToGraphConstruction,
-    ThetaGammaInversion
+    ThetaGammaInversion,
+
+    LastEnumValue // must always be the last enum value, used for iteration
   };
 
   virtual

--- a/tests/jlm/tooling/Makefile.sub
+++ b/tests/jlm/tooling/Makefile.sub
@@ -1,4 +1,5 @@
 TESTS += \
 	jlm/tooling/TestJlcCommandGraphGenerator \
 	jlm/tooling/TestJlcCommandLineParser \
+	jlm/tooling/TestJlmOptCommand \
 	jlm/tooling/TestJlmOptCommandLineParser \

--- a/tests/jlm/tooling/TestJlcCommandLineParser.cpp
+++ b/tests/jlm/tooling/TestJlcCommandLineParser.cpp
@@ -179,6 +179,33 @@ TestFalseJlmOptOptimization()
   assert(exceptionThrown);
 }
 
+static void
+TestJlmOptPassStatistics()
+{
+  using namespace jlm::tooling;
+
+  // Arrange
+  std::vector<std::string> commandLineArguments(
+    {
+      "jlc",
+      "--JlmOptPassStatistics=print-aggregation-time",
+      "--JlmOptPassStatistics=print-steensgaard-analysis",
+      "foobar.c"
+    });
+
+  jlm::util::HashSet<jlm::util::Statistics::Id> expectedStatistics(
+    {
+      jlm::util::Statistics::Id::Aggregation,
+      jlm::util::Statistics::Id::SteensgaardAnalysis
+    });
+
+  // Act
+  auto & commandLineOptions = ParseCommandLineArguments(commandLineArguments);
+
+  // Assert
+  assert(commandLineOptions.JlmOptPassStatistics_ == expectedStatistics);
+}
+
 static int
 Test()
 {
@@ -188,6 +215,7 @@ Test()
   Test4();
   TestJlmOptOptimizations();
   TestFalseJlmOptOptimization();
+  TestJlmOptPassStatistics();
 
   return 0;
 }

--- a/tests/jlm/tooling/TestJlmOptCommand.cpp
+++ b/tests/jlm/tooling/TestJlmOptCommand.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <test-registry.hpp>
+
+#include <jlm/tooling/Command.hpp>
+#include <jlm/util/strfmt.hpp>
+
+static void
+TestStatistics()
+{
+  using namespace jlm::tooling;
+
+  // Arrange
+  jlm::util::StatisticsCollectorSettings statisticsCollectorSettings({jlm::util::Statistics::Id::SteensgaardAnalysis});
+
+  JlmOptCommandLineOptions commandLineOptions(
+    jlm::util::filepath("inputFile.ll"),
+    jlm::util::filepath("outputFile.ll"),
+    JlmOptCommandLineOptions::OutputFormat::Llvm,
+    statisticsCollectorSettings,
+    {
+      JlmOptCommandLineOptions::OptimizationId::DeadNodeElimination,
+      JlmOptCommandLineOptions::OptimizationId::LoopUnrolling
+    });
+
+  JlmOptCommand command("jlm-opt", commandLineOptions);
+
+  // Act
+  auto receivedCommandLine = command.ToString();
+
+  // Assert
+  std::string expectedCommandLine = jlm::util::strfmt(
+    "jlm-opt ",
+    "--llvm ",
+    "--DeadNodeElimination --LoopUnrolling ",
+    "--print-steensgaard-analysis ",
+    "-o outputFile.ll ",
+    "inputFile.ll");
+
+  assert(receivedCommandLine == expectedCommandLine);
+}
+
+static int
+TestJlmOptCommand()
+{
+  TestStatistics();
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER(
+  "jlm/tooling/TestJlmOptCommand",
+  TestJlmOptCommand)

--- a/tests/jlm/tooling/TestJlmOptCommandLineParser.cpp
+++ b/tests/jlm/tooling/TestJlmOptCommandLineParser.cpp
@@ -26,6 +26,23 @@ TestOptimizationCommandLineArgumentConversion()
 }
 
 static void
+TestStatisticsCommandLineArgumentConversion()
+{
+  using namespace jlm::tooling;
+  for (
+    size_t n = static_cast<std::size_t>(jlm::util::Statistics::Id::FirstEnumValue) + 1;
+    n != static_cast<std::size_t>(jlm::util::Statistics::Id::LastEnumValue);
+    n++)
+  {
+    auto expectedStatisticsId = static_cast<jlm::util::Statistics::Id>(n);
+    auto commandLineArgument = JlmOptCommandLineOptions::ToCommandLineArgument(expectedStatisticsId);
+    auto receivedStatisticsId = JlmOptCommandLineOptions::FromCommandLineArgumentToStatisticsId(commandLineArgument);
+
+    assert(receivedStatisticsId == expectedStatisticsId);
+  }
+}
+
+static void
 TestOptimizationIdToOptimizationTranslation()
 {
   using namespace jlm::tooling;
@@ -47,6 +64,7 @@ static int
 Test()
 {
   TestOptimizationCommandLineArgumentConversion();
+  TestStatisticsCommandLineArgumentConversion();
   TestOptimizationIdToOptimizationTranslation();
 
   return 0;

--- a/tests/jlm/tooling/TestJlmOptCommandLineParser.cpp
+++ b/tests/jlm/tooling/TestJlmOptCommandLineParser.cpp
@@ -19,7 +19,7 @@ TestOptimizationCommandLineArgumentConversion()
   {
     auto expectedOptimizationId = static_cast<JlmOptCommandLineOptions::OptimizationId>(n);
     auto commandLineArgument = JlmOptCommandLineOptions::ToCommandLineArgument(expectedOptimizationId);
-    auto receivedOptimizationId = JlmOptCommandLineOptions::FromCommandLineArgument(commandLineArgument);
+    auto receivedOptimizationId = JlmOptCommandLineOptions::FromCommandLineArgumentToOptimizationId(commandLineArgument);
 
     assert(receivedOptimizationId == expectedOptimizationId);
   }


### PR DESCRIPTION
Adds support for collecting jlm-opt statistics via jlc. Usage:

`jlc --JlmOptPassStatistics=print-aggregation-time inputFile.c`

It utilizes the same command line arguments for gathering statistics as jlm-opt.