### PR TITLE
Add Analyze() method to Steensgaard class

### DIFF
--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -1550,6 +1550,13 @@ Steensgaard::Analyze(const jlm::rvsdg::graph & graph)
 }
 
 std::unique_ptr<PointsToGraph>
+Steensgaard::Analyze(const RvsdgModule &rvsdgModule)
+{
+  util::StatisticsCollector statisticsCollector;
+  return Analyze(rvsdgModule, statisticsCollector);
+}
+
+std::unique_ptr<PointsToGraph>
 Steensgaard::Analyze(
   const RvsdgModule & module,
   jlm::util::StatisticsCollector & statisticsCollector)

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
@@ -186,6 +186,16 @@ public:
     const RvsdgModule & module,
     jlm::util::StatisticsCollector & statisticsCollector) override;
 
+  /**
+  * \brief Analyze RVSDG module
+  *
+  * \param module RVSDG module the analysis is performed on.
+  *
+  * \return A PointsTo graph.
+  */
+  std::unique_ptr<PointsToGraph>
+  Analyze(const RvsdgModule & rvsdgModule);
+
 private:
 	void
 	ResetState();


### PR DESCRIPTION
Add second Analyze() method to Steensgaard class for convenience. It does not take a StatisticsCollector parameter.