### PR TITLE
Move points-to graph unknown memory node sources redirection to Steensgaard alias analysis

### DIFF
--- a/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
@@ -118,6 +118,9 @@ private:
   static std::unique_ptr<PointsToGraph>
   ConstructPointsToGraph(const LocationSet & locationSets);
 
+  static void
+  RedirectUnknownMemoryNodeSources(PointsToGraph & pointsToGraph);
+
   std::unique_ptr<LocationSet> LocationSet_;
 };
 

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
@@ -118,6 +118,24 @@ private:
   static std::unique_ptr<PointsToGraph>
   ConstructPointsToGraph(const LocationSet & locationSets);
 
+  /**
+   * Resolves all points-to graph nodes that were marked throughout the analysis as pointing towards unknown memory
+   * locations, i.e., we have no idea where these marked nodes point to. The resolving of these nodes simply happens by
+   * adding edges from them to \b all existing points-to graph memory nodes. Note, that this strategy of resolving such
+   * nodes is extremely expensive for points-to graphs with a lot of nodes marked as pointing towards unknown memory
+   * locations as it leads to a quadratic number of edges.
+   *
+   * FIXME: We can do better than resolving these nodes by simply adding edges to all points-to graph memory nodes.
+   * The requirement is that the users of these marked nodes, i.e,, stores, loads, calls, etc., need to stay in the
+   * same place as dictated by the memory state given by the original program. In other words, a store referencing an
+   * address that is marked as unknown is not allowed to move before or after any other memory referencing operation.
+   * However, this does not necessarily require that the address needs to point to all points-to graph memory nodes in
+   * order to fulfill this requirement, it is just the simplest to go about it. We simply speculate on the fact that
+   * unknown marked points-to graph nodes are rare. If this turns out to be false, then we might want to invest in a
+   * better strategy.
+   *
+   * @param pointsToGraph The PointsToGraph constructed by ConstructPointsToGraph.
+   */
   static void
   RedirectUnknownMemoryNodeSources(PointsToGraph & pointsToGraph);
 

--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -334,7 +334,7 @@ Bits2PtrTest::SetupRvsdg()
   auto nf = graph->node_normal_form(typeid(jlm::rvsdg::operation));
   nf->set_mutable(false);
 
-  auto SetupBit2PtrFunction = [&]()
+  auto setupBit2PtrFunction = [&]()
   {
     PointerType pt;
     iostatetype iOStateType;
@@ -358,10 +358,12 @@ Bits2PtrTest::SetupRvsdg()
 
     lambda->finalize({cast, iOStateArgument, memoryStateArgument, loopStateArgument});
 
-    return std::make_tuple(lambda, jlm::rvsdg::node_output::node(cast));
+    return std::make_tuple(
+      lambda,
+      jlm::rvsdg::node_output::node(cast));
   };
 
-  auto SetupTestFunction = [&](lambda::output * b2p)
+  auto setupTestFunction = [&](lambda::output * b2p)
   {
     iostatetype iOStateType;
     MemoryStateType memoryStateType;
@@ -388,23 +390,23 @@ Bits2PtrTest::SetupRvsdg()
       {valueArgument, iOStateArgument, memoryStateArgument, loopStateArgument});
 
     lambda->finalize({callResults[1], callResults[2], callResults[3]});
-    graph->add_export(lambda->output(), {PointerType(), "testfct"});
+    graph->add_export(lambda->output(), {PointerType(), "lambdaTest"});
 
-    return std::make_tuple(lambda, jlm::rvsdg::node_output::node(callResults[0]));
+    return std::make_tuple(
+      lambda,
+      util::AssertedCast<CallNode>(rvsdg::node_output::node(callResults[0])));
   };
 
-  auto [bits2ptrFunction, castNode] = SetupBit2PtrFunction();
-  auto [testfct, callNode] = SetupTestFunction(bits2ptrFunction->output());
+  auto [lambdaBits2Ptr, bitsToPtrNode] = setupBit2PtrFunction();
+  auto [lambdaTest, callNode] = setupTestFunction(lambdaBits2Ptr->output());
 
-  /*
-   * Assign nodes
-   */
-  this->lambda_bits2ptr = bits2ptrFunction;
-  this->lambda_test = testfct;
+  // Assign nodes
+  this->LambdaBits2Ptr_ = lambdaBits2Ptr;
+  this->LambdaTest_ = lambdaTest;
 
