### PR TITLE
Add lambda input removal methods

### DIFF
--- a/jlm/llvm/ir/operators/lambda.hpp
+++ b/jlm/llvm/ir/operators/lambda.hpp
@@ -276,8 +276,9 @@ public:
    *
    * \see cvargument#IsDead()
    */
-  template <typename F> size_t
-  RemoveLambdaInputsWhere(const F& match);
+  template<typename F>
+  size_t
+  RemoveLambdaInputsWhere(const F & match);
 
   /**
    * Remove all dead inputs.
@@ -289,7 +290,7 @@ public:
   size_t
   PruneLambdaInputs()
   {
-    auto match = [](const cvinput&)
+    auto match = [](const cvinput &)
     {
       return true;
     };
@@ -840,13 +841,14 @@ private:
   std::vector<rvsdg::input *> OtherUsers_;
 };
 
-template <typename F> size_t
-lambda::node::RemoveLambdaInputsWhere(const F& match)
+template<typename F>
+size_t
+lambda::node::RemoveLambdaInputsWhere(const F & match)
 {
   size_t numRemovedInputs = 0;
 
   // iterate backwards to avoid the invalidation of 'n' by RemoveInput()
-  for (size_t n = ninputs()-1; n != static_cast<size_t>(-1); n--)
+  for (size_t n = ninputs() - 1; n != static_cast<size_t>(-1); n--)
   {
     auto & lambdaInput = *input(n);
     auto & argument = *lambdaInput.argument();

--- a/jlm/llvm/ir/operators/lambda.hpp
+++ b/jlm/llvm/ir/operators/lambda.hpp
@@ -279,6 +279,24 @@ public:
   template <typename F> size_t
   RemoveLambdaInputsWhere(const F& match);
 
+  /**
+   * Remove all dead inputs.
+   *
+   * @return The number of removed inputs.
+   *
+   * \see RemoveLambdaInputsWhere()
+   */
+  size_t
+  PruneLambdaInputs()
+  {
+    auto match = [](const cvinput&)
+    {
+      return true;
+    };
+
+    return RemoveLambdaInputsWhere(match);
+  }
+
   [[nodiscard]] cvinput *
   input(size_t n) const noexcept;
 

--- a/jlm/llvm/ir/operators/lambda.hpp
+++ b/jlm/llvm/ir/operators/lambda.hpp
@@ -265,6 +265,20 @@ public:
   lambda::cvargument *
   add_ctxvar(jlm::rvsdg::output * origin);
 
+  /**
+   * Remove lambda inputs and their respective arguments.
+   *
+   * An input must match the condition specified by \p match and its argument must be dead.
+   *
+   * @tparam F A type that supports the function call operator: bool operator(const cvinput&)
+   * @param match Defines the condition of the elements to remove.
+   * @return The number of removed inputs.
+   *
+   * \see cvargument#IsDead()
+   */
+  template <typename F> size_t
+  RemoveLambdaInputsWhere(const F& match);
+
   [[nodiscard]] cvinput *
   input(size_t n) const noexcept;
 
@@ -807,6 +821,28 @@ private:
   std::vector<CallNode *> DirectCalls_;
   std::vector<rvsdg::input *> OtherUsers_;
 };
+
+template <typename F> size_t
+lambda::node::RemoveLambdaInputsWhere(const F& match)
+{
+  size_t numRemovedInputs = 0;
+
+  // iterate backwards to avoid the invalidation of 'n' by RemoveInput()
+  for (size_t n = ninputs()-1; n != static_cast<size_t>(-1); n--)
+  {
+    auto & lambdaInput = *input(n);
+    auto & argument = *lambdaInput.argument();
+
+    if (argument.IsDead() && match(lambdaInput))
+    {
+      subregion()->RemoveArgument(argument.index());
+      RemoveInput(n);
+      numRemovedInputs++;
+    }
+  }
+
+  return numRemovedInputs;
+}
 
 }
 }

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -517,18 +517,7 @@ void
 DeadNodeElimination::SweepLambda(lambda::node & lambdaNode) const
 {
   SweepRegion(*lambdaNode.subregion());
-
-  // Remove dead arguments and inputs
-  for (size_t n = lambdaNode.ninputs() - 1; n != static_cast<size_t>(-1); n--)
-  {
-    auto input = lambdaNode.input(n);
-
-    if (!Context_->IsAlive(*input->argument()))
-    {
-      lambdaNode.subregion()->RemoveArgument(input->argument()->index());
-      lambdaNode.RemoveInput(n);
-    }
-  }
+  lambdaNode.PruneLambdaInputs();
 }
 
 void

