### PR TITLE
Fix several bugs in points-to graph

### DIFF
--- a/jlm/llvm/opt/alias-analyses/PointsToGraph.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraph.cpp
@@ -357,6 +357,9 @@ PointsToGraph::ToDot(
   for (auto & registerNode : pointsToGraph.RegisterNodes())
     dot += printNodeAndEdges(registerNode);
 
+  for (auto & registerSetNode : pointsToGraph.RegisterSetNodes())
+    dot += printNodeAndEdges(registerSetNode);
+
   dot += nodeString(pointsToGraph.GetUnknownMemoryNode());
   dot += nodeString(pointsToGraph.GetExternalMemoryNode());
   dot += "label=\"Yellow = Escaping memory node\"\n";

--- a/jlm/llvm/opt/alias-analyses/PointsToGraph.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraph.cpp
@@ -173,25 +173,25 @@ PointsToGraph::RegisterNodes() const
 PointsToGraph::RegisterSetNodeRange
 PointsToGraph::RegisterSetNodes()
 {
-  auto mapToPointer = [](const RegisterSetNodeMap::iterator & it)
+  auto mapToPointer = [](const RegisterSetNodeVector::iterator & it)
   {
-    return it->second;
+    return it->get();
   };
 
-  return { RegisterSetNodeIterator(RegisterSetNodeMap_.begin(), mapToPointer),
-           RegisterSetNodeIterator(RegisterSetNodeMap_.end(), mapToPointer) };
+  return { RegisterSetNodeIterator(RegisterSetNodes_.begin(), mapToPointer),
+           RegisterSetNodeIterator(RegisterSetNodes_.end(), mapToPointer) };
 }
 
 PointsToGraph::RegisterSetNodeConstRange
 PointsToGraph::RegisterSetNodes() const
 {
-  auto mapToPointer = [](const RegisterSetNodeMap::const_iterator & it)
+  auto mapToPointer = [](const RegisterSetNodeVector::const_iterator & it)
   {
-    return it->second;
+    return it->get();
   };
 
-  return { RegisterSetNodeConstIterator(RegisterSetNodeMap_.begin(), mapToPointer),
-           RegisterSetNodeConstIterator(RegisterSetNodeMap_.end(), mapToPointer) };
+  return { RegisterSetNodeConstIterator(RegisterSetNodes_.begin(), mapToPointer),
+           RegisterSetNodeConstIterator(RegisterSetNodes_.end(), mapToPointer) };
 }
 
 PointsToGraph::AllocaNode &

--- a/jlm/llvm/opt/alias-analyses/PointsToGraph.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraph.cpp
@@ -29,93 +29,169 @@ PointsToGraph::AddEscapedMemoryNode(PointsToGraph::MemoryNode & memoryNode)
 PointsToGraph::AllocaNodeRange
 PointsToGraph::AllocaNodes()
 {
-  return { AllocaNodeIterator(AllocaNodes_.begin()), AllocaNodeIterator(AllocaNodes_.end()) };
+  auto mapToPointer = [](const AllocaNodeMap::iterator & it)
+  {
+    return it->second.get();
+  };
+
+  return { AllocaNodeIterator(AllocaNodes_.begin(), mapToPointer),
+           AllocaNodeIterator(AllocaNodes_.end(), mapToPointer) };
 }
 
 PointsToGraph::AllocaNodeConstRange
 PointsToGraph::AllocaNodes() const
 {
-  return { AllocaNodeConstIterator(AllocaNodes_.begin()),
-           AllocaNodeConstIterator(AllocaNodes_.end()) };
+  auto mapToPointer = [](const AllocaNodeMap::const_iterator & it)
+  {
+    return it->second.get();
+  };
+
+  return { AllocaNodeConstIterator(AllocaNodes_.begin(), mapToPointer),
+           AllocaNodeConstIterator(AllocaNodes_.end(), mapToPointer) };
 }
 
 PointsToGraph::DeltaNodeRange
 PointsToGraph::DeltaNodes()
 {
-  return { DeltaNodeIterator(DeltaNodes_.begin()), DeltaNodeIterator(DeltaNodes_.end()) };
+  auto mapToPointer = [](const DeltaNodeMap::iterator & it)
+  {
+    return it->second.get();
+  };
+
+  return { DeltaNodeIterator(DeltaNodes_.begin(), mapToPointer),
+           DeltaNodeIterator(DeltaNodes_.end(), mapToPointer) };
 }
 
 PointsToGraph::DeltaNodeConstRange
 PointsToGraph::DeltaNodes() const
 {
-  return { DeltaNodeConstIterator(DeltaNodes_.begin()), DeltaNodeConstIterator(DeltaNodes_.end()) };
+  auto mapToPointer = [](const DeltaNodeMap::const_iterator & it)
+  {
+    return it->second.get();
+  };
+
+  return { DeltaNodeConstIterator(DeltaNodes_.begin(), mapToPointer),
+           DeltaNodeConstIterator(DeltaNodes_.end(), mapToPointer) };
 }
 
 PointsToGraph::LambdaNodeRange
 PointsToGraph::LambdaNodes()
 {
-  return { LambdaNodeIterator(LambdaNodes_.begin()), LambdaNodeIterator(LambdaNodes_.end()) };
+  auto mapToPointer = [](const LambdaNodeMap::iterator & it)
+  {
+    return it->second.get();
+  };
+
+  return { LambdaNodeIterator(LambdaNodes_.begin(), mapToPointer),
+           LambdaNodeIterator(LambdaNodes_.end(), mapToPointer) };
 }
 
 PointsToGraph::LambdaNodeConstRange
 PointsToGraph::LambdaNodes() const
 {
-  return { LambdaNodeConstIterator(LambdaNodes_.begin()),
-           LambdaNodeConstIterator(LambdaNodes_.end()) };
+  auto mapToPointer = [](const LambdaNodeMap::const_iterator & it)
+  {
+    return it->second.get();
+  };
+
+  return { LambdaNodeConstIterator(LambdaNodes_.begin(), mapToPointer),
+           LambdaNodeConstIterator(LambdaNodes_.end(), mapToPointer) };
 }
 
 PointsToGraph::MallocNodeRange
 PointsToGraph::MallocNodes()
 {
-  return { MallocNodeIterator(MallocNodes_.begin()), MallocNodeIterator(MallocNodes_.end()) };
+  auto mapToPointer = [](const MallocNodeMap::iterator & it)
+  {
+    return it->second.get();
+  };
+
+  return { MallocNodeIterator(MallocNodes_.begin(), mapToPointer),
+           MallocNodeIterator(MallocNodes_.end(), mapToPointer) };
 }
 
 PointsToGraph::MallocNodeConstRange
 PointsToGraph::MallocNodes() const
 {
-  return { MallocNodeConstIterator(MallocNodes_.begin()),
-           MallocNodeConstIterator(MallocNodes_.end()) };
+  auto mapToPointer = [](const MallocNodeMap::const_iterator & it)
+  {
+    return it->second.get();
+  };
+
+  return { MallocNodeConstIterator(MallocNodes_.begin(), mapToPointer),
+           MallocNodeConstIterator(MallocNodes_.end(), mapToPointer) };
 }
 
 PointsToGraph::ImportNodeRange
 PointsToGraph::ImportNodes()
 {
-  return { ImportNodeIterator(ImportNodes_.begin()), ImportNodeIterator(ImportNodes_.end()) };
+  auto mapToPointer = [](const ImportNodeMap::iterator & it)
+  {
+    return it->second.get();
+  };
+
+  return { ImportNodeIterator(ImportNodes_.begin(), mapToPointer),
+           ImportNodeIterator(ImportNodes_.end(), mapToPointer) };
 }
 
 PointsToGraph::ImportNodeConstRange
 PointsToGraph::ImportNodes() const
 {
-  return { ImportNodeConstIterator(ImportNodes_.begin()),
-           ImportNodeConstIterator(ImportNodes_.end()) };
+  auto mapToPointer = [](const ImportNodeMap::const_iterator & it)
+  {
+    return it->second.get();
+  };
+
+  return { ImportNodeConstIterator(ImportNodes_.begin(), mapToPointer),
+           ImportNodeConstIterator(ImportNodes_.end(), mapToPointer) };
 }
 
 PointsToGraph::RegisterNodeRange
 PointsToGraph::RegisterNodes()
 {
-  return { RegisterNodeIterator(RegisterNodes_.begin()),
-           RegisterNodeIterator(RegisterNodes_.end()) };
+  auto mapToPointer = [](const RegisterNodeMap::iterator & it)
+  {
+    return it->second.get();
+  };
+
+  return { RegisterNodeIterator(RegisterNodes_.begin(), mapToPointer),
+           RegisterNodeIterator(RegisterNodes_.end(), mapToPointer) };
 }
 
 PointsToGraph::RegisterNodeConstRange
 PointsToGraph::RegisterNodes() const
 {
-  return { RegisterNodeConstIterator(RegisterNodes_.begin()),
-           RegisterNodeConstIterator(RegisterNodes_.end()) };
+  auto mapToPointer = [](const RegisterNodeMap::const_iterator & it)
+  {
+    return it->second.get();
+  };
+
+  return { RegisterNodeConstIterator(RegisterNodes_.begin(), mapToPointer),
+           RegisterNodeConstIterator(RegisterNodes_.end(), mapToPointer) };
 }
 
 PointsToGraph::RegisterSetNodeRange
 PointsToGraph::RegisterSetNodes()
 {
-  return { RegisterSetNodeIterator(RegisterSetNodeMap_.begin()),
-           RegisterSetNodeIterator(RegisterSetNodeMap_.end()) };
+  auto mapToPointer = [](const RegisterSetNodeMap::iterator & it)
+  {
+    return it->second;
+  };
+
+  return { RegisterSetNodeIterator(RegisterSetNodeMap_.begin(), mapToPointer),
+           RegisterSetNodeIterator(RegisterSetNodeMap_.end(), mapToPointer) };
 }
 
 PointsToGraph::RegisterSetNodeConstRange
 PointsToGraph::RegisterSetNodes() const
 {
-  return { RegisterSetNodeConstIterator(RegisterSetNodeMap_.begin()),
-           RegisterSetNodeConstIterator(RegisterSetNodeMap_.end()) };
+  auto mapToPointer = [](const RegisterSetNodeMap::const_iterator & it)
+  {
+    return it->second;
+  };
+
+  return { RegisterSetNodeConstIterator(RegisterSetNodeMap_.begin(), mapToPointer),
+           RegisterSetNodeConstIterator(RegisterSetNodeMap_.end(), mapToPointer) };
 }
 
 PointsToGraph::AllocaNode &

--- a/jlm/llvm/opt/alias-analyses/PointsToGraph.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraph.cpp
@@ -448,13 +448,15 @@ PointsToGraph::RegisterSetNode::~RegisterSetNode() noexcept = default;
 std::string
 PointsToGraph::RegisterSetNode::DebugString() const
 {
-  auto lastOutput = *std::prev(GetOutputs().Items().end());
+  auto & outputs = GetOutputs();
 
+  size_t n = 0;
   std::string debugString("{");
-  for (auto output : GetOutputs().Items())
+  for (auto output : outputs.Items())
   {
     debugString += CreateDotString(*output);
-    debugString += output != lastOutput ? ", " : "";
+    debugString += n != (outputs.Size() - 1) ? ", " : "";
+    n++;
   }
   debugString += "}";
 

--- a/jlm/llvm/opt/alias-analyses/PointsToGraph.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraph.cpp
@@ -451,14 +451,13 @@ PointsToGraph::RegisterSetNode::DebugString() const
   auto & outputs = GetOutputs();
 
   size_t n = 0;
-  std::string debugString("{");
+  std::string debugString;
   for (auto output : outputs.Items())
   {
     debugString += CreateDotString(*output);
-    debugString += n != (outputs.Size() - 1) ? ", " : "";
+    debugString += n != (outputs.Size() - 1) ? "\n" : "";
     n++;
   }
-  debugString += "}";
 
   return debugString;
 }

--- a/jlm/llvm/opt/alias-analyses/PointsToGraph.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraph.cpp
@@ -29,169 +29,93 @@ PointsToGraph::AddEscapedMemoryNode(PointsToGraph::MemoryNode & memoryNode)
 PointsToGraph::AllocaNodeRange
 PointsToGraph::AllocaNodes()
 {
-  auto mapToPointer = [](const AllocaNodeMap::iterator & it)
-  {
-    return it->second.get();
-  };
-
-  return { AllocaNodeIterator(AllocaNodes_.begin(), mapToPointer),
-           AllocaNodeIterator(AllocaNodes_.end(), mapToPointer) };
+  return { AllocaNodeIterator(AllocaNodes_.begin()), AllocaNodeIterator(AllocaNodes_.end()) };
 }
 
 PointsToGraph::AllocaNodeConstRange
 PointsToGraph::AllocaNodes() const
 {
-  auto mapToPointer = [](const AllocaNodeMap::const_iterator & it)
-  {
-    return it->second.get();
-  };
-
-  return { AllocaNodeConstIterator(AllocaNodes_.begin(), mapToPointer),
-           AllocaNodeConstIterator(AllocaNodes_.end(), mapToPointer) };
+  return { AllocaNodeConstIterator(AllocaNodes_.begin()),
+           AllocaNodeConstIterator(AllocaNodes_.end()) };
 }
 
 PointsToGraph::DeltaNodeRange
 PointsToGraph::DeltaNodes()
 {
-  auto mapToPointer = [](const DeltaNodeMap::iterator & it)
-  {
-    return it->second.get();
-  };
-
-  return { DeltaNodeIterator(DeltaNodes_.begin(), mapToPointer),
-           DeltaNodeIterator(DeltaNodes_.end(), mapToPointer) };
+  return { DeltaNodeIterator(DeltaNodes_.begin()), DeltaNodeIterator(DeltaNodes_.end()) };
 }
 
 PointsToGraph::DeltaNodeConstRange
 PointsToGraph::DeltaNodes() const
 {
-  auto mapToPointer = [](const DeltaNodeMap::const_iterator & it)
-  {
-    return it->second.get();
-  };
-
-  return { DeltaNodeConstIterator(DeltaNodes_.begin(), mapToPointer),
-           DeltaNodeConstIterator(DeltaNodes_.end(), mapToPointer) };
+  return { DeltaNodeConstIterator(DeltaNodes_.begin()), DeltaNodeConstIterator(DeltaNodes_.end()) };
 }
 
 PointsToGraph::LambdaNodeRange
 PointsToGraph::LambdaNodes()
 {
-  auto mapToPointer = [](const LambdaNodeMap::iterator & it)
-  {
-    return it->second.get();
-  };
-
-  return { LambdaNodeIterator(LambdaNodes_.begin(), mapToPointer),
-           LambdaNodeIterator(LambdaNodes_.end(), mapToPointer) };
+  return { LambdaNodeIterator(LambdaNodes_.begin()), LambdaNodeIterator(LambdaNodes_.end()) };
 }
 
 PointsToGraph::LambdaNodeConstRange
 PointsToGraph::LambdaNodes() const
 {
-  auto mapToPointer = [](const LambdaNodeMap::const_iterator & it)
-  {
-    return it->second.get();
-  };
-
-  return { LambdaNodeConstIterator(LambdaNodes_.begin(), mapToPointer),
-           LambdaNodeConstIterator(LambdaNodes_.end(), mapToPointer) };
+  return { LambdaNodeConstIterator(LambdaNodes_.begin()),
+           LambdaNodeConstIterator(LambdaNodes_.end()) };
 }
 
 PointsToGraph::MallocNodeRange
 PointsToGraph::MallocNodes()
 {
-  auto mapToPointer = [](const MallocNodeMap::iterator & it)
-  {
-    return it->second.get();
-  };
-
-  return { MallocNodeIterator(MallocNodes_.begin(), mapToPointer),
-           MallocNodeIterator(MallocNodes_.end(), mapToPointer) };
+  return { MallocNodeIterator(MallocNodes_.begin()), MallocNodeIterator(MallocNodes_.end()) };
 }
 
 PointsToGraph::MallocNodeConstRange
 PointsToGraph::MallocNodes() const
 {
-  auto mapToPointer = [](const MallocNodeMap::const_iterator & it)
-  {
-    return it->second.get();
-  };
-
-  return { MallocNodeConstIterator(MallocNodes_.begin(), mapToPointer),
-           MallocNodeConstIterator(MallocNodes_.end(), mapToPointer) };
+  return { MallocNodeConstIterator(MallocNodes_.begin()),
+           MallocNodeConstIterator(MallocNodes_.end()) };
 }
 
 PointsToGraph::ImportNodeRange
 PointsToGraph::ImportNodes()
 {
-  auto mapToPointer = [](const ImportNodeMap::iterator & it)
-  {
-    return it->second.get();
-  };
-
-  return { ImportNodeIterator(ImportNodes_.begin(), mapToPointer),
-           ImportNodeIterator(ImportNodes_.end(), mapToPointer) };
+  return { ImportNodeIterator(ImportNodes_.begin()), ImportNodeIterator(ImportNodes_.end()) };
 }
 
 PointsToGraph::ImportNodeConstRange
 PointsToGraph::ImportNodes() const
 {
-  auto mapToPointer = [](const ImportNodeMap::const_iterator & it)
-  {
-    return it->second.get();
-  };
-
-  return { ImportNodeConstIterator(ImportNodes_.begin(), mapToPointer),
-           ImportNodeConstIterator(ImportNodes_.end(), mapToPointer) };
+  return { ImportNodeConstIterator(ImportNodes_.begin()),
+           ImportNodeConstIterator(ImportNodes_.end()) };
 }
 
 PointsToGraph::RegisterNodeRange
 PointsToGraph::RegisterNodes()
 {
-  auto mapToPointer = [](const RegisterNodeMap::iterator & it)
-  {
-    return it->second.get();
-  };
-
-  return { RegisterNodeIterator(RegisterNodes_.begin(), mapToPointer),
-           RegisterNodeIterator(RegisterNodes_.end(), mapToPointer) };
+  return { RegisterNodeIterator(RegisterNodes_.begin()),
+           RegisterNodeIterator(RegisterNodes_.end()) };
 }
 
 PointsToGraph::RegisterNodeConstRange
 PointsToGraph::RegisterNodes() const
 {
-  auto mapToPointer = [](const RegisterNodeMap::const_iterator & it)
-  {
-    return it->second.get();
-  };
-
-  return { RegisterNodeConstIterator(RegisterNodes_.begin(), mapToPointer),
-           RegisterNodeConstIterator(RegisterNodes_.end(), mapToPointer) };
+  return { RegisterNodeConstIterator(RegisterNodes_.begin()),
+           RegisterNodeConstIterator(RegisterNodes_.end()) };
 }
 
 PointsToGraph::RegisterSetNodeRange
 PointsToGraph::RegisterSetNodes()
 {
-  auto mapToPointer = [](const RegisterSetNodeVector::iterator & it)
-  {
-    return it->get();
-  };
-
-  return { RegisterSetNodeIterator(RegisterSetNodes_.begin(), mapToPointer),
-           RegisterSetNodeIterator(RegisterSetNodes_.end(), mapToPointer) };
+  return { RegisterSetNodeIterator(RegisterSetNodes_.begin()),
+           RegisterSetNodeIterator(RegisterSetNodes_.end()) };
 }
 
 PointsToGraph::RegisterSetNodeConstRange
 PointsToGraph::RegisterSetNodes() const
 {
-  auto mapToPointer = [](const RegisterSetNodeVector::const_iterator & it)
-  {
-    return it->get();
-  };
-
-  return { RegisterSetNodeConstIterator(RegisterSetNodes_.begin(), mapToPointer),
-           RegisterSetNodeConstIterator(RegisterSetNodes_.end(), mapToPointer) };
+  return { RegisterSetNodeConstIterator(RegisterSetNodes_.begin()),
+           RegisterSetNodeConstIterator(RegisterSetNodes_.end()) };
 }
 
 PointsToGraph::AllocaNode &

--- a/jlm/llvm/opt/alias-analyses/PointsToGraph.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraph.hpp
@@ -31,10 +31,10 @@ namespace aa
  */
 class PointsToGraph final
 {
-  template<class DATATYPE, class ITERATORTYPE>
+  template<class DATATYPE, class ITERATORTYPE, typename IteratorToPointer>
   class NodeIterator;
 
-  template<class DATATYPE, class ITERATORTYPE>
+  template<class DATATYPE, class ITERATORTYPE, typename IteratorToPointer>
   class NodeConstIterator;
 
 public:
@@ -66,40 +66,118 @@ public:
       std::unordered_map<const rvsdg::output *, PointsToGraph::RegisterSetNode *>;
   using RegisterSetNodeVector = std::vector<std::unique_ptr<PointsToGraph::RegisterSetNode>>;
 
-  using AllocaNodeIterator = NodeIterator<AllocaNode, AllocaNodeMap::iterator>;
-  using AllocaNodeConstIterator = NodeConstIterator<AllocaNode, AllocaNodeMap::const_iterator>;
+  template<class DataType, class IteratorType>
+  struct NodeIteratorFunctor
+  {
+    DataType *
+    operator()(const IteratorType & it) const
+    {
+      return it->second.get();
+    }
+  };
+
+  template<class DataType, class IteratorType>
+  struct NodeConstIteratorFunctor
+  {
+    const DataType *
+    operator()(const IteratorType & it) const
+    {
+      return it->second.get();
+    }
+  };
+
+  using AllocaNodeIterator = NodeIterator<
+      AllocaNode,
+      AllocaNodeMap::iterator,
+      NodeIteratorFunctor<AllocaNode, AllocaNodeMap::iterator>>;
+  using AllocaNodeConstIterator = NodeConstIterator<
+      AllocaNode,
+      AllocaNodeMap::const_iterator,
+      NodeConstIteratorFunctor<AllocaNode, AllocaNodeMap::const_iterator>>;
   using AllocaNodeRange = jlm::util::iterator_range<AllocaNodeIterator>;
   using AllocaNodeConstRange = jlm::util::iterator_range<AllocaNodeConstIterator>;
 
-  using DeltaNodeIterator = NodeIterator<DeltaNode, DeltaNodeMap::iterator>;
-  using DeltaNodeConstIterator = NodeConstIterator<DeltaNode, DeltaNodeMap::const_iterator>;
+  using DeltaNodeIterator = NodeIterator<
+      DeltaNode,
+      DeltaNodeMap::iterator,
+      NodeIteratorFunctor<DeltaNode, DeltaNodeMap::iterator>>;
+  using DeltaNodeConstIterator = NodeConstIterator<
+      DeltaNode,
+      DeltaNodeMap::const_iterator,
+      NodeConstIteratorFunctor<DeltaNode, DeltaNodeMap::const_iterator>>;
   using DeltaNodeRange = jlm::util::iterator_range<DeltaNodeIterator>;
   using DeltaNodeConstRange = jlm::util::iterator_range<DeltaNodeConstIterator>;
 
-  using ImportNodeIterator = NodeIterator<ImportNode, ImportNodeMap::iterator>;
-  using ImportNodeConstIterator = NodeConstIterator<ImportNode, ImportNodeMap::const_iterator>;
+  using ImportNodeIterator = NodeIterator<
+      ImportNode,
+      ImportNodeMap::iterator,
+      NodeIteratorFunctor<ImportNode, ImportNodeMap::iterator>>;
+  using ImportNodeConstIterator = NodeConstIterator<
+      ImportNode,
+      ImportNodeMap::const_iterator,
+      NodeConstIteratorFunctor<ImportNode, ImportNodeMap::const_iterator>>;
   using ImportNodeRange = jlm::util::iterator_range<ImportNodeIterator>;
   using ImportNodeConstRange = jlm::util::iterator_range<ImportNodeConstIterator>;
 
-  using LambdaNodeIterator = NodeIterator<LambdaNode, LambdaNodeMap::iterator>;
-  using LambdaNodeConstIterator = NodeConstIterator<LambdaNode, LambdaNodeMap::const_iterator>;
+  using LambdaNodeIterator = NodeIterator<
+      LambdaNode,
+      LambdaNodeMap::iterator,
+      NodeIteratorFunctor<LambdaNode, LambdaNodeMap::iterator>>;
+  using LambdaNodeConstIterator = NodeConstIterator<
+      LambdaNode,
+      LambdaNodeMap::const_iterator,
+      NodeConstIteratorFunctor<LambdaNode, LambdaNodeMap::const_iterator>>;
   using LambdaNodeRange = jlm::util::iterator_range<LambdaNodeIterator>;
   using LambdaNodeConstRange = jlm::util::iterator_range<LambdaNodeConstIterator>;
 
-  using MallocNodeIterator = NodeIterator<MallocNode, MallocNodeMap::iterator>;
-  using MallocNodeConstIterator = NodeConstIterator<MallocNode, MallocNodeMap::const_iterator>;
+  using MallocNodeIterator = NodeIterator<
+      MallocNode,
+      MallocNodeMap::iterator,
+      NodeIteratorFunctor<MallocNode, MallocNodeMap::iterator>>;
+  using MallocNodeConstIterator = NodeConstIterator<
+      MallocNode,
+      MallocNodeMap::const_iterator,
+      NodeConstIteratorFunctor<MallocNode, MallocNodeMap::const_iterator>>;
   using MallocNodeRange = jlm::util::iterator_range<MallocNodeIterator>;
   using MallocNodeConstRange = jlm::util::iterator_range<MallocNodeConstIterator>;
 
-  using RegisterNodeIterator = NodeIterator<RegisterNode, RegisterNodeMap::iterator>;
-  using RegisterNodeConstIterator =
-      NodeConstIterator<RegisterNode, RegisterNodeMap::const_iterator>;
+  using RegisterNodeIterator = NodeIterator<
+      RegisterNode,
+      RegisterNodeMap::iterator,
+      NodeIteratorFunctor<RegisterNode, RegisterNodeMap::iterator>>;
+  using RegisterNodeConstIterator = NodeConstIterator<
+      RegisterNode,
+      RegisterNodeMap::const_iterator,
+      NodeConstIteratorFunctor<RegisterNode, RegisterNodeMap::const_iterator>>;
   using RegisterNodeRange = jlm::util::iterator_range<RegisterNodeIterator>;
   using RegisterNodeConstRange = jlm::util::iterator_range<RegisterNodeConstIterator>;
 
-  using RegisterSetNodeIterator = NodeIterator<RegisterSetNode, RegisterSetNodeVector::iterator>;
-  using RegisterSetNodeConstIterator =
-      NodeConstIterator<RegisterSetNode, RegisterSetNodeVector::const_iterator>;
+  struct RegisterSetNodeIteratorFunctor
+  {
+    RegisterSetNode *
+    operator()(const RegisterSetNodeVector::iterator & it) const
+    {
+      return it->get();
+    }
+  };
+
+  struct RegisterSetNodeConstIteratorFunctor
+  {
+    const RegisterSetNode *
+    operator()(const RegisterSetNodeVector::const_iterator & it) const
+    {
+      return it->get();
+    }
+  };
+
+  using RegisterSetNodeIterator = NodeIterator<
+      RegisterSetNode,
+      RegisterSetNodeVector::iterator,
+      RegisterSetNodeIteratorFunctor>;
+  using RegisterSetNodeConstIterator = NodeConstIterator<
+      RegisterSetNode,
+      RegisterSetNodeVector::const_iterator,
+      RegisterSetNodeConstIteratorFunctor>;
   using RegisterSetNodeRange = util::iterator_range<RegisterSetNodeIterator>;
   using RegisterSetNodeConstRange = util::iterator_range<RegisterSetNodeConstIterator>;
 
@@ -812,7 +890,7 @@ private:
 
 /** \brief Points-to graph node iterator
  */
-template<class DATATYPE, class ITERATORTYPE>
+template<class DATATYPE, class ITERATORTYPE, typename IteratorToPointer>
 class PointsToGraph::NodeIterator final
 {
 public:
@@ -825,18 +903,15 @@ public:
 private:
   friend PointsToGraph;
 
-  explicit NodeIterator(
-      const ITERATORTYPE & it,
-      const std::function<DATATYPE *(const ITERATORTYPE &)> & mapToPointer)
-      : it_(it),
-        MapToPointer_(mapToPointer)
+  explicit NodeIterator(const ITERATORTYPE & it)
+      : it_(it)
   {}
 
 public:
   [[nodiscard]] DATATYPE *
   Node() const noexcept
   {
-    return MapToPointer_(it_);
+    return IteratorToPointer_(it_);
   }
 
   DATATYPE &
@@ -881,12 +956,12 @@ public:
 
 private:
   ITERATORTYPE it_;
-  std::function<DATATYPE *(const ITERATORTYPE &)> MapToPointer_;
+  IteratorToPointer IteratorToPointer_;
 };
 
 /** \brief Points-to graph node const iterator
  */
-template<class DATATYPE, class ITERATORTYPE>
+template<class DATATYPE, class ITERATORTYPE, typename IteratorToPointer>
 class PointsToGraph::NodeConstIterator final
 {
 public:
@@ -899,18 +974,15 @@ public:
 private:
   friend PointsToGraph;
 
-  explicit NodeConstIterator(
-      const ITERATORTYPE & it,
-      const std::function<DATATYPE *(const ITERATORTYPE &)> & mapToPointer)
-      : it_(it),
-        MapToPointer_(mapToPointer)
+  explicit NodeConstIterator(const ITERATORTYPE & it)
+      : it_(it)
   {}
 
 public:
   [[nodiscard]] const DATATYPE *
   Node() const noexcept
   {
-    return MapToPointer_(it_);
+    return IteratorToPointer_(it_);
   }
 
   const DATATYPE &
@@ -955,7 +1027,7 @@ public:
 
 private:
   ITERATORTYPE it_;
-  std::function<DATATYPE *(const ITERATORTYPE &)> MapToPointer_;
+  IteratorToPointer IteratorToPointer_;
 };
 
 /** \brief Points-to graph edge iterator

--- a/jlm/llvm/opt/alias-analyses/PointsToGraph.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraph.hpp
@@ -67,19 +67,9 @@ public:
   using RegisterSetNodeVector = std::vector<std::unique_ptr<PointsToGraph::RegisterSetNode>>;
 
   template<class DataType, class IteratorType>
-  struct NodeIteratorFunctor
+  struct IteratorToPointerFunctor
   {
     DataType *
-    operator()(const IteratorType & it) const
-    {
-      return it->second.get();
-    }
-  };
-
-  template<class DataType, class IteratorType>
-  struct NodeConstIteratorFunctor
-  {
-    const DataType *
     operator()(const IteratorType & it) const
     {
       return it->second.get();
@@ -89,82 +79,74 @@ public:
   using AllocaNodeIterator = NodeIterator<
       AllocaNode,
       AllocaNodeMap::iterator,
-      NodeIteratorFunctor<AllocaNode, AllocaNodeMap::iterator>>;
+      IteratorToPointerFunctor<AllocaNode, AllocaNodeMap::iterator>>;
   using AllocaNodeConstIterator = NodeConstIterator<
       AllocaNode,
       AllocaNodeMap::const_iterator,
-      NodeConstIteratorFunctor<AllocaNode, AllocaNodeMap::const_iterator>>;
+      IteratorToPointerFunctor<AllocaNode, AllocaNodeMap::const_iterator>>;
   using AllocaNodeRange = jlm::util::iterator_range<AllocaNodeIterator>;
   using AllocaNodeConstRange = jlm::util::iterator_range<AllocaNodeConstIterator>;
 
   using DeltaNodeIterator = NodeIterator<
       DeltaNode,
       DeltaNodeMap::iterator,
-      NodeIteratorFunctor<DeltaNode, DeltaNodeMap::iterator>>;
+      IteratorToPointerFunctor<DeltaNode, DeltaNodeMap::iterator>>;
   using DeltaNodeConstIterator = NodeConstIterator<
       DeltaNode,
       DeltaNodeMap::const_iterator,
-      NodeConstIteratorFunctor<DeltaNode, DeltaNodeMap::const_iterator>>;
+      IteratorToPointerFunctor<DeltaNode, DeltaNodeMap::const_iterator>>;
   using DeltaNodeRange = jlm::util::iterator_range<DeltaNodeIterator>;
   using DeltaNodeConstRange = jlm::util::iterator_range<DeltaNodeConstIterator>;
 
   using ImportNodeIterator = NodeIterator<
       ImportNode,
       ImportNodeMap::iterator,
-      NodeIteratorFunctor<ImportNode, ImportNodeMap::iterator>>;
+      IteratorToPointerFunctor<ImportNode, ImportNodeMap::iterator>>;
   using ImportNodeConstIterator = NodeConstIterator<
       ImportNode,
       ImportNodeMap::const_iterator,
-      NodeConstIteratorFunctor<ImportNode, ImportNodeMap::const_iterator>>;
+      IteratorToPointerFunctor<ImportNode, ImportNodeMap::const_iterator>>;
   using ImportNodeRange = jlm::util::iterator_range<ImportNodeIterator>;
   using ImportNodeConstRange = jlm::util::iterator_range<ImportNodeConstIterator>;
 
   using LambdaNodeIterator = NodeIterator<
       LambdaNode,
       LambdaNodeMap::iterator,
-      NodeIteratorFunctor<LambdaNode, LambdaNodeMap::iterator>>;
+      IteratorToPointerFunctor<LambdaNode, LambdaNodeMap::iterator>>;
   using LambdaNodeConstIterator = NodeConstIterator<
       LambdaNode,
       LambdaNodeMap::const_iterator,
-      NodeConstIteratorFunctor<LambdaNode, LambdaNodeMap::const_iterator>>;
+      IteratorToPointerFunctor<LambdaNode, LambdaNodeMap::const_iterator>>;
   using LambdaNodeRange = jlm::util::iterator_range<LambdaNodeIterator>;
   using LambdaNodeConstRange = jlm::util::iterator_range<LambdaNodeConstIterator>;
 
   using MallocNodeIterator = NodeIterator<
       MallocNode,
       MallocNodeMap::iterator,
-      NodeIteratorFunctor<MallocNode, MallocNodeMap::iterator>>;
+      IteratorToPointerFunctor<MallocNode, MallocNodeMap::iterator>>;
   using MallocNodeConstIterator = NodeConstIterator<
       MallocNode,
       MallocNodeMap::const_iterator,
-      NodeConstIteratorFunctor<MallocNode, MallocNodeMap::const_iterator>>;
+      IteratorToPointerFunctor<MallocNode, MallocNodeMap::const_iterator>>;
   using MallocNodeRange = jlm::util::iterator_range<MallocNodeIterator>;
   using MallocNodeConstRange = jlm::util::iterator_range<MallocNodeConstIterator>;
 
   using RegisterNodeIterator = NodeIterator<
       RegisterNode,
       RegisterNodeMap::iterator,
-      NodeIteratorFunctor<RegisterNode, RegisterNodeMap::iterator>>;
+      IteratorToPointerFunctor<RegisterNode, RegisterNodeMap::iterator>>;
   using RegisterNodeConstIterator = NodeConstIterator<
       RegisterNode,
       RegisterNodeMap::const_iterator,
-      NodeConstIteratorFunctor<RegisterNode, RegisterNodeMap::const_iterator>>;
+      IteratorToPointerFunctor<RegisterNode, RegisterNodeMap::const_iterator>>;
   using RegisterNodeRange = jlm::util::iterator_range<RegisterNodeIterator>;
   using RegisterNodeConstRange = jlm::util::iterator_range<RegisterNodeConstIterator>;
 
-  struct RegisterSetNodeIteratorFunctor
+  template<class IteratorType>
+  struct RegisterSetNodeIteratorToPointerFunctor
   {
     RegisterSetNode *
-    operator()(const RegisterSetNodeVector::iterator & it) const
-    {
-      return it->get();
-    }
-  };
-
-  struct RegisterSetNodeConstIteratorFunctor
-  {
-    const RegisterSetNode *
-    operator()(const RegisterSetNodeVector::const_iterator & it) const
+    operator()(const IteratorType & it) const
     {
       return it->get();
     }
@@ -173,11 +155,11 @@ public:
   using RegisterSetNodeIterator = NodeIterator<
       RegisterSetNode,
       RegisterSetNodeVector::iterator,
-      RegisterSetNodeIteratorFunctor>;
+      RegisterSetNodeIteratorToPointerFunctor<RegisterSetNodeVector::iterator>>;
   using RegisterSetNodeConstIterator = NodeConstIterator<
       RegisterSetNode,
       RegisterSetNodeVector::const_iterator,
-      RegisterSetNodeConstIteratorFunctor>;
+      RegisterSetNodeIteratorToPointerFunctor<RegisterSetNodeVector::const_iterator>>;
   using RegisterSetNodeRange = util::iterator_range<RegisterSetNodeIterator>;
   using RegisterSetNodeConstRange = util::iterator_range<RegisterSetNodeConstIterator>;
 

--- a/jlm/llvm/opt/alias-analyses/PointsToGraph.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraph.hpp
@@ -64,6 +64,7 @@ public:
       std::unordered_map<const jlm::rvsdg::output *, std::unique_ptr<PointsToGraph::RegisterNode>>;
   using RegisterSetNodeMap =
       std::unordered_map<const rvsdg::output *, PointsToGraph::RegisterSetNode *>;
+  using RegisterSetNodeVector = std::vector<std::unique_ptr<PointsToGraph::RegisterSetNode>>;
 
   using AllocaNodeIterator = NodeIterator<AllocaNode, AllocaNodeMap::iterator>;
   using AllocaNodeConstIterator = NodeConstIterator<AllocaNode, AllocaNodeMap::const_iterator>;
@@ -96,9 +97,9 @@ public:
   using RegisterNodeRange = jlm::util::iterator_range<RegisterNodeIterator>;
   using RegisterNodeConstRange = jlm::util::iterator_range<RegisterNodeConstIterator>;
 
-  using RegisterSetNodeIterator = NodeIterator<RegisterSetNode, RegisterSetNodeMap::iterator>;
+  using RegisterSetNodeIterator = NodeIterator<RegisterSetNode, RegisterSetNodeVector::iterator>;
   using RegisterSetNodeConstIterator =
-      NodeConstIterator<RegisterSetNode, RegisterSetNodeMap::const_iterator>;
+      NodeConstIterator<RegisterSetNode, RegisterSetNodeVector::const_iterator>;
   using RegisterSetNodeRange = util::iterator_range<RegisterSetNodeIterator>;
   using RegisterSetNodeConstRange = util::iterator_range<RegisterSetNodeConstIterator>;
 
@@ -377,7 +378,7 @@ private:
   RegisterNodeMap RegisterNodes_;
 
   RegisterSetNodeMap RegisterSetNodeMap_;
-  std::vector<std::unique_ptr<PointsToGraph::RegisterSetNode>> RegisterSetNodes_;
+  RegisterSetNodeVector RegisterSetNodes_;
 
   std::unique_ptr<PointsToGraph::UnknownMemoryNode> UnknownMemoryNode_;
   std::unique_ptr<ExternalMemoryNode> ExternalMemoryNode_;

--- a/jlm/llvm/opt/alias-analyses/PointsToGraph.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraph.hpp
@@ -824,15 +824,18 @@ public:
 private:
   friend PointsToGraph;
 
-  explicit NodeIterator(const ITERATORTYPE & it)
-      : it_(it)
+  explicit NodeIterator(
+      const ITERATORTYPE & it,
+      const std::function<DATATYPE *(const ITERATORTYPE &)> & mapToPointer)
+      : it_(it),
+        MapToPointer_(mapToPointer)
   {}
 
 public:
   [[nodiscard]] DATATYPE *
   Node() const noexcept
   {
-    return it_->second.get();
+    return MapToPointer_(it_);
   }
 
   DATATYPE &
@@ -877,6 +880,7 @@ public:
 
 private:
   ITERATORTYPE it_;
+  std::function<DATATYPE *(const ITERATORTYPE &)> MapToPointer_;
 };
 
 /** \brief Points-to graph node const iterator
@@ -894,15 +898,18 @@ public:
 private:
   friend PointsToGraph;
 
-  explicit NodeConstIterator(const ITERATORTYPE & it)
-      : it_(it)
+  explicit NodeConstIterator(
+      const ITERATORTYPE & it,
+      const std::function<DATATYPE *(const ITERATORTYPE &)> & mapToPointer)
+      : it_(it),
+        MapToPointer_(mapToPointer)
   {}
 
 public:
   [[nodiscard]] const DATATYPE *
   Node() const noexcept
   {
-    return it_->second.get();
+    return MapToPointer_(it_);
   }
 
   const DATATYPE &
@@ -947,6 +954,7 @@ public:
 
 private:
   ITERATORTYPE it_;
+  std::function<DATATYPE *(const ITERATORTYPE &)> MapToPointer_;
 };
 
 /** \brief Points-to graph edge iterator

--- a/tests/jlm/llvm/opt/alias-analyses/Makefile.sub
+++ b/tests/jlm/llvm/opt/alias-analyses/Makefile.sub
@@ -3,5 +3,6 @@ TESTS += \
 	jlm/llvm/opt/alias-analyses/TestAndersen \
 	jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder \
 	jlm/llvm/opt/alias-analyses/TestPointerObjectSet \
+	jlm/llvm/opt/alias-analyses/TestPointsToGraph \
 	jlm/llvm/opt/alias-analyses/TestRegionAwareMemoryNodeProvider \
 	jlm/llvm/opt/alias-analyses/TestSteensgaard \

--- a/tests/jlm/llvm/opt/alias-analyses/TestPointsToGraph.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestPointsToGraph.cpp
@@ -197,7 +197,7 @@ TestRegisterSetNodeIteration()
   test.InitializeTest();
 
   auto pointsToGraph = aa::PointsToGraph::Create();
-  
+
   jlm::util::HashSet<const jlm::rvsdg::output *> registers(
       { test.alloca_a->output(0), test.alloca_b->output(0) });
   aa::PointsToGraph::RegisterSetNode::Create(*pointsToGraph, registers);

--- a/tests/jlm/llvm/opt/alias-analyses/TestPointsToGraph.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestPointsToGraph.cpp
@@ -187,10 +187,35 @@ TestNodeIterators()
   }
 }
 
+static void
+TestRegisterSetNodeIteration()
+{
+  using namespace jlm::llvm;
+
+  // Arrange
+  jlm::tests::StoreTest2 test;
+  test.InitializeTest();
+
+  auto pointsToGraph = aa::PointsToGraph::Create();
+  
+  jlm::util::HashSet<const jlm::rvsdg::output *> registers(
+      { test.alloca_a->output(0), test.alloca_b->output(0) });
+  aa::PointsToGraph::RegisterSetNode::Create(*pointsToGraph, registers);
+
+  // Act
+  size_t numIteratedRegisterSetNodes = 0;
+  for ([[maybe_unused]] auto & registerSetNode : pointsToGraph->RegisterSetNodes())
+    numIteratedRegisterSetNodes++;
+
+  // Assert
+  assert(numIteratedRegisterSetNodes == pointsToGraph->NumRegisterSetNodes());
+}
+
 static int
 TestPointsToGraph()
 {
   TestNodeIterators();
+  TestRegisterSetNodeIteration();
 
   return 0;
 }

--- a/tests/jlm/llvm/opt/alias-analyses/TestPointsToGraph.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestPointsToGraph.cpp
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2023 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <test-registry.hpp>
+#include <TestRvsdgs.hpp>
+
+#include <jlm/llvm/opt/alias-analyses/AliasAnalysis.hpp>
+#include <jlm/llvm/opt/alias-analyses/PointsToGraph.hpp>
+#include <jlm/util/Statistics.hpp>
+
+/**
+ * A simple test analysis that does nothing else than creating some points-to graph nodes and edges.
+ */
+class TestAnalysis final : public jlm::llvm::aa::AliasAnalysis
+{
+public:
+  std::unique_ptr<jlm::llvm::aa::PointsToGraph>
+  Analyze(
+      const jlm::llvm::RvsdgModule & rvsdgModule,
+      jlm::util::StatisticsCollector & statisticsCollector) override
+  {
+    PointsToGraph_ = jlm::llvm::aa::PointsToGraph::Create();
+
+    AnalyzeImports(rvsdgModule.Rvsdg());
+    AnalyzeRegion(*rvsdgModule.Rvsdg().root());
+
+    return std::move(PointsToGraph_);
+  }
+
+  std::unique_ptr<jlm::llvm::aa::PointsToGraph>
+  Analyze(const jlm::llvm::RvsdgModule & rvsdgModule)
+  {
+    jlm::util::StatisticsCollector statisticsCollector;
+    return Analyze(rvsdgModule, statisticsCollector);
+  }
+
+  static std::unique_ptr<jlm::llvm::aa::PointsToGraph>
+  CreateAndAnalyze(const jlm::llvm::RvsdgModule & rvsdgModule)
+  {
+    TestAnalysis analysis;
+    return analysis.Analyze(rvsdgModule);
+  }
+
+private:
+  void
+  AnalyzeRegion(jlm::rvsdg::region & region)
+  {
+    using namespace jlm::llvm;
+
+    for (auto & node : region.nodes)
+    {
+      if (jlm::rvsdg::is<alloca_op>(&node))
+      {
+        auto & allocaNode = aa::PointsToGraph::AllocaNode::Create(*PointsToGraph_, node);
+        auto & registerNode =
+            aa::PointsToGraph::RegisterSetNode::Create(*PointsToGraph_, { node.output(0) });
+        registerNode.AddEdge(allocaNode);
+      }
+      else if (jlm::rvsdg::is<malloc_op>(&node))
+      {
+        auto & mallocNode = aa::PointsToGraph::MallocNode::Create(*PointsToGraph_, node);
+        auto & registerNode =
+            aa::PointsToGraph::RegisterSetNode::Create(*PointsToGraph_, { node.output(0) });
+        registerNode.AddEdge(mallocNode);
+      }
+      else if (auto deltaNode = dynamic_cast<const delta::node *>(&node))
+      {
+        auto & deltaPtgNode = aa::PointsToGraph::DeltaNode::Create(*PointsToGraph_, *deltaNode);
+        auto & registerNode =
+            aa::PointsToGraph::RegisterSetNode::Create(*PointsToGraph_, { deltaNode->output() });
+        registerNode.AddEdge(deltaPtgNode);
+
+        AnalyzeRegion(*deltaNode->subregion());
+      }
+      else if (auto lambdaNode = dynamic_cast<const lambda::node *>(&node))
+      {
+        auto & lambdaPtgNode = aa::PointsToGraph::LambdaNode::Create(*PointsToGraph_, *lambdaNode);
+        auto & registerNode =
+            aa::PointsToGraph::RegisterSetNode::Create(*PointsToGraph_, { lambdaNode->output() });
+        registerNode.AddEdge(lambdaPtgNode);
+
+        AnalyzeRegion(*lambdaNode->subregion());
+      }
+    }
+  }
+
+  void
+  AnalyzeImports(const jlm::rvsdg::graph & rvsdg)
+  {
+    using namespace jlm::llvm;
+
+    auto & rootRegion = *rvsdg.root();
+    for (size_t n = 0; n < rootRegion.narguments(); n++)
+    {
+      auto & argument = *rootRegion.argument(n);
+
+      auto & importNode = aa::PointsToGraph::ImportNode::Create(*PointsToGraph_, argument);
+      auto & registerNode =
+          aa::PointsToGraph::RegisterSetNode::Create(*PointsToGraph_, { &argument });
+      registerNode.AddEdge(importNode);
+    }
+  }
+
+  std::unique_ptr<jlm::llvm::aa::PointsToGraph> PointsToGraph_;
+};
+
+static void
+TestNodeIterators()
+{
+  // Arrange
+  jlm::tests::AllMemoryNodesTest test;
+  auto pointsToGraph = TestAnalysis::CreateAndAnalyze(test.module());
+  auto constPointsToGraph = static_cast<const jlm::llvm::aa::PointsToGraph *>(pointsToGraph.get());
+
+  // Act and Arrange
+  assert(pointsToGraph->NumImportNodes() == 1);
+  for (auto & importNode : pointsToGraph->ImportNodes())
+  {
+    assert(&importNode.GetArgument() == &test.GetImportOutput());
+  }
+  for (auto & importNode : constPointsToGraph->ImportNodes())
+  {
+    assert(&importNode.GetArgument() == &test.GetImportOutput());
+  }
+
+  assert(pointsToGraph->NumLambdaNodes() == 1);
+  for (auto & lambdaNode : pointsToGraph->LambdaNodes())
+  {
+    assert(&lambdaNode.GetLambdaNode() == &test.GetLambdaNode());
+  }
+  for (auto & lambdaNode : constPointsToGraph->LambdaNodes())
+  {
+    assert(&lambdaNode.GetLambdaNode() == &test.GetLambdaNode());
+  }
+
+  assert(pointsToGraph->NumDeltaNodes() == 1);
+  for (auto & deltaNode : pointsToGraph->DeltaNodes())
+  {
+    assert(&deltaNode.GetDeltaNode() == &test.GetDeltaNode());
+  }
+  for (auto & deltaNode : constPointsToGraph->DeltaNodes())
+  {
+    assert(&deltaNode.GetDeltaNode() == &test.GetDeltaNode());
+  }
+
+  assert(pointsToGraph->NumAllocaNodes() == 1);
+  for (auto & allocaNode : pointsToGraph->AllocaNodes())
+  {
+    assert(&allocaNode.GetAllocaNode() == &test.GetAllocaNode());
+  }
+  for (auto & allocaNode : constPointsToGraph->AllocaNodes())
+  {
+    assert(&allocaNode.GetAllocaNode() == &test.GetAllocaNode());
+  }
+
+  assert(pointsToGraph->NumMallocNodes() == 1);
+  for (auto & mallocNode : pointsToGraph->MallocNodes())
+  {
+    assert(&mallocNode.GetMallocNode() == &test.GetMallocNode());
+  }
+  for (auto & mallocNode : constPointsToGraph->MallocNodes())
+  {
+    assert(&mallocNode.GetMallocNode() == &test.GetMallocNode());
+  }
+
+  assert(pointsToGraph->NumRegisterSetNodes() == 5);
+  jlm::util::HashSet<const jlm::rvsdg::output *> expectedRegisters({ &test.GetImportOutput(),
+                                                                     &test.GetLambdaOutput(),
+                                                                     &test.GetDeltaOutput(),
+                                                                     &test.GetAllocaOutput(),
+                                                                     &test.GetMallocOutput() });
+  for (auto & registerNode : pointsToGraph->RegisterSetNodes())
+  {
+    for (auto & output : registerNode.GetOutputs().Items())
+    {
+      assert(expectedRegisters.Contains(output));
+    }
+  }
+  for (auto & registerNode : constPointsToGraph->RegisterSetNodes())
+  {
+    for (auto & output : registerNode.GetOutputs().Items())
+    {
+      assert(expectedRegisters.Contains(output));
+    }
+  }
+}
+
+static int
+TestPointsToGraph()
+{
+  TestNodeIterators();
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER("jlm/llvm/opt/alias-analyses/TestPointsToGraph", TestPointsToGraph)


### PR DESCRIPTION
This PR fixes four bugs introduced by this [PR](https://github.com/phate/jlm/pull/324):

1. It fixes the instantiation for the register-set node iterators. They were never instantiated and the code actually did not compile. A unit test was added that this cannot happen again.
2. The register-set nodes are now part of the DOT output. They were not printed before. :-/ This was only manually checked, and no unit test was added. We would need a graphviz data model to check this conveniently, i.e., without a string parsing mess.
3. It fixes the DebugString() method of the RegisterSetNode class. It segfaulted.
4. The iteration through the register set nodes of a points-to graph resulted in multiple visitations to the same register set nodes. The consequence was a messed up graphviz output. A unit test was added to ensure that this problem won't occur again.

Finally, the register-set node debug string was improved, making the dot graph more readable.

Moral of the story: Don't be too lazy to write unit test kids. All of these bugs could have been avoided if I would have invested in some unit tests for the points-to graph when I created the data structure. Oh well....