### PR TITLE
Clean up HLS dead node elimination transformation

### DIFF
--- a/jlm/hls/Makefile.sub
+++ b/jlm/hls/Makefile.sub
@@ -40,6 +40,7 @@ libhls_HEADERS = \
 	jlm/hls/backend/rvsdg2rhls/add-sinks.hpp \
 
 libhls_TESTS += \
+	tests/jlm/hls/backend/rvsdg2rhls/DeadNodeEliminationTests \
 	tests/jlm/hls/backend/rvsdg2rhls/TestGamma \
 	tests/jlm/hls/backend/rvsdg2rhls/TestTheta \
 

--- a/jlm/hls/Makefile.sub
+++ b/jlm/hls/Makefile.sub
@@ -3,12 +3,12 @@
 
 libhls_SOURCES = \
     jlm/hls/backend/rvsdg2rhls/add-triggers.cpp \
+    jlm/hls/backend/rvsdg2rhls/DeadNodeElimination.cpp \
     jlm/hls/backend/rvsdg2rhls/GammaConversion.cpp \
     jlm/hls/backend/rvsdg2rhls/ThetaConversion.cpp \
     jlm/hls/backend/rvsdg2rhls/add-sinks.cpp \
     jlm/hls/backend/rvsdg2rhls/add-forks.cpp \
     jlm/hls/backend/rvsdg2rhls/check-rhls.cpp \
-    jlm/hls/backend/rvsdg2rhls/rhls-dne.cpp \
     jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp \
     jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp \
     jlm/hls/backend/rvsdg2rhls/add-prints.cpp \

--- a/jlm/hls/backend/rvsdg2rhls/DeadNodeElimination.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/DeadNodeElimination.cpp
@@ -101,7 +101,7 @@ dne(jlm::rvsdg::region * sr)
 }
 
 void
-dne(llvm::RvsdgModule & rvsdgModule)
+EliminateDeadNodes(llvm::RvsdgModule & rvsdgModule)
 {
   auto & graph = rvsdgModule.Rvsdg();
   auto root = graph.root();

--- a/jlm/hls/backend/rvsdg2rhls/DeadNodeElimination.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/DeadNodeElimination.cpp
@@ -3,7 +3,7 @@
  * See COPYING for terms of redistribution.
  */
 
-#include <jlm/hls/backend/rvsdg2rhls/rhls-dne.hpp>
+#include <jlm/hls/backend/rvsdg2rhls/DeadNodeElimination.hpp>
 #include <jlm/llvm/ir/operators/lambda.hpp>
 #include <jlm/rvsdg/traverser.hpp>
 

--- a/jlm/hls/backend/rvsdg2rhls/DeadNodeElimination.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/DeadNodeElimination.cpp
@@ -101,9 +101,9 @@ dne(jlm::rvsdg::region * sr)
 }
 
 void
