### PR TITLE
Remove deprecated command line options

### DIFF
--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -119,25 +119,17 @@ JlmOptCommandLineOptions::FromCommandLineArgumentToOptimizationId(
           OptimizationId::AASteensgaardRegionAware },
         { OptimizationCommandLineArgument::CommonNodeElimination_,
           OptimizationId::CommonNodeElimination },
-        { OptimizationCommandLineArgument::CommonNodeEliminationDeprecated_, OptimizationId::cne },
         { OptimizationCommandLineArgument::DeadNodeElimination_,
           OptimizationId::DeadNodeElimination },
-        { OptimizationCommandLineArgument::DeadNodeEliminationDeprecated_, OptimizationId::dne },
         { OptimizationCommandLineArgument::FunctionInlining_, OptimizationId::FunctionInlining },
-        { OptimizationCommandLineArgument::FunctionInliningDeprecated_, OptimizationId::iln },
         { OptimizationCommandLineArgument::InvariantValueRedirection_,
           OptimizationId::InvariantValueRedirection },
         { OptimizationCommandLineArgument::NodePushOut_, OptimizationId::NodePushOut },
-        { OptimizationCommandLineArgument::NodePushOutDeprecated_, OptimizationId::psh },
         { OptimizationCommandLineArgument::NodePullIn_, OptimizationId::NodePullIn },
-        { OptimizationCommandLineArgument::NodePullInDeprecated_, OptimizationId::pll },
         { OptimizationCommandLineArgument::NodeReduction_, OptimizationId::NodeReduction },
-        { OptimizationCommandLineArgument::NodeReductionDeprecated_, OptimizationId::red },
         { OptimizationCommandLineArgument::ThetaGammaInversion_,
           OptimizationId::ThetaGammaInversion },
-        { OptimizationCommandLineArgument::ThetaGammaInversionDeprecated_, OptimizationId::ivt },
-        { OptimizationCommandLineArgument::LoopUnrolling_, OptimizationId::LoopUnrolling },
-        { OptimizationCommandLineArgument::LoopUnrollingDeprecated_, OptimizationId::url } });
+        { OptimizationCommandLineArgument::LoopUnrolling_, OptimizationId::LoopUnrolling } });
 
   if (map.find(commandLineArgument) != map.end())
     return map[commandLineArgument];
@@ -153,25 +145,17 @@ JlmOptCommandLineOptions::ToCommandLineArgument(OptimizationId optimizationId)
           OptimizationCommandLineArgument::AaSteensgaardAgnostic_ },
         { OptimizationId::AASteensgaardRegionAware,
           OptimizationCommandLineArgument::AaSteensgaardRegionAware_ },
-        { OptimizationId::cne, OptimizationCommandLineArgument::CommonNodeEliminationDeprecated_ },
         { OptimizationId::CommonNodeElimination,
           OptimizationCommandLineArgument::CommonNodeElimination_ },
         { OptimizationId::DeadNodeElimination,
           OptimizationCommandLineArgument::DeadNodeElimination_ },
-        { OptimizationId::dne, OptimizationCommandLineArgument::DeadNodeEliminationDeprecated_ },
         { OptimizationId::FunctionInlining, OptimizationCommandLineArgument::FunctionInlining_ },
-        { OptimizationId::iln, OptimizationCommandLineArgument::FunctionInliningDeprecated_ },
         { OptimizationId::InvariantValueRedirection,
           OptimizationCommandLineArgument::InvariantValueRedirection_ },
         { OptimizationId::LoopUnrolling, OptimizationCommandLineArgument::LoopUnrolling_ },
         { OptimizationId::NodePullIn, OptimizationCommandLineArgument::NodePullIn_ },
         { OptimizationId::NodePushOut, OptimizationCommandLineArgument::NodePushOut_ },
         { OptimizationId::NodeReduction, OptimizationCommandLineArgument::NodeReduction_ },
-        { OptimizationId::psh, OptimizationCommandLineArgument::NodePushOutDeprecated_ },
-        { OptimizationId::pll, OptimizationCommandLineArgument::NodePullInDeprecated_ },
-        { OptimizationId::red, OptimizationCommandLineArgument::NodeReductionDeprecated_ },
-        { OptimizationId::ivt, OptimizationCommandLineArgument::ThetaGammaInversionDeprecated_ },
-        { OptimizationId::url, OptimizationCommandLineArgument::LoopUnrollingDeprecated_ },
         { OptimizationId::ThetaGammaInversion,
           OptimizationCommandLineArgument::ThetaGammaInversion_ } });
 
