### PR TITLE
Add methods for removing multiple inputs and outputs

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
@@ -62,7 +62,7 @@ add_lambda_argument(llvm::lambda::node *ln, const jlm::rvsdg::type *type) {
   assert((*ln->output()->begin())->region() == ln->region()->graph()->root());
 
 //            ln->output()->divert_users(new_out);
-  ln->region()->remove_result((*ln->output()->begin())->index());
+  ln->region()->RemoveResult((*ln->output()->begin())->index());
   remove(ln);
   jlm::rvsdg::result::create(new_lambda->region(), new_out, nullptr, new_out->type());
   return new_lambda;

--- a/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
@@ -71,7 +71,7 @@ remove_gamma_passthrough(jlm::rvsdg::gamma_node *gn) {// remove inputs in revers
       gn->RemoveOutput(res_index);
       // remove input
       gn->input(i + 1)->arguments.clear();
-      gn->remove_input(i + 1);
+      gn->RemoveInput(i + 1);
       for (size_t j = 0; j < gn->nsubregions(); ++j) {
         JLM_ASSERT(gn->subregion(j)->result(res_index)->origin() == gn->subregion(j)->argument(i));
         JLM_ASSERT(gn->subregion(j)->argument(i)->nusers() == 1);
@@ -153,7 +153,7 @@ remove_region_passthrough(const jlm::rvsdg::argument *arg) {
   // remove result first so argument has no users
   arg->region()->RemoveResult(res->index());
   arg->region()->RemoveArgument(arg->index());
-  arg->region()->node()->remove_input(arg->input()->index());
+  arg->region()->node()->RemoveInput(arg->input()->index());
   arg->region()->node()->RemoveOutput(res->output()->index());
 }
 

--- a/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
@@ -75,7 +75,7 @@ remove_gamma_passthrough(jlm::rvsdg::gamma_node *gn) {// remove inputs in revers
       for (size_t j = 0; j < gn->nsubregions(); ++j) {
         JLM_ASSERT(gn->subregion(j)->result(res_index)->origin() == gn->subregion(j)->argument(i));
         JLM_ASSERT(gn->subregion(j)->argument(i)->nusers() == 1);
-        gn->subregion(j)->remove_result(res_index);
+        gn->subregion(j)->RemoveResult(res_index);
         JLM_ASSERT(gn->subregion(j)->argument(i)->nusers() == 0);
         gn->subregion(j)->remove_argument(i);
       }
@@ -138,7 +138,7 @@ remove_lambda_passthrough(llvm::lambda::node *ln) {
 
 //	ln->output()->divert_users(new_out); // can't divert since the type changed
   JLM_ASSERT(ln->output()->nusers() == 1);
-  ln->region()->remove_result((*ln->output()->begin())->index());
+  ln->region()->RemoveResult((*ln->output()->begin())->index());
   remove(ln);
   jlm::rvsdg::result::create(new_lambda->region(), new_out, nullptr, new_out->type());
   return new_lambda;
@@ -151,7 +151,7 @@ remove_region_passthrough(const jlm::rvsdg::argument *arg) {
   // divert users of output to origin of input
   arg->region()->node()->output(res->output()->index())->divert_users(origin);
   // remove result first so argument has no users
-  arg->region()->remove_result(res->index());
+  arg->region()->RemoveResult(res->index());
   arg->region()->remove_argument(arg->index());
   arg->region()->node()->remove_input(arg->input()->index());
   arg->region()->node()->RemoveOutput(res->output()->index());

--- a/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
@@ -68,7 +68,7 @@ remove_gamma_passthrough(jlm::rvsdg::gamma_node *gn) {// remove inputs in revers
 
       gn->output(res_index)->divert_users(origin);
       gn->output(res_index)->results.clear();
-      gn->RemoveOutputByIndex(res_index);
+      gn->RemoveOutput(res_index);
       // remove input
       gn->input(i + 1)->arguments.clear();
       gn->remove_input(i + 1);
@@ -154,7 +154,7 @@ remove_region_passthrough(const jlm::rvsdg::argument *arg) {
   arg->region()->remove_result(res->index());
   arg->region()->remove_argument(arg->index());
   arg->region()->node()->remove_input(arg->input()->index());
-  arg->region()->node()->RemoveOutputByIndex(res->output()->index());
+  arg->region()->node()->RemoveOutput(res->output()->index());
 }
 
 bool

--- a/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
@@ -77,7 +77,7 @@ remove_gamma_passthrough(jlm::rvsdg::gamma_node *gn) {// remove inputs in revers
         JLM_ASSERT(gn->subregion(j)->argument(i)->nusers() == 1);
         gn->subregion(j)->RemoveResult(res_index);
         JLM_ASSERT(gn->subregion(j)->argument(i)->nusers() == 0);
-        gn->subregion(j)->remove_argument(i);
+        gn->subregion(j)->RemoveArgument(i);
       }
     }
   }
@@ -152,7 +152,7 @@ remove_region_passthrough(const jlm::rvsdg::argument *arg) {
   arg->region()->node()->output(res->output()->index())->divert_users(origin);
   // remove result first so argument has no users
   arg->region()->RemoveResult(res->index());
-  arg->region()->remove_argument(arg->index());
+  arg->region()->RemoveArgument(arg->index());
   arg->region()->node()->remove_input(arg->input()->index());
   arg->region()->node()->RemoveOutput(res->output()->index());
 }

--- a/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
@@ -68,7 +68,7 @@ remove_gamma_passthrough(jlm::rvsdg::gamma_node *gn) {// remove inputs in revers
 
       gn->output(res_index)->divert_users(origin);
       gn->output(res_index)->results.clear();
-      gn->remove_output(res_index);
+      gn->RemoveOutputByIndex(res_index);
       // remove input
       gn->input(i + 1)->arguments.clear();
       gn->remove_input(i + 1);
@@ -154,7 +154,7 @@ remove_region_passthrough(const jlm::rvsdg::argument *arg) {
   arg->region()->remove_result(res->index());
   arg->region()->remove_argument(arg->index());
   arg->region()->node()->remove_input(arg->input()->index());
-  arg->region()->node()->remove_output(res->output()->index());
+  arg->region()->node()->RemoveOutputByIndex(res->output()->index());
 }
 
 bool

--- a/jlm/hls/backend/rvsdg2rhls/rhls-dne.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rhls-dne.cpp
@@ -20,7 +20,7 @@ remove_unused_loop_outputs(hls::loop_node *ln) {
       assert(out->results.size() == 1);
       auto result = out->results.begin();
       sr->remove_result(result->index());
-      ln->remove_output(out->index());
+      ln->RemoveOutputByIndex(out->index());
       any_changed = true;
     }
   }

--- a/jlm/hls/backend/rvsdg2rhls/rhls-dne.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rhls-dne.cpp
@@ -20,7 +20,7 @@ remove_unused_loop_outputs(hls::loop_node *ln) {
       assert(out->results.size() == 1);
       auto result = out->results.begin();
       sr->remove_result(result->index());
-      ln->RemoveOutputByIndex(out->index());
+      ln->RemoveOutput(out->index());
       any_changed = true;
     }
   }

--- a/jlm/hls/backend/rvsdg2rhls/rhls-dne.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rhls-dne.cpp
@@ -19,7 +19,7 @@ remove_unused_loop_outputs(hls::loop_node *ln) {
     if (out->nusers() == 0) {
       assert(out->results.size() == 1);
       auto result = out->results.begin();
-      sr->remove_result(result->index());
+      sr->RemoveResult(result->index());
       ln->RemoveOutput(out->index());
       any_changed = true;
     }
@@ -50,7 +50,7 @@ remove_unused_loop_inputs(hls::loop_node *ln) {
       auto result = ba->result();
       assert(result->type() == arg->type());
       if (arg->nusers() == 0 || (arg->nusers() == 1 && result->origin() == arg)) {
-        sr->remove_result(result->index());
+        sr->RemoveResult(result->index());
         sr->remove_argument(arg->index());
       }
     } else {

--- a/jlm/hls/backend/rvsdg2rhls/rhls-dne.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rhls-dne.cpp
@@ -37,7 +37,7 @@ remove_unused_loop_inputs(hls::loop_node *ln) {
     assert(in->arguments.size() == 1);
     auto arg = in->arguments.begin();
     if (arg->nusers() == 0) {
-      sr->remove_argument(arg->index());
+      sr->RemoveArgument(arg->index());
       ln->remove_input(in->index());
       any_changed = true;
     }
@@ -51,7 +51,7 @@ remove_unused_loop_inputs(hls::loop_node *ln) {
       assert(result->type() == arg->type());
       if (arg->nusers() == 0 || (arg->nusers() == 1 && result->origin() == arg)) {
         sr->RemoveResult(result->index());
-        sr->remove_argument(arg->index());
+        sr->RemoveArgument(arg->index());
       }
     } else {
       assert(arg->nusers() != 0);

--- a/jlm/hls/backend/rvsdg2rhls/rhls-dne.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rhls-dne.cpp
@@ -38,7 +38,7 @@ remove_unused_loop_inputs(hls::loop_node *ln) {
     auto arg = in->arguments.begin();
     if (arg->nusers() == 0) {
       sr->RemoveArgument(arg->index());
-      ln->remove_input(in->index());
+      ln->RemoveInput(in->index());
       any_changed = true;
     }
   }

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -450,7 +450,7 @@ DeadNodeElimination::SweepGamma(jlm::rvsdg::gamma_node & gammaNode) const
       {
         gammaNode.subregion(r)->RemoveArgument(n - 1);
       }
-      gammaNode.remove_input(n);
+      gammaNode.RemoveInput(n);
     }
   }
 }
@@ -488,7 +488,7 @@ DeadNodeElimination::SweepTheta(jlm::rvsdg::theta_node & thetaNode) const
     {
       JLM_ASSERT(thetaOutput.results.empty());
       subregion->RemoveArgument(thetaArgument.index());
-      thetaNode.remove_input(thetaInput.index());
+      thetaNode.RemoveInput(thetaInput.index());
       thetaNode.RemoveOutput(thetaOutput.index());
     }
   }
@@ -510,7 +510,7 @@ DeadNodeElimination::SweepLambda(lambda::node & lambdaNode) const
     if (!Context_->IsAlive(*input->argument()))
     {
       lambdaNode.subregion()->RemoveArgument(input->argument()->index());
-      lambdaNode.remove_input(n);
+      lambdaNode.RemoveInput(n);
     }
   }
 }
@@ -544,7 +544,7 @@ DeadNodeElimination::SweepPhi(phi::node & phiNode) const
       subregion->RemoveArgument(n);
       if (input)
       {
-        phiNode.remove_input(input->index());
+        phiNode.RemoveInput(input->index());
       }
     }
   }
