### PR TITLE
Add an attempt at a .clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -65,7 +65,6 @@ SpacesInAngles: Never
 # public:
 #   int field;
 AccessModifierOffset: -2
-AlignAfterOpenBracket: Align
 
 AlignEscapedNewlines: Left
 AlignOperands: AlignAfterOperator
@@ -76,6 +75,8 @@ BinPackArguments: false
 BinPackParameters: false
 AllowAllArgumentsOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: false
+# If parameters/arguments don't fit on a single line, put the first parameter on the next line
+AlignAfterOpenBracket: AlwaysBreak
 
 # Always give constructor initializers their own line
 PackConstructorInitializers: Never

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,119 @@
+---
+Language:      Cpp
+Standard:      Latest
+BasedOnStyle:  LLVM
+
+# int * a and int & a
+PointerAlignment: Middle
+ReferenceAlignment: Pointer
+SpaceAroundPointerQualifiers: Both
+# Don't touch position of "const int *" vs "int const *"
+QualifierAlignment: Leave
+
+ColumnLimit: 100
+
+# Indentation width related flags
+IndentWidth: 2
+TabWidth:    2
+UseTab:      Never
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+IndentCaseBlocks: false
+IndentCaseLabels: false
+IndentExternBlock: NoIndent
+NamespaceIndentation: None
+
+# Newline rules
+InsertNewlineAtEOF: true
+LineEnding: LF
+MaxEmptyLinesToKeep: 1
+
+# Collection of all brace wrapping rules
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      true
+  AfterControlStatement: Never
+  AfterEnum:       true
+  AfterExternBlock: true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeCatch:     true
+  BeforeElse:      false
+  BeforeLambdaBody: true
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: false # Allow empty functions to have {} body
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+
+# class X
+# {
+# public:
+#   int field;
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignEscapedNewlines: Left
+AlignOperands: Align
+BreakBeforeBinaryOperators: NonAssignment
+
+# callFunction(
+#     a, b, c, d, e);
+AllowAllArgumentsOnNextLine: true
+
+# Short blocks should still get their own lines
+AllowShortBlocksOnASingleLine: Empty
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: None
+AllowShortLoopsOnASingleLine: false
+
+# We like to do [[nodiscard]] int
+BreakAfterAttributes: Never
+
+# const int &
+# MyFunction()
+AlwaysBreakAfterReturnType: All
+AlwaysBreakTemplateDeclarations: Yes
+
+# If possible, put all constructor initializers on same line
+# Otherwise try to put all on next line
+# Otherwise one initializer per line
+PackConstructorInitializers: NextLine
+
+# Makes initializer lists "tighter" {1, 2, 3}
+Cpp11BracedListStyle: true
+
+# false: do not add // jlm::rvsdg::delta to the closing curly bracket
+FixNamespaceComments: false
+
+# Allow multiple alphabetically sorted include blocks
+IncludeBlocks:   Preserve
+# Only have one category, use alphabetical sorting within each include block
+IncludeCategories:
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '^(Test)?'
+
+ReflowComments:  true
+
+# Changed from "Leave", forces space between definitions (functions, classes, structs)
+SeparateDefinitionBlocks: Always
+
+SortIncludes: CaseInsensitive
+SortUsingDeclarations: LexicographicNumeric
+
+# Inserting space settings, pretty much all of these are default
+SpaceAfterTemplateKeyword: false
+# vector<int>{1, 2, 3}
+SpaceBeforeCpp11BracedList: false
+# if (...), but func();
+SpaceBeforeParens: ControlStatements
+# for (auto it : myList) {
+SpaceBeforeRangeBasedForLoopColon: true
+# vector<int>
+SpacesInAngles:  Never

--- a/.clang-format
+++ b/.clang-format
@@ -31,9 +31,9 @@ MaxEmptyLinesToKeep: 1
 # Collection of all brace wrapping rules
 BreakBeforeBraces: Custom
 BraceWrapping:
-  AfterCaseLabel:  false
+  AfterCaseLabel:  true
   AfterClass:      true
-  AfterControlStatement: Never
+  AfterControlStatement: Always
   AfterEnum:       true
   AfterExternBlock: true
   AfterFunction:   true
@@ -41,7 +41,7 @@ BraceWrapping:
   AfterStruct:     true
   AfterUnion:      true
   BeforeCatch:     true
-  BeforeElse:      false
+  BeforeElse:      true
   BeforeLambdaBody: true
   BeforeWhile:     false
   IndentBraces:    false
@@ -49,22 +49,39 @@ BraceWrapping:
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
 
+# Inserting space settings, pretty much all of these are default
+SpaceAfterTemplateKeyword: false
+# vector<int>{1, 2, 3}
+SpaceBeforeCpp11BracedList: false
+# if (...), but func();
+SpaceBeforeParens: ControlStatements
+# for (auto it : myList) {
+SpaceBeforeRangeBasedForLoopColon: true
+# vector<int>
+SpacesInAngles: Never
+
 # class X
 # {
 # public:
 #   int field;
 AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
+
 AlignEscapedNewlines: Left
-AlignOperands: Align
+AlignOperands: AlignAfterOperator
 BreakBeforeBinaryOperators: NonAssignment
 
-# callFunction(
-#     a, b, c, d, e);
-AllowAllArgumentsOnNextLine: true
+# if arguments or parameters overflow, give them a line each
+BinPackArguments: false
+BinPackParameters: false
+AllowAllArgumentsOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
 
