### PR TITLE
Improve handling of imported entities in Steensgaard

### DIFF
--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -425,6 +425,10 @@ private:
  *
  * This class represents all global variable and function locations that are imported to the
  * translation unit.
+ *
+ * FIXME: We should be able to further distinguish imported locations between function and data
+ * locations. Function locations cannot point to any other memory locations, helping us to
+ * potentially improve analysis precision.
  */
 class ImportLocation final : public MemoryLocation
 {
@@ -1666,7 +1670,6 @@ Steensgaard::AnalyzeImports(const rvsdg::graph & graph)
     if (!rvsdg::is<PointerType>(argument.type()))
       continue;
 
-    // FIXME: we should not add function imports
     auto & importLocation = LocationSet_->InsertImportLocation(argument);
     auto & importArgumentLocation =
         LocationSet_->FindOrInsertRegisterLocation(argument, PointsToFlags::PointsToNone);

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -421,8 +421,7 @@ private:
   const delta::node & Delta_;
 };
 
-/** \brief ImportLocation class
- *
+/**
  * This class represents all global variable and function locations that are imported to the
  * translation unit.
  *
@@ -474,7 +473,9 @@ private:
   const rvsdg::argument & Argument_;
 };
 
-/** \brief FIXME: write documentation
+/**
+ * This class represents a location that only exists for structural purposes of the algorithm. It
+ * has no equivalent in the RVSDG.
  */
 class DummyLocation final : public Location
 {

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -421,8 +421,10 @@ private:
   const delta::node & Delta_;
 };
 
-/** \brief FIXME: write documentation
+/** \brief ImportLocation class
  *
+ * This class represents all global variable and function locations that are imported to the
+ * translation unit.
  */
 class ImportLocation final : public MemoryLocation
 {

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -459,6 +459,8 @@ public:
   {
     JLM_ASSERT(is<PointerType>(argument.type()));
 
+    // If the imported memory location is a pointer type or contains a pointer type, then these
+    // pointers can point to values that escaped this module.
     auto & rvsdgImport = *util::AssertedCast<const impport>(&argument.port());
     bool isOrContainsPointerType = IsOrContains<PointerType>(rvsdgImport.GetValueType());
 

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -423,18 +423,17 @@ private:
 
 /** \brief FIXME: write documentation
  *
- * FIXME: This class should be derived from a meloc, but we do not
- * have a node to hand in.
  */
-class ImportLocation final : public Location
+class ImportLocation final : public MemoryLocation
 {
   ~ImportLocation() override = default;
 
   ImportLocation(const jlm::rvsdg::argument & argument, PointsToFlags pointsToFlags)
-      : Location(pointsToFlags),
+      : MemoryLocation(),
         Argument_(argument)
   {
     JLM_ASSERT(dynamic_cast<const llvm::impport *>(&argument.port()));
+    SetPointsToFlags(pointsToFlags);
   }
 
 public:
@@ -1832,12 +1831,6 @@ Steensgaard::ConstructPointsToGraph() const
           escapingRegisterLocations.Insert(registerLocation);
       }
       else if (Location::Is<MemoryLocation>(*location))
-      {
-        auto & pointsToGraphNode = CreatePointsToGraphMemoryNode(*location, *pointsToGraph);
-        memoryNodesInSet[&locationSet].push_back(&pointsToGraphNode);
-        locationMap[location] = &pointsToGraphNode;
-      }
-      else if (Location::Is<ImportLocation>(*location))
       {
         auto & pointsToGraphNode = CreatePointsToGraphMemoryNode(*location, *pointsToGraph);
         memoryNodesInSet[&locationSet].push_back(&pointsToGraphNode);

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -1666,17 +1666,17 @@ Steensgaard::AnalyzeRvsdg(const jlm::rvsdg::graph & graph)
 void
 Steensgaard::AnalyzeImports(const rvsdg::graph & graph)
 {
-  auto region = graph.root();
-  for (size_t n = 0; n < region->narguments(); n++)
+  auto rootRegion = graph.root();
+  for (size_t n = 0; n < rootRegion->narguments(); n++)
   {
-    auto & argument = *region->argument(n);
+    auto & argument = *rootRegion->argument(n);
     if (!rvsdg::is<PointerType>(argument.type()))
       continue;
 
     auto & importLocation = LocationSet_->InsertImportLocation(argument);
-    auto & importArgumentLocation =
+    auto & registerLocation =
         LocationSet_->FindOrInsertRegisterLocation(argument, PointsToFlags::PointsToNone);
-    importArgumentLocation.SetPointsTo(importLocation);
+    registerLocation.SetPointsTo(importLocation);
   }
 }
 


### PR DESCRIPTION
This PR does the following:

1. Make MemoryLocation the base class of the ImportLocation class. This simplifies some code in the points-to graph construction pass.
2. Add documentation to the ImportLocation class.
3. Drop PointsToUnknown flag from imported memory locations. We know what they can point to, it is only to external memory and all memory locations that escaped from the module.
4. Move a FIXME that concerns the ImportLocation class also to the ImportLocation class
5. Add some documentation to the DummyLocation class
6. Clean up the AnalyzeImports method code a little bit.

This PR removes several FIXMEs from the code.