### PR TITLE
Remove jlm-opt's single statistics file

### DIFF
--- a/jlm/tooling/Command.cpp
+++ b/jlm/tooling/Command.cpp
@@ -280,10 +280,16 @@ JlmOptCommand::ToString() const
     statisticsArguments += "--" + std::string(JlmOptCommandLineOptions::ToCommandLineArgument(statisticsId)) + " ";
   }
 
+  std::string statisticsDirArgument =
+    "-s "
+    + CommandLineOptions_.GetStatisticsCollectorSettings().GetFilePath().path()
+    + " ";
+
   return util::strfmt(
     ProgramName_ + " ",
     outputFormatArgument,
     optimizationArguments,
+    statisticsDirArgument,
     statisticsArguments,
     outputFileArgument,
     CommandLineOptions_.GetInputFile().to_str());

--- a/jlm/tooling/CommandGraphGenerator.cpp
+++ b/jlm/tooling/CommandGraphGenerator.cpp
@@ -114,11 +114,18 @@ JlcCommandGraphGenerator::GenerateCommandGraph(const JlcCommandLineOptions & com
 
     if (compilation.RequiresOptimization())
     {
+      auto statisticsFilePath = util::StatisticsCollectorSettings::CreateUniqueStatisticsFile(
+        util::filepath(std::filesystem::temp_directory_path()),
+        compilation.InputFile());
+      util::StatisticsCollectorSettings statisticsCollectorSettings(
+        statisticsFilePath,
+        commandLineOptions.JlmOptPassStatistics_);
+
       JlmOptCommandLineOptions jlmOptCommandLineOptions(
         CreateParserCommandOutputFile(compilation.InputFile()),
         CreateJlmOptCommandOutputFile(compilation.InputFile()),
         JlmOptCommandLineOptions::OutputFormat::Llvm,
-        util::StatisticsCollectorSettings(commandLineOptions.JlmOptPassStatistics_),
+        statisticsCollectorSettings,
         commandLineOptions.JlmOptOptimizations_);
 
       auto & jlmOptCommandNode = JlmOptCommand::Create(

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -745,8 +745,6 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, char **argv)
 
   cl::TopLevelSubCommand->reset();
 
-  util::StatisticsCollectorSettings statisticsCollectorSettings;
-
   cl::opt<std::string> inputFile(
     cl::Positional,
     cl::desc("<input>"));
@@ -757,14 +755,15 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, char **argv)
     cl::desc("Write output to <file>"),
     cl::value_desc("file"));
 
-  const auto statisticFileDesc = "Write stats to <file>. Default is "
-                                 + statisticsCollectorSettings.GetFilePath().to_str()
-                                 + ".";
-  cl::opt<std::string> statisticFile(
+  std::string statisticsDirectoryDefault = std::filesystem::temp_directory_path();
+  const auto statisticDirectoryDescription = "Write statistics to file in <dir>. Default is "
+                                             + statisticsDirectoryDefault
+                                             + ".";
+  cl::opt<std::string> statisticDirectory(
     "s",
-    cl::init(statisticsCollectorSettings.GetFilePath().to_str()),
-    cl::desc(statisticFileDesc),
-    cl::value_desc("file"));
+    cl::init(statisticsDirectoryDefault),
+    cl::desc(statisticDirectoryDescription),
+    cl::value_desc("dir"));
 
   auto aggregationStatisticsId = util::Statistics::Id::Aggregation;
   auto annotationStatisticsId = util::Statistics::Id::Annotation;
@@ -989,13 +988,25 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, char **argv)
 
   cl::ParseCommandLineOptions(argc, argv);
 
-  statisticsCollectorSettings.SetFilePath(statisticFile);
+  jlm::util::filepath statisticsDirectoryFilePath(statisticDirectory);
+  if (!statisticsDirectoryFilePath.Exists()
+  && !statisticsDirectoryFilePath.IsDirectory())
+  {
+    throw CommandLineParser::Exception(statisticsDirectoryFilePath.to_str() + " does not exist or is not a directory.");
+  }
+
+  jlm::util::filepath inputFilePath(inputFile);
+  jlm::util::filepath statisticsFilePath = jlm::util::filepath::CreateUniqueFile(
+    statisticsDirectoryFilePath,
+    inputFilePath.base() + "-",
+    "-statistics.log");
 
   util::HashSet<util::Statistics::Id> demandedStatistics({printStatistics.begin(), printStatistics.end()});
