### PR TITLE
Improve call node accessors

### DIFF
--- a/jlm/llvm/ir/operators/call.hpp
+++ b/jlm/llvm/ir/operators/call.hpp
@@ -287,7 +287,8 @@ public:
   [[nodiscard]] jlm::rvsdg::input *
   Argument(size_t n) const
   {
-    return input(n);
+    JLM_ASSERT(n < NumArguments());
+    return input(n + 1);
   }
 
   [[nodiscard]] size_t

--- a/jlm/llvm/ir/operators/call.hpp
+++ b/jlm/llvm/ir/operators/call.hpp
@@ -278,12 +278,21 @@ public:
     return *jlm::util::AssertedCast<const CallOperation>(&operation());
   }
 
+  /**
+   * @return The number of arguments to the call.
+   *
+   * \note This is equivalent to ninputs() - 1 as NumArguments() ignores the function input.
+   */
   [[nodiscard]] size_t
   NumArguments() const noexcept
   {
     return ninputs() - 1;
   }
 
+  /**
+   * @param n The index of the function argument.
+   * @return The input for the given index \p n.
+   */
   [[nodiscard]] jlm::rvsdg::input *
   Argument(size_t n) const
   {
@@ -291,18 +300,29 @@ public:
     return input(n + 1);
   }
 
+  /**
+   * @return The number of results from the call.
+   */
   [[nodiscard]] size_t
   NumResults() const noexcept
   {
     return noutputs();
   }
 
+  /**
+   * @param n The index of the function result.
+   * @return The output for the given index \p n.
+   */
   [[nodiscard]] jlm::rvsdg::output *
   Result(size_t n) const noexcept
   {
+    JLM_ASSERT(n < NumResults());
     return output(n);
   }
 
+  /**
+   * @return The call node's function input.
+   */
   [[nodiscard]] jlm::rvsdg::input *
   GetFunctionInput() const noexcept
   {
@@ -311,6 +331,9 @@ public:
     return functionInput;
   }
 
+  /**
+   * @return The call node's input/output state input.
+   */
   [[nodiscard]] jlm::rvsdg::input *
   GetIoStateInput() const noexcept
   {
@@ -319,6 +342,9 @@ public:
     return iOState;
   }
 
+  /**
+   * @return The call node's memory state input.
+   */
   [[nodiscard]] jlm::rvsdg::input *
   GetMemoryStateInput() const noexcept
   {
@@ -327,6 +353,9 @@ public:
     return memoryState;
   }
 
+  /**
+   * @return The call node's loop state input.
+   */
   [[nodiscard]] jlm::rvsdg::input *
   GetLoopStateInput() const noexcept
   {
@@ -335,6 +364,9 @@ public:
     return loopState;
   }
 
+  /**
+   * @return The call node's input/output state output.
+   */
   [[nodiscard]] jlm::rvsdg::output *
   GetIoStateOutput() const noexcept
   {
@@ -343,6 +375,9 @@ public:
     return iOState;
   }
 
+  /**
+   * @return The call node's memory state output.
+   */
   [[nodiscard]] jlm::rvsdg::output *
   GetMemoryStateOutput() const noexcept
   {
@@ -351,6 +386,9 @@ public:
     return memoryState;
   }
 
+  /**
+   * @return The call node's loop state output.
+   */
   [[nodiscard]] jlm::rvsdg::output *
   GetLoopStateOutput() const noexcept
   {


### PR DESCRIPTION
This PR closes #295. It makes the following changes:
1. Fixes a bug in the CallNode::Argument() method
2. Adds documentation to all call node accessors.
3. Adds a unit test for the accessors

