### PR TITLE
Add ExtractTailNodes method to rvsdg::graph class

### DIFF
--- a/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.cpp
+++ b/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.cpp
@@ -875,7 +875,7 @@ RegionAwareMemoryNodeProvider::ResolveUnknownMemoryNodeReferences(const RvsdgMod
     }
   };
 
-  auto nodes = ExtractRvsdgTailNodes(rvsdgModule);
+  auto nodes = rvsdg::graph::ExtractTailNodes(rvsdgModule.Rvsdg());
   for (auto & node : nodes)
   {
     if (auto lambdaNode = dynamic_cast<const lambda::node*>(node))
@@ -901,52 +901,6 @@ RegionAwareMemoryNodeProvider::ResolveUnknownMemoryNodeReferences(const RvsdgMod
       JLM_UNREACHABLE("Unhandled node type!");
     }
   }
-}
-
-std::vector<const jlm::rvsdg::node*>
-RegionAwareMemoryNodeProvider::ExtractRvsdgTailNodes(const RvsdgModule & rvsdgModule)
-{
-  auto IsOnlyExported = [](const jlm::rvsdg::output & output)
-  {
-    auto IsRootRegionExport = [](const jlm::rvsdg::input * input)
-    {
-      if (!input->region()->IsRootRegion())
-      {
-        return false;
-      }
-
-      if (jlm::rvsdg::node_input::node(*input))
-      {
-        return false;
-      }
-
-      return true;
-    };
-
-    return std::all_of(
-      output.begin(),
-      output.end(),
-      IsRootRegionExport);
-  };
-
-  auto & rootRegion = *rvsdgModule.Rvsdg().root();
-
-  std::vector<const jlm::rvsdg::node*> nodes;
-  for (auto & node : rootRegion.bottom_nodes)
-  {
-      nodes.push_back(&node);
-  }
-
-  for (size_t n = 0; n < rootRegion.nresults(); n++)
-  {
-    auto output = rootRegion.result(n)->origin();
-    if (IsOnlyExported(*output))
-    {
-      nodes.push_back(jlm::rvsdg::node_output::node(output));
-    }
-  }
-
-  return nodes;
 }
 
 }

--- a/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.hpp
+++ b/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.hpp
@@ -179,18 +179,6 @@ private:
   void
   ResolveUnknownMemoryNodeReferences(const RvsdgModule & rvsdgModule);
 
-  /**
-   * Extracts all tail nodes of the RVSDG root region.
-   *
-   * A tail node is any node in the root region on which no other node in the root region depends on. An example would
-   * be a lambda node that is not called within the RVSDG module.
-   *
-   * @param rvsdgModule The RVSDG module from which to extract the tail nodes.
-   * @return A vector of tail nodes.
-   */
-  static std::vector<const jlm::rvsdg::node*>
-  ExtractRvsdgTailNodes(const RvsdgModule & rvsdgModule);
-
   std::unique_ptr<RegionAwareMemoryNodeProvisioning> Provisioning_;
 };
 

--- a/jlm/rvsdg/graph.hpp
+++ b/jlm/rvsdg/graph.hpp
@@ -165,6 +165,18 @@ public:
 		root()->prune(true);
 	}
 
+  /**
+   * Extracts all tail nodes of the RVSDG root region.
+   *
+   * A tail node is any node in the root region on which no other node in the root region depends on. An example would
+   * be a lambda node that is not called within the RVSDG module.
+   *
+   * @param rvsdg The RVSDG from which to extract the tail nodes.
+   * @return A vector of tail nodes.
+   */
+  static std::vector<rvsdg::node*>
+  ExtractTailNodes(const graph & rvsdg);
+
 private:
 	bool normalized_;
 	jlm::rvsdg::region * root_;


### PR DESCRIPTION
The ExtractTailNodes function is a useful little piece of code that will be needed elsewhere. Move it from the RegionAwareMemoryNodeProvider class to the rvsdg::graph class.