@@ -563,7 +563,7 @@ DeadNodeElimination::SweepDelta(delta::node & deltaNode) const
     if (!Context_->IsAlive(*input->argument()))
     {
       deltaNode.subregion()->RemoveArgument(input->argument()->index());
-      deltaNode.remove_input(input->index());
+      deltaNode.RemoveInput(input->index());
     }
   }
 }

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -344,7 +344,7 @@ DeadNodeElimination::SweepRvsdg(jlm::rvsdg::graph & rvsdg) const
   {
     if (!Context_->IsAlive(*rvsdg.root()->argument(n)))
     {
-      rvsdg.root()->remove_argument(n);
+      rvsdg.root()->RemoveArgument(n);
     }
   }
 }
@@ -448,7 +448,7 @@ DeadNodeElimination::SweepGamma(jlm::rvsdg::gamma_node & gammaNode) const
     {
       for (size_t r = 0; r < gammaNode.nsubregions(); r++)
       {
-        gammaNode.subregion(r)->remove_argument(n-1);
+        gammaNode.subregion(r)->RemoveArgument(n - 1);
       }
       gammaNode.remove_input(n);
     }
@@ -487,7 +487,7 @@ DeadNodeElimination::SweepTheta(jlm::rvsdg::theta_node & thetaNode) const
         && !Context_->IsAlive(thetaOutput))
     {
       JLM_ASSERT(thetaOutput.results.empty());
-      subregion->remove_argument(thetaArgument.index());
+      subregion->RemoveArgument(thetaArgument.index());
       thetaNode.remove_input(thetaInput.index());
       thetaNode.RemoveOutput(thetaOutput.index());
     }
@@ -509,7 +509,7 @@ DeadNodeElimination::SweepLambda(lambda::node & lambdaNode) const
 
     if (!Context_->IsAlive(*input->argument()))
     {
-      lambdaNode.subregion()->remove_argument(input->argument()->index());
+      lambdaNode.subregion()->RemoveArgument(input->argument()->index());
       lambdaNode.remove_input(n);
     }
   }
@@ -541,7 +541,7 @@ DeadNodeElimination::SweepPhi(phi::node & phiNode) const
     auto input = argument->input();
     if (!Context_->IsAlive(*argument))
     {
-      subregion->remove_argument(n);
+      subregion->RemoveArgument(n);
       if (input)
       {
         phiNode.remove_input(input->index());
@@ -562,7 +562,7 @@ DeadNodeElimination::SweepDelta(delta::node & deltaNode) const
     auto input = deltaNode.input(n);
     if (!Context_->IsAlive(*input->argument()))
     {
-      deltaNode.subregion()->remove_argument(input->argument()->index());
+      deltaNode.subregion()->RemoveArgument(input->argument()->index());
       deltaNode.remove_input(input->index());
     }
   }

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -421,7 +421,7 @@ DeadNodeElimination::SweepGamma(jlm::rvsdg::gamma_node & gammaNode) const
     {
       gammaNode.subregion(r)->remove_result(n);
     }
-    gammaNode.remove_output(n);
+    gammaNode.RemoveOutputByIndex(n);
   }
 
   // Sweep gamma subregions
@@ -489,7 +489,7 @@ DeadNodeElimination::SweepTheta(jlm::rvsdg::theta_node & thetaNode) const
       JLM_ASSERT(thetaOutput.results.empty());
       subregion->remove_argument(thetaArgument.index());
       thetaNode.remove_input(thetaInput.index());
