### PR TITLE
Minor statistics fixes

### DIFF
--- a/jlm/llvm/opt/alias-analyses/AgnosticMemoryNodeProvider.cpp
+++ b/jlm/llvm/opt/alias-analyses/AgnosticMemoryNodeProvider.cpp
@@ -98,11 +98,11 @@ AgnosticMemoryNodeProvider::~AgnosticMemoryNodeProvider()
 
 std::unique_ptr<MemoryNodeProvisioning>
 AgnosticMemoryNodeProvider::ProvisionMemoryNodes(
-  const RvsdgModule&,
+  const RvsdgModule & rvsdgModule,
   const PointsToGraph & pointsToGraph,
   util::StatisticsCollector& statisticsCollector)
 {
-  auto statistics = Statistics::Create(statisticsCollector, pointsToGraph);
+  auto statistics = Statistics::Create(rvsdgModule.SourceFileName(), statisticsCollector, pointsToGraph);
   statistics->StartCollecting();
 
   util::HashSet<const PointsToGraph::MemoryNode*> memoryNodes;

--- a/jlm/llvm/opt/alias-analyses/AgnosticMemoryNodeProvider.hpp
+++ b/jlm/llvm/opt/alias-analyses/AgnosticMemoryNodeProvider.hpp
@@ -135,7 +135,7 @@ public:
   ToString() const override
   {
     return util::strfmt(
-      "AgnosticMemoryNodeProvision ",
+      "AgnosticMemoryNodeProvider ",
       "#PointsToGraphMemoryNodes:", NumPointsToGraphMemoryNodes_, " ",
       "Time[ns]:", Timer_.ns()
       );

--- a/jlm/llvm/opt/alias-analyses/AgnosticMemoryNodeProvider.hpp
+++ b/jlm/llvm/opt/alias-analyses/AgnosticMemoryNodeProvider.hpp
@@ -89,9 +89,11 @@ class AgnosticMemoryNodeProvider::Statistics final : public util::Statistics
 {
 public:
   Statistics(
+    util::filepath sourceFile,
     const util::StatisticsCollector & statisticsCollector,
     const PointsToGraph & pointsToGraph)
     : util::Statistics(Statistics::Id::MemoryNodeProvisioning)
+    , SourceFile_(std::move(sourceFile))
     , NumPointsToGraphMemoryNodes_(0)
     , StatisticsCollector_(statisticsCollector)
   {
@@ -111,6 +113,12 @@ public:
   GetTime() const noexcept
   {
     return Timer_.ns();
+  }
+
+  [[nodiscard]] const util::filepath&
+  GetSourceFile() const noexcept
+  {
+    return SourceFile_;
   }
 
   void
@@ -136,6 +144,7 @@ public:
   {
     return util::strfmt(
       "AgnosticMemoryNodeProvider ",
+      SourceFile_.to_str(), " ",
       "#PointsToGraphMemoryNodes:", NumPointsToGraphMemoryNodes_, " ",
       "Time[ns]:", Timer_.ns()
       );
@@ -143,14 +152,16 @@ public:
 
   static std::unique_ptr<Statistics>
   Create(
+    const util::filepath & sourceFile,
     const util::StatisticsCollector & statisticsCollector,
     const PointsToGraph & pointsToGraph)
   {
-    return std::make_unique<Statistics>(statisticsCollector, pointsToGraph);
+    return std::make_unique<Statistics>(sourceFile, statisticsCollector, pointsToGraph);
   }
 
 private:
   util::timer Timer_;
+  util::filepath SourceFile_;
   size_t NumPointsToGraphMemoryNodes_;
   const util::StatisticsCollector & StatisticsCollector_;
 };

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
@@ -46,10 +46,11 @@ public:
   [[nodiscard]] std::string
   ToString() const override
   {
-    return jlm::util::strfmt("BasicEncoderEncoding ",
-                  SourceFile_.to_str(), " ",
-                  "#RvsdgNodes:", NumNodesBefore_, " ",
-                  "Time[ns]:", Timer_.ns());
+    return jlm::util::strfmt(
+      "MemoryStateEncoder ",
+      SourceFile_.to_str(), " ",
+      "#RvsdgNodes:", NumNodesBefore_, " ",
+      "Time[ns]:", Timer_.ns());
   }
 
   static std::unique_ptr<EncodingStatistics>

--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -123,7 +123,7 @@ LoadTest1::SetupRvsdg()
   PointerType pointerType;
   FunctionType fcttype({&pointerType, &mt}, {&jlm::rvsdg::bit32, &mt});
 
-  auto module = RvsdgModule::Create(jlm::util::filepath(""), "", "");
+  auto module = RvsdgModule::Create(jlm::util::filepath("LoadTest1.c"), "", "");
   auto graph = &module->Rvsdg();
 
   auto nf = graph->node_normal_form(typeid(jlm::rvsdg::operation));

--- a/tests/jlm/llvm/opt/alias-analyses/TestAgnosticMemoryNodeProvider.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestAgnosticMemoryNodeProvider.cpp
@@ -821,9 +821,7 @@ TestMemcpy()
 static void
 TestStatistics()
 {
-  /*
-   * Arrange
-   */
+   // Arrange
   jlm::tests::LoadTest1 test;
   jlm::util::filepath filePath("/tmp/TestStatistics");
   auto pointsToGraph = RunSteensgaard(test.module());
@@ -833,22 +831,19 @@ TestStatistics()
     {jlm::util::Statistics::Id::MemoryNodeProvisioning});
   jlm::util::StatisticsCollector statisticsCollector(statisticsCollectorSettings);
 
-  /*
-   * Act
-   */
+   // Act
   jlm::llvm::aa::AgnosticMemoryNodeProvider::Create(
     test.module(),
     *pointsToGraph,
     statisticsCollector);
 
-  /*
-   * Assert
-   */
+   // Assert
   assert(statisticsCollector.NumCollectedStatistics() == 1);
 
   auto & statistics = dynamic_cast<const jlm::llvm::aa::AgnosticMemoryNodeProvider::Statistics&>(
     *statisticsCollector.CollectedStatistics().begin());
 
+  assert(statistics.GetSourceFile() == test.module().SourceFileName());
   assert(statistics.NumPointsToGraphMemoryNodes() == 2);
   assert(statistics.GetTime() != 0);
 }


### PR DESCRIPTION
This PR fixes some minor statistics inconveniences:

1. Fixes the statistics tag of the agnostic memory node provider
2. Ensures the source file is collected and printed as part of the agnostic memory node provider statistics
3. Fixes the statistics tag of the memory state encoder