### PR TITLE
Add TopDownMemoryNodeEliminator

### DIFF
--- a/jlm/llvm/Makefile.sub
+++ b/jlm/llvm/Makefile.sub
@@ -49,7 +49,7 @@ libllvm_SOURCES = \
     jlm/llvm/opt/alias-analyses/PointsToGraph.cpp \
     jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.cpp \
     jlm/llvm/opt/alias-analyses/Steensgaard.cpp \
-	jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.cpp \
+    jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.cpp \
     jlm/llvm/opt/cne.cpp \
     jlm/llvm/opt/DeadNodeElimination.cpp \
     jlm/llvm/opt/inlining.cpp \

--- a/jlm/llvm/Makefile.sub
+++ b/jlm/llvm/Makefile.sub
@@ -170,6 +170,7 @@ libllvm_TESTS += \
 	tests/jlm/llvm/opt/alias-analyses/TestPointsToGraph \
 	tests/jlm/llvm/opt/alias-analyses/TestRegionAwareMemoryNodeProvider \
 	tests/jlm/llvm/opt/alias-analyses/TestSteensgaard \
+	tests/jlm/llvm/opt/alias-analyses/TestTopDownMemoryNodeEliminator \
 	tests/jlm/llvm/opt/test-cne \
 	tests/jlm/llvm/opt/TestDeadNodeElimination \
 	tests/jlm/llvm/opt/test-inlining \

--- a/jlm/llvm/Makefile.sub
+++ b/jlm/llvm/Makefile.sub
@@ -49,6 +49,7 @@ libllvm_SOURCES = \
     jlm/llvm/opt/alias-analyses/PointsToGraph.cpp \
     jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.cpp \
     jlm/llvm/opt/alias-analyses/Steensgaard.cpp \
+	jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.cpp \
     jlm/llvm/opt/cne.cpp \
     jlm/llvm/opt/DeadNodeElimination.cpp \
     jlm/llvm/opt/inlining.cpp \

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
@@ -255,7 +255,7 @@ public:
     return memoryNodeStatePairs;
   }
 
-  MemoryNodeStatePair*
+  MemoryNodeStatePair *
   InsertState(const PointsToGraph::MemoryNode & memoryNode, jlm::rvsdg::output & state)
   {
     JLM_ASSERT(!HasState(memoryNode));
@@ -305,16 +305,14 @@ public:
   RegionalizedStateMap &
   operator=(RegionalizedStateMap &&) = delete;
 
-  StateMap::MemoryNodeStatePair*
+  StateMap::MemoryNodeStatePair *
   InsertState(const PointsToGraph::MemoryNode & memoryNode, jlm::rvsdg::output & state)
   {
     return GetStateMap(*state.region()).InsertState(memoryNode, state);
   }
 
-  StateMap::MemoryNodeStatePair*
-  InsertUndefinedState(
-    jlm::rvsdg::region & region,
-    const PointsToGraph::MemoryNode & memoryNode)
+  StateMap::MemoryNodeStatePair *
+  InsertUndefinedState(jlm::rvsdg::region & region, const PointsToGraph::MemoryNode & memoryNode)
   {
     auto & undefinedState = GetOrInsertUndefinedMemoryState(region);
     return InsertState(memoryNode, undefinedState);
@@ -343,9 +341,7 @@ public:
   }
 
   bool
-  HasState(
-    const rvsdg::region & region,
-    const PointsToGraph::MemoryNode & memoryNode)
+  HasState(const rvsdg::region & region, const PointsToGraph::MemoryNode & memoryNode)
   {
     return GetStateMap(region).HasState(memoryNode);
   }
@@ -384,12 +380,11 @@ public:
   }
 
 private:
-  jlm::rvsdg::output&
+  jlm::rvsdg::output &
   GetOrInsertUndefinedMemoryState(jlm::rvsdg::region & region)
   {
-    return HasUndefinedMemoryState(region)
-           ? GetUndefinedMemoryState(region)
-           : InsertUndefinedMemoryState(region);
+    return HasUndefinedMemoryState(region) ? GetUndefinedMemoryState(region)
+                                           : InsertUndefinedMemoryState(region);
   }
 
   bool
@@ -398,14 +393,14 @@ private:
     return UndefinedMemoryStates_.find(&region) != UndefinedMemoryStates_.end();
   }
 
-  jlm::rvsdg::output&
+  jlm::rvsdg::output &
   GetUndefinedMemoryState(const jlm::rvsdg::region & region) const noexcept
   {
     JLM_ASSERT(HasUndefinedMemoryState(region));
     return *UndefinedMemoryStates_.find(&region)->second;
   }
 
-  jlm::rvsdg::output&
+  jlm::rvsdg::output &
   InsertUndefinedMemoryState(jlm::rvsdg::region & region) noexcept
   {
     auto undefinedMemoryState = UndefValueOperation::Create(region, MemoryStateType());
@@ -430,7 +425,7 @@ private:
   std::unordered_map<const jlm::rvsdg::region *, std::unique_ptr<StateMap>> StateMaps_;
   std::unordered_map<const jlm::rvsdg::region *, std::unique_ptr<MemoryNodeCache>>
       MemoryNodeCacheMaps_;
-  std::unordered_map<const jlm::rvsdg::region*, jlm::rvsdg::output*> UndefinedMemoryStates_;
+  std::unordered_map<const jlm::rvsdg::region *, jlm::rvsdg::output *> UndefinedMemoryStates_;
 
   const MemoryNodeProvisioning & MemoryNodeProvisioning_;
 };
@@ -624,7 +619,8 @@ MemoryStateEncoder::EncodeAlloca(const jlm::rvsdg::simple_node & allocaNode)
 
   if (stateMap.HasState(*allocaNode.region(), allocaMemoryNode))
   {
-    // The state for the alloca memory node should already exist in case of lifetime agnostic provisioning.
+    // The state for the alloca memory node should already exist in case of lifetime agnostic
+    // provisioning.
     auto memoryNodeStatePair = stateMap.GetState(*allocaNode.region(), allocaMemoryNode);
     memoryNodeStatePair->ReplaceState(allocaNodeStateOutput);
   }
@@ -727,7 +723,7 @@ MemoryStateEncoder::EncodeCall(const CallNode & callNode)
     auto & regionalizedStateMap = Context_->GetRegionalizedStateMap();
     auto & memoryNodes = Context_->GetMemoryNodeProvisioning().GetCallEntryNodes(callNode);
 
-    std::vector<StateMap::MemoryNodeStatePair*> memoryNodeStatePairs;
+    std::vector<StateMap::MemoryNodeStatePair *> memoryNodeStatePairs;
     for (auto memoryNode : memoryNodes.Items())
     {
       if (regionalizedStateMap.HasState(*region, *memoryNode))
@@ -737,7 +733,8 @@ MemoryStateEncoder::EncodeCall(const CallNode & callNode)
       else
       {
         // The state might not exist on the call side in case of lifetime aware provisioning
-        memoryNodeStatePairs.emplace_back(regionalizedStateMap.InsertUndefinedState(*region, *memoryNode));
+        memoryNodeStatePairs.emplace_back(
+            regionalizedStateMap.InsertUndefinedState(*region, *memoryNode));
       }
     }
 

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
@@ -233,7 +233,7 @@ public:
   operator=(StateMap &&) = delete;
 
   bool
-  Contains(const PointsToGraph::MemoryNode & memoryNode) const noexcept
+  HasState(const PointsToGraph::MemoryNode & memoryNode) const noexcept
   {
     return states_.find(&memoryNode) != states_.end();
   }
@@ -241,7 +241,7 @@ public:
   MemoryNodeStatePair *
   GetState(const PointsToGraph::MemoryNode & memoryNode) noexcept
   {
-    JLM_ASSERT(Contains(memoryNode));
+    JLM_ASSERT(HasState(memoryNode));
     return &states_.at(&memoryNode);
   }
 
@@ -255,15 +255,16 @@ public:
     return memoryNodeStatePairs;
   }
 
-  void
+  MemoryNodeStatePair*
   InsertState(const PointsToGraph::MemoryNode & memoryNode, jlm::rvsdg::output & state)
   {
-    JLM_ASSERT(!Contains(memoryNode));
+    JLM_ASSERT(!HasState(memoryNode));
 
     auto pair = std::make_pair<const PointsToGraph::MemoryNode *, MemoryNodeStatePair>(
         &memoryNode,
         { memoryNode, state });
     states_.insert(pair);
+    return GetState(memoryNode);
   }
 
   static std::unique_ptr<StateMap>
@@ -304,10 +305,19 @@ public:
   RegionalizedStateMap &
   operator=(RegionalizedStateMap &&) = delete;
 
-  void
+  StateMap::MemoryNodeStatePair*
   InsertState(const PointsToGraph::MemoryNode & memoryNode, jlm::rvsdg::output & state)
   {
-    GetStateMap(*state.region()).InsertState(memoryNode, state);
+    return GetStateMap(*state.region()).InsertState(memoryNode, state);
+  }
+
+  StateMap::MemoryNodeStatePair*
+  InsertUndefinedState(
+    jlm::rvsdg::region & region,
+    const PointsToGraph::MemoryNode & memoryNode)
+  {
+    auto & undefinedState = GetOrInsertUndefinedMemoryState(region);
+    return InsertState(memoryNode, undefinedState);
   }
 
   void
@@ -330,6 +340,14 @@ public:
       const jlm::util::HashSet<const PointsToGraph::MemoryNode *> & memoryNodes)
   {
     return GetStateMap(region).GetStates(memoryNodes);
+  }
+
+  bool
+  HasState(
+    const rvsdg::region & region,
+    const PointsToGraph::MemoryNode & memoryNode)
+  {
+    return GetStateMap(region).HasState(memoryNode);
   }
 
   StateMap::MemoryNodeStatePair *
@@ -366,6 +384,35 @@ public:
   }
 
 private:
+  jlm::rvsdg::output&
+  GetOrInsertUndefinedMemoryState(jlm::rvsdg::region & region)
+  {
+    return HasUndefinedMemoryState(region)
+           ? GetUndefinedMemoryState(region)
+           : InsertUndefinedMemoryState(region);
+  }
+
+  bool
+  HasUndefinedMemoryState(const jlm::rvsdg::region & region) const noexcept
+  {
+    return UndefinedMemoryStates_.find(&region) != UndefinedMemoryStates_.end();
+  }
+
+  jlm::rvsdg::output&
+  GetUndefinedMemoryState(const jlm::rvsdg::region & region) const noexcept
+  {
+    JLM_ASSERT(HasUndefinedMemoryState(region));
+    return *UndefinedMemoryStates_.find(&region)->second;
+  }
+
+  jlm::rvsdg::output&
+  InsertUndefinedMemoryState(jlm::rvsdg::region & region) noexcept
+  {
+    auto undefinedMemoryState = UndefValueOperation::Create(region, MemoryStateType());
+    UndefinedMemoryStates_[&region] = undefinedMemoryState;
+    return *undefinedMemoryState;
+  }
+
   StateMap &
   GetStateMap(const jlm::rvsdg::region & region) const noexcept
   {
@@ -383,6 +430,7 @@ private:
   std::unordered_map<const jlm::rvsdg::region *, std::unique_ptr<StateMap>> StateMaps_;
   std::unordered_map<const jlm::rvsdg::region *, std::unique_ptr<MemoryNodeCache>>
       MemoryNodeCacheMaps_;
+  std::unordered_map<const jlm::rvsdg::region*, jlm::rvsdg::output*> UndefinedMemoryStates_;
 
   const MemoryNodeProvisioning & MemoryNodeProvisioning_;
 };
@@ -568,12 +616,22 @@ void
 MemoryStateEncoder::EncodeAlloca(const jlm::rvsdg::simple_node & allocaNode)
 {
   JLM_ASSERT(is<alloca_op>(&allocaNode));
-  auto & stateMap = Context_->GetRegionalizedStateMap();
 
+  auto & stateMap = Context_->GetRegionalizedStateMap();
   auto & allocaMemoryNode =
       Context_->GetMemoryNodeProvisioning().GetPointsToGraph().GetAllocaNode(allocaNode);
-  auto memoryNodeStatePair = stateMap.GetState(*allocaNode.region(), allocaMemoryNode);
-  memoryNodeStatePair->ReplaceState(*allocaNode.output(1));
+  auto & allocaNodeStateOutput = *allocaNode.output(1);
+
+  if (stateMap.HasState(*allocaNode.region(), allocaMemoryNode))
+  {
+    // The state for the alloca memory node should already exist in case of lifetime agnostic provisioning.
+    auto memoryNodeStatePair = stateMap.GetState(*allocaNode.region(), allocaMemoryNode);
+    memoryNodeStatePair->ReplaceState(allocaNodeStateOutput);
+  }
+  else
+  {
+    stateMap.InsertState(allocaMemoryNode, allocaNodeStateOutput);
+  }
 }
 
 void
@@ -668,7 +726,21 @@ MemoryStateEncoder::EncodeCall(const CallNode & callNode)
     auto region = callNode.region();
     auto & memoryNodes = Context_->GetMemoryNodeProvisioning().GetCallEntryNodes(callNode);
 