-dne(llvm::RvsdgModule & rm)
+dne(llvm::RvsdgModule & rvsdgModule)
 {
-  auto & graph = rm.Rvsdg();
+  auto & graph = rvsdgModule.Rvsdg();
   auto root = graph.root();
   if (root->nodes.size() != 1)
   {

--- a/jlm/hls/backend/rvsdg2rhls/DeadNodeElimination.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/DeadNodeElimination.hpp
@@ -13,7 +13,7 @@ namespace jlm::hls
 {
 
 void
-dne(llvm::RvsdgModule & rm);
+dne(llvm::RvsdgModule & rvsdgModule);
 
 }
 

--- a/jlm/hls/backend/rvsdg2rhls/DeadNodeElimination.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/DeadNodeElimination.hpp
@@ -3,8 +3,8 @@
  * See COPYING for terms of redistribution.
  */
 
-#ifndef JLM_HLS_BACKEND_RVSDG2RHLS_RHLS_DNE_HPP
-#define JLM_HLS_BACKEND_RVSDG2RHLS_RHLS_DNE_HPP
+#ifndef JLM_HLS_BACKEND_RVSDG2RHLS_DEADNODEELIMINATION_HPP
+#define JLM_HLS_BACKEND_RVSDG2RHLS_DEADNODEELIMINATION_HPP
 
 #include <jlm/hls/ir/hls.hpp>
 #include <jlm/llvm/ir/RvsdgModule.hpp>
@@ -17,4 +17,4 @@ dne(llvm::RvsdgModule & rm);
 
 }
 
-#endif // JLM_HLS_BACKEND_RVSDG2RHLS_RHLS_DNE_HPP
+#endif // JLM_HLS_BACKEND_RVSDG2RHLS_DEADNODEELIMINATION_HPP

--- a/jlm/hls/backend/rvsdg2rhls/DeadNodeElimination.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/DeadNodeElimination.hpp
@@ -13,7 +13,7 @@ namespace jlm::hls
 {
 
 void
-dne(llvm::RvsdgModule & rvsdgModule);
+EliminateDeadNodes(llvm::RvsdgModule & rvsdgModule);
 
 }
 

--- a/jlm/hls/backend/rvsdg2rhls/DeadNodeElimination.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/DeadNodeElimination.hpp
@@ -12,6 +12,17 @@
 namespace jlm::hls
 {
 
+/**
+ * Removes dead loop nodes and their outputs and inputs.
+ *
+ * @param rvsdgModule The RVSDG module the transformation is performed on.
+ *
+ * FIXME: This code should be incorporated into llvm::DeadNodeElimination. However, before this
+ * can happen, llvm::DeadNodeElimination needs to be moved into the rvsdg namespace and made
+ * extensible such that transformation users can register clean up functions for structural nodes.
+ *
+ * \see hls::loop_node
+ */
 void
 EliminateDeadNodes(llvm::RvsdgModule & rvsdgModule);
 

--- a/jlm/hls/backend/rvsdg2rhls/rhls-dne.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rhls-dne.cpp
@@ -10,7 +10,7 @@
 namespace jlm::hls
 {
 
-bool
+static bool
 remove_unused_loop_outputs(hls::loop_node * ln)
 {
   bool any_changed = false;
@@ -31,7 +31,7 @@ remove_unused_loop_outputs(hls::loop_node * ln)
   return any_changed;
 }
 
-bool
+static bool
 remove_unused_loop_inputs(hls::loop_node * ln)
 {
   bool any_changed = false;
@@ -72,7 +72,7 @@ remove_unused_loop_inputs(hls::loop_node * ln)
   return any_changed;
 }
 
-bool
+static bool
 dne(jlm::rvsdg::region * sr)
 {
   bool any_changed = false;

--- a/jlm/hls/backend/rvsdg2rhls/rhls-dne.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/rhls-dne.hpp
@@ -12,15 +12,6 @@
 namespace jlm::hls
 {
 
-bool
-remove_unused_loop_outputs(hls::loop_node * ln);
-
-bool
-remove_unused_loop_inputs(hls::loop_node * ln);
-
-bool
-dne(jlm::rvsdg::region * sr);
-
 void
 dne(llvm::RvsdgModule & rm);
 

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -8,9 +8,9 @@
 #include <jlm/hls/backend/rvsdg2rhls/add-sinks.hpp>
 #include <jlm/hls/backend/rvsdg2rhls/add-triggers.hpp>
 #include <jlm/hls/backend/rvsdg2rhls/check-rhls.hpp>
+#include <jlm/hls/backend/rvsdg2rhls/DeadNodeElimination.hpp>
 #include <jlm/hls/backend/rvsdg2rhls/GammaConversion.hpp>
 #include <jlm/hls/backend/rvsdg2rhls/remove-unused-state.hpp>
-#include <jlm/hls/backend/rvsdg2rhls/rhls-dne.hpp>
 #include <jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.hpp>
 #include <jlm/hls/backend/rvsdg2rhls/ThetaConversion.hpp>
 #include <jlm/llvm/backend/jlm2llvm/jlm2llvm.hpp>

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -349,7 +349,7 @@ rvsdg2rhls(llvm::RvsdgModule & rhls)
   ConvertGammaNodes(rhls);
   ConvertThetaNodes(rhls);
   // rhls optimization
-  dne(rhls);
+  EliminateDeadNodes(rhls);
   // enforce 1:1 input output relationship
   add_sinks(rhls);
   add_forks(rhls);

--- a/tests/jlm/hls/backend/rvsdg2rhls/DeadNodeEliminationTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/DeadNodeEliminationTests.cpp
@@ -6,7 +6,7 @@
 #include <test-registry.hpp>
 #include <test-types.hpp>
 
-#include <jlm/hls/backend/rvsdg2rhls/rhls-dne.hpp>
+#include <jlm/hls/backend/rvsdg2rhls/DeadNodeElimination.hpp>
 #include <jlm/llvm/ir/operators/lambda.hpp>
 
 static void

--- a/tests/jlm/hls/backend/rvsdg2rhls/DeadNodeEliminationTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/DeadNodeEliminationTests.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2023 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <test-registry.hpp>
+#include <test-types.hpp>
+
+#include <jlm/hls/backend/rvsdg2rhls/rhls-dne.hpp>
+#include <jlm/llvm/ir/operators/lambda.hpp>
+
+static void
+TestDeadLoopNode()
+{
+  using namespace jlm::hls;
+
+  // Arrange
+  jlm::tests::valuetype valueType;
+  jlm::llvm::FunctionType functionType({ &jlm::rvsdg::ctl2, &valueType }, { &valueType });
+
+  jlm::llvm::RvsdgModule rvsdgModule(jlm::util::filepath(""), "", "");
+  auto & rvsdg = rvsdgModule.Rvsdg();
+
+  auto lambdaNode = jlm::llvm::lambda::node::create(
+      rvsdg.root(),
+      functionType,
+      "f",
+      jlm::llvm::linkage::external_linkage);
+
+  loop_node::create(lambdaNode->subregion());
+
+  lambdaNode->finalize({ lambdaNode->fctargument(1) });
+
+  // Act
+  dne(rvsdgModule);
+
+  // Assert
+  assert(lambdaNode->subregion()->nnodes() == 0);
+}
+
+static void
+TestDeadLoopNodeOutput()
+{
+  using namespace jlm::hls;
+
+  // Arrange
+  jlm::tests::valuetype valueType;
+  jlm::llvm::FunctionType functionType({ &jlm::rvsdg::ctl2, &valueType }, { &jlm::rvsdg::ctl2 });
+
+  jlm::llvm::RvsdgModule rvsdgModule(jlm::util::filepath(""), "", "");
+  auto & rvsdg = rvsdgModule.Rvsdg();
+
+  auto lambdaNode = jlm::llvm::lambda::node::create(
+      rvsdg.root(),
+      functionType,
+      "f",
+      jlm::llvm::linkage::external_linkage);
+
+  auto p = lambdaNode->fctargument(0);
+  auto x = lambdaNode->fctargument(1);
+
+  auto loopNode = loop_node::create(lambdaNode->subregion());
+
+  jlm::rvsdg::output * buffer;
+  auto output0 = loopNode->add_loopvar(p, &buffer);
+  loopNode->add_loopvar(x);
+  loopNode->set_predicate(buffer);
+
+  auto lambdaOutput = lambdaNode->finalize({ output0 });
+
+  rvsdg.add_export(lambdaOutput, { jlm::llvm::PointerType(), "f" });
+
+  // Act
+  dne(rvsdgModule);
+
+  // Assert
+  assert(loopNode->noutputs() == 1);
+  assert(loopNode->ninputs() == 2); // I believe that it actually should only have one input.
+  // FIXME: The DNE seems to already be broken for a simple dead edge through it. It removes the
+  // output from the loop node, but then seems to fail to remove the corresponding input, arguments,
+  // and results.
+}
+
+static int
+TestDeadNodeElimination()
+{
+  TestDeadLoopNode();
+  TestDeadLoopNodeOutput();
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER(
+    "jlm/hls/backend/rvsdg2rhls/DeadNodeEliminationTests",
+    TestDeadNodeElimination)

--- a/tests/jlm/hls/backend/rvsdg2rhls/DeadNodeEliminationTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/DeadNodeEliminationTests.cpp
@@ -32,7 +32,7 @@ TestDeadLoopNode()
   lambdaNode->finalize({ lambdaNode->fctargument(1) });
 
   // Act
-  dne(rvsdgModule);
+  EliminateDeadNodes(rvsdgModule);
 
   // Assert
   assert(lambdaNode->subregion()->nnodes() == 0);
@@ -71,7 +71,7 @@ TestDeadLoopNodeOutput()
   rvsdg.add_export(lambdaOutput, { jlm::llvm::PointerType(), "f" });
 
   // Act
-  dne(rvsdgModule);
+  EliminateDeadNodes(rvsdgModule);
 
   // Assert
   assert(loopNode->noutputs() == 1);


### PR DESCRIPTION
This PR cleans up the HLS dead node elimination transformation. It does the following:

1. Introduces unit tests such that I am not completely blind while cleaning up.
2. Clean up the code such that I can easily refactor the RemoveInput, RemoveOutput, ... methods.
3. Document the shortcomings of the transformation in the unit tests.

Ultimately, this transformation should be incorporated into the DeadNodeElimination transformation.