### PR TITLE
Clean up Steensgaard alias analysis

### DIFF
--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -8,6 +8,7 @@
 #include <jlm/llvm/opt/alias-analyses/PointsToGraph.hpp>
 #include <jlm/llvm/opt/alias-analyses/Steensgaard.hpp>
 #include <jlm/rvsdg/traverser.hpp>
+#include <jlm/util/disjointset.hpp>
 #include <jlm/util/Statistics.hpp>
 #include <jlm/util/time.hpp>
 

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -633,7 +633,7 @@ public:
   std::string
   ToDot() const
   {
-    auto dot_node = [](const DisjointLocationSet::set & set)
+    auto toDotNode = [](const DisjointLocationSet::set & set)
     {
       auto rootLocation = set.value();
 
@@ -659,7 +659,7 @@ public:
       return jlm::util::strfmt("{ ", (intptr_t)&set, " [label = \"", setLabel, "\"]; }");
     };
 
-    auto dot_edge = [&](const DisjointLocationSet::set & set, const DisjointLocationSet::set & pointsToSet)
+    auto toDotEdge = [](const DisjointLocationSet::set & set, const DisjointLocationSet::set & pointsToSet)
     {
       return jlm::util::strfmt((intptr_t)&set, " -> ", (intptr_t)&pointsToSet);
     };
@@ -668,12 +668,12 @@ public:
     str.append("digraph PointsToGraph {\n");
 
     for (auto & set : DisjointLocationSet_) {
-      str += dot_node(set) + "\n";
+      str += toDotNode(set) + "\n";
 
       auto pointsTo = set.value()->GetPointsTo();
       if (pointsTo != nullptr) {
         auto pointsToSet = DisjointLocationSet_.find(pointsTo);
-        str += dot_edge(set, *pointsToSet) + "\n";
+        str += toDotEdge(set, *pointsToSet) + "\n";
       }
     }
 

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -1622,6 +1622,9 @@ Steensgaard::Analyze(
 
   statisticsCollector.CollectDemandedStatistics(std::move(statistics));
 
+  // Discard internal state to free up memory after we are done with the analysis
+  LocationSet_.reset();
+
   return pointsToGraph;
 }
 

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -305,9 +305,9 @@ public:
   [[nodiscard]] static bool
   IsEscapingModule(const Location & location) noexcept
   {
-      auto registerLocation = dynamic_cast<const RegisterLocation*>(&location);
-      return registerLocation
-             && registerLocation->IsEscapingModule();
+    auto registerLocation = dynamic_cast<const RegisterLocation*>(&location);
+    return registerLocation
+           && registerLocation->IsEscapingModule();
   }
 
   static std::unique_ptr<RegisterLocation>
@@ -713,14 +713,14 @@ LocationSet::ToDot() const
       auto locationLabel = jlm::util::strfmt((intptr_t)location, " : ", location->DebugString());
 
       setLabel += location == rootLocation
-        ? jlm::util::strfmt("*",
-                 locationLabel,
-                 unknownLabel,
-                 pointsToEscapedMemoryLabel,
-                 escapesModuleLabel,
-                 pointsToLabel,
-                 "*\\n")
-        : jlm::util::strfmt(locationLabel, escapesModuleLabel, "\\n");
+                  ? jlm::util::strfmt("*",
+                                      locationLabel,
+                                      unknownLabel,
+                                      pointsToEscapedMemoryLabel,
+                                      escapesModuleLabel,
+                                      pointsToLabel,
+                                      "*\\n")
+                  : jlm::util::strfmt(locationLabel, escapesModuleLabel, "\\n");
     }
 
     return jlm::util::strfmt("{ ", (intptr_t)&set, " [label = \"", setLabel, "\"]; }");
@@ -1531,7 +1531,7 @@ Steensgaard::Analyze(
   // Perform Steensgaard analysis
   statistics->StartSteensgaardStatistics(module.Rvsdg());
   Analyze(module.Rvsdg());
-	// std::cout << LocationSet_.ToDot() << std::flush;
+  // std::cout << LocationSet_.ToDot() << std::flush;
   statistics->StopSteensgaardStatistics();
 
   // Construct PointsTo graph

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
@@ -11,7 +11,6 @@
 namespace jlm::llvm::aa
 {
 
-class Location;
 class LocationSet;
 
 /** \brief Steensgaard alias analysis
@@ -118,11 +117,6 @@ private:
 
   static std::unique_ptr<PointsToGraph>
   ConstructPointsToGraph(const LocationSet & locationSets);
-
-  /** \brief Perform a recursive union of Location \p x and \p y.
-  */
-  void
-  join(Location & x, Location & y);
 
   std::unique_ptr<LocationSet> LocationSet_;
 };

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
@@ -145,8 +145,11 @@ public:
   std::string
   ToDot() const;
 
-  void
-  Clear();
+  static std::unique_ptr<LocationSet>
+  Create()
+  {
+    return std::make_unique<LocationSet>();
+  }
 
 private:
   RegisterLocation &
@@ -189,9 +192,6 @@ public:
     jlm::util::StatisticsCollector & statisticsCollector) override;
 
 private:
-  void
-  ResetState();
-
   void
   Analyze(const jlm::rvsdg::graph & graph);
 
@@ -272,7 +272,7 @@ private:
   void
   join(Location & x, Location & y);
 
-  LocationSet LocationSet_;
+  std::unique_ptr<LocationSet> LocationSet_;
 };
 
 }}

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
@@ -53,38 +53,38 @@ operator&(PointsToFlags lhs, PointsToFlags rhs)
 class LocationSet final
 {
 public:
-	using DisjointLocationSet = typename jlm::util::disjointset<Location*>;
+  using DisjointLocationSet = typename jlm::util::disjointset<Location*>;
 
-	using const_iterator = std::unordered_map<
-	  const jlm::rvsdg::output*
-	, Location*
-	>::const_iterator;
+  using const_iterator = std::unordered_map<
+    const jlm::rvsdg::output*
+    , Location*
+  >::const_iterator;
 
-	~LocationSet();
+  ~LocationSet();
 
-	LocationSet();
+  LocationSet();
 
-	LocationSet(const LocationSet &) = delete;
+  LocationSet(const LocationSet &) = delete;
 
-	LocationSet(LocationSet &&) = delete;
+  LocationSet(LocationSet &&) = delete;
 
-	LocationSet &
-	operator=(const LocationSet &) = delete;
+  LocationSet &
+  operator=(const LocationSet &) = delete;
 
-	LocationSet &
-	operator=(LocationSet &&) = delete;
+  LocationSet &
+  operator=(LocationSet &&) = delete;
 
-	DisjointLocationSet::set_iterator
-	begin() const
-	{
-		return DisjointLocationSet_.begin();
-	}
+  DisjointLocationSet::set_iterator
+  begin() const
+  {
+    return DisjointLocationSet_.begin();
+  }
 
-	DisjointLocationSet::set_iterator
-	end() const
-	{
-		return DisjointLocationSet_.end();
-	}
+  DisjointLocationSet::set_iterator
+  end() const
+  {
+    return DisjointLocationSet_.end();
+  }
 
   Location &
   InsertAllocaLocation(const jlm::rvsdg::node & node);
@@ -98,25 +98,25 @@ public:
   Location &
   InsertDeltaLocation(const delta::node & delta);
 
-	Location &
-	InsertImportLocation(const jlm::rvsdg::argument & argument);
+  Location &
+  InsertImportLocation(const jlm::rvsdg::argument & argument);
 
-	Location &
-	InsertDummyLocation();
+  Location &
+  InsertDummyLocation();
 
-	bool
-	Contains(const jlm::rvsdg::output & output) const noexcept;
+  bool
+  Contains(const jlm::rvsdg::output & output) const noexcept;
 
-	Location &
-	FindOrInsertRegisterLocation(
+  Location &
+  FindOrInsertRegisterLocation(
     const jlm::rvsdg::output & output,
     PointsToFlags pointsToFlags);
 
-	const DisjointLocationSet::set &
-	GetSet(Location & location) const
-	{
-		return *DisjointLocationSet_.find(&location);
-	}
+  const DisjointLocationSet::set &
+  GetSet(Location & location) const
+  {
+    return *DisjointLocationSet_.find(&location);
+  }
 
   size_t
   NumDisjointSets() const noexcept
@@ -130,33 +130,33 @@ public:
     return DisjointLocationSet_.nvalues();
   }
 
-	Location &
-	GetRootLocation(Location & location) const;
+  Location &
+  GetRootLocation(Location & location) const;
 
-	Location &
-	Find(const jlm::rvsdg::output & output);
+  Location &
+  Find(const jlm::rvsdg::output & output);
 
   RegisterLocation *
   LookupRegisterLocation(const jlm::rvsdg::output & output);
 
-	Location &
-	Merge(Location & location1, Location & location2);
+  Location &
+  Merge(Location & location1, Location & location2);
 
-	std::string
-	ToDot() const;
+  std::string
+  ToDot() const;
 
-	void
-	Clear();
+  void
+  Clear();
 
 private:
-	RegisterLocation &
-	InsertRegisterLocation(
+  RegisterLocation &
+  InsertRegisterLocation(
     const jlm::rvsdg::output & output,
     PointsToFlags pointsToFlags);
 
-	DisjointLocationSet DisjointLocationSet_;
-	std::vector<std::unique_ptr<Location>> Locations_;
-	std::unordered_map<const jlm::rvsdg::output*, RegisterLocation*> LocationMap_;
+  DisjointLocationSet DisjointLocationSet_;
+  std::vector<std::unique_ptr<Location>> Locations_;
+  std::unordered_map<const jlm::rvsdg::output*, RegisterLocation*> LocationMap_;
 };
 
 /** \brief Steensgaard alias analysis
@@ -169,110 +169,110 @@ class Steensgaard final : public AliasAnalysis
 {
   class Statistics;
 public:
-	~Steensgaard() override;
+  ~Steensgaard() override;
 
-	Steensgaard() = default;
+  Steensgaard() = default;
 
-	Steensgaard(const Steensgaard &) = delete;
+  Steensgaard(const Steensgaard &) = delete;
 
-	Steensgaard(Steensgaard &&) = delete;
+  Steensgaard(Steensgaard &&) = delete;
 
-	Steensgaard &
-	operator=(const Steensgaard &) = delete;
+  Steensgaard &
+  operator=(const Steensgaard &) = delete;
 
-	Steensgaard &
-	operator=(Steensgaard &&) = delete;
+  Steensgaard &
+  operator=(Steensgaard &&) = delete;
 
-	std::unique_ptr<PointsToGraph>
-	Analyze(
+  std::unique_ptr<PointsToGraph>
+  Analyze(
     const RvsdgModule & module,
     jlm::util::StatisticsCollector & statisticsCollector) override;
 
 private:
-	void
-	ResetState();
+  void
+  ResetState();
 
-	void
-	Analyze(const jlm::rvsdg::graph & graph);
+  void
+  Analyze(const jlm::rvsdg::graph & graph);
 
-	void
-	Analyze(jlm::rvsdg::region & region);
+  void
+  Analyze(jlm::rvsdg::region & region);
 
-	void
-	Analyze(const lambda::node & node);
+  void
+  Analyze(const lambda::node & node);
 
-	void
-	Analyze(const delta::node & node);
+  void
+  Analyze(const delta::node & node);
 
-	void
-	Analyze(const phi::node & node);
+  void
+  Analyze(const phi::node & node);
 
-	void
-	Analyze(const jlm::rvsdg::gamma_node & node);
+  void
+  Analyze(const jlm::rvsdg::gamma_node & node);
 
-	void
-	Analyze(const jlm::rvsdg::theta_node & node);
+  void
+  Analyze(const jlm::rvsdg::theta_node & node);
 
-	void
-	Analyze(const jlm::rvsdg::simple_node & node);
+  void
+  Analyze(const jlm::rvsdg::simple_node & node);
 
-	void
-	Analyze(const jlm::rvsdg::structural_node & node);
+  void
+  Analyze(const jlm::rvsdg::structural_node & node);
 
-	void
-	AnalyzeAlloca(const jlm::rvsdg::simple_node & node);
+  void
+  AnalyzeAlloca(const jlm::rvsdg::simple_node & node);
 
-	void
-	AnalyzeMalloc(const jlm::rvsdg::simple_node & node);
+  void
+  AnalyzeMalloc(const jlm::rvsdg::simple_node & node);
 
-	void
-	AnalyzeLoad(const LoadNode & loadNode);
+  void
+  AnalyzeLoad(const LoadNode & loadNode);
 
-	void
-	AnalyzeStore(const StoreNode & storeNode);
+  void
+  AnalyzeStore(const StoreNode & storeNode);
 
-	void
-	AnalyzeCall(const CallNode & callNode);
+  void
+  AnalyzeCall(const CallNode & callNode);
 
-	void
-	AnalyzeGep(const jlm::rvsdg::simple_node & node);
+  void
+  AnalyzeGep(const jlm::rvsdg::simple_node & node);
 
-	void
-	AnalyzeBitcast(const jlm::rvsdg::simple_node & node);
+  void
+  AnalyzeBitcast(const jlm::rvsdg::simple_node & node);
 
-	void
-	AnalyzeBits2ptr(const jlm::rvsdg::simple_node & node);
+  void
+  AnalyzeBits2ptr(const jlm::rvsdg::simple_node & node);
 
-	void
-	AnalyzeConstantPointerNull(const jlm::rvsdg::simple_node & node);
+  void
+  AnalyzeConstantPointerNull(const jlm::rvsdg::simple_node & node);
 
-	void
-	AnalyzeUndef(const jlm::rvsdg::simple_node & node);
+  void
+  AnalyzeUndef(const jlm::rvsdg::simple_node & node);
 
-	void
-	AnalyzeMemcpy(const jlm::rvsdg::simple_node & node);
+  void
+  AnalyzeMemcpy(const jlm::rvsdg::simple_node & node);
 
-	void
-	AnalyzeConstantArray(const jlm::rvsdg::simple_node & node);
+  void
+  AnalyzeConstantArray(const jlm::rvsdg::simple_node & node);
 
-	void
-	AnalyzeConstantStruct(const jlm::rvsdg::simple_node & node);
+  void
+  AnalyzeConstantStruct(const jlm::rvsdg::simple_node & node);
 
-	void
-	AnalyzeConstantAggregateZero(const jlm::rvsdg::simple_node & node);
+  void
+  AnalyzeConstantAggregateZero(const jlm::rvsdg::simple_node & node);
 
-	void
-	AnalyzeExtractValue(const jlm::rvsdg::simple_node & node);
+  void
+  AnalyzeExtractValue(const jlm::rvsdg::simple_node & node);
 
-	static std::unique_ptr<PointsToGraph>
-	ConstructPointsToGraph(const LocationSet & locationSets);
+  static std::unique_ptr<PointsToGraph>
+  ConstructPointsToGraph(const LocationSet & locationSets);
 
-	/** \brief Perform a recursive union of Location \p x and \p y.
-	*/
-	void
-	join(Location & x, Location & y);
+  /** \brief Perform a recursive union of Location \p x and \p y.
+  */
+  void
+  join(Location & x, Location & y);
 
-	LocationSet LocationSet_;
+  LocationSet LocationSet_;
 };
 
 }}

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
@@ -58,31 +58,31 @@ public:
 
 private:
   void