-      thetaNode.remove_output(thetaOutput.index());
+      thetaNode.RemoveOutputByIndex(thetaOutput.index());
     }
   }
 
@@ -528,7 +528,7 @@ DeadNodeElimination::SweepPhi(phi::node & phiNode) const
         && !Context_->IsAlive(*subregion->argument(result->index())))
     {
       subregion->remove_result(n);
-      phiNode.remove_output(n);
+      phiNode.RemoveOutputByIndex(n);
     }
   }
 

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -419,7 +419,7 @@ DeadNodeElimination::SweepGamma(jlm::rvsdg::gamma_node & gammaNode) const
 
     for (size_t r = 0; r < gammaNode.nsubregions(); r++)
     {
-      gammaNode.subregion(r)->remove_result(n);
+      gammaNode.subregion(r)->RemoveResult(n);
     }
     gammaNode.RemoveOutput(n);
   }
@@ -470,7 +470,7 @@ DeadNodeElimination::SweepTheta(jlm::rvsdg::theta_node & thetaNode) const
     if (!Context_->IsAlive(thetaArgument)
         && !Context_->IsAlive(thetaOutput))
     {
-      subregion->remove_result(thetaResult.index());
+      subregion->RemoveResult(thetaResult.index());
     }
   }
 
@@ -527,7 +527,7 @@ DeadNodeElimination::SweepPhi(phi::node & phiNode) const
     if (!Context_->IsAlive(*result->output())
         && !Context_->IsAlive(*subregion->argument(result->index())))
     {
-      subregion->remove_result(n);
+      subregion->RemoveResult(n);
       phiNode.RemoveOutput(n);
     }
   }

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -421,7 +421,7 @@ DeadNodeElimination::SweepGamma(jlm::rvsdg::gamma_node & gammaNode) const
     {
       gammaNode.subregion(r)->remove_result(n);
     }
-    gammaNode.RemoveOutputByIndex(n);
+    gammaNode.RemoveOutput(n);
   }
 
   // Sweep gamma subregions
@@ -489,7 +489,7 @@ DeadNodeElimination::SweepTheta(jlm::rvsdg::theta_node & thetaNode) const
       JLM_ASSERT(thetaOutput.results.empty());
       subregion->remove_argument(thetaArgument.index());
       thetaNode.remove_input(thetaInput.index());
-      thetaNode.RemoveOutputByIndex(thetaOutput.index());
+      thetaNode.RemoveOutput(thetaOutput.index());
     }
   }
 
@@ -528,7 +528,7 @@ DeadNodeElimination::SweepPhi(phi::node & phiNode) const
         && !Context_->IsAlive(*subregion->argument(result->index())))
     {
       subregion->remove_result(n);
-      phiNode.RemoveOutputByIndex(n);
+      phiNode.RemoveOutput(n);
     }
   }
 

--- a/jlm/llvm/opt/pull.cpp
+++ b/jlm/llvm/opt/pull.cpp
@@ -88,7 +88,7 @@ remove(jlm::rvsdg::gamma_input * input)
 
 	for (size_t n = 0; n < gamma->nsubregions(); n++)
     gamma->subregion(n)->RemoveArgument(input->index() - 1);
-	gamma->remove_input(input->index());
+	gamma->RemoveInput(input->index());
 }
 
 static void

--- a/jlm/llvm/opt/pull.cpp
+++ b/jlm/llvm/opt/pull.cpp
@@ -87,7 +87,7 @@ remove(jlm::rvsdg::gamma_input * input)
 	auto gamma = input->node();
 
 	for (size_t n = 0; n < gamma->nsubregions(); n++)
-		gamma->subregion(n)->remove_argument(input->index()-1);
+    gamma->subregion(n)->RemoveArgument(input->index() - 1);
 	gamma->remove_input(input->index());
 }
 

--- a/jlm/llvm/opt/pull.cpp
+++ b/jlm/llvm/opt/pull.cpp
@@ -84,11 +84,11 @@ single_successor(const jlm::rvsdg::node * node)
 static void
 remove(jlm::rvsdg::gamma_input * input)
 {
-	auto gamma = input->node();
+  auto gamma = input->node();
 
-	for (size_t n = 0; n < gamma->nsubregions(); n++)
+  for (size_t n = 0; n < gamma->nsubregions(); n++)
     gamma->subregion(n)->RemoveArgument(input->index() - 1);
-	gamma->RemoveInput(input->index());
+  gamma->RemoveInput(input->index());
 }
 
 static void

--- a/jlm/rvsdg/gamma.hpp
+++ b/jlm/rvsdg/gamma.hpp
@@ -287,13 +287,14 @@ public:
 	add_exitvar(const std::vector<jlm::rvsdg::output*> & values);
 
   /**
-   * Removes all outputs that have no users and match the condition specified by \p match.
+   * Removes all gamma outputs and their respective results. The outputs must have no users and match the condition
+   * specified by \p match.
    *
    * @tparam F A type that supports the function call operator: bool operator(const gamma_output&)
    * @param match Defines the condition of the elements to remove.
    */
   template<typename F> void
-  RemoveOutputsWhere(const F& match);
+  RemoveGammaOutputsWhere(const F& match);
 
   /**
    * Removes all outputs that have no users.
@@ -306,7 +307,7 @@ public:
       return true;
     };
 
-    RemoveOutputsWhere(match);
+    RemoveGammaOutputsWhere(match);
   }
 
 	virtual jlm::rvsdg::gamma_node *
@@ -508,7 +509,7 @@ gamma_node::add_exitvar(const std::vector<jlm::rvsdg::output*> & values)
 }
 
 template<typename F> void
-gamma_node::RemoveOutputsWhere(const F& match)
+gamma_node::RemoveGammaOutputsWhere(const F& match)
 {
   // iterate backwards to avoid the invalidation of 'n' by RemoveOutput()
   for (size_t n = noutputs()-1; n != static_cast<size_t>(-1); n--)

--- a/jlm/rvsdg/gamma.hpp
+++ b/jlm/rvsdg/gamma.hpp
@@ -518,7 +518,7 @@ gamma_node::RemoveOutputsWhere(const F& match)
     {
       for (size_t r = 0; r < nsubregions(); r++)
       {
-        subregion(r)->remove_result(n);
+        subregion(r)->RemoveResult(n);
       }
 
       RemoveOutput(n);

--- a/jlm/rvsdg/gamma.hpp
+++ b/jlm/rvsdg/gamma.hpp
@@ -295,6 +295,20 @@ public:
   template<typename F> void
   RemoveOutputsWhere(const F& match);
 
+  /**
+   * Removes all outputs that have no users.
+   */
+  void
+  PruneOutputs()
+  {
+    auto match = [](const gamma_output&)
+    {
+      return true;
+    };
+
+    RemoveOutputsWhere(match);
+  }
+
 	virtual jlm::rvsdg::gamma_node *
 	copy(jlm::rvsdg::region * region, jlm::rvsdg::substitution_map & smap) const override;
 };

