### PR TITLE
Discard internal state after encoding in MemoryStateEncoder

### DIFF
--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
@@ -474,9 +474,10 @@ MemoryStateEncoder::Encode(
 
   statisticsCollector.CollectDemandedStatistics(std::move(statistics));
 
-  /*
-   * Remove all nodes that became dead throughout the encoding.
-   */
+  // Discard internal state to free up memory after we are done with the encoding
+  Context_.reset();
+
+  // Remove all nodes that became dead throughout the encoding.
   DeadNodeElimination deadNodeElimination;
   deadNodeElimination.run(rvsdgModule, statisticsCollector);
 }


### PR DESCRIPTION
This PR ensures that the internal state is only kept for as long as it is needed in the Encode method instead of for the lifetime of an instance of the class.