-    auto memoryNodeStatePairs = Context_->GetRegionalizedStateMap().GetStates(*region, memoryNodes);
+    std::vector<StateMap::MemoryNodeStatePair*> memoryNodeStatePairs;
+    for (auto memoryNode : memoryNodes.Items())
+    {
+      auto & regionalizedStateMap = Context_->GetRegionalizedStateMap();
+      if (regionalizedStateMap.HasState(*region, *memoryNode))
+      {
+        memoryNodeStatePairs.emplace_back(regionalizedStateMap.GetState(*region, *memoryNode));
+      }
+      else
+      {
+        // The state might not exist on the call side in case of lifetime aware provisioning
+        memoryNodeStatePairs.emplace_back(regionalizedStateMap.InsertUndefinedState(*region, *memoryNode));
+      }
+    }
+
     auto states = StateMap::MemoryNodeStatePair::States(memoryNodeStatePairs);
     auto state = CallEntryMemStateOperator::Create(region, states);
     callNode.GetMemoryStateInput()->divert_to(state);

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
@@ -724,12 +724,12 @@ MemoryStateEncoder::EncodeCall(const CallNode & callNode)
   auto EncodeEntry = [this](const CallNode & callNode)
   {
     auto region = callNode.region();
+    auto & regionalizedStateMap = Context_->GetRegionalizedStateMap();
     auto & memoryNodes = Context_->GetMemoryNodeProvisioning().GetCallEntryNodes(callNode);
 
     std::vector<StateMap::MemoryNodeStatePair*> memoryNodeStatePairs;
     for (auto memoryNode : memoryNodes.Items())
     {
-      auto & regionalizedStateMap = Context_->GetRegionalizedStateMap();
       if (regionalizedStateMap.HasState(*region, *memoryNode))
       {
         memoryNodeStatePairs.emplace_back(regionalizedStateMap.GetState(*region, *memoryNode));

--- a/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.cpp
+++ b/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.cpp
@@ -732,21 +732,13 @@ TopDownMemoryNodeEliminator::EliminateTopDownTheta(const rvsdg::theta_node& thet
 void
 TopDownMemoryNodeEliminator::EliminateTopDownSimpleNode(const rvsdg::simple_node & simpleNode)
 {
-  auto annotateAlloca = [](auto & p, auto & n) { p.EliminateTopDownAlloca(n); };
-  auto annotateCall = [](auto & p, auto & n) { p.EliminateTopDownCall(*util::AssertedCast<const CallNode>(&n)); };
-
-  static std::unordered_map<
-    std::type_index,
-    std::function<void(TopDownMemoryNodeEliminator&, const rvsdg::simple_node&)>> nodes
-    ({
-       {typeid(alloca_op), annotateAlloca},
-       {typeid(CallOperation), annotateCall}
-     });
-
-  auto & operation = simpleNode.operation();
-  if (nodes.find(typeid(operation)) != nodes.end())
+  if (is<alloca_op>(&simpleNode))
   {
-    nodes[typeid(operation)](*this, simpleNode);
+    EliminateTopDownAlloca(simpleNode);
+  }
+  else if (auto callNode = dynamic_cast<const CallNode*>(&simpleNode))
+  {
+    EliminateTopDownCall(*callNode);
   }
 }
 

--- a/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.cpp
+++ b/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.cpp
@@ -99,12 +99,8 @@ public:
   {
     auto callTypeClassifier = CallNode::ClassifyCall(callNode);
 
-    if (callTypeClassifier->IsNonRecursiveDirectCall())
-    {
-      auto & lambdaNode = *callTypeClassifier->GetLambdaOutput().node();
-      return GetLambdaEntryNodes(lambdaNode);
-    }
-    else if (callTypeClassifier->IsRecursiveDirectCall())
+    if (callTypeClassifier->IsNonRecursiveDirectCall()
+        || callTypeClassifier->IsRecursiveDirectCall())
     {
       auto & lambdaNode = *callTypeClassifier->GetLambdaOutput().node();
       return GetLambdaEntryNodes(lambdaNode);
@@ -126,12 +122,8 @@ public:
   {
     auto callTypeClassifier = CallNode::ClassifyCall(callNode);
 
-    if (callTypeClassifier->IsNonRecursiveDirectCall())
-    {
-      auto & lambdaNode = *callTypeClassifier->GetLambdaOutput().node();
-      return GetLambdaExitNodes(lambdaNode);
-    }
-    else if (callTypeClassifier->IsRecursiveDirectCall())
+    if (callTypeClassifier->IsNonRecursiveDirectCall()
+        || callTypeClassifier->IsRecursiveDirectCall())
     {
       auto & lambdaNode = *callTypeClassifier->GetLambdaOutput().node();
       return GetLambdaExitNodes(lambdaNode);

--- a/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.cpp
+++ b/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.cpp
@@ -23,14 +23,12 @@ IsAllocaNode(const PointsToGraph::MemoryNode * memoryNode) noexcept
 class TopDownMemoryNodeEliminator::Statistics final : public util::Statistics
 {
 public:
-  ~Statistics() override
-  = default;
+  ~Statistics() override = default;
 
-  explicit
-  Statistics(util::filepath sourceFile)
-    : util::Statistics(Statistics::Id::TopDownMemoryNodeEliminator)
-    , NumRvsdgNodes_(0)
-    , SourceFile_(std::move(sourceFile))
+  explicit Statistics(util::filepath sourceFile)
+      : util::Statistics(Statistics::Id::TopDownMemoryNodeEliminator),
+        NumRvsdgNodes_(0),
+        SourceFile_(std::move(sourceFile))
   {}
 
   void
@@ -49,10 +47,15 @@ public:
   [[nodiscard]] std::string
   ToString() const override
   {
-    return util::strfmt("TopDownMemoryNodeEliminator ",
-                        SourceFile_.to_str(), " ",
-                        "#RvsdgNodes:", NumRvsdgNodes_, " ",
-                        "Time[ns]:", Timer_.ns());
+    return util::strfmt(
+        "TopDownMemoryNodeEliminator ",
+        SourceFile_.to_str(),
+        " ",
+        "#RvsdgNodes:",
+        NumRvsdgNodes_,
+        " ",
+        "Time[ns]:",
+        Timer_.ns());
   }
 
   static std::unique_ptr<Statistics>
@@ -72,24 +75,25 @@ private:
  */
 class TopDownMemoryNodeEliminator::Provisioning final : public MemoryNodeProvisioning
 {
-  using RegionMap = std::unordered_map<const rvsdg::region*, util::HashSet<const PointsToGraph::MemoryNode*>>;
-  using CallMap = std::unordered_map<const CallNode*, util::HashSet<const PointsToGraph::MemoryNode*>>;
+  using RegionMap =
+      std::unordered_map<const rvsdg::region *, util::HashSet<const PointsToGraph::MemoryNode *>>;
+  using CallMap =
+      std::unordered_map<const CallNode *, util::HashSet<const PointsToGraph::MemoryNode *>>;
 
 public:
-  explicit
-  Provisioning(const PointsToGraph & pointsToGraph)
-    : PointsToGraph_(pointsToGraph)
+  explicit Provisioning(const PointsToGraph & pointsToGraph)
+      : PointsToGraph_(pointsToGraph)
   {}
 
-  Provisioning(const Provisioning&) = delete;
+  Provisioning(const Provisioning &) = delete;
 
-  Provisioning(Provisioning&&) = delete;
+  Provisioning(Provisioning &&) = delete;
 
-  Provisioning&
-  operator=(const Provisioning&) = delete;
+  Provisioning &
+  operator=(const Provisioning &) = delete;
 
-  Provisioning&
-  operator=(Provisioning&&) = delete;
+  Provisioning &
+  operator=(Provisioning &&) = delete;
 
   [[nodiscard]] const PointsToGraph &
   GetPointsToGraph() const noexcept override
@@ -97,21 +101,21 @@ public:
     return PointsToGraph_;
   }
 
-  [[nodiscard]] const util::HashSet<const PointsToGraph::MemoryNode*> &
+  [[nodiscard]] const util::HashSet<const PointsToGraph::MemoryNode *> &
   GetRegionEntryNodes(const rvsdg::region & region) const override
   {
     JLM_ASSERT(HasRegionEntryMemoryNodesSet(region));
     return RegionEntryMemoryNodes_.find(&region)->second;
   }
 
-  [[nodiscard]] const util::HashSet<const PointsToGraph::MemoryNode*> &
+  [[nodiscard]] const util::HashSet<const PointsToGraph::MemoryNode *> &
   GetRegionExitNodes(const rvsdg::region & region) const override
   {
     JLM_ASSERT(HasRegionExitMemoryNodesSet(region));
     return RegionExitMemoryNodes_.find(&region)->second;
   }
 
-  [[nodiscard]] const util::HashSet<const PointsToGraph::MemoryNode*> &
+  [[nodiscard]] const util::HashSet<const PointsToGraph::MemoryNode *> &
   GetCallEntryNodes(const CallNode & callNode) const override
   {
     auto callTypeClassifier = CallNode::ClassifyCall(callNode);
@@ -138,7 +142,7 @@ public:
     JLM_UNREACHABLE("Unhandled call type!");
   }
 
-  [[nodiscard]] const util::HashSet<const PointsToGraph::MemoryNode*> &
+  [[nodiscard]] const util::HashSet<const PointsToGraph::MemoryNode *> &
   GetCallExitNodes(const CallNode & callNode) const override
   {
     auto callTypeClassifier = CallNode::ClassifyCall(callNode);
@@ -165,13 +169,13 @@ public:
     JLM_UNREACHABLE("Unhandled call type!");
   }
 
-  [[nodiscard]] util::HashSet<const PointsToGraph::MemoryNode*>
+  [[nodiscard]] util::HashSet<const PointsToGraph::MemoryNode *>
   GetOutputNodes(const rvsdg::output & output) const override
   {
     JLM_ASSERT(is<PointerType>(output.type()));
     auto & registerNode = PointsToGraph_.GetRegisterNode(output);
 
-    util::HashSet<const PointsToGraph::MemoryNode*> memoryNodes;
+    util::HashSet<const PointsToGraph::MemoryNode *> memoryNodes;
     for (auto & memoryNode : registerNode.Targets())
       memoryNodes.Insert(&memoryNode);
 
@@ -180,8 +184,8 @@ public:
 
   void
   AddRegionEntryNodes(
-    const rvsdg::region & region,
-    const util::HashSet<const PointsToGraph::MemoryNode*> & memoryNodes)
+      const rvsdg::region & region,
+      const util::HashSet<const PointsToGraph::MemoryNode *> & memoryNodes)
   {
     auto & set = GetOrCreateRegionEntryMemoryNodesSet(region);
     set.UnionWith(memoryNodes);
@@ -189,8 +193,8 @@ public:
 
   void
   AddRegionExitNodes(
-    const rvsdg::region & region,
-    const util::HashSet<const PointsToGraph::MemoryNode*> & memoryNodes)
+      const rvsdg::region & region,
+      const util::HashSet<const PointsToGraph::MemoryNode *> & memoryNodes)
   {
     auto & set = GetOrCreateRegionExitMemoryNodesSet(region);
     set.UnionWith(memoryNodes);
@@ -198,8 +202,8 @@ public:
 
   void
   AddExternalCallNodes(
-    const CallNode & externalCall,
-    const util::HashSet<const PointsToGraph::MemoryNode*> & memoryNodes)
+      const CallNode & externalCall,
+      const util::HashSet<const PointsToGraph::MemoryNode *> & memoryNodes)
   {
     auto & set = GetOrCreateExternalCallNodesSet(externalCall);
     set.UnionWith(memoryNodes);
@@ -207,8 +211,8 @@ public:
 
   void
   AddIndirectCallNodes(
-    const CallNode & indirectCall,
-    const util::HashSet<const PointsToGraph::MemoryNode*> & memoryNodes)
+      const CallNode & indirectCall,
+      const util::HashSet<const PointsToGraph::MemoryNode *> & memoryNodes)
   {
     JLM_ASSERT(CallNode::ClassifyCall(indirectCall)->IsIndirectCall());
     auto & set = CreateIndirectCallNodesSet(indirectCall);
@@ -246,7 +250,7 @@ private:
     return RegionExitMemoryNodes_.find(&region) != RegionExitMemoryNodes_.end();
   }
 
-  util::HashSet<const PointsToGraph::MemoryNode*> &
+  util::HashSet<const PointsToGraph::MemoryNode *> &
   GetOrCreateRegionEntryMemoryNodesSet(const rvsdg::region & region)
   {
     if (!HasRegionEntryMemoryNodesSet(region))
@@ -257,7 +261,7 @@ private:
     return RegionEntryMemoryNodes_[&region];
   }
 
-  util::HashSet<const PointsToGraph::MemoryNode*> &
+  util::HashSet<const PointsToGraph::MemoryNode *> &
   GetOrCreateRegionExitMemoryNodesSet(const rvsdg::region & region)
   {
     if (!HasRegionExitMemoryNodesSet(region))
@@ -268,7 +272,7 @@ private:
     return RegionExitMemoryNodes_[&region];
   }
 
-  util::HashSet<const PointsToGraph::MemoryNode*> &
+  util::HashSet<const PointsToGraph::MemoryNode *> &
   GetOrCreateExternalCallNodesSet(const CallNode & externalCall)
   {
     if (!HasExternalCallNodesSet(externalCall))
@@ -279,7 +283,7 @@ private:
     return ExternalCallNodes_[&externalCall];
   }
 
-  util::HashSet<const PointsToGraph::MemoryNode*> &
+  util::HashSet<const PointsToGraph::MemoryNode *> &
   CreateIndirectCallNodesSet(const CallNode & indirectCall)
   {
     JLM_ASSERT(!HasIndirectCallNodesSet(indirectCall));
@@ -287,14 +291,14 @@ private:
     return IndirectCallNodes_[&indirectCall];
   }
 
-  const util::HashSet<const PointsToGraph::MemoryNode*> &
+  const util::HashSet<const PointsToGraph::MemoryNode *> &
   GetExternalCallNodesSet(const CallNode & externalCall) const
   {
     JLM_ASSERT(HasExternalCallNodesSet(externalCall));
     return (*ExternalCallNodes_.find(&externalCall)).second;
   }
 
-  const util::HashSet<const PointsToGraph::MemoryNode*> &
+  const util::HashSet<const PointsToGraph::MemoryNode *> &
   GetIndirectCallNodesSet(const CallNode & indirectCall) const
   {
     JLM_ASSERT(HasIndirectCallNodesSet(indirectCall));
@@ -318,21 +322,20 @@ private:
 class TopDownMemoryNodeEliminator::Context final
 {
 public:
-  explicit
-  Context(const MemoryNodeProvisioning & seedProvisioning)
-    : SeedProvisioning_(seedProvisioning)
-    , Provisioning_(Provisioning::Create(seedProvisioning.GetPointsToGraph()))
+  explicit Context(const MemoryNodeProvisioning & seedProvisioning)
+      : SeedProvisioning_(seedProvisioning),
+        Provisioning_(Provisioning::Create(seedProvisioning.GetPointsToGraph()))
   {}
 
-  Context(const Context&) = delete;
+  Context(const Context &) = delete;
 
-  Context(Context&&) noexcept = delete;
+  Context(Context &&) noexcept = delete;
 
-  Context&
-  operator=(const Context&) = delete;
+  Context &
+  operator=(const Context &) = delete;
 
-  Context&
-  operator=(Context&&) noexcept = delete;
+  Context &
+  operator=(Context &&) noexcept = delete;
 
   [[nodiscard]] const MemoryNodeProvisioning &
   GetSeedProvisioning() const noexcept
@@ -358,7 +361,7 @@ public:
     return std::move(Provisioning_);
   }
 
-  const util::HashSet<const PointsToGraph::MemoryNode*> &
+  const util::HashSet<const PointsToGraph::MemoryNode *> &
   GetLiveNodes(const rvsdg::region & region) noexcept
   {
     return GetOrCreateLiveNodesSet(region);
@@ -366,8 +369,8 @@ public:
 
   void
   AddLiveNodes(
-    const rvsdg::region & region,
-    const util::HashSet<const PointsToGraph::MemoryNode*> & memoryNodes)
+      const rvsdg::region & region,
+      const util::HashSet<const PointsToGraph::MemoryNode *> & memoryNodes)
   {
     auto & liveNodes = GetOrCreateLiveNodesSet(region);
     liveNodes.UnionWith(memoryNodes);
@@ -398,7 +401,7 @@ private:
     return LiveNodes_.find(&region) != LiveNodes_.end();
   }
 
-  util::HashSet<const PointsToGraph::MemoryNode*> &
+  util::HashSet<const PointsToGraph::MemoryNode *> &
   GetOrCreateLiveNodesSet(const rvsdg::region & region)
   {
     if (!HasLiveNodesSet(region))
@@ -413,23 +416,22 @@ private:
   std::unique_ptr<Provisioning> Provisioning_;
 
   // Keeps track of the memory nodes that are live within a region.
-  std::unordered_map<const rvsdg::region*, util::HashSet<const PointsToGraph::MemoryNode*>> LiveNodes_;
+  std::unordered_map<const rvsdg::region *, util::HashSet<const PointsToGraph::MemoryNode *>>
+      LiveNodes_;
 
   // Keeps track of all lambda nodes where we annotated live nodes BEFORE traversing its subregion.
-  util::HashSet<const lambda::node*> LiveNodesAnnotatedLambdaNodes_;
+  util::HashSet<const lambda::node *> LiveNodesAnnotatedLambdaNodes_;
 };
 
-TopDownMemoryNodeEliminator::~TopDownMemoryNodeEliminator() noexcept
-= default;
+TopDownMemoryNodeEliminator::~TopDownMemoryNodeEliminator() noexcept = default;
 
-TopDownMemoryNodeEliminator::TopDownMemoryNodeEliminator()
-= default;
+TopDownMemoryNodeEliminator::TopDownMemoryNodeEliminator() = default;
 
 std::unique_ptr<MemoryNodeProvisioning>
 TopDownMemoryNodeEliminator::EliminateMemoryNodes(
-  const RvsdgModule &rvsdgModule,
-  const MemoryNodeProvisioning & seedProvisioning,
-  util::StatisticsCollector &statisticsCollector)
+    const RvsdgModule & rvsdgModule,
+    const MemoryNodeProvisioning & seedProvisioning,
+    util::StatisticsCollector & statisticsCollector)
 {
   Context_ = Context::Create(seedProvisioning);
   auto statistics = Statistics::Create(rvsdgModule.SourceFileName());
@@ -450,9 +452,9 @@ TopDownMemoryNodeEliminator::EliminateMemoryNodes(
 
 std::unique_ptr<MemoryNodeProvisioning>
 TopDownMemoryNodeEliminator::CreateAndEliminate(
-  const RvsdgModule &rvsdgModule,
-  const MemoryNodeProvisioning &seedProvisioning,
-  util::StatisticsCollector &statisticsCollector)
+    const RvsdgModule & rvsdgModule,
+    const MemoryNodeProvisioning & seedProvisioning,
+    util::StatisticsCollector & statisticsCollector)
 {
   TopDownMemoryNodeEliminator provider;
   return provider.EliminateMemoryNodes(rvsdgModule, seedProvisioning, statisticsCollector);
@@ -460,15 +462,15 @@ TopDownMemoryNodeEliminator::CreateAndEliminate(
 
 std::unique_ptr<MemoryNodeProvisioning>
 TopDownMemoryNodeEliminator::CreateAndEliminate(
-  const RvsdgModule &rvsdgModule,
-  const MemoryNodeProvisioning &seedProvisioning)
+    const RvsdgModule & rvsdgModule,
+    const MemoryNodeProvisioning & seedProvisioning)
 {
   util::StatisticsCollector statisticsCollector;
   return CreateAndEliminate(rvsdgModule, seedProvisioning, statisticsCollector);
 }
 
 void
-TopDownMemoryNodeEliminator::EliminateTopDown(const RvsdgModule &rvsdgModule)
+TopDownMemoryNodeEliminator::EliminateTopDown(const RvsdgModule & rvsdgModule)
 {
   InitializeLiveNodes(rvsdgModule);
   EliminateTopDownRootRegion(*rvsdgModule.Rvsdg().root());
@@ -480,15 +482,15 @@ TopDownMemoryNodeEliminator::EliminateTopDownRootRegion(rvsdg::region & region)
   rvsdg::bottomup_traverser traverser(&region);
   for (auto & node : traverser)
   {
-    if (auto lambdaNode = dynamic_cast<const lambda::node*>(node))
+    if (auto lambdaNode = dynamic_cast<const lambda::node *>(node))
     {
       EliminateTopDownLambda(*lambdaNode);
     }
-    else if (auto phiNode = dynamic_cast<const phi::node*>(node))
+    else if (auto phiNode = dynamic_cast<const phi::node *>(node))
     {
       EliminateTopDownPhi(*phiNode);
     }
-    else if (dynamic_cast<const delta::node*>(node))
+    else if (dynamic_cast<const delta::node *>(node))
     {
       // Nothing needs to be done.
     }
@@ -505,11 +507,11 @@ TopDownMemoryNodeEliminator::EliminateTopDownRegion(rvsdg::region & region)
   rvsdg::topdown_traverser traverser(&region);
   for (auto & node : traverser)
   {
-    if (auto simpleNode = dynamic_cast<const rvsdg::simple_node*>(node))
+    if (auto simpleNode = dynamic_cast<const rvsdg::simple_node *>(node))
     {
       EliminateTopDownSimpleNode(*simpleNode);
     }
-    else if (auto structuralNode = dynamic_cast<const rvsdg::structural_node*>(node))
+    else if (auto structuralNode = dynamic_cast<const rvsdg::structural_node *>(node))
     {
       EliminateTopDownStructuralNode(*structuralNode);
     }
@@ -521,13 +523,14 @@ TopDownMemoryNodeEliminator::EliminateTopDownRegion(rvsdg::region & region)
 }
 
 void
-TopDownMemoryNodeEliminator::EliminateTopDownStructuralNode(const rvsdg::structural_node & structuralNode)
+TopDownMemoryNodeEliminator::EliminateTopDownStructuralNode(
+    const rvsdg::structural_node & structuralNode)
 {
-  if (auto gammaNode = dynamic_cast<const rvsdg::gamma_node*>(&structuralNode))
+  if (auto gammaNode = dynamic_cast<const rvsdg::gamma_node *>(&structuralNode))
   {
     EliminateTopDownGamma(*gammaNode);
   }
-  else if (auto thetaNode = dynamic_cast<const rvsdg::theta_node*>(&structuralNode))
+  else if (auto thetaNode = dynamic_cast<const rvsdg::theta_node *>(&structuralNode))
   {
     EliminateTopDownTheta(*thetaNode);
   }
@@ -546,7 +549,7 @@ TopDownMemoryNodeEliminator::EliminateTopDownLambda(const lambda::node & lambdaN
 }
 
 void
-TopDownMemoryNodeEliminator::EliminateTopDownLambdaEntry(const lambda::node &lambdaNode)
+TopDownMemoryNodeEliminator::EliminateTopDownLambdaEntry(const lambda::node & lambdaNode)
 {
   auto & lambdaSubregion = *lambdaNode.subregion();
   auto & provisioning = Context_->GetProvisioning();
@@ -560,9 +563,9 @@ TopDownMemoryNodeEliminator::EliminateTopDownLambdaEntry(const lambda::node &lam
   }
   else
   {
-    // The lambda node has only indirect calls (no direct calls or exported). We therefore have no idea what memory
-    // nodes are live at its entry. Thus, we need to be conservative and simply say that all memory nodes
-    // from the seed provisioning are live.
+    // The lambda node has only indirect calls (no direct calls or exported). We therefore have no
+    // idea what memory nodes are live at its entry. Thus, we need to be conservative and simply say
+    // that all memory nodes from the seed provisioning are live.
     auto & seedLambdaEntryNodes = seedProvisioning.GetLambdaEntryNodes(lambdaNode);
     Context_->AddLiveNodes(lambdaSubregion, seedLambdaEntryNodes);
     provisioning.AddRegionEntryNodes(lambdaSubregion, seedLambdaEntryNodes);
@@ -570,7 +573,7 @@ TopDownMemoryNodeEliminator::EliminateTopDownLambdaEntry(const lambda::node &lam
 }
 
 void
-TopDownMemoryNodeEliminator::EliminateTopDownLambdaExit(const lambda::node &lambdaNode)
+TopDownMemoryNodeEliminator::EliminateTopDownLambdaExit(const lambda::node & lambdaNode)
 {
   auto & lambdaSubregion = *lambdaNode.subregion();
   auto & provisioning = Context_->GetProvisioning();
@@ -583,9 +586,9 @@ TopDownMemoryNodeEliminator::EliminateTopDownLambdaExit(const lambda::node &lamb
   }
   else
   {
-    // The lambda node has only indirect calls (no direct calls or exported). We therefore have no idea what memory
-    // nodes are live or dead at its exit. Thus, we need to be conservative and simply say that all memory nodes
-    // from the seed provisioning are live.
+    // The lambda node has only indirect calls (no direct calls or exported). We therefore have no
+    // idea what memory nodes are live or dead at its exit. Thus, we need to be conservative and
+    // simply say that all memory nodes from the seed provisioning are live.
     auto & seedLambdaExitNodes = seedProvisioning.GetLambdaExitNodes(lambdaNode);
     provisioning.AddRegionExitNodes(lambdaSubregion, seedLambdaExitNodes);
   }
@@ -596,11 +599,11 @@ TopDownMemoryNodeEliminator::EliminateTopDownPhi(const phi::node & phiNode)
 {
   auto computeLiveNodes = [&](const rvsdg::region & phiSubregion)
   {
-    std::vector<const lambda::node*> lambdaNodes;
-    util::HashSet<const PointsToGraph::MemoryNode*> liveNodes;
+    std::vector<const lambda::node *> lambdaNodes;
+    util::HashSet<const PointsToGraph::MemoryNode *> liveNodes;
     for (auto & node : phiSubregion.nodes)
     {
-      if (auto lambdaNode = dynamic_cast<const lambda::node*>(&node))
+      if (auto lambdaNode = dynamic_cast<const lambda::node *>(&node))
       {
         lambdaNodes.emplace_back(lambdaNode);
 
@@ -608,7 +611,7 @@ TopDownMemoryNodeEliminator::EliminateTopDownPhi(const phi::node & phiNode)
         auto & lambdaLiveNodes = Context_->GetLiveNodes(lambdaSubregion);
         liveNodes.UnionWith(lambdaLiveNodes);
       }
-      else if (dynamic_cast<const delta::node*>(&node))
+      else if (dynamic_cast<const delta::node *>(&node))
       {
         // Nothing needs to be done.
       }
@@ -636,9 +639,8 @@ TopDownMemoryNodeEliminator::EliminateTopDownPhi(const phi::node & phiNode)
 void
 TopDownMemoryNodeEliminator::EliminateTopDownGamma(const rvsdg::gamma_node & gammaNode)
 {
-  auto addSubregionLiveAndEntryNodes = [](
-    const rvsdg::gamma_node & gammaNode,
-    TopDownMemoryNodeEliminator::Context & context)
+  auto addSubregionLiveAndEntryNodes =
+      [](const rvsdg::gamma_node & gammaNode, TopDownMemoryNodeEliminator::Context & context)
   {
     auto & gammaRegion = *gammaNode.region();
     auto & seedProvisioning = context.GetSeedProvisioning();
@@ -666,9 +668,8 @@ TopDownMemoryNodeEliminator::EliminateTopDownGamma(const rvsdg::gamma_node & gam
     }
   };
 
-  auto addSubregionExitNodes = [](
-    const rvsdg::gamma_node & gammaNode,
-    TopDownMemoryNodeEliminator::Context & context)
+  auto addSubregionExitNodes =
+      [](const rvsdg::gamma_node & gammaNode, TopDownMemoryNodeEliminator::Context & context)
   {
     auto & provisioning = context.GetProvisioning();
 
@@ -680,9 +681,8 @@ TopDownMemoryNodeEliminator::EliminateTopDownGamma(const rvsdg::gamma_node & gam
     }
   };
 
-  auto updateGammaRegionLiveNodes = [](
-    const rvsdg::gamma_node & gammaNode,
-    TopDownMemoryNodeEliminator::Context & context)
+  auto updateGammaRegionLiveNodes =
+      [](const rvsdg::gamma_node & gammaNode, TopDownMemoryNodeEliminator::Context & context)
   {
     auto & gammaRegion = *gammaNode.region();
     auto & provisioning = context.GetProvisioning();
@@ -702,7 +702,7 @@ TopDownMemoryNodeEliminator::EliminateTopDownGamma(const rvsdg::gamma_node & gam
 }
 
 void
-TopDownMemoryNodeEliminator::EliminateTopDownTheta(const rvsdg::theta_node& thetaNode)
+TopDownMemoryNodeEliminator::EliminateTopDownTheta(const rvsdg::theta_node & thetaNode)
 {
   auto & thetaRegion = *thetaNode.region();
   auto & thetaSubregion = *thetaNode.subregion();
@@ -736,7 +736,7 @@ TopDownMemoryNodeEliminator::EliminateTopDownSimpleNode(const rvsdg::simple_node
   {
     EliminateTopDownAlloca(simpleNode);
   }
-  else if (auto callNode = dynamic_cast<const CallNode*>(&simpleNode))
+  else if (auto callNode = dynamic_cast<const CallNode *>(&simpleNode))
   {
     EliminateTopDownCall(*callNode);
   }
@@ -748,7 +748,7 @@ TopDownMemoryNodeEliminator::EliminateTopDownAlloca(const rvsdg::simple_node & n
   JLM_ASSERT(is<alloca_op>(&node));
 
   auto & allocaNode = Context_->GetPointsToGraph().GetAllocaNode(node);
-  Context_->AddLiveNodes(*node.region(), {&allocaNode});
+  Context_->AddLiveNodes(*node.region(), { &allocaNode });
 }
 
 void
@@ -758,27 +758,27 @@ TopDownMemoryNodeEliminator::EliminateTopDownCall(const CallNode & callNode)
 
   switch (callTypeClassifier->GetCallType())
   {
-    case CallTypeClassifier::CallType::NonRecursiveDirectCall:
-      EliminateTopDownNonRecursiveDirectCall(callNode, *callTypeClassifier);
-      break;
-    case CallTypeClassifier::CallType::RecursiveDirectCall:
-      EliminateTopDownRecursiveDirectCall(callNode, *callTypeClassifier);
-      break;
-    case CallTypeClassifier::CallType::ExternalCall:
-      EliminateTopDownExternalCall(callNode, *callTypeClassifier);
-      break;
-    case CallTypeClassifier::CallType::IndirectCall:
-      EliminateTopDownIndirectCall(callNode, *callTypeClassifier);
-      break;
-    default:
-      JLM_UNREACHABLE("Unhandled call type classifier!");
+  case CallTypeClassifier::CallType::NonRecursiveDirectCall:
+    EliminateTopDownNonRecursiveDirectCall(callNode, *callTypeClassifier);
+    break;
+  case CallTypeClassifier::CallType::RecursiveDirectCall:
+    EliminateTopDownRecursiveDirectCall(callNode, *callTypeClassifier);
+    break;
+  case CallTypeClassifier::CallType::ExternalCall:
+    EliminateTopDownExternalCall(callNode, *callTypeClassifier);
+    break;
+  case CallTypeClassifier::CallType::IndirectCall:
+    EliminateTopDownIndirectCall(callNode, *callTypeClassifier);
+    break;
+  default:
+    JLM_UNREACHABLE("Unhandled call type classifier!");
   }
 }
 
 void
 TopDownMemoryNodeEliminator::EliminateTopDownNonRecursiveDirectCall(
-  const CallNode & callNode,
-  const CallTypeClassifier & callTypeClassifier)
+    const CallNode & callNode,
+    const CallTypeClassifier & callTypeClassifier)
 {
   JLM_ASSERT(callTypeClassifier.IsNonRecursiveDirectCall());
 
@@ -791,8 +791,8 @@ TopDownMemoryNodeEliminator::EliminateTopDownNonRecursiveDirectCall(
 
 void
 TopDownMemoryNodeEliminator::EliminateTopDownRecursiveDirectCall(
-  const CallNode &callNode,
-  const CallTypeClassifier &callTypeClassifier)
+    const CallNode & callNode,
+    const CallTypeClassifier & callTypeClassifier)
 {
   JLM_ASSERT(callTypeClassifier.IsRecursiveDirectCall());
 
@@ -805,8 +805,8 @@ TopDownMemoryNodeEliminator::EliminateTopDownRecursiveDirectCall(
 
 void
 TopDownMemoryNodeEliminator::EliminateTopDownExternalCall(
-  const CallNode &callNode,
-  const CallTypeClassifier &callTypeClassifier)
+    const CallNode & callNode,
+    const CallTypeClassifier & callTypeClassifier)
 {
   JLM_ASSERT(callTypeClassifier.IsExternalCall());
 
@@ -823,8 +823,8 @@ TopDownMemoryNodeEliminator::EliminateTopDownExternalCall(
 
 void
 TopDownMemoryNodeEliminator::EliminateTopDownIndirectCall(
-  const CallNode &indirectCall,
-  const CallTypeClassifier &callTypeClassifier)
+    const CallNode & indirectCall,
+    const CallTypeClassifier & callTypeClassifier)
 {
   JLM_ASSERT(callTypeClassifier.IsIndirectCall());
 
@@ -845,11 +845,11 @@ TopDownMemoryNodeEliminator::InitializeLiveNodes(const RvsdgModule & rvsdgModule
   auto nodes = rvsdg::graph::ExtractTailNodes(rvsdgModule.Rvsdg());
   for (auto & node : nodes)
   {
-    if (auto lambdaNode = dynamic_cast<const lambda::node*>(node))
+    if (auto lambdaNode = dynamic_cast<const lambda::node *>(node))
     {
       InitializeLiveNodesLambda(*lambdaNode);
     }
-    else if (auto phiNode = dynamic_cast<const phi::node*>(node))
+    else if (auto phiNode = dynamic_cast<const phi::node *>(node))
     {
       auto lambdaNodes = phi::node::ExtractLambdaNodes(*phiNode);
       for (auto & phiLambdaNode : lambdaNodes)
@@ -857,7 +857,7 @@ TopDownMemoryNodeEliminator::InitializeLiveNodes(const RvsdgModule & rvsdgModule
         InitializeLiveNodesLambda(*phiLambdaNode);
       }
     }
-    else if (dynamic_cast<const delta::node*>(node))
+    else if (dynamic_cast<const delta::node *>(node))
     {
       // Nothing needs to be done for delta nodes.
     }
@@ -882,30 +882,32 @@ TopDownMemoryNodeEliminator::InitializeLiveNodesLambda(const lambda::node & lamb
 
 bool
 TopDownMemoryNodeEliminator::CheckInvariants(
-  const RvsdgModule & rvsdgModule,
-  const MemoryNodeProvisioning &seedProvisioning,
-  const Provisioning &provisioning)
+    const RvsdgModule & rvsdgModule,
+    const MemoryNodeProvisioning & seedProvisioning,
+    const Provisioning & provisioning)
 {
-  std::function<void(const rvsdg::region&, std::vector<const rvsdg::region*>&, std::vector<const CallNode*>&)>
-    collectRegionsAndCalls = [&](
-      const rvsdg::region & rootRegion,
-      std::vector<const rvsdg::region*> & regions,
-      std::vector<const CallNode*> & callNodes)
+  std::function<void(
+      const rvsdg::region &,
+      std::vector<const rvsdg::region *> &,
+      std::vector<const CallNode *> &)>
+      collectRegionsAndCalls = [&](const rvsdg::region & rootRegion,
+                                   std::vector<const rvsdg::region *> & regions,
+                                   std::vector<const CallNode *> & callNodes)
   {
     for (auto & node : rootRegion.nodes)
     {
-      if (auto lambdaNode = dynamic_cast<const lambda::node*>(&node))
+      if (auto lambdaNode = dynamic_cast<const lambda::node *>(&node))
       {
         auto lambdaSubregion = lambdaNode->subregion();
         regions.push_back(lambdaSubregion);
         collectRegionsAndCalls(*lambdaSubregion, regions, callNodes);
       }
-      else if (auto phiNode = dynamic_cast<const phi::node*>(&node))
+      else if (auto phiNode = dynamic_cast<const phi::node *>(&node))
       {
         auto subregion = phiNode->subregion();
         collectRegionsAndCalls(*subregion, regions, callNodes);
       }
-      else if (auto gammaNode = dynamic_cast<const rvsdg::gamma_node*>(&node))
+      else if (auto gammaNode = dynamic_cast<const rvsdg::gamma_node *>(&node))
       {
         for (size_t n = 0; n < gammaNode->nsubregions(); n++)
         {
@@ -914,21 +916,21 @@ TopDownMemoryNodeEliminator::CheckInvariants(
           collectRegionsAndCalls(*subregion, regions, callNodes);
         }
       }
-      else if (auto thetaNode = dynamic_cast<const rvsdg::theta_node*>(&node))
+      else if (auto thetaNode = dynamic_cast<const rvsdg::theta_node *>(&node))
       {
         auto subregion = thetaNode->subregion();
         regions.push_back(subregion);
         collectRegionsAndCalls(*subregion, regions, callNodes);
       }
-      else if (auto callNode = dynamic_cast<const CallNode*>(&node))
+      else if (auto callNode = dynamic_cast<const CallNode *>(&node))
       {
         callNodes.push_back(callNode);
       }
     }
   };
 
-  std::vector<const CallNode*> callNodes;
-  std::vector<const rvsdg::region*> regions;
+  std::vector<const CallNode *> callNodes;
+  std::vector<const rvsdg::region *> regions;
   collectRegionsAndCalls(*rvsdgModule.Rvsdg().root(), regions, callNodes);
 
   for (auto region : regions)
@@ -952,7 +954,7 @@ TopDownMemoryNodeEliminator::CheckInvariants(
   {
     auto & callEntry = provisioning.GetCallEntryNodes(*callNode);
     auto & seedCallEntry = provisioning.GetCallEntryNodes(*callNode);
-    if(!callEntry.IsSubsetOf(seedCallEntry))
+    if (!callEntry.IsSubsetOf(seedCallEntry))
     {
       return false;
     }

--- a/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.cpp
+++ b/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.cpp
@@ -25,37 +25,21 @@ class TopDownMemoryNodeEliminator::Statistics final : public util::Statistics
 public:
   ~Statistics() override = default;
 
-  explicit Statistics(util::filepath sourceFile)
-      : util::Statistics(Statistics::Id::TopDownMemoryNodeEliminator),
-        NumRvsdgNodes_(0),
-        SourceFile_(std::move(sourceFile))
+  explicit Statistics(const util::filepath & sourceFile)
+      : util::Statistics(Statistics::Id::TopDownMemoryNodeEliminator, sourceFile)
   {}
 
   void
   Start(const rvsdg::graph & graph) noexcept
   {
-    NumRvsdgNodes_ = rvsdg::nnodes(graph.root());
-    Timer_.start();
+    AddMeasurement(Label::NumRvsdgNodes, rvsdg::nnodes(graph.root()));
+    AddTimer(Label::Timer).start();
   }
 
   void
   Stop() noexcept
   {
-    Timer_.stop();
-  }
-
-  [[nodiscard]] std::string
-  ToString() const override
-  {
-    return util::strfmt(
-        "TopDownMemoryNodeEliminator ",
-        SourceFile_.to_str(),
-        " ",
-        "#RvsdgNodes:",
-        NumRvsdgNodes_,
-        " ",
-        "Time[ns]:",
-        Timer_.ns());
+    GetTimer(Label::Timer).stop();
   }
 
   static std::unique_ptr<Statistics>
@@ -63,11 +47,6 @@ public:
   {
     return std::make_unique<Statistics>(sourceFile);
   }
-
-private:
-  size_t NumRvsdgNodes_;
-  util::filepath SourceFile_;
-  util::timer Timer_;
 };
 
 /** \brief Memory node provisioning of TopDownMemoryNodeEliminator

--- a/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.hpp
+++ b/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.hpp
@@ -169,11 +169,25 @@ private:
       const CallNode & indirectCall,
       const CallTypeClassifier & callTypeClassifier);
 
+  /**
+   * Collects for every tail-lambda all the memory nodes that would be alive at the beginning of a
+   * tail-lambda's execution. A tail-lambda is a lambda that is only dead or exported, i.e., no
+   * other node in \p rvsdgModule depends on it.
+   *
+   * @param rvsdgModule RVSDG module the analysis is performed on.
+   */
   void
-  InitializeLiveNodes(const RvsdgModule & rvsdgModule);
+  InitializeLiveNodesTailLambdas(const RvsdgModule & rvsdgModule);
 
+  /**
+   * Initializes the memory nodes that are alive at the beginning of every tail-lambda.
+   *
+   * @param tailLambdaNode Lambda node for which the memory nodes are initialized.
+   *
+   * @see InitializeLiveNodesTailLambdas()
+   */
   void
-  InitializeLiveNodesLambda(const lambda::node & lambdaNode);
+  InitializeLiveNodesTailLambda(const lambda::node & tailLambdaNode);
 
   /**
    * The function checks the following invariants:

--- a/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.hpp
+++ b/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.hpp
@@ -126,7 +126,7 @@ private:
   /**
    * Processes the intra-procedural nodes in a lambda, theta, or gamma subregion top-down. The
    * top-down visitation ensures that the live memory nodes are added to the live sets when the
-   * respective RVSDG nodes appear in the execution.
+   * respective RVSDG nodes appear in the execution order.
    *
    * @param region A lambda, theta, or gamma subregion.
    */

--- a/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.hpp
+++ b/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.hpp
@@ -101,7 +101,6 @@ public:
    *
    * @param rvsdgModule The RVSDG module on which the provisioning should be performed.
    * @param seedProvisioning A provisioning from which memory nodes will be eliminated.
-   * @param statisticsCollector The statistics collector for collecting pass statistics.
    *
    * @return A new instance of MemoryNodeProvisioning.
    */

--- a/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.hpp
+++ b/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.hpp
@@ -175,19 +175,21 @@ private:
    * other node in \p rvsdgModule depends on it.
    *
    * @param rvsdgModule RVSDG module the analysis is performed on.
+   *
+   * @see graph::ExtractTailNodes()
    */
   void
-  InitializeLiveNodesTailLambdas(const RvsdgModule & rvsdgModule);
+  InitializeLiveNodesOfTailLambdas(const RvsdgModule & rvsdgModule);
 
   /**
    * Initializes the memory nodes that are alive at the beginning of every tail-lambda.
    *
    * @param tailLambdaNode Lambda node for which the memory nodes are initialized.
    *
-   * @see InitializeLiveNodesTailLambdas()
+   * @see InitializeLiveNodesOfTailLambdas()
    */
   void
-  InitializeLiveNodesTailLambda(const lambda::node & tailLambdaNode);
+  InitializeLiveNodesOfTailLambda(const lambda::node & tailLambdaNode);
 
   /**
    * The function checks the following invariants:

--- a/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.hpp
+++ b/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.hpp
@@ -14,8 +14,15 @@ namespace jlm::llvm
 class CallNode;
 class CallTypeClassifier;
 
-namespace lambda { class node; }
-namespace phi { class node; }
+namespace lambda
+{
+class node;
+}
+
+namespace phi
+{
+class node;
+}
 }
 
 namespace jlm::rvsdg
@@ -33,18 +40,19 @@ namespace jlm::llvm::aa
 
 /** \brief Top-down memory node eliminator
  *
- * The key idea of the TopDownMemoryNodeEliminator is to restrict the lifetime of memory states by eliminating the
- * respective memory nodes from regions where the corresponding RVSDG nodes are not alive. For example, the lifetime
- * of a stack allocation from an alloca node is only within the function the alloca node is alive.
+ * The key idea of the TopDownMemoryNodeEliminator is to restrict the lifetime of memory states by
+ * eliminating the respective memory nodes from regions where the corresponding RVSDG nodes are not
+ * alive. For example, the lifetime of a stack allocation from an alloca node is only within the
+ * function the alloca node is alive.
  *
- * The AgnosticMemoryNodeProvider and the RegionAwareMemoryNodeProvider are only region-aware, but not
- * lifetime-aware. In other words, they restrict the number of regions a memory state needs to be routed through, but do
- * not limit the lifetime of the respective memory states. The provisioning produced by these memory node providers
- * serves as seed provisioning for the TopDownMemoryNodeEliminator, which restricts then the lifetime of memory
- * locations.
+ * The AgnosticMemoryNodeProvider and the RegionAwareMemoryNodeProvider are only region-aware, but
+ * not lifetime-aware. In other words, they restrict the number of regions a memory state needs to
+ * be routed through, but do not limit the lifetime of the respective memory states. The
+ * provisioning produced by these memory node providers serves as seed provisioning for the
+ * TopDownMemoryNodeEliminator, which restricts then the lifetime of memory locations.
  *
- * The TopDownMemoryNodeEliminator only restricts the lifetime of memory states from alloca nodes before the nodes
- * are alive.
+ * The TopDownMemoryNodeEliminator only restricts the lifetime of memory states from alloca nodes
+ * before the nodes are alive.
  */
 class TopDownMemoryNodeEliminator final : public MemoryNodeEliminator
 {
@@ -57,21 +65,21 @@ public:
 
   TopDownMemoryNodeEliminator();
 
-  TopDownMemoryNodeEliminator(const TopDownMemoryNodeEliminator&) = delete;
+  TopDownMemoryNodeEliminator(const TopDownMemoryNodeEliminator &) = delete;
 
-  TopDownMemoryNodeEliminator(TopDownMemoryNodeEliminator&&) = delete;
+  TopDownMemoryNodeEliminator(TopDownMemoryNodeEliminator &&) = delete;
 
-  TopDownMemoryNodeEliminator&
-  operator=(const TopDownMemoryNodeEliminator&) = delete;
+  TopDownMemoryNodeEliminator &
+  operator=(const TopDownMemoryNodeEliminator &) = delete;
 
-  TopDownMemoryNodeEliminator&
-  operator=(TopDownMemoryNodeEliminator&&) = delete;
+  TopDownMemoryNodeEliminator &
+  operator=(TopDownMemoryNodeEliminator &&) = delete;
 
   std::unique_ptr<MemoryNodeProvisioning>
   EliminateMemoryNodes(
-    const RvsdgModule & rvsdgModule,
-    const MemoryNodeProvisioning & seedProvisioning,
-    util::StatisticsCollector & statisticsCollector) override;
+      const RvsdgModule & rvsdgModule,
+      const MemoryNodeProvisioning & seedProvisioning,
+      util::StatisticsCollector & statisticsCollector) override;
 
   /**
    * Creates a TopDownMemoryNodeEliminator and calls the EliminateMemoryNodes() method.
@@ -84,9 +92,9 @@ public:
    */
   static std::unique_ptr<MemoryNodeProvisioning>
   CreateAndEliminate(
-    const RvsdgModule & rvsdgModule,
-    const MemoryNodeProvisioning & seedProvisioning,
-    util::StatisticsCollector & statisticsCollector);
+      const RvsdgModule & rvsdgModule,
+      const MemoryNodeProvisioning & seedProvisioning,
+      util::StatisticsCollector & statisticsCollector);
 
   /**
    * Creates a TopDownMemoryNodeEliminator and calls the EliminateMemoryNodes() method.
@@ -99,8 +107,8 @@ public:
    */
   static std::unique_ptr<MemoryNodeProvisioning>
   CreateAndEliminate(
-    const RvsdgModule & rvsdgModule,
-    const MemoryNodeProvisioning & seedProvisioning);
+      const RvsdgModule & rvsdgModule,
+      const MemoryNodeProvisioning & seedProvisioning);
 
 private:
   void
@@ -144,23 +152,23 @@ private:
 
   void
   EliminateTopDownNonRecursiveDirectCall(
-    const CallNode & callNode,
-    const CallTypeClassifier & callTypeClassifier);
+      const CallNode & callNode,
+      const CallTypeClassifier & callTypeClassifier);
 
   void
   EliminateTopDownRecursiveDirectCall(
-    const CallNode & callNode,
-    const CallTypeClassifier & callTypeClassifier);
+      const CallNode & callNode,
+      const CallTypeClassifier & callTypeClassifier);
 
   void
   EliminateTopDownExternalCall(
-    const CallNode & callNode,
-    const CallTypeClassifier & callTypeClassifier);
+      const CallNode & callNode,
+      const CallTypeClassifier & callTypeClassifier);
 
   void
   EliminateTopDownIndirectCall(
-    const CallNode & indirectCall,
-    const CallTypeClassifier & callTypeClassifier);
+      const CallNode & indirectCall,
+      const CallTypeClassifier & callTypeClassifier);
 
   void
   InitializeLiveNodes(const RvsdgModule & rvsdgModule);
@@ -171,8 +179,9 @@ private:
   /**
    * The function checks the following invariants:
    *
-   * 1. The set of memory nodes computed for each region and call node by TopDownMemoryNodeEliminator are a subset of
-   * the corresponding set of memory nodes from the seed provisioning.
+   * 1. The set of memory nodes computed for each region and call node by
+   * TopDownMemoryNodeEliminator are a subset of the corresponding set of memory nodes from the seed
+   * provisioning.
    *
    * @param rvsdgModule The RVSDG module for which the provisioning is computed.
    * @param seedProvisioning The seed provisioning. \see EliminateMemoryNodes
@@ -182,13 +191,13 @@ private:
    */
   static bool
   CheckInvariants(
-    const RvsdgModule & rvsdgModule,
-    const MemoryNodeProvisioning & seedProvisioning,
-    const Provisioning & provisioning);
+      const RvsdgModule & rvsdgModule,
+      const MemoryNodeProvisioning & seedProvisioning,
+      const Provisioning & provisioning);
 
   std::unique_ptr<Context> Context_;
 };
 
 }
 
-#endif //JLM_LLVM_OPT_ALIAS_ANALYSIS_TOPDOWNMEMORYNODEELIMINATOR_HPP
+#endif // JLM_LLVM_OPT_ALIAS_ANALYSIS_TOPDOWNMEMORYNODEELIMINATOR_HPP

--- a/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.hpp
+++ b/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.hpp
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2023 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#ifndef JLM_LLVM_OPT_ALIAS_ANALYSIS_TOPDOWNMEMORYNODEELIMINATOR_HPP
+#define JLM_LLVM_OPT_ALIAS_ANALYSIS_TOPDOWNMEMORYNODEELIMINATOR_HPP
+
+#include <jlm/llvm/opt/alias-analyses/MemoryNodeEliminator.hpp>
+#include <jlm/util/Statistics.hpp>
+
+namespace jlm::llvm
+{
+class CallNode;
+class CallTypeClassifier;
+
+namespace lambda { class node; }
+namespace phi { class node; }
+}
+
+namespace jlm::rvsdg
+{
+class gamma_node;
+class node;
+class region;
+class simple_node;
+class structural_node;
+class theta_node;
+}
+
+namespace jlm::llvm::aa
+{
+
+/** \brief Top-down memory node eliminator
+ *
+ * The key idea of the TopDownMemoryNodeEliminator is to restrict the lifetime of memory states by eliminating the
+ * respective memory nodes from regions where the corresponding RVSDG nodes are not alive. For example, the lifetime
+ * of a stack allocation from an alloca node is only within the function the alloca node is alive.
+ *
+ * The AgnosticMemoryNodeProvider and the RegionAwareMemoryNodeProvider are only region-aware, but not
+ * lifetime-aware. In other words, they restrict the number of regions a memory state needs to be routed through, but do
+ * not limit the lifetime of the respective memory states. The provisioning produced by these memory node providers
+ * serves as seed provisioning for the TopDownMemoryNodeEliminator, which restricts then the lifetime of memory
+ * locations.
+ *
+ * The TopDownMemoryNodeEliminator only restricts the lifetime of memory states from alloca nodes before the nodes
+ * are alive.
+ */
+class TopDownMemoryNodeEliminator final : public MemoryNodeEliminator
+{
+  class Context;
+  class Provisioning;
+  class Statistics;
+
+public:
+  ~TopDownMemoryNodeEliminator() noexcept override;
+
+  TopDownMemoryNodeEliminator();
+
+  TopDownMemoryNodeEliminator(const TopDownMemoryNodeEliminator&) = delete;
+
+  TopDownMemoryNodeEliminator(TopDownMemoryNodeEliminator&&) = delete;
+
+  TopDownMemoryNodeEliminator&
+  operator=(const TopDownMemoryNodeEliminator&) = delete;
+
+  TopDownMemoryNodeEliminator&
+  operator=(TopDownMemoryNodeEliminator&&) = delete;
+
+  std::unique_ptr<MemoryNodeProvisioning>
+  EliminateMemoryNodes(
+    const RvsdgModule & rvsdgModule,
+    const MemoryNodeProvisioning & seedProvisioning,
+    util::StatisticsCollector & statisticsCollector) override;
+
+  /**
+   * Creates a TopDownMemoryNodeEliminator and calls the EliminateMemoryNodes() method.
+   *
+   * @param rvsdgModule The RVSDG module on which the provisioning should be performed.
+   * @param seedProvisioning A provisioning from which memory nodes will be eliminated.
+   * @param statisticsCollector The statistics collector for collecting pass statistics.
+   *
+   * @return A new instance of MemoryNodeProvisioning.
+   */
+  static std::unique_ptr<MemoryNodeProvisioning>
+  CreateAndEliminate(
+    const RvsdgModule & rvsdgModule,
+    const MemoryNodeProvisioning & seedProvisioning,
+    util::StatisticsCollector & statisticsCollector);
+
+  /**
+   * Creates a TopDownMemoryNodeEliminator and calls the EliminateMemoryNodes() method.
+   *
+   * @param rvsdgModule The RVSDG module on which the provisioning should be performed.
+   * @param seedProvisioning A provisioning from which memory nodes will be eliminated.
+   * @param statisticsCollector The statistics collector for collecting pass statistics.
+   *
+   * @return A new instance of MemoryNodeProvisioning.
+   */
+  static std::unique_ptr<MemoryNodeProvisioning>
+  CreateAndEliminate(
+    const RvsdgModule & rvsdgModule,
+    const MemoryNodeProvisioning & seedProvisioning);
+
+private:
+  void
+  EliminateTopDown(const RvsdgModule & rvsdgModule);
+
+  void
+  EliminateTopDownRootRegion(rvsdg::region & region);
+
+  void
+  EliminateTopDownRegion(rvsdg::region & region);
+
+  void
+  EliminateTopDownStructuralNode(const rvsdg::structural_node & structuralNode);
+
+  void
+  EliminateTopDownLambda(const lambda::node & lambdaNode);
+
+  void
+  EliminateTopDownLambdaEntry(const lambda::node & lambdaNode);
+
+  void
+  EliminateTopDownLambdaExit(const lambda::node & lambdaNode);
+
+  void
+  EliminateTopDownPhi(const phi::node & phiNode);
+
+  void
+  EliminateTopDownGamma(const rvsdg::gamma_node & gammaNode);
+
+  void
+  EliminateTopDownTheta(const rvsdg::theta_node & thetaNode);
+
+  void
+  EliminateTopDownSimpleNode(const rvsdg::simple_node & simpleNode);
+
+  void
+  EliminateTopDownAlloca(const rvsdg::simple_node & node);
+
+  void
+  EliminateTopDownCall(const CallNode & callNode);
+
+  void
+  EliminateTopDownNonRecursiveDirectCall(
+    const CallNode & callNode,
+    const CallTypeClassifier & callTypeClassifier);
+
+  void
+  EliminateTopDownRecursiveDirectCall(
+    const CallNode & callNode,
+    const CallTypeClassifier & callTypeClassifier);
+
+  void
+  EliminateTopDownExternalCall(
+    const CallNode & callNode,
+    const CallTypeClassifier & callTypeClassifier);
+
+  void
+  EliminateTopDownIndirectCall(
+    const CallNode & indirectCall,
+    const CallTypeClassifier & callTypeClassifier);
+
+  void
+  InitializeLiveNodes(const RvsdgModule & rvsdgModule);
+
+  void
+  InitializeLiveNodesLambda(const lambda::node & lambdaNode);
+
+  /**
+   * The function checks the following invariants:
+   *
+   * 1. The set of memory nodes computed for each region and call node by TopDownMemoryNodeEliminator are a subset of
+   * the corresponding set of memory nodes from the seed provisioning.
+   *
+   * @param rvsdgModule The RVSDG module for which the provisioning is computed.
+   * @param seedProvisioning The seed provisioning. \see EliminateMemoryNodes
+   * @param provisioning The computed provisioning from TopDownMemoryNodeEliminator.
+   *
+   * @return Returns true if all invariants are fulfilled, otherwise false.
+   */
+  static bool
+  CheckInvariants(
+    const RvsdgModule & rvsdgModule,
+    const MemoryNodeProvisioning & seedProvisioning,
+    const Provisioning & provisioning);
+
+  std::unique_ptr<Context> Context_;
+};
+
+}
+
+#endif //JLM_LLVM_OPT_ALIAS_ANALYSIS_TOPDOWNMEMORYNODEELIMINATOR_HPP

--- a/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.hpp
+++ b/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.hpp
@@ -113,9 +113,23 @@ private:
   void
   EliminateTopDown(const RvsdgModule & rvsdgModule);
 
+  /**
+   * Processes the inter-procedural RVSDG nodes (lambda, phi, and delta nodes) in the root region
+   * or a phi subregion bottom-up. The bottom-up visitation ensures that all call nodes are
+   * visited before the respective lambda nodes are visited.
+   *
+   * @param region The RVSDG root region or a phi subregion.
+   */
   void
   EliminateTopDownRootRegion(rvsdg::region & region);
 
+  /**
+   * Processes the intra-procedural nodes in a lambda, theta, or gamma subregion top-down. The
+   * top-down visitation ensures that the live memory nodes are added to the live sets when the
+   * respective RVSDG nodes appear in the execution.
+   *
+   * @param region A lambda, theta, or gamma subregion.
+   */
   void
   EliminateTopDownRegion(rvsdg::region & region);
 

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -182,10 +182,10 @@ JlmOptCommandLineOptions::FromCommandLineArgumentToStatisticsId(
     const std::string & commandLineArgument)
 {
   try
-        {
-        return GetStatisticsIdCommandLineArguments().LookupValue(commandLineArgument);
-         }
-        catch (...)
+  {
+    return GetStatisticsIdCommandLineArguments().LookupValue(commandLineArgument);
+  }
+  catch (...)
   {
     throw util::error("Unknown command line argument: " + commandLineArgument);
   }
@@ -196,8 +196,8 @@ JlmOptCommandLineOptions::ToCommandLineArgument(util::Statistics::Id statisticsI
 {
   try{
     return GetStatisticsIdCommandLineArguments().LookupKey(statisticsId).data();
-   }
-        catch (...)
+  }
+  catch (...)
   {
     throw util::error("Unknown statistics identifier");
   }

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -296,7 +296,8 @@ JlmOptCommandLineOptions::GetStatisticsIdCommandLineArguments()
     { util::Statistics::Id::RvsdgDestruction, "print-rvsdg-destruction" },
     { util::Statistics::Id::RvsdgOptimization, "print-rvsdg-optimization" },
     { util::Statistics::Id::SteensgaardAnalysis, "print-steensgaard-analysis" },
-    { util::Statistics::Id::ThetaGammaInversion, "print-ivt-stat" }
+    { util::Statistics::Id::ThetaGammaInversion, "print-ivt-stat" },
+    { util::Statistics::Id::TopDownMemoryNodeEliminator, "TopDownMemoryNodeEliminator" }
   };
 
   auto firstIndex = static_cast<size_t>(util::Statistics::Id::FirstEnumValue);

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -194,7 +194,8 @@ JlmOptCommandLineOptions::FromCommandLineArgumentToStatisticsId(
 const char *
 JlmOptCommandLineOptions::ToCommandLineArgument(util::Statistics::Id statisticsId)
 {
-  try{
+  try
+  {
     return GetStatisticsIdCommandLineArguments().LookupKey(statisticsId).data();
   }
   catch (...)

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -182,10 +182,10 @@ JlmOptCommandLineOptions::FromCommandLineArgumentToStatisticsId(
     const std::string & commandLineArgument)
 {
   try
-  {
-    return GetStatisticsIdCommandLineArguments().LookupValue(commandLineArgument);
-  }
-  catch (...)
+        {
+        return GetStatisticsIdCommandLineArguments().LookupValue(commandLineArgument);
+         }
+        catch (...)
   {
     throw util::error("Unknown command line argument: " + commandLineArgument);
   }
@@ -194,11 +194,10 @@ JlmOptCommandLineOptions::FromCommandLineArgumentToStatisticsId(
 const char *
 JlmOptCommandLineOptions::ToCommandLineArgument(util::Statistics::Id statisticsId)
 {
-  try
-  {
+  try{
     return GetStatisticsIdCommandLineArguments().LookupKey(statisticsId).data();
-  }
-  catch (...)
+   }
+        catch (...)
   {
     throw util::error("Unknown statistics identifier");
   }

--- a/jlm/util/Statistics.cpp
+++ b/jlm/util/Statistics.cpp
@@ -40,7 +40,8 @@ GetStatisticsIdNames()
     { Statistics::Id::RvsdgDestruction, "RVSDGDESTRUCTION" },
     { Statistics::Id::RvsdgOptimization, "RVSDGOPTIMIZATION" },
     { Statistics::Id::SteensgaardAnalysis, "SteensgaardAnalysis" },
-    { Statistics::Id::ThetaGammaInversion, "IVT" }
+    { Statistics::Id::ThetaGammaInversion, "IVT" },
+    { Statistics::Id::TopDownMemoryNodeEliminator, "TopDownMemoryNodeEliminator" }
   };
   // Make sure every Statistic is mentioned in the mapping
   auto lastIdx = static_cast<size_t>(Statistics::Id::LastEnumValue);

--- a/jlm/util/Statistics.hpp
+++ b/jlm/util/Statistics.hpp
@@ -52,6 +52,7 @@ public:
     RvsdgOptimization,
     SteensgaardAnalysis,
     ThetaGammaInversion,
+    TopDownMemoryNodeEliminator,
 
     LastEnumValue // must always be the last enum value, used for iteration
   };

--- a/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
@@ -2016,10 +2016,10 @@ ValidateMemcpyTestSteensgaardAgnosticTopDown(const jlm::tests::MemcpyTest & test
     assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 5, 1));
 
     auto load = jlm::rvsdg::node_output::node(test.LambdaF().fctresult(0)->origin());
-    assert(is<LoadOperation>(*load, 2, 2));
+    assert(is<LoadOperation>(*load, 3, 3));
 
     auto store = jlm::rvsdg::node_output::node(load->input(1)->origin());
-    assert(is<StoreOperation>(*store, 3, 1));
+    assert(is<StoreOperation>(*store, 4, 2));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(store->input(2)->origin());
     assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 5));
@@ -2047,7 +2047,7 @@ ValidateMemcpyTestSteensgaardAgnosticTopDown(const jlm::tests::MemcpyTest & test
         memcpy = node;
     }
     assert(memcpy != nullptr);
-    assert(is<Memcpy>(*memcpy, 6, 2));
+    assert(is<Memcpy>(*memcpy, 8, 4));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(memcpy->input(5)->origin());
     assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 5));

--- a/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
@@ -40,8 +40,8 @@ ValidateTest(std::function<void(const Test &)> validateEncoding)
       "Provider should be derived from MemoryNodeProvider class.");
 
   std::cout << "\n###\n";
-  std::cout << "### Performing Test " << typeid(Test).name()
-            << " using [" << typeid(Analysis).name() << ", " << typeid(Provider).name() << "]\n";
+  std::cout << "### Performing Test " << typeid(Test).name() << " using ["
+            << typeid(Analysis).name() << ", " << typeid(Provider).name() << "]\n";
   std::cout << "###\n";
 
   Test test;
@@ -753,7 +753,7 @@ ValidateIndirectCallTest1SteensgaardAgnostic(const jlm::tests::IndirectCallTest1
     assert(test.GetLambdaIndcall().subregion()->nnodes() == 5);
 
     auto lambda_exit_mux =
-          jlm::rvsdg::node_output::node(test.GetLambdaIndcall().fctresult(2)->origin());
+        jlm::rvsdg::node_output::node(test.GetLambdaIndcall().fctresult(2)->origin());
     assert(is<aa::LambdaExitMemStateOperator>(*lambda_exit_mux, 5, 1));
 
     auto call_exit_mux = jlm::rvsdg::node_output::node(lambda_exit_mux->input(0)->origin());
@@ -774,7 +774,7 @@ ValidateIndirectCallTest1SteensgaardAgnostic(const jlm::tests::IndirectCallTest1
     assert(test.GetLambdaTest().subregion()->nnodes() == 9);
 
     auto lambda_exit_mux =
-          jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
+        jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
     assert(is<aa::LambdaExitMemStateOperator>(*lambda_exit_mux, 5, 1));
 
     auto call_exit_mux = jlm::rvsdg::node_output::node(lambda_exit_mux->input(0)->origin());
@@ -810,7 +810,7 @@ ValidateIndirectCallTest1SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(test.GetLambdaIndcall().subregion()->nnodes() == 5);
 
     auto lambdaExitMerge =
-          jlm::rvsdg::node_output::node(test.GetLambdaIndcall().fctresult(2)->origin());
+        jlm::rvsdg::node_output::node(test.GetLambdaIndcall().fctresult(2)->origin());
     assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 1, 1));
 
     auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
@@ -831,7 +831,7 @@ ValidateIndirectCallTest1SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(test.GetLambdaTest().subregion()->nnodes() == 9);
 
     auto lambdaExitMerge =
-          jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
+        jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
     assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 1, 1));
 
     auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
@@ -867,7 +867,7 @@ ValidateIndirectCallTest1SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(test.GetLambdaIndcall().subregion()->nnodes() == 5);
 
     auto lambda_exit_mux =
-          jlm::rvsdg::node_output::node(test.GetLambdaIndcall().fctresult(2)->origin());
+        jlm::rvsdg::node_output::node(test.GetLambdaIndcall().fctresult(2)->origin());
     assert(is<aa::LambdaExitMemStateOperator>(*lambda_exit_mux, 5, 1));
 
     auto call_exit_mux = jlm::rvsdg::node_output::node(lambda_exit_mux->input(0)->origin());
@@ -888,7 +888,7 @@ ValidateIndirectCallTest1SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(test.GetLambdaTest().subregion()->nnodes() == 9);
 
     auto lambda_exit_mux =
-          jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
+        jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
     assert(is<aa::LambdaExitMemStateOperator>(*lambda_exit_mux, 5, 1));
 
     auto call_exit_mux = jlm::rvsdg::node_output::node(lambda_exit_mux->input(0)->origin());
@@ -970,7 +970,8 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
   {
     assert(test.GetLambdaThree().subregion()->nnodes() == 2);
 
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaThree().fctresult(2)->origin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::node_output::node(test.GetLambdaThree().fctresult(2)->origin());
     assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 0, 1));
   }
 
@@ -978,7 +979,8 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
   {
     assert(test.GetLambdaFour().subregion()->nnodes() == 2);
 
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaFour().fctresult(2)->origin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::node_output::node(test.GetLambdaFour().fctresult(2)->origin());
     assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 0, 1));
   }
 
@@ -1009,7 +1011,8 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
     assert(is<aa::CallExitMemStateOperator>(*callExitSplit, 1, 6));
 
-    auto callEntryMerge = jlm::rvsdg::node_output::node(test.GetCallIWithThree().input(3)->origin());
+    auto callEntryMerge =
+        jlm::rvsdg::node_output::node(test.GetCallIWithThree().input(3)->origin());
     assert(is<aa::CallEntryMemStateOperator>(*callEntryMerge, 6, 1));
 
     const jlm::rvsdg::node * storeNode = nullptr;
@@ -1075,7 +1078,8 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
   {
     assert(test.GetLambdaTest().subregion()->nnodes() == 16);
 
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
     assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 6, 1));
 
     auto loadG1 = input_node(*test.GetLambdaTest().cvargument(2)->begin());
@@ -1084,7 +1088,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     auto loadG2 = input_node(*test.GetLambdaTest().cvargument(3)->begin());
     assert(is<LoadOperation>(*loadG2, 2, 2));
 
-    auto lambdaEntrySplit= input_node(*test.GetLambdaTest().fctargument(1)->begin());
+    auto lambdaEntrySplit = input_node(*test.GetLambdaTest().fctargument(1)->begin());
     assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 6));
   }
 
@@ -1092,10 +1096,11 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
   {
     assert(test.GetLambdaTest2().subregion()->nnodes() == 7);
 
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaTest2().fctresult(2)->origin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::node_output::node(test.GetLambdaTest2().fctresult(2)->origin());
     assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 6, 1));
 
-    auto lambdaEntrySplit= input_node(*test.GetLambdaTest().fctargument(1)->begin());
+    auto lambdaEntrySplit = input_node(*test.GetLambdaTest().fctargument(1)->begin());
     assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 6));
   }
 }
@@ -1109,7 +1114,8 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
   {
     assert(test.GetLambdaThree().subregion()->nnodes() == 3);
 
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaThree().fctresult(2)->origin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::node_output::node(test.GetLambdaThree().fctresult(2)->origin());
     assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 13, 1));
 
     auto lambdaEntrySplit = input_node(*test.GetLambdaThree().fctargument(1)->begin());
@@ -1120,7 +1126,8 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
   {
     assert(test.GetLambdaFour().subregion()->nnodes() == 3);
 
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaFour().fctresult(2)->origin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::node_output::node(test.GetLambdaFour().fctresult(2)->origin());
     assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 13, 1));
 
     auto lambdaEntrySplit = input_node(*test.GetLambdaFour().fctargument(1)->begin());
@@ -1154,7 +1161,8 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
     assert(is<aa::CallExitMemStateOperator>(*callExitSplit, 1, 13));
 
-    auto callEntryMerge = jlm::rvsdg::node_output::node(test.GetCallIWithThree().input(3)->origin());
+    auto callEntryMerge =
+        jlm::rvsdg::node_output::node(test.GetCallIWithThree().input(3)->origin());
     assert(is<aa::CallEntryMemStateOperator>(*callEntryMerge, 13, 1));
 
     const jlm::rvsdg::node * storeNode = nullptr;
@@ -1227,7 +1235,8 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
   {
     assert(test.GetLambdaTest().subregion()->nnodes() == 17);
 
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
     assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 10, 1));
 
     auto loadG1 = input_node(*test.GetLambdaTest().cvargument(2)->begin());
@@ -1255,7 +1264,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     auto loadG2 = input_node(*test.GetLambdaTest().cvargument(3)->begin());
     assert(is<LoadOperation>(*loadG2, 2, 2));
 
-    auto lambdaEntrySplit= input_node(*test.GetLambdaTest().fctargument(1)->begin());
+    auto lambdaEntrySplit = input_node(*test.GetLambdaTest().fctargument(1)->begin());
     assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 10));
   }
 