--- a/jlm/rvsdg/node.hpp
+++ b/jlm/rvsdg/node.hpp
@@ -322,11 +322,26 @@ public:
     return users_.size();
   }
 
-  inline void
-  divert_users(jlm::rvsdg::output * new_origin)
+  /**
+   * Determines whether the output is dead.
+   *
+   * An output is considered dead when it has no users.
+   *
+   * @return True, if the output is dead, otherwise false.
+   *
+   * \see nusers()
+   */
+  [[nodiscard]] bool
+  IsDead() const noexcept
   {
-    if (this == new_origin)
-      return;
+    return nusers() == 0;
+  }
+
+	inline void
+	divert_users(jlm::rvsdg::output * new_origin)
+	{
+		if (this == new_origin)
+			return;
 
     while (users_.size())
       (*users_.begin())->divert_to(new_origin);

--- a/jlm/rvsdg/node.hpp
+++ b/jlm/rvsdg/node.hpp
@@ -337,11 +337,11 @@ public:
     return nusers() == 0;
   }
 
-	inline void
-	divert_users(jlm::rvsdg::output * new_origin)
-	{
-		if (this == new_origin)
-			return;
+  inline void
+  divert_users(jlm::rvsdg::output * new_origin)
+  {
+    if (this == new_origin)
+      return;
 
     while (users_.size())
       (*users_.begin())->divert_to(new_origin);

--- a/tests/jlm/llvm/ir/operators/TestLambda.cpp
+++ b/tests/jlm/llvm/ir/operators/TestLambda.cpp
@@ -128,7 +128,7 @@ TestRemoveLambdaInputsWhere()
 
   auto lambdaInput0 = lambdaNode->add_ctxvar(x)->input();
   auto lambdaInput1 = lambdaNode->add_ctxvar(x)->input();
-  auto lambdaInput2 = lambdaNode->add_ctxvar(x)->input();
+  lambdaNode->add_ctxvar(x)->input();
 
   auto result = jlm::tests::SimpleNode::Create(
                     *lambdaNode->subregion(),
@@ -153,7 +153,7 @@ TestRemoveLambdaInputsWhere()
   numRemovedInputs = lambdaNode->RemoveLambdaInputsWhere(
       [&](const lambda::cvinput & input)
       {
-        return input.index() == lambdaInput2->index();
+        return input.index() == 2;
       });
   assert(numRemovedInputs == 1);
   assert(lambdaNode->ninputs() == 2);
@@ -165,7 +165,7 @@ TestRemoveLambdaInputsWhere()
   numRemovedInputs = lambdaNode->RemoveLambdaInputsWhere(
       [&](const lambda::cvinput & input)
       {
-        return input.index() == lambdaInput0->index();
+        return input.index() == 0;
       });
   assert(numRemovedInputs == 1);
   assert(lambdaNode->ninputs() == 1);

--- a/tests/jlm/llvm/ir/operators/TestLambda.cpp
+++ b/tests/jlm/llvm/ir/operators/TestLambda.cpp
@@ -116,42 +116,45 @@ TestRemoveLambdaInputsWhere()
 
   // Arrange
   jlm::tests::valuetype valueType;
-  FunctionType functionType({}, {&valueType});
+  FunctionType functionType({}, { &valueType });
 
   auto rvsdgModule = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto & rvsdg = rvsdgModule->Rvsdg();
 
-  auto x = rvsdg.add_import({valueType, "x"});
+  auto x = rvsdg.add_import({ valueType, "x" });
 
-  auto lambdaNode = lambda::node::create(
-    rvsdg.root(),
-    functionType,
-    "f",
-    linkage::external_linkage);
+  auto lambdaNode =
+      lambda::node::create(rvsdg.root(), functionType, "f", linkage::external_linkage);
 
   auto lambdaInput0 = lambdaNode->add_ctxvar(x)->input();
   auto lambdaInput1 = lambdaNode->add_ctxvar(x)->input();
   auto lambdaInput2 = lambdaNode->add_ctxvar(x)->input();
 
   auto result = jlm::tests::SimpleNode::Create(
-    *lambdaNode->subregion(),
-    {lambdaInput1->argument()},
-    {&valueType})
-    .output(0);
+                    *lambdaNode->subregion(),
+                    { lambdaInput1->argument() },
+                    { &valueType })
+                    .output(0);
 
-  lambdaNode->finalize({result});
+  lambdaNode->finalize({ result });
 
   // Act & Assert
   // Try to remove lambdaInput1 even though it is used
   auto numRemovedInputs = lambdaNode->RemoveLambdaInputsWhere(
-    [&](const lambda::cvinput& input){ return input.index() == lambdaInput1->index(); });
+      [&](const lambda::cvinput & input)
+      {
+        return input.index() == lambdaInput1->index();
+      });
   assert(numRemovedInputs == 0);
   assert(lambdaNode->ninputs() == 3);
   assert(lambdaNode->ncvarguments() == 3);
 
   // Remove lambdaInput2
   numRemovedInputs = lambdaNode->RemoveLambdaInputsWhere(
-    [&](const lambda::cvinput& input){ return input.index() == lambdaInput2->index(); });
+      [&](const lambda::cvinput & input)
+      {
+        return input.index() == lambdaInput2->index();
+      });
   assert(numRemovedInputs == 1);
   assert(lambdaNode->ninputs() == 2);
   assert(lambdaNode->ncvarguments() == 2);
