### PR TITLE
Remove deprecated PointsToGraph::RegisterNode class

### DIFF
--- a/jlm/llvm/opt/alias-analyses/AgnosticMemoryNodeProvider.cpp
+++ b/jlm/llvm/opt/alias-analyses/AgnosticMemoryNodeProvider.cpp
@@ -71,13 +71,11 @@ public:
     JLM_ASSERT(is<PointerType>(output.type()));
 
     util::HashSet<const PointsToGraph::MemoryNode *> memoryNodes;
-    if (GetOutputNodesFromRegisterNode(output, memoryNodes))
-      return memoryNodes;
+    auto registerSetNode = &PointsToGraph_.GetRegisterSetNode(output);
+    for (auto & memoryNode : registerSetNode->Targets())
+      memoryNodes.Insert(&memoryNode);
 
-    if (GetOutputNodesFromRegisterSetNode(output, memoryNodes))
-      return memoryNodes;
-
-    throw util::error("Cannot find register in points-to graph.");
+    return memoryNodes;
   }
 
   static std::unique_ptr<AgnosticMemoryNodeProvisioning>
@@ -90,48 +88,6 @@ public:
   }
 
 private:
-  [[nodiscard]] bool
-  GetOutputNodesFromRegisterNode(
-      const rvsdg::output & output,
-      util::HashSet<const PointsToGraph::MemoryNode *> & memoryNodes) const
-  {
-    const PointsToGraph::RegisterNode * registerNode;
-    try
-    {
-      registerNode = &PointsToGraph_.GetRegisterNode(output);
-    }
-    catch (...)
-    {
-      return false;
-    }
-
-    for (auto & memoryNode : registerNode->Targets())
-      memoryNodes.Insert(&memoryNode);
-
-    return true;
-  }
-
-  [[nodiscard]] bool
-  GetOutputNodesFromRegisterSetNode(
-      const rvsdg::output & output,
-      util::HashSet<const PointsToGraph::MemoryNode *> & memoryNodes) const
-  {
-    const PointsToGraph::RegisterSetNode * registerSetNode;
-    try
-    {
-      registerSetNode = &PointsToGraph_.GetRegisterSetNode(output);
-    }
-    catch (...)
-    {
-      return false;
-    }
-
-    for (auto & memoryNode : registerSetNode->Targets())
-      memoryNodes.Insert(&memoryNode);
-
-    return true;
-  }
-
   const PointsToGraph & PointsToGraph_;
   util::HashSet<const PointsToGraph::MemoryNode *> MemoryNodes_;
 };

--- a/jlm/llvm/opt/alias-analyses/AgnosticMemoryNodeProvider.cpp
+++ b/jlm/llvm/opt/alias-analyses/AgnosticMemoryNodeProvider.cpp
@@ -71,8 +71,8 @@ public:
     JLM_ASSERT(is<PointerType>(output.type()));
 
     util::HashSet<const PointsToGraph::MemoryNode *> memoryNodes;
-    auto registerSetNode = &PointsToGraph_.GetRegisterSetNode(output);
-    for (auto & memoryNode : registerSetNode->Targets())
+    auto registerNode = &PointsToGraph_.GetRegisterNode(output);
+    for (auto & memoryNode : registerNode->Targets())
       memoryNodes.Insert(&memoryNode);
 
     return memoryNodes;

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -666,10 +666,10 @@ Andersen::ConstructPointsToGraphFromPointerObjectSet(const PointerObjectSet & se
     outputsInRegister[registerIdx].Insert(outputNode);
   }
 
-  // Create PointsToGraph::RegisterSetNodes for each PointerObject of register kind, and add edges
+  // Create PointsToGraph::RegisterNodes for each PointerObject of register kind, and add edges
   for (auto & [registerIdx, outputNodes] : outputsInRegister)
   {
-    auto & node = PointsToGraph::RegisterSetNode::Create(*pointsToGraph, std::move(outputNodes));
+    auto & node = PointsToGraph::RegisterNode::Create(*pointsToGraph, std::move(outputNodes));
     applyPointsToSet(node, registerIdx);
   }
 

--- a/jlm/llvm/opt/alias-analyses/PointsToGraph.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraph.cpp
@@ -90,18 +90,18 @@ PointsToGraph::ImportNodes() const
            ImportNodeConstIterator(ImportNodes_.end()) };
 }
 
-PointsToGraph::RegisterSetNodeRange
-PointsToGraph::RegisterSetNodes()
+PointsToGraph::RegisterNodeRange
+PointsToGraph::RegisterNodes()
 {
-  return { RegisterSetNodeIterator(RegisterSetNodes_.begin()),
-           RegisterSetNodeIterator(RegisterSetNodes_.end()) };
+  return { RegisterNodeIterator(RegisterNodes_.begin()),
+           RegisterNodeIterator(RegisterNodes_.end()) };
 }
 
-PointsToGraph::RegisterSetNodeConstRange
-PointsToGraph::RegisterSetNodes() const
+PointsToGraph::RegisterNodeConstRange
+PointsToGraph::RegisterNodes() const
 {
-  return { RegisterSetNodeConstIterator(RegisterSetNodes_.begin()),
-           RegisterSetNodeConstIterator(RegisterSetNodes_.end()) };
+  return { RegisterNodeConstIterator(RegisterNodes_.begin()),
+           RegisterNodeConstIterator(RegisterNodes_.end()) };
 }
 
 PointsToGraph::AllocaNode &
@@ -140,14 +140,14 @@ PointsToGraph::AddMallocNode(std::unique_ptr<PointsToGraph::MallocNode> node)
   return *tmp;
 }
 
-PointsToGraph::RegisterSetNode &
-PointsToGraph::AddRegisterSetNode(std::unique_ptr<PointsToGraph::RegisterSetNode> node)
+PointsToGraph::RegisterNode &
+PointsToGraph::AddRegisterNode(std::unique_ptr<PointsToGraph::RegisterNode> node)
 {
   auto tmp = node.get();
   for (auto output : node->GetOutputs().Items())
-    RegisterSetNodeMap_[output] = tmp;
+    RegisterNodeMap_[output] = tmp;
 
-  RegisterSetNodes_.emplace_back(std::move(node));
+  RegisterNodes_.emplace_back(std::move(node));
 
   return *tmp;
 }
@@ -183,7 +183,7 @@ PointsToGraph::ToDot(
           { typeid(ImportNode), "box" },
           { typeid(LambdaNode), "box" },
           { typeid(MallocNode), "box" },
-          { typeid(RegisterSetNode), "oval" },
+          { typeid(RegisterNode), "oval" },
           { typeid(UnknownMemoryNode), "box" },
           { typeid(ExternalMemoryNode), "box" } });
 