@@ -1263,7 +1272,8 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
   {
     assert(test.GetLambdaTest2().subregion()->nnodes() == 8);
 
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaTest2().fctresult(2)->origin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::node_output::node(test.GetLambdaTest2().fctresult(2)->origin());
     assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 10, 1));
 
     auto callXEntryMerge = jlm::rvsdg::node_output::node(test.GetTest2CallX().input(3)->origin());
@@ -1288,7 +1298,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
       assert(input_node(user) == callXEntryMerge);
     }
 
-    auto lambdaEntrySplit= input_node(*test.GetLambdaTest2().fctargument(1)->begin());
+    auto lambdaEntrySplit = input_node(*test.GetLambdaTest2().fctargument(1)->begin());
     assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 10));
   }
 }
@@ -1358,7 +1368,7 @@ ValidateThetaTestSteensgaardAgnostic(const jlm::tests::ThetaTest & test)
   assert(is<aa::LambdaExitMemStateOperator>(*lambda_exit_mux, 2, 1));
 
   auto thetaOutput =
-        jlm::util::AssertedCast<jlm::rvsdg::theta_output>(lambda_exit_mux->input(0)->origin());
+      jlm::util::AssertedCast<jlm::rvsdg::theta_output>(lambda_exit_mux->input(0)->origin());
   auto theta = jlm::rvsdg::node_output::node(thetaOutput);
   assert(theta == test.theta);
 
@@ -1382,7 +1392,7 @@ ValidateThetaTestSteensgaardRegionAware(const jlm::tests::ThetaTest & test)
   assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
 
   auto thetaOutput =
-        jlm::util::AssertedCast<jlm::rvsdg::theta_output>(lambdaExitMerge->input(0)->origin());
+      jlm::util::AssertedCast<jlm::rvsdg::theta_output>(lambdaExitMerge->input(0)->origin());
   auto theta = jlm::rvsdg::node_output::node(thetaOutput);
   assert(theta == test.theta);
 
@@ -1406,7 +1416,7 @@ ValidateThetaTestSteensgaardAgnosticTopDown(const jlm::tests::ThetaTest & test)
   assert(is<aa::LambdaExitMemStateOperator>(*lambda_exit_mux, 2, 1));
 
   auto thetaOutput =
-        jlm::util::AssertedCast<jlm::rvsdg::theta_output>(lambda_exit_mux->input(0)->origin());
+      jlm::util::AssertedCast<jlm::rvsdg::theta_output>(lambda_exit_mux->input(0)->origin());
   auto theta = jlm::rvsdg::node_output::node(thetaOutput);
   assert(theta == test.theta);
 
@@ -1828,7 +1838,7 @@ ValidatePhiTestSteensgaardAgnostic(const jlm::tests::PhiTest1 & test)
   auto gammaStateIndex = store->input(2)->origin()->index();
 
   auto load1 =
-        jlm::rvsdg::node_output::node(test.gamma->exitvar(gammaStateIndex)->result(0)->origin());
+      jlm::rvsdg::node_output::node(test.gamma->exitvar(gammaStateIndex)->result(0)->origin());
   assert(is<LoadOperation>(*load1, 2, 2));
 
   auto load2 = jlm::rvsdg::node_output::node(load1->input(1)->origin());
@@ -1856,7 +1866,7 @@ ValidatePhiTestSteensgaardRegionAware(const jlm::tests::PhiTest1 & test)
   auto gammaStateIndex = store->input(2)->origin()->index();
 
   auto load1 =
-        jlm::rvsdg::node_output::node(test.gamma->exitvar(gammaStateIndex)->result(0)->origin());
+      jlm::rvsdg::node_output::node(test.gamma->exitvar(gammaStateIndex)->result(0)->origin());
   assert(is<LoadOperation>(*load1, 2, 2));
 
   auto load2 = jlm::rvsdg::node_output::node(load1->input(1)->origin());
@@ -1898,7 +1908,7 @@ ValidatePhiTestSteensgaardAgnosticTopDown(const jlm::tests::PhiTest1 & test)
   auto gammaStateIndex = storeNode->input(2)->origin()->index();
 
   auto load1 =
-        jlm::rvsdg::node_output::node(test.gamma->exitvar(gammaStateIndex)->result(0)->origin());
+      jlm::rvsdg::node_output::node(test.gamma->exitvar(gammaStateIndex)->result(0)->origin());
   assert(is<LoadOperation>(*load1, 2, 2));
 
   auto load2 = jlm::rvsdg::node_output::node(load1->input(1)->origin());
@@ -2074,276 +2084,124 @@ TestMemoryStateEncoder()
 {
   using namespace jlm::llvm::aa;
 
-  ValidateTest<
-    jlm::tests::StoreTest1,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidateStoreTest1SteensgaardAgnostic);
-  ValidateTest<
-    jlm::tests::StoreTest1,
-    Steensgaard,
-    RegionAwareMemoryNodeProvider
-  >(ValidateStoreTest1SteensgaardRegionAware);
-  ValidateTest<
-      jlm::tests::StoreTest1,
-      Steensgaard,
-      AgnosticTopDownMemoryNodeProvider
-      >(ValidateStoreTest1SteensgaardAgnosticTopDown);
+  ValidateTest<jlm::tests::StoreTest1, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateStoreTest1SteensgaardAgnostic);
+  ValidateTest<jlm::tests::StoreTest1, Steensgaard, RegionAwareMemoryNodeProvider>(
+      ValidateStoreTest1SteensgaardRegionAware);
+  ValidateTest<jlm::tests::StoreTest1, Steensgaard, AgnosticTopDownMemoryNodeProvider>(
+      ValidateStoreTest1SteensgaardAgnosticTopDown);
 
-  ValidateTest<
-    jlm::tests::StoreTest2,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidateStoreTest2SteensgaardAgnostic);
-  ValidateTest<
-    jlm::tests::StoreTest2,
-    Steensgaard,
-    RegionAwareMemoryNodeProvider
-  >(ValidateStoreTest2SteensgaardRegionAware);
-  ValidateTest<
-      jlm::tests::StoreTest2,
-      Steensgaard,
-      AgnosticTopDownMemoryNodeProvider
-      >(ValidateStoreTest2SteensgaardAgnosticTopDown);
+  ValidateTest<jlm::tests::StoreTest2, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateStoreTest2SteensgaardAgnostic);
+  ValidateTest<jlm::tests::StoreTest2, Steensgaard, RegionAwareMemoryNodeProvider>(
+      ValidateStoreTest2SteensgaardRegionAware);
+  ValidateTest<jlm::tests::StoreTest2, Steensgaard, AgnosticTopDownMemoryNodeProvider>(
+      ValidateStoreTest2SteensgaardAgnosticTopDown);
 
-  ValidateTest<
-    jlm::tests::LoadTest1,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidateLoadTest1SteensgaardAgnostic);
-  ValidateTest<
-    jlm::tests::LoadTest1,
-    Steensgaard,
-    RegionAwareMemoryNodeProvider
-  >(ValidateLoadTest1SteensgaardRegionAware);
-  ValidateTest<
-      jlm::tests::LoadTest1,
-      Steensgaard,
-      AgnosticTopDownMemoryNodeProvider
-      >(ValidateLoadTest1SteensgaardAgnosticTopDown);
+  ValidateTest<jlm::tests::LoadTest1, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateLoadTest1SteensgaardAgnostic);
+  ValidateTest<jlm::tests::LoadTest1, Steensgaard, RegionAwareMemoryNodeProvider>(
+      ValidateLoadTest1SteensgaardRegionAware);
+  ValidateTest<jlm::tests::LoadTest1, Steensgaard, AgnosticTopDownMemoryNodeProvider>(
+      ValidateLoadTest1SteensgaardAgnosticTopDown);
 
-  ValidateTest<
-    jlm::tests::LoadTest2,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidateLoadTest2SteensgaardAgnostic);
-  ValidateTest<
-    jlm::tests::LoadTest2,
-    Steensgaard,
-    RegionAwareMemoryNodeProvider
-  >(ValidateLoadTest2SteensgaardRegionAware);
-  ValidateTest<
-      jlm::tests::LoadTest2,
-      Steensgaard,
-      AgnosticTopDownMemoryNodeProvider
-      >(ValidateLoadTest2SteensgaardAgnosticTopDown);
+  ValidateTest<jlm::tests::LoadTest2, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateLoadTest2SteensgaardAgnostic);
+  ValidateTest<jlm::tests::LoadTest2, Steensgaard, RegionAwareMemoryNodeProvider>(
+      ValidateLoadTest2SteensgaardRegionAware);
+  ValidateTest<jlm::tests::LoadTest2, Steensgaard, AgnosticTopDownMemoryNodeProvider>(
+      ValidateLoadTest2SteensgaardAgnosticTopDown);
 
-  ValidateTest<
-    jlm::tests::LoadFromUndefTest,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidateLoadFromUndefSteensgaardAgnostic);
-  ValidateTest<
-    jlm::tests::LoadFromUndefTest,
-    Steensgaard,
-    RegionAwareMemoryNodeProvider
-  >(ValidateLoadFromUndefSteensgaardRegionAware);
-  ValidateTest<
-      jlm::tests::LoadFromUndefTest,
-      Steensgaard,
-      AgnosticTopDownMemoryNodeProvider
-      >(ValidateLoadFromUndefSteensgaardAgnosticTopDown);
+  ValidateTest<jlm::tests::LoadFromUndefTest, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateLoadFromUndefSteensgaardAgnostic);
+  ValidateTest<jlm::tests::LoadFromUndefTest, Steensgaard, RegionAwareMemoryNodeProvider>(
+      ValidateLoadFromUndefSteensgaardRegionAware);
+  ValidateTest<jlm::tests::LoadFromUndefTest, Steensgaard, AgnosticTopDownMemoryNodeProvider>(
+      ValidateLoadFromUndefSteensgaardAgnosticTopDown);
 
-  ValidateTest<
-    jlm::tests::CallTest1,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidateCallTest1SteensgaardAgnostic);
-  ValidateTest<
-    jlm::tests::CallTest1,
-    Steensgaard,
-    RegionAwareMemoryNodeProvider
-  >(ValidateCallTest1SteensgaardRegionAware);
-  ValidateTest<
-      jlm::tests::CallTest1,
-      Steensgaard,
-      AgnosticTopDownMemoryNodeProvider
-      >(ValidateCallTest1SteensgaardAgnosticTopDown);
+  ValidateTest<jlm::tests::CallTest1, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateCallTest1SteensgaardAgnostic);
+  ValidateTest<jlm::tests::CallTest1, Steensgaard, RegionAwareMemoryNodeProvider>(
+      ValidateCallTest1SteensgaardRegionAware);
+  ValidateTest<jlm::tests::CallTest1, Steensgaard, AgnosticTopDownMemoryNodeProvider>(
+      ValidateCallTest1SteensgaardAgnosticTopDown);
 
-  ValidateTest<
-    jlm::tests::CallTest2,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidateCallTest2SteensgaardAgnostic);
-  ValidateTest<
-    jlm::tests::CallTest2,
-    Steensgaard,
-    RegionAwareMemoryNodeProvider
-  >(ValidateCallTest2SteensgaardRegionAware);
-  ValidateTest<
-      jlm::tests::CallTest2,
-      Steensgaard,
-      AgnosticTopDownMemoryNodeProvider
-      >(ValidateCallTest2SteensgaardAgnosticTopDown);
+  ValidateTest<jlm::tests::CallTest2, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateCallTest2SteensgaardAgnostic);
+  ValidateTest<jlm::tests::CallTest2, Steensgaard, RegionAwareMemoryNodeProvider>(
+      ValidateCallTest2SteensgaardRegionAware);
+  ValidateTest<jlm::tests::CallTest2, Steensgaard, AgnosticTopDownMemoryNodeProvider>(
+      ValidateCallTest2SteensgaardAgnosticTopDown);
 
-  ValidateTest<
-    jlm::tests::IndirectCallTest1,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidateIndirectCallTest1SteensgaardAgnostic);
-  ValidateTest<
-    jlm::tests::IndirectCallTest1,
-    Steensgaard,
-    RegionAwareMemoryNodeProvider
-  >(ValidateIndirectCallTest1SteensgaardRegionAware);
-  ValidateTest<
-      jlm::tests::IndirectCallTest1,
-      Steensgaard,
-      AgnosticTopDownMemoryNodeProvider
-      >(ValidateIndirectCallTest1SteensgaardAgnosticTopDown);
+  ValidateTest<jlm::tests::IndirectCallTest1, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateIndirectCallTest1SteensgaardAgnostic);
+  ValidateTest<jlm::tests::IndirectCallTest1, Steensgaard, RegionAwareMemoryNodeProvider>(
+      ValidateIndirectCallTest1SteensgaardRegionAware);
+  ValidateTest<jlm::tests::IndirectCallTest1, Steensgaard, AgnosticTopDownMemoryNodeProvider>(
+      ValidateIndirectCallTest1SteensgaardAgnosticTopDown);
 
-  ValidateTest<
-      jlm::tests::IndirectCallTest2,
-      Steensgaard,
-      AgnosticMemoryNodeProvider
-      >(ValidateIndirectCallTest2SteensgaardAgnostic);
-  ValidateTest<
-      jlm::tests::IndirectCallTest2,
-      Steensgaard,
-      RegionAwareMemoryNodeProvider
-      >(ValidateIndirectCallTest2SteensgaardRegionAware);
-  ValidateTest<
-      jlm::tests::IndirectCallTest2,
-      Steensgaard,
-      AgnosticTopDownMemoryNodeProvider
-      >(ValidateIndirectCallTest2SteensgaardAgnosticTopDown);
+  ValidateTest<jlm::tests::IndirectCallTest2, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateIndirectCallTest2SteensgaardAgnostic);
+  ValidateTest<jlm::tests::IndirectCallTest2, Steensgaard, RegionAwareMemoryNodeProvider>(
+      ValidateIndirectCallTest2SteensgaardRegionAware);
+  ValidateTest<jlm::tests::IndirectCallTest2, Steensgaard, AgnosticTopDownMemoryNodeProvider>(
+      ValidateIndirectCallTest2SteensgaardAgnosticTopDown);
 
-  ValidateTest<
-    jlm::tests::GammaTest,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidateGammaTestSteensgaardAgnostic);
-  ValidateTest<
-    jlm::tests::GammaTest,
-    Steensgaard,
-    RegionAwareMemoryNodeProvider
-  >(ValidateGammaTestSteensgaardRegionAware);
-  ValidateTest<
-      jlm::tests::GammaTest,
-      Steensgaard,
-      AgnosticTopDownMemoryNodeProvider
-      >(ValidateGammaTestSteensgaardAgnosticTopDown);
+  ValidateTest<jlm::tests::GammaTest, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateGammaTestSteensgaardAgnostic);
+  ValidateTest<jlm::tests::GammaTest, Steensgaard, RegionAwareMemoryNodeProvider>(
+      ValidateGammaTestSteensgaardRegionAware);
+  ValidateTest<jlm::tests::GammaTest, Steensgaard, AgnosticTopDownMemoryNodeProvider>(
+      ValidateGammaTestSteensgaardAgnosticTopDown);
 
-  ValidateTest<
-    jlm::tests::ThetaTest,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidateThetaTestSteensgaardAgnostic);
-  ValidateTest<
-    jlm::tests::ThetaTest,
-    Steensgaard,
-    RegionAwareMemoryNodeProvider
-  >(ValidateThetaTestSteensgaardRegionAware);
-  ValidateTest<
-      jlm::tests::ThetaTest,
-      Steensgaard,
-      AgnosticMemoryNodeProvider
-      >(ValidateThetaTestSteensgaardAgnosticTopDown);
+  ValidateTest<jlm::tests::ThetaTest, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateThetaTestSteensgaardAgnostic);
+  ValidateTest<jlm::tests::ThetaTest, Steensgaard, RegionAwareMemoryNodeProvider>(
+      ValidateThetaTestSteensgaardRegionAware);
+  ValidateTest<jlm::tests::ThetaTest, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateThetaTestSteensgaardAgnosticTopDown);
 