-  statisticsCollectorSettings.SetDemandedStatistics(std::move(demandedStatistics));
+
+  util::StatisticsCollectorSettings statisticsCollectorSettings(statisticsFilePath, demandedStatistics);
 
   CommandLineOptions_ = JlmOptCommandLineOptions::Create(
-    inputFile,
+    std::move(inputFilePath),
     outputFile,
     outputFormat,
     std::move(statisticsCollectorSettings),

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -996,10 +996,9 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, char **argv)
   }
 
   jlm::util::filepath inputFilePath(inputFile);
-  jlm::util::filepath statisticsFilePath = jlm::util::filepath::CreateUniqueFile(
+  jlm::util::filepath statisticsFilePath = jlm::util::StatisticsCollectorSettings::CreateUniqueStatisticsFile(
     statisticsDirectoryFilePath,
-    inputFilePath.base() + "-",
-    "-statistics.log");
+    inputFilePath);
 
   util::HashSet<util::Statistics::Id> demandedStatistics({printStatistics.begin(), printStatistics.end()});
 

--- a/jlm/util/Statistics.cpp
+++ b/jlm/util/Statistics.cpp
@@ -17,8 +17,14 @@ StatisticsCollector::PrintStatistics() const
   if (NumCollectedStatistics() == 0)
     return;
 
-  util::file file(GetSettings().GetFilePath());
-  file.open("a");
+  auto & filePath = GetSettings().GetFilePath();
+  if (filePath.Exists() && !filePath.IsFile())
+  {
+    return;
+  }
+
+  util::file file(filePath);
+  file.open("w");
 
   for (auto & statistics : CollectedStatistics())
   {

--- a/jlm/util/Statistics.hpp
+++ b/jlm/util/Statistics.hpp
@@ -134,6 +134,14 @@ public:
     return DemandedStatistics_;
   }
 
+  static filepath
+  CreateUniqueStatisticsFile(
+    const filepath & directory,
+    const filepath & inputFile)
+  {
+    return filepath::CreateUniqueFile(directory, inputFile.base() + "-", "-statistics.log");
+  }
+
 private:
   filepath FilePath_;
   HashSet<Statistics::Id> DemandedStatistics_;

--- a/jlm/util/Statistics.hpp
+++ b/jlm/util/Statistics.hpp
@@ -73,16 +73,14 @@ private:
  */
 class StatisticsCollectorSettings final
 {
-  inline static const char* DefaultFilePath_ = "/tmp/jlm-stats.log";
-
 public:
   StatisticsCollectorSettings()
-    : FilePath_(DefaultFilePath_)
+    : FilePath_("")
   {}
 
   explicit
   StatisticsCollectorSettings(HashSet<Statistics::Id> demandedStatistics)
-    : FilePath_(DefaultFilePath_)
+    : FilePath_("")
     , DemandedStatistics_(std::move(demandedStatistics))
   {}
 

--- a/jlm/util/file.hpp
+++ b/jlm/util/file.hpp
@@ -8,6 +8,8 @@
 
 #include <jlm/util/common.hpp>
 
+#include <filesystem>
+#include <random>
 #include <string>
 
 namespace jlm::util
@@ -138,6 +140,40 @@ public:
 		return path_.substr(0, pos+1);
 	}
 
+  /**
+   * \brief Determines whether the filepath exists
+   *
+   * @return True if the filepath exists, otherwise false.
+   */
+  [[nodiscard]] bool
+  Exists() const noexcept
+  {
+    auto fileStatus = std::filesystem::status(path_);
+    return std::filesystem::exists(fileStatus);
+  }
+
+  /** \brief Determines whether filepath is a directory.
+   *
+   * @return True if the filepath is a directory, otherwise false.
+   */
+  [[nodiscard]] bool
+  IsDirectory() const noexcept
+  {
+    auto fileStatus = std::filesystem::status(path_);
+    return std::filesystem::is_directory(fileStatus);
+  }
+
+  /** \brief Determines whether filepath is a file.
+   *
+   * @return True if the filepath is a file, otherwise false.
+   */
+  [[nodiscard]] bool
+  IsFile() const noexcept
+  {
+    auto fileStatus = std::filesystem::status(path_);
+    return std::filesystem::is_regular_file(fileStatus);
+  }
+
 	inline std::string
 	to_str() const noexcept
 	{
@@ -156,7 +192,48 @@ public:
 		return path_ == f;
 	}
 
