### PR TITLE
Add ExtractLambdaNodes method to phi::node class

### DIFF
--- a/jlm/llvm/ir/operators/Phi.cpp
+++ b/jlm/llvm/ir/operators/Phi.cpp
@@ -4,8 +4,8 @@
  * See COPYING for terms of redistribution.
  */
 
+#include <jlm/llvm/ir/operators/lambda.hpp>
 #include <jlm/llvm/ir/operators/Phi.hpp>
-#include <jlm/rvsdg/substitution.hpp>
 
 namespace jlm::llvm
 {
@@ -89,6 +89,32 @@ node::copy(
   }
 
   return pb.end();
+}
+
+std::vector<lambda::node*>
+node::ExtractLambdaNodes(const phi::node & phiNode)
+{
+  std::function<void(const phi::node&, std::vector<lambda::node*>&)> extractLambdaNodes = [&](
+    auto & phiNode,
+    auto & lambdaNodes)
+  {
+    for (auto & node : phiNode.subregion()->nodes)
+    {
+      if (auto lambdaNode = dynamic_cast<lambda::node*>(&node))
+      {
+        lambdaNodes.push_back(lambdaNode);
+      }
+      else if (auto innerPhiNode = dynamic_cast<const phi::node*>(&node))
+      {
+        extractLambdaNodes(*innerPhiNode, lambdaNodes);
+      }
+    }
+  };
+
+  std::vector<lambda::node*> lambdaNodes;
+  extractLambdaNodes(phiNode, lambdaNodes);
+
+  return lambdaNodes;
 }
 
 /* phi builder class */

--- a/jlm/llvm/ir/operators/Phi.hpp
+++ b/jlm/llvm/ir/operators/Phi.hpp
@@ -16,6 +16,8 @@
 namespace jlm::llvm
 {
 
+namespace lambda { class node; }
+
 namespace phi {
 
 /* phi operation class  */
@@ -394,6 +396,17 @@ public:
 
   virtual phi::node *
   copy(jlm::rvsdg::region * region, jlm::rvsdg::substitution_map & smap) const override;
+
+  /**
+   * Extracts all lambda nodes from a phi node.
+   *
+   * The function is capable of handling nested phi nodes.
+   *
+   * @param phiNode The phi node from which the lambda nodes should be extracted.
+   * @return A vector of lambda nodes.
+   */
+  static std::vector<lambda::node*>
+  ExtractLambdaNodes(const phi::node & phiNode);
 };
 
 /* phi builder class */

--- a/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.cpp
+++ b/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.cpp
@@ -817,7 +817,7 @@ RegionAwareMemoryNodeProvider::PropagatePhi(const phi::node & phiNode)
   auto & phiNodeSubregion = *phiNode.subregion();
   PropagateRegion(phiNodeSubregion);
 
-  auto lambdaNodes = ExtractLambdaNodes(phiNode);
+  auto lambdaNodes = phi::node::ExtractLambdaNodes(phiNode);
 
   util::HashSet<const PointsToGraph::MemoryNode*> memoryNodes;
   util::HashSet<const jlm::rvsdg::simple_node*> unknownMemoryNodeReferences;
@@ -881,7 +881,7 @@ RegionAwareMemoryNodeProvider::ResolveUnknownMemoryNodeReferences(const RvsdgMod
     }
     else if (auto phiNode = dynamic_cast<const phi::node*>(node))
     {
-      auto lambdaNodes = ExtractLambdaNodes(*phiNode);
+      auto lambdaNodes = phi::node::ExtractLambdaNodes(*phiNode);
       for (auto & lambda : lambdaNodes)
       {
         ResolveLambda(*lambda);
@@ -898,32 +898,6 @@ RegionAwareMemoryNodeProvider::ResolveUnknownMemoryNodeReferences(const RvsdgMod
       JLM_UNREACHABLE("Unhandled node type!");
     }
   }
-}
-
-std::vector<const lambda::node*>
-RegionAwareMemoryNodeProvider::ExtractLambdaNodes(const phi::node & phiNode)
-{
-  std::function<void(const phi::node&, std::vector<const lambda::node*>&)> extractLambdaNodes = [&](
-      auto & phiNode,
-      auto & lambdaNodes)
-  {
-    for (auto & node : phiNode.subregion()->nodes)
-    {
-      if (auto lambdaNode = dynamic_cast<const lambda::node*>(&node))
-      {
-        lambdaNodes.push_back(lambdaNode);
-      }
-      else if (auto innerPhiNode = dynamic_cast<const phi::node*>(&node))
-      {
-        extractLambdaNodes(*innerPhiNode, lambdaNodes);
-      }
-    }
-  };
-
-  std::vector<const lambda::node*> lambdaNodes;
-  extractLambdaNodes(phiNode, lambdaNodes);
-
-  return lambdaNodes;
 }
 
 std::vector<const jlm::rvsdg::node*>

--- a/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.hpp
+++ b/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.hpp
@@ -180,17 +180,6 @@ private:
   ResolveUnknownMemoryNodeReferences(const RvsdgModule & rvsdgModule);
 
   /**
-   * Extracts all lambda nodes from a phi node.
-   *
-   * The function is capable of handling nested phi nodes.
-   *
-   * @param phiNode The phi node from which the lambda nodes should be extracted.
-   * @return A vector of lambda nodes.
-   */
-  static std::vector<const lambda::node*>
-  ExtractLambdaNodes(const phi::node & phiNode);
-
-  /**
    * Extracts all tail nodes of the RVSDG root region.
    *
    * A tail node is any node in the root region on which no other node in the root region depends on. An example would


### PR DESCRIPTION
This PR moves the ExtractLambdaNodes function from the RegionAwareMemoryNodeProvider class to the Phi::node class. It is a useful little piece of code that could be used somewhere else as well.