-  ValidateTest<
-    jlm::tests::DeltaTest1,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidateDeltaTest1SteensgaardAgnostic);
-  ValidateTest<
-    jlm::tests::DeltaTest1,
-    Steensgaard,
-    RegionAwareMemoryNodeProvider
-  >(ValidateDeltaTest1SteensgaardRegionAware);
-  ValidateTest<
-      jlm::tests::DeltaTest1,
-      Steensgaard,
-      AgnosticMemoryNodeProvider
-      >(ValidateDeltaTest1SteensgaardAgnosticTopDown);
+  ValidateTest<jlm::tests::DeltaTest1, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateDeltaTest1SteensgaardAgnostic);
+  ValidateTest<jlm::tests::DeltaTest1, Steensgaard, RegionAwareMemoryNodeProvider>(
+      ValidateDeltaTest1SteensgaardRegionAware);
+  ValidateTest<jlm::tests::DeltaTest1, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateDeltaTest1SteensgaardAgnosticTopDown);
 
-  ValidateTest<
-    jlm::tests::DeltaTest2,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidateDeltaTest2SteensgaardAgnostic);
-  ValidateTest<
-    jlm::tests::DeltaTest2,
-    Steensgaard,
-    RegionAwareMemoryNodeProvider
-  >(ValidateDeltaTest2SteensgaardRegionAware);
-  ValidateTest<
-      jlm::tests::DeltaTest2,
-      Steensgaard,
-      AgnosticMemoryNodeProvider
-      >(ValidateDeltaTest2SteensgaardAgnosticTopDown);
+  ValidateTest<jlm::tests::DeltaTest2, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateDeltaTest2SteensgaardAgnostic);
+  ValidateTest<jlm::tests::DeltaTest2, Steensgaard, RegionAwareMemoryNodeProvider>(
+      ValidateDeltaTest2SteensgaardRegionAware);
+  ValidateTest<jlm::tests::DeltaTest2, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateDeltaTest2SteensgaardAgnosticTopDown);
 
-  ValidateTest<
-    jlm::tests::DeltaTest3,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidateDeltaTest3SteensgaardAgnostic);
-  ValidateTest<
-    jlm::tests::DeltaTest3,
-    Steensgaard,
-    RegionAwareMemoryNodeProvider
-  >(ValidateDeltaTest3SteensgaardRegionAware);
-  ValidateTest<
-      jlm::tests::DeltaTest3,
-      Steensgaard,
-      AgnosticMemoryNodeProvider
-      >(ValidateDeltaTest3SteensgaardAgnosticTopDown);
+  ValidateTest<jlm::tests::DeltaTest3, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateDeltaTest3SteensgaardAgnostic);
+  ValidateTest<jlm::tests::DeltaTest3, Steensgaard, RegionAwareMemoryNodeProvider>(
+      ValidateDeltaTest3SteensgaardRegionAware);
+  ValidateTest<jlm::tests::DeltaTest3, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateDeltaTest3SteensgaardAgnosticTopDown);
 
-  ValidateTest<
-    jlm::tests::ImportTest,
-    Steensgaard,
-    AgnosticMemoryNodeProvider>(ValidateImportTestSteensgaardAgnostic);
-  ValidateTest<
-    jlm::tests::ImportTest,
-    Steensgaard,
-    RegionAwareMemoryNodeProvider
-  >(ValidateImportTestSteensgaardRegionAware);
-  ValidateTest<
-      jlm::tests::ImportTest,
-      Steensgaard,
-      AgnosticMemoryNodeProvider
-      >(ValidateImportTestSteensgaardAgnosticTopDown);
+  ValidateTest<jlm::tests::ImportTest, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateImportTestSteensgaardAgnostic);
+  ValidateTest<jlm::tests::ImportTest, Steensgaard, RegionAwareMemoryNodeProvider>(
+      ValidateImportTestSteensgaardRegionAware);
+  ValidateTest<jlm::tests::ImportTest, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateImportTestSteensgaardAgnosticTopDown);
 
-  ValidateTest<
-    jlm::tests::PhiTest1,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidatePhiTestSteensgaardAgnostic);
-  ValidateTest<
-    jlm::tests::PhiTest1,
-    Steensgaard,
-    RegionAwareMemoryNodeProvider
-  >(ValidatePhiTestSteensgaardRegionAware);
-  ValidateTest<
-      jlm::tests::PhiTest1,
-      Steensgaard,
-      AgnosticMemoryNodeProvider
-      >(ValidatePhiTestSteensgaardAgnosticTopDown);
+  ValidateTest<jlm::tests::PhiTest1, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidatePhiTestSteensgaardAgnostic);
+  ValidateTest<jlm::tests::PhiTest1, Steensgaard, RegionAwareMemoryNodeProvider>(
+      ValidatePhiTestSteensgaardRegionAware);
+  ValidateTest<jlm::tests::PhiTest1, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidatePhiTestSteensgaardAgnosticTopDown);
 
-  ValidateTest<
-    jlm::tests::MemcpyTest,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidateMemcpySteensgaardAgnostic);
-  ValidateTest<
-    jlm::tests::MemcpyTest,
-    Steensgaard,
-    RegionAwareMemoryNodeProvider
-  >(ValidateMemcpySteensgaardRegionAware);
-  ValidateTest<
-      jlm::tests::MemcpyTest,
-      Steensgaard,
-      AgnosticMemoryNodeProvider
-      >(ValidateMemcpyTestSteensgaardAgnosticTopDown);
+  ValidateTest<jlm::tests::MemcpyTest, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateMemcpySteensgaardAgnostic);
+  ValidateTest<jlm::tests::MemcpyTest, Steensgaard, RegionAwareMemoryNodeProvider>(
+      ValidateMemcpySteensgaardRegionAware);
+  ValidateTest<jlm::tests::MemcpyTest, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateMemcpyTestSteensgaardAgnosticTopDown);
 
   ValidateTest<jlm::tests::FreeNullTest, Steensgaard, AgnosticMemoryNodeProvider>(
       ValidateFreeNullTestSteensgaardAgnostic);

--- a/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
@@ -55,7 +55,8 @@ ValidateTest(std::function<void(const Test &)> validateEncoding)
   std::cout << jlm::llvm::aa::PointsToGraph::ToDot(*pointsToGraph);
 
   Provider provider;
-  auto provisioning = provider.ProvisionMemoryNodes(rvsdgModule, *pointsToGraph, statisticsCollector);
+  auto provisioning =
+      provider.ProvisionMemoryNodes(rvsdgModule, *pointsToGraph, statisticsCollector);
 
   jlm::llvm::aa::MemoryStateEncoder encoder;
   encoder.Encode(rvsdgModule, *provisioning, statisticsCollector);
@@ -752,7 +753,7 @@ ValidateIndirectCallTest1SteensgaardAgnostic(const jlm::tests::IndirectCallTest1
     assert(test.GetLambdaIndcall().subregion()->nnodes() == 5);
 
     auto lambda_exit_mux =
-        jlm::rvsdg::node_output::node(test.GetLambdaIndcall().fctresult(2)->origin());
+          jlm::rvsdg::node_output::node(test.GetLambdaIndcall().fctresult(2)->origin());
     assert(is<aa::LambdaExitMemStateOperator>(*lambda_exit_mux, 5, 1));
 
     auto call_exit_mux = jlm::rvsdg::node_output::node(lambda_exit_mux->input(0)->origin());
@@ -773,7 +774,7 @@ ValidateIndirectCallTest1SteensgaardAgnostic(const jlm::tests::IndirectCallTest1
     assert(test.GetLambdaTest().subregion()->nnodes() == 9);
 
     auto lambda_exit_mux =
-        jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
+          jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
     assert(is<aa::LambdaExitMemStateOperator>(*lambda_exit_mux, 5, 1));
 
     auto call_exit_mux = jlm::rvsdg::node_output::node(lambda_exit_mux->input(0)->origin());
@@ -809,7 +810,7 @@ ValidateIndirectCallTest1SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(test.GetLambdaIndcall().subregion()->nnodes() == 5);
 
     auto lambdaExitMerge =
-        jlm::rvsdg::node_output::node(test.GetLambdaIndcall().fctresult(2)->origin());
+          jlm::rvsdg::node_output::node(test.GetLambdaIndcall().fctresult(2)->origin());
     assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 1, 1));
 
     auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
@@ -830,7 +831,7 @@ ValidateIndirectCallTest1SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(test.GetLambdaTest().subregion()->nnodes() == 9);
 
     auto lambdaExitMerge =
-        jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
+          jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
     assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 1, 1));
 
     auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
@@ -865,7 +866,8 @@ ValidateIndirectCallTest1SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
   {
     assert(test.GetLambdaIndcall().subregion()->nnodes() == 5);
 
-    auto lambda_exit_mux = jlm::rvsdg::node_output::node(test.GetLambdaIndcall().fctresult(2)->origin());
+    auto lambda_exit_mux =
+          jlm::rvsdg::node_output::node(test.GetLambdaIndcall().fctresult(2)->origin());
     assert(is<aa::LambdaExitMemStateOperator>(*lambda_exit_mux, 5, 1));
 
     auto call_exit_mux = jlm::rvsdg::node_output::node(lambda_exit_mux->input(0)->origin());
@@ -885,7 +887,8 @@ ValidateIndirectCallTest1SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
   {
     assert(test.GetLambdaTest().subregion()->nnodes() == 9);
 
-    auto lambda_exit_mux = jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
+    auto lambda_exit_mux =
+          jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
     assert(is<aa::LambdaExitMemStateOperator>(*lambda_exit_mux, 5, 1));
 
     auto call_exit_mux = jlm::rvsdg::node_output::node(lambda_exit_mux->input(0)->origin());
@@ -908,6 +911,385 @@ ValidateIndirectCallTest1SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
 
     auto lambda_entry_mux = jlm::rvsdg::node_output::node(call_entry_mux->input(2)->origin());
     assert(is<aa::LambdaEntryMemStateOperator>(*lambda_entry_mux, 1, 5));
+  }
+}
+
+static void
+ValidateIndirectCallTest2SteensgaardAgnostic(const jlm::tests::IndirectCallTest2 & test)
+{
+  using namespace jlm::llvm;
+
+  // validate function three()
+  {
+    assert(test.GetLambdaThree().subregion()->nnodes() == 3);
+
+    auto lambdaExitMerge =
+        jlm::rvsdg::node_output::node(test.GetLambdaThree().fctresult(2)->origin());
+    assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 13, 1));
+
+    auto lambdaEntrySplit = input_node(*test.GetLambdaThree().fctargument(1)->begin());
+    assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 13));
+  }
+
+  // validate function four()
+  {
+    assert(test.GetLambdaFour().subregion()->nnodes() == 3);
+
+    auto lambdaExitMerge =
+        jlm::rvsdg::node_output::node(test.GetLambdaFour().fctresult(2)->origin());
+    assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 13, 1));
+
+    auto lambdaEntrySplit = input_node(*test.GetLambdaFour().fctargument(1)->begin());
+    assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 13));
+  }
+
+  // validate function i()
+  {
+    assert(test.GetLambdaI().subregion()->nnodes() == 5);
+
+    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaI().fctresult(2)->origin());
+    assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 13, 1));
+
+    auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+    assert(is<aa::CallExitMemStateOperator>(*callExitSplit, 1, 13));
+
+    auto callEntryMerge = jlm::rvsdg::node_output::node(test.GetIndirectCall().input(2)->origin());
+    assert(is<aa::CallEntryMemStateOperator>(*callEntryMerge, 13, 1));
+
+    auto lambdaEntrySplit = jlm::rvsdg::node_output::node(callEntryMerge->input(0)->origin());
+    assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 13));
+  }
+}
+
+static void
+ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTest2 & test)
+{
+  using namespace jlm::llvm;
+
+  // validate function three()
+  {
+    assert(test.GetLambdaThree().subregion()->nnodes() == 2);
+
+    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaThree().fctresult(2)->origin());
+    assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 0, 1));
+  }
+
+  // validate function four()
+  {
+    assert(test.GetLambdaFour().subregion()->nnodes() == 2);
+
+    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaFour().fctresult(2)->origin());
+    assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 0, 1));
+  }
+
+  // validate function i()
+  {
+    assert(test.GetLambdaI().subregion()->nnodes() == 5);
+
+    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaI().fctresult(2)->origin());
+    assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 6, 1));
+
+    auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+    assert(is<aa::CallExitMemStateOperator>(*callExitSplit, 1, 6));
+
+    auto callEntryMerge = jlm::rvsdg::node_output::node(test.GetIndirectCall().input(2)->origin());
+    assert(is<aa::CallEntryMemStateOperator>(*callEntryMerge, 6, 1));
+
+    auto lambdaEntrySplit = jlm::rvsdg::node_output::node(callEntryMerge->input(0)->origin());
+    assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 6));
+  }
+
+  // validate function x()
+  {
+    assert(test.GetLambdaX().subregion()->nnodes() == 7);
+
+    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaX().fctresult(2)->origin());
+    assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 6, 1));
+
+    auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+    assert(is<aa::CallExitMemStateOperator>(*callExitSplit, 1, 6));
+
+    auto callEntryMerge = jlm::rvsdg::node_output::node(test.GetCallIWithThree().input(3)->origin());
+    assert(is<aa::CallEntryMemStateOperator>(*callEntryMerge, 6, 1));
+
+    const jlm::rvsdg::node * storeNode = nullptr;
+    const jlm::rvsdg::node * lambdaEntrySplit = nullptr;
+    for (size_t n = 0; n < callEntryMerge->ninputs(); n++)
+    {
+      auto node = jlm::rvsdg::node_output::node(callEntryMerge->input(n)->origin());
+      if (is<StoreOperation>(node))
+      {
+        storeNode = node;
+      }
+      else if (is<aa::LambdaEntryMemStateOperator>(node))
+      {
+        lambdaEntrySplit = node;
+      }
+      else
+      {
+        assert(0 && "This should not have happened!");
+      }
+    }
+    assert(storeNode && lambdaEntrySplit);
+    assert(is<StoreOperation>(*storeNode, 4, 2));
+    assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 6));
+  }
+
+  // validate function y()
+  {
+    assert(test.GetLambdaY().subregion()->nnodes() == 7);
+
+    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaY().fctresult(2)->origin());
+    assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 6, 1));
+
+    auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+    assert(is<aa::CallExitMemStateOperator>(*callExitSplit, 1, 6));
+
+    auto callEntryMerge = jlm::rvsdg::node_output::node(test.GetCallIWithFour().input(3)->origin());
+    assert(is<aa::CallEntryMemStateOperator>(*callEntryMerge, 6, 1));
+
+    const jlm::rvsdg::node * storeNode = nullptr;
+    const jlm::rvsdg::node * lambdaEntrySplit = nullptr;
+    for (size_t n = 0; n < callEntryMerge->ninputs(); n++)
+    {
+      auto node = jlm::rvsdg::node_output::node(callEntryMerge->input(n)->origin());
+      if (is<StoreOperation>(node))
+      {
+        storeNode = node;
+      }
+      else if (is<aa::LambdaEntryMemStateOperator>(node))
+      {
+        lambdaEntrySplit = node;
+      }
+      else
+      {
+        assert(0 && "This should not have happened!");
+      }
+    }
+    assert(storeNode && lambdaEntrySplit);
+    assert(is<StoreOperation>(*storeNode, 3, 1));
+    assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 6));
+  }
+
+  // validate function test()
+  {
+    assert(test.GetLambdaTest().subregion()->nnodes() == 16);
+
+    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
+    assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 6, 1));
+
+    auto loadG1 = input_node(*test.GetLambdaTest().cvargument(2)->begin());
+    assert(is<LoadOperation>(*loadG1, 2, 2));
+
+    auto loadG2 = input_node(*test.GetLambdaTest().cvargument(3)->begin());
+    assert(is<LoadOperation>(*loadG2, 2, 2));
+
+    auto lambdaEntrySplit= input_node(*test.GetLambdaTest().fctargument(1)->begin());
+    assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 6));
+  }
+
+  // validate function test2()
+  {
+    assert(test.GetLambdaTest2().subregion()->nnodes() == 7);
+
+    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaTest2().fctresult(2)->origin());
+    assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 6, 1));
+
+    auto lambdaEntrySplit= input_node(*test.GetLambdaTest().fctargument(1)->begin());
+    assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 6));
+  }
+}
+
+static void
+ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCallTest2 & test)
+{
+  using namespace jlm::llvm;
+
+  // validate function three()
+  {
+    assert(test.GetLambdaThree().subregion()->nnodes() == 3);
+
+    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaThree().fctresult(2)->origin());
+    assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 13, 1));
+
+    auto lambdaEntrySplit = input_node(*test.GetLambdaThree().fctargument(1)->begin());
+    assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 13));
+  }
+
+  // validate function four()
+  {
+    assert(test.GetLambdaFour().subregion()->nnodes() == 3);
+
+    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaFour().fctresult(2)->origin());
+    assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 13, 1));
+
+    auto lambdaEntrySplit = input_node(*test.GetLambdaFour().fctargument(1)->begin());
+    assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 13));
+  }
+
+  // validate function i()
+  {
+    assert(test.GetLambdaI().subregion()->nnodes() == 5);
+
+    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaI().fctresult(2)->origin());
+    assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 13, 1));
+
+    auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+    assert(is<aa::CallExitMemStateOperator>(*callExitSplit, 1, 13));
+
+    auto callEntryMerge = jlm::rvsdg::node_output::node(test.GetIndirectCall().input(2)->origin());
+    assert(is<aa::CallEntryMemStateOperator>(*callEntryMerge, 13, 1));
+
+    auto lambdaEntrySplit = jlm::rvsdg::node_output::node(callEntryMerge->input(0)->origin());
+    assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 13));
+  }
+
+  // validate function x()
+  {
+    assert(test.GetLambdaX().subregion()->nnodes() == 7);
+
+    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaX().fctresult(2)->origin());
+    assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 13, 1));
+
+    auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+    assert(is<aa::CallExitMemStateOperator>(*callExitSplit, 1, 13));
+
+    auto callEntryMerge = jlm::rvsdg::node_output::node(test.GetCallIWithThree().input(3)->origin());
+    assert(is<aa::CallEntryMemStateOperator>(*callEntryMerge, 13, 1));
+
+    const jlm::rvsdg::node * storeNode = nullptr;
+    const jlm::rvsdg::node * lambdaEntrySplit = nullptr;
+    for (size_t n = 0; n < callEntryMerge->ninputs(); n++)
+    {
+      auto node = jlm::rvsdg::node_output::node(callEntryMerge->input(n)->origin());
+      if (is<StoreOperation>(node))
+      {
+        storeNode = node;
+      }
+      else if (is<aa::LambdaEntryMemStateOperator>(node))
+      {
+        lambdaEntrySplit = node;
+      }
+      else
+      {
+        assert(0 && "This should not have happened!");
+      }
+    }
+    assert(storeNode && lambdaEntrySplit);
+    assert(is<StoreOperation>(*storeNode, 4, 2));
+    assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 13));
+  }
+
+  // validate function y()
+  {
+    assert(test.GetLambdaY().subregion()->nnodes() == 8);
+
+    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaY().fctresult(2)->origin());
+    assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 12, 1));
+
+    auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+    assert(is<aa::CallExitMemStateOperator>(*callExitSplit, 1, 13));
+
+    auto callEntryMerge = jlm::rvsdg::node_output::node(test.GetCallIWithFour().input(3)->origin());
+    assert(is<aa::CallEntryMemStateOperator>(*callEntryMerge, 13, 1));
+
+    jlm::rvsdg::node * undefNode = nullptr;
+    const jlm::rvsdg::node * storeNode = nullptr;
+    const jlm::rvsdg::node * lambdaEntrySplit = nullptr;
+    for (size_t n = 0; n < callEntryMerge->ninputs(); n++)
+    {
+      auto node = jlm::rvsdg::node_output::node(callEntryMerge->input(n)->origin());
+      if (is<StoreOperation>(node))
+      {
+        assert(storeNode == nullptr);
+        storeNode = node;
+      }
+      else if (is<aa::LambdaEntryMemStateOperator>(node))
+      {
+        lambdaEntrySplit = node;
+      }
+      else if (is<UndefValueOperation>(node))
+      {
+        assert(undefNode == nullptr);
+        undefNode = node;
+      }
+      else
+      {
+        assert(0 && "This should not have happened!");
+      }
+    }
+    assert(storeNode && lambdaEntrySplit && undefNode);
+    assert(is<StoreOperation>(*storeNode, 3, 1));
+    assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 12));
+  }
+
+  // validate function test()
+  {
+    assert(test.GetLambdaTest().subregion()->nnodes() == 17);
+
+    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
+    assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 10, 1));
+
+    auto loadG1 = input_node(*test.GetLambdaTest().cvargument(2)->begin());
+    assert(is<LoadOperation>(*loadG1, 2, 2));
+
+    auto callXEntryMerge = jlm::rvsdg::node_output::node(test.GetTestCallX().input(3)->origin());
+    assert(is<aa::CallEntryMemStateOperator>(*callXEntryMerge, 13, 1));
+
+    auto callXExitSplit = input_node(*test.GetTestCallX().output(2)->begin());
+    assert(is<aa::CallExitMemStateOperator>(*callXExitSplit, 1, 13));
+
+    jlm::rvsdg::node * undefNode = nullptr;
+    for (auto & node : test.GetLambdaTest().subregion()->nodes)
+    {
+      if (is<UndefValueOperation>(&node))
+      {
+        undefNode = &node;
+        break;
+      }
+    }
+    assert(undefNode != nullptr);
+    assert(undefNode->output(0)->nusers() == 1);
+    assert(input_node(*undefNode->output(0)->begin()) == callXEntryMerge);
+
+    auto loadG2 = input_node(*test.GetLambdaTest().cvargument(3)->begin());
+    assert(is<LoadOperation>(*loadG2, 2, 2));
+
+    auto lambdaEntrySplit= input_node(*test.GetLambdaTest().fctargument(1)->begin());
+    assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 10));
+  }
+
+  // validate function test2()
+  {
+    assert(test.GetLambdaTest2().subregion()->nnodes() == 8);
+
+    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaTest2().fctresult(2)->origin());
+    assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 10, 1));
+
+    auto callXEntryMerge = jlm::rvsdg::node_output::node(test.GetTest2CallX().input(3)->origin());
+    assert(is<aa::CallEntryMemStateOperator>(*callXEntryMerge, 13, 1));
+
+    auto callXExitSplit = input_node(*test.GetTest2CallX().output(2)->begin());
+    assert(is<aa::CallExitMemStateOperator>(*callXExitSplit, 1, 13));
+
+    jlm::rvsdg::node * undefNode = nullptr;
+    for (auto & node : test.GetLambdaTest2().subregion()->nodes)
+    {
+      if (is<UndefValueOperation>(&node))
+      {
+        undefNode = &node;
+        break;
+      }
+    }
+    assert(undefNode != nullptr);
+    assert(undefNode->output(0)->nusers() == 2);
+    for (auto & user : *undefNode->output(0))
+    {
+      assert(input_node(user) == callXEntryMerge);
+    }
+
+    auto lambdaEntrySplit= input_node(*test.GetLambdaTest2().fctargument(1)->begin());
+    assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 10));
   }
 }
 
@@ -976,7 +1358,7 @@ ValidateThetaTestSteensgaardAgnostic(const jlm::tests::ThetaTest & test)
   assert(is<aa::LambdaExitMemStateOperator>(*lambda_exit_mux, 2, 1));
 
   auto thetaOutput =
-      jlm::util::AssertedCast<jlm::rvsdg::theta_output>(lambda_exit_mux->input(0)->origin());
+        jlm::util::AssertedCast<jlm::rvsdg::theta_output>(lambda_exit_mux->input(0)->origin());
   auto theta = jlm::rvsdg::node_output::node(thetaOutput);
   assert(theta == test.theta);
 
@@ -1000,7 +1382,7 @@ ValidateThetaTestSteensgaardRegionAware(const jlm::tests::ThetaTest & test)
   assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
 
   auto thetaOutput =
-      jlm::util::AssertedCast<jlm::rvsdg::theta_output>(lambdaExitMerge->input(0)->origin());
+        jlm::util::AssertedCast<jlm::rvsdg::theta_output>(lambdaExitMerge->input(0)->origin());
   auto theta = jlm::rvsdg::node_output::node(thetaOutput);
   assert(theta == test.theta);
 
@@ -1023,14 +1405,15 @@ ValidateThetaTestSteensgaardAgnosticTopDown(const jlm::tests::ThetaTest & test)
   auto lambda_exit_mux = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
   assert(is<aa::LambdaExitMemStateOperator>(*lambda_exit_mux, 2, 1));
 
-  auto thetaOutput = jlm::util::AssertedCast<jlm::rvsdg::theta_output>(lambda_exit_mux->input(0)->origin());
+  auto thetaOutput =
+        jlm::util::AssertedCast<jlm::rvsdg::theta_output>(lambda_exit_mux->input(0)->origin());
   auto theta = jlm::rvsdg::node_output::node(thetaOutput);
   assert(theta == test.theta);
 
   auto storeStateOutput = thetaOutput->result()->origin();
   auto store = jlm::rvsdg::node_output::node(storeStateOutput);
   assert(is<StoreOperation>(*store, 4, 2));
-  assert(store->input(storeStateOutput->index()+2)->origin() == thetaOutput->argument());
+  assert(store->input(storeStateOutput->index() + 2)->origin() == thetaOutput->argument());
 
   auto lambda_entry_mux = jlm::rvsdg::node_output::node(thetaOutput->input()->origin());
   assert(is<aa::LambdaEntryMemStateOperator>(*lambda_entry_mux, 1, 2));
@@ -1445,7 +1828,7 @@ ValidatePhiTestSteensgaardAgnostic(const jlm::tests::PhiTest1 & test)
   auto gammaStateIndex = store->input(2)->origin()->index();
 
   auto load1 =
-      jlm::rvsdg::node_output::node(test.gamma->exitvar(gammaStateIndex)->result(0)->origin());
+        jlm::rvsdg::node_output::node(test.gamma->exitvar(gammaStateIndex)->result(0)->origin());
   assert(is<LoadOperation>(*load1, 2, 2));
 
   auto load2 = jlm::rvsdg::node_output::node(load1->input(1)->origin());
@@ -1473,7 +1856,7 @@ ValidatePhiTestSteensgaardRegionAware(const jlm::tests::PhiTest1 & test)
   auto gammaStateIndex = store->input(2)->origin()->index();
 
   auto load1 =
-      jlm::rvsdg::node_output::node(test.gamma->exitvar(gammaStateIndex)->result(0)->origin());
+        jlm::rvsdg::node_output::node(test.gamma->exitvar(gammaStateIndex)->result(0)->origin());
   assert(is<LoadOperation>(*load1, 2, 2));
 
   auto load2 = jlm::rvsdg::node_output::node(load1->input(1)->origin());
@@ -1495,11 +1878,11 @@ ValidatePhiTestSteensgaardAgnosticTopDown(const jlm::tests::PhiTest1 & test)
   for (size_t n = 0; n < lambdaExitMerge->ninputs(); n++)
   {
     auto node = jlm::rvsdg::node_output::node(lambdaExitMerge->input(n)->origin());
-    if (auto castedStoreNode = dynamic_cast<const StoreNode*>(node))
+    if (auto castedStoreNode = dynamic_cast<const StoreNode *>(node))
     {
       storeNode = castedStoreNode;
     }
-    else if (auto castedGammaNode = dynamic_cast<const jlm::rvsdg::gamma_node*>(node))
+    else if (auto castedGammaNode = dynamic_cast<const jlm::rvsdg::gamma_node *>(node))
     {
       gammaNode = castedGammaNode;
     }
@@ -1514,7 +1897,8 @@ ValidatePhiTestSteensgaardAgnosticTopDown(const jlm::tests::PhiTest1 & test)
 
   auto gammaStateIndex = storeNode->input(2)->origin()->index();
 
-  auto load1 = jlm::rvsdg::node_output::node(test.gamma->exitvar(gammaStateIndex)->result(0)->origin());
+  auto load1 =
+        jlm::rvsdg::node_output::node(test.gamma->exitvar(gammaStateIndex)->result(0)->origin());
   assert(is<LoadOperation>(*load1, 2, 2));
 
   auto load2 = jlm::rvsdg::node_output::node(load1->input(1)->origin());
@@ -1686,7 +2070,7 @@ ValidateFreeNullTestSteensgaardAgnostic(const jlm::tests::FreeNullTest & test)
 }
 
 static int
-test()
+TestMemoryStateEncoder()
 {
   using namespace jlm::llvm::aa;
 
@@ -1817,6 +2201,22 @@ test()
       Steensgaard,
       AgnosticTopDownMemoryNodeProvider
       >(ValidateIndirectCallTest1SteensgaardAgnosticTopDown);
+
+  ValidateTest<
+      jlm::tests::IndirectCallTest2,
+      Steensgaard,
+      AgnosticMemoryNodeProvider
+      >(ValidateIndirectCallTest2SteensgaardAgnostic);
+  ValidateTest<
+      jlm::tests::IndirectCallTest2,
+      Steensgaard,
+      RegionAwareMemoryNodeProvider
+      >(ValidateIndirectCallTest2SteensgaardRegionAware);
+  ValidateTest<
+      jlm::tests::IndirectCallTest2,
+      Steensgaard,
+      AgnosticTopDownMemoryNodeProvider
+      >(ValidateIndirectCallTest2SteensgaardAgnosticTopDown);
 
   ValidateTest<
     jlm::tests::GammaTest,
@@ -1951,4 +2351,4 @@ test()
   return 0;
 }
 
-JLM_UNIT_TEST_REGISTER("jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder", test)
+JLM_UNIT_TEST_REGISTER("jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder", TestMemoryStateEncoder)

--- a/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
@@ -10,12 +10,18 @@
 #include <jlm/rvsdg/view.hpp>
 
 #include <jlm/llvm/opt/alias-analyses/AgnosticMemoryNodeProvider.hpp>
+#include <jlm/llvm/opt/alias-analyses/EliminatedMemoryNodeProvider.hpp>
 #include <jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp>
 #include <jlm/llvm/opt/alias-analyses/Operators.hpp>
 #include <jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.hpp>
 #include <jlm/llvm/opt/alias-analyses/Steensgaard.hpp>
+#include <jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.hpp>
 
 #include <iostream>
+
+using AgnosticTopDownMemoryNodeProvider = jlm::llvm::aa::EliminatedMemoryNodeProvider<
+    jlm::llvm::aa::AgnosticMemoryNodeProvider,
+    jlm::llvm::aa::TopDownMemoryNodeEliminator>;
 
 template<class Test, class Analysis, class Provider>
 static void
@@ -33,6 +39,11 @@ ValidateTest(std::function<void(const Test &)> validateEncoding)
       std::is_base_of<jlm::llvm::aa::MemoryNodeProvider, Provider>::value,
       "Provider should be derived from MemoryNodeProvider class.");
 
+  std::cout << "\n###\n";
+  std::cout << "### Performing Test " << typeid(Test).name()
+            << " using [" << typeid(Analysis).name() << ", " << typeid(Provider).name() << "]\n";
+  std::cout << "###\n";
+
   Test test;
   auto & rvsdgModule = test.module();
   jlm::rvsdg::view(rvsdgModule.Rvsdg().root(), stdout);
@@ -43,7 +54,8 @@ ValidateTest(std::function<void(const Test &)> validateEncoding)
   auto pointsToGraph = aliasAnalysis.Analyze(rvsdgModule, statisticsCollector);
   std::cout << jlm::llvm::aa::PointsToGraph::ToDot(*pointsToGraph);
 
-  auto provisioning = Provider::Create(rvsdgModule, *pointsToGraph);
+  Provider provider;
+  auto provisioning = provider.ProvisionMemoryNodes(rvsdgModule, *pointsToGraph, statisticsCollector);
 
   jlm::llvm::aa::MemoryStateEncoder encoder;
   encoder.Encode(rvsdgModule, *provisioning, statisticsCollector);
@@ -123,6 +135,21 @@ ValidateStoreTest1SteensgaardRegionAware(const jlm::tests::StoreTest1 & test)
   assert(is<StoreOperation>(*storeB, 3, 1));
   assert(storeB->input(0)->origin() == test.alloca_a->output(0));
   assert(storeB->input(1)->origin() == test.alloca_b->output(0));
+}
+
+static void
+ValidateStoreTest1SteensgaardAgnosticTopDown(const jlm::tests::StoreTest1 & test)
+{
+  using namespace jlm::llvm;
+
+  assert(test.lambda->subregion()->nnodes() == 2);
+
+  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
+  assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
+
+  auto lambdaEntrySplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+  assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 2));
+  assert(lambdaEntrySplit == jlm::rvsdg::node_output::node(lambdaExitMerge->input(1)->origin()));
 }
 
 static void
@@ -206,6 +233,21 @@ ValidateStoreTest2SteensgaardRegionAware(const jlm::tests::StoreTest2 & test)
 }
 
 static void