-  Analyze(const jlm::rvsdg::graph & graph);
+  AnalyzeRvsdg(const jlm::rvsdg::graph & graph);
 
   void
-  Analyze(jlm::rvsdg::region & region);
+  AnalyzeRegion(jlm::rvsdg::region & region);
 
   void
-  Analyze(const lambda::node & node);
+  AnalyzeLambda(const lambda::node & node);
 
   void
-  Analyze(const delta::node & node);
+  AnalyzeDelta(const delta::node & node);
 
   void
-  Analyze(const phi::node & node);
+  AnalyzePhi(const phi::node & node);
 
   void
-  Analyze(const jlm::rvsdg::gamma_node & node);
+  AnalyzeGamma(const jlm::rvsdg::gamma_node & node);
 
   void
-  Analyze(const jlm::rvsdg::theta_node & node);
+  AnalyzeTheta(const jlm::rvsdg::theta_node & node);
 
   void
-  Analyze(const jlm::rvsdg::simple_node & node);
+  AnalyzeSimpleNode(const jlm::rvsdg::simple_node & node);
 
   void
-  Analyze(const jlm::rvsdg::structural_node & node);
+  AnalyzeStructuralNode(const jlm::rvsdg::structural_node & node);
 
   void
   AnalyzeAlloca(const jlm::rvsdg::simple_node & node);

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
@@ -7,25 +7,12 @@
 #define JLM_LLVM_OPT_ALIAS_ANALYSES_STEENSGAARD_HPP
 
 #include <jlm/llvm/opt/alias-analyses/AliasAnalysis.hpp>