-# Short blocks should still get their own lines
-AllowShortBlocksOnASingleLine: Empty
+# Always give constructor initializers their own line
+PackConstructorInitializers: Never
+
+# Avoid exceptions for short blocks
+AllowShortBlocksOnASingleLine: Never
 AllowShortFunctionsOnASingleLine: None
 AllowShortIfStatementsOnASingleLine: Never
 AllowShortLambdasOnASingleLine: None
@@ -72,19 +89,13 @@ AllowShortLoopsOnASingleLine: false
 
 # We like to do [[nodiscard]] int
 BreakAfterAttributes: Never
-
 # const int &
 # MyFunction()
 AlwaysBreakAfterReturnType: All
 AlwaysBreakTemplateDeclarations: Yes
 
-# If possible, put all constructor initializers on same line
-# Otherwise try to put all on next line
-# Otherwise one initializer per line
-PackConstructorInitializers: NextLine
-
-# Makes initializer lists "tighter" {1, 2, 3}
-Cpp11BracedListStyle: true
+# Makes initializer lists a bit more spacious { 1, 2, 3 }
+Cpp11BracedListStyle: false
 
 # false: do not add // jlm::rvsdg::delta to the closing curly bracket
 FixNamespaceComments: false
@@ -98,22 +109,10 @@ IncludeCategories:
     SortPriority:    0
     CaseSensitive:   false
 IncludeIsMainRegex: '^(Test)?'
+SortIncludes: CaseInsensitive
+SortUsingDeclarations: LexicographicNumeric
 
 ReflowComments:  true
 
 # Changed from "Leave", forces space between definitions (functions, classes, structs)
 SeparateDefinitionBlocks: Always
-
-SortIncludes: CaseInsensitive
-SortUsingDeclarations: LexicographicNumeric
-
-# Inserting space settings, pretty much all of these are default
-SpaceAfterTemplateKeyword: false
-# vector<int>{1, 2, 3}
-SpaceBeforeCpp11BracedList: false
-# if (...), but func();
-SpaceBeforeParens: ControlStatements
-# for (auto it : myList) {
-SpaceBeforeRangeBasedForLoopColon: true
-# vector<int>
-SpacesInAngles:  Never


### PR DESCRIPTION
There are two reasons I attempted to make a `.clang-format` file for the project.

First and foremost, I want to free up the time Nico spends correcting my curly bracket placement.
I'm also sometimes a bit unsure how to format certain things.

Secondly, I have started to use the [CLion Nova](https://blog.jetbrains.com/clion/2023/11/clion-nova/) preview, in hopes its RAM usage is more modest and stable than CLion Classic.
Reading their blog, it seems it will be merged into CLion in the future, and my experience so far has been ok.
It is better at informing about unnecessarily precise namespaces, inline and stuff.

Formatting (and completion / indenting as you type) is now done by either ReSharper or clang-format, so instead of mucking about in the ReSharper settings dialog, I thought it would be better to make a proper `.clang-format`.
Do however note, that the built in `clang-format` binary is a bit older, because it does some silly stuff. Passing in my system's `/usr/bin/clang-format` worked nicely.

**I'm not suggesting running clang-format on the whole project, or forcing formatting on new PRs, only as an aid to people who want it / IDEs inserting indentation when you press enter**

Without further ado, here is some example output, representing the `.clang-format` from the latest commit:

### Example
```cpp
#include <jlm/llvm/opt/Something.hpp>
#include <jlm/rvsdg/SomethingElse.hpp>

#include <vector>

namespace jlm::test
{

class MyClass final : public ParentClass
{
  class ForwardDeclared;

public:
  explicit MyClass(const char * name)
      : ParentClass(name),
        Member1_(param)
  {}

  explicit MyClass(int & param)
      : ParentClass("MyClass"),
        Member1_(param),
        Member2_(2),
        Member3_(3),
        Member4_(4),
        AVeryLongMember5ThatNeedsToBeSuperLong_(5)
  {}

  virtual ~MyClass() override = default;

  MyClass &
  MyClass(const MyClass & other) = delete;

  template<typename T>
  [[nodiscard]] int
  GetSum(util::HashSet<const PointsToGraph::MemoryNode *> hashSet)
  {
    if (Member1_ == 0)
      return Memeber1_;

    if (Member1_ > 10)
    {
      int & tmpVar = Member2_;
      tmpVar += Member3_;
    }
    else
    {
      std::swap(Member1_, Member2_);
    }

    return Member1_ + Member2_ + Member3_;
  }

  int
  VeryLongFunctionNameWithALotOfParameters(
      const SomeClass & param1,
      const OtherClass & param2,
      int x,
      int y,
      int z,
      Quaterion rotation,
      Vector3 scale)
  {
    switch (Member1_)
    {
    case 1:
      return 2;
    case 2:
    {
      Member2_++;
      return VeryLongFunctionNameWithALotOfParameters(
          param1,
          param2,
          x + 500,
          y - 400,
          z * 50 + 2,
          rotation,
          scale);
    }
    default:
      break;
    }

    auto myFancyLambda = augmentLambda(
        [&](int arg)
        {
          return arg;
        },
        arg2);

    return myFancyLambda(Member3_);
  }

private:
  /**
   * \brief a documentation comment
   */
  int Member1_;
  int Member2_, Member3_;
  int Member4_, AVeryLongMember5ThatNeedsToBeSuperLong_;
};

enum class Xyz : uint8_t
{
  Enum1,
  Enum2,
  Enum3
};

}
```

It is based on the LLVM format, with most unchanged rules removed for brevity.
Some unchanged rules are still included, in cases where I'm uncertain, or feel like it should be present.