+ValidateStoreTest2SteensgaardAgnosticTopDown(const jlm::tests::StoreTest2 & test)
+{
+  using namespace jlm::llvm;
+
+  assert(test.lambda->subregion()->nnodes() == 2);
+
+  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
+  assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
+
+  auto lambdaEntrySplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+  assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 2));
+  assert(lambdaEntrySplit == jlm::rvsdg::node_output::node(lambdaExitMerge->input(1)->origin()));
+}
+
+static void
 ValidateLoadTest1SteensgaardAgnostic(const jlm::tests::LoadTest1 & test)
 {
   using namespace jlm::llvm;
@@ -231,6 +273,30 @@ ValidateLoadTest1SteensgaardAgnostic(const jlm::tests::LoadTest1 & test)
 
 static void
 ValidateLoadTest1SteensgaardRegionAware(const jlm::tests::LoadTest1 & test)
+{
+  using namespace jlm::llvm;
+
+  assert(test.lambda->subregion()->nnodes() == 4);
+
+  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(1)->origin());
+  assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
+
+  auto lambdaEntrySplit = input_node(*test.lambda->fctargument(1)->begin());
+  assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 2));
+
+  auto loadA = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
+  auto loadX = jlm::rvsdg::node_output::node(loadA->input(0)->origin());
+
+  assert(is<LoadOperation>(*loadA, 3, 3));
+  assert(jlm::rvsdg::node_output::node(loadA->input(1)->origin()) == loadX);
+
+  assert(is<LoadOperation>(*loadX, 3, 3));
+  assert(loadX->input(0)->origin() == test.lambda->fctargument(0));
+  assert(jlm::rvsdg::node_output::node(loadX->input(1)->origin()) == lambdaEntrySplit);
+}
+
+static void
+ValidateLoadTest1SteensgaardAgnosticTopDown(const jlm::tests::LoadTest1 & test)
 {
   using namespace jlm::llvm;
 
@@ -351,6 +417,21 @@ ValidateLoadTest2SteensgaardRegionAware(const jlm::tests::LoadTest2 & test)
 }
 
 static void
+ValidateLoadTest2SteensgaardAgnosticTopDown(const jlm::tests::LoadTest2 & test)
+{
+  using namespace jlm::llvm;
+
+  assert(test.lambda->subregion()->nnodes() == 2);
+
+  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
+  assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
+
+  auto lambdaEntrySplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+  assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 2));
+  assert(lambdaEntrySplit == jlm::rvsdg::node_output::node(lambdaExitMerge->input(1)->origin()));
+}
+
+static void
 ValidateLoadFromUndefSteensgaardAgnostic(const jlm::tests::LoadFromUndefTest & test)
 {
   using namespace jlm::llvm;
@@ -379,6 +460,23 @@ ValidateLoadFromUndefSteensgaardRegionAware(const jlm::tests::LoadFromUndefTest 
 
   auto load = jlm::rvsdg::node_output::node(test.Lambda().fctresult(0)->origin());
   assert(is<LoadOperation>(*load, 1, 1));
+}
+
+static void
+ValidateLoadFromUndefSteensgaardAgnosticTopDown(const jlm::tests::LoadFromUndefTest & test)
+{
+  using namespace jlm::llvm;
+
+  assert(test.Lambda().subregion()->nnodes() == 4);
+
+  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.Lambda().fctresult(1)->origin());
+  assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
+
+  auto load = jlm::rvsdg::node_output::node(test.Lambda().fctresult(0)->origin());
+  assert(is<LoadOperation>(*load, 1, 1));
+
+  auto lambdaEntrySplit = input_node(*test.Lambda().fctargument(0)->begin());
+  assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 2));
 }
 
 static void
@@ -492,6 +590,61 @@ ValidateCallTest1SteensgaardRegionAware(const jlm::tests::CallTest1 & test)
 }
 
 static void
+ValidateCallTest1SteensgaardAgnosticTopDown(const jlm::tests::CallTest1 & test)
+{
+  using namespace jlm::llvm;
+
+  // validate function f
+  {
+    auto lambdaEntrySplit = input_node(*test.lambda_f->fctargument(3)->begin());
+    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda_f->fctresult(2)->origin());
+    auto loadX = input_node(*test.lambda_f->fctargument(0)->begin());
+    auto loadY = input_node(*test.lambda_f->fctargument(1)->begin());
+
+    assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 7, 1));
+    assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 7));
+
+    assert(is<LoadOperation>(*loadX, 2, 2));
+    assert(jlm::rvsdg::node_output::node(loadX->input(1)->origin()) == lambdaEntrySplit);
+
+    assert(is<LoadOperation>(*loadY, 2, 2));
+    assert(jlm::rvsdg::node_output::node(loadY->input(1)->origin()) == lambdaEntrySplit);
+  }
+
+  // validate function g
+  {
+    auto lambdaEntrySplit = input_node(*test.lambda_g->fctargument(3)->begin());
+    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda_g->fctresult(2)->origin());
+    auto loadX = input_node(*test.lambda_g->fctargument(0)->begin());
+    auto loadY = input_node(*test.lambda_g->fctargument(1)->begin());
+
+    assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 7, 1));
+    assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 7));
+
+    assert(is<LoadOperation>(*loadX, 2, 2));
+    assert(jlm::rvsdg::node_output::node(loadX->input(1)->origin()) == lambdaEntrySplit);
+
+    assert(is<LoadOperation>(*loadY, 2, 2));
+    assert(jlm::rvsdg::node_output::node(loadY->input(1)->origin()) == loadX);
+  }
+
+  // validate function h
+  {
+    auto callEntryMerge = jlm::rvsdg::node_output::node(test.CallF().input(4)->origin());
+    auto callExitSplit = input_node(*test.CallF().output(2)->begin());
+
+    assert(is<aa::CallEntryMemStateOperator>(*callEntryMerge, 7, 1));
+    assert(is<aa::CallExitMemStateOperator>(*callExitSplit, 1, 7));
+
+    callEntryMerge = jlm::rvsdg::node_output::node(test.CallG().input(4)->origin());
+    callExitSplit = input_node(*test.CallG().output(2)->begin());
+
+    assert(is<aa::CallEntryMemStateOperator>(*callEntryMerge, 7, 1));
+    assert(is<aa::CallExitMemStateOperator>(*callExitSplit, 1, 7));
+  }
+}
+
+static void
 ValidateCallTest2SteensgaardAgnostic(const jlm::tests::CallTest2 & test)
 {
   using namespace jlm::llvm;
@@ -554,6 +707,36 @@ ValidateCallTest2SteensgaardRegionAware(const jlm::tests::CallTest2 & test)
   }
 
   /* validate test function */
+  {
+    assert(test.lambda_test->subregion()->nnodes() == 16);
+  }
+}
+
+static void
+ValidateCallTest2SteensgaardAgnosticTopDown(const jlm::tests::CallTest2 & test)
+{
+  using namespace jlm::llvm;
+
+  // validate create function
+  {
+    assert(test.lambda_create->subregion()->nnodes() == 7);
+
+    auto stateMerge = input_node(*test.malloc->output(1)->begin());
+    assert(is<MemStateMergeOperator>(*stateMerge, 2, 1));
+
+    auto lambdaEntrySplit = jlm::rvsdg::node_output::node(stateMerge->input(1)->origin());
+    assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 5));
+
+    auto lambdaExitMerge = input_node(*stateMerge->output(0)->begin());
+    assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 5, 1));
+  }
+
+  // validate destroy function
+  {
+    assert(test.lambda_destroy->subregion()->nnodes() == 4);
+  }
+
+  // validate test function
   {
     assert(test.lambda_test->subregion()->nnodes() == 16);
   }
@@ -674,6 +857,61 @@ ValidateIndirectCallTest1SteensgaardRegionAware(const jlm::tests::IndirectCallTe
 }
 
 static void
+ValidateIndirectCallTest1SteensgaardAgnosticTopDown(const jlm::tests::IndirectCallTest1 & test)
+{
+  using namespace jlm::llvm;
+
+  // validate indcall function
+  {
+    assert(test.GetLambdaIndcall().subregion()->nnodes() == 5);
+
+    auto lambda_exit_mux = jlm::rvsdg::node_output::node(test.GetLambdaIndcall().fctresult(2)->origin());
+    assert(is<aa::LambdaExitMemStateOperator>(*lambda_exit_mux, 5, 1));
+
+    auto call_exit_mux = jlm::rvsdg::node_output::node(lambda_exit_mux->input(0)->origin());
+    assert(is<aa::CallExitMemStateOperator>(*call_exit_mux, 1, 5));
+
+    auto call = jlm::rvsdg::node_output::node(call_exit_mux->input(0)->origin());
+    assert(is<CallOperation>(*call, 4, 4));
+
+    auto call_entry_mux = jlm::rvsdg::node_output::node(call->input(2)->origin());
+    assert(is<aa::CallEntryMemStateOperator>(*call_entry_mux, 5, 1));
+
+    auto lambda_entry_mux = jlm::rvsdg::node_output::node(call_entry_mux->input(2)->origin());
+    assert(is<aa::LambdaEntryMemStateOperator>(*lambda_entry_mux, 1, 5));
+  }
+
+  // validate test function
+  {
+    assert(test.GetLambdaTest().subregion()->nnodes() == 9);
+
+    auto lambda_exit_mux = jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
+    assert(is<aa::LambdaExitMemStateOperator>(*lambda_exit_mux, 5, 1));
+
+    auto call_exit_mux = jlm::rvsdg::node_output::node(lambda_exit_mux->input(0)->origin());
+    assert(is<aa::CallExitMemStateOperator>(*call_exit_mux, 1, 5));
+
+    auto call = jlm::rvsdg::node_output::node(call_exit_mux->input(0)->origin());
+    assert(is<CallOperation>(*call, 5, 4));
+
+    auto call_entry_mux = jlm::rvsdg::node_output::node(call->input(3)->origin());
+    assert(is<aa::CallEntryMemStateOperator>(*call_entry_mux, 5, 1));
+
+    call_exit_mux = jlm::rvsdg::node_output::node(call_entry_mux->input(0)->origin());
+    assert(is<aa::CallExitMemStateOperator>(*call_exit_mux, 1, 5));
+
+    call = jlm::rvsdg::node_output::node(call_exit_mux->input(0)->origin());
+    assert(is<CallOperation>(*call, 5, 4));
+
+    call_entry_mux = jlm::rvsdg::node_output::node(call->input(3)->origin());
+    assert(is<aa::CallEntryMemStateOperator>(*call_entry_mux, 5, 1));
+
+    auto lambda_entry_mux = jlm::rvsdg::node_output::node(call_entry_mux->input(2)->origin());
+    assert(is<aa::LambdaEntryMemStateOperator>(*lambda_entry_mux, 1, 5));
+  }
+}
+
+static void
 ValidateGammaTestSteensgaardAgnostic(const jlm::tests::GammaTest & test)
 {
   using namespace jlm::llvm;
@@ -707,6 +945,24 @@ ValidateGammaTestSteensgaardRegionAware(const jlm::tests::GammaTest & test)
 
   auto lambdaEntrySplit = jlm::rvsdg::node_output::node(loadTmp1->input(1)->origin());
   assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 2));
+}
+
+static void
+ValidateGammaTestSteensgaardAgnosticTopDown(const jlm::tests::GammaTest & test)
+{
+  using namespace jlm::llvm;
+
+  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(1)->origin());
+  assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
+
+  auto loadTmp2 = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+  assert(is<LoadOperation>(*loadTmp2, 3, 3));
+
+  auto loadTmp1 = jlm::rvsdg::node_output::node(loadTmp2->input(1)->origin());
+  assert(is<LoadOperation>(*loadTmp1, 3, 3));
+
+  auto gamma = jlm::rvsdg::node_output::node(loadTmp1->input(1)->origin());
+  assert(gamma == test.gamma);
 }
 
 static void
@@ -758,6 +1014,29 @@ ValidateThetaTestSteensgaardRegionAware(const jlm::tests::ThetaTest & test)
 }
 
 static void
+ValidateThetaTestSteensgaardAgnosticTopDown(const jlm::tests::ThetaTest & test)
+{
+  using namespace jlm::llvm;
+
+  assert(test.lambda->subregion()->nnodes() == 4);
+
+  auto lambda_exit_mux = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
+  assert(is<aa::LambdaExitMemStateOperator>(*lambda_exit_mux, 2, 1));
+
+  auto thetaOutput = jlm::util::AssertedCast<jlm::rvsdg::theta_output>(lambda_exit_mux->input(0)->origin());
+  auto theta = jlm::rvsdg::node_output::node(thetaOutput);
+  assert(theta == test.theta);
+
+  auto storeStateOutput = thetaOutput->result()->origin();
+  auto store = jlm::rvsdg::node_output::node(storeStateOutput);
+  assert(is<StoreOperation>(*store, 4, 2));
+  assert(store->input(storeStateOutput->index()+2)->origin() == thetaOutput->argument());
+
+  auto lambda_entry_mux = jlm::rvsdg::node_output::node(thetaOutput->input()->origin());
+  assert(is<aa::LambdaEntryMemStateOperator>(*lambda_entry_mux, 1, 2));
+}
+
+static void
 ValidateDeltaTest1SteensgaardAgnostic(const jlm::tests::DeltaTest1 & test)
 {
   using namespace jlm::llvm;
@@ -797,6 +1076,24 @@ ValidateDeltaTest1SteensgaardRegionAware(const jlm::tests::DeltaTest1 & test)
   auto loadF = input_node(*test.lambda_g->fctargument(0)->begin());
   assert(is<LoadOperation>(*loadF, 2, 2));
   assert(loadF->input(1)->origin()->index() == deltaStateIndex);
+}
+
+static void
+ValidateDeltaTest1SteensgaardAgnosticTopDown(const jlm::tests::DeltaTest1 & test)
+{
+  using namespace jlm::llvm;
+
+  assert(test.lambda_h->subregion()->nnodes() == 7);
+
+  auto lambdaEntrySplit = input_node(*test.lambda_h->fctargument(1)->begin());
+  assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 4));
+
+  auto storeF = input_node(*test.constantFive->output(0)->begin());
+  assert(is<StoreOperation>(*storeF, 3, 1));
+  assert(jlm::rvsdg::node_output::node(storeF->input(2)->origin()) == lambdaEntrySplit);
+
+  auto loadF = input_node(*test.lambda_g->fctargument(0)->begin());
+  assert(is<LoadOperation>(*loadF, 2, 2));
 }
 
 static void
@@ -875,6 +1172,31 @@ ValidateDeltaTest2SteensgaardRegionAware(const jlm::tests::DeltaTest2 & test)
 }
 
 static void
+ValidateDeltaTest2SteensgaardAgnosticTopDown(const jlm::tests::DeltaTest2 & test)
+{
+  using namespace jlm::llvm;
+
+  assert(test.lambda_f2->subregion()->nnodes() == 9);
+
+  auto lambdaEntrySplit = input_node(*test.lambda_f2->fctargument(1)->begin());
+  assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 5));
+
+  auto storeD1InF2 = input_node(*test.lambda_f2->cvargument(0)->begin());
+  assert(is<StoreOperation>(*storeD1InF2, 3, 1));
+  assert(jlm::rvsdg::node_output::node(storeD1InF2->input(2)->origin()) == lambdaEntrySplit);
+
+  auto d1StateIndex = storeD1InF2->input(2)->origin()->index();
+
+  auto storeD1InF1 = input_node(*test.lambda_f1->cvargument(0)->begin());
+  assert(is<StoreOperation>(*storeD1InF1, 3, 1));
+
+  auto storeD2InF2 = input_node(*test.lambda_f2->cvargument(1)->begin());
+  assert(is<StoreOperation>(*storeD1InF2, 3, 1));
+
+  assert(d1StateIndex != storeD2InF2->input(2)->origin()->index());
+}
+
+static void
 ValidateDeltaTest3SteensgaardAgnostic(const jlm::tests::DeltaTest3 & test)
 {
   using namespace jlm::llvm;
@@ -936,6 +1258,48 @@ ValidateDeltaTest3SteensgaardRegionAware(const jlm::tests::DeltaTest3 & test)
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(loadG1Node->input(1)->origin());
     assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 2));
+
+    jlm::rvsdg::node * storeG2Node = nullptr;
+    for (size_t n = 0; n < lambdaExitMerge->ninputs(); n++)
+    {
+      auto input = lambdaExitMerge->input(n);
+      auto node = jlm::rvsdg::node_output::node(input->origin());
+      if (is<StoreOperation>(node))
+      {
+        storeG2Node = node;
+        break;
+      }
+    }
+    assert(storeG2Node != nullptr);
+
+    auto loadG2Node = jlm::rvsdg::node_output::node(storeG2Node->input(2)->origin());
+    assert(is<LoadOperation>(*loadG2Node, 2, 2));
+
+    auto node = jlm::rvsdg::node_output::node(loadG2Node->input(1)->origin());
+    assert(node == lambdaEntrySplit);
+  }
+}
+
+static void
+ValidateDeltaTest3SteensgaardAgnosticTopDown(const jlm::tests::DeltaTest3 & test)
+{
+  using namespace jlm::llvm;
+
+  // validate f()
+  {
+    assert(test.LambdaF().subregion()->nnodes() == 6);
+
+    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.LambdaF().fctresult(2)->origin());
+    assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 5, 1));
+
+    auto truncNode = jlm::rvsdg::node_output::node(test.LambdaF().fctresult(0)->origin());
+    assert(is<trunc_op>(*truncNode, 1, 1));
+
+    auto loadG1Node = jlm::rvsdg::node_output::node(truncNode->input(0)->origin());
+    assert(is<LoadOperation>(*loadG1Node, 2, 2));
+
+    auto lambdaEntrySplit = jlm::rvsdg::node_output::node(loadG1Node->input(1)->origin());
+    assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 5));
 
     jlm::rvsdg::node * storeG2Node = nullptr;
     for (size_t n = 0; n < lambdaExitMerge->ninputs(); n++)
@@ -1034,6 +1398,35 @@ ValidateImportTestSteensgaardRegionAware(const jlm::tests::ImportTest & test)
 }
 
 static void
+ValidateImportTestSteensgaardAgnosticTopDown(const jlm::tests::ImportTest & test)
+{
+  using namespace jlm::llvm;
+
+  assert(test.lambda_f2->subregion()->nnodes() == 9);
+
+  auto lambdaEntrySplit = input_node(*test.lambda_f2->fctargument(1)->begin());
+  assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 5));
+
+  auto storeD1InF2 = input_node(*test.lambda_f2->cvargument(0)->begin());
+  assert(is<StoreOperation>(*storeD1InF2, 3, 1));
+  assert(jlm::rvsdg::node_output::node(storeD1InF2->input(2)->origin()) == lambdaEntrySplit);
+
+  assert(storeD1InF2->output(0)->nusers() == 1);
+  auto d1StateIndexEntry = (*storeD1InF2->output(0)->begin())->index();
+
+  auto storeD1InF1 = input_node(*test.lambda_f1->cvargument(0)->begin());
+  assert(is<StoreOperation>(*storeD1InF1, 3, 1));
+  assert(d1StateIndexEntry == storeD1InF1->input(2)->origin()->index());
+  assert(storeD1InF1->output(0)->nusers() == 1);
+  auto d1StateIndexExit = (*storeD1InF1->output(0)->begin())->index();
+
+  auto storeD2InF2 = input_node(*test.lambda_f2->cvargument(1)->begin());
+  assert(is<StoreOperation>(*storeD1InF2, 3, 1));
+
+  assert(d1StateIndexExit != storeD2InF2->input(2)->origin()->index());
+}
+
+static void
 ValidatePhiTestSteensgaardAgnostic(const jlm::tests::PhiTest1 & test)
 {
   using namespace jlm::llvm;
@@ -1087,6 +1480,45 @@ ValidatePhiTestSteensgaardRegionAware(const jlm::tests::PhiTest1 & test)
   assert(is<LoadOperation>(*load2, 2, 2));
 
   assert(load2->input(1)->origin()->index() == arrayStateIndex);
+}
+
+static void
+ValidatePhiTestSteensgaardAgnosticTopDown(const jlm::tests::PhiTest1 & test)
+{
+  using namespace jlm::llvm;
+
+  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda_fib->fctresult(1)->origin());
+  assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 4, 1));
+
+  const StoreNode * storeNode = nullptr;
+  const jlm::rvsdg::gamma_node * gammaNode = nullptr;
+  for (size_t n = 0; n < lambdaExitMerge->ninputs(); n++)
+  {
+    auto node = jlm::rvsdg::node_output::node(lambdaExitMerge->input(n)->origin());
+    if (auto castedStoreNode = dynamic_cast<const StoreNode*>(node))
+    {
+      storeNode = castedStoreNode;
+    }
+    else if (auto castedGammaNode = dynamic_cast<const jlm::rvsdg::gamma_node*>(node))
+    {
+      gammaNode = castedGammaNode;
+    }
+    else
+    {
+      assert(0 && "This should not have happened!");
+    }
+  }
+  assert(gammaNode != nullptr && storeNode != nullptr);
+
+  assert(is<StoreOperation>(*storeNode, 3, 1));
+
+  auto gammaStateIndex = storeNode->input(2)->origin()->index();
+
+  auto load1 = jlm::rvsdg::node_output::node(test.gamma->exitvar(gammaStateIndex)->result(0)->origin());
+  assert(is<LoadOperation>(*load1, 2, 2));
+
+  auto load2 = jlm::rvsdg::node_output::node(load1->input(1)->origin());
+  assert(is<LoadOperation>(*load2, 2, 2));
 }
 
 static void
@@ -1190,6 +1622,55 @@ ValidateMemcpySteensgaardRegionAware(const jlm::tests::MemcpyTest & test)
 }
 
 static void
+ValidateMemcpyTestSteensgaardAgnosticTopDown(const jlm::tests::MemcpyTest & test)
+{
+  using namespace jlm::llvm;
+
+  // Validate function f
+  {
+    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.LambdaF().fctresult(2)->origin());
+    assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 5, 1));
+
+    auto load = jlm::rvsdg::node_output::node(test.LambdaF().fctresult(0)->origin());
+    assert(is<LoadOperation>(*load, 2, 2));
+
+    auto store = jlm::rvsdg::node_output::node(load->input(1)->origin());
+    assert(is<StoreOperation>(*store, 3, 1));
+
+    auto lambdaEntrySplit = jlm::rvsdg::node_output::node(store->input(2)->origin());
+    assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 5));
+  }
+
+  // Validate function g
+  {
+    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.LambdaG().fctresult(2)->origin());
+    assert(is<aa::LambdaExitMemStateOperator>(*lambdaExitMerge, 5, 1));
+
+    auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+    assert(is<aa::CallExitMemStateOperator>(*callExitSplit, 1, 5));
+
+    auto call = jlm::rvsdg::node_output::node(callExitSplit->input(0)->origin());
+    assert(is<CallOperation>(*call, 4, 4));
+
+    auto callEntryMerge = jlm::rvsdg::node_output::node(call->input(2)->origin());
+    assert(is<aa::CallEntryMemStateOperator>(*callEntryMerge, 5, 1));
+
+    jlm::rvsdg::node * memcpy = nullptr;
+    for (size_t n = 0; n < callEntryMerge->ninputs(); n++)
+    {
+      auto node = jlm::rvsdg::node_output::node(callEntryMerge->input(n)->origin());
+      if (is<Memcpy>(node))
+        memcpy = node;
+    }
+    assert(memcpy != nullptr);
+    assert(is<Memcpy>(*memcpy, 6, 2));
+
+    auto lambdaEntrySplit = jlm::rvsdg::node_output::node(memcpy->input(5)->origin());
+    assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 5));
+  }
+}
+
+static void
 ValidateFreeNullTestSteensgaardAgnostic(const jlm::tests::FreeNullTest & test)
 {
   using namespace jlm::llvm;
@@ -1209,85 +1690,260 @@ test()
 {
   using namespace jlm::llvm::aa;
 
-  ValidateTest<jlm::tests::StoreTest1, Steensgaard, AgnosticMemoryNodeProvider>(
-      ValidateStoreTest1SteensgaardAgnostic);
-  ValidateTest<jlm::tests::StoreTest1, Steensgaard, RegionAwareMemoryNodeProvider>(
-      ValidateStoreTest1SteensgaardRegionAware);
+  ValidateTest<
+    jlm::tests::StoreTest1,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidateStoreTest1SteensgaardAgnostic);
+  ValidateTest<
+    jlm::tests::StoreTest1,
+    Steensgaard,
+    RegionAwareMemoryNodeProvider
+  >(ValidateStoreTest1SteensgaardRegionAware);
+  ValidateTest<
+      jlm::tests::StoreTest1,
+      Steensgaard,
+      AgnosticTopDownMemoryNodeProvider
+      >(ValidateStoreTest1SteensgaardAgnosticTopDown);
 
-  ValidateTest<jlm::tests::StoreTest2, Steensgaard, AgnosticMemoryNodeProvider>(
-      ValidateStoreTest2SteensgaardAgnostic);
-  ValidateTest<jlm::tests::StoreTest2, Steensgaard, RegionAwareMemoryNodeProvider>(
-      ValidateStoreTest2SteensgaardRegionAware);
+  ValidateTest<
+    jlm::tests::StoreTest2,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidateStoreTest2SteensgaardAgnostic);
+  ValidateTest<
+    jlm::tests::StoreTest2,
+    Steensgaard,
+    RegionAwareMemoryNodeProvider
+  >(ValidateStoreTest2SteensgaardRegionAware);
+  ValidateTest<
+      jlm::tests::StoreTest2,
+      Steensgaard,
+      AgnosticTopDownMemoryNodeProvider
+      >(ValidateStoreTest2SteensgaardAgnosticTopDown);
 
-  ValidateTest<jlm::tests::LoadTest1, Steensgaard, AgnosticMemoryNodeProvider>(
-      ValidateLoadTest1SteensgaardAgnostic);
-  ValidateTest<jlm::tests::LoadTest1, Steensgaard, RegionAwareMemoryNodeProvider>(
-      ValidateLoadTest1SteensgaardRegionAware);
+  ValidateTest<
+    jlm::tests::LoadTest1,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidateLoadTest1SteensgaardAgnostic);
+  ValidateTest<
+    jlm::tests::LoadTest1,
+    Steensgaard,
+    RegionAwareMemoryNodeProvider
+  >(ValidateLoadTest1SteensgaardRegionAware);
+  ValidateTest<
+      jlm::tests::LoadTest1,
+      Steensgaard,
+      AgnosticTopDownMemoryNodeProvider
+      >(ValidateLoadTest1SteensgaardAgnosticTopDown);
 
-  ValidateTest<jlm::tests::LoadTest2, Steensgaard, AgnosticMemoryNodeProvider>(
-      ValidateLoadTest2SteensgaardAgnostic);
-  ValidateTest<jlm::tests::LoadTest2, Steensgaard, RegionAwareMemoryNodeProvider>(
-      ValidateLoadTest2SteensgaardRegionAware);
+  ValidateTest<
+    jlm::tests::LoadTest2,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidateLoadTest2SteensgaardAgnostic);
+  ValidateTest<
+    jlm::tests::LoadTest2,
+    Steensgaard,
+    RegionAwareMemoryNodeProvider
+  >(ValidateLoadTest2SteensgaardRegionAware);
+  ValidateTest<
+      jlm::tests::LoadTest2,
+      Steensgaard,
+      AgnosticTopDownMemoryNodeProvider
+      >(ValidateLoadTest2SteensgaardAgnosticTopDown);
 
-  ValidateTest<jlm::tests::LoadFromUndefTest, Steensgaard, AgnosticMemoryNodeProvider>(
-      ValidateLoadFromUndefSteensgaardAgnostic);
-  ValidateTest<jlm::tests::LoadFromUndefTest, Steensgaard, RegionAwareMemoryNodeProvider>(
-      ValidateLoadFromUndefSteensgaardRegionAware);
+  ValidateTest<
+    jlm::tests::LoadFromUndefTest,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidateLoadFromUndefSteensgaardAgnostic);
+  ValidateTest<
+    jlm::tests::LoadFromUndefTest,
+    Steensgaard,
+    RegionAwareMemoryNodeProvider
+  >(ValidateLoadFromUndefSteensgaardRegionAware);
+  ValidateTest<
+      jlm::tests::LoadFromUndefTest,
+      Steensgaard,
+      AgnosticTopDownMemoryNodeProvider
+      >(ValidateLoadFromUndefSteensgaardAgnosticTopDown);
 
-  ValidateTest<jlm::tests::CallTest1, Steensgaard, AgnosticMemoryNodeProvider>(
-      ValidateCallTest1SteensgaardAgnostic);
-  ValidateTest<jlm::tests::CallTest1, Steensgaard, RegionAwareMemoryNodeProvider>(
-      ValidateCallTest1SteensgaardRegionAware);
+  ValidateTest<
+    jlm::tests::CallTest1,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidateCallTest1SteensgaardAgnostic);
+  ValidateTest<
+    jlm::tests::CallTest1,
+    Steensgaard,
+    RegionAwareMemoryNodeProvider
+  >(ValidateCallTest1SteensgaardRegionAware);
+  ValidateTest<
+      jlm::tests::CallTest1,
+      Steensgaard,
+      AgnosticTopDownMemoryNodeProvider
+      >(ValidateCallTest1SteensgaardAgnosticTopDown);
 
-  ValidateTest<jlm::tests::CallTest2, Steensgaard, AgnosticMemoryNodeProvider>(
-      ValidateCallTest2SteensgaardAgnostic);
-  ValidateTest<jlm::tests::CallTest2, Steensgaard, RegionAwareMemoryNodeProvider>(
-      ValidateCallTest2SteensgaardRegionAware);
+  ValidateTest<
+    jlm::tests::CallTest2,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidateCallTest2SteensgaardAgnostic);
+  ValidateTest<
+    jlm::tests::CallTest2,
+    Steensgaard,
+    RegionAwareMemoryNodeProvider
+  >(ValidateCallTest2SteensgaardRegionAware);
+  ValidateTest<
+      jlm::tests::CallTest2,
+      Steensgaard,
+      AgnosticTopDownMemoryNodeProvider
+      >(ValidateCallTest2SteensgaardAgnosticTopDown);
 
-  ValidateTest<jlm::tests::IndirectCallTest1, Steensgaard, AgnosticMemoryNodeProvider>(
-      ValidateIndirectCallTest1SteensgaardAgnostic);
-  ValidateTest<jlm::tests::IndirectCallTest1, Steensgaard, RegionAwareMemoryNodeProvider>(
-      ValidateIndirectCallTest1SteensgaardRegionAware);
+  ValidateTest<
+    jlm::tests::IndirectCallTest1,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidateIndirectCallTest1SteensgaardAgnostic);
+  ValidateTest<
+    jlm::tests::IndirectCallTest1,
+    Steensgaard,
+    RegionAwareMemoryNodeProvider
+  >(ValidateIndirectCallTest1SteensgaardRegionAware);
+  ValidateTest<
+      jlm::tests::IndirectCallTest1,
+      Steensgaard,
+      AgnosticTopDownMemoryNodeProvider
+      >(ValidateIndirectCallTest1SteensgaardAgnosticTopDown);
 
-  ValidateTest<jlm::tests::GammaTest, Steensgaard, AgnosticMemoryNodeProvider>(
-      ValidateGammaTestSteensgaardAgnostic);
-  ValidateTest<jlm::tests::GammaTest, Steensgaard, RegionAwareMemoryNodeProvider>(
-      ValidateGammaTestSteensgaardRegionAware);
+  ValidateTest<
+    jlm::tests::GammaTest,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidateGammaTestSteensgaardAgnostic);
+  ValidateTest<
+    jlm::tests::GammaTest,
+    Steensgaard,
+    RegionAwareMemoryNodeProvider
+  >(ValidateGammaTestSteensgaardRegionAware);
+  ValidateTest<
+      jlm::tests::GammaTest,
+      Steensgaard,
+      AgnosticTopDownMemoryNodeProvider
+      >(ValidateGammaTestSteensgaardAgnosticTopDown);
 
-  ValidateTest<jlm::tests::ThetaTest, Steensgaard, AgnosticMemoryNodeProvider>(
-      ValidateThetaTestSteensgaardAgnostic);
-  ValidateTest<jlm::tests::ThetaTest, Steensgaard, RegionAwareMemoryNodeProvider>(
-      ValidateThetaTestSteensgaardRegionAware);
+  ValidateTest<
+    jlm::tests::ThetaTest,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidateThetaTestSteensgaardAgnostic);
+  ValidateTest<
+    jlm::tests::ThetaTest,
+    Steensgaard,
+    RegionAwareMemoryNodeProvider
+  >(ValidateThetaTestSteensgaardRegionAware);
+  ValidateTest<
+      jlm::tests::ThetaTest,
+      Steensgaard,
+      AgnosticMemoryNodeProvider
+      >(ValidateThetaTestSteensgaardAgnosticTopDown);
 