@@ -160,7 +163,10 @@ TestRemoveLambdaInputsWhere()
 
   // Remove lambdaInput0
   numRemovedInputs = lambdaNode->RemoveLambdaInputsWhere(
-    [&](const lambda::cvinput& input){ return input.index() == lambdaInput0->index(); });
+      [&](const lambda::cvinput & input)
+      {
+        return input.index() == lambdaInput0->index();
+      });
   assert(numRemovedInputs == 1);
   assert(lambdaNode->ninputs() == 1);
   assert(lambdaNode->ncvarguments() == 1);
@@ -179,30 +185,27 @@ TestPruneLambdaInputs()
 
   // Arrange
   jlm::tests::valuetype valueType;
-  FunctionType functionType({}, {&valueType});
+  FunctionType functionType({}, { &valueType });
 
   auto rvsdgModule = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto & rvsdg = rvsdgModule->Rvsdg();
 
-  auto x = rvsdg.add_import({valueType, "x"});
+  auto x = rvsdg.add_import({ valueType, "x" });
 
-  auto lambdaNode = lambda::node::create(
-    rvsdg.root(),
-    functionType,
-    "f",
-    linkage::external_linkage);
+  auto lambdaNode =
+      lambda::node::create(rvsdg.root(), functionType, "f", linkage::external_linkage);
 
   lambdaNode->add_ctxvar(x)->input();
   auto lambdaInput1 = lambdaNode->add_ctxvar(x)->input();
   lambdaNode->add_ctxvar(x)->input();
 
   auto result = jlm::tests::SimpleNode::Create(
-    *lambdaNode->subregion(),
-    {lambdaInput1->argument()},
-    {&valueType})
-    .output(0);
+                    *lambdaNode->subregion(),
+                    { lambdaInput1->argument() },
+                    { &valueType })
+                    .output(0);
 
-  lambdaNode->finalize({result});
+  lambdaNode->finalize({ result });
 
   // Act
   auto numRemovedInputs = lambdaNode->PruneLambdaInputs();


### PR DESCRIPTION
This PR adds an API for lambda input removal. It contains the following:

1. Add RemoveLambdaInputsWhere and PruneLambdaInputs method to lambda node class
2. These implementation hide nasty implementation details, such as iteration order, from outside the class hierarchy
3. Removes the usage of RemoveInput and RemoveArgument from outside the structural node class hierarchy.

The implementation of RemoveLambdaInputsWhere will be simplified further down the road. The implementation details, such as iteration order, will be pushed further up the class hierarchy at a later point in time.
