### PR TITLE
Add theta input/output removal methods

### DIFF
--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -483,15 +483,13 @@ DeadNodeElimination::SweepTheta(jlm::rvsdg::theta_node & thetaNode) const
     auto & argument = *output.argument();
     return !Context_->IsAlive(argument) && !Context_->IsAlive(output);
   };
-  thetaNode.RemoveThetaOutputsWhere(matchOutput);
+  auto deadInputs = thetaNode.RemoveThetaOutputsWhere(matchOutput);
 
   SweepRegion(thetaSubregion);
 
   auto matchInput = [&](const rvsdg::theta_input & input)
   {
-    auto & output = *input.output();
-    auto & argument = *input.argument();
-    return !Context_->IsAlive(argument) && !Context_->IsAlive(output);
+    return deadInputs.Contains(&input);
   };
   thetaNode.RemoveThetaInputsWhere(matchInput);
 

--- a/jlm/rvsdg/theta.hpp
+++ b/jlm/rvsdg/theta.hpp
@@ -161,13 +161,38 @@ public:
    *
    * \note The application of this method might leave the phi node in an invalid state. Some
    * arguments might refer to outputs that have been removed by the application of this method. It
-   * is up to the caller to ensure that the invariants of the phi node will eventually be met again.
+   * is up to the caller to ensure that the invariants of the theta node will eventually be met
+   * again.
    *
    * \see theta_output#IsDead()
    */
   template<typename F>
   size_t
   RemoveThetaOutputsWhere(const F & match);
+
+  /**
+   * Remove all dead theta outputs and their respective results.
+   *
+   * @return The number of removed outputs.
+   *
+   * \note The application of this method might leave the phi node in an invalid state. Some
+   * arguments might refer to outputs that have been removed by the application of this method. It
+   * is up to the caller to ensure that the invariants of the theta node will eventually be met
+   * again.
+   *
+   * \see RemoveThetaOutputsWhere()
+   * \see theta_output#IsDead()
+   */
+  size_t
+  PruneThetaOutputs()
+  {
+    auto match = [](const theta_output &)
+    {
+      return true;
+    };
+
+    return RemoveThetaOutputsWhere(match);
+  }
 
   theta_input *
   input(size_t index) const noexcept;

--- a/jlm/rvsdg/theta.hpp
+++ b/jlm/rvsdg/theta.hpp
@@ -161,7 +161,7 @@ public:
    * @return The inputs corresponding to the removed outputs.
    *
    * \note The application of this method might leave the theta node in an invalid state. Some
-   * arguments might refer to outputs that have been removed by the application of this method. It
+   * inputs might refer to outputs that have been removed by the application of this method. It
    * is up to the caller to ensure that the invariants of the theta node will eventually be met
    * again.
    *
@@ -178,7 +178,7 @@ public:
    * @return The inputs corresponding to the removed outputs.
    *
    * \note The application of this method might leave the theta node in an invalid state. Some
-   * arguments might refer to outputs that have been removed by the application of this method. It
+   * inputs might refer to outputs that have been removed by the application of this method. It
    * is up to the caller to ensure that the invariants of the theta node will eventually be met
    * again.
    *

--- a/jlm/rvsdg/theta.hpp
+++ b/jlm/rvsdg/theta.hpp
@@ -215,6 +215,30 @@ public:
   size_t
   RemoveThetaInputsWhere(const F & match);
 
+  /**
+   * Remove all dead theta inputs and their respective arguments.
+   *
+   * @return The number of removed inputs.
+   *
+   * \note The application of this method might leave the theta node in an invalid state. Some
+   * outputs might refer to inputs that have been removed by the application of this method. It
+   * is up to the caller to ensure that the invariants of the theta node will eventually be met
+   * again.
+   *
+   * \see RemoveThetaInputsWhere()
+   * \see argument#IsDead()
+   */
+  size_t
+  PruneThetaInputs()
+  {
+    auto match = [](const theta_input &)
+    {
+      return true;
+    };
+
+    return RemoveThetaInputsWhere(match);
+  }
+
   theta_input *
   input(size_t index) const noexcept;
 

--- a/jlm/util/HashSet.hpp
+++ b/jlm/util/HashSet.hpp
@@ -138,7 +138,7 @@ public:
    * @return True if the HashSet object contains \p item, otherwise false.
    */
   bool
-  Contains(ItemType item) const noexcept
+  Contains(const ItemType & item) const noexcept
   {
     return Set_.find(item) != Set_.end();
   }