-  ValidateTest<jlm::tests::DeltaTest1, Steensgaard, AgnosticMemoryNodeProvider>(
-      ValidateDeltaTest1SteensgaardAgnostic);
-  ValidateTest<jlm::tests::DeltaTest1, Steensgaard, RegionAwareMemoryNodeProvider>(
-      ValidateDeltaTest1SteensgaardRegionAware);
+  ValidateTest<
+    jlm::tests::DeltaTest1,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidateDeltaTest1SteensgaardAgnostic);
+  ValidateTest<
+    jlm::tests::DeltaTest1,
+    Steensgaard,
+    RegionAwareMemoryNodeProvider
+  >(ValidateDeltaTest1SteensgaardRegionAware);
+  ValidateTest<
+      jlm::tests::DeltaTest1,
+      Steensgaard,
+      AgnosticMemoryNodeProvider
+      >(ValidateDeltaTest1SteensgaardAgnosticTopDown);
 
-  ValidateTest<jlm::tests::DeltaTest2, Steensgaard, AgnosticMemoryNodeProvider>(
-      ValidateDeltaTest2SteensgaardAgnostic);
-  ValidateTest<jlm::tests::DeltaTest2, Steensgaard, RegionAwareMemoryNodeProvider>(
-      ValidateDeltaTest2SteensgaardRegionAware);
+  ValidateTest<
+    jlm::tests::DeltaTest2,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidateDeltaTest2SteensgaardAgnostic);
+  ValidateTest<
+    jlm::tests::DeltaTest2,
+    Steensgaard,
+    RegionAwareMemoryNodeProvider
+  >(ValidateDeltaTest2SteensgaardRegionAware);
+  ValidateTest<
+      jlm::tests::DeltaTest2,
+      Steensgaard,
+      AgnosticMemoryNodeProvider
+      >(ValidateDeltaTest2SteensgaardAgnosticTopDown);
 
-  ValidateTest<jlm::tests::DeltaTest3, Steensgaard, AgnosticMemoryNodeProvider>(
-      ValidateDeltaTest3SteensgaardAgnostic);
-  ValidateTest<jlm::tests::DeltaTest3, Steensgaard, RegionAwareMemoryNodeProvider>(
-      ValidateDeltaTest3SteensgaardRegionAware);
+  ValidateTest<
+    jlm::tests::DeltaTest3,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidateDeltaTest3SteensgaardAgnostic);
+  ValidateTest<
+    jlm::tests::DeltaTest3,
+    Steensgaard,
+    RegionAwareMemoryNodeProvider
+  >(ValidateDeltaTest3SteensgaardRegionAware);
+  ValidateTest<
+      jlm::tests::DeltaTest3,
+      Steensgaard,
+      AgnosticMemoryNodeProvider
+      >(ValidateDeltaTest3SteensgaardAgnosticTopDown);
 
-  ValidateTest<jlm::tests::ImportTest, Steensgaard, AgnosticMemoryNodeProvider>(
-      ValidateImportTestSteensgaardAgnostic);
-  ValidateTest<jlm::tests::ImportTest, Steensgaard, RegionAwareMemoryNodeProvider>(
-      ValidateImportTestSteensgaardRegionAware);
+  ValidateTest<
+    jlm::tests::ImportTest,
+    Steensgaard,
+    AgnosticMemoryNodeProvider>(ValidateImportTestSteensgaardAgnostic);
+  ValidateTest<
+    jlm::tests::ImportTest,
+    Steensgaard,
+    RegionAwareMemoryNodeProvider
+  >(ValidateImportTestSteensgaardRegionAware);
+  ValidateTest<
+      jlm::tests::ImportTest,
+      Steensgaard,
+      AgnosticMemoryNodeProvider
+      >(ValidateImportTestSteensgaardAgnosticTopDown);
 
-  ValidateTest<jlm::tests::PhiTest1, Steensgaard, AgnosticMemoryNodeProvider>(
-      ValidatePhiTestSteensgaardAgnostic);
-  ValidateTest<jlm::tests::PhiTest1, Steensgaard, RegionAwareMemoryNodeProvider>(
-      ValidatePhiTestSteensgaardRegionAware);
+  ValidateTest<
+    jlm::tests::PhiTest1,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidatePhiTestSteensgaardAgnostic);
+  ValidateTest<
+    jlm::tests::PhiTest1,
+    Steensgaard,
+    RegionAwareMemoryNodeProvider
+  >(ValidatePhiTestSteensgaardRegionAware);
+  ValidateTest<
+      jlm::tests::PhiTest1,
+      Steensgaard,
+      AgnosticMemoryNodeProvider
+      >(ValidatePhiTestSteensgaardAgnosticTopDown);
 
-  ValidateTest<jlm::tests::MemcpyTest, Steensgaard, AgnosticMemoryNodeProvider>(
-      ValidateMemcpySteensgaardAgnostic);
-  ValidateTest<jlm::tests::MemcpyTest, Steensgaard, RegionAwareMemoryNodeProvider>(
-      ValidateMemcpySteensgaardRegionAware);
+  ValidateTest<
+    jlm::tests::MemcpyTest,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidateMemcpySteensgaardAgnostic);
+  ValidateTest<
+    jlm::tests::MemcpyTest,
+    Steensgaard,
+    RegionAwareMemoryNodeProvider
+  >(ValidateMemcpySteensgaardRegionAware);
+  ValidateTest<
+      jlm::tests::MemcpyTest,
+      Steensgaard,
+      AgnosticMemoryNodeProvider
+      >(ValidateMemcpyTestSteensgaardAgnosticTopDown);
 
   ValidateTest<jlm::tests::FreeNullTest, Steensgaard, AgnosticMemoryNodeProvider>(
       ValidateFreeNullTestSteensgaardAgnostic);

--- a/tests/jlm/llvm/opt/alias-analyses/TestTopDownMemoryNodeEliminator.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestTopDownMemoryNodeEliminator.cpp
@@ -7,23 +7,25 @@
 #include <TestRvsdgs.hpp>
 
 #include <jlm/llvm/opt/alias-analyses/AgnosticMemoryNodeProvider.hpp>
-#include <jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.hpp>
 #include <jlm/llvm/opt/alias-analyses/Steensgaard.hpp>
+#include <jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.hpp>
 
-template <class Test, class Analysis, class Provider> static void
-ValidateTest(std::function<void(const Test&, const jlm::llvm::aa::MemoryNodeProvisioning&)> validateProvisioning)
+template<class Test, class Analysis, class Provider>
+static void
+ValidateTest(std::function<void(const Test &, const jlm::llvm::aa::MemoryNodeProvisioning &)>
+                 validateProvisioning)
 {
   static_assert(
-    std::is_base_of<jlm::tests::RvsdgTest, Test>::value,
-    "Test should be derived from RvsdgTest class.");
+      std::is_base_of<jlm::tests::RvsdgTest, Test>::value,
+      "Test should be derived from RvsdgTest class.");
 
   static_assert(
-    std::is_base_of<jlm::llvm::aa::AliasAnalysis, Analysis>::value,
-    "Analysis should be derived from AliasAnalysis class.");
+      std::is_base_of<jlm::llvm::aa::AliasAnalysis, Analysis>::value,
+      "Analysis should be derived from AliasAnalysis class.");
 
   static_assert(
-    std::is_base_of<jlm::llvm::aa::MemoryNodeProvider, Provider>::value,
-    "Provider should be derived from MemoryNodeProvider class.");
+      std::is_base_of<jlm::llvm::aa::MemoryNodeProvider, Provider>::value,
+      "Provider should be derived from MemoryNodeProvider class.");
 
   Test test;
   auto & rvsdgModule = test.module();
@@ -34,15 +36,17 @@ ValidateTest(std::function<void(const Test&, const jlm::llvm::aa::MemoryNodeProv
 
   auto seedProvisioning = Provider::Create(rvsdgModule, *pointsToGraph);
 
-  auto provisioning = jlm::llvm::aa::TopDownMemoryNodeEliminator::CreateAndEliminate(test.module(), *seedProvisioning);
+  auto provisioning = jlm::llvm::aa::TopDownMemoryNodeEliminator::CreateAndEliminate(
+      test.module(),
+      *seedProvisioning);
 
   validateProvisioning(test, *provisioning);
 }
 
 static void
 ValidateStoreTest1SteensgaardAgnostic(
-  const jlm::tests::StoreTest1 & test,
-  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+    const jlm::tests::StoreTest1 & test,
+    const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
 {
   auto & pointsToGraph = provisioning.GetPointsToGraph();
 
@@ -50,10 +54,7 @@ ValidateStoreTest1SteensgaardAgnostic(
   auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
 
   jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
-    {
-      &lambdaMemoryNode,
-      &externalMemoryNode
-    });
+      { &lambdaMemoryNode, &externalMemoryNode });
 
   auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(*test.lambda);
   assert(lambdaEntryNodes == expectedMemoryNodes);
@@ -64,19 +65,16 @@ ValidateStoreTest1SteensgaardAgnostic(
 
 static void
 ValidateStoreTest2SteensgaardAgnostic(
-  const jlm::tests::StoreTest2 & test,
-  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+    const jlm::tests::StoreTest2 & test,
+    const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
 {
   auto & pointsToGraph = provisioning.GetPointsToGraph();
 
   auto & lambdaMemoryNode = pointsToGraph.GetLambdaNode(*test.lambda);
   auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
 
-  jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode*> expectedMemoryNodes(
-    {
-      &lambdaMemoryNode,
-      &externalMemoryNode
-    });
+  jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+      { &lambdaMemoryNode, &externalMemoryNode });
 
   auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(*test.lambda);
   assert(lambdaEntryNodes == expectedMemoryNodes);
@@ -87,8 +85,8 @@ ValidateStoreTest2SteensgaardAgnostic(
 
 static void
 ValidateLoadTest1SteensgaardAgnostic(
-  const jlm::tests::LoadTest1 & test,
-  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+    const jlm::tests::LoadTest1 & test,
+    const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
 {
   auto & pointsToGraph = provisioning.GetPointsToGraph();
 
@@ -96,10 +94,7 @@ ValidateLoadTest1SteensgaardAgnostic(
   auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
 
   jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
-    {
-      &lambdaMemoryNode,
-      &externalMemoryNode
-    });
+      { &lambdaMemoryNode, &externalMemoryNode });
 
   auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(*test.lambda);
   assert(lambdaEntryNodes == expectedMemoryNodes);
@@ -110,8 +105,8 @@ ValidateLoadTest1SteensgaardAgnostic(
 
 static void
 ValidateLoadTest2SteensgaardAgnostic(
-  const jlm::tests::LoadTest2 & test,
-  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+    const jlm::tests::LoadTest2 & test,
+    const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
 {
   auto & pointsToGraph = provisioning.GetPointsToGraph();
 
@@ -119,10 +114,7 @@ ValidateLoadTest2SteensgaardAgnostic(
   auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
 
   jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
-    {
-      &lambdaMemoryNode,
-      &externalMemoryNode
-    });
+      { &lambdaMemoryNode, &externalMemoryNode });
 
   auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(*test.lambda);
   assert(lambdaEntryNodes == expectedMemoryNodes);
@@ -133,8 +125,8 @@ ValidateLoadTest2SteensgaardAgnostic(
 
 static void
 ValidateLoadFromUndefTestSteensgaardAgnostic(
-  const jlm::tests::LoadFromUndefTest & test,
-  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+    const jlm::tests::LoadFromUndefTest & test,
+    const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
 {
   auto & pointsToGraph = provisioning.GetPointsToGraph();
 
@@ -142,10 +134,7 @@ ValidateLoadFromUndefTestSteensgaardAgnostic(
   auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
 
   jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
-    {
-      &lambdaMemoryNode,
-      &externalMemoryNode
-    });
+      { &lambdaMemoryNode, &externalMemoryNode });
 
   auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.Lambda());
   assert(lambdaEntryNodes == expectedMemoryNodes);
@@ -156,8 +145,8 @@ ValidateLoadFromUndefTestSteensgaardAgnostic(
 
 static void
 ValidateCallTest1SteensgaardAgnostic(
-  const jlm::tests::CallTest1 & test,
-  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+    const jlm::tests::CallTest1 & test,
+    const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
 {
   auto & pointsToGraph = provisioning.GetPointsToGraph();
 
@@ -172,15 +161,13 @@ ValidateCallTest1SteensgaardAgnostic(
   // Validate function f
   {
     jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
-      {
-        &allocaXMemoryNode,
-        &allocaYMemoryNode,
-        &allocaZMemoryNode,
-        &lambdaFMemoryNode,
-        &lambdaGMemoryNode,
-        &lambdaHMemoryNode,
-        &externalMemoryNode
-      });
+        { &allocaXMemoryNode,
+          &allocaYMemoryNode,
+          &allocaZMemoryNode,
+          &lambdaFMemoryNode,
+          &lambdaGMemoryNode,
+          &lambdaHMemoryNode,
+          &externalMemoryNode });
 
     auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(*test.lambda_f);
     assert(lambdaEntryNodes == expectedMemoryNodes);
@@ -192,15 +179,13 @@ ValidateCallTest1SteensgaardAgnostic(
   // Validate function g
   {
     jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
-      {
-        &allocaXMemoryNode,
-        &allocaYMemoryNode,
-        &allocaZMemoryNode,
-        &lambdaFMemoryNode,
-        &lambdaGMemoryNode,
-        &lambdaHMemoryNode,
-        &externalMemoryNode
-      });
+        { &allocaXMemoryNode,
+          &allocaYMemoryNode,
+          &allocaZMemoryNode,
+          &lambdaFMemoryNode,
+          &lambdaGMemoryNode,
+          &lambdaHMemoryNode,
+          &externalMemoryNode });
 
     auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(*test.lambda_g);
     assert(lambdaEntryNodes == expectedMemoryNodes);
@@ -212,12 +197,7 @@ ValidateCallTest1SteensgaardAgnostic(
   // Validate function h
   {
     jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
-      {
-        &lambdaFMemoryNode,
-        &lambdaGMemoryNode,
-        &lambdaHMemoryNode,
-        &externalMemoryNode
-      });
+        { &lambdaFMemoryNode, &lambdaGMemoryNode, &lambdaHMemoryNode, &externalMemoryNode });
 
     auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(*test.lambda_h);
     assert(lambdaEntryNodes == expectedMemoryNodes);
@@ -229,15 +209,13 @@ ValidateCallTest1SteensgaardAgnostic(
   // Validate call to f
   {
     jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
-      {
-        &allocaXMemoryNode,
-        &allocaYMemoryNode,
-        &allocaZMemoryNode,
-        &lambdaFMemoryNode,
-        &lambdaGMemoryNode,
-        &lambdaHMemoryNode,
-        &externalMemoryNode
-      });
+        { &allocaXMemoryNode,
+          &allocaYMemoryNode,
+          &allocaZMemoryNode,
+          &lambdaFMemoryNode,
+          &lambdaGMemoryNode,
+          &lambdaHMemoryNode,
+          &externalMemoryNode });
 
     auto & callEntryNodes = provisioning.GetCallEntryNodes(test.CallF());
     assert(callEntryNodes == expectedMemoryNodes);
@@ -249,15 +227,13 @@ ValidateCallTest1SteensgaardAgnostic(
   // Validate call to g
   {
     jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
-      {
-        &allocaXMemoryNode,
-        &allocaYMemoryNode,
-        &allocaZMemoryNode,
-        &lambdaFMemoryNode,
-        &lambdaGMemoryNode,
-        &lambdaHMemoryNode,
-        &externalMemoryNode
-      });
+        { &allocaXMemoryNode,
+          &allocaYMemoryNode,
+          &allocaZMemoryNode,
+          &lambdaFMemoryNode,
+          &lambdaGMemoryNode,
+          &lambdaHMemoryNode,
+          &externalMemoryNode });
 
     auto & callEntryNodes = provisioning.GetCallEntryNodes(test.CallG());
     assert(callEntryNodes == expectedMemoryNodes);
@@ -269,8 +245,8 @@ ValidateCallTest1SteensgaardAgnostic(
 
 static void
 ValidateIndirectCallTest1SteensgaardAgnostic(
-  const jlm::tests::IndirectCallTest1 & test,
-  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+    const jlm::tests::IndirectCallTest1 & test,
+    const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
 {
   auto & pointsToGraph = provisioning.GetPointsToGraph();
 
@@ -281,13 +257,11 @@ ValidateIndirectCallTest1SteensgaardAgnostic(
   auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
 
   jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
-    {
-      &lambdaFourMemoryNode,
-      &lambdaThreeMemoryNode,
-      &lambdaIndCallMemoryNode,
-      &lambdaTestMemoryNode,
-      &externalMemoryNode
-    });
+      { &lambdaFourMemoryNode,
+        &lambdaThreeMemoryNode,
+        &lambdaIndCallMemoryNode,
+        &lambdaTestMemoryNode,
+        &externalMemoryNode });
 
   // Validate function four
   {
@@ -355,8 +329,8 @@ ValidateIndirectCallTest1SteensgaardAgnostic(
 
 static void
 ValidateIndirectCallTest2SteensgaardAgnostic(
-  const jlm::tests::IndirectCallTest2 & test,
-  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+    const jlm::tests::IndirectCallTest2 & test,
+    const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
 {
   auto & pointsToGraph = provisioning.GetPointsToGraph();
 
@@ -380,20 +354,18 @@ ValidateIndirectCallTest2SteensgaardAgnostic(
   // Validate function test2
   {
     jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
-      {
-        &lambdaThreeMemoryNode,
-        &lambdaFourMemoryNode,
-        &lambdaIMemoryNode,
-        &lambdaXMemoryNode,
-        &lambdaYMemoryNode,
-        &lambdaTestMemoryNode,
-        &lambdaTest2MemoryNode,
+        { &lambdaThreeMemoryNode,
+          &lambdaFourMemoryNode,
+          &lambdaIMemoryNode,
+          &lambdaXMemoryNode,
+          &lambdaYMemoryNode,
+          &lambdaTestMemoryNode,
+          &lambdaTest2MemoryNode,
 
-        &deltaG1MemoryNode,
-        &deltaG2MemoryNode,
+          &deltaG1MemoryNode,
+          &deltaG2MemoryNode,
 
-        &externalMemoryNode
-      });
+          &externalMemoryNode });
 
     auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaTest2());
     assert(lambdaEntryNodes == expectedMemoryNodes);
@@ -405,20 +377,18 @@ ValidateIndirectCallTest2SteensgaardAgnostic(
   // Validate function test
   {
     jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
-      {
-        &lambdaThreeMemoryNode,
-        &lambdaFourMemoryNode,
-        &lambdaIMemoryNode,
-        &lambdaXMemoryNode,
-        &lambdaYMemoryNode,
-        &lambdaTestMemoryNode,
-        &lambdaTest2MemoryNode,
+        { &lambdaThreeMemoryNode,
+          &lambdaFourMemoryNode,
+          &lambdaIMemoryNode,
+          &lambdaXMemoryNode,
+          &lambdaYMemoryNode,
+          &lambdaTestMemoryNode,
+          &lambdaTest2MemoryNode,
 
-        &deltaG1MemoryNode,
-        &deltaG2MemoryNode,
+          &deltaG1MemoryNode,
+          &deltaG2MemoryNode,
 
-        &externalMemoryNode
-      });
+          &externalMemoryNode });
 
     auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaTest());
     assert(lambdaEntryNodes == expectedMemoryNodes);
@@ -430,23 +400,21 @@ ValidateIndirectCallTest2SteensgaardAgnostic(
   // Validate function y
   {
     jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
-      {
-        &lambdaThreeMemoryNode,
-        &lambdaFourMemoryNode,
-        &lambdaIMemoryNode,
-        &lambdaXMemoryNode,
-        &lambdaYMemoryNode,
-        &lambdaTestMemoryNode,
-        &lambdaTest2MemoryNode,
+        { &lambdaThreeMemoryNode,
+          &lambdaFourMemoryNode,
+          &lambdaIMemoryNode,
+          &lambdaXMemoryNode,
+          &lambdaYMemoryNode,
+          &lambdaTestMemoryNode,
+          &lambdaTest2MemoryNode,
 
-        &deltaG1MemoryNode,
-        &deltaG2MemoryNode,
+          &deltaG1MemoryNode,
+          &deltaG2MemoryNode,
 
-        &allocaPxMemoryNode,
-        &allocaPyMemoryNode,
+          &allocaPxMemoryNode,
+          &allocaPyMemoryNode,
 
-        &externalMemoryNode
-      });
+          &externalMemoryNode });
 
     auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaY());
     assert(lambdaEntryNodes == expectedMemoryNodes);
@@ -458,24 +426,22 @@ ValidateIndirectCallTest2SteensgaardAgnostic(
   // Validate function x
   {
     jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
-      {
-        &lambdaThreeMemoryNode,
-        &lambdaFourMemoryNode,
-        &lambdaIMemoryNode,
-        &lambdaXMemoryNode,
-        &lambdaYMemoryNode,
-        &lambdaTestMemoryNode,
-        &lambdaTest2MemoryNode,
+        { &lambdaThreeMemoryNode,
+          &lambdaFourMemoryNode,
+          &lambdaIMemoryNode,
+          &lambdaXMemoryNode,
+          &lambdaYMemoryNode,
+          &lambdaTestMemoryNode,
+          &lambdaTest2MemoryNode,
 
-        &deltaG1MemoryNode,
-        &deltaG2MemoryNode,
+          &deltaG1MemoryNode,
+          &deltaG2MemoryNode,
 
-        &allocaPxMemoryNode,
-        &allocaPyMemoryNode,
-        &allocaPzMemoryNode,
+          &allocaPxMemoryNode,
+          &allocaPyMemoryNode,
+          &allocaPzMemoryNode,
 
-        &externalMemoryNode
-      });
+          &externalMemoryNode });
 
     auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaX());
     assert(lambdaEntryNodes == expectedMemoryNodes);
@@ -487,24 +453,22 @@ ValidateIndirectCallTest2SteensgaardAgnostic(
   // Validate function i
   {
     jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
-      {
-        &lambdaThreeMemoryNode,
-        &lambdaFourMemoryNode,
-        &lambdaIMemoryNode,
-        &lambdaXMemoryNode,
-        &lambdaYMemoryNode,
-        &lambdaTestMemoryNode,
-        &lambdaTest2MemoryNode,
+        { &lambdaThreeMemoryNode,
+          &lambdaFourMemoryNode,
+          &lambdaIMemoryNode,
+          &lambdaXMemoryNode,
+          &lambdaYMemoryNode,
+          &lambdaTestMemoryNode,
+          &lambdaTest2MemoryNode,
 
-        &deltaG1MemoryNode,
-        &deltaG2MemoryNode,
+          &deltaG1MemoryNode,
+          &deltaG2MemoryNode,
 
-        &allocaPxMemoryNode,
-        &allocaPyMemoryNode,
-        &allocaPzMemoryNode,
+          &allocaPxMemoryNode,
+          &allocaPyMemoryNode,
+          &allocaPzMemoryNode,
 
-        &externalMemoryNode
-      });
+          &externalMemoryNode });
 
     auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaI());
     assert(lambdaEntryNodes == expectedMemoryNodes);
@@ -516,24 +480,22 @@ ValidateIndirectCallTest2SteensgaardAgnostic(
   // Validate function four
   {
     jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
-      {
-        &lambdaThreeMemoryNode,
-        &lambdaFourMemoryNode,
-        &lambdaIMemoryNode,
-        &lambdaXMemoryNode,
-        &lambdaYMemoryNode,
-        &lambdaTestMemoryNode,
-        &lambdaTest2MemoryNode,
+        { &lambdaThreeMemoryNode,
+          &lambdaFourMemoryNode,
+          &lambdaIMemoryNode,
+          &lambdaXMemoryNode,
+          &lambdaYMemoryNode,
+          &lambdaTestMemoryNode,
+          &lambdaTest2MemoryNode,
 
-        &deltaG1MemoryNode,
-        &deltaG2MemoryNode,
+          &deltaG1MemoryNode,
+          &deltaG2MemoryNode,
 
-        &allocaPxMemoryNode,
-        &allocaPyMemoryNode,
-        &allocaPzMemoryNode,
+          &allocaPxMemoryNode,
+          &allocaPyMemoryNode,
+          &allocaPzMemoryNode,
 
-        &externalMemoryNode
-      });
+          &externalMemoryNode });
 
     auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaFour());
     assert(lambdaEntryNodes == expectedMemoryNodes);
@@ -545,24 +507,22 @@ ValidateIndirectCallTest2SteensgaardAgnostic(
   // Validate function three
   {
     jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
-      {
-        &lambdaThreeMemoryNode,
-        &lambdaFourMemoryNode,
-        &lambdaIMemoryNode,
-        &lambdaXMemoryNode,
-        &lambdaYMemoryNode,
-        &lambdaTestMemoryNode,
-        &lambdaTest2MemoryNode,
+        { &lambdaThreeMemoryNode,
+          &lambdaFourMemoryNode,
+          &lambdaIMemoryNode,
+          &lambdaXMemoryNode,
+          &lambdaYMemoryNode,
+          &lambdaTestMemoryNode,
+          &lambdaTest2MemoryNode,
 
-        &deltaG1MemoryNode,
-        &deltaG2MemoryNode,
+          &deltaG1MemoryNode,
+          &deltaG2MemoryNode,
 
-        &allocaPxMemoryNode,
-        &allocaPyMemoryNode,
-        &allocaPzMemoryNode,
+          &allocaPxMemoryNode,
+          &allocaPyMemoryNode,
+          &allocaPzMemoryNode,
 
-        &externalMemoryNode
-      });
+          &externalMemoryNode });
 
     auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaThree());
     assert(lambdaEntryNodes == expectedMemoryNodes);
@@ -574,24 +534,22 @@ ValidateIndirectCallTest2SteensgaardAgnostic(
   // Validate indirect call
   {
     jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
-      {
-        &lambdaThreeMemoryNode,
-        &lambdaFourMemoryNode,
-        &lambdaIMemoryNode,
-        &lambdaXMemoryNode,
-        &lambdaYMemoryNode,
-        &lambdaTestMemoryNode,
-        &lambdaTest2MemoryNode,
+        { &lambdaThreeMemoryNode,
+          &lambdaFourMemoryNode,
+          &lambdaIMemoryNode,
+          &lambdaXMemoryNode,
+          &lambdaYMemoryNode,
+          &lambdaTestMemoryNode,
+          &lambdaTest2MemoryNode,
 
-        &deltaG1MemoryNode,
-        &deltaG2MemoryNode,
+          &deltaG1MemoryNode,
+          &deltaG2MemoryNode,
 
-        &allocaPxMemoryNode,
-        &allocaPyMemoryNode,
-        &allocaPzMemoryNode,
+          &allocaPxMemoryNode,
+          &allocaPyMemoryNode,
+          &allocaPzMemoryNode,
 
-        &externalMemoryNode
-      });
+          &externalMemoryNode });
 
     auto & callEntryNodes = provisioning.GetCallEntryNodes(test.GetIndirectCall());
     assert(callEntryNodes == expectedMemoryNodes);
@@ -603,24 +561,22 @@ ValidateIndirectCallTest2SteensgaardAgnostic(
   // Validate call to i from x
   {
     jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
-      {
-        &lambdaThreeMemoryNode,
-        &lambdaFourMemoryNode,
-        &lambdaIMemoryNode,
-        &lambdaXMemoryNode,
-        &lambdaYMemoryNode,
-        &lambdaTestMemoryNode,
-        &lambdaTest2MemoryNode,
+        { &lambdaThreeMemoryNode,
+          &lambdaFourMemoryNode,
+          &lambdaIMemoryNode,
+          &lambdaXMemoryNode,
+          &lambdaYMemoryNode,
+          &lambdaTestMemoryNode,
+          &lambdaTest2MemoryNode,
 
-        &deltaG1MemoryNode,
-        &deltaG2MemoryNode,
+          &deltaG1MemoryNode,
+          &deltaG2MemoryNode,
 
-        &allocaPxMemoryNode,
-        &allocaPyMemoryNode,
-        &allocaPzMemoryNode,
+          &allocaPxMemoryNode,
+          &allocaPyMemoryNode,
+          &allocaPzMemoryNode,
 
-        &externalMemoryNode
-      });
+          &externalMemoryNode });
 
     auto & callEntryNodes = provisioning.GetCallEntryNodes(test.GetCallIWithThree());
     assert(callEntryNodes == expectedMemoryNodes);
@@ -632,24 +588,22 @@ ValidateIndirectCallTest2SteensgaardAgnostic(
   // Validate call to i from y
   {
     jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
-      {
-        &lambdaThreeMemoryNode,
-        &lambdaFourMemoryNode,
-        &lambdaIMemoryNode,
-        &lambdaXMemoryNode,
-        &lambdaYMemoryNode,
-        &lambdaTestMemoryNode,
-        &lambdaTest2MemoryNode,
+        { &lambdaThreeMemoryNode,
+          &lambdaFourMemoryNode,
+          &lambdaIMemoryNode,
+          &lambdaXMemoryNode,
+          &lambdaYMemoryNode,
+          &lambdaTestMemoryNode,
+          &lambdaTest2MemoryNode,
 
-        &deltaG1MemoryNode,
-        &deltaG2MemoryNode,
+          &deltaG1MemoryNode,
+          &deltaG2MemoryNode,
 
-        &allocaPxMemoryNode,
-        &allocaPyMemoryNode,
-        &allocaPzMemoryNode,
+          &allocaPxMemoryNode,
+          &allocaPyMemoryNode,
+          &allocaPzMemoryNode,
 
-        &externalMemoryNode
-      });
+          &externalMemoryNode });
 
     auto & callEntryNodes = provisioning.GetCallEntryNodes(test.GetCallIWithFour());
     assert(callEntryNodes == expectedMemoryNodes);
@@ -661,24 +615,22 @@ ValidateIndirectCallTest2SteensgaardAgnostic(
   // Validate call to x from test
   {
     jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
-      {
-        &lambdaThreeMemoryNode,
-        &lambdaFourMemoryNode,
-        &lambdaIMemoryNode,
-        &lambdaXMemoryNode,
-        &lambdaYMemoryNode,
-        &lambdaTestMemoryNode,
-        &lambdaTest2MemoryNode,
+        { &lambdaThreeMemoryNode,
+          &lambdaFourMemoryNode,
+          &lambdaIMemoryNode,
+          &lambdaXMemoryNode,
+          &lambdaYMemoryNode,
+          &lambdaTestMemoryNode,
+          &lambdaTest2MemoryNode,
 
-        &deltaG1MemoryNode,
-        &deltaG2MemoryNode,
+          &deltaG1MemoryNode,
+          &deltaG2MemoryNode,
 
-        &allocaPxMemoryNode,
-        &allocaPyMemoryNode,
-        &allocaPzMemoryNode,
+          &allocaPxMemoryNode,
+          &allocaPyMemoryNode,
+          &allocaPzMemoryNode,
 
-        &externalMemoryNode
-      });
+          &externalMemoryNode });
 
     auto & callEntryNodes = provisioning.GetCallEntryNodes(test.GetTestCallX());
     assert(callEntryNodes == expectedMemoryNodes);
@@ -690,23 +642,21 @@ ValidateIndirectCallTest2SteensgaardAgnostic(
   // Validate call to y from test
   {
     jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
-      {
-        &lambdaThreeMemoryNode,
-        &lambdaFourMemoryNode,
-        &lambdaIMemoryNode,
-        &lambdaXMemoryNode,
-        &lambdaYMemoryNode,
-        &lambdaTestMemoryNode,
-        &lambdaTest2MemoryNode,
+        { &lambdaThreeMemoryNode,
+          &lambdaFourMemoryNode,
+          &lambdaIMemoryNode,
+          &lambdaXMemoryNode,
+          &lambdaYMemoryNode,
+          &lambdaTestMemoryNode,
+          &lambdaTest2MemoryNode,
 
-        &deltaG1MemoryNode,
-        &deltaG2MemoryNode,
+          &deltaG1MemoryNode,
+          &deltaG2MemoryNode,
 
-        &allocaPxMemoryNode,
-        &allocaPyMemoryNode,
+          &allocaPxMemoryNode,
+          &allocaPyMemoryNode,
 
-        &externalMemoryNode
-      });
+          &externalMemoryNode });
 
     auto & callEntryNodes = provisioning.GetCallEntryNodes(test.GetCallY());
     assert(callEntryNodes == expectedMemoryNodes);
@@ -718,24 +668,22 @@ ValidateIndirectCallTest2SteensgaardAgnostic(
   // Validate call to x from test2
   {
     jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
-      {
-        &lambdaThreeMemoryNode,
-        &lambdaFourMemoryNode,
-        &lambdaIMemoryNode,
-        &lambdaXMemoryNode,
-        &lambdaYMemoryNode,
-        &lambdaTestMemoryNode,
-        &lambdaTest2MemoryNode,
+        { &lambdaThreeMemoryNode,
+          &lambdaFourMemoryNode,
+          &lambdaIMemoryNode,
+          &lambdaXMemoryNode,
+          &lambdaYMemoryNode,
+          &lambdaTestMemoryNode,
+          &lambdaTest2MemoryNode,
 
-        &deltaG1MemoryNode,
-        &deltaG2MemoryNode,
+          &deltaG1MemoryNode,
+          &deltaG2MemoryNode,
 
-        &allocaPxMemoryNode,
-        &allocaPyMemoryNode,
-        &allocaPzMemoryNode,
+          &allocaPxMemoryNode,
+          &allocaPyMemoryNode,
+          &allocaPzMemoryNode,
 
-        &externalMemoryNode
-      });
+          &externalMemoryNode });
 
     auto & callEntryNodes = provisioning.GetCallEntryNodes(test.GetTest2CallX());
     assert(callEntryNodes == expectedMemoryNodes);
@@ -747,8 +695,8 @@ ValidateIndirectCallTest2SteensgaardAgnostic(
 
 static void
 ValidateGammaTestSteensgaardAgnostic(
-  const jlm::tests::GammaTest & test,
-  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+    const jlm::tests::GammaTest & test,
+    const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
 {
   auto & pointsToGraph = provisioning.GetPointsToGraph();
 
@@ -756,10 +704,7 @@ ValidateGammaTestSteensgaardAgnostic(
   auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
 
   jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
-    {
-      &lambdaMemoryNode,
-      &externalMemoryNode
-    });
+      { &lambdaMemoryNode, &externalMemoryNode });
 
   auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(*test.lambda);
   assert(lambdaEntryNodes == expectedMemoryNodes);
@@ -787,8 +732,8 @@ ValidateGammaTestSteensgaardAgnostic(
 
 static void
 ValidateGammaTest2SteensgaardAgnostic(
-  const jlm::tests::GammaTest2 & test,
-  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+    const jlm::tests::GammaTest2 & test,
+    const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
 {
   auto & pointsToGraph = provisioning.GetPointsToGraph();
 
@@ -802,25 +747,19 @@ ValidateGammaTest2SteensgaardAgnostic(
   auto & lambdaHMemoryNode = pointsToGraph.GetLambdaNode(test.GetLambdaH());
   auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
 
-  jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedLambdaGHEntryExitMemoryNodes(
-    {
-      &lambdaFMemoryNode,
-      &lambdaGMemoryNode,
-      &lambdaHMemoryNode,
-      &externalMemoryNode
-    });
+  jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *>
+      expectedLambdaGHEntryExitMemoryNodes(
+          { &lambdaFMemoryNode, &lambdaGMemoryNode, &lambdaHMemoryNode, &externalMemoryNode });
 
-  jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedLambdaFEntryExitMemoryNodes(
-    {
-      &allocaXFromGMemoryNode,
-      &allocaYFromGMemoryNode,
-      &allocaXFromHMemoryNode,
-      &allocaYFromHMemoryNode,
-      &lambdaFMemoryNode,
-      &lambdaGMemoryNode,
-      &lambdaHMemoryNode,
-      &externalMemoryNode
-    });
+  jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *>
+      expectedLambdaFEntryExitMemoryNodes({ &allocaXFromGMemoryNode,
+                                            &allocaYFromGMemoryNode,
+                                            &allocaXFromHMemoryNode,
+                                            &allocaYFromHMemoryNode,
+                                            &lambdaFMemoryNode,
+                                            &lambdaGMemoryNode,
+                                            &lambdaHMemoryNode,
+                                            &externalMemoryNode });
 
   // Validate g
   {
@@ -855,17 +794,15 @@ ValidateGammaTest2SteensgaardAgnostic(
   // Validate f
   {
     jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedGammaMemoryNodes(
-      {
-        &allocaZMemoryNode,
-        &allocaXFromGMemoryNode,
-        &allocaYFromGMemoryNode,
-        &allocaXFromHMemoryNode,
-        &allocaYFromHMemoryNode,
-        &lambdaFMemoryNode,
-        &lambdaGMemoryNode,
-        &lambdaHMemoryNode,
-        &externalMemoryNode
-      });
+        { &allocaZMemoryNode,
+          &allocaXFromGMemoryNode,
+          &allocaYFromGMemoryNode,
+          &allocaXFromHMemoryNode,
+          &allocaYFromHMemoryNode,
+          &lambdaFMemoryNode,
+          &lambdaGMemoryNode,
+          &lambdaHMemoryNode,
+          &externalMemoryNode });
 
     auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaF());
     assert(lambdaEntryNodes == expectedLambdaFEntryExitMemoryNodes);
@@ -894,8 +831,8 @@ ValidateGammaTest2SteensgaardAgnostic(
 
 static void
 ValidateThetaTestSteensgaardAgnostic(
-  const jlm::tests::ThetaTest & test,
-  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+    const jlm::tests::ThetaTest & test,
+    const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
 {
   auto & pointsToGraph = provisioning.GetPointsToGraph();
 
@@ -903,10 +840,7 @@ ValidateThetaTestSteensgaardAgnostic(
   auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
 
   jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
-    {
-      &lambdaMemoryNode,
-      &externalMemoryNode
-    });
+      { &lambdaMemoryNode, &externalMemoryNode });
 
   auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(*test.lambda);
   assert(lambdaEntryNodes == expectedMemoryNodes);
@@ -920,8 +854,8 @@ ValidateThetaTestSteensgaardAgnostic(
 
 static void
 ValidatePhiTest1SteensgaardAgnostic(
-  const jlm::tests::PhiTest1 & test,
-  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+    const jlm::tests::PhiTest1 & test,
+    const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
 {
   auto & pointsToGraph = provisioning.GetPointsToGraph();
 
@@ -933,12 +867,7 @@ ValidatePhiTest1SteensgaardAgnostic(
   // validate function fib()
   {
     jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
-      {
-        &lambdaFibMemoryNode,
-        &lambdaTestMemoryNode,
-        &allocaMemoryNode,
-        &externalMemoryNode
-      });
+        { &lambdaFibMemoryNode, &lambdaTestMemoryNode, &allocaMemoryNode, &externalMemoryNode });
 
     auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(*test.lambda_fib);
     assert(lambdaEntryNodes == expectedMemoryNodes);
@@ -968,19 +897,10 @@ ValidatePhiTest1SteensgaardAgnostic(
   // validate function test()
   {
     jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedLambdaMemoryNodes(
-      {
-        &lambdaFibMemoryNode,
-        &lambdaTestMemoryNode,
-        &externalMemoryNode
-      });
+        { &lambdaFibMemoryNode, &lambdaTestMemoryNode, &externalMemoryNode });
 
     jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedCallMemoryNodes(
-      {
-        &lambdaFibMemoryNode,
-        &lambdaTestMemoryNode,
-        &allocaMemoryNode,
-        &externalMemoryNode
-      });
+        { &lambdaFibMemoryNode, &lambdaTestMemoryNode, &allocaMemoryNode, &externalMemoryNode });
 
     auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(*test.lambda_test);
     assert(lambdaEntryNodes == expectedLambdaMemoryNodes);
@@ -996,11 +916,10 @@ ValidatePhiTest1SteensgaardAgnostic(
   }
 }
 
-
 static void
 ValidatePhiTest2SteensgaardAgnostic(
-  const jlm::tests::PhiTest2 & test,
-  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+    const jlm::tests::PhiTest2 & test,
+    const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
 {
   auto & pointsToGraph = provisioning.GetPointsToGraph();
 
@@ -1019,21 +938,19 @@ ValidatePhiTest2SteensgaardAgnostic(
   auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
 
   jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
-    {
-      &lambdaAMemoryNode,
-      &lambdaBMemoryNode,
-      &lambdaCMemoryNode,
-      &lambdaDMemoryNode,
-      &lambdaIMemoryNode,
-      &lambdaEightMemoryNode,
-      &lambdaTestMemoryNode,
-      &allocaPaMemoryNode,
-      &allocaPbMemoryNode,
-      &allocaPcMemoryNode,
-      &allocaPdMemoryNode,
-      &allocaPTestMemoryNode,
-      &externalMemoryNode
-    });
+      { &lambdaAMemoryNode,
+        &lambdaBMemoryNode,
+        &lambdaCMemoryNode,
+        &lambdaDMemoryNode,
+        &lambdaIMemoryNode,
+        &lambdaEightMemoryNode,
+        &lambdaTestMemoryNode,
+        &allocaPaMemoryNode,
+        &allocaPbMemoryNode,
+        &allocaPcMemoryNode,
+        &allocaPdMemoryNode,
+        &allocaPTestMemoryNode,
+        &externalMemoryNode });
 
   // validate function eight()
   {
@@ -1134,16 +1051,14 @@ ValidatePhiTest2SteensgaardAgnostic(
   // validate function test()
   {
     jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedLambdaMemoryNodes(
-      {
-        &lambdaAMemoryNode,
-        &lambdaBMemoryNode,
-        &lambdaCMemoryNode,
-        &lambdaDMemoryNode,
-        &lambdaIMemoryNode,
-        &lambdaEightMemoryNode,
-        &lambdaTestMemoryNode,
-        &externalMemoryNode
-      });
+        { &lambdaAMemoryNode,
+          &lambdaBMemoryNode,
+          &lambdaCMemoryNode,
+          &lambdaDMemoryNode,
+          &lambdaIMemoryNode,
+          &lambdaEightMemoryNode,
+          &lambdaTestMemoryNode,
+          &externalMemoryNode });
 
     auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaTest());
     assert(lambdaEntryNodes == expectedLambdaMemoryNodes);
@@ -1161,8 +1076,8 @@ ValidatePhiTest2SteensgaardAgnostic(
 
 static void
 ValidateEscapedMemoryTest3SteensgaardAgnostic(
-  const jlm::tests::EscapedMemoryTest3 & test,
-  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+    const jlm::tests::EscapedMemoryTest3 & test,
+    const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
 {
   auto & pointsToGraph = provisioning.GetPointsToGraph();
 
@@ -1172,12 +1087,7 @@ ValidateEscapedMemoryTest3SteensgaardAgnostic(
   auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
 
   jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
-    {
-      &lambdaTestMemoryNode,
-      &deltaGlobalMemoryNode,
-      &importMemoryNode,
-      &externalMemoryNode
-    });
+      { &lambdaTestMemoryNode, &deltaGlobalMemoryNode, &importMemoryNode, &externalMemoryNode });
 
   auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(*test.LambdaTest);
   assert(lambdaEntryNodes == expectedMemoryNodes);
@@ -1194,8 +1104,8 @@ ValidateEscapedMemoryTest3SteensgaardAgnostic(
 
 static void
 ValidateMemcpyTestSteensgaardAgnostic(
-  const jlm::tests::MemcpyTest & test,
-  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+    const jlm::tests::MemcpyTest & test,
+    const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
 {
   auto & pointsToGraph = provisioning.GetPointsToGraph();
 
@@ -1206,13 +1116,11 @@ ValidateMemcpyTestSteensgaardAgnostic(
   auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
 
   jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
-    {
-      &lambdaFMemoryNode,
-      &lambdaGMemoryNode,
-      &globalArrayMemoryNode,
-      &localArrayMemoryNode,
-      &externalMemoryNode
-    });
+      { &lambdaFMemoryNode,
+        &lambdaGMemoryNode,
+        &globalArrayMemoryNode,
+        &localArrayMemoryNode,
+        &externalMemoryNode });
 
   // Validate function f()
   {
@@ -1248,21 +1156,21 @@ TestStatistics()
   std::remove(filePath.to_str().c_str());
 
   jlm::util::StatisticsCollectorSettings statisticsCollectorSettings(
-    filePath,
-    {jlm::util::Statistics::Id::TopDownMemoryNodeEliminator});
+      filePath,
+      { jlm::util::Statistics::Id::TopDownMemoryNodeEliminator });
   jlm::util::StatisticsCollector statisticsCollector(statisticsCollectorSettings);
 
   auto pointsToGraph = jlm::llvm::aa::PointsToGraph::Create();
   auto provisioning = jlm::llvm::aa::AgnosticMemoryNodeProvider::Create(
-    test.module(),
-    *pointsToGraph,
-    statisticsCollector);
+      test.module(),
+      *pointsToGraph,
+      statisticsCollector);
 
   // Act
   jlm::llvm::aa::TopDownMemoryNodeEliminator::CreateAndEliminate(
-    test.module(),
-    *provisioning,
-    statisticsCollector);
+      test.module(),
+      *provisioning,
+      statisticsCollector);
 
   // Assert
   assert(statisticsCollector.NumCollectedStatistics() == 1);
@@ -1273,95 +1181,50 @@ TestTopDownMemoryNodeEliminator()
 {
   using namespace jlm::llvm::aa;
 
-  ValidateTest<
-    jlm::tests::StoreTest1,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidateStoreTest1SteensgaardAgnostic);
+  ValidateTest<jlm::tests::StoreTest1, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateStoreTest1SteensgaardAgnostic);
 
-  ValidateTest<
-    jlm::tests::StoreTest2,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidateStoreTest2SteensgaardAgnostic);
+  ValidateTest<jlm::tests::StoreTest2, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateStoreTest2SteensgaardAgnostic);
 
-  ValidateTest<
-    jlm::tests::LoadTest1,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidateLoadTest1SteensgaardAgnostic);
+  ValidateTest<jlm::tests::LoadTest1, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateLoadTest1SteensgaardAgnostic);
 
-  ValidateTest<
-    jlm::tests::LoadTest2,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidateLoadTest2SteensgaardAgnostic);
+  ValidateTest<jlm::tests::LoadTest2, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateLoadTest2SteensgaardAgnostic);
 
-  ValidateTest<
-    jlm::tests::LoadFromUndefTest,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidateLoadFromUndefTestSteensgaardAgnostic);
+  ValidateTest<jlm::tests::LoadFromUndefTest, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateLoadFromUndefTestSteensgaardAgnostic);
 
-  ValidateTest<
-    jlm::tests::CallTest1,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidateCallTest1SteensgaardAgnostic);
+  ValidateTest<jlm::tests::CallTest1, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateCallTest1SteensgaardAgnostic);
 
-  ValidateTest<
-    jlm::tests::IndirectCallTest1,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidateIndirectCallTest1SteensgaardAgnostic);
+  ValidateTest<jlm::tests::IndirectCallTest1, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateIndirectCallTest1SteensgaardAgnostic);
 
-  ValidateTest<
-    jlm::tests::IndirectCallTest2,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidateIndirectCallTest2SteensgaardAgnostic);
+  ValidateTest<jlm::tests::IndirectCallTest2, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateIndirectCallTest2SteensgaardAgnostic);
 
-  ValidateTest<
-    jlm::tests::GammaTest,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidateGammaTestSteensgaardAgnostic);
+  ValidateTest<jlm::tests::GammaTest, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateGammaTestSteensgaardAgnostic);
 
-  ValidateTest<
-    jlm::tests::GammaTest2,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidateGammaTest2SteensgaardAgnostic);
+  ValidateTest<jlm::tests::GammaTest2, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateGammaTest2SteensgaardAgnostic);
 
-  ValidateTest<
-    jlm::tests::ThetaTest,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidateThetaTestSteensgaardAgnostic);
+  ValidateTest<jlm::tests::ThetaTest, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateThetaTestSteensgaardAgnostic);
 
-  ValidateTest<
-    jlm::tests::PhiTest1,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidatePhiTest1SteensgaardAgnostic);
+  ValidateTest<jlm::tests::PhiTest1, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidatePhiTest1SteensgaardAgnostic);
 
-  ValidateTest<
-    jlm::tests::PhiTest2,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidatePhiTest2SteensgaardAgnostic);
+  ValidateTest<jlm::tests::PhiTest2, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidatePhiTest2SteensgaardAgnostic);
 
-  ValidateTest<
-    jlm::tests::EscapedMemoryTest3,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidateEscapedMemoryTest3SteensgaardAgnostic);
+  ValidateTest<jlm::tests::EscapedMemoryTest3, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateEscapedMemoryTest3SteensgaardAgnostic);
 
