### PR TITLE
Ensure creation of unique intermediate files throughout compilation

### DIFF
--- a/jlm/tooling/CommandGraphGenerator.cpp
+++ b/jlm/tooling/CommandGraphGenerator.cpp
@@ -203,7 +203,7 @@ JhlsCommandGraphGenerator::CreateParserCommandOutputFile(
     const util::filepath & tmpDirectory,
     const util::filepath & inputFile)
 {
-  return util::filepath::CreateUniqueFile(tmpDirectory, inputFile.base(), "-clang.ll");
+  return util::filepath::CreateUniqueFile(tmpDirectory, inputFile.base() + "-", "-clang.ll");
 }
 
 util::filepath
@@ -211,7 +211,7 @@ JhlsCommandGraphGenerator::CreateJlmOptCommandOutputFile(
     const util::filepath & tmpDirectory,
     const util::filepath & inputFile)
 {
-  return util::filepath::CreateUniqueFile(tmpDirectory, inputFile.base(), "-jlm-opt.ll");
+  return util::filepath::CreateUniqueFile(tmpDirectory, inputFile.base() + "-", "-jlm-opt.ll");
 }
 
 ClangCommand::LanguageStandard

--- a/jlm/tooling/CommandGraphGenerator.cpp
+++ b/jlm/tooling/CommandGraphGenerator.cpp
@@ -203,7 +203,7 @@ JhlsCommandGraphGenerator::CreateParserCommandOutputFile(
     const util::filepath & tmpDirectory,
     const util::filepath & inputFile)
 {
-  return { tmpDirectory.to_str() + "tmp-" + inputFile.base() + "-clang-out.ll" };
+  return util::filepath::CreateUniqueFile(tmpDirectory, inputFile.base(), "-clang.ll");
 }
 
 util::filepath
@@ -211,7 +211,7 @@ JhlsCommandGraphGenerator::CreateJlmOptCommandOutputFile(
     const util::filepath & tmpDirectory,
     const util::filepath & inputFile)
 {
-  return { tmpDirectory.to_str() + "tmp-" + inputFile.base() + "-jlm-opt-out.ll" };
+  return util::filepath::CreateUniqueFile(tmpDirectory, inputFile.base(), "-jlm-opt.ll");
 }
 
 ClangCommand::LanguageStandard