--- a/tests/jlm/rvsdg/test-theta.cpp
+++ b/tests/jlm/rvsdg/test-theta.cpp
@@ -96,11 +96,45 @@ TestRemoveThetaOutputsWhere()
   assert(thetaOutput0->result()->index() == 1);
 }
 
+static void
+TestPruneThetaOutputs()
+{
+  using namespace jlm::rvsdg;
+
+  // Arrange
+  graph rvsdg;
+  jlm::tests::valuetype valueType;
+
+  auto ctl = rvsdg.add_import({ ctl2, "ctl" });
+  auto x = rvsdg.add_import({ valueType, "x" });
+  auto y = rvsdg.add_import({ valueType, "y" });
+
+  auto thetaNode = theta_node::create(rvsdg.root());
+
+  auto thetaOutput0 = thetaNode->add_loopvar(ctl);
+  thetaNode->add_loopvar(x);
+  thetaNode->add_loopvar(y);
+  thetaNode->set_predicate(thetaOutput0->argument());
+
+  rvsdg.add_export(thetaOutput0, { ctl2, "" });
+
+  // Act
+  auto numRemovedOutputs = thetaNode->PruneThetaOutputs();
+
+  // Assert
+  assert(numRemovedOutputs == 2);
+  assert(thetaNode->noutputs() == 1);
+  assert(thetaNode->subregion()->nresults() == 2);
+  assert(thetaOutput0->index() == 0);
+  assert(thetaOutput0->result()->index() == 1);
+}
+
 static int
 TestTheta()
 {
   TestThetaCreation();
   TestRemoveThetaOutputsWhere();
+  TestPruneThetaOutputs();
 
   return 0;
 }

--- a/tests/jlm/rvsdg/test-theta.cpp
+++ b/tests/jlm/rvsdg/test-theta.cpp
@@ -71,12 +71,13 @@ TestRemoveThetaOutputsWhere()
   rvsdg.add_export(thetaOutput0, { ctl2, "" });
 
   // Act & Assert
