### PR TITLE
Add delta input removal methods

### DIFF
--- a/jlm/llvm/ir/operators/delta.cpp
+++ b/jlm/llvm/ir/operators/delta.cpp
@@ -110,6 +110,12 @@ node::input(size_t n) const noexcept
   return static_cast<cvinput *>(structural_node::input(n));
 }
 
+cvargument *
+node::cvargument(size_t n) const noexcept
+{
+  return util::AssertedCast<delta::cvargument>(subregion()->argument(n));
+}
+
 delta::output *
 node::output() const noexcept
 {

--- a/jlm/llvm/ir/operators/delta.hpp
+++ b/jlm/llvm/ir/operators/delta.hpp
@@ -245,8 +245,8 @@ public:
     return RemoveDeltaInputsWhere(match);
   }
 
-	cvinput *
-	input(size_t n) const noexcept;
+  cvinput *
+  input(size_t n) const noexcept;
 
   delta::cvargument *
   cvargument(size_t n) const noexcept;

--- a/jlm/llvm/ir/operators/delta.hpp
+++ b/jlm/llvm/ir/operators/delta.hpp
@@ -227,6 +227,24 @@ public:
   template <typename F> size_t
   RemoveDeltaInputsWhere(const F& match);
 
+  /**
+   * Remove all dead inputs.
+   *
+   * @return The number of removed inputs.
+   *
+   * \see RemoveDeltaInputsWhere()
+   */
+  size_t
+  PruneDeltaInputs()
+  {
+    auto match = [](const cvinput&)
+    {
+      return true;
+    };
+
+    return RemoveDeltaInputsWhere(match);
+  }
+
 	cvinput *
 	input(size_t n) const noexcept;
 

--- a/jlm/llvm/ir/operators/delta.hpp
+++ b/jlm/llvm/ir/operators/delta.hpp
@@ -224,8 +224,9 @@ public:
    *
    * \see cvargument#IsDead()
    */
-  template <typename F> size_t
-  RemoveDeltaInputsWhere(const F& match);
+  template<typename F>
+  size_t
+  RemoveDeltaInputsWhere(const F & match);
 
   /**
    * Remove all dead inputs.
@@ -237,7 +238,7 @@ public:
   size_t
   PruneDeltaInputs()
   {
-    auto match = [](const cvinput&)
+    auto match = [](const cvinput &)
     {
       return true;
     };
@@ -463,13 +464,14 @@ public:
   }
 };
 
-template <typename F> size_t
-delta::node::RemoveDeltaInputsWhere(const F &match)
+template<typename F>
+size_t
+delta::node::RemoveDeltaInputsWhere(const F & match)
 {
   size_t numRemovedInputs = 0;
 
   // iterate backwards to avoid the invalidation of 'n' by RemoveInput()
-  for (size_t n = ninputs()-1; n != static_cast<size_t>(-1); n--)
+  for (size_t n = ninputs() - 1; n != static_cast<size_t>(-1); n--)
   {
     auto & deltaInput = *input(n);
     auto & argument = *deltaInput.argument();

--- a/jlm/llvm/ir/operators/delta.hpp
+++ b/jlm/llvm/ir/operators/delta.hpp
@@ -213,8 +213,22 @@ public:
   delta::cvargument *
   add_ctxvar(rvsdg::output * origin);
 
-  cvinput *
-  input(size_t n) const noexcept;
+  /**
+   * Remove delta inputs and their respective arguments.
+   *
+   * An input must match the condition specified by \p match and its argument must be dead.
+   *
+   * @tparam F A type that supports the function call operator: bool operator(const cvinput&)
+   * @param match Defines the condition of the elements to remove.
+   * @return The number of removed inputs.
+   *
+   * \see cvargument#IsDead()
+   */
+  template <typename F> size_t
+  RemoveDeltaInputsWhere(const F& match);
+
+	cvinput *
+	input(size_t n) const noexcept;
 
   delta::cvargument *
   cvargument(size_t n) const noexcept;
@@ -430,6 +444,28 @@ public:
     return static_cast<delta::output *>(rvsdg::result::output());
   }
 };
