### PR TITLE
Add lambda result case to ComputeCallSummary() method

### DIFF
--- a/jlm/llvm/ir/operators/lambda.cpp
+++ b/jlm/llvm/ir/operators/lambda.cpp
@@ -259,6 +259,12 @@ node::ComputeCallSummary() const
       continue;
     }
 
+    if (auto lambdaResult = dynamic_cast<lambda::result *>(input))
+    {
+      otherUsers.emplace_back(lambdaResult);
+      continue;
+    }
+
     if (auto gamma_input = dynamic_cast<rvsdg::gamma_input *>(input))
     {
       for (auto & argument : *gamma_input)


### PR DESCRIPTION
Add missing case of where a function is returned as a result of another function to the `ComputeCallSummary()` method. Closes #318.