--- a/jlm/rvsdg/node.cpp
+++ b/jlm/rvsdg/node.cpp
@@ -210,7 +210,7 @@ node::add_input(std::unique_ptr<node_input> input)
 }
 
 void
-node::remove_input(size_t index)
+node::RemoveInput(size_t index)
 {
 	JLM_ASSERT(index < ninputs());
 	auto producer = node_output::node(input(index)->origin());

--- a/jlm/rvsdg/node.cpp
+++ b/jlm/rvsdg/node.cpp
@@ -239,7 +239,7 @@ node::remove_input(size_t index)
 }
 
 void
-node::RemoveOutputByIndex(size_t index)
+node::RemoveOutput(size_t index)
 {
 	JLM_ASSERT(index < noutputs());
 

--- a/jlm/rvsdg/node.cpp
+++ b/jlm/rvsdg/node.cpp
@@ -239,7 +239,7 @@ node::remove_input(size_t index)
 }
 
 void
-node::remove_output(size_t index)
+node::RemoveOutputByIndex(size_t index)
 {
 	JLM_ASSERT(index < noutputs());
 

--- a/jlm/rvsdg/node.hpp
+++ b/jlm/rvsdg/node.hpp
@@ -714,8 +714,8 @@ protected:
    * \see recompute_depth()
    * \see input#index()
    */
-	void
-	RemoveInput(size_t index);
+  void
+  RemoveInput(size_t index);
 
   /**
    * Removes all inputs that match the condition specified by \p match.
@@ -760,8 +760,8 @@ protected:
    * \see output#index()
    * \see output#nusers()
    */
-	void
-	RemoveOutput(size_t index);
+  void
+  RemoveOutput(size_t index);
 
   /**
    * Removes all outputs that have no users and match the condition specified by \p match.

--- a/jlm/rvsdg/node.hpp
+++ b/jlm/rvsdg/node.hpp
@@ -700,6 +700,20 @@ protected:
 	node_input *
 	add_input(std::unique_ptr<node_input> input);
 
+  /**
+   * Removes an input from the node given the inputs' index.
+   *
+   * The removal of an input invalidates the node's existing input iterators.
+   *
+   * @param index The inputs' index. It must be between [0, ninputs()).
+   *
+   * \note The method must adjust the indices of the other inputs after the removal. Moreover, it also might need to
+   * recompute the depth of the node.
+   *
+   * \see ninputs()
+   * \see recompute_depth()
+   * \see input#index()
+   */
 	void
 	RemoveInput(size_t index);
 

--- a/jlm/rvsdg/node.hpp
+++ b/jlm/rvsdg/node.hpp
@@ -711,6 +711,21 @@ protected:
 		return this->output(noutputs()-1);
 	}
 
+  /**
+   * Removes an output from the node given the outputs' index.
+   *
+   * An output can only be removed, if it has no users. The removal of an output invalidates the node's existing output
+   * iterators.
+   *
+   * @param index The outputs' index. It must be between [0, noutputs()).
+   *
+   * \note The method must adjust the indices of the other outputs after the removal. The methods' runtime is therefore
+   * O(n), where n is the node's number of outputs.
+   *
+   * \see noutputs()
+   * \see output#index()
+   * \see output#nusers()
+   */
 	void
 	RemoveOutputByIndex(size_t index);
 

--- a/jlm/rvsdg/node.hpp
+++ b/jlm/rvsdg/node.hpp
@@ -727,7 +727,7 @@ protected:
    * \see output#nusers()
    */
 	void
-	RemoveOutputByIndex(size_t index);
+	RemoveOutput(size_t index);
 
 public:
 	inline jlm::rvsdg::graph *

--- a/jlm/rvsdg/node.hpp
+++ b/jlm/rvsdg/node.hpp
@@ -717,6 +717,26 @@ protected:
 	void
 	RemoveInput(size_t index);
 
+  /**
+   * Removes all inputs that match the condition specified by \p match.
+   *
+   * @tparam F A type that supports the function call operator: bool operator(const node_input&)
+   * @param match Defines the condition for the inputs to remove.
+   */
+  template<typename F> void
+  RemoveInputsWhere(const F& match)
+  {
+    // iterate backwards to avoid the invalidation of 'n' by RemoveInput()
+    for (size_t n = ninputs()-1; n != static_cast<size_t>(-1); n--)
+    {
+      auto & input = *node::input(n);
+      if (match(input))
+      {
+        RemoveInput(n);
+      }
+    }
+  }
+
 	node_output *
 	add_output(std::unique_ptr<node_output> output)
 	{

--- a/jlm/rvsdg/node.hpp
+++ b/jlm/rvsdg/node.hpp
@@ -712,7 +712,7 @@ protected:
 	}
 
 	void
-	remove_output(size_t index);
+	RemoveOutputByIndex(size_t index);
 
 public:
 	inline jlm::rvsdg::graph *

--- a/jlm/rvsdg/node.hpp
+++ b/jlm/rvsdg/node.hpp
@@ -701,7 +701,7 @@ protected:
 	add_input(std::unique_ptr<node_input> input);
 
 	void
-	remove_input(size_t index);
+	RemoveInput(size_t index);
 
 	node_output *
 	add_output(std::unique_ptr<node_output> output)

--- a/jlm/rvsdg/node.hpp
+++ b/jlm/rvsdg/node.hpp
@@ -743,6 +743,28 @@ protected:
 	void
 	RemoveOutput(size_t index);
 
+  /**
+   * Removes all outputs that have no users and match the condition specified by \p match.
+   *
+   * @tparam F A type that supports the function call operator: bool operator(const node_output&)
+   * @param match Defines the condition for the outputs to remove.
+   *
+   * \see output#nusers()
+   */
+  template <typename F> void
+  RemoveOutputsWhere(const F& match)
+  {
+    // iterate backwards to avoid the invalidation of 'n' by RemoveOutput()
+    for (size_t n = noutputs()-1; n != static_cast<size_t>(-1); n--)
+    {
+      auto & output = *node::output(n);
+      if (output.nusers() == 0 && match(output))
+      {
+        RemoveOutput(n);
+      }
+    }
+  }
+
 public:
 	inline jlm::rvsdg::graph *
 	graph() const noexcept

--- a/jlm/rvsdg/region.cpp
+++ b/jlm/rvsdg/region.cpp
@@ -91,17 +91,17 @@ result::create(
 
 region::~region()
 {
-	on_region_destroy(this);
+  on_region_destroy(this);
 
-	while (results_.size())
+  while (results_.size())
     RemoveResult(results_.size() - 1);
 
-	prune(false);
-	JLM_ASSERT(nodes.empty());
-	JLM_ASSERT(top_nodes.empty());
-	JLM_ASSERT(bottom_nodes.empty());
+  prune(false);
+  JLM_ASSERT(nodes.empty());
+  JLM_ASSERT(top_nodes.empty());
+  JLM_ASSERT(bottom_nodes.empty());
 
-	while (arguments_.size())
+  while (arguments_.size())
     RemoveArgument(arguments_.size() - 1);
 }
 

--- a/jlm/rvsdg/region.cpp
+++ b/jlm/rvsdg/region.cpp
@@ -94,7 +94,7 @@ region::~region()
 	on_region_destroy(this);
 
 	while (results_.size())
-		remove_result(results_.size()-1);
+    RemoveResult(results_.size() - 1);
 
 	prune(false);
 	JLM_ASSERT(nodes.empty());
@@ -175,7 +175,7 @@ region::append_result(jlm::rvsdg::result * result)
 }
 
 void
