### PR TITLE
Drop JLM_ASSERT in CreateUniqueFile() method

### DIFF
--- a/jlm/tooling/CommandGraphGenerator.cpp
+++ b/jlm/tooling/CommandGraphGenerator.cpp
@@ -20,7 +20,7 @@ JlcCommandGraphGenerator::~JlcCommandGraphGenerator() noexcept = default;
 util::filepath
 JlcCommandGraphGenerator::CreateJlmOptCommandOutputFile(const util::filepath & inputFile)
 {
-  return util::filepath::CreateUniqueFile(
+  return util::filepath::CreateUniqueFileName(
       std::filesystem::temp_directory_path().string(),
       inputFile.base() + "-",
       "-jlm-opt.ll");
@@ -29,7 +29,7 @@ JlcCommandGraphGenerator::CreateJlmOptCommandOutputFile(const util::filepath & i
 util::filepath
 JlcCommandGraphGenerator::CreateParserCommandOutputFile(const util::filepath & inputFile)
 {
-  return util::filepath::CreateUniqueFile(
+  return util::filepath::CreateUniqueFileName(
       std::filesystem::temp_directory_path().string(),
       inputFile.base() + "-",
       "-clang.ll");
@@ -203,7 +203,7 @@ JhlsCommandGraphGenerator::CreateParserCommandOutputFile(
     const util::filepath & tmpDirectory,
     const util::filepath & inputFile)
 {
-  return util::filepath::CreateUniqueFile(tmpDirectory, inputFile.base() + "-", "-clang.ll");
+  return util::filepath::CreateUniqueFileName(tmpDirectory, inputFile.base() + "-", "-clang.ll");
 }
 
 util::filepath
@@ -211,7 +211,7 @@ JhlsCommandGraphGenerator::CreateJlmOptCommandOutputFile(
     const util::filepath & tmpDirectory,
     const util::filepath & inputFile)
 {
-  return util::filepath::CreateUniqueFile(tmpDirectory, inputFile.base() + "-", "-jlm-opt.ll");
+  return util::filepath::CreateUniqueFileName(tmpDirectory, inputFile.base() + "-", "-jlm-opt.ll");
 }
 
 ClangCommand::LanguageStandard

--- a/jlm/util/Statistics.hpp
+++ b/jlm/util/Statistics.hpp
@@ -131,7 +131,7 @@ public:
   static filepath
   CreateUniqueStatisticsFile(const filepath & directory, const filepath & inputFile)
   {
-    return filepath::CreateUniqueFile(directory, inputFile.base() + "-", "-statistics.log");
+    return filepath::CreateUniqueFileName(directory, inputFile.base() + "-", "-statistics.log");
   }
 
 private:

--- a/jlm/util/file.hpp
+++ b/jlm/util/file.hpp
@@ -206,8 +206,6 @@ public:
       const std::string & fileNamePrefix,
       const std::string & fileNameSuffix)
   {
-    JLM_ASSERT(directory.Exists() && directory.IsDirectory());
-
     auto randomString = CreateRandomString(6);
     filepath filePath(directory.to_str() + "/" + fileNamePrefix + randomString + fileNameSuffix);
 

--- a/jlm/util/file.hpp
+++ b/jlm/util/file.hpp
@@ -201,7 +201,7 @@ public:
    * @return A unique file
    */
   static jlm::util::filepath
-  CreateUniqueFile(
+  CreateUniqueFileName(
       const jlm::util::filepath & directory,
       const std::string & fileNamePrefix,
       const std::string & fileNameSuffix)

--- a/tests/jlm/util/Makefile.sub
+++ b/tests/jlm/util/Makefile.sub
@@ -1,9 +1,9 @@
 TESTS += \
     jlm/util/test-disjointset \
-    jlm/util/test-file \
     jlm/util/test-intrusive-hash \
     jlm/util/test-intrusive-list \
     jlm/util/TestBijectiveMap \
+    jlm/util/TestFile \
     jlm/util/TestHashSet \
     jlm/util/TestMath \
     jlm/util/TestStatistics \

--- a/tests/jlm/util/TestFile.cpp
+++ b/tests/jlm/util/TestFile.cpp
@@ -23,4 +23,4 @@ test()
   return 0;
 }
 
-JLM_UNIT_TEST_REGISTER("jlm/util/test-file", test)
+JLM_UNIT_TEST_REGISTER("jlm/util/TestFile", test)

--- a/tests/jlm/util/TestFile.cpp
+++ b/tests/jlm/util/TestFile.cpp
@@ -7,10 +7,10 @@
 
 #include <jlm/util/file.hpp>
 
-#include <assert.h>
+#include <cassert>
 
-static int
-test()
+static void
+TestFilePathMethods()
 {
   jlm::util::filepath f("/tmp/archive.tar.gz");
 
@@ -19,8 +19,14 @@ test()
   assert(f.suffix() == "gz");
   assert(f.complete_suffix() == "tar.gz");
   assert(f.path() == "/tmp/");
+}
+
+static int
+TestFile()
+{
+  TestFilePathMethods();
 
   return 0;
 }
 
-JLM_UNIT_TEST_REGISTER("jlm/util/TestFile", test)
+JLM_UNIT_TEST_REGISTER("jlm/util/TestFile", TestFile)

--- a/tests/jlm/util/TestFile.cpp
+++ b/tests/jlm/util/TestFile.cpp
@@ -9,6 +9,26 @@
 
 #include <cassert>
 
+// FIXME: This was shamelessly copied from util/file.hpp.
+// We should introduce our own string wrapper where we can have such methods.
+static std::string
+CreateRandomString(std::size_t length)
+{
+  const std::string characterSet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+  std::random_device random_device;
+  std::mt19937 generator(random_device());
+  std::uniform_int_distribution<> distribution(0, characterSet.size() - 1);
+
+  std::string result;
+  for (std::size_t i = 0; i < length; ++i)
+  {
+    result += characterSet[distribution(generator)];
+  }
+
+  return result;
+}
+
 static void
 TestFilePathMethods()
 {
@@ -21,10 +41,25 @@ TestFilePathMethods()
   assert(f.path() == "/tmp/");
 }
 
+static void
+TestCreateUniqueFileName()
+{
+  // Arrange
+  auto randomString = CreateRandomString(6);
+  auto tmpDirectory = std::filesystem::temp_directory_path().string() + "/" + randomString;
+
+  // Act
+  auto filePath = jlm::util::filepath::CreateUniqueFileName(tmpDirectory, "myPrefix", "mySuffix");
+
+  // Assert
+  assert(filePath.path() == (tmpDirectory + "/"));
+}
+
 static int
 TestFile()
 {
   TestFilePathMethods();
+  TestCreateUniqueFileName();
 
   return 0;
 }


### PR DESCRIPTION
The CreateUniqueFile() method assumed so far that the directory provided needs to exist. This was a little bit too strict for some use cases. Simply drop this invariant. In addition, this PR also performs some minor clean ups. Closes #327.