### PR TITLE
Fix possible C++ constructor ordering issue when creating test registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,10 @@ debug: jlm-debug check
 .PHONY: check
 check: jlm-check
 
-.PHONY: check-ctets
+.PHONY: check-ctests
 check-ctests: jlm-check-ctests
 
-.PHONY: check-utets
+.PHONY: check-utests
 check-utests: jlm-check-utests
 
 .PHONY: valgrind-check

--- a/tests/test-registry.cpp
+++ b/tests/test-registry.cpp
@@ -12,7 +12,8 @@
 namespace jlm::tests
 {
 
-class unit_test {
+class unit_test
+{
 public:
 	unit_test(int (*v)())
 	: verify(v)
@@ -21,20 +22,25 @@ public:
 	int (*verify)();
 };
 
-static std::unordered_map<std::string, std::unique_ptr<unit_test>> unit_test_map;
+static std::unordered_map<std::string, std::unique_ptr<unit_test>> &
+GetUnitTestMap()
+{
+	static std::unordered_map<std::string, std::unique_ptr<unit_test>> unit_test_map;
+	return unit_test_map;
+}
 
 void
 register_unit_test(const std::string & name, int (*verify)())
 {
-	assert(unit_test_map.find(name) == unit_test_map.end());
-	unit_test_map.insert(std::make_pair(name,std::make_unique<unit_test>(verify)));
+	assert(GetUnitTestMap().find(name) == GetUnitTestMap().end());
+	GetUnitTestMap().insert(std::make_pair(name,std::make_unique<unit_test>(verify)));
 }
 
 int
 run_unit_test(const std::string & name)
 {
-	assert(unit_test_map.find(name) != unit_test_map.end());
-	return unit_test_map[name]->verify();
+	assert(GetUnitTestMap().find(name) != GetUnitTestMap().end());
+	return GetUnitTestMap()[name]->verify();
 }
 
 }


### PR DESCRIPTION
The order of constructor invocation across translation units is not well defined, though it seems fair to guess that the clang++ and g++ linkers, and maybe even MSVC++ use the same order as the object files on the command line. New incremental linkers and other tools may however not expect those constraints.

This can cause the registration of tests to segfault, when the global map is not ready yet. Putting it behind a function ensures that the constructor is called before use.

Also fixes typos in the definition of the PHONY targets `check-ctets` and `check-utets`.
I could not find any reason for these typos being load bearing in this repo nor in the jlm-eval-suite repo.

If only the latter change is desired, I will of course change the PR.