-#include <jlm/util/disjointset.hpp>
 
-#include <string>
-
-namespace jlm::llvm
+namespace jlm::llvm::aa
 {
-
-namespace delta { class node; }
-namespace lambda { class node; }
-namespace phi { class node; }
-
-class LoadNode;
-class StoreNode;
-
-namespace aa {
 
 class Location;
 class LocationSet;
-class PointsToGraph;
 
 /** \brief Steensgaard alias analysis
  *
@@ -140,6 +127,6 @@ private:
   std::unique_ptr<LocationSet> LocationSet_;
 };
 
-}}
+}
 
 #endif

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
@@ -24,143 +24,8 @@ class StoreNode;
 namespace aa {
 
 class Location;
+class LocationSet;
 class PointsToGraph;
-class RegisterLocation;
-
-enum class PointsToFlags {
-  PointsToNone           = 1 << 0,
-  PointsToUnknownMemory  = 1 << 1,
-  PointsToExternalMemory = 1 << 2,
-  PointsToEscapedMemory  = 1 << 3,
-};
-
-static inline PointsToFlags
-operator|(PointsToFlags lhs, PointsToFlags rhs)
-{
-  typedef typename std::underlying_type<PointsToFlags>::type underlyingType;
-  return static_cast<PointsToFlags>(static_cast<underlyingType>(lhs) | static_cast<underlyingType>(rhs));
-}
-
-static inline PointsToFlags
-operator&(PointsToFlags lhs, PointsToFlags rhs)
-{
-  typedef typename std::underlying_type<PointsToFlags>::type underlyingType;
-  return static_cast<PointsToFlags>(static_cast<underlyingType>(lhs) & static_cast<underlyingType>(rhs));
-}
-
-/** \brief LocationSet class
-*/
-class LocationSet final
-{
-public:
-  using DisjointLocationSet = typename jlm::util::disjointset<Location*>;
-
-  using const_iterator = std::unordered_map<
-    const jlm::rvsdg::output*
-    , Location*
-  >::const_iterator;
-
-  ~LocationSet();
-
-  LocationSet();
-
-  LocationSet(const LocationSet &) = delete;
-
-  LocationSet(LocationSet &&) = delete;
-
-  LocationSet &
-  operator=(const LocationSet &) = delete;
-
-  LocationSet &
-  operator=(LocationSet &&) = delete;
-
-  DisjointLocationSet::set_iterator
-  begin() const
-  {
-    return DisjointLocationSet_.begin();
-  }
-
-  DisjointLocationSet::set_iterator
-  end() const
-  {
-    return DisjointLocationSet_.end();
-  }
-
-  Location &
-  InsertAllocaLocation(const jlm::rvsdg::node & node);
-
-  Location &
-  InsertMallocLocation(const jlm::rvsdg::node & node);
-
-  Location &
-  InsertLambdaLocation(const lambda::node & lambda);
-
-  Location &
-  InsertDeltaLocation(const delta::node & delta);
-
-  Location &
-  InsertImportLocation(const jlm::rvsdg::argument & argument);
-
-  Location &
-  InsertDummyLocation();
-
-  bool
-  Contains(const jlm::rvsdg::output & output) const noexcept;
-
-  Location &
-  FindOrInsertRegisterLocation(
-    const jlm::rvsdg::output & output,
-    PointsToFlags pointsToFlags);
-
-  const DisjointLocationSet::set &
-  GetSet(Location & location) const
-  {
-    return *DisjointLocationSet_.find(&location);
-  }
-
-  size_t
-  NumDisjointSets() const noexcept
-  {
-    return DisjointLocationSet_.nsets();
-  }
-
-  size_t
-  NumLocations() const noexcept
-  {
-    return DisjointLocationSet_.nvalues();
-  }
-
-  Location &
-  GetRootLocation(Location & location) const;
-
-  Location &
-  Find(const jlm::rvsdg::output & output);
-
-  RegisterLocation *
-  LookupRegisterLocation(const jlm::rvsdg::output & output);
-
-  Location &
-  Merge(Location & location1, Location & location2);
-
-  std::string
-  ToDot() const;
-
-  static std::unique_ptr<LocationSet>
-  Create()
-  {
-    return std::make_unique<LocationSet>();
-  }
-
-private:
-  RegisterLocation &
-  InsertRegisterLocation(
-    const jlm::rvsdg::output & output,
-    PointsToFlags pointsToFlags);
-
-  DisjointLocationSet DisjointLocationSet_;
-  std::vector<std::unique_ptr<Location>> Locations_;
-  std::unordered_map<const jlm::rvsdg::output*, RegisterLocation*> LocationMap_;
-};
 
 /** \brief Steensgaard alias analysis
  *
@@ -174,7 +39,7 @@ class Steensgaard final : public AliasAnalysis
 public:
   ~Steensgaard() override;
 
-  Steensgaard() = default;
+  Steensgaard();
 
   Steensgaard(const Steensgaard &) = delete;
 


### PR DESCRIPTION
This PR cleans up the Steensgaard alias analysis. Specifically, it does the following:
1. Align layout of Steensgaard.hpp and Steensgaard.cpp
2. Move LocationSet class to Steensgaard.cpp
3. Discard the internal state after we are done with the analysis to free up memory
4. Rename some private methods for clarity
5. Move join method from Steensgaard class to LocationSet class