@@ -196,18 +196,18 @@ PointsToGraph::ToDot(
   auto nodeLabel = [&](const PointsToGraph::Node & node)
   {
     // If the node is NOT a register node, then the label is just the DebugString
-    auto registerSetNode = dynamic_cast<const RegisterSetNode *>(&node);
-    if (registerSetNode == nullptr)
+    auto registerNode = dynamic_cast<const RegisterNode *>(&node);
+    if (registerNode == nullptr)
     {
       return node.DebugString();
     }
 
     // Otherwise, include the mapped name (if any) to its rvsdg::outputs.
     std::string label;
-    auto outputs = registerSetNode->GetOutputs();
+    auto outputs = registerNode->GetOutputs();
     for (auto output : outputs.Items())
     {
-      label += RegisterSetNode::ToString(*output);
+      label += RegisterNode::ToString(*output);
       if (auto it = outputMap.find(output); it != outputMap.end())
       {
         label += util::strfmt(" (", it->second, ")");
@@ -268,8 +268,8 @@ PointsToGraph::ToDot(
   for (auto & mallocNode : pointsToGraph.MallocNodes())
     dot += printNodeAndEdges(mallocNode);
 
-  for (auto & registerSetNode : pointsToGraph.RegisterSetNodes())
-    dot += printNodeAndEdges(registerSetNode);
+  for (auto & registerNode : pointsToGraph.RegisterNodes())
+    dot += printNodeAndEdges(registerNode);
 
   dot += nodeString(pointsToGraph.GetUnknownMemoryNode());
   dot += nodeString(pointsToGraph.GetExternalMemoryNode());
@@ -325,10 +325,10 @@ PointsToGraph::Node::RemoveEdge(PointsToGraph::MemoryNode & target)
   Targets_.erase(&target);
 }
 
-PointsToGraph::RegisterSetNode::~RegisterSetNode() noexcept = default;
+PointsToGraph::RegisterNode::~RegisterNode() noexcept = default;
 
 std::string
-PointsToGraph::RegisterSetNode::ToString(const rvsdg::output & output)
+PointsToGraph::RegisterNode::ToString(const rvsdg::output & output)
 {
   auto node = jlm::rvsdg::node_output::node(&output);
 
@@ -349,7 +349,7 @@ PointsToGraph::RegisterSetNode::ToString(const rvsdg::output & output)
 }
 
 std::string
-PointsToGraph::RegisterSetNode::DebugString() const
+PointsToGraph::RegisterNode::DebugString() const
 {
   auto & outputs = GetOutputs();
 

--- a/jlm/llvm/opt/alias-analyses/PointsToGraph.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraph.hpp
@@ -45,7 +45,6 @@ public:
   class MallocNode;
   class MemoryNode;
   class Node;
-  class RegisterNode;
   class RegisterSetNode;
   class UnknownMemoryNode;
   class ExternalMemoryNode;
@@ -60,8 +59,6 @@ public:
       std::unordered_map<const lambda::node *, std::unique_ptr<PointsToGraph::LambdaNode>>;
   using MallocNodeMap =
       std::unordered_map<const jlm::rvsdg::node *, std::unique_ptr<PointsToGraph::MallocNode>>;
-  using RegisterNodeMap =
-      std::unordered_map<const jlm::rvsdg::output *, std::unique_ptr<PointsToGraph::RegisterNode>>;
   using RegisterSetNodeMap =
       std::unordered_map<const rvsdg::output *, PointsToGraph::RegisterSetNode *>;
   using RegisterSetNodeVector = std::vector<std::unique_ptr<PointsToGraph::RegisterSetNode>>;
@@ -131,17 +128,6 @@ public:
   using MallocNodeRange = jlm::util::iterator_range<MallocNodeIterator>;
   using MallocNodeConstRange = jlm::util::iterator_range<MallocNodeConstIterator>;
 
-  using RegisterNodeIterator = NodeIterator<
-      RegisterNode,
-      RegisterNodeMap::iterator,
-      IteratorToPointerFunctor<RegisterNode, RegisterNodeMap::iterator>>;
-  using RegisterNodeConstIterator = NodeConstIterator<
-      RegisterNode,
-      RegisterNodeMap::const_iterator,
-      IteratorToPointerFunctor<RegisterNode, RegisterNodeMap::const_iterator>>;
-  using RegisterNodeRange = jlm::util::iterator_range<RegisterNodeIterator>;
-  using RegisterNodeConstRange = jlm::util::iterator_range<RegisterNodeConstIterator>;
-
   template<class IteratorType>
   struct RegisterSetNodeIteratorToPointerFunctor
   {
@@ -207,12 +193,6 @@ public:
   MallocNodeConstRange
   MallocNodes() const;
 
-  RegisterNodeRange
-  RegisterNodes();
-
-  RegisterNodeConstRange
-  RegisterNodes() const;
-
   RegisterSetNodeRange
   RegisterSetNodes();
 
@@ -249,12 +229,6 @@ public:
     return MallocNodes_.size();
   }
 
-  size_t
-  NumRegisterNodes() const noexcept
-  {
-    return RegisterNodes_.size();
-  }
-
   [[nodiscard]] size_t
   NumRegisterSetNodes() const noexcept
   {
@@ -271,7 +245,7 @@ public:
   size_t
   NumNodes() const noexcept
   {
-    return NumMemoryNodes() + NumRegisterNodes() + NumRegisterSetNodes();
+    return NumMemoryNodes() + NumRegisterSetNodes();
   }
 
   PointsToGraph::UnknownMemoryNode &
@@ -336,16 +310,6 @@ public:
     return *it->second;
   }
 
-  const PointsToGraph::RegisterNode &
-  GetRegisterNode(const jlm::rvsdg::output & output) const
-  {
-    auto it = RegisterNodes_.find(&output);
-    if (it == RegisterNodes_.end())
-      throw jlm::util::error("Cannot find register node in points-to graph.");
-
-    return *it->second;
-  }
-
   const PointsToGraph::RegisterSetNode &
   GetRegisterSetNode(const rvsdg::output & output) const
   {
@@ -380,9 +344,6 @@ public:
 
   PointsToGraph::MallocNode &
   AddMallocNode(std::unique_ptr<PointsToGraph::MallocNode> node);
-
-  PointsToGraph::RegisterNode &
-  AddRegisterNode(std::unique_ptr<PointsToGraph::RegisterNode> node);
 
   PointsToGraph::RegisterSetNode &
   AddRegisterSetNode(std::unique_ptr<PointsToGraph::RegisterSetNode> node);
@@ -435,7 +396,6 @@ private:
   ImportNodeMap ImportNodes_;
   LambdaNodeMap LambdaNodes_;
   MallocNodeMap MallocNodes_;
-  RegisterNodeMap RegisterNodes_;
 
   RegisterSetNodeMap RegisterSetNodeMap_;
   RegisterSetNodeVector RegisterSetNodes_;
@@ -539,42 +499,6 @@ private:
   std::unordered_set<PointsToGraph::Node *> Sources_;
 };
 
-/** \brief PointsTo graph register node
- *
- */
-class PointsToGraph::RegisterNode final : public PointsToGraph::Node
-{
-public:
-  ~RegisterNode() noexcept override;
-
-private:
-  RegisterNode(PointsToGraph & pointsToGraph, const jlm::rvsdg::output & output)
-      : Node(pointsToGraph),
-        Output_(&output)
-  {}
-
-public:
-  const jlm::rvsdg::output &
-  GetOutput() const noexcept
-  {
-    return *Output_;
-  }
-
-  std::string
-  DebugString() const override;
-
-  static PointsToGraph::RegisterNode &
-  Create(PointsToGraph & pointsToGraph, const jlm::rvsdg::output & output)
-  {
-    auto node =
-        std::unique_ptr<PointsToGraph::RegisterNode>(new RegisterNode(pointsToGraph, output));
-    return pointsToGraph.AddRegisterNode(std::move(node));
-  }
-
-private:
-  const jlm::rvsdg::output * Output_;
-};
-
 /**
  * Represents a set of registers from the RVSDG that all point to the same
  * PointsToGraph::MemoryNode%s.
@@ -599,6 +523,9 @@ public:
 
   std::string
   DebugString() const override;
+
+  static std::string
+  ToString(const rvsdg::output & output);
 
   static PointsToGraph::RegisterSetNode &
   Create(PointsToGraph & pointsToGraph, util::HashSet<const rvsdg::output *> outputs)

--- a/jlm/llvm/opt/alias-analyses/PointsToGraph.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraph.hpp
@@ -45,7 +45,7 @@ public:
   class MallocNode;
   class MemoryNode;
   class Node;
-  class RegisterSetNode;
+  class RegisterNode;
   class UnknownMemoryNode;
   class ExternalMemoryNode;
 
@@ -59,9 +59,8 @@ public:
       std::unordered_map<const lambda::node *, std::unique_ptr<PointsToGraph::LambdaNode>>;
   using MallocNodeMap =
       std::unordered_map<const jlm::rvsdg::node *, std::unique_ptr<PointsToGraph::MallocNode>>;
-  using RegisterSetNodeMap =
-      std::unordered_map<const rvsdg::output *, PointsToGraph::RegisterSetNode *>;
-  using RegisterSetNodeVector = std::vector<std::unique_ptr<PointsToGraph::RegisterSetNode>>;
+  using RegisterNodeMap = std::unordered_map<const rvsdg::output *, PointsToGraph::RegisterNode *>;
+  using RegisterNodeVector = std::vector<std::unique_ptr<PointsToGraph::RegisterNode>>;
 
   template<class DataType, class IteratorType>
   struct IteratorToPointerFunctor
@@ -129,25 +128,25 @@ public:
   using MallocNodeConstRange = jlm::util::iterator_range<MallocNodeConstIterator>;
 
   template<class IteratorType>
-  struct RegisterSetNodeIteratorToPointerFunctor
+  struct RegisterNodeIteratorToPointerFunctor
   {
-    RegisterSetNode *
+    RegisterNode *
     operator()(const IteratorType & it) const
     {
       return it->get();
     }
   };
 
-  using RegisterSetNodeIterator = NodeIterator<
-      RegisterSetNode,
-      RegisterSetNodeVector::iterator,
-      RegisterSetNodeIteratorToPointerFunctor<RegisterSetNodeVector::iterator>>;
-  using RegisterSetNodeConstIterator = NodeConstIterator<
-      RegisterSetNode,
-      RegisterSetNodeVector::const_iterator,
-      RegisterSetNodeIteratorToPointerFunctor<RegisterSetNodeVector::const_iterator>>;
-  using RegisterSetNodeRange = util::iterator_range<RegisterSetNodeIterator>;
-  using RegisterSetNodeConstRange = util::iterator_range<RegisterSetNodeConstIterator>;
+  using RegisterNodeIterator = NodeIterator<
+      RegisterNode,
+      RegisterNodeVector::iterator,
+      RegisterNodeIteratorToPointerFunctor<RegisterNodeVector::iterator>>;
+  using RegisterNodeConstIterator = NodeConstIterator<
+      RegisterNode,
+      RegisterNodeVector::const_iterator,
+      RegisterNodeIteratorToPointerFunctor<RegisterNodeVector::const_iterator>>;
+  using RegisterNodeRange = util::iterator_range<RegisterNodeIterator>;
+  using RegisterNodeConstRange = util::iterator_range<RegisterNodeConstIterator>;
 
 private:
   PointsToGraph();
@@ -193,11 +192,11 @@ public:
   MallocNodeConstRange
   MallocNodes() const;
 
-  RegisterSetNodeRange
-  RegisterSetNodes();
+  RegisterNodeRange
+  RegisterNodes();
 
-  RegisterSetNodeConstRange
-  RegisterSetNodes() const;
+  RegisterNodeConstRange
+  RegisterNodes() const;
 
   size_t
   NumAllocaNodes() const noexcept
@@ -230,9 +229,9 @@ public:
   }
 
   [[nodiscard]] size_t
-  NumRegisterSetNodes() const noexcept
+  NumRegisterNodes() const noexcept
   {
-    return RegisterSetNodes_.size();
+    return RegisterNodes_.size();
   }
 
   size_t
@@ -245,7 +244,7 @@ public:
   size_t
   NumNodes() const noexcept
   {
-    return NumMemoryNodes() + NumRegisterSetNodes();
+    return NumMemoryNodes() + NumRegisterNodes();
   }
 
   PointsToGraph::UnknownMemoryNode &
@@ -310,11 +309,11 @@ public:
     return *it->second;
   }
 
-  const PointsToGraph::RegisterSetNode &
-  GetRegisterSetNode(const rvsdg::output & output) const
+  const PointsToGraph::RegisterNode &
+  GetRegisterNode(const rvsdg::output & output) const
   {
-    auto it = RegisterSetNodeMap_.find(&output);
-    if (it == RegisterSetNodeMap_.end())
+    auto it = RegisterNodeMap_.find(&output);
+    if (it == RegisterNodeMap_.end())
       throw util::error("Cannot find register set node in points-to graph.");
 
     return *it->second;
@@ -345,8 +344,8 @@ public:
   PointsToGraph::MallocNode &
   AddMallocNode(std::unique_ptr<PointsToGraph::MallocNode> node);
 
-  PointsToGraph::RegisterSetNode &
-  AddRegisterSetNode(std::unique_ptr<PointsToGraph::RegisterSetNode> node);
+  PointsToGraph::RegisterNode &
+  AddRegisterNode(std::unique_ptr<PointsToGraph::RegisterNode> node);
 
   PointsToGraph::ImportNode &
   AddImportNode(std::unique_ptr<PointsToGraph::ImportNode> node);
@@ -397,8 +396,8 @@ private:
   LambdaNodeMap LambdaNodes_;
   MallocNodeMap MallocNodes_;
 
-  RegisterSetNodeMap RegisterSetNodeMap_;
-  RegisterSetNodeVector RegisterSetNodes_;
+  RegisterNodeMap RegisterNodeMap_;
+  RegisterNodeVector RegisterNodes_;
 
   std::unique_ptr<PointsToGraph::UnknownMemoryNode> UnknownMemoryNode_;
   std::unique_ptr<ExternalMemoryNode> ExternalMemoryNode_;
@@ -503,13 +502,13 @@ private:
  * Represents a set of registers from the RVSDG that all point to the same
  * PointsToGraph::MemoryNode%s.
  */
-class PointsToGraph::RegisterSetNode final : public PointsToGraph::Node
+class PointsToGraph::RegisterNode final : public PointsToGraph::Node
 {
 public:
-  ~RegisterSetNode() noexcept override;
+  ~RegisterNode() noexcept override;
 
 private:
-  RegisterSetNode(PointsToGraph & pointsToGraph, util::HashSet<const rvsdg::output *> outputs)
+  RegisterNode(PointsToGraph & pointsToGraph, util::HashSet<const rvsdg::output *> outputs)
       : Node(pointsToGraph),
         Outputs_(std::move(outputs))
   {}
@@ -527,12 +526,12 @@ public:
   static std::string
   ToString(const rvsdg::output & output);
 
-  static PointsToGraph::RegisterSetNode &
+  static PointsToGraph::RegisterNode &
   Create(PointsToGraph & pointsToGraph, util::HashSet<const rvsdg::output *> outputs)
   {
-    auto node = std::unique_ptr<PointsToGraph::RegisterSetNode>(
-        new RegisterSetNode(pointsToGraph, std::move(outputs)));
-    return pointsToGraph.AddRegisterSetNode(std::move(node));
+    auto node = std::unique_ptr<PointsToGraph::RegisterNode>(
+        new RegisterNode(pointsToGraph, std::move(outputs)));
+    return pointsToGraph.AddRegisterNode(std::move(node));
   }
 
 private:

--- a/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.cpp
+++ b/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.cpp
@@ -301,8 +301,8 @@ public:
     JLM_ASSERT(is<PointerType>(output.type()));
 
     util::HashSet<const PointsToGraph::MemoryNode *> memoryNodes;
-    auto registerSetNode = &PointsToGraph_.GetRegisterSetNode(output);
-    for (auto & memoryNode : registerSetNode->Targets())
+    auto registerNode = &PointsToGraph_.GetRegisterNode(output);
+    for (auto & memoryNode : registerNode->Targets())
       memoryNodes.Insert(&memoryNode);
 
     return memoryNodes;

--- a/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.cpp
+++ b/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.cpp
@@ -301,13 +301,11 @@ public:
     JLM_ASSERT(is<PointerType>(output.type()));
 
     util::HashSet<const PointsToGraph::MemoryNode *> memoryNodes;
-    if (GetOutputNodesFromRegisterNode(output, memoryNodes))
-      return memoryNodes;
+    auto registerSetNode = &PointsToGraph_.GetRegisterSetNode(output);
+    for (auto & memoryNode : registerSetNode->Targets())
+      memoryNodes.Insert(&memoryNode);
 
-    if (GetOutputNodesFromRegisterSetNode(output, memoryNodes))
-      return memoryNodes;
-
-    throw util::error("Cannot find register in points-to graph.");
+    return memoryNodes;
   }
 
   RegionSummaryConstRange
@@ -464,48 +462,6 @@ public:
   }
 
 private:
-  [[nodiscard]] bool
-  GetOutputNodesFromRegisterNode(
-      const rvsdg::output & output,
-      util::HashSet<const PointsToGraph::MemoryNode *> & memoryNodes) const
-  {
-    const PointsToGraph::RegisterNode * registerNode;
-    try
-    {
-      registerNode = &PointsToGraph_.GetRegisterNode(output);
-    }
-    catch (...)
-    {
-      return false;
-    }
-
-    for (auto & memoryNode : registerNode->Targets())
-      memoryNodes.Insert(&memoryNode);
-
-    return true;
-  }
-
-  [[nodiscard]] bool
-  GetOutputNodesFromRegisterSetNode(
-      const rvsdg::output & output,
-      util::HashSet<const PointsToGraph::MemoryNode *> & memoryNodes) const
-  {
-    const PointsToGraph::RegisterSetNode * registerSetNode;
-    try
-    {
-      registerSetNode = &PointsToGraph_.GetRegisterSetNode(output);
-    }
-    catch (...)
-    {
-      return false;
-    }
-
-    for (auto & memoryNode : registerSetNode->Targets())
-      memoryNodes.Insert(&memoryNode);
-
-    return true;
-  }
-
   [[nodiscard]] const util::HashSet<const PointsToGraph::MemoryNode *> &
   GetIndirectCallNodes(const CallNode & callNode) const
   {

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -795,7 +795,7 @@ public:
         NumLambdaNodes_(0),
         NumMallocNodes_(0),
         NumMemoryNodes_(0),
-        NumRegisterSetNodes_(0),
+        NumRegisterNodes_(0),
         NumUnknownMemorySources_(0)
   {}
 
@@ -831,7 +831,7 @@ public:
     NumLambdaNodes_ = pointsToGraph.NumLambdaNodes();
     NumMallocNodes_ = pointsToGraph.NumMallocNodes();
     NumMemoryNodes_ = pointsToGraph.NumMemoryNodes();
-    NumRegisterSetNodes_ = pointsToGraph.NumRegisterSetNodes();
+    NumRegisterNodes_ = pointsToGraph.NumRegisterNodes();
     NumUnknownMemorySources_ = pointsToGraph.GetUnknownMemoryNode().NumSources();
   }
 
@@ -887,8 +887,8 @@ public:
         "#MemoryNodes:",
         NumMemoryNodes_,
         " ",
-        "#RegisterSetNodes:",
-        NumRegisterSetNodes_,
+        "#RegisterNodes:",
+        NumRegisterNodes_,
         " ",
         "#UnknownMemorySources:",
         NumUnknownMemorySources_,
@@ -920,7 +920,7 @@ private:
   size_t NumLambdaNodes_;
   size_t NumMallocNodes_;
   size_t NumMemoryNodes_;
-  size_t NumRegisterSetNodes_;
+  size_t NumRegisterNodes_;
   size_t NumUnknownMemorySources_;
 
   util::timer AnalysisTimer_;
@@ -1857,10 +1857,10 @@ Steensgaard::ConstructPointsToGraph() const
     }
 
     // We found register locations in this set.
-    // Create a single points-to graph register-set node for all of them.
+    // Create a single points-to graph register node for all of them.
     if (!registerLocations.IsEmpty())
     {
-      auto & pointsToGraphNode = PointsToGraph::RegisterSetNode::Create(*pointsToGraph, registers);
+      auto & pointsToGraphNode = PointsToGraph::RegisterNode::Create(*pointsToGraph, registers);
       for (auto registerLocation : registerLocations.Items())
         locationMap[registerLocation] = &pointsToGraphNode;
     }

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -795,7 +795,7 @@ public:
         NumLambdaNodes_(0),
         NumMallocNodes_(0),
         NumMemoryNodes_(0),
-        NumRegisterNodes_(0),
+        NumRegisterSetNodes_(0),
         NumUnknownMemorySources_(0)
   {}
 
@@ -831,7 +831,7 @@ public:
     NumLambdaNodes_ = pointsToGraph.NumLambdaNodes();
     NumMallocNodes_ = pointsToGraph.NumMallocNodes();
     NumMemoryNodes_ = pointsToGraph.NumMemoryNodes();
-    NumRegisterNodes_ = pointsToGraph.NumRegisterNodes();
+    NumRegisterSetNodes_ = pointsToGraph.NumRegisterSetNodes();
     NumUnknownMemorySources_ = pointsToGraph.GetUnknownMemoryNode().NumSources();
   }
 
@@ -887,8 +887,8 @@ public:
         "#MemoryNodes:",
         NumMemoryNodes_,
         " ",
-        "#RegisterNodes:",
-        NumRegisterNodes_,
+        "#RegisterSetNodes:",
+        NumRegisterSetNodes_,
         " ",
         "#UnknownMemorySources:",
         NumUnknownMemorySources_,
@@ -920,7 +920,7 @@ private:
   size_t NumLambdaNodes_;
   size_t NumMallocNodes_;
   size_t NumMemoryNodes_;
-  size_t NumRegisterNodes_;
+  size_t NumRegisterSetNodes_;
   size_t NumUnknownMemorySources_;
 
   util::timer AnalysisTimer_;

--- a/tests/jlm/llvm/opt/alias-analyses/TestAndersen.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestAndersen.cpp
@@ -68,20 +68,20 @@ TestStore1()
 
   assert(ptg->NumAllocaNodes() == 4);
   assert(ptg->NumLambdaNodes() == 1);
-  assert(ptg->NumRegisterSetNodes() == 5);
+  assert(ptg->NumRegisterNodes() == 5);
 
   auto & alloca_a = ptg->GetAllocaNode(*test.alloca_a);
   auto & alloca_b = ptg->GetAllocaNode(*test.alloca_b);
   auto & alloca_c = ptg->GetAllocaNode(*test.alloca_c);
   auto & alloca_d = ptg->GetAllocaNode(*test.alloca_d);
 
-  auto & palloca_a = ptg->GetRegisterSetNode(*test.alloca_a->output(0));
-  auto & palloca_b = ptg->GetRegisterSetNode(*test.alloca_b->output(0));
-  auto & palloca_c = ptg->GetRegisterSetNode(*test.alloca_c->output(0));
-  auto & palloca_d = ptg->GetRegisterSetNode(*test.alloca_d->output(0));
+  auto & palloca_a = ptg->GetRegisterNode(*test.alloca_a->output(0));
+  auto & palloca_b = ptg->GetRegisterNode(*test.alloca_b->output(0));
+  auto & palloca_c = ptg->GetRegisterNode(*test.alloca_c->output(0));
+  auto & palloca_d = ptg->GetRegisterNode(*test.alloca_d->output(0));
 
   auto & lambda = ptg->GetLambdaNode(*test.lambda);
-  auto & plambda = ptg->GetRegisterSetNode(*test.lambda->output());
+  auto & plambda = ptg->GetRegisterNode(*test.lambda->output());
 
   assert(TargetsExactly(alloca_a, { &alloca_b }));
   assert(TargetsExactly(alloca_b, { &alloca_c }));
@@ -107,7 +107,7 @@ TestStore2()
 
   assert(ptg->NumAllocaNodes() == 5);
   assert(ptg->NumLambdaNodes() == 1);
-  assert(ptg->NumRegisterSetNodes() == 6);
+  assert(ptg->NumRegisterNodes() == 6);
 
   auto & alloca_a = ptg->GetAllocaNode(*test.alloca_a);
   auto & alloca_b = ptg->GetAllocaNode(*test.alloca_b);
@@ -115,14 +115,14 @@ TestStore2()
   auto & alloca_y = ptg->GetAllocaNode(*test.alloca_y);
   auto & alloca_p = ptg->GetAllocaNode(*test.alloca_p);
 
-  auto & palloca_a = ptg->GetRegisterSetNode(*test.alloca_a->output(0));
-  auto & palloca_b = ptg->GetRegisterSetNode(*test.alloca_b->output(0));
-  auto & palloca_x = ptg->GetRegisterSetNode(*test.alloca_x->output(0));
-  auto & palloca_y = ptg->GetRegisterSetNode(*test.alloca_y->output(0));
-  auto & palloca_p = ptg->GetRegisterSetNode(*test.alloca_p->output(0));
+  auto & palloca_a = ptg->GetRegisterNode(*test.alloca_a->output(0));
+  auto & palloca_b = ptg->GetRegisterNode(*test.alloca_b->output(0));
+  auto & palloca_x = ptg->GetRegisterNode(*test.alloca_x->output(0));
+  auto & palloca_y = ptg->GetRegisterNode(*test.alloca_y->output(0));
+  auto & palloca_p = ptg->GetRegisterNode(*test.alloca_p->output(0));
 
   auto & lambda = ptg->GetLambdaNode(*test.lambda);
-  auto & plambda = ptg->GetRegisterSetNode(*test.lambda->output());
+  auto & plambda = ptg->GetRegisterNode(*test.lambda->output());
 
   assert(TargetsExactly(alloca_a, {}));
   assert(TargetsExactly(alloca_b, {}));
@@ -149,13 +149,13 @@ TestLoad1()
   const auto ptg = RunAndersen(test.module());
 
   assert(ptg->NumLambdaNodes() == 1);
-  assert(ptg->NumRegisterSetNodes() == 3);
+  assert(ptg->NumRegisterNodes() == 3);
 
-  auto & loadResult = ptg->GetRegisterSetNode(*test.load_p->output(0));
+  auto & loadResult = ptg->GetRegisterNode(*test.load_p->output(0));
 
   auto & lambda = ptg->GetLambdaNode(*test.lambda);
-  auto & lambdaOutput = ptg->GetRegisterSetNode(*test.lambda->output());
-  auto & lambdaArgument0 = ptg->GetRegisterSetNode(*test.lambda->fctargument(0));
+  auto & lambdaOutput = ptg->GetRegisterNode(*test.lambda->output());
+  auto & lambdaArgument0 = ptg->GetRegisterNode(*test.lambda->fctargument(0));
 
   assert(TargetsExactly(loadResult, { &lambda, &ptg->GetExternalMemoryNode() }));
 
@@ -173,7 +173,7 @@ TestLoad2()
 
   assert(ptg->NumAllocaNodes() == 5);
   assert(ptg->NumLambdaNodes() == 1);
-  assert(ptg->NumRegisterSetNodes() == 8);
+  assert(ptg->NumRegisterNodes() == 8);
 
   auto & alloca_a = ptg->GetAllocaNode(*test.alloca_a);
   auto & alloca_b = ptg->GetAllocaNode(*test.alloca_b);
@@ -181,8 +181,8 @@ TestLoad2()
   auto & alloca_y = ptg->GetAllocaNode(*test.alloca_y);
   auto & alloca_p = ptg->GetAllocaNode(*test.alloca_p);
 
-  auto & pload_x = ptg->GetRegisterSetNode(*test.load_x->output(0));
-  auto & pload_a = ptg->GetRegisterSetNode(*test.load_a->output(0));
+  auto & pload_x = ptg->GetRegisterNode(*test.load_x->output(0));
+  auto & pload_a = ptg->GetRegisterNode(*test.load_a->output(0));
 
   auto & lambdaMemoryNode = ptg->GetLambdaNode(*test.lambda);
 
@@ -203,10 +203,10 @@ TestLoadFromUndef()
   const auto ptg = RunAndersen(test.module());
 
   assert(ptg->NumLambdaNodes() == 1);
-  assert(ptg->NumRegisterSetNodes() == 2);
+  assert(ptg->NumRegisterNodes() == 2);
 
   auto & lambdaMemoryNode = ptg->GetLambdaNode(test.Lambda());
-  auto & undefValueNode = ptg->GetRegisterSetNode(*test.UndefValueNode()->output(0));
+  auto & undefValueNode = ptg->GetRegisterNode(*test.UndefValueNode()->output(0));
 
   assert(TargetsExactly(undefValueNode, {}));
   assert(EscapedIsExactly(*ptg, { &lambdaMemoryNode }));
@@ -219,14 +219,14 @@ TestGetElementPtr()
   const auto ptg = RunAndersen(test.module());
 
   assert(ptg->NumLambdaNodes() == 1);
-  assert(ptg->NumRegisterSetNodes() == 2);
+  assert(ptg->NumRegisterNodes() == 2);
 
   // We only care about the getelemenptr's in this test, skipping the validation for all other nodes
   auto & lambda = ptg->GetLambdaNode(*test.lambda);
-  auto & gepX = ptg->GetRegisterSetNode(*test.getElementPtrX->output(0));
-  auto & gepY = ptg->GetRegisterSetNode(*test.getElementPtrY->output(0));
+  auto & gepX = ptg->GetRegisterNode(*test.getElementPtrX->output(0));
+  auto & gepY = ptg->GetRegisterNode(*test.getElementPtrY->output(0));
 
-  // The RegisterSetNode is the same
+  // The RegisterNode is the same
   assert(&gepX == &gepY);
 
   assert(TargetsExactly(gepX, { &lambda, &ptg->GetExternalMemoryNode() }));
@@ -241,12 +241,12 @@ TestBitCast()
   const auto ptg = RunAndersen(test.module());
 
   assert(ptg->NumLambdaNodes() == 1);
-  assert(ptg->NumRegisterSetNodes() == 2);
+  assert(ptg->NumRegisterNodes() == 2);
 
   auto & lambda = ptg->GetLambdaNode(*test.lambda);
-  auto & lambdaOut = ptg->GetRegisterSetNode(*test.lambda->output());
-  auto & lambdaArg = ptg->GetRegisterSetNode(*test.lambda->fctargument(0));
-  auto & bitCast = ptg->GetRegisterSetNode(*test.bitCast->output(0));
+  auto & lambdaOut = ptg->GetRegisterNode(*test.lambda->output());
+  auto & lambdaArg = ptg->GetRegisterNode(*test.lambda->fctargument(0));
+  auto & bitCast = ptg->GetRegisterNode(*test.bitCast->output(0));
 
   assert(TargetsExactly(lambdaOut, { &lambda }));
   assert(TargetsExactly(lambdaArg, { &lambda, &ptg->GetExternalMemoryNode() }));
@@ -262,13 +262,13 @@ TestConstantPointerNull()
   const auto ptg = RunAndersen(test.module());
 
   assert(ptg->NumLambdaNodes() == 1);
-  assert(ptg->NumRegisterSetNodes() == 3);
+  assert(ptg->NumRegisterNodes() == 3);
 
   auto & lambda = ptg->GetLambdaNode(*test.lambda);
-  auto & lambdaOut = ptg->GetRegisterSetNode(*test.lambda->output());
-  auto & lambdaArg = ptg->GetRegisterSetNode(*test.lambda->fctargument(0));
+  auto & lambdaOut = ptg->GetRegisterNode(*test.lambda->output());
+  auto & lambdaArg = ptg->GetRegisterNode(*test.lambda->fctargument(0));
 
-  auto & constantPointerNull = ptg->GetRegisterSetNode(*test.constantPointerNullNode->output(0));
+  auto & constantPointerNull = ptg->GetRegisterNode(*test.constantPointerNullNode->output(0));
 
   assert(TargetsExactly(lambdaOut, { &lambda }));
   assert(TargetsExactly(lambdaArg, { &lambda, &ptg->GetExternalMemoryNode() }));
@@ -284,13 +284,13 @@ TestBits2Ptr()
   const auto ptg = RunAndersen(test.module());
 
   assert(ptg->NumLambdaNodes() == 2);
-  assert(ptg->NumRegisterSetNodes() == 4);
+  assert(ptg->NumRegisterNodes() == 4);
 
   auto & lambdaTestMemoryNode = ptg->GetLambdaNode(test.GetLambdaTest());
   auto & externalMemoryNode = ptg->GetExternalMemoryNode();
 
-  auto & callOutput0 = ptg->GetRegisterSetNode(*test.GetCallNode().output(0));
-  auto & bits2ptr = ptg->GetRegisterSetNode(*test.GetBitsToPtrNode().output(0));
+  auto & callOutput0 = ptg->GetRegisterNode(*test.GetCallNode().output(0));
+  auto & bits2ptr = ptg->GetRegisterNode(*test.GetBitsToPtrNode().output(0));
 
   assert(TargetsExactly(callOutput0, { &lambdaTestMemoryNode, &externalMemoryNode }));
   assert(TargetsExactly(bits2ptr, { &lambdaTestMemoryNode, &externalMemoryNode }));
@@ -306,32 +306,32 @@ TestCall1()
 
   assert(ptg->NumAllocaNodes() == 3);
   assert(ptg->NumLambdaNodes() == 3);
-  assert(ptg->NumRegisterSetNodes() == 10);
+  assert(ptg->NumRegisterNodes() == 10);
 
   auto & alloca_x = ptg->GetAllocaNode(*test.alloca_x);
   auto & alloca_y = ptg->GetAllocaNode(*test.alloca_y);
   auto & alloca_z = ptg->GetAllocaNode(*test.alloca_z);
 
-  auto & palloca_x = ptg->GetRegisterSetNode(*test.alloca_x->output(0));
-  auto & palloca_y = ptg->GetRegisterSetNode(*test.alloca_y->output(0));
-  auto & palloca_z = ptg->GetRegisterSetNode(*test.alloca_z->output(0));
+  auto & palloca_x = ptg->GetRegisterNode(*test.alloca_x->output(0));
+  auto & palloca_y = ptg->GetRegisterNode(*test.alloca_y->output(0));
+  auto & palloca_z = ptg->GetRegisterNode(*test.alloca_z->output(0));
 
   auto & lambda_f = ptg->GetLambdaNode(*test.lambda_f);
   auto & lambda_g = ptg->GetLambdaNode(*test.lambda_g);
   auto & lambda_h = ptg->GetLambdaNode(*test.lambda_h);
 
-  auto & plambda_f = ptg->GetRegisterSetNode(*test.lambda_f->output());
-  auto & plambda_g = ptg->GetRegisterSetNode(*test.lambda_g->output());
-  auto & plambda_h = ptg->GetRegisterSetNode(*test.lambda_h->output());
+  auto & plambda_f = ptg->GetRegisterNode(*test.lambda_f->output());
+  auto & plambda_g = ptg->GetRegisterNode(*test.lambda_g->output());
+  auto & plambda_h = ptg->GetRegisterNode(*test.lambda_h->output());
 
-  auto & lambda_f_arg0 = ptg->GetRegisterSetNode(*test.lambda_f->fctargument(0));
-  auto & lambda_f_arg1 = ptg->GetRegisterSetNode(*test.lambda_f->fctargument(1));
+  auto & lambda_f_arg0 = ptg->GetRegisterNode(*test.lambda_f->fctargument(0));
+  auto & lambda_f_arg1 = ptg->GetRegisterNode(*test.lambda_f->fctargument(1));
 
-  auto & lambda_g_arg0 = ptg->GetRegisterSetNode(*test.lambda_g->fctargument(0));
-  auto & lambda_g_arg1 = ptg->GetRegisterSetNode(*test.lambda_g->fctargument(1));
+  auto & lambda_g_arg0 = ptg->GetRegisterNode(*test.lambda_g->fctargument(0));
+  auto & lambda_g_arg1 = ptg->GetRegisterNode(*test.lambda_g->fctargument(1));
 
-  auto & lambda_h_cv0 = ptg->GetRegisterSetNode(*test.lambda_h->cvargument(0));
-  auto & lambda_h_cv1 = ptg->GetRegisterSetNode(*test.lambda_h->cvargument(1));
+  auto & lambda_h_cv0 = ptg->GetRegisterNode(*test.lambda_h->cvargument(0));
+  auto & lambda_h_cv1 = ptg->GetRegisterNode(*test.lambda_h->cvargument(1));
 
   assert(TargetsExactly(palloca_x, { &alloca_x }));
   assert(TargetsExactly(palloca_y, { &alloca_y }));
@@ -362,25 +362,25 @@ TestCall2()
   assert(ptg->NumLambdaNodes() == 3);
   assert(ptg->NumMallocNodes() == 1);
   assert(ptg->NumImportNodes() == 0);
-  assert(ptg->NumRegisterSetNodes() == 7);
+  assert(ptg->NumRegisterNodes() == 7);
 
   auto & lambda_create = ptg->GetLambdaNode(*test.lambda_create);
-  auto & lambda_create_out = ptg->GetRegisterSetNode(*test.lambda_create->output());
+  auto & lambda_create_out = ptg->GetRegisterNode(*test.lambda_create->output());
 
   auto & lambda_destroy = ptg->GetLambdaNode(*test.lambda_destroy);
-  auto & lambda_destroy_out = ptg->GetRegisterSetNode(*test.lambda_destroy->output());
-  auto & lambda_destroy_arg = ptg->GetRegisterSetNode(*test.lambda_destroy->fctargument(0));
+  auto & lambda_destroy_out = ptg->GetRegisterNode(*test.lambda_destroy->output());
+  auto & lambda_destroy_arg = ptg->GetRegisterNode(*test.lambda_destroy->fctargument(0));
 
   auto & lambda_test = ptg->GetLambdaNode(*test.lambda_test);
-  auto & lambda_test_out = ptg->GetRegisterSetNode(*test.lambda_test->output());
-  auto & lambda_test_cv1 = ptg->GetRegisterSetNode(*test.lambda_test->cvargument(0));
-  auto & lambda_test_cv2 = ptg->GetRegisterSetNode(*test.lambda_test->cvargument(1));
+  auto & lambda_test_out = ptg->GetRegisterNode(*test.lambda_test->output());
+  auto & lambda_test_cv1 = ptg->GetRegisterNode(*test.lambda_test->cvargument(0));
+  auto & lambda_test_cv2 = ptg->GetRegisterNode(*test.lambda_test->cvargument(1));
 
-  auto & call_create1_out = ptg->GetRegisterSetNode(*test.CallCreate1().output(0));
-  auto & call_create2_out = ptg->GetRegisterSetNode(*test.CallCreate2().output(0));
+  auto & call_create1_out = ptg->GetRegisterNode(*test.CallCreate1().output(0));
+  auto & call_create2_out = ptg->GetRegisterNode(*test.CallCreate2().output(0));
 
   auto & malloc = ptg->GetMallocNode(*test.malloc);
-  auto & malloc_out = ptg->GetRegisterSetNode(*test.malloc->output(0));
+  auto & malloc_out = ptg->GetRegisterNode(*test.malloc->output(0));
 
   assert(TargetsExactly(lambda_create_out, { &lambda_create }));
 
@@ -407,23 +407,23 @@ TestIndirectCall1()
 
   assert(ptg->NumLambdaNodes() == 4);
   assert(ptg->NumImportNodes() == 0);
-  assert(ptg->NumRegisterSetNodes() == 5);
+  assert(ptg->NumRegisterNodes() == 5);
 
   auto & lambda_three = ptg->GetLambdaNode(test.GetLambdaThree());
-  auto & lambda_three_out = ptg->GetRegisterSetNode(*test.GetLambdaThree().output());
+  auto & lambda_three_out = ptg->GetRegisterNode(*test.GetLambdaThree().output());
 
   auto & lambda_four = ptg->GetLambdaNode(test.GetLambdaFour());
-  auto & lambda_four_out = ptg->GetRegisterSetNode(*test.GetLambdaFour().output());
+  auto & lambda_four_out = ptg->GetRegisterNode(*test.GetLambdaFour().output());
 
   auto & lambda_indcall = ptg->GetLambdaNode(test.GetLambdaIndcall());
-  auto & lambda_indcall_out = ptg->GetRegisterSetNode(*test.GetLambdaIndcall().output());
-  auto & lambda_indcall_arg = ptg->GetRegisterSetNode(*test.GetLambdaIndcall().fctargument(0));
+  auto & lambda_indcall_out = ptg->GetRegisterNode(*test.GetLambdaIndcall().output());
+  auto & lambda_indcall_arg = ptg->GetRegisterNode(*test.GetLambdaIndcall().fctargument(0));
 
   auto & lambda_test = ptg->GetLambdaNode(test.GetLambdaTest());
-  auto & lambda_test_out = ptg->GetRegisterSetNode(*test.GetLambdaTest().output());
-  auto & lambda_test_cv0 = ptg->GetRegisterSetNode(*test.GetLambdaTest().cvargument(0));
-  auto & lambda_test_cv1 = ptg->GetRegisterSetNode(*test.GetLambdaTest().cvargument(1));
-  auto & lambda_test_cv2 = ptg->GetRegisterSetNode(*test.GetLambdaTest().cvargument(2));
+  auto & lambda_test_out = ptg->GetRegisterNode(*test.GetLambdaTest().output());
+  auto & lambda_test_cv0 = ptg->GetRegisterNode(*test.GetLambdaTest().cvargument(0));
+  auto & lambda_test_cv1 = ptg->GetRegisterNode(*test.GetLambdaTest().cvargument(1));
+  auto & lambda_test_cv2 = ptg->GetRegisterNode(*test.GetLambdaTest().cvargument(2));
 
   assert(TargetsExactly(lambda_three_out, { &lambda_three }));
 
@@ -449,13 +449,13 @@ TestIndirectCall2()
   assert(ptg->NumAllocaNodes() == 3);
   assert(ptg->NumLambdaNodes() == 7);
   assert(ptg->NumDeltaNodes() == 2);
-  assert(ptg->NumRegisterSetNodes() == 15);
+  assert(ptg->NumRegisterNodes() == 15);
 
   auto & lambdaThree = ptg->GetLambdaNode(test.GetLambdaThree());
-  auto & lambdaThreeOutput = ptg->GetRegisterSetNode(*test.GetLambdaThree().output());
+  auto & lambdaThreeOutput = ptg->GetRegisterNode(*test.GetLambdaThree().output());
 
   auto & lambdaFour = ptg->GetLambdaNode(test.GetLambdaFour());
-  auto & lambdaFourOutput = ptg->GetRegisterSetNode(*test.GetLambdaFour().output());
+  auto & lambdaFourOutput = ptg->GetRegisterNode(*test.GetLambdaFour().output());
 
   assert(TargetsExactly(lambdaThreeOutput, { &lambdaThree }));
   assert(TargetsExactly(lambdaFourOutput, { &lambdaFour }));
@@ -470,14 +470,14 @@ TestExternalCall()
   assert(ptg->NumAllocaNodes() == 2);
   assert(ptg->NumLambdaNodes() == 1);
   assert(ptg->NumImportNodes() == 1);
-  assert(ptg->NumRegisterSetNodes() == 9);
+  assert(ptg->NumRegisterNodes() == 9);
 
   auto & lambdaF = ptg->GetLambdaNode(test.LambdaF());
-  auto & lambdaFArgument0 = ptg->GetRegisterSetNode(*test.LambdaF().fctargument(0));
-  auto & lambdaFArgument1 = ptg->GetRegisterSetNode(*test.LambdaF().fctargument(1));
+  auto & lambdaFArgument0 = ptg->GetRegisterNode(*test.LambdaF().fctargument(0));
+  auto & lambdaFArgument1 = ptg->GetRegisterNode(*test.LambdaF().fctargument(1));
   auto & importG = ptg->GetImportNode(test.ExternalGArgument());
 
-  auto & callResult = ptg->GetRegisterSetNode(*test.CallG().Result(0));
+  auto & callResult = ptg->GetRegisterNode(*test.CallG().Result(0));
 
   auto & externalMemory = ptg->GetExternalMemoryNode();
 
@@ -493,20 +493,20 @@ TestGamma()
   const auto ptg = RunAndersen(test.module());
 
   assert(ptg->NumLambdaNodes() == 1);
-  assert(ptg->NumRegisterSetNodes() == 7);
+  assert(ptg->NumRegisterNodes() == 7);
 
   auto & lambda = ptg->GetLambdaNode(*test.lambda);
 
   for (size_t n = 1; n < 5; n++)
   {
-    auto & lambdaArgument = ptg->GetRegisterSetNode(*test.lambda->fctargument(n));
+    auto & lambdaArgument = ptg->GetRegisterNode(*test.lambda->fctargument(n));
     assert(TargetsExactly(lambdaArgument, { &lambda, &ptg->GetExternalMemoryNode() }));
   }
 
   for (size_t n = 0; n < 4; n++)
   {
-    auto & argument0 = ptg->GetRegisterSetNode(*test.gamma->entryvar(n)->argument(0));
-    auto & argument1 = ptg->GetRegisterSetNode(*test.gamma->entryvar(n)->argument(1));
+    auto & argument0 = ptg->GetRegisterNode(*test.gamma->entryvar(n)->argument(0));
+    auto & argument1 = ptg->GetRegisterNode(*test.gamma->entryvar(n)->argument(1));
 
     assert(TargetsExactly(argument0, { &lambda, &ptg->GetExternalMemoryNode() }));
     assert(TargetsExactly(argument1, { &lambda, &ptg->GetExternalMemoryNode() }));
@@ -514,7 +514,7 @@ TestGamma()
 
   for (size_t n = 0; n < 4; n++)
   {
-    auto & gammaOutput = ptg->GetRegisterSetNode(*test.gamma->exitvar(0));
+    auto & gammaOutput = ptg->GetRegisterNode(*test.gamma->exitvar(0));
     assert(TargetsExactly(gammaOutput, { &lambda, &ptg->GetExternalMemoryNode() }));
   }
 
@@ -528,16 +528,16 @@ TestTheta()
   const auto ptg = RunAndersen(test.module());
 
   assert(ptg->NumLambdaNodes() == 1);
-  assert(ptg->NumRegisterSetNodes() == 3);
+  assert(ptg->NumRegisterNodes() == 3);
 
   auto & lambda = ptg->GetLambdaNode(*test.lambda);
-  auto & lambdaArgument1 = ptg->GetRegisterSetNode(*test.lambda->fctargument(1));
-  auto & lambdaOutput = ptg->GetRegisterSetNode(*test.lambda->output());
+  auto & lambdaArgument1 = ptg->GetRegisterNode(*test.lambda->fctargument(1));
+  auto & lambdaOutput = ptg->GetRegisterNode(*test.lambda->output());
 
-  auto & gepOutput = ptg->GetRegisterSetNode(*test.gep->output(0));
+  auto & gepOutput = ptg->GetRegisterNode(*test.gep->output(0));
 
-  auto & thetaArgument2 = ptg->GetRegisterSetNode(*test.theta->output(2)->argument());
-  auto & thetaOutput2 = ptg->GetRegisterSetNode(*test.theta->output(2));
+  auto & thetaArgument2 = ptg->GetRegisterNode(*test.theta->output(2)->argument());
+  auto & thetaOutput2 = ptg->GetRegisterNode(*test.theta->output(2));
 
   assert(TargetsExactly(lambdaArgument1, { &lambda, &ptg->GetExternalMemoryNode() }));
   assert(TargetsExactly(lambdaOutput, { &lambda }));
@@ -558,19 +558,19 @@ TestDelta1()
 
   assert(ptg->NumDeltaNodes() == 1);
   assert(ptg->NumLambdaNodes() == 2);
-  assert(ptg->NumRegisterSetNodes() == 4);
+  assert(ptg->NumRegisterNodes() == 4);
 
   auto & delta_f = ptg->GetDeltaNode(*test.delta_f);
-  auto & pdelta_f = ptg->GetRegisterSetNode(*test.delta_f->output());
+  auto & pdelta_f = ptg->GetRegisterNode(*test.delta_f->output());
 
   auto & lambda_g = ptg->GetLambdaNode(*test.lambda_g);
-  auto & plambda_g = ptg->GetRegisterSetNode(*test.lambda_g->output());
-  auto & lambda_g_arg0 = ptg->GetRegisterSetNode(*test.lambda_g->fctargument(0));
+  auto & plambda_g = ptg->GetRegisterNode(*test.lambda_g->output());
+  auto & lambda_g_arg0 = ptg->GetRegisterNode(*test.lambda_g->fctargument(0));
 
   auto & lambda_h = ptg->GetLambdaNode(*test.lambda_h);
-  auto & plambda_h = ptg->GetRegisterSetNode(*test.lambda_h->output());
-  auto & lambda_h_cv0 = ptg->GetRegisterSetNode(*test.lambda_h->cvargument(0));
-  auto & lambda_h_cv1 = ptg->GetRegisterSetNode(*test.lambda_h->cvargument(1));
+  auto & plambda_h = ptg->GetRegisterNode(*test.lambda_h->output());
+  auto & lambda_h_cv0 = ptg->GetRegisterNode(*test.lambda_h->cvargument(0));
+  auto & lambda_h_cv1 = ptg->GetRegisterNode(*test.lambda_h->cvargument(1));
 
   assert(TargetsExactly(pdelta_f, { &delta_f }));
 
@@ -593,23 +593,23 @@ TestDelta2()
 
   assert(ptg->NumDeltaNodes() == 2);
   assert(ptg->NumLambdaNodes() == 2);
-  assert(ptg->NumRegisterSetNodes() == 4);
+  assert(ptg->NumRegisterNodes() == 4);
 
   auto & delta_d1 = ptg->GetDeltaNode(*test.delta_d1);
-  auto & delta_d1_out = ptg->GetRegisterSetNode(*test.delta_d1->output());
+  auto & delta_d1_out = ptg->GetRegisterNode(*test.delta_d1->output());
 
   auto & delta_d2 = ptg->GetDeltaNode(*test.delta_d2);
-  auto & delta_d2_out = ptg->GetRegisterSetNode(*test.delta_d2->output());
+  auto & delta_d2_out = ptg->GetRegisterNode(*test.delta_d2->output());
 
   auto & lambda_f1 = ptg->GetLambdaNode(*test.lambda_f1);
-  auto & lambda_f1_out = ptg->GetRegisterSetNode(*test.lambda_f1->output());
-  auto & lambda_f1_cvd1 = ptg->GetRegisterSetNode(*test.lambda_f1->cvargument(0));
+  auto & lambda_f1_out = ptg->GetRegisterNode(*test.lambda_f1->output());
+  auto & lambda_f1_cvd1 = ptg->GetRegisterNode(*test.lambda_f1->cvargument(0));
 
   auto & lambda_f2 = ptg->GetLambdaNode(*test.lambda_f2);
-  auto & lambda_f2_out = ptg->GetRegisterSetNode(*test.lambda_f2->output());
-  auto & lambda_f2_cvd1 = ptg->GetRegisterSetNode(*test.lambda_f2->cvargument(0));
-  auto & lambda_f2_cvd2 = ptg->GetRegisterSetNode(*test.lambda_f2->cvargument(1));
-  auto & lambda_f2_cvf1 = ptg->GetRegisterSetNode(*test.lambda_f2->cvargument(2));
+  auto & lambda_f2_out = ptg->GetRegisterNode(*test.lambda_f2->output());
+  auto & lambda_f2_cvd1 = ptg->GetRegisterNode(*test.lambda_f2->cvargument(0));
+  auto & lambda_f2_cvd2 = ptg->GetRegisterNode(*test.lambda_f2->cvargument(1));
+  auto & lambda_f2_cvf1 = ptg->GetRegisterNode(*test.lambda_f2->cvargument(2));
 
   assert(TargetsExactly(delta_d1_out, { &delta_d1 }));
   assert(TargetsExactly(delta_d2_out, { &delta_d2 }));
@@ -633,23 +633,23 @@ TestImports()
 
   assert(ptg->NumLambdaNodes() == 2);
   assert(ptg->NumImportNodes() == 2);
-  assert(ptg->NumRegisterSetNodes() == 4);
+  assert(ptg->NumRegisterNodes() == 4);
 
   auto & d1 = ptg->GetImportNode(*test.import_d1);
-  auto & import_d1 = ptg->GetRegisterSetNode(*test.import_d1);
+  auto & import_d1 = ptg->GetRegisterNode(*test.import_d1);
 
   auto & d2 = ptg->GetImportNode(*test.import_d2);
-  auto & import_d2 = ptg->GetRegisterSetNode(*test.import_d2);
+  auto & import_d2 = ptg->GetRegisterNode(*test.import_d2);
 
   auto & lambda_f1 = ptg->GetLambdaNode(*test.lambda_f1);
-  auto & lambda_f1_out = ptg->GetRegisterSetNode(*test.lambda_f1->output());
-  auto & lambda_f1_cvd1 = ptg->GetRegisterSetNode(*test.lambda_f1->cvargument(0));
+  auto & lambda_f1_out = ptg->GetRegisterNode(*test.lambda_f1->output());
+  auto & lambda_f1_cvd1 = ptg->GetRegisterNode(*test.lambda_f1->cvargument(0));
 
   auto & lambda_f2 = ptg->GetLambdaNode(*test.lambda_f2);
-  auto & lambda_f2_out = ptg->GetRegisterSetNode(*test.lambda_f2->output());
-  auto & lambda_f2_cvd1 = ptg->GetRegisterSetNode(*test.lambda_f2->cvargument(0));
-  auto & lambda_f2_cvd2 = ptg->GetRegisterSetNode(*test.lambda_f2->cvargument(1));
-  auto & lambda_f2_cvf1 = ptg->GetRegisterSetNode(*test.lambda_f2->cvargument(2));
+  auto & lambda_f2_out = ptg->GetRegisterNode(*test.lambda_f2->output());
+  auto & lambda_f2_cvd1 = ptg->GetRegisterNode(*test.lambda_f2->cvargument(0));
+  auto & lambda_f2_cvd2 = ptg->GetRegisterNode(*test.lambda_f2->cvargument(1));
+  auto & lambda_f2_cvf1 = ptg->GetRegisterNode(*test.lambda_f2->cvargument(2));
 
   assert(TargetsExactly(import_d1, { &d1 }));
   assert(TargetsExactly(import_d2, { &d2 }));
@@ -673,23 +673,23 @@ TestPhi1()
 
   assert(ptg->NumAllocaNodes() == 1);
   assert(ptg->NumLambdaNodes() == 2);
-  assert(ptg->NumRegisterSetNodes() == 5);
+  assert(ptg->NumRegisterNodes() == 5);
 
   auto & lambda_fib = ptg->GetLambdaNode(*test.lambda_fib);
-  auto & lambda_fib_out = ptg->GetRegisterSetNode(*test.lambda_fib->output());
-  auto & lambda_fib_arg1 = ptg->GetRegisterSetNode(*test.lambda_fib->fctargument(1));
+  auto & lambda_fib_out = ptg->GetRegisterNode(*test.lambda_fib->output());
+  auto & lambda_fib_arg1 = ptg->GetRegisterNode(*test.lambda_fib->fctargument(1));
 
   auto & lambda_test = ptg->GetLambdaNode(*test.lambda_test);
-  auto & lambda_test_out = ptg->GetRegisterSetNode(*test.lambda_test->output());
+  auto & lambda_test_out = ptg->GetRegisterNode(*test.lambda_test->output());
 
-  auto & phi_rv = ptg->GetRegisterSetNode(*test.phi->begin_rv().output());
-  auto & phi_rv_arg = ptg->GetRegisterSetNode(*test.phi->begin_rv().output()->argument());
+  auto & phi_rv = ptg->GetRegisterNode(*test.phi->begin_rv().output());
+  auto & phi_rv_arg = ptg->GetRegisterNode(*test.phi->begin_rv().output()->argument());
 
-  auto & gamma_result = ptg->GetRegisterSetNode(*test.gamma->subregion(0)->argument(1));
-  auto & gamma_fib = ptg->GetRegisterSetNode(*test.gamma->subregion(0)->argument(2));
+  auto & gamma_result = ptg->GetRegisterNode(*test.gamma->subregion(0)->argument(1));
+  auto & gamma_fib = ptg->GetRegisterNode(*test.gamma->subregion(0)->argument(2));
 
   auto & alloca = ptg->GetAllocaNode(*test.alloca);
-  auto & alloca_out = ptg->GetRegisterSetNode(*test.alloca->output(0));
+  auto & alloca_out = ptg->GetRegisterNode(*test.alloca->output(0));
 
   assert(TargetsExactly(lambda_fib_out, { &lambda_fib }));
   assert(TargetsExactly(lambda_fib_arg1, { &alloca }));
@@ -714,11 +714,11 @@ TestExternalMemory()
   const auto ptg = RunAndersen(test.module());
 
   assert(ptg->NumLambdaNodes() == 1);
-  assert(ptg->NumRegisterSetNodes() == 3);
+  assert(ptg->NumRegisterNodes() == 3);
 
   auto & lambdaF = ptg->GetLambdaNode(*test.LambdaF);
-  auto & lambdaFArgument0 = ptg->GetRegisterSetNode(*test.LambdaF->fctargument(0));
-  auto & lambdaFArgument1 = ptg->GetRegisterSetNode(*test.LambdaF->fctargument(1));
+  auto & lambdaFArgument0 = ptg->GetRegisterNode(*test.LambdaF->fctargument(0));
+  auto & lambdaFArgument1 = ptg->GetRegisterNode(*test.LambdaF->fctargument(1));
 
   assert(TargetsExactly(lambdaFArgument0, { &lambdaF, &ptg->GetExternalMemoryNode() }));
   assert(TargetsExactly(lambdaFArgument1, { &lambdaF, &ptg->GetExternalMemoryNode() }));
@@ -734,11 +734,11 @@ TestEscapedMemory1()
 
   assert(ptg->NumDeltaNodes() == 4);
   assert(ptg->NumLambdaNodes() == 1);
-  assert(ptg->NumRegisterSetNodes() == 7);
+  assert(ptg->NumRegisterNodes() == 7);
 
-  auto & lambdaTestArgument0 = ptg->GetRegisterSetNode(*test.LambdaTest->fctargument(0));
-  auto & lambdaTestCv0 = ptg->GetRegisterSetNode(*test.LambdaTest->cvargument(0));
-  auto & loadNode1Output = ptg->GetRegisterSetNode(*test.LoadNode1->output(0));
+  auto & lambdaTestArgument0 = ptg->GetRegisterNode(*test.LambdaTest->fctargument(0));
+  auto & lambdaTestCv0 = ptg->GetRegisterNode(*test.LambdaTest->cvargument(0));
+  auto & loadNode1Output = ptg->GetRegisterNode(*test.LoadNode1->output(0));
 
   auto deltaA = &ptg->GetDeltaNode(*test.DeltaA);
   auto deltaB = &ptg->GetDeltaNode(*test.DeltaB);
@@ -764,7 +764,7 @@ TestEscapedMemory2()
   assert(ptg->NumImportNodes() == 2);
   assert(ptg->NumLambdaNodes() == 3);
   assert(ptg->NumMallocNodes() == 2);
-  assert(ptg->NumRegisterSetNodes() == 8);
+  assert(ptg->NumRegisterNodes() == 8);
 
   auto returnAddressFunction = &ptg->GetLambdaNode(*test.ReturnAddressFunction);
   auto callExternalFunction1 = &ptg->GetLambdaNode(*test.CallExternalFunction1);
@@ -775,8 +775,7 @@ TestEscapedMemory2()
   auto externalFunction1Import = &ptg->GetImportNode(*test.ExternalFunction1Import);
   auto externalFunction2Import = &ptg->GetImportNode(*test.ExternalFunction2Import);
 
-  auto & externalFunction2CallResult =
-      ptg->GetRegisterSetNode(*test.ExternalFunction2Call->Result(0));
+  auto & externalFunction2CallResult = ptg->GetRegisterNode(*test.ExternalFunction2Call->Result(0));
 
   assert(TargetsExactly(
       externalFunction2CallResult,
@@ -809,15 +808,14 @@ TestEscapedMemory3()
   assert(ptg->NumDeltaNodes() == 1);
   assert(ptg->NumImportNodes() == 1);
   assert(ptg->NumLambdaNodes() == 1);
-  assert(ptg->NumRegisterSetNodes() == 4);
+  assert(ptg->NumRegisterNodes() == 4);
 
   auto lambdaTest = &ptg->GetLambdaNode(*test.LambdaTest);
   auto deltaGlobal = &ptg->GetDeltaNode(*test.DeltaGlobal);
   auto importExternalFunction = &ptg->GetImportNode(*test.ImportExternalFunction);
   auto externalMemory = &ptg->GetExternalMemoryNode();
 
-  auto & callExternalFunctionResult =
-      ptg->GetRegisterSetNode(*test.CallExternalFunction->Result(0));
+  auto & callExternalFunctionResult = ptg->GetRegisterNode(*test.CallExternalFunction->Result(0));
 
   assert(TargetsExactly(
       callExternalFunctionResult,
@@ -834,13 +832,13 @@ TestMemcpy()
 
   assert(ptg->NumDeltaNodes() == 2);
   assert(ptg->NumLambdaNodes() == 2);
-  assert(ptg->NumRegisterSetNodes() == 4);
+  assert(ptg->NumRegisterNodes() == 4);
 
   auto localArray = &ptg->GetDeltaNode(test.LocalArray());
   auto globalArray = &ptg->GetDeltaNode(test.GlobalArray());
 
-  auto & memCpyDest = ptg->GetRegisterSetNode(*test.Memcpy().input(0)->origin());
-  auto & memCpySrc = ptg->GetRegisterSetNode(*test.Memcpy().input(1)->origin());
+  auto & memCpyDest = ptg->GetRegisterNode(*test.Memcpy().input(0)->origin());
+  auto & memCpySrc = ptg->GetRegisterNode(*test.Memcpy().input(1)->origin());
 
   auto lambdaF = &ptg->GetLambdaNode(test.LambdaF());
   auto lambdaG = &ptg->GetLambdaNode(test.LambdaG());

--- a/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
@@ -45,20 +45,20 @@ TestStore1()
   {
     assert(ptg.NumAllocaNodes() == 4);
     assert(ptg.NumLambdaNodes() == 1);
-    assert(ptg.NumRegisterSetNodes() == 5);
+    assert(ptg.NumRegisterNodes() == 5);
 
     auto & alloca_a = ptg.GetAllocaNode(*test.alloca_a);
     auto & alloca_b = ptg.GetAllocaNode(*test.alloca_b);
     auto & alloca_c = ptg.GetAllocaNode(*test.alloca_c);
     auto & alloca_d = ptg.GetAllocaNode(*test.alloca_d);
 
-    auto & palloca_a = ptg.GetRegisterSetNode(*test.alloca_a->output(0));
-    auto & palloca_b = ptg.GetRegisterSetNode(*test.alloca_b->output(0));
-    auto & palloca_c = ptg.GetRegisterSetNode(*test.alloca_c->output(0));
-    auto & palloca_d = ptg.GetRegisterSetNode(*test.alloca_d->output(0));
+    auto & palloca_a = ptg.GetRegisterNode(*test.alloca_a->output(0));
+    auto & palloca_b = ptg.GetRegisterNode(*test.alloca_b->output(0));
+    auto & palloca_c = ptg.GetRegisterNode(*test.alloca_c->output(0));
+    auto & palloca_d = ptg.GetRegisterNode(*test.alloca_d->output(0));
 
     auto & lambda = ptg.GetLambdaNode(*test.lambda);
-    auto & plambda = ptg.GetRegisterSetNode(*test.lambda->output());
+    auto & plambda = ptg.GetRegisterNode(*test.lambda->output());
 
     assertTargets(alloca_a, { &alloca_b });
     assertTargets(alloca_b, { &alloca_c });
@@ -94,7 +94,7 @@ TestStore2()
   {
     assert(ptg.NumAllocaNodes() == 5);
     assert(ptg.NumLambdaNodes() == 1);
-    assert(ptg.NumRegisterSetNodes() == 4);
+    assert(ptg.NumRegisterNodes() == 4);
 
     auto & alloca_a = ptg.GetAllocaNode(*test.alloca_a);
     auto & alloca_b = ptg.GetAllocaNode(*test.alloca_b);
@@ -102,14 +102,14 @@ TestStore2()
     auto & alloca_y = ptg.GetAllocaNode(*test.alloca_y);
     auto & alloca_p = ptg.GetAllocaNode(*test.alloca_p);
 
-    auto & palloca_a = ptg.GetRegisterSetNode(*test.alloca_a->output(0));
-    auto & palloca_b = ptg.GetRegisterSetNode(*test.alloca_b->output(0));
-    auto & palloca_x = ptg.GetRegisterSetNode(*test.alloca_x->output(0));
-    auto & palloca_y = ptg.GetRegisterSetNode(*test.alloca_y->output(0));
-    auto & palloca_p = ptg.GetRegisterSetNode(*test.alloca_p->output(0));
+    auto & palloca_a = ptg.GetRegisterNode(*test.alloca_a->output(0));
+    auto & palloca_b = ptg.GetRegisterNode(*test.alloca_b->output(0));
+    auto & palloca_x = ptg.GetRegisterNode(*test.alloca_x->output(0));
+    auto & palloca_y = ptg.GetRegisterNode(*test.alloca_y->output(0));
+    auto & palloca_p = ptg.GetRegisterNode(*test.alloca_p->output(0));
 
     auto & lambda = ptg.GetLambdaNode(*test.lambda);
-    auto & plambda = ptg.GetRegisterSetNode(*test.lambda->output());
+    auto & plambda = ptg.GetRegisterNode(*test.lambda->output());
 
     assertTargets(alloca_a, {});
     assertTargets(alloca_b, {});
@@ -146,13 +146,13 @@ TestLoad1()
       [](const jlm::llvm::aa::PointsToGraph & pointsToGraph, const jlm::tests::LoadTest1 & test)
   {
     assert(pointsToGraph.NumLambdaNodes() == 1);
-    assert(pointsToGraph.NumRegisterSetNodes() == 3);
+    assert(pointsToGraph.NumRegisterNodes() == 3);
 
-    auto & loadResult = pointsToGraph.GetRegisterSetNode(*test.load_p->output(0));
+    auto & loadResult = pointsToGraph.GetRegisterNode(*test.load_p->output(0));
 
     auto & lambda = pointsToGraph.GetLambdaNode(*test.lambda);
-    auto & lambdaOutput = pointsToGraph.GetRegisterSetNode(*test.lambda->output());
-    auto & lambdaArgument0 = pointsToGraph.GetRegisterSetNode(*test.lambda->fctargument(0));
+    auto & lambdaOutput = pointsToGraph.GetRegisterNode(*test.lambda->output());
+    auto & lambdaArgument0 = pointsToGraph.GetRegisterNode(*test.lambda->fctargument(0));
 
     assertTargets(loadResult, { &lambda, &pointsToGraph.GetExternalMemoryNode() });
 
@@ -180,7 +180,7 @@ TestLoad2()
   {
     assert(ptg.NumAllocaNodes() == 5);
     assert(ptg.NumLambdaNodes() == 1);
-    assert(ptg.NumRegisterSetNodes() == 5);
+    assert(ptg.NumRegisterNodes() == 5);
 
     /*
       We only care about the loads in this test, skipping the validation
@@ -191,8 +191,8 @@ TestLoad2()
     auto & alloca_x = ptg.GetAllocaNode(*test.alloca_x);
     auto & alloca_y = ptg.GetAllocaNode(*test.alloca_y);
 
-    auto & pload_x = ptg.GetRegisterSetNode(*test.load_x->output(0));
-    auto & pload_a = ptg.GetRegisterSetNode(*test.load_a->output(0));
+    auto & pload_x = ptg.GetRegisterNode(*test.load_x->output(0));
+    auto & pload_a = ptg.GetRegisterNode(*test.load_a->output(0));
 
     auto & lambdaMemoryNode = ptg.GetLambdaNode(*test.lambda);
 
@@ -219,10 +219,10 @@ TestLoadFromUndef()
                                   const jlm::tests::LoadFromUndefTest & test)
   {
     assert(pointsToGraph.NumLambdaNodes() == 1);
-    assert(pointsToGraph.NumRegisterSetNodes() == 2);
+    assert(pointsToGraph.NumRegisterNodes() == 2);
 
     auto & lambdaMemoryNode = pointsToGraph.GetLambdaNode(test.Lambda());
-    auto & undefValueNode = pointsToGraph.GetRegisterSetNode(*test.UndefValueNode()->output(0));
+    auto & undefValueNode = pointsToGraph.GetRegisterNode(*test.UndefValueNode()->output(0));
 
     assertTargets(undefValueNode, {});
 
@@ -246,15 +246,15 @@ TestGetElementPtr()
                                   const jlm::tests::GetElementPtrTest & test)
   {
     assert(pointsToGraph.NumLambdaNodes() == 1);
-    assert(pointsToGraph.NumRegisterSetNodes() == 2);
+    assert(pointsToGraph.NumRegisterNodes() == 2);
 
     /*
       We only care about the getelemenptr's in this test, skipping the validation
       for all other nodes.
     */
     auto & lambda = pointsToGraph.GetLambdaNode(*test.lambda);
-    auto & gepX = pointsToGraph.GetRegisterSetNode(*test.getElementPtrX->output(0));
-    auto & gepY = pointsToGraph.GetRegisterSetNode(*test.getElementPtrY->output(0));
+    auto & gepX = pointsToGraph.GetRegisterNode(*test.getElementPtrX->output(0));
+    auto & gepY = pointsToGraph.GetRegisterNode(*test.getElementPtrY->output(0));
 
     assertTargets(gepX, { &lambda, &pointsToGraph.GetExternalMemoryNode() });
     assertTargets(gepY, { &lambda, &pointsToGraph.GetExternalMemoryNode() });
@@ -279,13 +279,13 @@ TestBitCast()
       [](const jlm::llvm::aa::PointsToGraph & pointsToGraph, const jlm::tests::BitCastTest & test)
   {
     assert(pointsToGraph.NumLambdaNodes() == 1);
-    assert(pointsToGraph.NumRegisterSetNodes() == 2);
+    assert(pointsToGraph.NumRegisterNodes() == 2);
 
     auto & lambda = pointsToGraph.GetLambdaNode(*test.lambda);
-    auto & lambdaOut = pointsToGraph.GetRegisterSetNode(*test.lambda->output());
-    auto & lambdaArg = pointsToGraph.GetRegisterSetNode(*test.lambda->fctargument(0));
+    auto & lambdaOut = pointsToGraph.GetRegisterNode(*test.lambda->output());
+    auto & lambdaArg = pointsToGraph.GetRegisterNode(*test.lambda->fctargument(0));
 
-    auto & bitCast = pointsToGraph.GetRegisterSetNode(*test.bitCast->output(0));
+    auto & bitCast = pointsToGraph.GetRegisterNode(*test.bitCast->output(0));
 
     assertTargets(lambdaOut, { &lambda });
     assertTargets(lambdaArg, { &lambda, &pointsToGraph.GetExternalMemoryNode() });
@@ -311,14 +311,14 @@ TestConstantPointerNull()
                                   const jlm::tests::ConstantPointerNullTest & test)
   {
     assert(pointsToGraph.NumLambdaNodes() == 1);
-    assert(pointsToGraph.NumRegisterSetNodes() == 3);
+    assert(pointsToGraph.NumRegisterNodes() == 3);
 
     auto & lambda = pointsToGraph.GetLambdaNode(*test.lambda);
-    auto & lambdaOut = pointsToGraph.GetRegisterSetNode(*test.lambda->output());
-    auto & lambdaArg = pointsToGraph.GetRegisterSetNode(*test.lambda->fctargument(0));
+    auto & lambdaOut = pointsToGraph.GetRegisterNode(*test.lambda->output());
+    auto & lambdaArg = pointsToGraph.GetRegisterNode(*test.lambda->fctargument(0));
 
     auto & constantPointerNull =
-        pointsToGraph.GetRegisterSetNode(*test.constantPointerNullNode->output(0));
+        pointsToGraph.GetRegisterNode(*test.constantPointerNullNode->output(0));
 
     assertTargets(lambdaOut, { &lambda });
     assertTargets(lambdaArg, { &lambda, &pointsToGraph.GetExternalMemoryNode() });
@@ -346,7 +346,7 @@ TestBits2Ptr()
     using namespace jlm::llvm::aa;
 
     assert(pointsToGraph.NumLambdaNodes() == 2);
-    assert(pointsToGraph.NumRegisterSetNodes() == 3);
+    assert(pointsToGraph.NumRegisterNodes() == 3);
 
     auto & lambdaTestMemoryNode = pointsToGraph.GetLambdaNode(test.GetLambdaTest());
     auto & lambdaBitsToPtrMemoryNode = pointsToGraph.GetLambdaNode(test.GetLambdaBits2Ptr());
@@ -355,10 +355,10 @@ TestBits2Ptr()
     std::unordered_set<const PointsToGraph::Node *> expectedMemoryNodes(
         { &lambdaTestMemoryNode, &lambdaBitsToPtrMemoryNode, &externalMemoryNode });
 
-    auto & callOutput0 = pointsToGraph.GetRegisterSetNode(*test.GetCallNode().output(0));
+    auto & callOutput0 = pointsToGraph.GetRegisterNode(*test.GetCallNode().output(0));
     assertTargets(callOutput0, expectedMemoryNodes);
 
-    auto & bits2ptr = pointsToGraph.GetRegisterSetNode(*test.GetBitsToPtrNode().output(0));
+    auto & bits2ptr = pointsToGraph.GetRegisterNode(*test.GetBitsToPtrNode().output(0));
     assertTargets(bits2ptr, expectedMemoryNodes);
 
     jlm::util::HashSet<const PointsToGraph::MemoryNode *> expectedEscapedMemoryNodes(
@@ -382,32 +382,32 @@ TestCall1()
   {
     assert(ptg.NumAllocaNodes() == 3);
     assert(ptg.NumLambdaNodes() == 3);
-    assert(ptg.NumRegisterSetNodes() == 6);
+    assert(ptg.NumRegisterNodes() == 6);
 
     auto & alloca_x = ptg.GetAllocaNode(*test.alloca_x);
     auto & alloca_y = ptg.GetAllocaNode(*test.alloca_y);
     auto & alloca_z = ptg.GetAllocaNode(*test.alloca_z);
 
-    auto & palloca_x = ptg.GetRegisterSetNode(*test.alloca_x->output(0));
-    auto & palloca_y = ptg.GetRegisterSetNode(*test.alloca_y->output(0));
-    auto & palloca_z = ptg.GetRegisterSetNode(*test.alloca_z->output(0));
+    auto & palloca_x = ptg.GetRegisterNode(*test.alloca_x->output(0));
+    auto & palloca_y = ptg.GetRegisterNode(*test.alloca_y->output(0));
+    auto & palloca_z = ptg.GetRegisterNode(*test.alloca_z->output(0));
 
     auto & lambda_f = ptg.GetLambdaNode(*test.lambda_f);
     auto & lambda_g = ptg.GetLambdaNode(*test.lambda_g);
     auto & lambda_h = ptg.GetLambdaNode(*test.lambda_h);
 
-    auto & plambda_f = ptg.GetRegisterSetNode(*test.lambda_f->output());
-    auto & plambda_g = ptg.GetRegisterSetNode(*test.lambda_g->output());
-    auto & plambda_h = ptg.GetRegisterSetNode(*test.lambda_h->output());
+    auto & plambda_f = ptg.GetRegisterNode(*test.lambda_f->output());
+    auto & plambda_g = ptg.GetRegisterNode(*test.lambda_g->output());
+    auto & plambda_h = ptg.GetRegisterNode(*test.lambda_h->output());
 
-    auto & lambda_f_arg0 = ptg.GetRegisterSetNode(*test.lambda_f->fctargument(0));
-    auto & lambda_f_arg1 = ptg.GetRegisterSetNode(*test.lambda_f->fctargument(1));
+    auto & lambda_f_arg0 = ptg.GetRegisterNode(*test.lambda_f->fctargument(0));
+    auto & lambda_f_arg1 = ptg.GetRegisterNode(*test.lambda_f->fctargument(1));
 
-    auto & lambda_g_arg0 = ptg.GetRegisterSetNode(*test.lambda_g->fctargument(0));
-    auto & lambda_g_arg1 = ptg.GetRegisterSetNode(*test.lambda_g->fctargument(1));
+    auto & lambda_g_arg0 = ptg.GetRegisterNode(*test.lambda_g->fctargument(0));
+    auto & lambda_g_arg1 = ptg.GetRegisterNode(*test.lambda_g->fctargument(1));
 
-    auto & lambda_h_cv0 = ptg.GetRegisterSetNode(*test.lambda_h->cvargument(0));
-    auto & lambda_h_cv1 = ptg.GetRegisterSetNode(*test.lambda_h->cvargument(1));
+    auto & lambda_h_cv0 = ptg.GetRegisterNode(*test.lambda_h->cvargument(0));
+    auto & lambda_h_cv1 = ptg.GetRegisterNode(*test.lambda_h->cvargument(1));
 
     assertTargets(palloca_x, { &alloca_x });
     assertTargets(palloca_y, { &alloca_y });
@@ -448,25 +448,25 @@ TestCall2()
     assert(ptg.NumLambdaNodes() == 3);
     assert(ptg.NumMallocNodes() == 1);
     assert(ptg.NumImportNodes() == 0);
-    assert(ptg.NumRegisterSetNodes() == 4);
+    assert(ptg.NumRegisterNodes() == 4);
 
     auto & lambda_create = ptg.GetLambdaNode(*test.lambda_create);
-    auto & lambda_create_out = ptg.GetRegisterSetNode(*test.lambda_create->output());
+    auto & lambda_create_out = ptg.GetRegisterNode(*test.lambda_create->output());
 
     auto & lambda_destroy = ptg.GetLambdaNode(*test.lambda_destroy);
-    auto & lambda_destroy_out = ptg.GetRegisterSetNode(*test.lambda_destroy->output());
-    auto & lambda_destroy_arg = ptg.GetRegisterSetNode(*test.lambda_destroy->fctargument(0));
+    auto & lambda_destroy_out = ptg.GetRegisterNode(*test.lambda_destroy->output());
+    auto & lambda_destroy_arg = ptg.GetRegisterNode(*test.lambda_destroy->fctargument(0));
 
     auto & lambda_test = ptg.GetLambdaNode(*test.lambda_test);
-    auto & lambda_test_out = ptg.GetRegisterSetNode(*test.lambda_test->output());
-    auto & lambda_test_cv1 = ptg.GetRegisterSetNode(*test.lambda_test->cvargument(0));
-    auto & lambda_test_cv2 = ptg.GetRegisterSetNode(*test.lambda_test->cvargument(1));
+    auto & lambda_test_out = ptg.GetRegisterNode(*test.lambda_test->output());
+    auto & lambda_test_cv1 = ptg.GetRegisterNode(*test.lambda_test->cvargument(0));
+    auto & lambda_test_cv2 = ptg.GetRegisterNode(*test.lambda_test->cvargument(1));
 
-    auto & call_create1_out = ptg.GetRegisterSetNode(*test.CallCreate1().output(0));
-    auto & call_create2_out = ptg.GetRegisterSetNode(*test.CallCreate2().output(0));
+    auto & call_create1_out = ptg.GetRegisterNode(*test.CallCreate1().output(0));
+    auto & call_create2_out = ptg.GetRegisterNode(*test.CallCreate2().output(0));
 
     auto & malloc = ptg.GetMallocNode(*test.malloc);
-    auto & malloc_out = ptg.GetRegisterSetNode(*test.malloc->output(0));
+    auto & malloc_out = ptg.GetRegisterNode(*test.malloc->output(0));
 
     assertTargets(lambda_create_out, { &lambda_create });
 
@@ -503,23 +503,23 @@ TestIndirectCall()
   {
     assert(ptg.NumLambdaNodes() == 4);
     assert(ptg.NumImportNodes() == 0);
-    assert(ptg.NumRegisterSetNodes() == 3);
+    assert(ptg.NumRegisterNodes() == 3);
 
     auto & lambda_three = ptg.GetLambdaNode(test.GetLambdaThree());
-    auto & lambda_three_out = ptg.GetRegisterSetNode(*test.GetLambdaThree().output());
+    auto & lambda_three_out = ptg.GetRegisterNode(*test.GetLambdaThree().output());
 
     auto & lambda_four = ptg.GetLambdaNode(test.GetLambdaFour());
-    auto & lambda_four_out = ptg.GetRegisterSetNode(*test.GetLambdaFour().output());
+    auto & lambda_four_out = ptg.GetRegisterNode(*test.GetLambdaFour().output());
 
     auto & lambda_indcall = ptg.GetLambdaNode(test.GetLambdaIndcall());
-    auto & lambda_indcall_out = ptg.GetRegisterSetNode(*test.GetLambdaIndcall().output());
-    auto & lambda_indcall_arg = ptg.GetRegisterSetNode(*test.GetLambdaIndcall().fctargument(0));
+    auto & lambda_indcall_out = ptg.GetRegisterNode(*test.GetLambdaIndcall().output());
+    auto & lambda_indcall_arg = ptg.GetRegisterNode(*test.GetLambdaIndcall().fctargument(0));
 
     auto & lambda_test = ptg.GetLambdaNode(test.GetLambdaTest());
-    auto & lambda_test_out = ptg.GetRegisterSetNode(*test.GetLambdaTest().output());
-    auto & lambda_test_cv0 = ptg.GetRegisterSetNode(*test.GetLambdaTest().cvargument(0));
-    auto & lambda_test_cv1 = ptg.GetRegisterSetNode(*test.GetLambdaTest().cvargument(1));
-    auto & lambda_test_cv2 = ptg.GetRegisterSetNode(*test.GetLambdaTest().cvargument(2));
+    auto & lambda_test_out = ptg.GetRegisterNode(*test.GetLambdaTest().output());
+    auto & lambda_test_cv0 = ptg.GetRegisterNode(*test.GetLambdaTest().cvargument(0));
+    auto & lambda_test_cv1 = ptg.GetRegisterNode(*test.GetLambdaTest().cvargument(1));
+    auto & lambda_test_cv2 = ptg.GetRegisterNode(*test.GetLambdaTest().cvargument(2));
 
     assertTargets(lambda_three_out, { &lambda_three, &lambda_four });
 
@@ -556,13 +556,13 @@ TestIndirectCall2()
     assert(pointsToGraph.NumAllocaNodes() == 3);
     assert(pointsToGraph.NumLambdaNodes() == 7);
     assert(pointsToGraph.NumDeltaNodes() == 2);
-    assert(pointsToGraph.NumRegisterSetNodes() == 10);
+    assert(pointsToGraph.NumRegisterNodes() == 10);
 
     auto & lambdaThree = pointsToGraph.GetLambdaNode(test.GetLambdaThree());
-    auto & lambdaThreeOutput = pointsToGraph.GetRegisterSetNode(*test.GetLambdaThree().output());
+    auto & lambdaThreeOutput = pointsToGraph.GetRegisterNode(*test.GetLambdaThree().output());
 
     auto & lambdaFour = pointsToGraph.GetLambdaNode(test.GetLambdaFour());
-    auto & lambdaFourOutput = pointsToGraph.GetRegisterSetNode(*test.GetLambdaFour().output());
+    auto & lambdaFourOutput = pointsToGraph.GetRegisterNode(*test.GetLambdaFour().output());
 
     assertTargets(lambdaThreeOutput, { &lambdaThree, &lambdaFour });
     assertTargets(lambdaFourOutput, { &lambdaThree, &lambdaFour });
@@ -586,13 +586,13 @@ TestExternalCall()
     assert(pointsToGraph.NumAllocaNodes() == 2);
     assert(pointsToGraph.NumLambdaNodes() == 1);
     assert(pointsToGraph.NumImportNodes() == 1);
-    assert(pointsToGraph.NumRegisterSetNodes() == 7);
+    assert(pointsToGraph.NumRegisterNodes() == 7);
 
     auto & lambdaF = pointsToGraph.GetLambdaNode(test.LambdaF());
-    auto & lambdaFArgument0 = pointsToGraph.GetRegisterSetNode(*test.LambdaF().fctargument(0));
-    auto & lambdaFArgument1 = pointsToGraph.GetRegisterSetNode(*test.LambdaF().fctargument(1));
+    auto & lambdaFArgument0 = pointsToGraph.GetRegisterNode(*test.LambdaF().fctargument(0));
+    auto & lambdaFArgument1 = pointsToGraph.GetRegisterNode(*test.LambdaF().fctargument(1));
 
-    auto & callResult = pointsToGraph.GetRegisterSetNode(*test.CallG().Result(0));
+    auto & callResult = pointsToGraph.GetRegisterNode(*test.CallG().Result(0));
 
     auto & externalMemory = pointsToGraph.GetExternalMemoryNode();
 
@@ -617,20 +617,20 @@ TestGamma()
       [](const jlm::llvm::aa::PointsToGraph & pointsToGraph, const jlm::tests::GammaTest & test)
   {
     assert(pointsToGraph.NumLambdaNodes() == 1);
-    assert(pointsToGraph.NumRegisterSetNodes() == 3);
+    assert(pointsToGraph.NumRegisterNodes() == 3);
 
     auto & lambda = pointsToGraph.GetLambdaNode(*test.lambda);
 
     for (size_t n = 1; n < 5; n++)
     {
-      auto & lambdaArgument = pointsToGraph.GetRegisterSetNode(*test.lambda->fctargument(n));
+      auto & lambdaArgument = pointsToGraph.GetRegisterNode(*test.lambda->fctargument(n));
       assertTargets(lambdaArgument, { &lambda, &pointsToGraph.GetExternalMemoryNode() });
     }
 
     for (size_t n = 0; n < 4; n++)
     {
-      auto & argument0 = pointsToGraph.GetRegisterSetNode(*test.gamma->entryvar(n)->argument(0));
-      auto & argument1 = pointsToGraph.GetRegisterSetNode(*test.gamma->entryvar(n)->argument(1));
+      auto & argument0 = pointsToGraph.GetRegisterNode(*test.gamma->entryvar(n)->argument(0));
+      auto & argument1 = pointsToGraph.GetRegisterNode(*test.gamma->entryvar(n)->argument(1));
 
       assertTargets(argument0, { &lambda, &pointsToGraph.GetExternalMemoryNode() });
       assertTargets(argument1, { &lambda, &pointsToGraph.GetExternalMemoryNode() });
@@ -638,7 +638,7 @@ TestGamma()
 
     for (size_t n = 0; n < 4; n++)
     {
-      auto & gammaOutput = pointsToGraph.GetRegisterSetNode(*test.gamma->exitvar(0));
+      auto & gammaOutput = pointsToGraph.GetRegisterNode(*test.gamma->exitvar(0));
       assertTargets(gammaOutput, { &lambda, &pointsToGraph.GetExternalMemoryNode() });
     }
 
@@ -662,16 +662,16 @@ TestTheta()
       [](const jlm::llvm::aa::PointsToGraph & pointsToGraph, const jlm::tests::ThetaTest & test)
   {
     assert(pointsToGraph.NumLambdaNodes() == 1);
-    assert(pointsToGraph.NumRegisterSetNodes() == 2);
+    assert(pointsToGraph.NumRegisterNodes() == 2);
 
     auto & lambda = pointsToGraph.GetLambdaNode(*test.lambda);
-    auto & lambdaArgument1 = pointsToGraph.GetRegisterSetNode(*test.lambda->fctargument(1));
-    auto & lambdaOutput = pointsToGraph.GetRegisterSetNode(*test.lambda->output());
+    auto & lambdaArgument1 = pointsToGraph.GetRegisterNode(*test.lambda->fctargument(1));
+    auto & lambdaOutput = pointsToGraph.GetRegisterNode(*test.lambda->output());
 
-    auto & gepOutput = pointsToGraph.GetRegisterSetNode(*test.gep->output(0));
+    auto & gepOutput = pointsToGraph.GetRegisterNode(*test.gep->output(0));
 
-    auto & thetaArgument2 = pointsToGraph.GetRegisterSetNode(*test.theta->output(2)->argument());
-    auto & thetaOutput2 = pointsToGraph.GetRegisterSetNode(*test.theta->output(2));
+    auto & thetaArgument2 = pointsToGraph.GetRegisterNode(*test.theta->output(2)->argument());
+    auto & thetaOutput2 = pointsToGraph.GetRegisterNode(*test.theta->output(2));
 
     assertTargets(lambdaArgument1, { &lambda, &pointsToGraph.GetExternalMemoryNode() });
     assertTargets(lambdaOutput, { &lambda });
@@ -702,19 +702,19 @@ TestDelta1()
   {
     assert(ptg.NumDeltaNodes() == 1);
     assert(ptg.NumLambdaNodes() == 2);
-    assert(ptg.NumRegisterSetNodes() == 3);
+    assert(ptg.NumRegisterNodes() == 3);
 
     auto & delta_f = ptg.GetDeltaNode(*test.delta_f);
-    auto & pdelta_f = ptg.GetRegisterSetNode(*test.delta_f->output());
+    auto & pdelta_f = ptg.GetRegisterNode(*test.delta_f->output());
 
     auto & lambda_g = ptg.GetLambdaNode(*test.lambda_g);
-    auto & plambda_g = ptg.GetRegisterSetNode(*test.lambda_g->output());
-    auto & lambda_g_arg0 = ptg.GetRegisterSetNode(*test.lambda_g->fctargument(0));
+    auto & plambda_g = ptg.GetRegisterNode(*test.lambda_g->output());
+    auto & lambda_g_arg0 = ptg.GetRegisterNode(*test.lambda_g->fctargument(0));
 
     auto & lambda_h = ptg.GetLambdaNode(*test.lambda_h);
-    auto & plambda_h = ptg.GetRegisterSetNode(*test.lambda_h->output());
-    auto & lambda_h_cv0 = ptg.GetRegisterSetNode(*test.lambda_h->cvargument(0));
-    auto & lambda_h_cv1 = ptg.GetRegisterSetNode(*test.lambda_h->cvargument(1));
+    auto & plambda_h = ptg.GetRegisterNode(*test.lambda_h->output());
+    auto & lambda_h_cv0 = ptg.GetRegisterNode(*test.lambda_h->cvargument(0));
+    auto & lambda_h_cv1 = ptg.GetRegisterNode(*test.lambda_h->cvargument(1));
 
     assertTargets(pdelta_f, { &delta_f });
 
@@ -747,23 +747,23 @@ TestDelta2()
   {
     assert(ptg.NumDeltaNodes() == 2);
     assert(ptg.NumLambdaNodes() == 2);
-    assert(ptg.NumRegisterSetNodes() == 4);
+    assert(ptg.NumRegisterNodes() == 4);
 
     auto & delta_d1 = ptg.GetDeltaNode(*test.delta_d1);
-    auto & delta_d1_out = ptg.GetRegisterSetNode(*test.delta_d1->output());
+    auto & delta_d1_out = ptg.GetRegisterNode(*test.delta_d1->output());
 
     auto & delta_d2 = ptg.GetDeltaNode(*test.delta_d2);
-    auto & delta_d2_out = ptg.GetRegisterSetNode(*test.delta_d2->output());
+    auto & delta_d2_out = ptg.GetRegisterNode(*test.delta_d2->output());
 
     auto & lambda_f1 = ptg.GetLambdaNode(*test.lambda_f1);
-    auto & lambda_f1_out = ptg.GetRegisterSetNode(*test.lambda_f1->output());
-    auto & lambda_f1_cvd1 = ptg.GetRegisterSetNode(*test.lambda_f1->cvargument(0));
+    auto & lambda_f1_out = ptg.GetRegisterNode(*test.lambda_f1->output());
+    auto & lambda_f1_cvd1 = ptg.GetRegisterNode(*test.lambda_f1->cvargument(0));
 
     auto & lambda_f2 = ptg.GetLambdaNode(*test.lambda_f2);
-    auto & lambda_f2_out = ptg.GetRegisterSetNode(*test.lambda_f2->output());
-    auto & lambda_f2_cvd1 = ptg.GetRegisterSetNode(*test.lambda_f2->cvargument(0));
-    auto & lambda_f2_cvd2 = ptg.GetRegisterSetNode(*test.lambda_f2->cvargument(1));
-    auto & lambda_f2_cvf1 = ptg.GetRegisterSetNode(*test.lambda_f2->cvargument(2));
+    auto & lambda_f2_out = ptg.GetRegisterNode(*test.lambda_f2->output());
+    auto & lambda_f2_cvd1 = ptg.GetRegisterNode(*test.lambda_f2->cvargument(0));
+    auto & lambda_f2_cvd2 = ptg.GetRegisterNode(*test.lambda_f2->cvargument(1));
+    auto & lambda_f2_cvf1 = ptg.GetRegisterNode(*test.lambda_f2->cvargument(2));
 
     assertTargets(delta_d1_out, { &delta_d1 });
     assertTargets(delta_d2_out, { &delta_d2 });
@@ -797,23 +797,23 @@ TestImports()
   {
     assert(ptg.NumLambdaNodes() == 2);
     assert(ptg.NumImportNodes() == 2);
-    assert(ptg.NumRegisterSetNodes() == 4);
+    assert(ptg.NumRegisterNodes() == 4);
 
     auto & d1 = ptg.GetImportNode(*test.import_d1);
-    auto & import_d1 = ptg.GetRegisterSetNode(*test.import_d1);
+    auto & import_d1 = ptg.GetRegisterNode(*test.import_d1);
 
     auto & d2 = ptg.GetImportNode(*test.import_d2);
-    auto & import_d2 = ptg.GetRegisterSetNode(*test.import_d2);
+    auto & import_d2 = ptg.GetRegisterNode(*test.import_d2);
 
     auto & lambda_f1 = ptg.GetLambdaNode(*test.lambda_f1);
-    auto & lambda_f1_out = ptg.GetRegisterSetNode(*test.lambda_f1->output());
-    auto & lambda_f1_cvd1 = ptg.GetRegisterSetNode(*test.lambda_f1->cvargument(0));
+    auto & lambda_f1_out = ptg.GetRegisterNode(*test.lambda_f1->output());
+    auto & lambda_f1_cvd1 = ptg.GetRegisterNode(*test.lambda_f1->cvargument(0));
 
     auto & lambda_f2 = ptg.GetLambdaNode(*test.lambda_f2);
-    auto & lambda_f2_out = ptg.GetRegisterSetNode(*test.lambda_f2->output());
-    auto & lambda_f2_cvd1 = ptg.GetRegisterSetNode(*test.lambda_f2->cvargument(0));
-    auto & lambda_f2_cvd2 = ptg.GetRegisterSetNode(*test.lambda_f2->cvargument(1));
-    auto & lambda_f2_cvf1 = ptg.GetRegisterSetNode(*test.lambda_f2->cvargument(2));
+    auto & lambda_f2_out = ptg.GetRegisterNode(*test.lambda_f2->output());
+    auto & lambda_f2_cvd1 = ptg.GetRegisterNode(*test.lambda_f2->cvargument(0));
+    auto & lambda_f2_cvd2 = ptg.GetRegisterNode(*test.lambda_f2->cvargument(1));
+    auto & lambda_f2_cvf1 = ptg.GetRegisterNode(*test.lambda_f2->cvargument(2));
 
     assertTargets(import_d1, { &d1 });
     assertTargets(import_d2, { &d2 });
@@ -847,23 +847,23 @@ TestPhi1()
   {
     assert(ptg.NumAllocaNodes() == 1);
     assert(ptg.NumLambdaNodes() == 2);
-    assert(ptg.NumRegisterSetNodes() == 3);
+    assert(ptg.NumRegisterNodes() == 3);
 
     auto & lambda_fib = ptg.GetLambdaNode(*test.lambda_fib);
-    auto & lambda_fib_out = ptg.GetRegisterSetNode(*test.lambda_fib->output());
-    auto & lambda_fib_arg1 = ptg.GetRegisterSetNode(*test.lambda_fib->fctargument(1));
+    auto & lambda_fib_out = ptg.GetRegisterNode(*test.lambda_fib->output());
+    auto & lambda_fib_arg1 = ptg.GetRegisterNode(*test.lambda_fib->fctargument(1));
 
     auto & lambda_test = ptg.GetLambdaNode(*test.lambda_test);
-    auto & lambda_test_out = ptg.GetRegisterSetNode(*test.lambda_test->output());
+    auto & lambda_test_out = ptg.GetRegisterNode(*test.lambda_test->output());
 
-    auto & phi_rv = ptg.GetRegisterSetNode(*test.phi->begin_rv().output());
-    auto & phi_rv_arg = ptg.GetRegisterSetNode(*test.phi->begin_rv().output()->argument());
+    auto & phi_rv = ptg.GetRegisterNode(*test.phi->begin_rv().output());
+    auto & phi_rv_arg = ptg.GetRegisterNode(*test.phi->begin_rv().output()->argument());
 
-    auto & gamma_result = ptg.GetRegisterSetNode(*test.gamma->subregion(0)->argument(1));
-    auto & gamma_fib = ptg.GetRegisterSetNode(*test.gamma->subregion(0)->argument(2));
+    auto & gamma_result = ptg.GetRegisterNode(*test.gamma->subregion(0)->argument(1));
+    auto & gamma_fib = ptg.GetRegisterNode(*test.gamma->subregion(0)->argument(2));
 
     auto & alloca = ptg.GetAllocaNode(*test.alloca);
-    auto & alloca_out = ptg.GetRegisterSetNode(*test.alloca->output(0));
+    auto & alloca_out = ptg.GetRegisterNode(*test.alloca->output(0));
 
     assertTargets(lambda_fib_out, { &lambda_fib });
     assertTargets(lambda_fib_arg1, { &alloca });
@@ -898,11 +898,11 @@ TestExternalMemory()
                                   const jlm::tests::ExternalMemoryTest & test)
   {
     assert(pointsToGraph.NumLambdaNodes() == 1);
-    assert(pointsToGraph.NumRegisterSetNodes() == 3);
+    assert(pointsToGraph.NumRegisterNodes() == 3);
 
     auto & lambdaF = pointsToGraph.GetLambdaNode(*test.LambdaF);
-    auto & lambdaFArgument0 = pointsToGraph.GetRegisterSetNode(*test.LambdaF->fctargument(0));
-    auto & lambdaFArgument1 = pointsToGraph.GetRegisterSetNode(*test.LambdaF->fctargument(1));
+    auto & lambdaFArgument0 = pointsToGraph.GetRegisterNode(*test.LambdaF->fctargument(0));
+    auto & lambdaFArgument1 = pointsToGraph.GetRegisterNode(*test.LambdaF->fctargument(1));
 
     assertTargets(lambdaFArgument0, { &lambdaF, &pointsToGraph.GetExternalMemoryNode() });
     assertTargets(lambdaFArgument1, { &lambdaF, &pointsToGraph.GetExternalMemoryNode() });
@@ -928,11 +928,11 @@ TestEscapedMemory1()
   {
     assert(pointsToGraph.NumDeltaNodes() == 4);
     assert(pointsToGraph.NumLambdaNodes() == 1);
-    assert(pointsToGraph.NumRegisterSetNodes() == 7);
+    assert(pointsToGraph.NumRegisterNodes() == 7);
 
-    auto & lambdaTestArgument0 = pointsToGraph.GetRegisterSetNode(*test.LambdaTest->fctargument(0));
-    auto & lambdaTestCv0 = pointsToGraph.GetRegisterSetNode(*test.LambdaTest->cvargument(0));
-    auto & loadNode1Output = pointsToGraph.GetRegisterSetNode(*test.LoadNode1->output(0));
+    auto & lambdaTestArgument0 = pointsToGraph.GetRegisterNode(*test.LambdaTest->fctargument(0));
+    auto & lambdaTestCv0 = pointsToGraph.GetRegisterNode(*test.LambdaTest->cvargument(0));
+    auto & loadNode1Output = pointsToGraph.GetRegisterNode(*test.LoadNode1->output(0));
 
     auto deltaA = &pointsToGraph.GetDeltaNode(*test.DeltaA);
     auto deltaB = &pointsToGraph.GetDeltaNode(*test.DeltaB);
@@ -968,7 +968,7 @@ TestEscapedMemory2()
     assert(pointsToGraph.NumImportNodes() == 2);
     assert(pointsToGraph.NumLambdaNodes() == 3);
     assert(pointsToGraph.NumMallocNodes() == 2);
-    assert(pointsToGraph.NumRegisterSetNodes() == 8);
+    assert(pointsToGraph.NumRegisterNodes() == 8);
 
     auto returnAddressFunction = &pointsToGraph.GetLambdaNode(*test.ReturnAddressFunction);
     auto callExternalFunction1 = &pointsToGraph.GetLambdaNode(*test.CallExternalFunction1);
@@ -979,7 +979,7 @@ TestEscapedMemory2()
     auto externalMemory = &pointsToGraph.GetExternalMemoryNode();
 
     auto & externalFunction2CallResult =
-        pointsToGraph.GetRegisterSetNode(*test.ExternalFunction2Call->Result(0));
+        pointsToGraph.GetRegisterNode(*test.ExternalFunction2Call->Result(0));
 
     assertTargets(
         externalFunction2CallResult,
@@ -1017,14 +1017,14 @@ TestEscapedMemory3()
     assert(pointsToGraph.NumDeltaNodes() == 1);
     assert(pointsToGraph.NumImportNodes() == 1);
     assert(pointsToGraph.NumLambdaNodes() == 1);
-    assert(pointsToGraph.NumRegisterSetNodes() == 4);
+    assert(pointsToGraph.NumRegisterNodes() == 4);
 
     auto lambdaTest = &pointsToGraph.GetLambdaNode(*test.LambdaTest);
     auto deltaGlobal = &pointsToGraph.GetDeltaNode(*test.DeltaGlobal);
     auto externalMemory = &pointsToGraph.GetExternalMemoryNode();
 
     auto & callExternalFunctionResult =
-        pointsToGraph.GetRegisterSetNode(*test.CallExternalFunction->Result(0));
+        pointsToGraph.GetRegisterNode(*test.CallExternalFunction->Result(0));
 
     assertTargets(callExternalFunctionResult, { lambdaTest, deltaGlobal, externalMemory });
 
@@ -1052,13 +1052,13 @@ TestMemcpy()
   {
     assert(pointsToGraph.NumDeltaNodes() == 2);
     assert(pointsToGraph.NumLambdaNodes() == 2);
-    assert(pointsToGraph.NumRegisterSetNodes() == 4);
+    assert(pointsToGraph.NumRegisterNodes() == 4);
 
     auto localArray = &pointsToGraph.GetDeltaNode(test.LocalArray());
     auto globalArray = &pointsToGraph.GetDeltaNode(test.GlobalArray());
 
-    auto & memCpyDest = pointsToGraph.GetRegisterSetNode(*test.Memcpy().input(0)->origin());
-    auto & memCpySrc = pointsToGraph.GetRegisterSetNode(*test.Memcpy().input(1)->origin());
+    auto & memCpyDest = pointsToGraph.GetRegisterNode(*test.Memcpy().input(0)->origin());
+    auto & memCpySrc = pointsToGraph.GetRegisterNode(*test.Memcpy().input(1)->origin());
 
     auto lambdaF = &pointsToGraph.GetLambdaNode(test.LambdaF());
     auto lambdaG = &pointsToGraph.GetLambdaNode(test.LambdaG());
@@ -1122,7 +1122,7 @@ TestLambdaCallArgumentMismatch()
   // Assert
   assert(pointsToGraph->NumAllocaNodes() == 1);
   assert(pointsToGraph->NumLambdaNodes() == 2);
-  assert(pointsToGraph->NumRegisterSetNodes() == 3);
+  assert(pointsToGraph->NumRegisterNodes() == 3);
 }
 
 static void


### PR DESCRIPTION
1. Removes the old PointsToGraph::RegisterNode class
2. Renames the PointsToGraph::RegisterSetNode class to PointsToGraph::RegisterNode

The graphviz output for the RegisterSetNodes was manually checked to contain the variable names of the debug output  and look "proper".