### PR TITLE
Add phi input/output removal methods

### DIFF
--- a/jlm/llvm/ir/operators/Phi.hpp
+++ b/jlm/llvm/ir/operators/Phi.hpp
@@ -399,6 +399,10 @@ public:
    * @param match Defines the condition of the elements to remove.
    * @return The number of removed arguments.
    *
+   * \note The application of this method might leave the phi node in an invalid state. Some
+   * outputs might refer to arguments that have been removed by the application of this method. It
+   * is up to the caller to ensure that the invariants of the phi node will eventually be met again.
+   *
    * \see argument#IsDead()
    */
   template <typename F> size_t

--- a/jlm/llvm/ir/operators/Phi.hpp
+++ b/jlm/llvm/ir/operators/Phi.hpp
@@ -405,8 +405,9 @@ public:
    *
    * \see argument#IsDead()
    */
-  template <typename F> size_t
-  RemovePhiArgumentsWhere(const F& match);
+  template<typename F>
+  size_t
+  RemovePhiArgumentsWhere(const F & match);
 
   /**
    * Remove all dead phi arguments and their respective inputs.
@@ -868,13 +869,14 @@ rvoutput::set_rvorigin(jlm::rvsdg::output * origin)
   result()->divert_to(origin);
 }
 
-template <typename F> size_t
-phi::node::RemovePhiArgumentsWhere(const F &match)
+template<typename F>
+size_t
+phi::node::RemovePhiArgumentsWhere(const F & match)
 {
   size_t numRemovedArguments = 0;
 
   // iterate backwards to avoid the invalidation of 'n' by RemoveArgument()
-  for (size_t n = subregion()->narguments()-1; n != static_cast<size_t>(-1); n--)
+  for (size_t n = subregion()->narguments() - 1; n != static_cast<size_t>(-1); n--)
   {
     auto & argument = *subregion()->argument(n);
     auto input = argument.input();

--- a/jlm/llvm/ir/operators/Phi.hpp
+++ b/jlm/llvm/ir/operators/Phi.hpp
@@ -404,6 +404,24 @@ public:
   template <typename F> size_t
   RemovePhiArgumentsWhere(const F& match);
 
+  /**
+   * Remove all dead phi arguments and their respective inputs.
+   *
+   * @return The number of removed arguments.
+   *
+   * \see RemovePhiArgumentsWhere()
+   */
+  size_t
+  PrunePhiArguments()
+  {
+    auto match = [](const jlm::rvsdg::argument &)
+    {
+      return true;
+    };
+
+    return RemovePhiArgumentsWhere(match);
+  }
+
   cvinput *
   input(size_t n) const noexcept;
 

--- a/jlm/llvm/ir/operators/Phi.hpp
+++ b/jlm/llvm/ir/operators/Phi.hpp
@@ -435,11 +435,34 @@ public:
    * arguments might refer to outputs that have been removed by the application of this method. It
    * is up to the caller to ensure that the invariants of the phi node will eventually be met again.
    *
-   * \see rvoutput::IsDead()
+   * \see rvoutput#IsDead()
    */
   template<typename F>
   size_t
   RemovePhiOutputsWhere(const F & match);
+
+  /**
+   * Remove all dead phi outputs and their respective results.
+   *
+   * @return The number of removed outputs.
+   *
+   * \note The application of this method might leave the phi node in an invalid state. Some
+   * arguments might refer to outputs that have been removed by the application of this method. It
+   * is up to the caller to ensure that the invariants of the phi node will eventually be met again.
+   *
+   * \see RemovePhiOutputsWhere()
+   * \see rvoutput#IsDead()
+   */
+  size_t
+  PrunePhiOutputs()
+  {
+    auto match = [](const phi::rvoutput &)
+    {
+      return true;
+    };
+
+    return RemovePhiOutputsWhere(match);
+  }
 
   cvinput *
   input(size_t n) const noexcept;

--- a/jlm/llvm/ir/operators/Phi.hpp
+++ b/jlm/llvm/ir/operators/Phi.hpp
@@ -404,6 +404,9 @@ public:
    * is up to the caller to ensure that the invariants of the phi node will eventually be met again.
    *
    * \see argument#IsDead()
+   * \see PrunePhiArguments()
+   * \see RemovePhiOutputsWhere()
+   * \see PrunePhiOutputs()
    */
   template<typename F>
   size_t
@@ -413,6 +416,10 @@ public:
    * Remove all dead phi arguments and their respective inputs.
    *
    * @return The number of removed arguments.
+   *
+   * \note The application of this method might leave the phi node in an invalid state. Some
+   * outputs might refer to arguments that have been removed by the application of this method. It
+   * is up to the caller to ensure that the invariants of the phi node will eventually be met again.
    *
    * \see RemovePhiArgumentsWhere()
    */
@@ -441,6 +448,9 @@ public:
    * is up to the caller to ensure that the invariants of the phi node will eventually be met again.
    *
    * \see rvoutput#IsDead()
+   * \see PrunePhiOutputs()
+   * \see RemovePhiArgumentsWhere()
+   * \see PrunePhiArguments()
    */
   template<typename F>
   size_t

--- a/tests/jlm/llvm/ir/operators/TestPhi.cpp
+++ b/tests/jlm/llvm/ir/operators/TestPhi.cpp
@@ -90,7 +90,7 @@ TestRemovePhiArgumentsWhere()
   jlm::tests::valuetype valueType;
   RvsdgModule rvsdgModule(jlm::util::filepath(""), "", "");
 