+  /** \brief Generates a unique file in a given \p directory with a prefix and suffix.
+   *
+   * @param directory The directory in which the file is created.
+   * @param fileNamePrefix The file name prefix.
+   * @param fileNameSuffix The file name suffix.
+   *
+   * @return A unique file
+   */
+  static jlm::util::filepath
+  CreateUniqueFile(
+    const jlm::util::filepath & directory,
+    const std::string & fileNamePrefix,
+    const std::string & fileNameSuffix)
+  {
+    JLM_ASSERT(directory.Exists() && directory.IsDirectory());
+
+    auto randomString = CreateRandomString(6);
+    filepath filePath(directory.to_str() + "/" + fileNamePrefix + randomString + fileNameSuffix);
+
+    JLM_ASSERT(!filePath.Exists());
+    return filePath;
+  }
+
 private:
+  static std::string
+  CreateRandomString(std::size_t length)
+  {
+    const std::string characterSet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+    std::random_device random_device;
+    std::mt19937 generator(random_device());
+    std::uniform_int_distribution<> distribution(0, characterSet.size() - 1);
+
+    std::string result;
+    for (std::size_t i = 0; i < length; ++i)
+    {
+      result += characterSet[distribution(generator)];
+    }
+
+    return result;
+  }
+
 	std::string path_;
 };
 

--- a/tests/jlm/tooling/TestJlmOptCommand.cpp
+++ b/tests/jlm/tooling/TestJlmOptCommand.cpp
@@ -14,7 +14,11 @@ TestStatistics()
   using namespace jlm::tooling;
 
   // Arrange
-  jlm::util::StatisticsCollectorSettings statisticsCollectorSettings({jlm::util::Statistics::Id::SteensgaardAnalysis});
+  std::string expectedStatisticsDir = "/myStatisticsDir/";
+
+  jlm::util::StatisticsCollectorSettings statisticsCollectorSettings(
+    jlm::util::filepath(expectedStatisticsDir + "myStatisticsFile"),
+    {jlm::util::Statistics::Id::SteensgaardAnalysis});
 
   JlmOptCommandLineOptions commandLineOptions(
     jlm::util::filepath("inputFile.ll"),
@@ -36,6 +40,7 @@ TestStatistics()
     "jlm-opt ",
     "--llvm ",
     "--DeadNodeElimination --LoopUnrolling ",
+    "-s " + expectedStatisticsDir + " ",
     "--print-steensgaard-analysis ",
     "-o outputFile.ll ",
     "inputFile.ll");

--- a/tests/jlm/util/TestStatistics.cpp
+++ b/tests/jlm/util/TestStatistics.cpp
@@ -67,14 +67,11 @@ void
 TestStatisticsPrinting()
 {
   using namespace jlm::util;
-  /*
-   * Arrange
-   */
-  filepath filePath("/tmp/TestStatistics");
 
-  /*
-   * Ensure file is not around from last test run.
-   */
+  // Arrange
+  filepath filePath(std::string(std::filesystem::temp_directory_path()) + "/TestStatistics");
+
+  // Ensure file is not around from last test run.
   std::remove(filePath.to_str().c_str());
 
   std::string myText("MyTestStatistics");
@@ -89,14 +86,10 @@ TestStatisticsPrinting()
   StatisticsCollector collector(std::move(settings));
   collector.CollectDemandedStatistics(std::move(testStatistics));
 
-  /*
-   * Act
-   */
+  // Act
   collector.PrintStatistics();
 
-  /*
-   * Assert
-   */
+  // Assert
   std::stringstream stringStream;
   std::ifstream file(filePath.to_str());
   stringStream << file.rdbuf();


### PR DESCRIPTION
The single statistics file could lead to problems when compiling in parallel as multiple processes would write to the file. Instead we create a unique statistics file per jlm-opt invocation. This PR does the following:

1. Change the semantics of the -s command line option of jlm-opt from specifying the statistics file to specifying a directory. This directory is where the statistics file will end up in.
2. Ensure that unique statistics files are created per jlm-opt invocation.