### PR TITLE
Handle mismatch of call/lambda arguments in Steensgaard

### DIFF
--- a/jlm/llvm/ir/operators/operators.hpp
+++ b/jlm/llvm/ir/operators/operators.hpp
@@ -1382,6 +1382,18 @@ public:
     return tac::create(op, arguments);
   }
 
+  static rvsdg::output *
+  Create(rvsdg::region & region, const std::vector<rvsdg::output *> & operands)
+  {
+    std::vector<std::unique_ptr<rvsdg::type>> operandTypes;
+    operandTypes.reserve(operands.size());
+    for (auto & operand : operands)
+      operandTypes.emplace_back(operand->type().copy());
+
+    valist_op operation(std::move(operandTypes));
+    return jlm::rvsdg::simple_node::create_normalized(&region, operation, operands)[0];
+  }
+
 private:
   static inline std::vector<jlm::rvsdg::port>
   create_srcports(std::vector<std::unique_ptr<jlm::rvsdg::type>> types)

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -1122,100 +1122,6 @@ Steensgaard::AnalyzeStore(const StoreNode & storeNode)
 void
 Steensgaard::AnalyzeCall(const CallNode & callNode)
 {
-  auto AnalyzeDirectCall = [&](const CallNode & callNode, const lambda::node & lambda)
-  {
-    /*
-      FIXME: What about varargs
-    */
-
-    /* handle call node arguments */
-    JLM_ASSERT(lambda.nfctarguments() == callNode.ninputs() - 1);
-    for (size_t n = 1; n < callNode.ninputs(); n++)
-    {
-      auto & callArgument = *callNode.input(n)->origin();
-      auto & lambdaArgument = *lambda.fctargument(n - 1);
-
-      if (!is<PointerType>(callArgument.type()))
-        continue;
-
-      auto & callArgumentLocation = LocationSet_->Find(callArgument);
-      auto & lambdaArgumentLocation =
-          LocationSet_->FindOrInsertRegisterLocation(lambdaArgument, PointsToFlags::PointsToNone);
-
-      LocationSet_->Join(callArgumentLocation, lambdaArgumentLocation);
-    }
-
-    /* handle call node results */
-    auto subregion = lambda.subregion();
-    JLM_ASSERT(subregion->nresults() == callNode.noutputs());
-    for (size_t n = 0; n < callNode.noutputs(); n++)
-    {
-      auto & callResult = *callNode.output(n);
-      auto & lambdaResult = *subregion->result(n)->origin();
-
-      if (!is<PointerType>(callResult.type()))
-        continue;
-
-      auto & callResultLocation =
-          LocationSet_->FindOrInsertRegisterLocation(callResult, PointsToFlags::PointsToNone);
-      auto & lambdaResultLocation =
-          LocationSet_->FindOrInsertRegisterLocation(lambdaResult, PointsToFlags::PointsToNone);
-
-      LocationSet_->Join(callResultLocation, lambdaResultLocation);
-    }
-  };
-
-  auto AnalyzeExternalCall = [&](const CallNode & callNode)
-  {
-    /*
-      FIXME: What about varargs
-    */
-    for (size_t n = 1; n < callNode.NumArguments(); n++)
-    {
-      auto & callArgument = *callNode.input(n)->origin();
-
-      if (is<PointerType>(callArgument.type()))
-      {
-        auto registerLocation = LocationSet_->LookupRegisterLocation(callArgument);
-        registerLocation->SetIsEscapingModule(true);
-      }
-    }
-
-    for (size_t n = 0; n < callNode.NumResults(); n++)
-    {
-      auto & callResult = *callNode.Result(n);
-
-      if (is<PointerType>(callResult.type()))
-      {
-        LocationSet_->FindOrInsertRegisterLocation(
-            callResult,
-            PointsToFlags::PointsToExternalMemory | PointsToFlags::PointsToEscapedMemory);
-      }
-    }
-  };
-
-  auto AnalyzeIndirectCall = [&](const CallNode & call)
-  {
-    /*
-      Nothing can be done for the call/lambda arguments, as it is
-      an indirect call and the lambda node cannot be retrieved.
-    */
-
-    /* handle call node results */
-    for (size_t n = 0; n < call.noutputs(); n++)
-    {
-      auto & callResult = *call.output(n);
-
-      if (is<PointerType>(callResult.type()))
-      {
-        LocationSet_->FindOrInsertRegisterLocation(
-            callResult,
-            PointsToFlags::PointsToUnknownMemory | PointsToFlags::PointsToExternalMemory
-                | PointsToFlags::PointsToEscapedMemory);
-      }
-    }
-  };
-
   auto callTypeClassifier = CallNode::ClassifyCall(callNode);
   switch (callTypeClassifier->GetCallType())
   {
@@ -1231,6 +1137,97 @@ Steensgaard::AnalyzeCall(const CallNode & callNode)
     break;
   default:
     JLM_UNREACHABLE("Unhandled call type.");
+  }
+}
+
+void
+Steensgaard::AnalyzeDirectCall(const CallNode & callNode, const lambda::node & lambdaNode)
+{
+  // FIXME: What about varargs
+
+  // Handle call node operands
+  JLM_ASSERT(lambdaNode.nfctarguments() == callNode.ninputs() - 1);
+  for (size_t n = 1; n < callNode.ninputs(); n++)
+  {
+    auto & callArgument = *callNode.input(n)->origin();
+    auto & lambdaArgument = *lambdaNode.fctargument(n - 1);
+
+    if (!is<PointerType>(callArgument.type()))
+      continue;
+
+    auto & callArgumentLocation = LocationSet_->Find(callArgument);
+    auto & lambdaArgumentLocation =
+        LocationSet_->FindOrInsertRegisterLocation(lambdaArgument, PointsToFlags::PointsToNone);
+
+    LocationSet_->Join(callArgumentLocation, lambdaArgumentLocation);
+  }
+
+  // Handle call node results
+  auto subregion = lambdaNode.subregion();
+  JLM_ASSERT(subregion->nresults() == callNode.noutputs());
+  for (size_t n = 0; n < callNode.noutputs(); n++)
+  {
+    auto & callResult = *callNode.output(n);
+    auto & lambdaResult = *subregion->result(n)->origin();
+
+    if (!is<PointerType>(callResult.type()))
+      continue;
+
+    auto & callResultLocation =
+        LocationSet_->FindOrInsertRegisterLocation(callResult, PointsToFlags::PointsToNone);
+    auto & lambdaResultLocation =
+        LocationSet_->FindOrInsertRegisterLocation(lambdaResult, PointsToFlags::PointsToNone);
+
+    LocationSet_->Join(callResultLocation, lambdaResultLocation);
+  }
+}
+
+void
+Steensgaard::AnalyzeExternalCall(const CallNode & callNode)
+{
+  // FIXME: What about varargs
+  for (size_t n = 1; n < callNode.NumArguments(); n++)
+  {
+    auto & callArgument = *callNode.input(n)->origin();
+
+    if (is<PointerType>(callArgument.type()))
+    {
+      auto registerLocation = LocationSet_->LookupRegisterLocation(callArgument);
+      registerLocation->SetIsEscapingModule(true);
+    }
+  }
+
+  for (size_t n = 0; n < callNode.NumResults(); n++)
+  {
+    auto & callResult = *callNode.Result(n);
+
+    if (is<PointerType>(callResult.type()))
+    {
+      LocationSet_->FindOrInsertRegisterLocation(
+          callResult,
+          PointsToFlags::PointsToExternalMemory | PointsToFlags::PointsToEscapedMemory);
+    }
+  }
+}
+
+void
+Steensgaard::AnalyzeIndirectCall(const CallNode & callNode)
+{
+  // Nothing can be done for the call/lambda arguments, as it is
+  // an indirect call and the lambda node cannot be retrieved.
+
+  // Handle call node results
+  for (size_t n = 0; n < callNode.noutputs(); n++)
+  {
+    auto & callResult = *callNode.output(n);
+
+    if (is<PointerType>(callResult.type()))
+    {
+      LocationSet_->FindOrInsertRegisterLocation(
+          callResult,
+          PointsToFlags::PointsToUnknownMemory | PointsToFlags::PointsToExternalMemory
+              | PointsToFlags::PointsToEscapedMemory);
+    }
   }
 }
 

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -1143,10 +1143,21 @@ Steensgaard::AnalyzeCall(const CallNode & callNode)
 void
 Steensgaard::AnalyzeDirectCall(const CallNode & callNode, const lambda::node & lambdaNode)
 {
-  // FIXME: What about varargs
+  auto & lambdaFunctionType = lambdaNode.operation().type();
+  auto & callFunctionType = callNode.GetOperation().GetFunctionType();
+  if (callFunctionType != lambdaFunctionType)
+  {
+    // LLVM permits code where it can happen that the number and type of the arguments handed in to
+    // the call node do not agree with the number and type of lambda parameters, even though it is a
+    // direct call. See jlm::tests::LambdaCallArgumentMismatch for an example. We handle this case
+    // the same as an indirect call, as it is impossible to join the call argument/result locations
+    // with the corresponding lambda argument/result locations.
+    AnalyzeIndirectCall(callNode);
+    return;
+  }
 
+  // FIXME: What about varargs
   // Handle call node operands
-  JLM_ASSERT(lambdaNode.nfctarguments() == callNode.ninputs() - 1);
   for (size_t n = 1; n < callNode.ninputs(); n++)
   {
     auto & callArgument = *callNode.input(n)->origin();

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
@@ -97,6 +97,15 @@ private:
   AnalyzeCall(const CallNode & callNode);
 
   void
+  AnalyzeDirectCall(const CallNode & callNode, const lambda::node & lambdaNode);
+
+  void
+  AnalyzeExternalCall(const CallNode & callNode);
+
+  void
+  AnalyzeIndirectCall(const CallNode & callNode);
+
+  void
   AnalyzeGep(const jlm::rvsdg::simple_node & node);
 
   void

--- a/tests/TestRvsdgs.hpp
+++ b/tests/TestRvsdgs.hpp
@@ -2088,4 +2088,56 @@ private:
   jlm::llvm::lambda::node * ExportedFunc_ = {};
 };
 
+/** \brief RVSDG module containing a static function that is called with the wrong number of
+ * arguments.
+ *
+ * LLVM permits such code, albeit with issuing the warning: too many arguments in call to 'g'
+ *
+ * The class sets up an RVSDG module corresponding to the following code:
+ *
+ * \code{.c}
+ *   static unsigned int
+ *   g()
+ *   {
+ *     return 5;
+ *   }
+ *
+ *   int
+ *   main()
+ *   {
+ *     unsigned int x = 6;
+ *     return g(x);
+ *   }
+ * \endcode
+ */
+class LambdaCallArgumentMismatch final : public RvsdgTest
+{
+public:
+  [[nodiscard]] const llvm::lambda::node &
+  GetLambdaMain() const noexcept
+  {
+    return *LambdaMain_;
+  }
+
+  [[nodiscard]] const llvm::lambda::node &
+  GetLambdaG() const noexcept
+  {
+    return *LambdaG_;
+  }
+
+  [[nodiscard]] const llvm::CallNode &
+  GetCall() const noexcept
+  {
+    return *Call_;
+  }
+
+private:
+  std::unique_ptr<llvm::RvsdgModule>
+  SetupRvsdg() override;
+
+  llvm::lambda::node * LambdaG_ = {};
+  llvm::lambda::node * LambdaMain_ = {};
+  llvm::CallNode * Call_ = {};
+};
+
 }