@@ -300,22 +284,14 @@ JlmOptCommandLineOptions::GetOptimization(enum OptimizationId id)
   static std::unordered_map<OptimizationId, llvm::optimization *> map(
       { { OptimizationId::AASteensgaardAgnostic, &steensgaardAgnostic },
         { OptimizationId::AASteensgaardRegionAware, &steensgaardRegionAware },
-        { OptimizationId::cne, &commonNodeElimination },
         { OptimizationId::CommonNodeElimination, &commonNodeElimination },
         { OptimizationId::DeadNodeElimination, &deadNodeElimination },
-        { OptimizationId::dne, &deadNodeElimination },
         { OptimizationId::FunctionInlining, &functionInlining },
-        { OptimizationId::iln, &functionInlining },
         { OptimizationId::InvariantValueRedirection, &invariantValueRedirection },
         { OptimizationId::LoopUnrolling, &loopUnrolling },
         { OptimizationId::NodePullIn, &nodePullIn },
         { OptimizationId::NodePushOut, &nodePushOut },
         { OptimizationId::NodeReduction, &nodeReduction },
-        { OptimizationId::pll, &nodePullIn },
-        { OptimizationId::psh, &nodePushOut },
-        { OptimizationId::ivt, &thetaGammaInversion },
-        { OptimizationId::url, &loopUnrolling },
-        { OptimizationId::red, &nodeReduction },
         { OptimizationId::ThetaGammaInversion, &thetaGammaInversion } });
 
   if (map.find(id) != map.end())
@@ -891,23 +867,15 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, char ** argv)
   auto aASteensgaardRegionAware =
       JlmOptCommandLineOptions::OptimizationId::AASteensgaardRegionAware;
   auto commonNodeElimination = JlmOptCommandLineOptions::OptimizationId::CommonNodeElimination;
-  auto commonNodeEliminationDeprecated = JlmOptCommandLineOptions::OptimizationId::cne;
   auto deadNodeElimination = JlmOptCommandLineOptions::OptimizationId::DeadNodeElimination;
-  auto deadNodeEliminationDeprecated = JlmOptCommandLineOptions::OptimizationId::dne;
   auto functionInlining = JlmOptCommandLineOptions::OptimizationId::FunctionInlining;
-  auto functionInliningDeprecated = JlmOptCommandLineOptions::OptimizationId::iln;
   auto invariantValueRedirection =
       JlmOptCommandLineOptions::OptimizationId::InvariantValueRedirection;
   auto nodePushOut = JlmOptCommandLineOptions::OptimizationId::NodePushOut;
-  auto nodePushOutDeprecated = JlmOptCommandLineOptions::OptimizationId::psh;
   auto nodePullIn = JlmOptCommandLineOptions::OptimizationId::NodePullIn;
-  auto nodePullInDeprecated = JlmOptCommandLineOptions::OptimizationId::pll;
   auto nodeReduction = JlmOptCommandLineOptions::OptimizationId::NodeReduction;
-  auto nodeReductionDeprecated = JlmOptCommandLineOptions::OptimizationId::red;
   auto thetaGammaInversion = JlmOptCommandLineOptions::OptimizationId::ThetaGammaInversion;
-  auto thetaGammaInversionDeprecated = JlmOptCommandLineOptions::OptimizationId::ivt;
   auto loopUnrolling = JlmOptCommandLineOptions::OptimizationId::LoopUnrolling;
-  auto loopUnrollingDeprecated = JlmOptCommandLineOptions::OptimizationId::url;
 
   cl::list<JlmOptCommandLineOptions::OptimizationId> optimizationIds(
       cl::values(
@@ -924,25 +892,13 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, char ** argv)
               JlmOptCommandLineOptions::ToCommandLineArgument(commonNodeElimination),
               "Common Node Elimination"),
           ::clEnumValN(
-              commonNodeEliminationDeprecated,
-              JlmOptCommandLineOptions::ToCommandLineArgument(commonNodeEliminationDeprecated),
-              "[Deprecated] Use --CommonNodeElimination flag instead"),
-          ::clEnumValN(
               deadNodeElimination,
               JlmOptCommandLineOptions::ToCommandLineArgument(deadNodeElimination),
               "Dead Node Elimination"),
           ::clEnumValN(
-              deadNodeEliminationDeprecated,
-              JlmOptCommandLineOptions::ToCommandLineArgument(deadNodeEliminationDeprecated),
-              "[Deprecated] Use --DeadNodeElimination flag instead"),
-          ::clEnumValN(
               functionInlining,
               JlmOptCommandLineOptions::ToCommandLineArgument(functionInlining),
               "Function Inlining"),
-          ::clEnumValN(
-              functionInliningDeprecated,
-              JlmOptCommandLineOptions::ToCommandLineArgument(functionInliningDeprecated),
-              "[Deprecated] Use --FunctionInlining flag instead"),
           ::clEnumValN(
               invariantValueRedirection,
               JlmOptCommandLineOptions::ToCommandLineArgument(invariantValueRedirection),
@@ -952,41 +908,21 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, char ** argv)
               JlmOptCommandLineOptions::ToCommandLineArgument(nodePushOut),
               "Node Push Out"),
           ::clEnumValN(
-              nodePushOutDeprecated,
-              JlmOptCommandLineOptions::ToCommandLineArgument(nodePushOutDeprecated),
-              "[Deprecated] Use --NodePushOut flag instead"),
-          ::clEnumValN(
               nodePullIn,
               JlmOptCommandLineOptions::ToCommandLineArgument(nodePullIn),
               "Node Pull In"),
