### PR TITLE
Clean up DeadNodeElimination

### DIFF
--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -44,27 +44,27 @@ public:
   MarkAlive(const jlm::rvsdg::output & output)
   {
     if (auto simpleOutput = dynamic_cast<const jlm::rvsdg::simple_output*>(&output)) {
-      SimpleNodes_.insert(simpleOutput->node());
+      SimpleNodes_.Insert(simpleOutput->node());
       return;
     }
 
-    Outputs_.insert(&output);
+    Outputs_.Insert(&output);
   }
 
   bool
   IsAlive(const jlm::rvsdg::output & output) const noexcept
   {
     if (auto simpleOutput = dynamic_cast<const jlm::rvsdg::simple_output*>(&output))
-      return SimpleNodes_.find(simpleOutput->node()) != SimpleNodes_.end();
+      return SimpleNodes_.Contains(simpleOutput->node());
 
-    return Outputs_.find(&output) != Outputs_.end();
+    return Outputs_.Contains(&output);
   }
 
   bool
   IsAlive(const jlm::rvsdg::node & node) const noexcept
   {
     if (auto simpleNode = dynamic_cast<const jlm::rvsdg::simple_node*>(&node))
-      return SimpleNodes_.find(simpleNode) != SimpleNodes_.end();
+      return SimpleNodes_.Contains(simpleNode);
 
     for (size_t n = 0; n < node.noutputs(); n++) {
       if (IsAlive(*node.output(n)))
@@ -81,8 +81,8 @@ public:
   }
 
 private:
-  std::unordered_set<const jlm::rvsdg::simple_node*> SimpleNodes_;
-  std::unordered_set<const jlm::rvsdg::output*> Outputs_;
+  util::HashSet<const jlm::rvsdg::simple_node*> SimpleNodes_;
+  util::HashSet<const jlm::rvsdg::output*> Outputs_;
 };
 
 /** \brief Dead Node Elimination statistics class

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -98,53 +98,56 @@ private:
  */
 class DeadNodeElimination::Statistics final : public util::Statistics {
 public:
-  ~Statistics() override = default;
+  ~Statistics() override
+  = default;
 
   Statistics()
-    : util::Statistics(Statistics::Id::DeadNodeElimination)
-    , numNodesBefore_(0), numNodesAfter_(0)
-    , numInputsBefore_(0), numInputsAfter_(0)
+    : util::Statistics(Statistics::Id::DeadNodeElimination),
+    NumRvsdgNodesBefore_(0),
+    NumRvsdgNodesAfter_(0),
+    NumInputsBefore_(0),
+    NumInputsAfter_(0)
   {}
 
   void
   StartMarkStatistics(const jlm::rvsdg::graph & graph) noexcept
   {
-    numNodesBefore_ = jlm::rvsdg::nnodes(graph.root());
-    numInputsBefore_ = jlm::rvsdg::ninputs(graph.root());
-    markTimer_.start();
+    NumRvsdgNodesBefore_ = jlm::rvsdg::nnodes(graph.root());
+    NumInputsBefore_ = jlm::rvsdg::ninputs(graph.root());
+    MarkTimer_.start();
   }
 
   void
   StopMarkStatistics() noexcept
   {
-    markTimer_.stop();
+    MarkTimer_.stop();
   }
 
   void
   StartSweepStatistics() noexcept
   {
-    sweepTimer_.start();
+    SweepTimer_.start();
   }
 
   void
   StopSweepStatistics(const jlm::rvsdg::graph & graph) noexcept
   {
-    sweepTimer_.stop();
-    numNodesAfter_ = jlm::rvsdg::nnodes(graph.root());
-    numInputsAfter_ = jlm::rvsdg::ninputs(graph.root());
+    SweepTimer_.stop();
+    NumRvsdgNodesAfter_ = jlm::rvsdg::nnodes(graph.root());
+    NumInputsAfter_ = jlm::rvsdg::ninputs(graph.root());
   }
 
   [[nodiscard]] std::string
   ToString() const override
   {
-    return util::strfmt("DeadNodeElimination ",
-                        "#RvsdgNodesBeforeDNE:", numNodesBefore_, " ",
-                        "#RvsdgNodesAfterDNE:", numNodesAfter_, " ",
-                        "#RvsdgInputsBeforeDNE:", numInputsBefore_, " ",
-                        "#RvsdgInputsAfterDNE:", numInputsAfter_, " ",
-                        "MarkTime[ns]:", markTimer_.ns(), " ",
-                        "SweepTime[ns]:", sweepTimer_.ns()
-    );
+    return util::strfmt(
+      "DeadNodeElimination ",
+      "#RvsdgNodesBeforeDNE:", NumRvsdgNodesBefore_, " ",
+      "#RvsdgNodesAfterDNE:", NumRvsdgNodesAfter_, " ",
+      "#RvsdgInputsBeforeDNE:", NumInputsBefore_, " ",
+      "#RvsdgInputsAfterDNE:", NumInputsAfter_, " ",
+      "MarkTime[ns]:", MarkTimer_.ns(), " ",
+      "SweepTime[ns]:", SweepTimer_.ns());
   }
 
   static std::unique_ptr<Statistics>
@@ -154,12 +157,13 @@ public:
   }
 
 private:
-  size_t numNodesBefore_;
-  size_t numNodesAfter_;
-  size_t numInputsBefore_;
-  size_t numInputsAfter_;
-  util::timer markTimer_;
-  util::timer sweepTimer_;
+  size_t NumRvsdgNodesBefore_;
+  size_t NumRvsdgNodesAfter_;
+  size_t NumInputsBefore_;
+  size_t NumInputsAfter_;
+
+  util::timer MarkTimer_;
+  util::timer SweepTimer_;
 };
 
 DeadNodeElimination::~DeadNodeElimination() noexcept

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -288,9 +288,7 @@ DeadNodeElimination::SweepRvsdg(jlm::rvsdg::graph & rvsdg) const
 {
   SweepRegion(*rvsdg.root());
 
-  /**
-   * Remove dead imports
-   */
+  // Remove dead imports
   for (size_t n = rvsdg.root()->narguments() - 1; n != static_cast<size_t>(-1); n--) {
     if (!Context_->IsAlive(*rvsdg.root()->argument(n)))
       rvsdg.root()->remove_argument(n);
@@ -343,9 +341,7 @@ DeadNodeElimination::SweepStructuralNode(jlm::rvsdg::structural_node & node) con
 void
 DeadNodeElimination::SweepGamma(jlm::rvsdg::gamma_node & gammaNode) const
 {
-  /**
-   * Remove dead outputs and results
-   */
+  // Remove dead outputs and results
   for (size_t n = gammaNode.noutputs()-1; n != static_cast<size_t>(-1); n--) {
     if (Context_->IsAlive(*gammaNode.output(n)))
       continue;
@@ -355,15 +351,11 @@ DeadNodeElimination::SweepGamma(jlm::rvsdg::gamma_node & gammaNode) const
     gammaNode.remove_output(n);
   }
 
-  /**
-   * Sweep Gamma subregions
-   */
+  // Sweep gamma subregions
   for (size_t r = 0; r < gammaNode.nsubregions(); r++)
     SweepRegion(*gammaNode.subregion(r));
 
-  /**
-   * Remove dead arguments and inputs
-   */
+  // Remove dead arguments and inputs
   for (size_t n = gammaNode.ninputs()-1; n >= 1; n--) {
     auto input = gammaNode.input(n);
 
@@ -387,9 +379,7 @@ DeadNodeElimination::SweepTheta(jlm::rvsdg::theta_node & thetaNode) const
 {
   auto subregion = thetaNode.subregion();
 
-  /**
-   * Remove dead results
-   */
+  // Remove dead results
   for (size_t n = thetaNode.noutputs()-1; n != static_cast<size_t>(-1); n--) {
     auto & thetaOutput = *thetaNode.output(n);
     auto & thetaArgument = *thetaOutput.argument();
@@ -401,9 +391,7 @@ DeadNodeElimination::SweepTheta(jlm::rvsdg::theta_node & thetaNode) const
 
   SweepRegion(*subregion);
 
-  /**
-   * Remove dead outputs, inputs, and arguments
-   */
+  // Remove dead outputs, inputs, and arguments
   for (size_t n = thetaNode.ninputs()-1; n != static_cast<size_t>(-1); n--) {
     auto & thetaInput = *thetaNode.input(n);
     auto & thetaArgument = *thetaInput.argument();
@@ -426,9 +414,7 @@ DeadNodeElimination::SweepLambda(lambda::node & lambdaNode) const
 {
   SweepRegion(*lambdaNode.subregion());
 
-  /**
-   * Remove dead arguments and inputs
-   */
+  // Remove dead arguments and inputs
   for (size_t n = lambdaNode.ninputs()-1; n != static_cast<size_t>(-1); n--) {
     auto input = lambdaNode.input(n);
 
@@ -444,9 +430,7 @@ DeadNodeElimination::SweepPhi(phi::node & phiNode) const
 {
   auto subregion = phiNode.subregion();
 
-  /**
-   * Remove dead outputs and results
-   */
+  // Remove dead outputs and results
   for (size_t n = subregion->nresults()-1; n != static_cast<size_t>(-1); n--) {
     auto result = subregion->result(n);
     if (!Context_->IsAlive(*result->output())
@@ -458,9 +442,7 @@ DeadNodeElimination::SweepPhi(phi::node & phiNode) const
 
   SweepRegion(*subregion);
 
-  /**
-   * Remove dead arguments and inputs
-   */
+  // Remove dead arguments and inputs
   for (size_t n = subregion->narguments()-1; n != static_cast<size_t>(-1); n--) {
     auto argument = subregion->argument(n);
     auto input = argument->input();
@@ -476,14 +458,10 @@ DeadNodeElimination::SweepPhi(phi::node & phiNode) const
 void
 DeadNodeElimination::SweepDelta(delta::node & deltaNode) const
 {
-  /**
-   * A delta subregion can only contain simple nodes. Thus, a simple prune is sufficient.
-   */
+  // A delta subregion can only contain simple nodes. Thus, a simple prune is sufficient.
   deltaNode.subregion()->prune(false);
 
-  /**
-   * Remove dead arguments and inputs.
-   */
+  // Remove dead arguments and inputs.
   for (size_t n = deltaNode.ninputs()-1; n != static_cast<size_t>(-1); n--) {
     auto input = deltaNode.input(n);
     if (!Context_->IsAlive(*input->argument())) {

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -378,16 +378,23 @@ DeadNodeElimination::SweepRegion(jlm::rvsdg::region & region) const
 void
 DeadNodeElimination::SweepStructuralNode(jlm::rvsdg::structural_node & node) const
 {
+  auto sweepGamma =  [](auto & d, auto & n){ d.SweepGamma(*util::AssertedCast<jlm::rvsdg::gamma_node>(&n)); };
+  auto sweepTheta =  [](auto & d, auto & n){ d.SweepTheta(*util::AssertedCast<jlm::rvsdg::theta_node>(&n)); };
+  auto sweepLambda = [](auto & d, auto & n){ d.SweepLambda(*util::AssertedCast<lambda::node>(&n)); };
+  auto sweepPhi =    [](auto & d, auto & n){ d.SweepPhi(*util::AssertedCast<phi::node>(&n)); };
+  auto sweepDelta =  [](auto & d, auto & n){ d.SweepDelta(*util::AssertedCast<delta::node>(&n)); };
+
   static std::unordered_map<
     std::type_index,
     std::function<void(const DeadNodeElimination&, jlm::rvsdg::structural_node&)>
-  > map({
-          {typeid(jlm::rvsdg::gamma_op), [](auto & d, auto & n){ d.SweepGamma(*static_cast<jlm::rvsdg::gamma_node*>(&n)); }},
-          {typeid(jlm::rvsdg::theta_op), [](auto & d, auto & n){ d.SweepTheta(*static_cast<jlm::rvsdg::theta_node*>(&n)); }},
-          {typeid(lambda::operation),    [](auto & d, auto & n){ d.SweepLambda(*static_cast<lambda::node*>(&n));    }},
-          {typeid(phi::operation),       [](auto & d, auto & n){ d.SweepPhi(*static_cast<phi::node*>(&n));          }},
-          {typeid(delta::operation),     [](auto & d, auto & n){ d.SweepDelta(*static_cast<delta::node*>(&n));      }}
-        });
+  > map(
+    {
+      {typeid(jlm::rvsdg::gamma_op), sweepGamma},
+      {typeid(jlm::rvsdg::theta_op), sweepTheta},
+      {typeid(lambda::operation),    sweepLambda},
+      {typeid(phi::operation),       sweepPhi},
+      {typeid(delta::operation),     sweepDelta}
+    });
 
   auto & op = node.operation();
   JLM_ASSERT(map.find(typeid(op)) != map.end());

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -257,7 +257,7 @@ DeadNodeElimination::MarkOutput(const jlm::rvsdg::output & output)
 
   if (auto thetaArgument = is_theta_argument(&output))
   {
-    auto thetaInput = static_cast<const jlm::rvsdg::theta_input*>(thetaArgument->input());
+    auto thetaInput = util::AssertedCast<const jlm::rvsdg::theta_input>(thetaArgument->input());
     MarkOutput(*thetaInput->output());
     MarkOutput(*thetaInput->origin());
     return;
@@ -285,14 +285,14 @@ DeadNodeElimination::MarkOutput(const jlm::rvsdg::output & output)
 
   if (is_phi_output(&output))
   {
-    auto soutput = static_cast<const jlm::rvsdg::structural_output*>(&output);
-    MarkOutput(*soutput->results.first()->origin());
+    auto structuralOutput = util::AssertedCast<const jlm::rvsdg::structural_output>(&output);
+    MarkOutput(*structuralOutput->results.first()->origin());
     return;
   }
 
   if (is_phi_argument(&output))
   {
-    auto argument = static_cast<const jlm::rvsdg::argument*>(&output);
+    auto argument = util::AssertedCast<const jlm::rvsdg::argument>(&output);
     if (argument->input())
     {
       MarkOutput(*argument->input()->origin());

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -154,7 +154,7 @@ private:
   util::timer sweepTimer_;
 };
 
-DeadNodeElimination::~DeadNodeElimination()
+DeadNodeElimination::~DeadNodeElimination() noexcept
 = default;
 
 void

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -125,7 +125,7 @@ DeadNodeElimination::run(
 void
 DeadNodeElimination::ResetState()
 {
-  context_.Clear();
+  Context_.Clear();
 }
 
 void
@@ -138,10 +138,10 @@ DeadNodeElimination::Mark(const jlm::rvsdg::region & region)
 void
 DeadNodeElimination::Mark(const jlm::rvsdg::output & output)
 {
-  if (context_.IsAlive(output))
+  if (Context_.IsAlive(output))
     return;
 
-  context_.MarkAlive(output);
+  Context_.MarkAlive(output);
 
   if (is_import(&output))
     return;
@@ -228,7 +228,7 @@ DeadNodeElimination::Sweep(jlm::rvsdg::graph & graph) const
    * Remove dead imports
    */
   for (size_t n = graph.root()->narguments()-1; n != static_cast<size_t>(-1); n--) {
-    if (!context_.IsAlive(*graph.root()->argument(n)))
+    if (!Context_.IsAlive(*graph.root()->argument(n)))
       graph.root()->remove_argument(n);
   }
 }
@@ -244,7 +244,7 @@ DeadNodeElimination::Sweep(jlm::rvsdg::region & region) const
 
   for (auto it = nodesTopDown.rbegin(); it != nodesTopDown.rend(); it++) {
     for (auto node : *it) {
-      if (!context_.IsAlive(*node)) {
+      if (!Context_.IsAlive(*node)) {
         remove(node);
         continue;
       }
@@ -283,7 +283,7 @@ DeadNodeElimination::SweepGamma(jlm::rvsdg::gamma_node & gammaNode) const
    * Remove dead outputs and results
    */
   for (size_t n = gammaNode.noutputs()-1; n != static_cast<size_t>(-1); n--) {
-    if (context_.IsAlive(*gammaNode.output(n)))
+    if (Context_.IsAlive(*gammaNode.output(n)))
       continue;
 
     for (size_t r = 0; r < gammaNode.nsubregions(); r++)
@@ -305,7 +305,7 @@ DeadNodeElimination::SweepGamma(jlm::rvsdg::gamma_node & gammaNode) const
 
     bool alive = false;
     for (auto & argument : input->arguments) {
-      if (context_.IsAlive(argument)) {
+      if (Context_.IsAlive(argument)) {
         alive = true;
         break;
       }
@@ -331,7 +331,7 @@ DeadNodeElimination::SweepTheta(jlm::rvsdg::theta_node & thetaNode) const
     auto & thetaArgument = *thetaOutput.argument();
     auto & thetaResult = *thetaOutput.result();
 
-    if (!context_.IsAlive(thetaArgument) && !context_.IsAlive(thetaOutput))
+    if (!Context_.IsAlive(thetaArgument) && !Context_.IsAlive(thetaOutput))
       subregion->remove_result(thetaResult.index());
   }
 
@@ -345,7 +345,7 @@ DeadNodeElimination::SweepTheta(jlm::rvsdg::theta_node & thetaNode) const
     auto & thetaArgument = *thetaInput.argument();
     auto & thetaOutput = *thetaInput.output();
 
-    if (!context_.IsAlive(thetaArgument) && !context_.IsAlive(thetaOutput)) {
+    if (!Context_.IsAlive(thetaArgument) && !Context_.IsAlive(thetaOutput)) {
       JLM_ASSERT(thetaOutput.results.empty());
       subregion->remove_argument(thetaArgument.index());
       thetaNode.remove_input(thetaInput.index());
@@ -368,7 +368,7 @@ DeadNodeElimination::SweepLambda(lambda::node & lambdaNode) const
   for (size_t n = lambdaNode.ninputs()-1; n != static_cast<size_t>(-1); n--) {
     auto input = lambdaNode.input(n);
 
-    if (!context_.IsAlive(*input->argument())) {
+    if (!Context_.IsAlive(*input->argument())) {
       lambdaNode.subregion()->remove_argument(input->argument()->index());
       lambdaNode.remove_input(n);
     }
@@ -385,8 +385,8 @@ DeadNodeElimination::SweepPhi(phi::node & phiNode) const
    */
   for (size_t n = subregion->nresults()-1; n != static_cast<size_t>(-1); n--) {
     auto result = subregion->result(n);
-    if (!context_.IsAlive(*result->output())
-        && !context_.IsAlive(*subregion->argument(result->index()))) {
+    if (!Context_.IsAlive(*result->output())
+        && !Context_.IsAlive(*subregion->argument(result->index()))) {
       subregion->remove_result(n);
       phiNode.remove_output(n);
     }
@@ -400,7 +400,7 @@ DeadNodeElimination::SweepPhi(phi::node & phiNode) const
   for (size_t n = subregion->narguments()-1; n != static_cast<size_t>(-1); n--) {
     auto argument = subregion->argument(n);
     auto input = argument->input();
-    if (!context_.IsAlive(*argument)) {
+    if (!Context_.IsAlive(*argument)) {
       subregion->remove_argument(n);
       if (input) {
         phiNode.remove_input(input->index());
@@ -422,7 +422,7 @@ DeadNodeElimination::SweepDelta(delta::node & deltaNode) const
    */
   for (size_t n = deltaNode.ninputs()-1; n != static_cast<size_t>(-1); n--) {
     auto input = deltaNode.input(n);
-    if (!context_.IsAlive(*input->argument())) {
+    if (!Context_.IsAlive(*input->argument())) {
       deltaNode.subregion()->remove_argument(input->argument()->index());
       deltaNode.remove_input(input->index());
     }

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -21,6 +21,70 @@ is_phi_argument(const jlm::rvsdg::output * output)
          && is<phi::operation>(argument->region()->node());
 }
 
+/** \brief Dead Node Elimination context class
+ *
+ * This class keeps track of all the nodes and outputs that are alive. In contrast to all other nodes, a simple node
+ * is considered alive if already a single of its outputs is alive. For this reason, this class keeps separately track
+ * of simple nodes and therefore avoids to store all its outputs (and instead stores the node itself).
+ * By marking the entire node as alive, we also avoid that we reiterate through all inputs of this node again in the
+ * future. The following example illustrates the issue:
+ *
+ * o1 ... oN = Node2 i1 ... iN
+ * p1 ... pN = Node1 o1 ... oN
+ *
+ * When we mark o1 as alive, we actually mark the entire Node2 as alive. This means that when we try to mark o2 alive
+ * in the future, we can immediately stop marking instead of reiterating through i1 ... iN again. Thus, by marking the
+ * entire simple node instead of just its outputs, we reduce the runtime for marking Node2 from
+ * O(oN x iN) to O(oN + iN).
+ */
+class DeadNodeElimination::Context final
+{
+public:
+  void
+  MarkAlive(const jlm::rvsdg::output & output)
+  {
+    if (auto simpleOutput = dynamic_cast<const jlm::rvsdg::simple_output*>(&output)) {
+      simpleNodes_.insert(simpleOutput->node());
+      return;
+    }
+
+    outputs_.insert(&output);
+  }
+
+  bool
+  IsAlive(const jlm::rvsdg::output & output) const noexcept
+  {
+    if (auto simpleOutput = dynamic_cast<const jlm::rvsdg::simple_output*>(&output))
+      return simpleNodes_.find(simpleOutput->node()) != simpleNodes_.end();
+
+    return outputs_.find(&output) != outputs_.end();
+  }
+
+  bool
+  IsAlive(const jlm::rvsdg::node & node) const noexcept
+  {
+    if (auto simpleNode = dynamic_cast<const jlm::rvsdg::simple_node*>(&node))
+      return simpleNodes_.find(simpleNode) != simpleNodes_.end();
+
+    for (size_t n = 0; n < node.noutputs(); n++) {
+      if (IsAlive(*node.output(n)))
+        return true;
+    }
+
+    return false;
+  }
+
+  static std::unique_ptr<Context>
+  Create()
+  {
+    return std::make_unique<Context>();
+  }
+
+private:
+  std::unordered_set<const jlm::rvsdg::simple_node*> simpleNodes_;
+  std::unordered_set<const jlm::rvsdg::output*> outputs_;
+};
+
 /** \brief Dead Node Elimination statistics class
  *
  */

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -284,16 +284,16 @@ DeadNodeElimination::MarkOutput(const jlm::rvsdg::output & output)
 }
 
 void
-DeadNodeElimination::SweepRvsdg(jlm::rvsdg::graph & graph) const
+DeadNodeElimination::SweepRvsdg(jlm::rvsdg::graph & rvsdg) const
 {
-  SweepRegion(*graph.root());
+  SweepRegion(*rvsdg.root());
 
   /**
    * Remove dead imports
    */
-  for (size_t n = graph.root()->narguments()-1; n != static_cast<size_t>(-1); n--) {
-    if (!Context_->IsAlive(*graph.root()->argument(n)))
-      graph.root()->remove_argument(n);
+  for (size_t n = rvsdg.root()->narguments() - 1; n != static_cast<size_t>(-1); n--) {
+    if (!Context_->IsAlive(*rvsdg.root()->argument(n)))
+      rvsdg.root()->remove_argument(n);
   }
 }
 

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -44,27 +44,27 @@ public:
   MarkAlive(const jlm::rvsdg::output & output)
   {
     if (auto simpleOutput = dynamic_cast<const jlm::rvsdg::simple_output*>(&output)) {
-      simpleNodes_.insert(simpleOutput->node());
+      SimpleNodes_.insert(simpleOutput->node());
       return;
     }
 
-    outputs_.insert(&output);
+    Outputs_.insert(&output);
   }
 
   bool
   IsAlive(const jlm::rvsdg::output & output) const noexcept
   {
     if (auto simpleOutput = dynamic_cast<const jlm::rvsdg::simple_output*>(&output))
-      return simpleNodes_.find(simpleOutput->node()) != simpleNodes_.end();
+      return SimpleNodes_.find(simpleOutput->node()) != SimpleNodes_.end();
 
-    return outputs_.find(&output) != outputs_.end();
+    return Outputs_.find(&output) != Outputs_.end();
   }
 
   bool
   IsAlive(const jlm::rvsdg::node & node) const noexcept
   {
     if (auto simpleNode = dynamic_cast<const jlm::rvsdg::simple_node*>(&node))
-      return simpleNodes_.find(simpleNode) != simpleNodes_.end();
+      return SimpleNodes_.find(simpleNode) != SimpleNodes_.end();
 
     for (size_t n = 0; n < node.noutputs(); n++) {
       if (IsAlive(*node.output(n)))
@@ -81,8 +81,8 @@ public:
   }
 
 private:
-  std::unordered_set<const jlm::rvsdg::simple_node*> simpleNodes_;
-  std::unordered_set<const jlm::rvsdg::output*> outputs_;
+  std::unordered_set<const jlm::rvsdg::simple_node*> SimpleNodes_;
+  std::unordered_set<const jlm::rvsdg::output*> Outputs_;
 };
 
 /** \brief Dead Node Elimination statistics class

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -90,54 +90,54 @@ private:
  */
 class DeadNodeElimination::Statistics final : public util::Statistics {
 public:
-	~Statistics() override = default;
+  ~Statistics() override = default;
 
-	Statistics()
-	: util::Statistics(Statistics::Id::DeadNodeElimination)
-  , numNodesBefore_(0), numNodesAfter_(0)
-	, numInputsBefore_(0), numInputsAfter_(0)
-	{}
+  Statistics()
+    : util::Statistics(Statistics::Id::DeadNodeElimination)
+    , numNodesBefore_(0), numNodesAfter_(0)
+    , numInputsBefore_(0), numInputsAfter_(0)
+  {}
 
-	void
-	StartMarkStatistics(const jlm::rvsdg::graph & graph) noexcept
-	{
+  void
+  StartMarkStatistics(const jlm::rvsdg::graph & graph) noexcept
+  {
     numNodesBefore_ = jlm::rvsdg::nnodes(graph.root());
     numInputsBefore_ = jlm::rvsdg::ninputs(graph.root());
-		markTimer_.start();
-	}
+    markTimer_.start();
+  }
 
-	void
-	StopMarkStatistics() noexcept
-	{
-		markTimer_.stop();
-	}
+  void
+  StopMarkStatistics() noexcept
+  {
+    markTimer_.stop();
+  }
 
-	void
-	StartSweepStatistics() noexcept
-	{
-		sweepTimer_.start();
-	}
+  void
+  StartSweepStatistics() noexcept
+  {
+    sweepTimer_.start();
+  }
 
-	void
-	StopSweepStatistics(const jlm::rvsdg::graph & graph) noexcept
-	{
+  void
+  StopSweepStatistics(const jlm::rvsdg::graph & graph) noexcept
+  {
     sweepTimer_.stop();
     numNodesAfter_ = jlm::rvsdg::nnodes(graph.root());
     numInputsAfter_ = jlm::rvsdg::ninputs(graph.root());
-	}
+  }
 
-	[[nodiscard]] std::string
-	ToString() const override
-	{
-		return util::strfmt("DeadNodeElimination ",
-                  "#RvsdgNodesBeforeDNE:", numNodesBefore_, " ",
-                  "#RvsdgNodesAfterDNE:", numNodesAfter_, " ",
-                  "#RvsdgInputsBeforeDNE:", numInputsBefore_, " ",
-                  "#RvsdgInputsAfterDNE:", numInputsAfter_, " ",
-                  "MarkTime[ns]:", markTimer_.ns(), " ",
-                  "SweepTime[ns]:", sweepTimer_.ns()
-		);
-	}
+  [[nodiscard]] std::string
+  ToString() const override
+  {
+    return util::strfmt("DeadNodeElimination ",
+                        "#RvsdgNodesBeforeDNE:", numNodesBefore_, " ",
+                        "#RvsdgNodesAfterDNE:", numNodesAfter_, " ",
+                        "#RvsdgInputsBeforeDNE:", numInputsBefore_, " ",
+                        "#RvsdgInputsAfterDNE:", numInputsAfter_, " ",
+                        "MarkTime[ns]:", markTimer_.ns(), " ",
+                        "SweepTime[ns]:", sweepTimer_.ns()
+    );
+  }
 
   static std::unique_ptr<Statistics>
   Create()
@@ -146,11 +146,11 @@ public:
   }
 
 private:
-	size_t numNodesBefore_;
+  size_t numNodesBefore_;
   size_t numNodesAfter_;
-	size_t numInputsBefore_;
+  size_t numInputsBefore_;
   size_t numInputsAfter_;
-	util::timer markTimer_;
+  util::timer markTimer_;
   util::timer sweepTimer_;
 };
 
@@ -162,8 +162,8 @@ DeadNodeElimination::run(jlm::rvsdg::region & region)
 {
   Context_ = Context::Create();
 
-	Mark(region);
-	Sweep(region);
+  Mark(region);
+  Sweep(region);
 
   // Discard internal state to free up memory after we are done
   Context_.reset();
@@ -328,12 +328,12 @@ DeadNodeElimination::Sweep(jlm::rvsdg::structural_node & node) const
     std::type_index,
     std::function<void(const DeadNodeElimination&, jlm::rvsdg::structural_node&)>
   > map({
-    {typeid(jlm::rvsdg::gamma_op),       [](auto & d, auto & n){ d.SweepGamma(*static_cast<jlm::rvsdg::gamma_node*>(&n)); }},
-    {typeid(jlm::rvsdg::theta_op),       [](auto & d, auto & n){ d.SweepTheta(*static_cast<jlm::rvsdg::theta_node*>(&n)); }},
-    {typeid(lambda::operation),    [](auto & d, auto & n){ d.SweepLambda(*static_cast<lambda::node*>(&n));    }},
-    {typeid(phi::operation),       [](auto & d, auto & n){ d.SweepPhi(*static_cast<phi::node*>(&n));          }},
-    {typeid(delta::operation),     [](auto & d, auto & n){ d.SweepDelta(*static_cast<delta::node*>(&n));      }}
-  });
+          {typeid(jlm::rvsdg::gamma_op), [](auto & d, auto & n){ d.SweepGamma(*static_cast<jlm::rvsdg::gamma_node*>(&n)); }},
+          {typeid(jlm::rvsdg::theta_op), [](auto & d, auto & n){ d.SweepTheta(*static_cast<jlm::rvsdg::theta_node*>(&n)); }},
+          {typeid(lambda::operation),    [](auto & d, auto & n){ d.SweepLambda(*static_cast<lambda::node*>(&n));    }},
+          {typeid(phi::operation),       [](auto & d, auto & n){ d.SweepPhi(*static_cast<phi::node*>(&n));          }},
+          {typeid(delta::operation),     [](auto & d, auto & n){ d.SweepDelta(*static_cast<delta::node*>(&n));      }}
+        });
 
   auto & op = node.operation();
   JLM_ASSERT(map.find(typeid(op)) != map.end());

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -43,7 +43,8 @@ public:
   void
   MarkAlive(const jlm::rvsdg::output & output)
   {
-    if (auto simpleOutput = dynamic_cast<const jlm::rvsdg::simple_output*>(&output)) {
+    if (auto simpleOutput = dynamic_cast<const jlm::rvsdg::simple_output*>(&output))
+    {
       SimpleNodes_.Insert(simpleOutput->node());
       return;
     }
@@ -55,7 +56,9 @@ public:
   IsAlive(const jlm::rvsdg::output & output) const noexcept
   {
     if (auto simpleOutput = dynamic_cast<const jlm::rvsdg::simple_output*>(&output))
+    {
       return SimpleNodes_.Contains(simpleOutput->node());
+    }
 
     return Outputs_.Contains(&output);
   }
@@ -64,11 +67,16 @@ public:
   IsAlive(const jlm::rvsdg::node & node) const noexcept
   {
     if (auto simpleNode = dynamic_cast<const jlm::rvsdg::simple_node*>(&node))
+    {
       return SimpleNodes_.Contains(simpleNode);
+    }
 
-    for (size_t n = 0; n < node.noutputs(); n++) {
+    for (size_t n = 0; n < node.noutputs(); n++)
+    {
       if (IsAlive(*node.output(n)))
+      {
         return true;
+      }
     }
 
     return false;
@@ -199,87 +207,118 @@ void
 DeadNodeElimination::MarkRegion(const jlm::rvsdg::region & region)
 {
   for (size_t n = 0; n < region.nresults(); n++)
+  {
     MarkOutput(*region.result(n)->origin());
+  }
 }
 
 void
 DeadNodeElimination::MarkOutput(const jlm::rvsdg::output & output)
 {
   if (Context_->IsAlive(output))
+  {
     return;
+  }
 
   Context_->MarkAlive(output);
 
   if (is_import(&output))
-    return;
-
-  if (auto gammaOutput = is_gamma_output(&output)) {
-    MarkOutput(*gammaOutput->node()->predicate()->origin());
-    for (const auto & result : gammaOutput->results)
-      MarkOutput(*result.origin());
+  {
     return;
   }
 
-  if (auto argument = is_gamma_argument(&output)) {
+  if (auto gammaOutput = is_gamma_output(&output))
+  {
+    MarkOutput(*gammaOutput->node()->predicate()->origin());
+    for (const auto & result : gammaOutput->results)
+    {
+      MarkOutput(*result.origin());
+    }
+    return;
+  }
+
+  if (auto argument = is_gamma_argument(&output))
+  {
     MarkOutput(*argument->input()->origin());
     return;
   }
 
-  if (auto thetaOutput = is_theta_output(&output)) {
+  if (auto thetaOutput = is_theta_output(&output))
+  {
     MarkOutput(*thetaOutput->node()->predicate()->origin());
     MarkOutput(*thetaOutput->result()->origin());
     MarkOutput(*thetaOutput->input()->origin());
     return;
   }
 
-  if (auto thetaArgument = is_theta_argument(&output)) {
+  if (auto thetaArgument = is_theta_argument(&output))
+  {
     auto thetaInput = static_cast<const jlm::rvsdg::theta_input*>(thetaArgument->input());
     MarkOutput(*thetaInput->output());
     MarkOutput(*thetaInput->origin());
     return;
   }
 
-  if (auto o = dynamic_cast<const lambda::output*>(&output)) {
+  if (auto o = dynamic_cast<const lambda::output*>(&output))
+  {
     for (auto & result : o->node()->fctresults())
+    {
       MarkOutput(*result.origin());
+    }
     return;
   }
 
   if (is<lambda::fctargument>(&output))
+  {
     return;
+  }
 
-  if (auto cv = dynamic_cast<const lambda::cvargument*>(&output)) {
+  if (auto cv = dynamic_cast<const lambda::cvargument*>(&output))
+  {
     MarkOutput(*cv->input()->origin());
     return;
   }
 
-  if (is_phi_output(&output)) {
+  if (is_phi_output(&output))
+  {
     auto soutput = static_cast<const jlm::rvsdg::structural_output*>(&output);
     MarkOutput(*soutput->results.first()->origin());
     return;
   }
 
-  if (is_phi_argument(&output)) {
+  if (is_phi_argument(&output))
+  {
     auto argument = static_cast<const jlm::rvsdg::argument*>(&output);
-    if (argument->input()) MarkOutput(*argument->input()->origin());
-    else MarkOutput(*argument->region()->result(argument->index())->origin());
+    if (argument->input())
+    {
+      MarkOutput(*argument->input()->origin());
+    }
+    else
+    {
+      MarkOutput(*argument->region()->result(argument->index())->origin());
+    }
     return;
   }
 
-  if (auto deltaOutput = dynamic_cast<const delta::output*>(&output)) {
+  if (auto deltaOutput = dynamic_cast<const delta::output*>(&output))
+  {
     MarkOutput(*deltaOutput->node()->subregion()->result(0)->origin());
     return;
   }
 
-  if (auto deltaCvArgument = dynamic_cast<const delta::cvargument*>(&output)) {
+  if (auto deltaCvArgument = dynamic_cast<const delta::cvargument*>(&output))
+  {
     MarkOutput(*deltaCvArgument->input()->origin());
     return;
   }
 
-  if (auto simpleOutput = dynamic_cast<const jlm::rvsdg::simple_output*>(&output)) {
+  if (auto simpleOutput = dynamic_cast<const jlm::rvsdg::simple_output*>(&output))
+  {
     auto node = simpleOutput->node();
     for (size_t n = 0; n < node->ninputs(); n++)
+    {
       MarkOutput(*node->input(n)->origin());
+    }
     return;
   }
 
@@ -292,9 +331,12 @@ DeadNodeElimination::SweepRvsdg(jlm::rvsdg::graph & rvsdg) const
   SweepRegion(*rvsdg.root());
 
   // Remove dead imports
-  for (size_t n = rvsdg.root()->narguments() - 1; n != static_cast<size_t>(-1); n--) {
+  for (size_t n = rvsdg.root()->narguments() - 1; n != static_cast<size_t>(-1); n--)
+  {
     if (!Context_->IsAlive(*rvsdg.root()->argument(n)))
+    {
       rvsdg.root()->remove_argument(n);
+    }
   }
 }
 
@@ -305,17 +347,24 @@ DeadNodeElimination::SweepRegion(jlm::rvsdg::region & region) const
 
   std::vector<std::vector<jlm::rvsdg::node*>> nodesTopDown(region.nnodes());
   for (auto & node : region.nodes)
+  {
     nodesTopDown[node.depth()].push_back(&node);
+  }
 
-  for (auto it = nodesTopDown.rbegin(); it != nodesTopDown.rend(); it++) {
-    for (auto node : *it) {
-      if (!Context_->IsAlive(*node)) {
+  for (auto it = nodesTopDown.rbegin(); it != nodesTopDown.rend(); it++)
+  {
+    for (auto node : *it)
+    {
+      if (!Context_->IsAlive(*node))
+      {
         remove(node);
         continue;
       }
 
       if (auto structuralNode = dynamic_cast<jlm::rvsdg::structural_node*>(node))
+      {
         SweepStructuralNode(*structuralNode);
+      }
     }
   }
 
@@ -345,33 +394,46 @@ void
 DeadNodeElimination::SweepGamma(jlm::rvsdg::gamma_node & gammaNode) const
 {
   // Remove dead outputs and results
-  for (size_t n = gammaNode.noutputs()-1; n != static_cast<size_t>(-1); n--) {
+  for (size_t n = gammaNode.noutputs()-1; n != static_cast<size_t>(-1); n--)
+  {
     if (Context_->IsAlive(*gammaNode.output(n)))
+    {
       continue;
+    }
 
     for (size_t r = 0; r < gammaNode.nsubregions(); r++)
+    {
       gammaNode.subregion(r)->remove_result(n);
+    }
     gammaNode.remove_output(n);
   }
 
   // Sweep gamma subregions
   for (size_t r = 0; r < gammaNode.nsubregions(); r++)
+  {
     SweepRegion(*gammaNode.subregion(r));
+  }
 
   // Remove dead arguments and inputs
-  for (size_t n = gammaNode.ninputs()-1; n >= 1; n--) {
+  for (size_t n = gammaNode.ninputs()-1; n >= 1; n--)
+  {
     auto input = gammaNode.input(n);
 
     bool alive = false;
-    for (auto & argument : input->arguments) {
-      if (Context_->IsAlive(argument)) {
+    for (auto & argument : input->arguments)
+    {
+      if (Context_->IsAlive(argument))
+      {
         alive = true;
         break;
       }
     }
-    if (!alive) {
+    if (!alive)
+    {
       for (size_t r = 0; r < gammaNode.nsubregions(); r++)
+      {
         gammaNode.subregion(r)->remove_argument(n-1);
+      }
       gammaNode.remove_input(n);
     }
   }
@@ -383,24 +445,31 @@ DeadNodeElimination::SweepTheta(jlm::rvsdg::theta_node & thetaNode) const
   auto subregion = thetaNode.subregion();
 
   // Remove dead results
-  for (size_t n = thetaNode.noutputs()-1; n != static_cast<size_t>(-1); n--) {
+  for (size_t n = thetaNode.noutputs()-1; n != static_cast<size_t>(-1); n--)
+  {
     auto & thetaOutput = *thetaNode.output(n);
     auto & thetaArgument = *thetaOutput.argument();
     auto & thetaResult = *thetaOutput.result();
 
-    if (!Context_->IsAlive(thetaArgument) && !Context_->IsAlive(thetaOutput))
+    if (!Context_->IsAlive(thetaArgument)
+        && !Context_->IsAlive(thetaOutput))
+    {
       subregion->remove_result(thetaResult.index());
+    }
   }
 
   SweepRegion(*subregion);
 
   // Remove dead outputs, inputs, and arguments
-  for (size_t n = thetaNode.ninputs()-1; n != static_cast<size_t>(-1); n--) {
+  for (size_t n = thetaNode.ninputs()-1; n != static_cast<size_t>(-1); n--)
+  {
     auto & thetaInput = *thetaNode.input(n);
     auto & thetaArgument = *thetaInput.argument();
     auto & thetaOutput = *thetaInput.output();
 
-    if (!Context_->IsAlive(thetaArgument) && !Context_->IsAlive(thetaOutput)) {
+    if (!Context_->IsAlive(thetaArgument)
+        && !Context_->IsAlive(thetaOutput))
+    {
       JLM_ASSERT(thetaOutput.results.empty());
       subregion->remove_argument(thetaArgument.index());
       thetaNode.remove_input(thetaInput.index());
@@ -418,10 +487,12 @@ DeadNodeElimination::SweepLambda(lambda::node & lambdaNode) const
   SweepRegion(*lambdaNode.subregion());
 
   // Remove dead arguments and inputs
-  for (size_t n = lambdaNode.ninputs()-1; n != static_cast<size_t>(-1); n--) {
+  for (size_t n = lambdaNode.ninputs()-1; n != static_cast<size_t>(-1); n--)
+  {
     auto input = lambdaNode.input(n);
 
-    if (!Context_->IsAlive(*input->argument())) {
+    if (!Context_->IsAlive(*input->argument()))
+    {
       lambdaNode.subregion()->remove_argument(input->argument()->index());
       lambdaNode.remove_input(n);
     }
@@ -434,10 +505,12 @@ DeadNodeElimination::SweepPhi(phi::node & phiNode) const
   auto subregion = phiNode.subregion();
 
   // Remove dead outputs and results
-  for (size_t n = subregion->nresults()-1; n != static_cast<size_t>(-1); n--) {
+  for (size_t n = subregion->nresults()-1; n != static_cast<size_t>(-1); n--)
+  {
     auto result = subregion->result(n);
     if (!Context_->IsAlive(*result->output())
-        && !Context_->IsAlive(*subregion->argument(result->index()))) {
+        && !Context_->IsAlive(*subregion->argument(result->index())))
+    {
       subregion->remove_result(n);
       phiNode.remove_output(n);
     }
@@ -446,12 +519,15 @@ DeadNodeElimination::SweepPhi(phi::node & phiNode) const
   SweepRegion(*subregion);
 
   // Remove dead arguments and inputs
-  for (size_t n = subregion->narguments()-1; n != static_cast<size_t>(-1); n--) {
+  for (size_t n = subregion->narguments()-1; n != static_cast<size_t>(-1); n--)
+  {
     auto argument = subregion->argument(n);
     auto input = argument->input();
-    if (!Context_->IsAlive(*argument)) {
+    if (!Context_->IsAlive(*argument))
+    {
       subregion->remove_argument(n);
-      if (input) {
+      if (input)
+      {
         phiNode.remove_input(input->index());
       }
     }
@@ -465,9 +541,11 @@ DeadNodeElimination::SweepDelta(delta::node & deltaNode) const
   deltaNode.subregion()->prune(false);
 
   // Remove dead arguments and inputs.
-  for (size_t n = deltaNode.ninputs()-1; n != static_cast<size_t>(-1); n--) {
+  for (size_t n = deltaNode.ninputs()-1; n != static_cast<size_t>(-1); n--)
+  {
     auto input = deltaNode.input(n);
-    if (!Context_->IsAlive(*input->argument())) {
+    if (!Context_->IsAlive(*input->argument()))
+    {
       deltaNode.subregion()->remove_argument(input->argument()->index());
       deltaNode.remove_input(input->index());
     }

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -157,6 +157,9 @@ private:
 DeadNodeElimination::~DeadNodeElimination() noexcept
 = default;
 
+DeadNodeElimination::DeadNodeElimination()
+= default;
+
 void
 DeadNodeElimination::run(jlm::rvsdg::region & region)
 {

--- a/jlm/llvm/opt/DeadNodeElimination.hpp
+++ b/jlm/llvm/opt/DeadNodeElimination.hpp
@@ -51,6 +51,18 @@ class DeadNodeElimination final : public optimization
 public:
   ~DeadNodeElimination() noexcept override;
 
+  DeadNodeElimination();
+
+  DeadNodeElimination(const DeadNodeElimination&) = delete;
+
+  DeadNodeElimination(DeadNodeElimination&&) = delete;
+
+  DeadNodeElimination&
+  operator=(const DeadNodeElimination&) = delete;
+
+  DeadNodeElimination&
+  operator=(DeadNodeElimination&&) = delete;
+
   void
   run(jlm::rvsdg::region & region);
 

--- a/jlm/llvm/opt/DeadNodeElimination.hpp
+++ b/jlm/llvm/opt/DeadNodeElimination.hpp
@@ -67,7 +67,7 @@ private:
   MarkOutput(const jlm::rvsdg::output & output);
 
   void
-  SweepRvsdg(jlm::rvsdg::graph & graph) const;
+  SweepRvsdg(jlm::rvsdg::graph & rvsdg) const;
 
   void
   SweepRegion(jlm::rvsdg::region & region) const;

--- a/jlm/llvm/opt/DeadNodeElimination.hpp
+++ b/jlm/llvm/opt/DeadNodeElimination.hpp
@@ -97,11 +97,10 @@ class DeadNodeElimination final : public optimization {
       return false;
     }
 
-    void
-    Clear()
+    static std::unique_ptr<Context>
+    Create()
     {
-      simpleNodes_.clear();
-      outputs_.clear();
+      return std::make_unique<Context>();
     }
 
   private:
@@ -123,9 +122,6 @@ public:
     jlm::util::StatisticsCollector & statisticsCollector) override;
 
 private:
-  void
-  ResetState();
-
   void
   Mark(const jlm::rvsdg::region & region);
 
@@ -156,7 +152,7 @@ private:
   void
   SweepDelta(delta::node & deltaNode) const;
 
-  Context Context_;
+  std::unique_ptr<Context> Context_;
 };
 
 }

--- a/jlm/llvm/opt/DeadNodeElimination.hpp
+++ b/jlm/llvm/opt/DeadNodeElimination.hpp
@@ -61,19 +61,19 @@ public:
 
 private:
   void
-  Mark(const jlm::rvsdg::region & region);
+  MarkRegion(const jlm::rvsdg::region & region);
 
   void
-  Mark(const jlm::rvsdg::output & output);
+  MarkOutput(const jlm::rvsdg::output & output);
 
   void
-  Sweep(jlm::rvsdg::graph & graph) const;
+  SweepRvsdg(jlm::rvsdg::graph & graph) const;
 
   void
-  Sweep(jlm::rvsdg::region & region) const;
+  SweepRegion(jlm::rvsdg::region & region) const;
 
   void
-  Sweep(jlm::rvsdg::structural_node & node) const;
+  SweepStructuralNode(jlm::rvsdg::structural_node & node) const;
 
   void
   SweepGamma(rvsdg::gamma_node & gammaNode) const;

--- a/jlm/llvm/opt/DeadNodeElimination.hpp
+++ b/jlm/llvm/opt/DeadNodeElimination.hpp
@@ -49,7 +49,7 @@ class DeadNodeElimination final : public optimization
   class Statistics;
 
 public:
-  ~DeadNodeElimination() override;
+  ~DeadNodeElimination() noexcept override;
 
   void
   run(jlm::rvsdg::region & region);

--- a/jlm/llvm/opt/DeadNodeElimination.hpp
+++ b/jlm/llvm/opt/DeadNodeElimination.hpp
@@ -43,71 +43,9 @@ class RvsdgModule;
  *
  * Please see TestDeadNodeElimination.cpp for Dead Node Elimination examples.
  */
-class DeadNodeElimination final : public optimization {
-
-  /** \brief Dead Node Elimination context class
-   *
-   * This class keeps track of all the nodes and outputs that are alive. In contrast to all other nodes, a simple node
-   * is considered alive if already a single of its outputs is alive. For this reason, this class keeps separately track
-   * of simple nodes and therefore avoids to store all its outputs (and instead stores the node itself).
-   * By marking the entire node as alive, we also avoid that we reiterate through all inputs of this node again in the
-   * future. The following example illustrates the issue:
-   *
-   * o1 ... oN = Node2 i1 ... iN
-   * p1 ... pN = Node1 o1 ... oN
-   *
-   * When we mark o1 as alive, we actually mark the entire Node2 as alive. This means that when we try to mark o2 alive
-   * in the future, we can immediately stop marking instead of reiterating through i1 ... iN again. Thus, by marking the
-   * entire simple node instead of just its outputs, we reduce the runtime for marking Node2 from
-   * O(oN x iN) to O(oN + iN).
-   */
-  class Context final {
-  public:
-    void
-    MarkAlive(const jlm::rvsdg::output & output)
-    {
-      if (auto simpleOutput = dynamic_cast<const jlm::rvsdg::simple_output*>(&output)) {
-          simpleNodes_.insert(simpleOutput->node());
-          return;
-      }
-
-      outputs_.insert(&output);
-    }
-
-    bool
-    IsAlive(const jlm::rvsdg::output & output) const noexcept
-    {
-      if (auto simpleOutput = dynamic_cast<const jlm::rvsdg::simple_output*>(&output))
-        return simpleNodes_.find(simpleOutput->node()) != simpleNodes_.end();
-
-      return outputs_.find(&output) != outputs_.end();
-    }
-
-    bool
-    IsAlive(const jlm::rvsdg::node & node) const noexcept
-    {
-      if (auto simpleNode = dynamic_cast<const jlm::rvsdg::simple_node*>(&node))
-        return simpleNodes_.find(simpleNode) != simpleNodes_.end();
-
-      for (size_t n = 0; n < node.noutputs(); n++) {
-        if (IsAlive(*node.output(n)))
-          return true;
-      }
-
-      return false;
-    }
-
-    static std::unique_ptr<Context>
-    Create()
-    {
-      return std::make_unique<Context>();
-    }
-
-  private:
-    std::unordered_set<const jlm::rvsdg::simple_node*> simpleNodes_;
-    std::unordered_set<const jlm::rvsdg::output*> outputs_;
-  };
-
+class DeadNodeElimination final : public optimization
+{
+  class Context;
   class Statistics;
 
 public:

--- a/jlm/llvm/opt/DeadNodeElimination.hpp
+++ b/jlm/llvm/opt/DeadNodeElimination.hpp
@@ -49,13 +49,13 @@ class DeadNodeElimination final : public optimization
   class Statistics;
 
 public:
-	~DeadNodeElimination() override;
+  ~DeadNodeElimination() override;
 
-	void
-	run(jlm::rvsdg::region & region);
+  void
+  run(jlm::rvsdg::region & region);
 
-	void
-	run(
+  void
+  run(
     RvsdgModule & module,
     jlm::util::StatisticsCollector & statisticsCollector) override;
 

--- a/jlm/llvm/opt/DeadNodeElimination.hpp
+++ b/jlm/llvm/opt/DeadNodeElimination.hpp
@@ -156,7 +156,7 @@ private:
   void
   SweepDelta(delta::node & deltaNode) const;
 
-  Context context_;
+  Context Context_;
 };
 
 }


### PR DESCRIPTION
This PR cleans up the dead node elimination pass:
1. Ensures that internal state is cleared after pass is finished
2. Follow naming conventions
3. Correct indentation in files
4. Clarify method names
5. Use // for comments
6. Add missing constructors and assignment operators
7. Move Context declaration from DeadNodeElimination.hpp to DeadNodeElimination.cpp
8. Clean up parethesis
9. Use AssertedCasts instead of static_casts