-region::remove_result(size_t index)
+region::RemoveResult(size_t index)
 {
 	JLM_ASSERT(index < results_.size());
 	jlm::rvsdg::result * result = results_[index];

--- a/jlm/rvsdg/region.cpp
+++ b/jlm/rvsdg/region.cpp
@@ -102,7 +102,7 @@ region::~region()
 	JLM_ASSERT(bottom_nodes.empty());
 
 	while (arguments_.size())
-		remove_argument(arguments_.size()-1);
+    RemoveArgument(arguments_.size() - 1);
 }
 
 region::region(jlm::rvsdg::region * parent, jlm::rvsdg::graph * graph)
@@ -141,7 +141,7 @@ region::append_argument(jlm::rvsdg::argument * argument)
 }
 
 void
-region::remove_argument(size_t index)
+region::RemoveArgument(size_t index)
 {
 	JLM_ASSERT(index < narguments());
 	jlm::rvsdg::argument * argument = arguments_[index];

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -204,7 +204,7 @@ public:
 	append_argument(jlm::rvsdg::argument * argument);
 
 	void
-	remove_argument(size_t index);
+	RemoveArgument(size_t index);
 
 	inline size_t
 	narguments() const noexcept

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -221,6 +221,26 @@ public:
 	void
 	RemoveArgument(size_t index);
 
+  /**
+   * Removes all arguments that have no users and match the condition specified by \p match.
+   *
+   * @tparam F A type that supports the function call operator: bool operator(const argument&)
+   * @param match Defines the condition for the arguments to remove.
+   */
+  template <typename F> void
+  RemoveArgumentsWhere(const F& match)
+  {
+    // iterate backwards to avoid the invalidation of 'n' by RemoveArgument()
+    for (size_t n = narguments()-1; n != static_cast<size_t>(-1); n--)
+    {
+      auto & argument = *this->argument(n);
+      if (argument.nusers() == 0 && match(argument))
+      {
+        RemoveArgument(n);
+      }
+    }
+  }
+
 	inline size_t
 	narguments() const noexcept
 	{

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -242,6 +242,26 @@ public:
   void
   RemoveResult(size_t index);
 
+  /**
+   * Remove all results that match the condition specified by \p match.
+   *
+   * @tparam F A type that supports the function call operator: bool operator(const result&)
+   * @param match Defines the condition for the results to remove.
+   */
+  template <typename F> void
+  RemoveResultsWhere(const F& match)
+  {
+    // iterate backwards to avoid the invalidation of 'n' by RemoveResult()
+    for (size_t n = nresults()-1; n != static_cast<size_t>(-1); n--)
+    {
+      auto & result = *this->result(n);
+      if (match(result))
+      {
+        RemoveResult(n);
+      }
+    }
+  }
+
 	inline size_t
 	nresults() const noexcept
 	{

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -203,6 +203,21 @@ public:
 	void
 	append_argument(jlm::rvsdg::argument * argument);
 
+  /**
+   * Removes an argument from the region given a arguments' index.
+   *
+   * An argument can only be removed, if it has no users. The removal of an argument invalidates the region's existing
+   * argument iterators.
+   *
+   * @param index The arguments' index. It must be between [0, narguments()].
+   *
+   * \note The method must adjust the indices of the other arguments after the removal. The methods' runtime is
+   * therefore O(n), where n is the region's number of arguments.
+   *
+   * \see narguments()
+   * \see argument#index()
+   * \see argument::nusers()
+   */
 	void
 	RemoveArgument(size_t index);
 

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -297,6 +297,20 @@ public:
     }
   }
 
+  /**
+   * Remove all arguments that have no users.
+   */
+  void
+  PruneArguments()
+  {
+    auto match = [](const rvsdg::argument&)
+    {
+      return true;
+    };
+
+    RemoveArgumentsWhere(match);
+  }
+
 	inline size_t
 	nresults() const noexcept
 	{

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -227,7 +227,7 @@ public:
 	append_result(jlm::rvsdg::result * result);
 
 	void
-	remove_result(size_t index);
+	RemoveResult(size_t index);
 
 	inline size_t
 	nresults() const noexcept

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -226,8 +226,21 @@ public:
 	void
 	append_result(jlm::rvsdg::result * result);
 
-	void
-	RemoveResult(size_t index);
+  /**
+   * Removes a result from the region given a results' index.
+   *
+   * The removal of a result invalidates the region's existing result iterators.
+   *
+   * @param index The results' index. It must be between [0, nresults()).
+   *
+   * \note The method must adjust the indices of the other results after the removal. The methods' runtime is therefore
+   * O(n), where n is the region's number of results.
+   *
+   * \see nresults()
+   * \see result#index()
+   */
+  void
+  RemoveResult(size_t index);
 
 	inline size_t
 	nresults() const noexcept

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -218,8 +218,8 @@ public:
    * \see argument#index()
    * \see argument::nusers()
    */
-	void
-	RemoveArgument(size_t index);
+  void
+  RemoveArgument(size_t index);
 
   /**
    * Removes all arguments that have no users and match the condition specified by \p match.

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -204,7 +204,7 @@ public:
 	append_argument(jlm::rvsdg::argument * argument);
 
   /**
-   * Removes an argument from the region given a arguments' index.
+   * Removes an argument from the region given an arguments' index.
    *
    * An argument can only be removed, if it has no users. The removal of an argument invalidates the region's existing
    * argument iterators.

--- a/jlm/rvsdg/structural-node.hpp
+++ b/jlm/rvsdg/structural-node.hpp
@@ -65,7 +65,7 @@ public:
 	inline void
 	remove_output(size_t index)
 	{
-		node::remove_output(index);
+    node::RemoveOutputByIndex(index);
 	}
 
 private:

--- a/jlm/rvsdg/structural-node.hpp
+++ b/jlm/rvsdg/structural-node.hpp
@@ -56,11 +56,7 @@ public:
 	structural_output *
 	append_output(std::unique_ptr<structural_output> output);
 
-	inline void
-	remove_input(size_t index)
-	{
-    node::RemoveInput(index);
-	}
+  using node::RemoveInput;
 
   using node::RemoveOutput;
 

--- a/jlm/rvsdg/structural-node.hpp
+++ b/jlm/rvsdg/structural-node.hpp
@@ -62,7 +62,7 @@ public:
 		node::remove_input(index);
 	}
 
-  using node::RemoveOutputByIndex;
+  using node::RemoveOutput;
 
 private:
 	std::vector<std::unique_ptr<jlm::rvsdg::region>> subregions_;

--- a/jlm/rvsdg/structural-node.hpp
+++ b/jlm/rvsdg/structural-node.hpp
@@ -59,7 +59,7 @@ public:
 	inline void
 	remove_input(size_t index)
 	{
-		node::remove_input(index);
+    node::RemoveInput(index);
 	}
 
   using node::RemoveOutput;

--- a/jlm/rvsdg/structural-node.hpp
+++ b/jlm/rvsdg/structural-node.hpp
@@ -62,11 +62,7 @@ public:
 		node::remove_input(index);
 	}
 
-	inline void
-	remove_output(size_t index)
-	{
-    node::RemoveOutputByIndex(index);
-	}
+  using node::RemoveOutputByIndex;
 
 private:
 	std::vector<std::unique_ptr<jlm::rvsdg::region>> subregions_;

--- a/tests/jlm/rvsdg/Makefile.sub
+++ b/tests/jlm/rvsdg/Makefile.sub
@@ -12,3 +12,4 @@ TESTS+=\
 	jlm/rvsdg/test-topdown \
 	jlm/rvsdg/test-typemismatch \
 	jlm/rvsdg/TestRegion \
+	jlm/rvsdg/TestStructuralNode \

--- a/tests/jlm/rvsdg/TestRegion.cpp
+++ b/tests/jlm/rvsdg/TestRegion.cpp
@@ -135,6 +135,43 @@ TestNumRegions()
   }
 }
 
+/**
+ * Test region::RemoveResultsWhere()
+ */
+static void
+TestRemoveResultsWhere()
+{
+  // Arrange
+  jlm::rvsdg::graph rvsdg;
+  jlm::rvsdg::region region(rvsdg.root(), &rvsdg);
+
+  jlm::tests::valuetype valueType;
+  auto node = jlm::tests::test_op::Create(&region, {}, {}, {&valueType});
+
+  auto result0 = jlm::rvsdg::result::create(&region, node->output(0), nullptr, jlm::rvsdg::port(valueType));
+  auto result1 = jlm::rvsdg::result::create(&region, node->output(0), nullptr, jlm::rvsdg::port(valueType));
+  auto result2 = jlm::rvsdg::result::create(&region, node->output(0), nullptr, jlm::rvsdg::port(valueType));
+
+  // Act & Arrange
+  assert(region.nresults() == 3);
+  assert(result0->index() == 0);
+  assert(result1->index() == 1);
+  assert(result2->index() == 2);
+
+  region.RemoveResultsWhere([](const jlm::rvsdg::result &result){ return result.index() == 1; });
+  assert(region.nresults() == 2);
+  assert(result0->index() == 0);
+  assert(result2->index() == 1);
+
+  region.RemoveResultsWhere([](const jlm::rvsdg::result & result){ return false; });
+  assert(region.nresults() == 2);
+  assert(result0->index() == 0);
+  assert(result2->index() == 1);
+
+  region.RemoveResultsWhere([](const jlm::rvsdg::result & result){ return true; });
+  assert(region.nresults() == 0);
+}
+
 static int
 Test()
 {
@@ -144,6 +181,7 @@ Test()
   TestContainsMethod();
   TestIsRootRegion();
   TestNumRegions();
+  TestRemoveResultsWhere();
 
   return 0;
 }

--- a/tests/jlm/rvsdg/TestRegion.cpp
+++ b/tests/jlm/rvsdg/TestRegion.cpp
@@ -208,6 +208,36 @@ TestRemoveArgumentsWhere()
   assert(region.narguments() == 0);
 }
 
+/**
+ * Test region::PruneArguments()
+ */
+static void
+TestPruneArguments()
+{
+  // Arrange
+  jlm::rvsdg::graph rvsdg;
+  jlm::rvsdg::region region(rvsdg.root(), &rvsdg);
+
+  jlm::tests::valuetype valueType;
+  auto argument0 = jlm::rvsdg::argument::create(&region, nullptr, jlm::rvsdg::port(valueType));
+  jlm::rvsdg::argument::create(&region, nullptr, jlm::rvsdg::port(valueType));
+  auto argument2 = jlm::rvsdg::argument::create(&region, nullptr, jlm::rvsdg::port(valueType));
+
+  auto node = jlm::tests::test_op::Create(&region, {&valueType, &valueType}, {argument0, argument2}, {&valueType});
+
+  // Act & Arrange
+  assert(region.narguments() == 3);
+
+  region.PruneArguments();
+  assert(region.narguments() == 2);
+  assert(argument0->index() == 0);
+  assert(argument2->index() == 1);
+
+  region.remove_node(node);
+  region.PruneArguments();
+  assert(region.narguments() == 0);
+}
+
 static int
 Test()
 {
@@ -219,6 +249,7 @@ Test()
   TestNumRegions();
   TestRemoveResultsWhere();
   TestRemoveArgumentsWhere();
+  TestPruneArguments();
 
   return 0;
 }

--- a/tests/jlm/rvsdg/TestRegion.cpp
+++ b/tests/jlm/rvsdg/TestRegion.cpp
@@ -172,6 +172,42 @@ TestRemoveResultsWhere()
   assert(region.nresults() == 0);
 }
 