-          ::clEnumValN(
-              nodePullInDeprecated,
-              JlmOptCommandLineOptions::ToCommandLineArgument(nodePullInDeprecated),
-              "[Deprecated] Use --NodePullIn flag instead"),
           ::clEnumValN(
               nodeReduction,
               JlmOptCommandLineOptions::ToCommandLineArgument(nodeReduction),
               "Node Reduction"),
           ::clEnumValN(
-              nodeReductionDeprecated,
-              JlmOptCommandLineOptions::ToCommandLineArgument(nodeReductionDeprecated),
-              "[Deprecated] Use --NodeReduction flag instead"),
-          ::clEnumValN(
               thetaGammaInversion,
               JlmOptCommandLineOptions::ToCommandLineArgument(thetaGammaInversion),
               "Theta-Gamma Inversion"),
           ::clEnumValN(
-              thetaGammaInversionDeprecated,
-              JlmOptCommandLineOptions::ToCommandLineArgument(thetaGammaInversionDeprecated),
-              "[Deprecated] Use --ThetaGammaInversion flag instead"),
-          ::clEnumValN(
               loopUnrolling,
               JlmOptCommandLineOptions::ToCommandLineArgument(loopUnrolling),
-              "Loop Unrolling"),
-          ::clEnumValN(
-              loopUnrollingDeprecated,
-              JlmOptCommandLineOptions::ToCommandLineArgument(loopUnrollingDeprecated),
-              "[Deprecated] Use --LoopUnrolling flag instead")),
+              "Loop Unrolling")),
       cl::desc("Perform optimization"));
 
   cl::ParseCommandLineOptions(argc, argv);

--- a/jlm/tooling/CommandLine.hpp
+++ b/jlm/tooling/CommandLine.hpp
@@ -52,62 +52,14 @@ public:
 
     AASteensgaardAgnostic,
     AASteensgaardRegionAware,
-
-    /**
-     * \deprecated This flag is going to be removed in the future. Use \ref
-     * OptimizationId::CommonNodeElimination instead.
-     */
-    cne,
     CommonNodeElimination,
     DeadNodeElimination,
-
-    /**
-     * \deprecated This flag is going to be removed in the future. Use \ref
-     * OptimizationId::DeadNodeElimination instead.
-     */
-    dne,
     FunctionInlining,
-
-    /**
-     * \deprecated This flag is going to be removed in the future. Use \ref
-     * OptimizationId::FunctionInlining instead.
-     */
-    iln,
     InvariantValueRedirection,
     LoopUnrolling,
     NodePullIn,
     NodePushOut,
     NodeReduction,
-
-    /**
-     * \deprecated This flag is going to be removed in the future. Use \ref
-     * OptimizationId::NodePushOut instead.
-     */
-    psh,
-
-    /**
-     * \deprecated This flag is going to be removed in the future. Use \ref
-     * OptimizationId::NodeReduction instead.
-     */
-    red,
-
-    /**
-     * \deprecated This flag is going to be removed in the future. Use \ref
-     * OptimizationId::ThetaGammaInversion instead.
-     */
-    ivt,
-
-    /**
-     * \deprecated This flag is going to be removed in the future. Use \ref
-     * OptimizationId::LoopUnrolling instead.
-     */
-    url,
-
-    /**
-     * \deprecated This flag is going to be removed in the future. Use \ref
-     * OptimizationId::NodePullIn instead.
-     */
-    pll,
     ThetaGammaInversion,
 
     LastEnumValue // must always be the last enum value, used for iteration
@@ -208,22 +160,14 @@ private:
     inline static const char * AaSteensgaardAgnostic_ = "AASteensgaardAgnostic";
     inline static const char * AaSteensgaardRegionAware_ = "AASteensgaardRegionAware";
     inline static const char * CommonNodeElimination_ = "CommonNodeElimination";
-    inline static const char * CommonNodeEliminationDeprecated_ = "cne";
     inline static const char * DeadNodeElimination_ = "DeadNodeElimination";
-    inline static const char * DeadNodeEliminationDeprecated_ = "dne";
     inline static const char * FunctionInlining_ = "FunctionInlining";
-    inline static const char * FunctionInliningDeprecated_ = "iln";
     inline static const char * InvariantValueRedirection_ = "InvariantValueRedirection";
     inline static const char * NodePullIn_ = "NodePullIn";
-    inline static const char * NodePullInDeprecated_ = "pll";
     inline static const char * NodePushOut_ = "NodePushOut";
-    inline static const char * NodePushOutDeprecated_ = "psh";
     inline static const char * ThetaGammaInversion_ = "ThetaGammaInversion";
-    inline static const char * ThetaGammaInversionDeprecated_ = "ivt";
     inline static const char * LoopUnrolling_ = "LoopUnrolling";
-    inline static const char * LoopUnrollingDeprecated_ = "url";
     inline static const char * NodeReduction_ = "NodeReduction";
-    inline static const char * NodeReductionDeprecated_ = "red";
   };
 
   struct StatisticsCommandLineArgument


### PR DESCRIPTION
jlc and jlm-opt no longer support short hand optimization names such as red, cne, dne, etc.