-  auto x = rvsdgModule.Rvsdg().add_import({valueType, ""});
+  auto x = rvsdgModule.Rvsdg().add_import({ valueType, "" });
 
   phi::builder phiBuilder;
   phiBuilder.begin(rvsdgModule.Rvsdg().root());
@@ -102,10 +102,10 @@ TestRemovePhiArgumentsWhere()
   auto phiArgument4 = phiBuilder.add_ctxvar(x);
 
   auto result = jlm::tests::SimpleNode::Create(
-    *phiBuilder.subregion(),
-    {phiOutput0->argument(), phiOutput2->argument(), phiArgument4},
-    {&valueType})
-    .output(0);
+                    *phiBuilder.subregion(),
+                    { phiOutput0->argument(), phiOutput2->argument(), phiArgument4 },
+                    { &valueType })
+                    .output(0);
 
   phiOutput0->set_rvorigin(result);
   phiOutput1->set_rvorigin(result);
@@ -116,14 +116,20 @@ TestRemovePhiArgumentsWhere()
   // Act & Assert
   // Try to remove phiArgument0 even though it is used
   auto numRemovedArguments = phiNode.RemovePhiArgumentsWhere(
-    [&](const jlm::rvsdg::argument& argument){ return argument.index() == phiOutput0->argument()->index(); });
+      [&](const jlm::rvsdg::argument & argument)
+      {
+        return argument.index() == phiOutput0->argument()->index();
+      });
   assert(numRemovedArguments == 0);
   assert(phiNode.subregion()->narguments() == 5);
   assert(phiNode.ninputs() == 2);
 
   // Remove phiArgument1
   numRemovedArguments = phiNode.RemovePhiArgumentsWhere(
-    [&](const jlm::rvsdg::argument& argument){ return argument.index() == phiOutput1->argument()->index(); });
+      [&](const jlm::rvsdg::argument & argument)
+      {
+        return argument.index() == phiOutput1->argument()->index();
+      });
   assert(numRemovedArguments == 1);
   assert(phiNode.subregion()->narguments() == 4);
   assert(phiNode.ninputs() == 2);
@@ -134,13 +140,20 @@ TestRemovePhiArgumentsWhere()
 
   // Try to remove anything else, but the only dead argument, i.e, phiArgument3
   numRemovedArguments = phiNode.RemovePhiArgumentsWhere(
-    [&](const jlm::rvsdg::argument& argument){ return argument.index() != phiArgument3->index(); });
+      [&](const jlm::rvsdg::argument & argument)
+      {
+        return argument.index() != phiArgument3->index();
+      });
   assert(numRemovedArguments == 0);
   assert(phiNode.subregion()->narguments() == 4);
   assert(phiNode.ninputs() == 2);
 
   // Remove everything that is dead, i.e., phiArgument3
-  numRemovedArguments = phiNode.RemovePhiArgumentsWhere([&](const jlm::rvsdg::argument& argument){ return true; });
+  numRemovedArguments = phiNode.RemovePhiArgumentsWhere(
+      [&](const jlm::rvsdg::argument & argument)
+      {
+        return true;
+      });
   assert(numRemovedArguments == 1);
   assert(phiNode.subregion()->narguments() == 3);
   assert(phiNode.ninputs() == 1);
@@ -294,6 +307,4 @@ TestPhi()
   return 0;
 }
 
-JLM_UNIT_TEST_REGISTER(
-  "jlm/llvm/ir/operators/TestPhi",
-  TestPhi)
+JLM_UNIT_TEST_REGISTER("jlm/llvm/ir/operators/TestPhi", TestPhi)

--- a/tests/jlm/llvm/ir/operators/TestPhi.cpp
+++ b/tests/jlm/llvm/ir/operators/TestPhi.cpp
@@ -128,7 +128,7 @@ TestRemovePhiArgumentsWhere()
   numRemovedArguments = phiNode.RemovePhiArgumentsWhere(
       [&](const jlm::rvsdg::argument & argument)
       {
-        return argument.index() == phiOutput1->argument()->index();
+        return argument.index() == 1;
       });
   assert(numRemovedArguments == 1);
   assert(phiNode.subregion()->narguments() == 4);
@@ -242,7 +242,7 @@ TestRemovePhiOutputsWhere()
   auto numRemovedOutputs = phiNode.RemovePhiOutputsWhere(
       [&](const phi::rvoutput & output)
       {
-        return output.index() == phiOutput1->index();
+        return output.index() == 1;
       });
   assert(numRemovedOutputs == 1);
   assert(phiNode.noutputs() == 2);


### PR DESCRIPTION
This PR adds an API for phi input/output removal. It contains the following:

1. Add RemovePhiOutputsWhere and PrunePhiOutputs methods to phi node class
2. Add RemovePhiArgumentsWhere and PrunePhiArguments methods to phi node class
3. These implementations hide nasty implementation details, such as iteration order, from outside the class hierarchy
4. Removes the usage of RemoveInput, RemoveArgument, RemoveResult, and RemoveOutput from outside the structural node class hierarchy.

The implementations of RemovePhiOutputsWhere and RemovePhiArgumentsWhere will be simplified further down the road. The implementation details, such as iteration order, will be pushed further up the class hierarchy at a later point in time.