### PR TITLE
Add missing case to call summary computation

### DIFF
--- a/jlm/llvm/ir/operators/lambda.cpp
+++ b/jlm/llvm/ir/operators/lambda.cpp
@@ -248,7 +248,7 @@ node::ComputeCallSummary() const
 
   std::vector<CallNode*> directCalls;
   rvsdg::result * rvsdgExport = nullptr;
-  std::vector<rvsdg::simple_input*> otherUsers;
+  std::vector<rvsdg::input*> otherUsers;
 
   while (!worklist.empty()) {
     auto input = worklist.front();
@@ -302,6 +302,12 @@ node::ComputeCallSummary() const
     if (auto cvinput = dynamic_cast<delta::cvinput*>(input)) {
       auto argument = cvinput->arguments.first();
       worklist.insert(worklist.end(), argument->begin(), argument->end());
+      continue;
+    }
+
+    if (auto deltaResult = dynamic_cast<delta::result*>(input))
+    {
+      otherUsers.emplace_back(deltaResult);
       continue;
     }
 

--- a/jlm/llvm/ir/operators/lambda.hpp
+++ b/jlm/llvm/ir/operators/lambda.hpp
@@ -679,13 +679,13 @@ class node::fctresconstiterator final : public jlm::rvsdg::input::constiterator<
 class node::CallSummary final
 {
   using DirectCallsConstRange = util::iterator_range<std::vector<CallNode*>::const_iterator>;
-  using OtherUsersConstRange = util::iterator_range<std::vector<rvsdg::simple_input*>::const_iterator>;
+  using OtherUsersConstRange = util::iterator_range<std::vector<rvsdg::input*>::const_iterator>;
 
 public:
   CallSummary(
     rvsdg::result * rvsdgExport,
     std::vector<CallNode*> directCalls,
-    std::vector<rvsdg::simple_input*> otherUsers)
+    std::vector<rvsdg::input*> otherUsers)
     : RvsdgExport_(rvsdgExport)
     , DirectCalls_(std::move(directCalls))
     , OtherUsers_(std::move(otherUsers))
@@ -835,7 +835,7 @@ public:
   Create(
     rvsdg::result * rvsdgExport,
     std::vector<CallNode*> directCalls,
-    std::vector<rvsdg::simple_input*> otherUsers)
+    std::vector<rvsdg::input*> otherUsers)
   {
     return std::make_unique<CallSummary>(
       rvsdgExport,
@@ -846,7 +846,7 @@ public:
 private:
   rvsdg::result * RvsdgExport_;
   std::vector<CallNode*> DirectCalls_;
-  std::vector<rvsdg::simple_input*> OtherUsers_;
+  std::vector<rvsdg::input*> OtherUsers_;
 };
 
 }}


### PR DESCRIPTION
We forgot the case where a function pointer is stored in a global variable, i.e., a delta taking a lambda output. Closes #224.