-  ValidateTest<
-    jlm::tests::MemcpyTest,
-    Steensgaard,
-    AgnosticMemoryNodeProvider
-  >(ValidateMemcpyTestSteensgaardAgnostic);
+  ValidateTest<jlm::tests::MemcpyTest, Steensgaard, AgnosticMemoryNodeProvider>(
+      ValidateMemcpyTestSteensgaardAgnostic);
 
   TestStatistics();
 
@@ -1369,5 +1232,5 @@ TestTopDownMemoryNodeEliminator()
 }
 
 JLM_UNIT_TEST_REGISTER(
-  "jlm/llvm/opt/alias-analyses/TestTopDownMemoryNodeEliminator",
-  TestTopDownMemoryNodeEliminator)
+    "jlm/llvm/opt/alias-analyses/TestTopDownMemoryNodeEliminator",
+    TestTopDownMemoryNodeEliminator)

--- a/tests/jlm/llvm/opt/alias-analyses/TestTopDownMemoryNodeEliminator.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestTopDownMemoryNodeEliminator.cpp
@@ -1,0 +1,1405 @@
+/*
+ * Copyright 2023 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <test-registry.hpp>
+#include <TestRvsdgs.hpp>
+
+#include <jlm/llvm/opt/alias-analyses/AgnosticMemoryNodeProvider.hpp>
+#include <jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.hpp>
+#include <jlm/llvm/opt/alias-analyses/Steensgaard.hpp>
+
+static void
+UnlinkUnknownMemoryNode(jlm::llvm::aa::PointsToGraph & pointsToGraph)
+{
+  std::vector<jlm::llvm::aa::PointsToGraph::Node*> memoryNodes;
+  for (auto & allocaNode : pointsToGraph.AllocaNodes())
+    memoryNodes.push_back(&allocaNode);
+
+  for (auto & deltaNode : pointsToGraph.DeltaNodes())
+    memoryNodes.push_back(&deltaNode);
+
+  for (auto & lambdaNode : pointsToGraph.LambdaNodes())
+    memoryNodes.push_back(&lambdaNode);
+
+  for (auto & mallocNode : pointsToGraph.MallocNodes())
+    memoryNodes.push_back(&mallocNode);
+
+  for (auto & node : pointsToGraph.ImportNodes())
+    memoryNodes.push_back(&node);
+
+  auto & unknownMemoryNode = pointsToGraph.GetUnknownMemoryNode();
+  while (unknownMemoryNode.NumSources() != 0) {
+    auto & source = *unknownMemoryNode.Sources().begin();
+    for (auto & memoryNode : memoryNodes)
+      source.AddEdge(*dynamic_cast<jlm::llvm::aa::PointsToGraph::MemoryNode *>(memoryNode));
+    source.RemoveEdge(unknownMemoryNode);
+  }
+}
+
+template <class Test, class Analysis, class Provider> static void
+ValidateTest(std::function<void(const Test&, const jlm::llvm::aa::MemoryNodeProvisioning&)> validateProvisioning)
+{
+  static_assert(
+    std::is_base_of<jlm::tests::RvsdgTest, Test>::value,
+    "Test should be derived from RvsdgTest class.");
+
+  static_assert(
+    std::is_base_of<jlm::llvm::aa::AliasAnalysis, Analysis>::value,
+    "Analysis should be derived from AliasAnalysis class.");
+
+  static_assert(
+    std::is_base_of<jlm::llvm::aa::MemoryNodeProvider, Provider>::value,
+    "Provider should be derived from MemoryNodeProvider class.");
+
+  Test test;
+  auto & rvsdgModule = test.module();
+
+  jlm::util::StatisticsCollector statisticsCollector;
+
+  Analysis aliasAnalysis;
+  auto pointsToGraph = aliasAnalysis.Analyze(rvsdgModule, statisticsCollector);
+  std::cout << jlm::llvm::aa::PointsToGraph::ToDot(*pointsToGraph);
+
+  UnlinkUnknownMemoryNode(*pointsToGraph);
+
+  auto seedProvisioning = Provider::Create(rvsdgModule, *pointsToGraph);
+
+  auto provisioning = jlm::llvm::aa::TopDownMemoryNodeEliminator::CreateAndEliminate(test.module(), *seedProvisioning);
+
+  validateProvisioning(test, *provisioning);
+}
+
+static void
+ValidateStoreTest1SteensgaardAgnostic(
+  const jlm::tests::StoreTest1 & test,
+  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+{
+  auto & pointsToGraph = provisioning.GetPointsToGraph();
+
+  auto & lambdaMemoryNode = pointsToGraph.GetLambdaNode(*test.lambda);
+  auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
+
+  jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+    {
+      &lambdaMemoryNode,
+      &externalMemoryNode
+    });
+
+  auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(*test.lambda);
+  assert(lambdaEntryNodes == expectedMemoryNodes);
+
+  auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(*test.lambda);
+  assert(lambdaExitNodes == expectedMemoryNodes);
+}
+
+static void
+ValidateStoreTest2SteensgaardAgnostic(
+  const jlm::tests::StoreTest2 & test,
+  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+{
+  auto & pointsToGraph = provisioning.GetPointsToGraph();
+
+  auto & lambdaMemoryNode = pointsToGraph.GetLambdaNode(*test.lambda);
+  auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
+
+  jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode*> expectedMemoryNodes(
+    {
+      &lambdaMemoryNode,
+      &externalMemoryNode
+    });
+
+  auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(*test.lambda);
+  assert(lambdaEntryNodes == expectedMemoryNodes);
+
+  auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(*test.lambda);
+  assert(lambdaExitNodes == expectedMemoryNodes);
+}
+
+static void
+ValidateLoadTest1SteensgaardAgnostic(
+  const jlm::tests::LoadTest1 & test,
+  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+{
+  auto & pointsToGraph = provisioning.GetPointsToGraph();
+
+  auto & lambdaMemoryNode = pointsToGraph.GetLambdaNode(*test.lambda);
+  auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
+
+  jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+    {
+      &lambdaMemoryNode,
+      &externalMemoryNode
+    });
+
+  auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(*test.lambda);
+  assert(lambdaEntryNodes == expectedMemoryNodes);
+
+  auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(*test.lambda);
+  assert(lambdaExitNodes == expectedMemoryNodes);
+}
+
+static void
+ValidateLoadTest2SteensgaardAgnostic(
+  const jlm::tests::LoadTest2 & test,
+  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+{
+  auto & pointsToGraph = provisioning.GetPointsToGraph();
+
+  auto & lambdaMemoryNode = pointsToGraph.GetLambdaNode(*test.lambda);
+  auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
+
+  jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+    {
+      &lambdaMemoryNode,
+      &externalMemoryNode
+    });
+
+  auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(*test.lambda);
+  assert(lambdaEntryNodes == expectedMemoryNodes);
+
+  auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(*test.lambda);
+  assert(lambdaExitNodes == expectedMemoryNodes);
+}
+
+static void
+ValidateLoadFromUndefTestSteensgaardAgnostic(
+  const jlm::tests::LoadFromUndefTest & test,
+  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+{
+  auto & pointsToGraph = provisioning.GetPointsToGraph();
+
+  auto & lambdaMemoryNode = pointsToGraph.GetLambdaNode(test.Lambda());
+  auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
+
+  jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+    {
+      &lambdaMemoryNode,
+      &externalMemoryNode
+    });
+
+  auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.Lambda());
+  assert(lambdaEntryNodes == expectedMemoryNodes);
+
+  auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(test.Lambda());
+  assert(lambdaExitNodes == expectedMemoryNodes);
+}
+
+static void
+ValidateCallTest1SteensgaardAgnostic(
+  const jlm::tests::CallTest1 & test,
+  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+{
+  auto & pointsToGraph = provisioning.GetPointsToGraph();
+
+  auto & allocaXMemoryNode = pointsToGraph.GetAllocaNode(*test.alloca_x);
+  auto & allocaYMemoryNode = pointsToGraph.GetAllocaNode(*test.alloca_y);
+  auto & allocaZMemoryNode = pointsToGraph.GetAllocaNode(*test.alloca_z);
+  auto & lambdaFMemoryNode = pointsToGraph.GetLambdaNode(*test.lambda_f);
+  auto & lambdaGMemoryNode = pointsToGraph.GetLambdaNode(*test.lambda_g);
+  auto & lambdaHMemoryNode = pointsToGraph.GetLambdaNode(*test.lambda_h);
+  auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
+
+  // Validate function f
+  {
+    jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+      {
+        &allocaXMemoryNode,
+        &allocaYMemoryNode,
+        &allocaZMemoryNode,
+        &lambdaFMemoryNode,
+        &lambdaGMemoryNode,
+        &lambdaHMemoryNode,
+        &externalMemoryNode
+      });
+
+    auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(*test.lambda_f);
+    assert(lambdaEntryNodes == expectedMemoryNodes);
+
+    auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(*test.lambda_f);
+    assert(lambdaExitNodes == expectedMemoryNodes);
+  }
+
+  // Validate function g
+  {
+    jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+      {
+        &allocaXMemoryNode,
+        &allocaYMemoryNode,
+        &allocaZMemoryNode,
+        &lambdaFMemoryNode,
+        &lambdaGMemoryNode,
+        &lambdaHMemoryNode,
+        &externalMemoryNode
+      });
+
+    auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(*test.lambda_g);
+    assert(lambdaEntryNodes == expectedMemoryNodes);
+
+    auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(*test.lambda_g);
+    assert(lambdaExitNodes == expectedMemoryNodes);
+  }
+
+  // Validate function h
+  {
+    jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+      {
+        &lambdaFMemoryNode,
+        &lambdaGMemoryNode,
+        &lambdaHMemoryNode,
+        &externalMemoryNode
+      });
+
+    auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(*test.lambda_h);
+    assert(lambdaEntryNodes == expectedMemoryNodes);
+
+    auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(*test.lambda_h);
+    assert(lambdaExitNodes == expectedMemoryNodes);
+  }
+
+  // Validate call to f
+  {
+    jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+      {
+        &allocaXMemoryNode,
+        &allocaYMemoryNode,
+        &allocaZMemoryNode,
+        &lambdaFMemoryNode,
+        &lambdaGMemoryNode,
+        &lambdaHMemoryNode,
+        &externalMemoryNode
+      });
+
+    auto & callEntryNodes = provisioning.GetCallEntryNodes(test.CallF());
+    assert(callEntryNodes == expectedMemoryNodes);
+
+    auto & callExitNodes = provisioning.GetCallExitNodes(test.CallF());
+    assert(callExitNodes == expectedMemoryNodes);
+  }
+
+  // Validate call to g
+  {
+    jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+      {
+        &allocaXMemoryNode,
+        &allocaYMemoryNode,
+        &allocaZMemoryNode,
+        &lambdaFMemoryNode,
+        &lambdaGMemoryNode,
+        &lambdaHMemoryNode,
+        &externalMemoryNode
+      });
+
+    auto & callEntryNodes = provisioning.GetCallEntryNodes(test.CallG());
+    assert(callEntryNodes == expectedMemoryNodes);
+
+    auto & callExitNodes = provisioning.GetCallExitNodes(test.CallG());
+    assert(callExitNodes == expectedMemoryNodes);
+  }
+}
+
+static void
+ValidateIndirectCallTest1SteensgaardAgnostic(
+  const jlm::tests::IndirectCallTest1 & test,
+  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+{
+  auto & pointsToGraph = provisioning.GetPointsToGraph();
+
+  auto & lambdaFourMemoryNode = pointsToGraph.GetLambdaNode(test.GetLambdaFour());
+  auto & lambdaThreeMemoryNode = pointsToGraph.GetLambdaNode(test.GetLambdaThree());
+  auto & lambdaIndCallMemoryNode = pointsToGraph.GetLambdaNode(test.GetLambdaIndcall());
+  auto & lambdaTestMemoryNode = pointsToGraph.GetLambdaNode(test.GetLambdaTest());
+  auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
+
+  jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+    {
+      &lambdaFourMemoryNode,
+      &lambdaThreeMemoryNode,
+      &lambdaIndCallMemoryNode,
+      &lambdaTestMemoryNode,
+      &externalMemoryNode
+    });
+
+  // Validate function four
+  {
+    auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaFour());
+    assert(lambdaEntryNodes == expectedMemoryNodes);
+
+    auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(test.GetLambdaFour());
+    assert(lambdaExitNodes == expectedMemoryNodes);
+  }
+
+  // Validate function three
+  {
+    auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaThree());
+    assert(lambdaEntryNodes == expectedMemoryNodes);
+
+    auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(test.GetLambdaThree());
+    assert(lambdaExitNodes == expectedMemoryNodes);
+  }
+
+  // Validate function indcall
+  {
+    auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaIndcall());
+    assert(lambdaEntryNodes == expectedMemoryNodes);
+
+    auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(test.GetLambdaIndcall());
+    assert(lambdaExitNodes == expectedMemoryNodes);
+  }
+
+  // Validate function test
+  {
+    auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaIndcall());
+    assert(lambdaEntryNodes == expectedMemoryNodes);
+
+    auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(test.GetLambdaIndcall());
+    assert(lambdaExitNodes == expectedMemoryNodes);
+  }
+
+  // Validate call to indcall with four
+  {
+    auto & callEntryNodes = provisioning.GetCallEntryNodes(test.CallFour());
+    assert(callEntryNodes == expectedMemoryNodes);
+
+    auto & callExitNodes = provisioning.GetCallExitNodes(test.CallFour());
+    assert(callExitNodes == expectedMemoryNodes);
+  }
+
+  // Validate call to indcall with three
+  {
+    auto & callEntryNodes = provisioning.GetCallEntryNodes(test.CallThree());
+    assert(callEntryNodes == expectedMemoryNodes);
+
+    auto & callExitNodes = provisioning.GetCallExitNodes(test.CallThree());
+    assert(callExitNodes == expectedMemoryNodes);
+  }
+
+  // Validate indirect call
+  {
+    auto & callEntryNodes = provisioning.GetCallEntryNodes(test.CallIndcall());
+    assert(callEntryNodes == expectedMemoryNodes);
+
+    auto & callExitNodes = provisioning.GetCallExitNodes(test.CallIndcall());
+    assert(callExitNodes == expectedMemoryNodes);
+  }
+}
+
+static void
+ValidateIndirectCallTest2SteensgaardAgnostic(
+  const jlm::tests::IndirectCallTest2 & test,
+  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+{
+  auto & pointsToGraph = provisioning.GetPointsToGraph();
+
+  auto & lambdaThreeMemoryNode = pointsToGraph.GetLambdaNode(test.GetLambdaThree());
+  auto & lambdaFourMemoryNode = pointsToGraph.GetLambdaNode(test.GetLambdaFour());
+  auto & lambdaIMemoryNode = pointsToGraph.GetLambdaNode(test.GetLambdaI());
+  auto & lambdaXMemoryNode = pointsToGraph.GetLambdaNode(test.GetLambdaX());
+  auto & lambdaYMemoryNode = pointsToGraph.GetLambdaNode(test.GetLambdaY());
+  auto & lambdaTestMemoryNode = pointsToGraph.GetLambdaNode(test.GetLambdaTest());
+  auto & lambdaTest2MemoryNode = pointsToGraph.GetLambdaNode(test.GetLambdaTest2());
+
+  auto & deltaG1MemoryNode = pointsToGraph.GetDeltaNode(test.GetDeltaG1());
+  auto & deltaG2MemoryNode = pointsToGraph.GetDeltaNode(test.GetDeltaG2());
+
+  auto & allocaPxMemoryNode = pointsToGraph.GetAllocaNode(test.GetAllocaPx());
+  auto & allocaPyMemoryNode = pointsToGraph.GetAllocaNode(test.GetAllocaPy());
+  auto & allocaPzMemoryNode = pointsToGraph.GetAllocaNode(test.GetAllocaPz());
+
+  auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
+
+  // Validate function test2
+  {
+    jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+      {
+        &lambdaThreeMemoryNode,
+        &lambdaFourMemoryNode,
+        &lambdaIMemoryNode,
+        &lambdaXMemoryNode,
+        &lambdaYMemoryNode,
+        &lambdaTestMemoryNode,
+        &lambdaTest2MemoryNode,
+
+        &deltaG1MemoryNode,
+        &deltaG2MemoryNode,
+
+        &externalMemoryNode
+      });
+
+    auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaTest2());
+    assert(lambdaEntryNodes == expectedMemoryNodes);
+
+    auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(test.GetLambdaTest2());
+    assert(lambdaExitNodes == expectedMemoryNodes);
+  }
+
+  // Validate function test
+  {
+    jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+      {
+        &lambdaThreeMemoryNode,
+        &lambdaFourMemoryNode,
+        &lambdaIMemoryNode,
+        &lambdaXMemoryNode,
+        &lambdaYMemoryNode,
+        &lambdaTestMemoryNode,
+        &lambdaTest2MemoryNode,
+
+        &deltaG1MemoryNode,
+        &deltaG2MemoryNode,
+
+        &externalMemoryNode
+      });
+
+    auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaTest());
+    assert(lambdaEntryNodes == expectedMemoryNodes);
+
+    auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(test.GetLambdaTest());
+    assert(lambdaExitNodes == expectedMemoryNodes);
+  }
+
+  // Validate function y
+  {
+    jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+      {
+        &lambdaThreeMemoryNode,
+        &lambdaFourMemoryNode,
+        &lambdaIMemoryNode,
+        &lambdaXMemoryNode,
+        &lambdaYMemoryNode,
+        &lambdaTestMemoryNode,
+        &lambdaTest2MemoryNode,
+
+        &deltaG1MemoryNode,
+        &deltaG2MemoryNode,
+
+        &allocaPxMemoryNode,
+        &allocaPyMemoryNode,
+
+        &externalMemoryNode
+      });
+
+    auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaY());
+    assert(lambdaEntryNodes == expectedMemoryNodes);
+
+    auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(test.GetLambdaY());
+    assert(lambdaExitNodes == expectedMemoryNodes);
+  }
+
+  // Validate function x
+  {
+    jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+      {
+        &lambdaThreeMemoryNode,
+        &lambdaFourMemoryNode,
+        &lambdaIMemoryNode,
+        &lambdaXMemoryNode,
+        &lambdaYMemoryNode,
+        &lambdaTestMemoryNode,
+        &lambdaTest2MemoryNode,
+
+        &deltaG1MemoryNode,
+        &deltaG2MemoryNode,
+
+        &allocaPxMemoryNode,
+        &allocaPyMemoryNode,
+        &allocaPzMemoryNode,
+
+        &externalMemoryNode
+      });
+
+    auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaX());
+    assert(lambdaEntryNodes == expectedMemoryNodes);
+
+    auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(test.GetLambdaX());
+    assert(lambdaExitNodes == expectedMemoryNodes);
+  }
+
+  // Validate function i
+  {
+    jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+      {
+        &lambdaThreeMemoryNode,
+        &lambdaFourMemoryNode,
+        &lambdaIMemoryNode,
+        &lambdaXMemoryNode,
+        &lambdaYMemoryNode,
+        &lambdaTestMemoryNode,
+        &lambdaTest2MemoryNode,
+
+        &deltaG1MemoryNode,
+        &deltaG2MemoryNode,
+
+        &allocaPxMemoryNode,
+        &allocaPyMemoryNode,
+        &allocaPzMemoryNode,
+
+        &externalMemoryNode
+      });
+
+    auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaI());
+    assert(lambdaEntryNodes == expectedMemoryNodes);
+
+    auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(test.GetLambdaI());
+    assert(lambdaExitNodes == expectedMemoryNodes);
+  }
+
+  // Validate function four
+  {
+    jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+      {
+        &lambdaThreeMemoryNode,
+        &lambdaFourMemoryNode,
+        &lambdaIMemoryNode,
+        &lambdaXMemoryNode,
+        &lambdaYMemoryNode,
+        &lambdaTestMemoryNode,
+        &lambdaTest2MemoryNode,
+
+        &deltaG1MemoryNode,
+        &deltaG2MemoryNode,
+
+        &allocaPxMemoryNode,
+        &allocaPyMemoryNode,
+        &allocaPzMemoryNode,
+
+        &externalMemoryNode
+      });
+
+    auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaFour());
+    assert(lambdaEntryNodes == expectedMemoryNodes);
+
+    auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(test.GetLambdaFour());
+    assert(lambdaExitNodes == expectedMemoryNodes);
+  }
+
+  // Validate function three
+  {
+    jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+      {
+        &lambdaThreeMemoryNode,
+        &lambdaFourMemoryNode,
+        &lambdaIMemoryNode,
+        &lambdaXMemoryNode,
+        &lambdaYMemoryNode,
+        &lambdaTestMemoryNode,
+        &lambdaTest2MemoryNode,
+
+        &deltaG1MemoryNode,
+        &deltaG2MemoryNode,
+
+        &allocaPxMemoryNode,
+        &allocaPyMemoryNode,
+        &allocaPzMemoryNode,
+
+        &externalMemoryNode
+      });
+
+    auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaThree());
+    assert(lambdaEntryNodes == expectedMemoryNodes);
+
+    auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(test.GetLambdaThree());
+    assert(lambdaExitNodes == expectedMemoryNodes);
+  }
+
+  // Validate indirect call
+  {
+    jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+      {
+        &lambdaThreeMemoryNode,
+        &lambdaFourMemoryNode,
+        &lambdaIMemoryNode,
+        &lambdaXMemoryNode,
+        &lambdaYMemoryNode,
+        &lambdaTestMemoryNode,
+        &lambdaTest2MemoryNode,
+
+        &deltaG1MemoryNode,
+        &deltaG2MemoryNode,
+
+        &allocaPxMemoryNode,
+        &allocaPyMemoryNode,
+        &allocaPzMemoryNode,
+
+        &externalMemoryNode
+      });
+
+    auto & callEntryNodes = provisioning.GetCallEntryNodes(test.GetIndirectCall());
+    assert(callEntryNodes == expectedMemoryNodes);
+
+    auto & callExitNodes = provisioning.GetCallExitNodes(test.GetIndirectCall());
+    assert(callExitNodes == expectedMemoryNodes);
+  }
+
+  // Validate call to i from x
+  {
+    jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+      {
+        &lambdaThreeMemoryNode,
+        &lambdaFourMemoryNode,
+        &lambdaIMemoryNode,
+        &lambdaXMemoryNode,
+        &lambdaYMemoryNode,
+        &lambdaTestMemoryNode,
+        &lambdaTest2MemoryNode,
+
+        &deltaG1MemoryNode,
+        &deltaG2MemoryNode,
+
+        &allocaPxMemoryNode,
+        &allocaPyMemoryNode,
+        &allocaPzMemoryNode,
+
+        &externalMemoryNode
+      });
+
+    auto & callEntryNodes = provisioning.GetCallEntryNodes(test.GetCallIWithThree());
+    assert(callEntryNodes == expectedMemoryNodes);
+
+    auto & callExitNodes = provisioning.GetCallExitNodes(test.GetCallIWithThree());
+    assert(callExitNodes == expectedMemoryNodes);
+  }
+
+  // Validate call to i from y
+  {
+    jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+      {
+        &lambdaThreeMemoryNode,
+        &lambdaFourMemoryNode,
+        &lambdaIMemoryNode,
+        &lambdaXMemoryNode,
+        &lambdaYMemoryNode,
+        &lambdaTestMemoryNode,
+        &lambdaTest2MemoryNode,
+
+        &deltaG1MemoryNode,
+        &deltaG2MemoryNode,
+
+        &allocaPxMemoryNode,
+        &allocaPyMemoryNode,
+        &allocaPzMemoryNode,
+
+        &externalMemoryNode
+      });
+
+    auto & callEntryNodes = provisioning.GetCallEntryNodes(test.GetCallIWithFour());
+    assert(callEntryNodes == expectedMemoryNodes);
+
+    auto & callExitNodes = provisioning.GetCallExitNodes(test.GetCallIWithFour());
+    assert(callExitNodes == expectedMemoryNodes);
+  }
+
+  // Validate call to x from test
+  {
+    jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+      {
+        &lambdaThreeMemoryNode,
+        &lambdaFourMemoryNode,
+        &lambdaIMemoryNode,
+        &lambdaXMemoryNode,
+        &lambdaYMemoryNode,
+        &lambdaTestMemoryNode,
+        &lambdaTest2MemoryNode,
+
+        &deltaG1MemoryNode,
+        &deltaG2MemoryNode,
+
+        &allocaPxMemoryNode,
+        &allocaPyMemoryNode,
+        &allocaPzMemoryNode,
+
+        &externalMemoryNode
+      });
+
+    auto & callEntryNodes = provisioning.GetCallEntryNodes(test.GetTestCallX());
+    assert(callEntryNodes == expectedMemoryNodes);
+
+    auto & callExitNodes = provisioning.GetCallExitNodes(test.GetTestCallX());
+    assert(callExitNodes == expectedMemoryNodes);
+  }
+
+  // Validate call to y from test
+  {
+    jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+      {
+        &lambdaThreeMemoryNode,
+        &lambdaFourMemoryNode,
+        &lambdaIMemoryNode,
+        &lambdaXMemoryNode,
+        &lambdaYMemoryNode,
+        &lambdaTestMemoryNode,
+        &lambdaTest2MemoryNode,
+
+        &deltaG1MemoryNode,
+        &deltaG2MemoryNode,
+
+        &allocaPxMemoryNode,
+        &allocaPyMemoryNode,
+
+        &externalMemoryNode
+      });
+
+    auto & callEntryNodes = provisioning.GetCallEntryNodes(test.GetCallY());
+    assert(callEntryNodes == expectedMemoryNodes);
+
+    auto & callExitNodes = provisioning.GetCallExitNodes(test.GetCallY());
+    assert(callExitNodes == expectedMemoryNodes);
+  }
+
+  // Validate call to x from test2
+  {
+    jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+      {
+        &lambdaThreeMemoryNode,
+        &lambdaFourMemoryNode,
+        &lambdaIMemoryNode,
+        &lambdaXMemoryNode,
+        &lambdaYMemoryNode,
+        &lambdaTestMemoryNode,
+        &lambdaTest2MemoryNode,
+
+        &deltaG1MemoryNode,
+        &deltaG2MemoryNode,
+
+        &allocaPxMemoryNode,
+        &allocaPyMemoryNode,
+        &allocaPzMemoryNode,
+
+        &externalMemoryNode
+      });
+
+    auto & callEntryNodes = provisioning.GetCallEntryNodes(test.GetTest2CallX());
+    assert(callEntryNodes == expectedMemoryNodes);
+
+    auto & callExitNodes = provisioning.GetCallExitNodes(test.GetTest2CallX());
+    assert(callExitNodes == expectedMemoryNodes);
+  }
+}
+
+static void
+ValidateGammaTestSteensgaardAgnostic(
+  const jlm::tests::GammaTest & test,
+  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+{
+  auto & pointsToGraph = provisioning.GetPointsToGraph();
+
+  auto & lambdaMemoryNode = pointsToGraph.GetLambdaNode(*test.lambda);
+  auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
+
+  jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+    {
+      &lambdaMemoryNode,
+      &externalMemoryNode
+    });
+
+  auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(*test.lambda);
+  assert(lambdaEntryNodes == expectedMemoryNodes);
+
+  auto gammaEntryNodes = provisioning.GetGammaEntryNodes(*test.gamma);
+  assert(gammaEntryNodes == expectedMemoryNodes);
+
+  for (size_t n = 0; n < test.gamma->nsubregions(); n++)
+  {
+    auto & subregion = *test.gamma->subregion(n);
+
+    auto & subregionEntryNodes = provisioning.GetRegionEntryNodes(subregion);
+    assert(subregionEntryNodes == expectedMemoryNodes);
+
+    auto & subregionExitNodes = provisioning.GetRegionExitNodes(subregion);
+    assert(subregionExitNodes == expectedMemoryNodes);
+  }
+
+  auto gammaExitNodes = provisioning.GetGammaExitNodes(*test.gamma);
+  assert(gammaExitNodes == expectedMemoryNodes);
+
+  auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(*test.lambda);
+  assert(lambdaExitNodes == expectedMemoryNodes);
+}
+
+static void
+ValidateGammaTest2SteensgaardAgnostic(
+  const jlm::tests::GammaTest2 & test,
+  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+{
+  auto & pointsToGraph = provisioning.GetPointsToGraph();
+
+  auto & allocaXFromGMemoryNode = pointsToGraph.GetAllocaNode(test.GetAllocaXFromG());
+  auto & allocaYFromGMemoryNode = pointsToGraph.GetAllocaNode(test.GetAllocaYFromG());
+  auto & allocaXFromHMemoryNode = pointsToGraph.GetAllocaNode(test.GetAllocaXFromH());
+  auto & allocaYFromHMemoryNode = pointsToGraph.GetAllocaNode(test.GetAllocaYFromH());
+  auto & allocaZMemoryNode = pointsToGraph.GetAllocaNode(test.GetAllocaZ());
+  auto & lambdaFMemoryNode = pointsToGraph.GetLambdaNode(test.GetLambdaF());
+  auto & lambdaGMemoryNode = pointsToGraph.GetLambdaNode(test.GetLambdaG());
+  auto & lambdaHMemoryNode = pointsToGraph.GetLambdaNode(test.GetLambdaH());
+  auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
+
+  jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedLambdaGHEntryExitMemoryNodes(
+    {
+      &lambdaFMemoryNode,
+      &lambdaGMemoryNode,
+      &lambdaHMemoryNode,
+      &externalMemoryNode
+    });
+
+  jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedLambdaFEntryExitMemoryNodes(
+    {
+      &allocaXFromGMemoryNode,
+      &allocaYFromGMemoryNode,
+      &allocaXFromHMemoryNode,
+      &allocaYFromHMemoryNode,
+      &lambdaFMemoryNode,
+      &lambdaGMemoryNode,
+      &lambdaHMemoryNode,
+      &externalMemoryNode
+    });
+
+  // Validate g
+  {
+    auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaG());
+    assert(lambdaEntryNodes == expectedLambdaGHEntryExitMemoryNodes);
+
+    auto & callEntryNodes = provisioning.GetCallEntryNodes(test.GetCallFromG());
+    assert(callEntryNodes == expectedLambdaFEntryExitMemoryNodes);
+
+    auto & callExitNodes = provisioning.GetCallExitNodes(test.GetCallFromG());
+    assert(callExitNodes == expectedLambdaFEntryExitMemoryNodes);
+
+    auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(test.GetLambdaG());
+    assert(lambdaExitNodes == expectedLambdaGHEntryExitMemoryNodes);
+  }
+
+  // Validate h
+  {
+    auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaH());
+    assert(lambdaEntryNodes == expectedLambdaGHEntryExitMemoryNodes);
+
+    auto & callEntryNodes = provisioning.GetCallEntryNodes(test.GetCallFromH());
+    assert(callEntryNodes == expectedLambdaFEntryExitMemoryNodes);
+
+    auto & callExitNodes = provisioning.GetCallExitNodes(test.GetCallFromH());
+    assert(callExitNodes == expectedLambdaFEntryExitMemoryNodes);
+
+    auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(test.GetLambdaH());
+    assert(lambdaExitNodes == expectedLambdaGHEntryExitMemoryNodes);
+  }
+
+  // Validate f
+  {
+    jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedGammaMemoryNodes(
+      {
+        &allocaZMemoryNode,
+        &allocaXFromGMemoryNode,
+        &allocaYFromGMemoryNode,
+        &allocaXFromHMemoryNode,
+        &allocaYFromHMemoryNode,
+        &lambdaFMemoryNode,
+        &lambdaGMemoryNode,
+        &lambdaHMemoryNode,
+        &externalMemoryNode
+      });
+
+    auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaF());
+    assert(lambdaEntryNodes == expectedLambdaFEntryExitMemoryNodes);
+
+    auto gammaEntryNodes = provisioning.GetGammaEntryNodes(test.GetGamma());
+    assert(gammaEntryNodes == expectedGammaMemoryNodes);
+
+    for (size_t n = 0; n < test.GetGamma().nsubregions(); n++)
+    {
+      auto & subregion = *test.GetGamma().subregion(n);
+
+      auto & subregionEntryNodes = provisioning.GetRegionEntryNodes(subregion);
+      assert(subregionEntryNodes == expectedGammaMemoryNodes);
+
+      auto & subregionExitNodes = provisioning.GetRegionExitNodes(subregion);
+      assert(subregionExitNodes == expectedGammaMemoryNodes);
+    }
+
+    auto gammaExitNodes = provisioning.GetGammaExitNodes(test.GetGamma());
+    assert(gammaExitNodes == expectedGammaMemoryNodes);
+
+    auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(test.GetLambdaF());
+    assert(lambdaExitNodes == expectedLambdaFEntryExitMemoryNodes);
+  }
+}
+
+static void
+ValidateThetaTestSteensgaardAgnostic(
+  const jlm::tests::ThetaTest & test,
+  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+{
+  auto & pointsToGraph = provisioning.GetPointsToGraph();
+
+  auto & lambdaMemoryNode = pointsToGraph.GetLambdaNode(*test.lambda);
+  auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
+
+  jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+    {
+      &lambdaMemoryNode,
+      &externalMemoryNode
+    });
+
+  auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(*test.lambda);
+  assert(lambdaEntryNodes == expectedMemoryNodes);
+
+  auto & thetaEntryExitNodes = provisioning.GetThetaEntryExitNodes(*test.theta);
+  assert(thetaEntryExitNodes == expectedMemoryNodes);
+
+  auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(*test.lambda);
+  assert(lambdaExitNodes == expectedMemoryNodes);
+}
+
+static void
+ValidatePhiTest1SteensgaardAgnostic(
+  const jlm::tests::PhiTest1 & test,
+  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+{
+  auto & pointsToGraph = provisioning.GetPointsToGraph();
+
+  auto & lambdaFibMemoryNode = pointsToGraph.GetLambdaNode(*test.lambda_fib);
+  auto & lambdaTestMemoryNode = pointsToGraph.GetLambdaNode(*test.lambda_test);
+  auto & allocaMemoryNode = pointsToGraph.GetAllocaNode(*test.alloca);
+  auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
+
+  // validate function fib()
+  {
+    jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+      {
+        &lambdaFibMemoryNode,
+        &lambdaTestMemoryNode,
+        &allocaMemoryNode,
+        &externalMemoryNode
+      });
+
+    auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(*test.lambda_fib);
+    assert(lambdaEntryNodes == expectedMemoryNodes);
+
+    auto gammaEntryNodes = provisioning.GetGammaEntryNodes(*test.gamma);
+    assert(gammaEntryNodes == expectedMemoryNodes);
+
+    auto & callFib1EntryNodes = provisioning.GetCallEntryNodes(test.CallFibm1());
+    assert(callFib1EntryNodes == expectedMemoryNodes);
+
+    auto & callFib1ExitNodes = provisioning.GetCallExitNodes(test.CallFibm1());
+    assert(callFib1ExitNodes == expectedMemoryNodes);
+
+    auto & callFib2EntryNodes = provisioning.GetCallEntryNodes(test.CallFibm2());
+    assert(callFib2EntryNodes == expectedMemoryNodes);
+
+    auto & callFib2ExitNodes = provisioning.GetCallExitNodes(test.CallFibm2());
+    assert(callFib2ExitNodes == expectedMemoryNodes);
+
+    auto gammaExitNodes = provisioning.GetGammaExitNodes(*test.gamma);
+    assert(gammaExitNodes == expectedMemoryNodes);
+
+    auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(*test.lambda_fib);
+    assert(lambdaExitNodes == expectedMemoryNodes);
+  }
+
+  // validate function test()
+  {
+    jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedLambdaMemoryNodes(
+      {
+        &lambdaFibMemoryNode,
+        &lambdaTestMemoryNode,
+        &externalMemoryNode
+      });
+
+    jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedCallMemoryNodes(
+      {
+        &lambdaFibMemoryNode,
+        &lambdaTestMemoryNode,
+        &allocaMemoryNode,
+        &externalMemoryNode
+      });
+
+    auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(*test.lambda_test);
+    assert(lambdaEntryNodes == expectedLambdaMemoryNodes);
+
+    auto & callEntryNodes = provisioning.GetCallEntryNodes(test.CallFib());
+    assert(callEntryNodes == expectedCallMemoryNodes);
+
+    auto & callExitNodes = provisioning.GetCallExitNodes(test.CallFib());
+    assert(callExitNodes == expectedCallMemoryNodes);
+
+    auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(*test.lambda_test);
+    assert(lambdaExitNodes == expectedLambdaMemoryNodes);
+  }
+}
+
+
+static void
+ValidatePhiTest2SteensgaardAgnostic(
+  const jlm::tests::PhiTest2 & test,
+  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+{
+  auto & pointsToGraph = provisioning.GetPointsToGraph();
+
+  auto & lambdaAMemoryNode = pointsToGraph.GetLambdaNode(test.GetLambdaA());
+  auto & lambdaBMemoryNode = pointsToGraph.GetLambdaNode(test.GetLambdaB());
+  auto & lambdaCMemoryNode = pointsToGraph.GetLambdaNode(test.GetLambdaC());
+  auto & lambdaDMemoryNode = pointsToGraph.GetLambdaNode(test.GetLambdaD());
+  auto & lambdaIMemoryNode = pointsToGraph.GetLambdaNode(test.GetLambdaI());
+  auto & lambdaEightMemoryNode = pointsToGraph.GetLambdaNode(test.GetLambdaEight());
+  auto & lambdaTestMemoryNode = pointsToGraph.GetLambdaNode(test.GetLambdaTest());
+  auto & allocaPaMemoryNode = pointsToGraph.GetAllocaNode(test.GetPaAlloca());
+  auto & allocaPbMemoryNode = pointsToGraph.GetAllocaNode(test.GetPbAlloca());
+  auto & allocaPcMemoryNode = pointsToGraph.GetAllocaNode(test.GetPcAlloca());
+  auto & allocaPdMemoryNode = pointsToGraph.GetAllocaNode(test.GetPdAlloca());
+  auto & allocaPTestMemoryNode = pointsToGraph.GetAllocaNode(test.GetPTestAlloca());
+  auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
+
+  jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+    {
+      &lambdaAMemoryNode,
+      &lambdaBMemoryNode,
+      &lambdaCMemoryNode,
+      &lambdaDMemoryNode,
+      &lambdaIMemoryNode,
+      &lambdaEightMemoryNode,
+      &lambdaTestMemoryNode,
+      &allocaPaMemoryNode,
+      &allocaPbMemoryNode,
+      &allocaPcMemoryNode,
+      &allocaPdMemoryNode,
+      &allocaPTestMemoryNode,
+      &externalMemoryNode
+    });
+
+  // validate function eight()
+  {
+    auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaEight());
+    assert(lambdaEntryNodes == expectedMemoryNodes);
+
+    auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(test.GetLambdaEight());
+    assert(lambdaExitNodes == expectedMemoryNodes);
+  }
+
+  // validate function i()
+  {
+    auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaI());
+    assert(lambdaEntryNodes == expectedMemoryNodes);
+
+    auto & callEntryNodes = provisioning.GetCallEntryNodes(test.GetIndirectCall());
+    assert(callEntryNodes == expectedMemoryNodes);
+
+    auto & callExitNodes = provisioning.GetCallExitNodes(test.GetIndirectCall());
+    assert(callExitNodes == expectedMemoryNodes);
+
+    auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(test.GetLambdaI());
+    assert(lambdaExitNodes == expectedMemoryNodes);
+  }
+
+  // validate function a()
+  {
+    auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaA());
+    assert(lambdaEntryNodes == expectedMemoryNodes);
+
+    auto & callBEntryNodes = provisioning.GetCallEntryNodes(test.GetCallB());
+    assert(callBEntryNodes == expectedMemoryNodes);
+
+    auto & callBExitNodes = provisioning.GetCallExitNodes(test.GetCallB());
+    assert(callBExitNodes == expectedMemoryNodes);
+
+    auto & callDEntryNodes = provisioning.GetCallEntryNodes(test.GetCallD());
+    assert(callDEntryNodes == expectedMemoryNodes);
+
+    auto & callDExitNodes = provisioning.GetCallExitNodes(test.GetCallD());
+    assert(callDExitNodes == expectedMemoryNodes);
+
+    auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(test.GetLambdaA());
+    assert(lambdaExitNodes == expectedMemoryNodes);
+  }
+
+  // validate function b()
+  {
+    auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaB());
+    assert(lambdaEntryNodes == expectedMemoryNodes);
+
+    auto & callIEntryNodes = provisioning.GetCallEntryNodes(test.GetCallI());
+    assert(callIEntryNodes == expectedMemoryNodes);
+
+    auto & callIExitNodes = provisioning.GetCallExitNodes(test.GetCallI());
+    assert(callIExitNodes == expectedMemoryNodes);
+
+    auto & callCEntryNodes = provisioning.GetCallEntryNodes(test.GetCallC());
+    assert(callCEntryNodes == expectedMemoryNodes);
+
+    auto & callCExitNodes = provisioning.GetCallExitNodes(test.GetCallC());
+    assert(callCExitNodes == expectedMemoryNodes);
+
+    auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(test.GetLambdaB());
+    assert(lambdaExitNodes == expectedMemoryNodes);
+  }
+
+  // validate function c()
+  {
+    auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaC());
+    assert(lambdaEntryNodes == expectedMemoryNodes);
+
+    auto & callEntryNodes = provisioning.GetCallEntryNodes(test.GetCallAFromC());
+    assert(callEntryNodes == expectedMemoryNodes);
+
+    auto & callExitNodes = provisioning.GetCallExitNodes(test.GetCallAFromC());
+    assert(callExitNodes == expectedMemoryNodes);
+
+    auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(test.GetLambdaC());
+    assert(lambdaExitNodes == expectedMemoryNodes);
+  }
+
+  // validate function d()
+  {
+    auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaD());
+    assert(lambdaEntryNodes == expectedMemoryNodes);
+
+    auto & callEntryNodes = provisioning.GetCallEntryNodes(test.GetCallAFromD());
+    assert(callEntryNodes == expectedMemoryNodes);
+
+    auto & callExitNodes = provisioning.GetCallExitNodes(test.GetCallAFromD());
+    assert(callExitNodes == expectedMemoryNodes);
+
+    auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(test.GetLambdaD());
+    assert(lambdaExitNodes == expectedMemoryNodes);
+  }
+
+  // validate function test()
+  {
+    jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedLambdaMemoryNodes(
+      {
+        &lambdaAMemoryNode,
+        &lambdaBMemoryNode,
+        &lambdaCMemoryNode,
+        &lambdaDMemoryNode,
+        &lambdaIMemoryNode,
+        &lambdaEightMemoryNode,
+        &lambdaTestMemoryNode,
+        &externalMemoryNode
+      });
+
+    auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.GetLambdaTest());
+    assert(lambdaEntryNodes == expectedLambdaMemoryNodes);
+
+    auto & callEntryNodes = provisioning.GetCallEntryNodes(test.GetCallAFromTest());
+    assert(callEntryNodes == expectedMemoryNodes);
+
+    auto & callExitNodes = provisioning.GetCallExitNodes(test.GetCallAFromTest());
+    assert(callExitNodes == expectedMemoryNodes);
+
+    auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(test.GetLambdaTest());
+    assert(lambdaExitNodes == expectedLambdaMemoryNodes);
+  }
+}
+
+static void
+ValidateEscapedMemoryTest3SteensgaardAgnostic(
+  const jlm::tests::EscapedMemoryTest3 & test,
+  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+{
+  auto & pointsToGraph = provisioning.GetPointsToGraph();
+
+  auto & lambdaTestMemoryNode = pointsToGraph.GetLambdaNode(*test.LambdaTest);
+  auto & deltaGlobalMemoryNode = pointsToGraph.GetDeltaNode(*test.DeltaGlobal);
+  auto & importMemoryNode = pointsToGraph.GetImportNode(*test.ImportExternalFunction);
+  auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
+
+  jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+    {
+      &lambdaTestMemoryNode,
+      &deltaGlobalMemoryNode,
+      &importMemoryNode,
+      &externalMemoryNode
+    });
+
+  auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(*test.LambdaTest);
+  assert(lambdaEntryNodes == expectedMemoryNodes);
+
+  auto & externalCallEntryNodes = provisioning.GetCallEntryNodes(*test.CallExternalFunction);
+  assert(externalCallEntryNodes == expectedMemoryNodes);
+
+  auto & externalCallExitNodes = provisioning.GetCallExitNodes(*test.CallExternalFunction);
+  assert(externalCallExitNodes == expectedMemoryNodes);
+
+  auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(*test.LambdaTest);
+  assert(lambdaExitNodes == expectedMemoryNodes);
+}
+
+static void
+ValidateMemcpyTestSteensgaardAgnostic(
+  const jlm::tests::MemcpyTest & test,
+  const jlm::llvm::aa::MemoryNodeProvisioning & provisioning)
+{
+  auto & pointsToGraph = provisioning.GetPointsToGraph();
+
+  auto & lambdaFMemoryNode = pointsToGraph.GetLambdaNode(test.LambdaF());
+  auto & lambdaGMemoryNode = pointsToGraph.GetLambdaNode(test.LambdaG());
+  auto & globalArrayMemoryNode = pointsToGraph.GetDeltaNode(test.GlobalArray());
+  auto & localArrayMemoryNode = pointsToGraph.GetDeltaNode(test.LocalArray());
+  auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
+
+  jlm::util::HashSet<const jlm::llvm::aa::PointsToGraph::MemoryNode *> expectedMemoryNodes(
+    {
+      &lambdaFMemoryNode,
+      &lambdaGMemoryNode,
+      &globalArrayMemoryNode,
+      &localArrayMemoryNode,
+      &externalMemoryNode
+    });
+
+  // Validate function f()
+  {
+    auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.LambdaF());
+    assert(lambdaEntryNodes == expectedMemoryNodes);
+
+    auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(test.LambdaF());
+    assert(lambdaExitNodes == expectedMemoryNodes);
+  }
+
+  // Validate function g()
+  {
+    auto & lambdaEntryNodes = provisioning.GetLambdaEntryNodes(test.LambdaG());
+    assert(lambdaEntryNodes == expectedMemoryNodes);
+
+    auto & callEntryNodes = provisioning.GetCallEntryNodes(test.CallF());
+    assert(callEntryNodes == expectedMemoryNodes);
+
+    auto & callExitNodes = provisioning.GetCallExitNodes(test.CallF());
+    assert(callExitNodes == expectedMemoryNodes);
+
+    auto & lambdaExitNodes = provisioning.GetLambdaExitNodes(test.LambdaG());
+    assert(lambdaExitNodes == expectedMemoryNodes);
+  }
+}
+
+static void
+TestStatistics()
+{
+  // Arrange
+  jlm::tests::LoadTest1 test;
+  jlm::util::filepath filePath("/tmp/TestDisabledStatistics");
+  std::remove(filePath.to_str().c_str());
+
+  jlm::util::StatisticsCollectorSettings statisticsCollectorSettings(
+    filePath,
+    {jlm::util::Statistics::Id::TopDownMemoryNodeEliminator});
+  jlm::util::StatisticsCollector statisticsCollector(statisticsCollectorSettings);
+
+  auto pointsToGraph = jlm::llvm::aa::PointsToGraph::Create();
+  auto provisioning = jlm::llvm::aa::AgnosticMemoryNodeProvider::Create(
+    test.module(),
+    *pointsToGraph,
+    statisticsCollector);
+
+  // Act
+  jlm::llvm::aa::TopDownMemoryNodeEliminator::CreateAndEliminate(
+    test.module(),
+    *provisioning,
+    statisticsCollector);
+
+  // Assert
+  assert(statisticsCollector.NumCollectedStatistics() == 1);
+}
+
+static int
+TestTopDownMemoryNodeEliminator()
+{
+  using namespace jlm::llvm::aa;
+
+  ValidateTest<
+    jlm::tests::StoreTest1,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidateStoreTest1SteensgaardAgnostic);
+
+  ValidateTest<
+    jlm::tests::StoreTest2,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidateStoreTest2SteensgaardAgnostic);
+
+  ValidateTest<
+    jlm::tests::LoadTest1,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidateLoadTest1SteensgaardAgnostic);
+
+  ValidateTest<
+    jlm::tests::LoadTest2,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidateLoadTest2SteensgaardAgnostic);
+
+  ValidateTest<
+    jlm::tests::LoadFromUndefTest,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidateLoadFromUndefTestSteensgaardAgnostic);
+
+  ValidateTest<
+    jlm::tests::CallTest1,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidateCallTest1SteensgaardAgnostic);
+
+  ValidateTest<
+    jlm::tests::IndirectCallTest1,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidateIndirectCallTest1SteensgaardAgnostic);
+
+  ValidateTest<
+    jlm::tests::IndirectCallTest2,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidateIndirectCallTest2SteensgaardAgnostic);
+
+  ValidateTest<
+    jlm::tests::GammaTest,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidateGammaTestSteensgaardAgnostic);
+
+  ValidateTest<
+    jlm::tests::GammaTest2,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidateGammaTest2SteensgaardAgnostic);
+
+  ValidateTest<
+    jlm::tests::ThetaTest,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidateThetaTestSteensgaardAgnostic);
+
+  ValidateTest<
+    jlm::tests::PhiTest1,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidatePhiTest1SteensgaardAgnostic);
+
+  ValidateTest<
+    jlm::tests::PhiTest2,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidatePhiTest2SteensgaardAgnostic);
+
+  ValidateTest<
+    jlm::tests::EscapedMemoryTest3,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidateEscapedMemoryTest3SteensgaardAgnostic);
+
+  ValidateTest<
+    jlm::tests::MemcpyTest,
+    Steensgaard,
+    AgnosticMemoryNodeProvider
+  >(ValidateMemcpyTestSteensgaardAgnostic);
+
+  TestStatistics();
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER(
+  "jlm/llvm/opt/alias-analyses/TestTopDownMemoryNodeEliminator",
+  TestTopDownMemoryNodeEliminator)


### PR DESCRIPTION
This PR introduces the TopDownMemoryNodeEliminator. The TopDownMemoryNodeEliminator restricts the number of regions memory states need to be routed through by taking the lifetime of memory nodes into account. For example, the lifetime of a memory node originating from an `alloca` is at most the function the alloca is defined in.

The AgnosticMemoryNodeProvider and RegionAwareMemoryNodeProvider do not take such liftime information into account when producing a memory node provisioning. The idea of the TopDownMemoryNodeEliminator is to take the memory node provisioning produced by these memory node providers as seed provisioning and produce a new provisioning which takes the lifetime information into account. This simple example illustrates the idea:

```
static void
f(int x)
{
  int* alloca;
  *alloca = x;
}
```

The AgnosticMemoryNodeProvider and the RegionAwareMemoryNodeProvider would produce the following provisioning:

RegionEntry: f -> {allocaMemoryNode}
RegionExit: f -> {allocaMemoryNode}

Thus, they would consider the allocaMemoryNode alive at the region entry even though the alloca node was not even defined yet.

The TopDownMemoryNodeEliminator would take this provisioning as input, track the lifetime of alloca nodes, and restrict the provisioning to the following:

RegionEntry: f -> {}
RegionExit: f- > {allocaMemoryNode}

Ultimately, this would mean that the MemoryStateEncoder would need to route no state through the entry of function `f`.

Currently, the TopDownMemoryNodeProvider restricts the lifetime ONLY for alloca nodes and ONLY for region entries.