@@ -370,8 +370,7 @@ JhlsCommandGraphGenerator::GenerateCommandGraph(const JhlsCommandLineOptions & c
     auto inputFile = dynamic_cast<JlmHlsCommand *>(&hls.GetCommand())->LlvmFile();
     auto & asmnode = LlcCommand::Create(
         *commandGraph,
-        commandLineOptions.Hls_
-            ? inputFile
+        commandLineOptions.Hls_ ? inputFile
                                 : CreateJlmOptCommandOutputFile(tmp_folder, inputFile).to_str(),
         assemblyFile,
         ConvertOptimizationLevel(commandLineOptions.OptimizationLevel_),

--- a/jlm/tooling/CommandGraphGenerator.cpp
+++ b/jlm/tooling/CommandGraphGenerator.cpp
@@ -199,15 +199,19 @@ JlcCommandGraphGenerator::GenerateCommandGraph(const JlcCommandLineOptions & com
 JhlsCommandGraphGenerator::~JhlsCommandGraphGenerator() noexcept = default;
 
 util::filepath
-JhlsCommandGraphGenerator::CreateParserCommandOutputFile(const util::filepath & inputFile)
+JhlsCommandGraphGenerator::CreateParserCommandOutputFile(
+    const util::filepath & tmpDirectory,
+    const util::filepath & inputFile)
 {
-  return { "tmp-" + inputFile.base() + "-clang-out.ll" };
+  return { tmpDirectory.to_str() + "tmp-" + inputFile.base() + "-clang-out.ll" };
 }
 
 util::filepath
-JhlsCommandGraphGenerator::CreateJlmOptCommandOutputFile(const util::filepath & inputFile)
+JhlsCommandGraphGenerator::CreateJlmOptCommandOutputFile(
+    const util::filepath & tmpDirectory,
+    const util::filepath & inputFile)
 {
-  return { "tmp-" + inputFile.base() + "-jlm-opt-out.ll" };
+  return { tmpDirectory.to_str() + "tmp-" + inputFile.base() + "-jlm-opt-out.ll" };
 }
 
 ClangCommand::LanguageStandard
@@ -287,7 +291,7 @@ JhlsCommandGraphGenerator::GenerateCommandGraph(const JhlsCommandLineOptions & c
       auto & parserNode = ClangCommand::CreateParsingCommand(
           *commandGraph,
           compilation.InputFile(),
-          tmp_folder.to_str() + CreateParserCommandOutputFile(compilation.InputFile()).to_str(),
+          CreateParserCommandOutputFile(tmp_folder, compilation.InputFile()).to_str(),
           compilation.DependencyFile(),
           commandLineOptions.IncludePaths_,
           commandLineOptions.MacroDefinitions_,
@@ -368,7 +372,7 @@ JhlsCommandGraphGenerator::GenerateCommandGraph(const JhlsCommandLineOptions & c
         *commandGraph,
         commandLineOptions.Hls_
             ? inputFile
-            : tmp_folder.to_str() + CreateJlmOptCommandOutputFile(inputFile).to_str(),
+                                : CreateJlmOptCommandOutputFile(tmp_folder, inputFile).to_str(),
         assemblyFile,
         ConvertOptimizationLevel(commandLineOptions.OptimizationLevel_),
         commandLineOptions.Hls_ ? LlcCommand::RelocationModel::Pic

--- a/jlm/tooling/CommandGraphGenerator.cpp
+++ b/jlm/tooling/CommandGraphGenerator.cpp
@@ -73,13 +73,14 @@ JlcCommandGraphGenerator::ConvertOptimizationLevel(
 CommandGraph::Node &
 JlcCommandGraphGenerator::CreateParserCommand(
     CommandGraph & commandGraph,
+    const util::filepath & outputFile,
     const JlcCommandLineOptions::Compilation & compilation,
     const JlcCommandLineOptions & commandLineOptions)
 {
   return ClangCommand::CreateParsingCommand(
       commandGraph,
       compilation.InputFile(),
-      CreateParserCommandOutputFile(compilation.InputFile()),
+      outputFile,
       compilation.DependencyFile(),
       commandLineOptions.IncludePaths_,
       commandLineOptions.MacroDefinitions_,
@@ -107,8 +108,9 @@ JlcCommandGraphGenerator::GenerateCommandGraph(const JlcCommandLineOptions & com
 
     if (compilation.RequiresParsing())
     {
+      auto outputFile = CreateParserCommandOutputFile(compilation.InputFile());
       auto & parserCommandNode =
-          CreateParserCommand(*commandGraph, compilation, commandLineOptions);
+          CreateParserCommand(*commandGraph, outputFile, compilation, commandLineOptions);
 
       lastNode->AddEdge(parserCommandNode);
       lastNode = &parserCommandNode;

--- a/jlm/tooling/CommandGraphGenerator.cpp
+++ b/jlm/tooling/CommandGraphGenerator.cpp
@@ -278,7 +278,7 @@ JhlsCommandGraphGenerator::GenerateCommandGraph(const JhlsCommandLineOptions & c
   }
   srandom((unsigned)time(nullptr) * getpid());
   tmp_identifier += std::to_string(random());
-  util::filepath tmp_folder("/tmp/" + tmp_identifier + "/");
+  util::filepath tmp_folder(std::filesystem::temp_directory_path().string() + tmp_identifier + "/");
   auto & mkdir = MkdirCommand::Create(*commandGraph, tmp_folder);
   commandGraph->GetEntryNode().AddEdge(mkdir);
 

--- a/jlm/tooling/CommandGraphGenerator.cpp
+++ b/jlm/tooling/CommandGraphGenerator.cpp
@@ -20,13 +20,19 @@ JlcCommandGraphGenerator::~JlcCommandGraphGenerator() noexcept = default;
 util::filepath
 JlcCommandGraphGenerator::CreateJlmOptCommandOutputFile(const util::filepath & inputFile)
 {
-  return util::strfmt("/tmp/tmp-", inputFile.base(), "-jlm-opt-out.ll");
+  return util::filepath::CreateUniqueFile(
+      std::filesystem::temp_directory_path().string(),
+      inputFile.base() + "-",
+      "-jlm-opt.ll");
 }
 
 util::filepath
 JlcCommandGraphGenerator::CreateParserCommandOutputFile(const util::filepath & inputFile)
 {
-  return util::strfmt("/tmp/tmp-", inputFile.base(), "-clang-out.ll");
+  return util::filepath::CreateUniqueFile(
+      std::filesystem::temp_directory_path().string(),
+      inputFile.base() + "-",
+      "-clang.ll");
 }
 
 ClangCommand::LanguageStandard

--- a/jlm/tooling/CommandGraphGenerator.cpp
+++ b/jlm/tooling/CommandGraphGenerator.cpp
@@ -278,7 +278,8 @@ JhlsCommandGraphGenerator::GenerateCommandGraph(const JhlsCommandLineOptions & c
   }
   srandom((unsigned)time(nullptr) * getpid());
   tmp_identifier += std::to_string(random());
-  util::filepath tmp_folder(std::filesystem::temp_directory_path().string() + tmp_identifier + "/");
+  util::filepath tmp_folder(
+      std::filesystem::temp_directory_path().string() + "/" + tmp_identifier + "/");
   auto & mkdir = MkdirCommand::Create(*commandGraph, tmp_folder);
   commandGraph->GetEntryNode().AddEdge(mkdir);
 

--- a/jlm/tooling/CommandGraphGenerator.hpp
+++ b/jlm/tooling/CommandGraphGenerator.hpp
@@ -75,6 +75,7 @@ private:
   static CommandGraph::Node &
   CreateParserCommand(
       CommandGraph & commandGraph,
+      const util::filepath & outputFile,
       const JlcCommandLineOptions::Compilation & compilation,
       const JlcCommandLineOptions & commandLineOptions);
 };

--- a/jlm/tooling/CommandGraphGenerator.hpp
+++ b/jlm/tooling/CommandGraphGenerator.hpp
@@ -102,10 +102,14 @@ public:
 
 private:
   static util::filepath
-  CreateParserCommandOutputFile(const util::filepath & inputFile);
+  CreateParserCommandOutputFile(
+      const util::filepath & tmpDirectory,
+      const util::filepath & inputFile);
 
   static util::filepath
-  CreateJlmOptCommandOutputFile(const util::filepath & inputFile);
+  CreateJlmOptCommandOutputFile(
+      const util::filepath & tmpDirectory,
+      const util::filepath & inputFile);
 
   static ClangCommand::LanguageStandard
   ConvertLanguageStandard(const JhlsCommandLineOptions::LanguageStandard & languageStandard);


### PR DESCRIPTION
We currently create intermediate files while compiling, but might run into problems when we compile in parallel as the intermediate file names are derived from the input file names. The intermediate file names were created by adding a suffix to the input file name. If we compile two input files with the same name in parallel, we create the same intermediate file names even though those two intermediate files originate from different input file names. This PR resolves this issue by adding some randomness into the intermediate file name. It solves this problems for the jlc and jhls command pipeline. Closes #312.