### PR TITLE
jhls and jlm-hls exits if CIRCT is not enabled

### DIFF
--- a/tools/jhls/jhls.cpp
+++ b/tools/jhls/jhls.cpp
@@ -9,6 +9,12 @@
 int
 main(int argc, char ** argv)
 {
+#ifndef CIRCT
+  ::llvm::outs() << "jhls has not been compiled with the CIRCT backend enabled.\n";
+  ::llvm::outs() << "Recompile jlm with -DCIRCT=1 if you want to use jhls.\n";
+  exit(0);
+#endif
+
   using namespace jlm::tooling;
 
   auto & commandLineOptions = JhlsCommandLineParser::Parse(argc, argv);

--- a/tools/jhls/jhls.cpp
+++ b/tools/jhls/jhls.cpp
@@ -12,7 +12,7 @@ main(int argc, char ** argv)
 #ifndef CIRCT
   ::llvm::outs() << "jhls has not been compiled with the CIRCT backend enabled.\n";
   ::llvm::outs() << "Recompile jlm with -DCIRCT=1 if you want to use jhls.\n";
-  exit(0);
+  exit(EXIT_SUCCESS);
 #endif
 
   using namespace jlm::tooling;

--- a/tools/jlm-hls/jlm-hls.cpp
+++ b/tools/jlm-hls/jlm-hls.cpp
@@ -48,7 +48,7 @@ main(int argc, char ** argv)
 #ifndef CIRCT
   ::llvm::outs() << "jlm-hls has not been compiled with the CIRCT backend enabled.\n";
   ::llvm::outs() << "Recompile jlm with -DCIRCT=1 if you want to use jlm-hls.\n";
-  exit(0);
+  exit(EXIT_SUCCESS);
 #endif
 
   auto & commandLineOptions = jlm::tooling::JlmHlsCommandLineParser::Parse(argc, argv);

--- a/tools/jlm-hls/jlm-hls.cpp
+++ b/tools/jlm-hls/jlm-hls.cpp
@@ -44,6 +44,13 @@ llvmToFile(jlm::llvm::RvsdgModule & module, std::string fileName)
 int
 main(int argc, char ** argv)
 {
+
+#ifndef CIRCT
+  ::llvm::outs() << "jlm-hls has not been compiled with the CIRCT backend enabled.\n";
+  ::llvm::outs() << "Recompile jlm with -DCIRCT=1 if you want to use jlm-hls.\n";
+  exit(0);
+#endif
+
   auto & commandLineOptions = jlm::tooling::JlmHlsCommandLineParser::Parse(argc, argv);
 
   llvm::LLVMContext ctx;


### PR DESCRIPTION
Both tools now informs the user if they are used and jlm has not been compiled with the CRICT backend enabled. Closes #322.