+
+template <typename F> size_t
+delta::node::RemoveDeltaInputsWhere(const F &match)
+{
+  size_t numRemovedInputs = 0;
+
+  // iterate backwards to avoid the invalidation of 'n' by RemoveInput()
+  for (size_t n = ninputs()-1; n != static_cast<size_t>(-1); n--)
+  {
+    auto & deltaInput = *input(n);
+    auto & argument = *deltaInput.argument();
+
+    if (argument.IsDead() && match(deltaInput))
+    {
+      subregion()->RemoveArgument(argument.index());
+      RemoveInput(deltaInput.index());
+      numRemovedInputs++;
+    }
+  }
+
+  return numRemovedInputs;
+}
 
 }
 }

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -567,21 +567,12 @@ DeadNodeElimination::SweepPhi(phi::node & phiNode) const
 }
 
 void
-DeadNodeElimination::SweepDelta(delta::node & deltaNode) const
+DeadNodeElimination::SweepDelta(delta::node & deltaNode)
 {
   // A delta subregion can only contain simple nodes. Thus, a simple prune is sufficient.
   deltaNode.subregion()->prune(false);
 
-  // Remove dead arguments and inputs.
-  for (size_t n = deltaNode.ninputs() - 1; n != static_cast<size_t>(-1); n--)
-  {
-    auto input = deltaNode.input(n);
-    if (!Context_->IsAlive(*input->argument()))
-    {
-      deltaNode.subregion()->RemoveArgument(input->argument()->index());
-      deltaNode.RemoveInput(input->index());
-    }
-  }
+  deltaNode.PruneDeltaInputs();
 }
 
 }

--- a/jlm/llvm/opt/DeadNodeElimination.hpp
+++ b/jlm/llvm/opt/DeadNodeElimination.hpp
@@ -105,8 +105,8 @@ private:
   void
   SweepPhi(phi::node & phiNode) const;
 
-  void
-  SweepDelta(delta::node & deltaNode) const;
+  static void
+  SweepDelta(delta::node & deltaNode);
 
   std::unique_ptr<Context> Context_;
 };

--- a/jlm/rvsdg/node.hpp
+++ b/jlm/rvsdg/node.hpp
@@ -322,11 +322,26 @@ public:
     return users_.size();
   }
 
-  inline void
-  divert_users(jlm::rvsdg::output * new_origin)
+  /**
+   * Determines whether the output is dead.
+   *
+   * An output is considered dead when it has no users.
+   *
+   * @return True, if the output is dead, otherwise false.
+   *
+   * \see nusers()
+   */
+  [[nodiscard]] bool
+  IsDead() const noexcept
   {
-    if (this == new_origin)
-      return;
+    return nusers() == 0;
+  }
+
+	inline void
+	divert_users(jlm::rvsdg::output * new_origin)
+	{
+		if (this == new_origin)
+			return;
 
     while (users_.size())
       (*users_.begin())->divert_to(new_origin);

--- a/jlm/rvsdg/node.hpp
+++ b/jlm/rvsdg/node.hpp
@@ -337,11 +337,11 @@ public:
     return nusers() == 0;
   }
 