+/**
+ * Test region::RemoveArgumentsWhere()
+ */
+static void
+TestRemoveArgumentsWhere()
+{
+  // Arrange
+  jlm::rvsdg::graph rvsdg;
+  jlm::rvsdg::region region(rvsdg.root(), &rvsdg);
+
+  jlm::tests::valuetype valueType;
+  auto argument0 = jlm::rvsdg::argument::create(&region, nullptr, jlm::rvsdg::port(valueType));
+  auto argument1 = jlm::rvsdg::argument::create(&region, nullptr, jlm::rvsdg::port(valueType));
+  auto argument2 = jlm::rvsdg::argument::create(&region, nullptr, jlm::rvsdg::port(valueType));
+
+  auto node = jlm::tests::test_op::Create(&region, {&valueType}, {argument1}, {&valueType});
+
+  // Act & Arrange
+  assert(region.narguments() == 3);
+  assert(argument0->index() == 0);
+  assert(argument1->index() == 1);
+  assert(argument2->index() == 2);
+
+  region.RemoveArgumentsWhere([](const jlm::rvsdg::argument &argument){ return true; });
+  assert(region.narguments() == 1);
+  assert(argument1->index() == 0);
+
+  region.remove_node(node);
+  region.RemoveArgumentsWhere([](const jlm::rvsdg::argument &argument){ return false; });
+  assert(region.narguments() == 1);
+  assert(argument1->index() == 0);
+
+  region.RemoveArgumentsWhere([](const jlm::rvsdg::argument &argument){ return argument.index() == 0; });
+  assert(region.narguments() == 0);
+}
+
 static int
 Test()
 {
@@ -182,6 +218,7 @@ Test()
   TestIsRootRegion();
   TestNumRegions();
   TestRemoveResultsWhere();
+  TestRemoveArgumentsWhere();
 
   return 0;
 }

--- a/tests/jlm/rvsdg/TestStructuralNode.cpp
+++ b/tests/jlm/rvsdg/TestStructuralNode.cpp
@@ -33,14 +33,14 @@ TestOutputRemoval()
   assert(output3->index() == 3);
   assert(output4->index() == 4);
 