--- a/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
@@ -1113,6 +1113,19 @@ TestLinkedList()
 }
 
 static void
+TestLambdaCallArgumentMismatch()
+{
+  // Arrange and Act
+  jlm::tests::LambdaCallArgumentMismatch test;
+  auto pointsToGraph = RunSteensgaard(test.module());
+
+  // Assert
+  assert(pointsToGraph->NumAllocaNodes() == 1);
+  assert(pointsToGraph->NumLambdaNodes() == 2);
+  assert(pointsToGraph->NumRegisterNodes() == 4);
+}
+
+static void
 TestStatistics()
 {
   // Arrange
@@ -1176,6 +1189,8 @@ TestSteensgaardAnalysis()
   TestMemcpy();
 
   TestLinkedList();
+
+  TestLambdaCallArgumentMismatch();
 
   TestStatistics();
 


### PR DESCRIPTION
LLVM permits code where the number of call arguments mismatch with the number of lambda arguments, even though it is a direct call. A simple example would be:

```
unsigned int                                                                                           
foo ()                                                                                                 
{                                                                                                      
  return 5;                                                                                            
}                                                                                                      
                                                                                                       
int                                                                                                    
main (void)                                                                                            
{                                                                                                      
  unsigned int x = 8;                                                                                  
  return foo(x);                                                                                       
} 
```

The Steensgaard alias analysis assumed that for direct calls the number of call and lambda arguments always coincide. This PR revises this assumption, and closes issue #319 and #274.