-	inline void
-	divert_users(jlm::rvsdg::output * new_origin)
-	{
-		if (this == new_origin)
-			return;
+  inline void
+  divert_users(jlm::rvsdg::output * new_origin)
+  {
+    if (this == new_origin)
+      return;
 
     while (users_.size())
       (*users_.begin())->divert_to(new_origin);

--- a/tests/jlm/llvm/ir/operators/test-delta.cpp
+++ b/tests/jlm/llvm/ir/operators/test-delta.cpp
@@ -12,56 +12,121 @@
 #include <jlm/llvm/ir/operators/delta.hpp>
 #include <jlm/llvm/ir/RvsdgModule.hpp>
 
-static int
-test()
+static  void
+TestDeltaCreation()
 {
   using namespace jlm::llvm;
 
-  /* setup graph */
+  // Arrange & Act
+  jlm::tests::valuetype valueType;
+  PointerType pointerType;
+  RvsdgModule rvsdgModule(jlm::util::filepath(""), "", "");
 
-  jlm::tests::valuetype vt;
-  PointerType pt;
-  RvsdgModule rm(jlm::util::filepath(""), "", "");
-
-  auto imp = rm.Rvsdg().add_import({ vt, "" });
+  auto imp = rvsdgModule.Rvsdg().add_import({ valueType, "" });
 
   auto delta1 = delta::node::Create(
-      rm.Rvsdg().root(),
-      vt,
-      "test-delta1",
-      linkage::external_linkage,
-      "",
-      true);
+    rvsdgModule.Rvsdg().root(),
+      valueType,
+    "test-delta1",
+    linkage::external_linkage,
+    "",
+    true);
   auto dep = delta1->add_ctxvar(imp);
-  auto d1 = delta1->finalize(jlm::tests::create_testop(delta1->subregion(), { dep }, { &vt })[0]);
+  auto d1 = delta1->finalize(jlm::tests::create_testop(delta1->subregion(), {dep}, {&valueType })[0]);
 
   auto delta2 = delta::node::Create(
-      rm.Rvsdg().root(),
-      vt,
-      "test-delta2",
-      linkage::internal_linkage,
-      "",
-      false);
-  auto d2 = delta2->finalize(jlm::tests::create_testop(delta2->subregion(), {}, { &vt })[0]);
+    rvsdgModule.Rvsdg().root(),
+      valueType,
+    "test-delta2",
+    linkage::internal_linkage,
+    "",
+    false);
+  auto d2 = delta2->finalize(jlm::tests::create_testop(delta2->subregion(), {}, {&valueType })[0]);
 
-  rm.Rvsdg().add_export(d1, { d1->type(), "" });
-  rm.Rvsdg().add_export(d2, { d2->type(), "" });
+  rvsdgModule.Rvsdg().add_export(d1, { d1->type(), "" });
+  rvsdgModule.Rvsdg().add_export(d2, { d2->type(), "" });
 
-  jlm::rvsdg::view(rm.Rvsdg(), stdout);
+  jlm::rvsdg::view(rvsdgModule.Rvsdg(), stdout);
 
-  /* verify graph */
-
-  assert(rm.Rvsdg().root()->nnodes() == 2);
+  // Assert
+  assert(rvsdgModule.Rvsdg().root()->nnodes() == 2);
 
   assert(delta1->linkage() == linkage::external_linkage);
   assert(delta1->constant() == true);
-  assert(delta1->type() == vt);
+  assert(delta1->type() == valueType);
 
   assert(delta2->linkage() == linkage::internal_linkage);
   assert(delta2->constant() == false);
-  assert(delta2->type() == vt);
+  assert(delta2->type() == valueType);
+}
+
+static void
+TestRemoveDeltaInputsWhere()
+{
+  using namespace jlm::llvm;
+
+  // Arrange
+  jlm::tests::valuetype valueType;
+  RvsdgModule rvsdgModule(jlm::util::filepath(""), "", "");
+
+  auto x = rvsdgModule.Rvsdg().add_import({valueType, ""});
+
+  auto deltaNode = delta::node::Create(
+    rvsdgModule.Rvsdg().root(),
+    valueType,
+    "delta",
+    linkage::external_linkage,
+    "",
+    true);
+  auto deltaInput0 = deltaNode->add_ctxvar(x)->input();
+  auto deltaInput1 = deltaNode->add_ctxvar(x)->input();
+  auto deltaInput2 = deltaNode->add_ctxvar(x)->input();
+
+  auto result = jlm::tests::SimpleNode::Create(
+    *deltaNode->subregion(),
+    {deltaInput1->argument()},
+    {&valueType})
+    .output(0);
+
+  deltaNode->finalize(result);
+
+  // Act & Assert
+  // Try to remove deltaInput1 even though it is used
+  auto numRemovedInputs = deltaNode->RemoveDeltaInputsWhere(
+    [&](const delta::cvinput& input){ return input.index() == deltaInput1->index(); });
+  assert(numRemovedInputs == 0);
+  assert(deltaNode->ninputs() == 3);
+  assert(deltaNode->ncvarguments() == 3);
+
+  // Remove deltaInput2
+  numRemovedInputs = deltaNode->RemoveDeltaInputsWhere(
+    [&](const delta::cvinput& input){ return input.index() == deltaInput2->index(); });
+  assert(numRemovedInputs == 1);
+  assert(deltaNode->ninputs() == 2);
+  assert(deltaNode->ncvarguments() == 2);
+  assert(deltaNode->input(0) == deltaInput0);
+  assert(deltaNode->input(1) == deltaInput1);
+
+  // Remove deltaInput0
+  numRemovedInputs = deltaNode->RemoveDeltaInputsWhere(
+    [&](const delta::cvinput& input){ return input.index() == deltaInput0->index(); });
+  assert(numRemovedInputs == 1);
+  assert(deltaNode->ninputs() == 1);
+  assert(deltaNode->ncvarguments() == 1);
+  assert(deltaNode->input(0) == deltaInput1);
+  assert(deltaInput1->index() == 0);
+  assert(deltaInput1->argument()->index() == 0);
+}
+
+static int
+TestDelta()
+{
+  TestDeltaCreation();
+  TestRemoveDeltaInputsWhere();
 
   return 0;
 }
 