-  structuralNode->RemoveOutputByIndex(2);
+  structuralNode->RemoveOutput(2);
   assert(structuralNode->noutputs() == 4);
   assert(output0->index() == 0);
   assert(output1->index() == 1);
   assert(output3->index() == 2);
   assert(output4->index() == 3);
 
-  structuralNode->RemoveOutputByIndex(3);
+  structuralNode->RemoveOutput(3);
   assert(structuralNode->noutputs() == 3);
   assert(output0->index() == 0);
   assert(output1->index() == 1);

--- a/tests/jlm/rvsdg/TestStructuralNode.cpp
+++ b/tests/jlm/rvsdg/TestStructuralNode.cpp
@@ -33,14 +33,14 @@ TestOutputRemoval()
   assert(output3->index() == 3);
   assert(output4->index() == 4);
 
-  structuralNode->remove_output(2);
+  structuralNode->RemoveOutputByIndex(2);
   assert(structuralNode->noutputs() == 4);
   assert(output0->index() == 0);
   assert(output1->index() == 1);
   assert(output3->index() == 2);
   assert(output4->index() == 3);
 
-  structuralNode->remove_output(3);
+  structuralNode->RemoveOutputByIndex(3);
   assert(structuralNode->noutputs() == 3);
   assert(output0->index() == 0);
   assert(output1->index() == 1);

--- a/tests/jlm/rvsdg/TestStructuralNode.cpp
+++ b/tests/jlm/rvsdg/TestStructuralNode.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <test-registry.hpp>
+#include <test-operation.hpp>
+#include <test-types.hpp>
+
+#include <cassert>
+
+static void
+TestOutputRemoval()
+{
+  using namespace jlm;
+
+  // Arrange
+  rvsdg::graph rvsdg;
+  tests::valuetype valueType;
+
+  auto structuralNode = tests::structural_node::create(rvsdg.root(), 1);
+  auto output0 = rvsdg::structural_output::create(structuralNode, {valueType});
+  auto output1 = rvsdg::structural_output::create(structuralNode, {valueType});
+  auto output2 = rvsdg::structural_output::create(structuralNode, {valueType});
+  auto output3 = rvsdg::structural_output::create(structuralNode, {valueType});
+  auto output4 = rvsdg::structural_output::create(structuralNode, {valueType});
+
+  // Act & Assert
+  assert(structuralNode->noutputs() == 5);
+  assert(output0->index() == 0);
+  assert(output1->index() == 1);
+  assert(output2->index() == 2);
+  assert(output3->index() == 3);
+  assert(output4->index() == 4);
+
+  structuralNode->remove_output(2);
+  assert(structuralNode->noutputs() == 4);
+  assert(output0->index() == 0);
+  assert(output1->index() == 1);
+  assert(output3->index() == 2);
+  assert(output4->index() == 3);
+
+  structuralNode->remove_output(3);
+  assert(structuralNode->noutputs() == 3);
+  assert(output0->index() == 0);
+  assert(output1->index() == 1);
+  assert(output3->index() == 2);
+
+}
+
+static int
+TestStructuralNode()
+{
+  TestOutputRemoval();
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER("jlm/rvsdg/TestStructuralNode", TestStructuralNode)

--- a/tests/jlm/rvsdg/test-gamma.cpp
+++ b/tests/jlm/rvsdg/test-gamma.cpp
@@ -179,7 +179,7 @@ test_control_constant_reduction2()
 }
 
 static void
-TestRemoveOutputsWhere()
+TestRemoveGammaOutputsWhere()
 {
   using namespace jlm::rvsdg;
 
@@ -212,7 +212,7 @@ TestRemoveOutputsWhere()
   assert(gammaNode->noutputs() == 4);
 
   // Remove gammaOutput1
-  gammaNode->RemoveOutputsWhere([&](const gamma_output & output){ return output.index() == gammaOutput1->index(); });
+  gammaNode->RemoveGammaOutputsWhere([&](const gamma_output & output){return output.index() == gammaOutput1->index();});
   assert(gammaNode->noutputs() == 3);
   assert(gammaNode->subregion(0)->nresults() == 3);
   assert(gammaNode->subregion(1)->nresults() == 3);
@@ -220,7 +220,7 @@ TestRemoveOutputsWhere()
   assert(gammaOutput3->index() == 2);
 
   // Try to remove gammaOutput2. This should result in no change as gammaOutput2 still has users.
-  gammaNode->RemoveOutputsWhere([&](const gamma_output & output){ return output.index() == gammaOutput2->index(); });
+  gammaNode->RemoveGammaOutputsWhere([&](const gamma_output & output){return output.index() == gammaOutput2->index();});
   assert(gammaNode->noutputs() == 3);
   assert(gammaNode->subregion(0)->nresults() == 3);
   assert(gammaNode->subregion(1)->nresults() == 3);
@@ -279,7 +279,7 @@ static int
 test_main()
 {
   test_gamma();
-  TestRemoveOutputsWhere();
+  TestRemoveGammaOutputsWhere();
   TestPruneOutputs();
 
   test_predicate_reduction();

--- a/tests/jlm/rvsdg/test-gamma.cpp
+++ b/tests/jlm/rvsdg/test-gamma.cpp
@@ -278,16 +278,16 @@ TestPruneOutputs()
 static int
 test_main()
 {
-	test_gamma();
+  test_gamma();
   TestRemoveOutputsWhere();
   TestPruneOutputs();
 
-	test_predicate_reduction();
-	test_invariant_reduction();
-	test_control_constant_reduction();
-	test_control_constant_reduction2();
+  test_predicate_reduction();
+  test_invariant_reduction();
+  test_control_constant_reduction();
+  test_control_constant_reduction2();
 
-	return 0;
+  return 0;
 }
 
 JLM_UNIT_TEST_REGISTER("jlm/rvsdg/test-gamma", test_main)

--- a/tests/jlm/rvsdg/test-nodes.cpp
+++ b/tests/jlm/rvsdg/test-nodes.cpp
@@ -158,12 +158,42 @@ TestRemoveOutputsWhere()
   assert(node1.noutputs() == 0);
 }
 
+/**
+ * Test node::RemoveInputsWhere()
+ */
+static void
+TestRemoveInputsWhere()
+{
+  // Arrange
+  jlm::rvsdg::graph rvsdg;
+  jlm::tests::valuetype valueType;
+  auto x = rvsdg.add_import({valueType, "x"});
+
+
+  auto & node = jlm::tests::SimpleNode::Create(
+    *rvsdg.root(),
+    {x, x, x},
+    {});
+  auto input0 = node.input(0);
+  auto input2 = node.input(2);
+
+  // Act & Assert
+  node.RemoveInputsWhere([](const jlm::rvsdg::input & input){ return input.index() == 1; });
+  assert(node.ninputs() == 2);
+  assert(node.input(0) == input0);
+  assert(node.input(1) == input2);
+
+  node.RemoveInputsWhere([](const jlm::rvsdg::input & input){ return true; });
+  assert(node.ninputs() == 0);
+}
+
 static int
 test_nodes()
 {
 	test_node_copy();
 	test_node_depth();
   TestRemoveOutputsWhere();
+  TestRemoveInputsWhere();
 
 	return 0;
 }

--- a/tests/jlm/rvsdg/test-nodes.cpp
+++ b/tests/jlm/rvsdg/test-nodes.cpp
@@ -190,12 +190,12 @@ TestRemoveInputsWhere()
 static int
 test_nodes()
 {
-	test_node_copy();
-	test_node_depth();
+  test_node_copy();
+  test_node_depth();
   TestRemoveOutputsWhere();
   TestRemoveInputsWhere();
 
-	return 0;
+  return 0;
 }
 
 JLM_UNIT_TEST_REGISTER("jlm/rvsdg/test-nodes", test_nodes)

--- a/tests/jlm/rvsdg/test-nodes.cpp
+++ b/tests/jlm/rvsdg/test-nodes.cpp
@@ -111,11 +111,59 @@ test_node_depth()
 	assert(un->depth() == 1);
 }
 
