### PR TITLE
make: Added clang format targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ help:
 	@$(HELP_TEXT)
 	@$(HELP_TEXT_JLM)
 	@echo ""
+	@echo "JLM Aliases"
+	@echo "--------------------------------------------------------------------------------"
 	@echo "all                    Compile jlm in release mode, and run unit and C tests"
 	@echo "release                Alias for jlm-release"
 	@echo "debug                  Alias for jlm-debug and check"

--- a/Makefile.sub
+++ b/Makefile.sub
@@ -11,6 +11,11 @@ echo "jlc-release            Compile jlc compiler in release mode"
 echo ""
 echo "jlm-opt-debug          Compile jlm optimizer in debug mode"
 echo "jlm-opt-release        Compile jlm optimizer in release mode"
+echo ""
+echo "Clang format Targets"
+echo "--------------------------------------------------------------------------------"
+echo "format                 Format all cpp and hpp files"
+echo "format-dry-run         Report incorrect formatting of cpp and hpp files"
 endef
 
 # Try to detect llvm-config 
@@ -57,6 +62,14 @@ include $(JLM_ROOT)/jlm/util/Makefile.sub
 include $(JLM_ROOT)/tools/Makefile.sub
 include $(JLM_ROOT)/docs/Makefile.sub
 include $(JLM_ROOT)/tests/Makefile.sub
+
+.PHONY: format
+format:
+	@find $(JLM_ROOT) -name "*.[ch]pp" -exec clang-format-16 --Werror --style="file:.clang-format" --verbose -i {} \;
+
+.PHONY: format-dry-run
+format-dry-run:
+	@find $(JLM_ROOT) -name "*.[ch]pp" -exec clang-format-16 --dry-run --Werror --style="file:.clang-format" --verbose -i {} \;
 
 .PHONY: jlm-debug
 jlm-debug: libutil-debug libhls-debug jlm-opt-debug jlm-hls-debug jlc-debug jhls-debug


### PR DESCRIPTION
One target for applying clang formatting and one for dry run that only reports formatting errors.