-  this->bits2ptr = castNode;
+  this->BitsToPtrNode_ = bitsToPtrNode;
 
-  this->call = callNode;
+  this->CallNode_ = callNode;
 
   return module;
 }

--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -390,7 +390,7 @@ Bits2PtrTest::SetupRvsdg()
       {valueArgument, iOStateArgument, memoryStateArgument, loopStateArgument});
 
     lambda->finalize({callResults[1], callResults[2], callResults[3]});
-    graph->add_export(lambda->output(), {PointerType(), "lambdaTest"});
+    graph->add_export(lambda->output(), {PointerType(), "testfct"});
 
     return std::make_tuple(
       lambda,

--- a/tests/TestRvsdgs.hpp
+++ b/tests/TestRvsdgs.hpp
@@ -326,12 +326,12 @@ private:
   std::unique_ptr<jlm::llvm::RvsdgModule>
   SetupRvsdg() override;
 
-	jlm::llvm::lambda::node * LambdaBits2Ptr_;
-	jlm::llvm::lambda::node * LambdaTest_;
+  jlm::llvm::lambda::node * LambdaBits2Ptr_;
+  jlm::llvm::lambda::node * LambdaTest_;
 
-	jlm::rvsdg::node * BitsToPtrNode_;
+  jlm::rvsdg::node * BitsToPtrNode_;
 
-	jlm::llvm::CallNode * CallNode_;
+  jlm::llvm::CallNode * CallNode_;
 };
 
 /** \brief ConstantPointerNullTest class

--- a/tests/TestRvsdgs.hpp
+++ b/tests/TestRvsdgs.hpp
@@ -295,18 +295,43 @@ public:
 *
 * It uses a single memory state to sequentialize the respective memory operations.
 */