-JLM_UNIT_TEST_REGISTER("jlm/llvm/ir/operators/test-delta", test)
+JLM_UNIT_TEST_REGISTER(
+  "jlm/llvm/ir/operators/test-delta",
+  TestDelta)

--- a/tests/jlm/llvm/ir/operators/test-delta.cpp
+++ b/tests/jlm/llvm/ir/operators/test-delta.cpp
@@ -81,7 +81,7 @@ TestRemoveDeltaInputsWhere()
       true);
   auto deltaInput0 = deltaNode->add_ctxvar(x)->input();
   auto deltaInput1 = deltaNode->add_ctxvar(x)->input();
-  auto deltaInput2 = deltaNode->add_ctxvar(x)->input();
+  deltaNode->add_ctxvar(x)->input();
 
   auto result = jlm::tests::SimpleNode::Create(
                     *deltaNode->subregion(),
@@ -106,7 +106,7 @@ TestRemoveDeltaInputsWhere()
   numRemovedInputs = deltaNode->RemoveDeltaInputsWhere(
       [&](const delta::cvinput & input)
       {
-        return input.index() == deltaInput2->index();
+        return input.index() == 2;
       });
   assert(numRemovedInputs == 1);
   assert(deltaNode->ninputs() == 2);
@@ -118,7 +118,7 @@ TestRemoveDeltaInputsWhere()
   numRemovedInputs = deltaNode->RemoveDeltaInputsWhere(
       [&](const delta::cvinput & input)
       {
-        return input.index() == deltaInput0->index();
+        return input.index() == 0;
       });
   assert(numRemovedInputs == 1);
   assert(deltaNode->ninputs() == 1);

--- a/tests/jlm/llvm/ir/operators/test-delta.cpp
+++ b/tests/jlm/llvm/ir/operators/test-delta.cpp
@@ -12,7 +12,7 @@
 #include <jlm/llvm/ir/operators/delta.hpp>
 #include <jlm/llvm/ir/RvsdgModule.hpp>
 
-static  void
+static void
 TestDeltaCreation()
 {
   using namespace jlm::llvm;
@@ -25,23 +25,24 @@ TestDeltaCreation()
   auto imp = rvsdgModule.Rvsdg().add_import({ valueType, "" });
 
   auto delta1 = delta::node::Create(
-    rvsdgModule.Rvsdg().root(),
+      rvsdgModule.Rvsdg().root(),
       valueType,
-    "test-delta1",
-    linkage::external_linkage,
-    "",
-    true);
+      "test-delta1",
+      linkage::external_linkage,
+      "",
+      true);
   auto dep = delta1->add_ctxvar(imp);
-  auto d1 = delta1->finalize(jlm::tests::create_testop(delta1->subregion(), {dep}, {&valueType })[0]);
+  auto d1 =
+      delta1->finalize(jlm::tests::create_testop(delta1->subregion(), { dep }, { &valueType })[0]);
 
   auto delta2 = delta::node::Create(
-    rvsdgModule.Rvsdg().root(),
+      rvsdgModule.Rvsdg().root(),
       valueType,
-    "test-delta2",
-    linkage::internal_linkage,
-    "",
-    false);
-  auto d2 = delta2->finalize(jlm::tests::create_testop(delta2->subregion(), {}, {&valueType })[0]);
+      "test-delta2",
+      linkage::internal_linkage,
+      "",
+      false);
+  auto d2 = delta2->finalize(jlm::tests::create_testop(delta2->subregion(), {}, { &valueType })[0]);
 
   rvsdgModule.Rvsdg().add_export(d1, { d1->type(), "" });
   rvsdgModule.Rvsdg().add_export(d2, { d2->type(), "" });
@@ -69,38 +70,44 @@ TestRemoveDeltaInputsWhere()
   jlm::tests::valuetype valueType;
   RvsdgModule rvsdgModule(jlm::util::filepath(""), "", "");
 
