### PR TITLE
Fix load-mux reduction

### DIFF
--- a/jlm/llvm/ir/operators/load.cpp
+++ b/jlm/llvm/ir/operators/load.cpp
@@ -59,7 +59,7 @@ is_load_mux_reducible(const std::vector<rvsdg::output *> & operands)
   auto memStateMergeNode = rvsdg::node_output::node(operands[1]);
   if (!is<MemStateMergeOperator>(memStateMergeNode))
     return false;
-  
+
   return true;
 }
 

--- a/jlm/llvm/ir/operators/load.cpp
+++ b/jlm/llvm/ir/operators/load.cpp
@@ -48,15 +48,18 @@ LoadOperation::copy() const
 static bool
 is_load_mux_reducible(const std::vector<rvsdg::output *> & operands)
 {
-  JLM_ASSERT(operands.size() >= 2);
-
-  auto memStateMergeNode = rvsdg::node_output::node(operands[1]);
-  if (!is<MemStateMergeOperator>(memStateMergeNode))
+  // Ignore loads that have no state edge.
+  // This can happen when the compiler can statically show that the address of a load is NULL.
+  if (operands.size() == 1)
     return false;
 
   if (operands.size() != 2)
     return false;
 
+  auto memStateMergeNode = rvsdg::node_output::node(operands[1]);
+  if (!is<MemStateMergeOperator>(memStateMergeNode))
+    return false;
+  
   return true;
 }
 

--- a/tests/jlm/llvm/opt/TestLoadMuxReduction.cpp
+++ b/tests/jlm/llvm/opt/TestLoadMuxReduction.cpp
@@ -12,10 +12,11 @@
 #include <jlm/rvsdg/view.hpp>
 
 static void
-test_load_mux_reduction()
+TestSuccess()
 {
   using namespace jlm::llvm;
 
+  // Arrange
   jlm::tests::valuetype vt;
   PointerType pt;
   MemoryStateType mt;
@@ -38,6 +39,7 @@ test_load_mux_reduction()
 
   // jlm::rvsdg::view(graph.root(), stdout);
 
+  // Act
   nf->set_mutable(true);
   nf->set_load_mux_reducible(true);
   graph.normalize();
@@ -45,6 +47,7 @@ test_load_mux_reduction()
 
   // jlm::rvsdg::view(graph.root(), stdout);
 
+  // Assert
   auto load = jlm::rvsdg::node_output::node(ex1->origin());
   assert(is<LoadOperation>(load));
   assert(load->ninputs() == 4);
@@ -63,11 +66,9 @@ test_load_mux_reduction()
 }
 
 static void
-test_load_mux_reduction2()
+TestWrongNumberOfOperands()
 {
-  /*
-   * Arrange
-   */
+  // Arrange
   using namespace jlm::llvm;
 
   jlm::tests::valuetype vt;
@@ -92,9 +93,7 @@ test_load_mux_reduction2()
 
   jlm::rvsdg::view(graph.root(), stdout);
 
-  /*
-   * Act
-   */
+  // Act
   nf->set_mutable(true);
   nf->set_load_mux_reducible(true);
   graph.normalize();
@@ -102,12 +101,10 @@ test_load_mux_reduction2()
 
   jlm::rvsdg::view(graph.root(), stdout);
 
-  /*
-   * Assert
-   *
-   * The LoadMux reduction should not be performed, as the current implementation does not correctly
-   * take care of the two identical load state operands originating from the merge node.
-   */
+  // Assert
+  
+  // The LoadMux reduction should not be performed, as the current implementation does not correctly
+  // take care of the two identical load state operands originating from the merge node.
   assert(ld.size() == 3);
   assert(ex1->origin() == ld[0]);
   assert(ex2->origin() == ld[1]);
@@ -115,12 +112,12 @@ test_load_mux_reduction2()
 }
 
 static int
-test()
+TestLoadMuxReduction()
 {
-  test_load_mux_reduction();
-  test_load_mux_reduction2();
+  TestSuccess();
+  TestWrongNumberOfOperands();
 
   return 0;
 }
 
-JLM_UNIT_TEST_REGISTER("jlm/llvm/opt/TestLoadMuxReduction", test)
+JLM_UNIT_TEST_REGISTER("jlm/llvm/opt/TestLoadMuxReduction", TestLoadMuxReduction)


### PR DESCRIPTION
The load-mux reduction was unable to handle loads without state edges. This can happen when the compiler can statically determine that the address of the load is NULL. Even though this is an undefined program, the compiler should not panic and throw a hard error. This PR fixes the reduction and adds a unit test for this case.

Closes #331
Closes #323 