-class Bits2PtrTest final : public RvsdgTest {
+class Bits2PtrTest final : public RvsdgTest
+{
+public:
+  [[nodiscard]] const jlm::llvm::lambda::node&
+  GetLambdaBits2Ptr() const noexcept
+  {
+    return *LambdaBits2Ptr_;
+  }
+
+  [[nodiscard]] const jlm::llvm::lambda::node&
+  GetLambdaTest() const noexcept
+  {
+    return *LambdaTest_;
+  }
+
+  [[nodiscard]] const jlm::llvm::CallNode&
+  GetCallNode() const noexcept
+  {
+    return *CallNode_;
+  }
+
+  [[nodiscard]] const jlm::rvsdg::node&
+  GetBitsToPtrNode() const noexcept
+  {
+    return *BitsToPtrNode_;
+  }
+
 private:
   std::unique_ptr<jlm::llvm::RvsdgModule>
-	SetupRvsdg() override;
+  SetupRvsdg() override;
 
-public:
-	jlm::llvm::lambda::node * lambda_bits2ptr;
-	jlm::llvm::lambda::node * lambda_test;
+	jlm::llvm::lambda::node * LambdaBits2Ptr_;
+	jlm::llvm::lambda::node * LambdaTest_;
 
-	jlm::rvsdg::node * bits2ptr;
+	jlm::rvsdg::node * BitsToPtrNode_;
 
-	jlm::rvsdg::node * call;
+	jlm::llvm::CallNode * CallNode_;
 };
 
 /** \brief ConstantPointerNullTest class

--- a/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
@@ -352,11 +352,12 @@ TestBits2Ptr()
     auto & lambdaBitsToPtrMemoryNode = pointsToGraph.GetLambdaNode(test.GetLambdaBits2Ptr());
     auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
 
-    std::unordered_set<const PointsToGraph::Node*> expectedMemoryNodes({
-      &lambdaTestMemoryNode,
-      &lambdaBitsToPtrMemoryNode,
-      &externalMemoryNode
-    });
+    std::unordered_set<const PointsToGraph::Node*> expectedMemoryNodes(
+      {
+        &lambdaTestMemoryNode,
+        &lambdaBitsToPtrMemoryNode,
+        &externalMemoryNode
+      });
 
     auto & callOutput0 = pointsToGraph.GetRegisterNode(*test.GetCallNode().output(0));
     assertTargets(callOutput0, expectedMemoryNodes);
@@ -372,7 +373,7 @@ TestBits2Ptr()
   // jlm::rvsdg::view(test.graph().root(), stdout);
 
   auto pointsToGraph = RunSteensgaard(test.module());
-	// std::cout << jlm::llvm::aa::PointsToGraph::ToDot(*pointsToGraph) << std::flush;
+  // std::cout << jlm::llvm::aa::PointsToGraph::ToDot(*pointsToGraph) << std::flush;
   validatePointsToGraph(*pointsToGraph, test);
 }
 

--- a/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
@@ -339,31 +339,41 @@ TestConstantPointerNull()
 static void
 TestBits2Ptr()
 {
-  auto validate_ptg = [](
-    const jlm::llvm::aa::PointsToGraph & ptg,
+  auto validatePointsToGraph = [](
+    const jlm::llvm::aa::PointsToGraph & pointsToGraph,
     const jlm::tests::Bits2PtrTest & test)
   {
-    assert(ptg.NumLambdaNodes() == 2);
-    assert(ptg.NumRegisterNodes() == 5);
+    using namespace jlm::llvm::aa;
 
-    auto & call_out0 = ptg.GetRegisterNode(*test.call->output(0));
-    assertTargets(call_out0, {&ptg.GetUnknownMemoryNode(), &ptg.GetExternalMemoryNode()});
+    assert(pointsToGraph.NumLambdaNodes() == 2);
+    assert(pointsToGraph.NumRegisterNodes() == 5);
 
-    auto & bits2ptr = ptg.GetRegisterNode(*test.call->output(0));
-    assertTargets(bits2ptr, {&ptg.GetUnknownMemoryNode(), &ptg.GetExternalMemoryNode()});
+    auto & lambdaTestMemoryNode = pointsToGraph.GetLambdaNode(test.GetLambdaTest());
+    auto & lambdaBitsToPtrMemoryNode = pointsToGraph.GetLambdaNode(test.GetLambdaBits2Ptr());
+    auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
 
-    auto & lambdaTestMemoryNode = ptg.GetLambdaNode(*test.lambda_test);
+    std::unordered_set<const PointsToGraph::Node*> expectedMemoryNodes({
+      &lambdaTestMemoryNode,
+      &lambdaBitsToPtrMemoryNode,
+      &externalMemoryNode
+    });
 
-    jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode*> expectedEscapedMemoryNodes({&lambdaTestMemoryNode});
-    assert(ptg.GetEscapedMemoryNodes() == expectedEscapedMemoryNodes);
+    auto & callOutput0 = pointsToGraph.GetRegisterNode(*test.GetCallNode().output(0));
+    assertTargets(callOutput0, expectedMemoryNodes);
+
+    auto & bits2ptr = pointsToGraph.GetRegisterNode(*test.GetBitsToPtrNode().output(0));
+    assertTargets(bits2ptr, expectedMemoryNodes);
+
+    jlm::util::HashSet<const PointsToGraph::MemoryNode*> expectedEscapedMemoryNodes({&lambdaTestMemoryNode});
+    assert(pointsToGraph.GetEscapedMemoryNodes() == expectedEscapedMemoryNodes);
   };
 
   jlm::tests::Bits2PtrTest test;
-//	jlm::rvsdg::view(test.graph().root(), stdout);
+  // jlm::rvsdg::view(test.graph().root(), stdout);
 
-  auto ptg = RunSteensgaard(test.module());
-//	std::cout << jlm::llvm::aa::PointsToGraph::ToDot(*PointsToGraph);
-  validate_ptg(*ptg, test);
+  auto pointsToGraph = RunSteensgaard(test.module());
+	// std::cout << jlm::llvm::aa::PointsToGraph::ToDot(*pointsToGraph) << std::flush;
+  validatePointsToGraph(*pointsToGraph, test);
 }
 
 static void


### PR DESCRIPTION
This PR makes does the following:
1. Moves the redirection of the points-to graph unknown memory sources to the Steensgaard alias analysis pass. This avoids code duplication and enables the gathering of statistics.
2. Adds some documentation about this pass.
3. Cleans up the Bits2PtrTest class
4. Cleans up the Steensgaard TestBits2Ptr test