-  auto x = rvsdgModule.Rvsdg().add_import({valueType, ""});
+  auto x = rvsdgModule.Rvsdg().add_import({ valueType, "" });
 
   auto deltaNode = delta::node::Create(
-    rvsdgModule.Rvsdg().root(),
-    valueType,
-    "delta",
-    linkage::external_linkage,
-    "",
-    true);
+      rvsdgModule.Rvsdg().root(),
+      valueType,
+      "delta",
+      linkage::external_linkage,
+      "",
+      true);
   auto deltaInput0 = deltaNode->add_ctxvar(x)->input();
   auto deltaInput1 = deltaNode->add_ctxvar(x)->input();
   auto deltaInput2 = deltaNode->add_ctxvar(x)->input();
 
   auto result = jlm::tests::SimpleNode::Create(
-    *deltaNode->subregion(),
-    {deltaInput1->argument()},
-    {&valueType})
-    .output(0);
+                    *deltaNode->subregion(),
+                    { deltaInput1->argument() },
+                    { &valueType })
+                    .output(0);
 
   deltaNode->finalize(result);
 
   // Act & Assert
   // Try to remove deltaInput1 even though it is used
   auto numRemovedInputs = deltaNode->RemoveDeltaInputsWhere(
-    [&](const delta::cvinput& input){ return input.index() == deltaInput1->index(); });
+      [&](const delta::cvinput & input)
+      {
+        return input.index() == deltaInput1->index();
+      });
   assert(numRemovedInputs == 0);
   assert(deltaNode->ninputs() == 3);
   assert(deltaNode->ncvarguments() == 3);
 
   // Remove deltaInput2
   numRemovedInputs = deltaNode->RemoveDeltaInputsWhere(
-    [&](const delta::cvinput& input){ return input.index() == deltaInput2->index(); });
+      [&](const delta::cvinput & input)
+      {
+        return input.index() == deltaInput2->index();
+      });
   assert(numRemovedInputs == 1);
   assert(deltaNode->ninputs() == 2);
   assert(deltaNode->ncvarguments() == 2);
@@ -109,7 +116,10 @@ TestRemoveDeltaInputsWhere()
 
   // Remove deltaInput0
   numRemovedInputs = deltaNode->RemoveDeltaInputsWhere(
-    [&](const delta::cvinput& input){ return input.index() == deltaInput0->index(); });
+      [&](const delta::cvinput & input)
+      {
+        return input.index() == deltaInput0->index();
+      });
   assert(numRemovedInputs == 1);
   assert(deltaNode->ninputs() == 1);
   assert(deltaNode->ncvarguments() == 1);
@@ -127,25 +137,25 @@ TestPruneDeltaInputs()
   jlm::tests::valuetype valueType;
   RvsdgModule rvsdgModule(jlm::util::filepath(""), "", "");
 
-  auto x = rvsdgModule.Rvsdg().add_import({valueType, ""});
+  auto x = rvsdgModule.Rvsdg().add_import({ valueType, "" });
 
   auto deltaNode = delta::node::Create(
-    rvsdgModule.Rvsdg().root(),
-    valueType,
-    "delta",
-    linkage::external_linkage,
-    "",
-    true);
+      rvsdgModule.Rvsdg().root(),
+      valueType,
+      "delta",
+      linkage::external_linkage,
+      "",
+      true);
 
   deltaNode->add_ctxvar(x);
   auto deltaInput1 = deltaNode->add_ctxvar(x)->input();
   deltaNode->add_ctxvar(x);
 
   auto result = jlm::tests::SimpleNode::Create(
-    *deltaNode->subregion(),
-    {deltaInput1->argument()},
-    {&valueType})
-    .output(0);
+                    *deltaNode->subregion(),
+                    { deltaInput1->argument() },
+                    { &valueType })
+                    .output(0);
 
   deltaNode->finalize(result);
 
@@ -172,6 +182,4 @@ TestDelta()
   return 0;
 }
 
-JLM_UNIT_TEST_REGISTER(
-  "jlm/llvm/ir/operators/test-delta",
-  TestDelta)
+JLM_UNIT_TEST_REGISTER("jlm/llvm/ir/operators/test-delta", TestDelta)


### PR DESCRIPTION
This PR adds an API for delta input removal. It contains the following:

1. Add RemoveDeltaInputsWhere and PruneDeltaInputs method to delta node class
2. These implementation hide nasty implementation details, such as iteration order, from outside the class hierarchy
3. Removes the usage of RemoveInput and RemoveArgument from outside the structural node class hierarchy.
4. Adds a test for delta nodes to the TestDeadNodeElimination.cpp. This node was untested.

The implementation of RemoveDeltaInputsWhere will be simplified further down the road. The implementation details, such as iteration order, will be pushed further up the class hierarchy at a later point in time.