+/**
+ * Test node::RemoveOutputsWhere()
+ */
+static void
+TestRemoveOutputsWhere()
+{
+  // Arrange
+  jlm::rvsdg::graph rvsdg;
+
+  jlm::tests::valuetype valueType;
+  auto & node1 = jlm::tests::SimpleNode::Create(
+    *rvsdg.root(),
+    {},
+    {&valueType, &valueType, &valueType});
+  auto output0 = node1.output(0);
+  auto output2 = node1.output(2);
+
+  auto & node2 = jlm::tests::SimpleNode::Create(
+    *rvsdg.root(),
+    {output0, output2},
+    {&valueType, &valueType});
+
+  // Act & Assert
+  node2.RemoveOutputsWhere([](const jlm::rvsdg::output &output){ return false; });
+  assert(node2.noutputs() == 2);
+
+  node1.RemoveOutputsWhere([](const jlm::rvsdg::output &output){ return true; });
+  assert(node1.noutputs() == 2);
+  assert(node1.output(0) == output0);
+  assert(node1.output(0)->index() == 0);
+  assert(node1.output(1) == output2);
+  assert(node1.output(1)->index() == 1);
+
+  node2.RemoveOutputsWhere([](const jlm::rvsdg::output &output){ return true; });
+  assert(node2.noutputs() == 0);
+
+  remove(&node2);
+
+  node1.RemoveOutputsWhere([](const jlm::rvsdg::output &output){ return output.index() == 0; });
+  assert(node1.noutputs() == 1);
+  assert(node1.output(0) == output2);
+  assert(node1.output(0)->index() == 0);
+
+  node1.RemoveOutputsWhere([](const jlm::rvsdg::output &output){ return true; });
+  assert(node1.noutputs() == 0);
+}
+
 static int
 test_nodes()
 {
 	test_node_copy();
 	test_node_depth();
+  TestRemoveOutputsWhere();
 
 	return 0;
 }

--- a/tests/test-operation.hpp
+++ b/tests/test-operation.hpp
@@ -248,6 +248,47 @@ private:
 	}
 };
 
+class SimpleNode final : public rvsdg::simple_node
+{
+private:
+  SimpleNode(
+    rvsdg::region & region,
+    const test_op & operation,
+    const std::vector<rvsdg::output*> & operands)
+  : simple_node(&region, operation, operands)
+  {}
+
+public:
+  using rvsdg::node::RemoveOutputsWhere;
+
+  static SimpleNode&
+  Create(
+    rvsdg::region & region,
+    const std::vector<rvsdg::output*> & operands,
+    const std::vector<const rvsdg::type*> & resultTypes)
+  {
+    auto operandTypes = ExtractTypes(operands);
+    test_op operation(operandTypes, resultTypes);
+
+    auto node = new SimpleNode(region, operation, operands);
+    return *node;
+  }
+
+private:
+  static std::vector<const rvsdg::type*>
+  ExtractTypes(const std::vector<rvsdg::output*> & outputs)
+  {
+    std::vector<const rvsdg::type*> types;
+    types.reserve(outputs.size());
+    for (auto output : outputs)
+    {
+      types.emplace_back(&output->type());
+    }
+
+    return types;
+  }
+};
+
 static inline std::unique_ptr<llvm::tac>
 create_testop_tac(
 	const std::vector<const llvm::variable*> & arguments,

--- a/tests/test-operation.hpp
+++ b/tests/test-operation.hpp
@@ -259,6 +259,8 @@ private:
   {}
 
 public:
+  using rvsdg::node::RemoveInputsWhere;
+
   using rvsdg::node::RemoveOutputsWhere;
 
   static SimpleNode&


### PR DESCRIPTION
The current interface for removing inputs/outputs from nodes/regions has the following downsides:

1. It exposes the way the inputs/outputs are removed to the caller. The caller needs to know how to iterate through the inputs/outputs while removing (some of) them in order to avoid the invalidation of indices:

```
// iterate backwards to avoid the invalidation of 'n' by RemoveOutput()
for (size_t n = noutputs()-1; n != static_cast<size_t>(-1); n--)
{
  RemoveOutput(n);
}
```
This is not great for a public interface.

2. The sweep phase of dead node elimination experiences a performance issue when removing multiple inputs/outputs from structural nodes. The removal of an output/input requires the adjustment of the index of (potentially) all other inputs/outputs. In other words, every time we remove a single input/output, we have (in the worst case) to touch all other inputs/outputs to adjust their index. This leads to noticeable quadratic behavior in the sweep phase:

```
// iterate backwards to avoid the invalidation of 'n' by RemoveOutput()
for (size_t n = noutputs()-1; n != static_cast<size_t>(-1); n--)
{
 auto & output = ...
  if (Context_.IsDead(output))
  {
    RemoveOutput(n); // Needs to iterate through all outputs with index > n to adjust their indices
  }
}
```

This PR is the first step towards fixing these two issues. It makes the following contributions:

1. It renames the `remove_input()`, `remove_output()`, `remove_argument()`, and `remove_result()` methods such that they align with the naming convention.
2. It adds documentation for the above methods.
3. It introduces `RemoveOutputsWhere()`, `RemoveInputsWhere()`, `RemoveArgumentsWhere()`, and `RemoveResultsWhere()` methods. These methods hide the required way of iterating through the inputs/outputs from the public.

Future PRs will then replace the usages of `RemoveInput()`, `RemoveOutput()`, `RemoveArgument()`, and `RemoveResult()` methods with usages of `RemoveInputsWhere()`, `RemoveOutputsWhere()`, `RemoveArgumentsWhere()`, and `RemoveResultsWhere()`, respectively. This will enable us to privatize the `RemoveInput()`, `RemoveOutput()`, `RemoveArgument()`, and `RemoveResult()` methods such that they cannot be used publicly any longer. Once all usage sides rely on the `RemoveInputsWhere()`, `RemoveOutputsWhere()`, `RemoveArgumentsWhere()`, and `RemoveResultsWhere()` methods, we can start to efficiently implement the removal of multiple inputs/outputs internally in the respective classes.