### PR TITLE
Add overloads for rvsdg::view and PointsToGraph::ToDot to allow giving the same unique names to outputs in both

### DIFF
--- a/jlm/llvm/opt/alias-analyses/PointsToGraph.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraph.cpp
@@ -216,7 +216,7 @@ PointsToGraph::ToDot(
         "\"]; }\n");
   };
 
-  auto edgeString = [&](const PointsToGraph::Node & node, const PointsToGraph::Node & target)
+  auto edgeString = [](const PointsToGraph::Node & node, const PointsToGraph::Node & target)
   {
     return util::strfmt(
         reinterpret_cast<uintptr_t>(&node),

--- a/jlm/llvm/opt/alias-analyses/PointsToGraph.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraph.cpp
@@ -159,8 +159,19 @@ PointsToGraph::AddImportNode(std::unique_ptr<PointsToGraph::ImportNode> node)
 }
 
 std::string
-PointsToGraph::ToDot(const PointsToGraph & pointsToGraph)
+PointsToGraph::ToDot(
+    const PointsToGraph & pointsToGraph,
+    const std::unordered_map<const rvsdg::output *, std::string> & outputMap)
 {
+  auto nodeFill = [&](const PointsToGraph::Node & node)
+  {
+    // Nodes that are marked as having escaped the module get a background color
+    if (const auto memoryNode = dynamic_cast<const MemoryNode *>(&node))
+      if (pointsToGraph.GetEscapedMemoryNodes().Contains(memoryNode))
+        return "style=filled, fillcolor=\"yellow\", ";
+    return "";
+  };
+
   auto nodeShape = [](const PointsToGraph::Node & node)
   {
     static std::unordered_map<std::type_index, std::string> shapes(
@@ -179,23 +190,39 @@ PointsToGraph::ToDot(const PointsToGraph & pointsToGraph)
     JLM_UNREACHABLE("Unknown points-to graph Node type.");
   };
 
+  auto nodeLabel = [&](const PointsToGraph::Node & node)
+  {
+    // If the node is a RegisterNode, and has a name mapped to its rvsdg::output, include that name
+    if (const auto registerNode = dynamic_cast<const RegisterNode *>(&node))
+      if (const auto it = outputMap.find(&registerNode->GetOutput()); it != outputMap.end())
+        return util::strfmt(node.DebugString(), " (", it->second, ")");
+
+    // Otherwise the label is just the DebugString.
+    return node.DebugString();
+  };
+
   auto nodeString = [&](const PointsToGraph::Node & node)
   {
     return util::strfmt(
         "{ ",
-        (intptr_t)&node,
+        reinterpret_cast<uintptr_t>(&node),
         " [",
+        nodeFill(node),
         "label = \"",
-        node.DebugString(),
+        nodeLabel(node),
         "\" ",
         "shape = \"",
         nodeShape(node),
         "\"]; }\n");
   };
 
-  auto edgeString = [](const PointsToGraph::Node & node, const PointsToGraph::Node & target)
+  auto edgeString = [&](const PointsToGraph::Node & node, const PointsToGraph::Node & target)
   {
-    return util::strfmt((intptr_t)&node, " -> ", (intptr_t)&target, "\n");
+    return util::strfmt(
+        reinterpret_cast<uintptr_t>(&node),
+        " -> ",
+        reinterpret_cast<uintptr_t>(&target),
+        "\n");
   };
 
   auto printNodeAndEdges = [&](const PointsToGraph::Node & node)
@@ -229,6 +256,7 @@ PointsToGraph::ToDot(const PointsToGraph & pointsToGraph)
 
   dot += nodeString(pointsToGraph.GetUnknownMemoryNode());
   dot += nodeString(pointsToGraph.GetExternalMemoryNode());
+  dot += "label=\"Yellow = Escaping memory node\"\n";
   dot += "}\n";
 
   return dot;

--- a/jlm/llvm/opt/alias-analyses/PointsToGraph.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraph.hpp
@@ -295,8 +295,30 @@ public:
   PointsToGraph::ImportNode &
   AddImportNode(std::unique_ptr<PointsToGraph::ImportNode> node);
 
+  /**
+   * Creates a GraphViz description of the given \p pointsToGraph,
+   * including the names given to rvsdg::outputs by the \p outputMap,
+   * for all RegisterNodes that correspond to names rvsdg::outputs.
+   * @param pointsToGraph the graph to be drawn as a dot-file.
+   * @param outputMap the mapping from rvsdg::output* to a unique name.
+   * @return the text content of the resulting dot-file.
+   */
   static std::string
-  ToDot(const PointsToGraph & pointsToGraph);
+  ToDot(
+      const PointsToGraph & pointsToGraph,
+      const std::unordered_map<const rvsdg::output *, std::string> & outputMap);
+
+  /**
+   * @brief Creates a GraphViz description of the given \p pointsToGraph.
+   * @param pointsToGraph the graph to be drawn as a dot-file.
+   * @return the text content of the resulting dot-file.
+   */
+  static std::string
+  ToDot(const PointsToGraph & pointsToGraph)
+  {
+    const std::unordered_map<const rvsdg::output *, std::string> outputMap;
+    return ToDot(pointsToGraph, outputMap);
+  }
 
   static std::unique_ptr<PointsToGraph>
   Create()

--- a/jlm/rvsdg/view.cpp
+++ b/jlm/rvsdg/view.cpp
@@ -15,27 +15,29 @@ static std::string
 region_to_string(
     const jlm::rvsdg::region * region,
     size_t depth,
-    std::unordered_map<output *, std::string> &);
+    std::unordered_map<const output *, std::string> &);
 
-static inline std::string
+static std::string
 indent(size_t depth)
 {
   return std::string(depth * 2, ' ');
 }
 
-static inline std::string
-create_port_name(const jlm::rvsdg::output * port, std::unordered_map<output *, std::string> & map)
+static std::string
+create_port_name(
+    const jlm::rvsdg::output * port,
+    std::unordered_map<const output *, std::string> & map)
 {
   std::string name = dynamic_cast<const jlm::rvsdg::argument *>(port) ? "a" : "o";
   name += jlm::util::strfmt(map.size());
   return name;
 }
 
-static inline std::string
+static std::string
 node_to_string(
     const jlm::rvsdg::node * node,
     size_t depth,
-    std::unordered_map<output *, std::string> & map)
+    std::unordered_map<const output *, std::string> & map)
 {
   std::string s(indent(depth));
   for (size_t n = 0; n < node->noutputs(); n++)
@@ -64,8 +66,10 @@ node_to_string(
   return s;
 }
 
-static inline std::string
-region_header(const jlm::rvsdg::region * region, std::unordered_map<output *, std::string> & map)
+static std::string
+region_header(
+    const jlm::rvsdg::region * region,
+    std::unordered_map<const output *, std::string> & map)
 {
   std::string header("[");
   for (size_t n = 0; n < region->narguments(); n++)
@@ -86,11 +90,11 @@ region_header(const jlm::rvsdg::region * region, std::unordered_map<output *, st
   return header;
 }
 
-static inline std::string
+static std::string
 region_body(
     const jlm::rvsdg::region * region,
     size_t depth,
-    std::unordered_map<output *, std::string> & map)
+    std::unordered_map<const output *, std::string> & map)
 {
   std::vector<std::vector<const jlm::rvsdg::node *>> context;
   for (const auto & node : region->nodes)
@@ -110,8 +114,10 @@ region_body(
   return body;
 }
 
-static inline std::string
-region_footer(const jlm::rvsdg::region * region, std::unordered_map<output *, std::string> & map)
+static std::string
+region_footer(
+    const jlm::rvsdg::region * region,
+    std::unordered_map<const output *, std::string> & map)
 {
   std::string footer("}[");
   for (size_t n = 0; n < region->nresults(); n++)
@@ -131,11 +137,11 @@ region_footer(const jlm::rvsdg::region * region, std::unordered_map<output *, st
   return footer;
 }
 
-static inline std::string
+static std::string
 region_to_string(
     const jlm::rvsdg::region * region,
     size_t depth,
-    std::unordered_map<output *, std::string> & map)
+    std::unordered_map<const output *, std::string> & map)
 {
   std::string s;
   s = indent(depth) + region_header(region, map) + "\n";
@@ -147,7 +153,13 @@ region_to_string(
 std::string
 view(const jlm::rvsdg::region * region)
 {
-  std::unordered_map<output *, std::string> map;
+  std::unordered_map<const output *, std::string> map;
+  return view(region, map);
+}
+
+std::string
+view(const jlm::rvsdg::region * region, std::unordered_map<const output *, std::string> & map)
+{
   return region_to_string(region, 0, map);
 }
 

--- a/jlm/rvsdg/view.hpp
+++ b/jlm/rvsdg/view.hpp
@@ -16,17 +16,45 @@ namespace jlm::rvsdg
 
 class region;
 
+/**
+ * Prints the given rvsdg region to a string,
+ * through recursive traversal of nodes and subregions.
+ * All outputs are given unique names to show dataflow in the graph.
+ * @param region the region to be printed
+ * @return the string describing the region.
+ * @see view(region, map)
+ */
+std::string
+view(const jlm::rvsdg::region * region);
+
+/**
+ * Prints the given rvsdg region to a string, and exposes the unique name given to each output.
+ * @param region the region to be printed
+ * @param map the map where each rvsdg::output is mapped to its unique name.
+ * Outputs without names will have a name added.
+ * @return the string describing the region.
+ */
+std::string
+view(const jlm::rvsdg::region * region, std::unordered_map<const output *, std::string> & map);
+
+/**
+ * Recursively traverses and prints the given rvsdg region to the given file.
+ * @param region the region to be printed.
+ * @param out the file to be written to.
+ */
 void
 view(const jlm::rvsdg::region * region, FILE * out);
 
-static inline void
+/**
+ * Recursively traverses and prints the root region of the given rvsdg graph to the given file.
+ * @param graph the rvsdg graph to be printed.
+ * @param out the file to be written to.
+ */
+inline void
 view(const jlm::rvsdg::graph & graph, FILE * out)
 {
   return view(graph.root(), out);
 }
-
-std::string
-view(const jlm::rvsdg::region * region);
 
 std::string
 region_tree(const jlm::rvsdg::region * region);


### PR DESCRIPTION
In practice this means the `PointsToGraph`'s dot output now adds an extra part to `RegisterNode`s, as seen here:
![image](https://github.com/phate/jlm/assets/3748845/0335945b-9f11-47f4-b655-91ba0442a18b)

The names in parentheses correspond to the names given by rvsdg::view in the following output:
```
[]{
  o0 := DELTA[MyList] 
    []{
      o1 := ConstantPointerNull 
    }[o1]
  o2 := LAMBDA[next] o0 
    [a3, a4, a5, a6 <= o0]{
      o7 := BITS32(0) 
      o8 := BITS32(4) 
      o9 o10 := ALLOCA[ptr] o8 
      o11 := MemStateMerge o10 a4 
      o12 o13 := LOAD a6 o11 
      o14 := STORE o9 o12 o13 
      o15 o16 := LOAD o9 o14 
      o17 := GetElementPtr o15 o7 o7 
      o18 o19 := LOAD o17 o16 
      o20 := STORE o9 o18 o19 
      o21 o22 := LOAD o9 o20 
    }[o21, a3, o22, a5]
}[o0, o2]
```

The example is generated by adding the following lines to the top of `TestAndersen.cpp`'s `TestLinkedList()`:
```cpp
  std::unordered_map<const jlm::rvsdg::output*, std::string> outputMap;
  std::cout << jlm::rvsdg::view(test.graph().root(), outputMap) << std::endl;
  std::cout << jlm::llvm::aa::PointsToGraph::ToDot(*ptg, outputMap) << std::endl;
```

The functionality is added through overloads that allow specifying the `unordered _map<const output*, std::string>` used to give outputs unique names. The `ToDot` method has been modified to be able to take in such a map, and use it while making output. It is not the cleanest approach ever, but it was very helpful during debugging.