-  auto numRemovedOutputs = thetaNode->RemoveThetaOutputsWhere(
+  auto deadInputs = thetaNode->RemoveThetaOutputsWhere(
       [&](const theta_output & output)
       {
         return output.index() == thetaOutput1->index();
       });
-  assert(numRemovedOutputs == 1);
+  assert(deadInputs.Size() == 1);
+  assert(deadInputs.Contains(thetaNode->input(1)));
   assert(thetaNode->noutputs() == 2);
   assert(thetaNode->subregion()->nresults() == 3);
   assert(thetaOutput0->index() == 0);
@@ -84,12 +85,13 @@ TestRemoveThetaOutputsWhere()
   assert(thetaOutput2->index() == 1);
   assert(thetaOutput2->result()->index() == 2);
 
-  numRemovedOutputs = thetaNode->RemoveThetaOutputsWhere(
+  deadInputs = thetaNode->RemoveThetaOutputsWhere(
       [](const theta_output &)
       {
         return true;
       });
-  assert(numRemovedOutputs == 1);
+  assert(deadInputs.Size() == 1);
+  assert(deadInputs.Contains(thetaNode->input(2)));
   assert(thetaNode->noutputs() == 1);
   assert(thetaNode->subregion()->nresults() == 2);
   assert(thetaOutput0->index() == 0);
@@ -119,10 +121,12 @@ TestPruneThetaOutputs()
   rvsdg.add_export(thetaOutput0, { ctl2, "" });
 
   // Act
-  auto numRemovedOutputs = thetaNode->PruneThetaOutputs();
+  auto deadInputs = thetaNode->PruneThetaOutputs();
 
   // Assert
-  assert(numRemovedOutputs == 2);
+  assert(deadInputs.Size() == 2);
+  assert(deadInputs.Contains(thetaNode->input(1)));
+  assert(deadInputs.Contains(thetaNode->input(2)));
   assert(thetaNode->noutputs() == 1);
   assert(thetaNode->subregion()->nresults() == 2);
   assert(thetaOutput0->index() == 0);
@@ -158,12 +162,13 @@ TestRemoveThetaInputsWhere()
   rvsdg.add_export(thetaOutput0, { ctl2, "" });
 
   // Act & Assert
-  auto numRemovedInputs = thetaNode->RemoveThetaInputsWhere(
+  auto deadOutputs = thetaNode->RemoveThetaInputsWhere(
       [&](const theta_input & input)
       {
         return input.index() == thetaOutput1->input()->index();
       });
-  assert(numRemovedInputs == 1);
+  assert(deadOutputs.Size() == 1);
+  assert(deadOutputs.Contains(thetaNode->output(1)));
   assert(thetaNode->ninputs() == 2);
   assert(thetaNode->subregion()->narguments() == 2);
   assert(thetaOutput0->input()->index() == 0);
@@ -171,12 +176,13 @@ TestRemoveThetaInputsWhere()
   assert(thetaOutput2->input()->index() == 1);
   assert(thetaOutput2->argument()->index() == 1);
 
-  numRemovedInputs = thetaNode->RemoveThetaInputsWhere(
+  deadOutputs = thetaNode->RemoveThetaInputsWhere(
       [](const theta_input & input)
       {
         return true;
       });
-  assert(numRemovedInputs == 1);
+  assert(deadOutputs.Size() == 1);
+  assert(deadOutputs.Contains(thetaNode->output(2)));
   assert(thetaNode->ninputs() == 1);
   assert(thetaNode->subregion()->narguments() == 1);
   assert(thetaOutput0->input()->index() == 0);
@@ -212,10 +218,12 @@ TestPruneThetaInputs()
   rvsdg.add_export(thetaOutput0, { ctl2, "" });
 
   // Act
-  auto numRemovedInputs = thetaNode->PruneThetaInputs();
+  auto deadOutputs = thetaNode->PruneThetaInputs();
 
   // Assert
-  assert(numRemovedInputs == 2);
+  assert(deadOutputs.Size() == 2);
+  assert(deadOutputs.Contains(thetaNode->output(1)));
+  assert(deadOutputs.Contains(thetaNode->output(2)));
   assert(thetaNode->ninputs() == 1);
   assert(thetaNode->subregion()->narguments() == 1);
   assert(thetaOutput0->input()->index() == 0);

--- a/tests/jlm/rvsdg/test-theta.cpp
+++ b/tests/jlm/rvsdg/test-theta.cpp
@@ -183,6 +183,45 @@ TestRemoveThetaInputsWhere()
   assert(thetaOutput0->argument()->index() == 0);
 }
 
+static void
+TestPruneThetaInputs()
+{
+  using namespace jlm::rvsdg;
+
+  // Arrange
+  graph rvsdg;
+  jlm::tests::valuetype valueType;
+
+  auto ctl = rvsdg.add_import({ ctl2, "ctl" });
+  auto x = rvsdg.add_import({ valueType, "x" });
+  auto y = rvsdg.add_import({ valueType, "y" });
+
+  auto thetaNode = theta_node::create(rvsdg.root());
+
+  auto thetaOutput0 = thetaNode->add_loopvar(ctl);
+  auto thetaOutput1 = thetaNode->add_loopvar(x);
+  auto thetaOutput2 = thetaNode->add_loopvar(y);
+  thetaNode->set_predicate(thetaOutput0->argument());
+
+  auto result =
+      jlm::tests::SimpleNode::Create(*thetaNode->subregion(), {}, { &valueType }).output(0);
+
+  thetaOutput1->result()->divert_to(result);
+  thetaOutput2->result()->divert_to(result);
+
+  rvsdg.add_export(thetaOutput0, { ctl2, "" });
+
+  // Act
+  auto numRemovedInputs = thetaNode->PruneThetaInputs();
+
+  // Assert
+  assert(numRemovedInputs == 2);
+  assert(thetaNode->ninputs() == 1);
+  assert(thetaNode->subregion()->narguments() == 1);
+  assert(thetaOutput0->input()->index() == 0);
+  assert(thetaOutput0->argument()->index() == 0);
+}
+
 static int
 TestTheta()
 {
@@ -190,6 +229,7 @@ TestTheta()
   TestRemoveThetaOutputsWhere();
   TestPruneThetaOutputs();
   TestRemoveThetaInputsWhere();
+  TestPruneThetaInputs();
 
   return 0;
 }


### PR DESCRIPTION
This PR adds an API for theta input/output removal. It contains the following:

1. Add RemoveThetaInputsWhere and PruneThetaInputs methods to the theta node class
2. Add RemoveThetaOutputsWhere and PruneThetaOutputs methods to the theta node class
3. These implementation hide nasty implementation details, such as iteration order, from outside the class hierarchy.
4. Removes the usage of RemoveInput, RemoveArgument, RemoveResult, and RemoveOutput from outside the structural node class hierarchy.

The implementation of RemoveThetaInputsWhere and RemoveThetaOutputsWhere will be simplified further down the road. The implementation details, such as iteration order, will be pushed further up the class hierarchy at a later point in time.