### PR TITLE
Add mandatory doxygen workflow

### DIFF
--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
-        run: sudo apt-get install graphviz doxygen
+        run: sudo apt-get install graphviz doxygen llvm-16-dev
       - name: Configure jlm
         run: ./configure.sh
       - name: Generate documentation

--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -5,7 +5,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  GenerateDocumentation:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -9,8 +9,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - name: Install dependencies
-        run: sudo apt-get install graphviz doxygen llvm-16-dev
+      - name: Install doxygen and graphviz
+        run: sudo apt-get install graphviz doxygen
+      - name: Install LLVM and Clang
+        uses: ./.github/actions/InstallLlvmDependencies
       - name: Configure jlm
         run: ./configure.sh
       - name: Generate documentation

--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -1,0 +1,17 @@
+name: Doxygen
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt-get install graphviz doxygen
+      - name: Configure jlm
+        run: ./configure.sh
+      - name: Generate documentation
+        run: make docs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,17 +5,6 @@ on:
     branches: [ master ]
 
 jobs:
-  docs:
-    runs-on: ubuntu-22.04
-    steps:
-    - uses: actions/checkout@v3
-    - name: Install dependencies
-      run: sudo apt-get install graphviz doxygen
-    - name: Configure jlm
-      run: ./configure.sh
-    - name: Generate documentation
-      run: make docs
-
   ClangFormat:
     runs-on: ubuntu-22.04
     steps:

--- a/doxygen.conf
+++ b/doxygen.conf
@@ -836,7 +836,7 @@ WARN_NO_PARAMDOC       = NO
 # Possible values are: NO, YES and FAIL_ON_WARNINGS.
 # The default value is: NO.
 
-WARN_AS_ERROR          = NO
+WARN_AS_ERROR          = FAIL_ON_WARNINGS
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which

--- a/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
+++ b/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
@@ -940,7 +940,6 @@ Convert(
   }
 }
 
-template<class NODE>
 static void
 ConvertAggregationNode(
     const aggnode & aggregationNode,
@@ -948,31 +947,34 @@ ConvertAggregationNode(
     lambda::node & lambdaNode,
     RegionalizedVariableMap & regionalizedVariableMap)
 {
-  JLM_ASSERT(dynamic_cast<const NODE *>(&aggregationNode));
-  auto & castedNode = *static_cast<const NODE *>(&aggregationNode);
-  Convert(castedNode, demandMap, lambdaNode, regionalizedVariableMap);
-}
-
-static void
-ConvertAggregationNode(
-    const aggnode & aggregationNode,
-    const AnnotationMap & demandMap,
-    lambda::node & lambdaNode,
-    RegionalizedVariableMap & regionalizedVariableMap)
-{
-  static std::unordered_map<
-      std::type_index,
-      std::function<
-          void(const aggnode &, const AnnotationMap &, lambda::node &, RegionalizedVariableMap &)>>
-      map({ { typeid(entryaggnode), ConvertAggregationNode<entryaggnode> },
-            { typeid(exitaggnode), ConvertAggregationNode<exitaggnode> },
-            { typeid(blockaggnode), ConvertAggregationNode<blockaggnode> },
-            { typeid(linearaggnode), ConvertAggregationNode<linearaggnode> },
-            { typeid(branchaggnode), ConvertAggregationNode<branchaggnode> },
-            { typeid(loopaggnode), ConvertAggregationNode<loopaggnode> } });
-
-  JLM_ASSERT(map.find(typeid(aggregationNode)) != map.end());
-  map[typeid(aggregationNode)](aggregationNode, demandMap, lambdaNode, regionalizedVariableMap);
+  if (auto entryNode = dynamic_cast<const entryaggnode *>(&aggregationNode))
+  {
+    Convert(*entryNode, demandMap, lambdaNode, regionalizedVariableMap);
+  }
+  else if (auto exitNode = dynamic_cast<const exitaggnode *>(&aggregationNode))
+  {
+    Convert(*exitNode, demandMap, lambdaNode, regionalizedVariableMap);
+  }
+  else if (auto blockNode = dynamic_cast<const blockaggnode *>(&aggregationNode))
+  {
+    Convert(*blockNode, demandMap, lambdaNode, regionalizedVariableMap);
+  }
+  else if (auto linearNode = dynamic_cast<const linearaggnode *>(&aggregationNode))
+  {
+    Convert(*linearNode, demandMap, lambdaNode, regionalizedVariableMap);
+  }
+  else if (auto branchNode = dynamic_cast<const branchaggnode *>(&aggregationNode))
+  {
+    Convert(*branchNode, demandMap, lambdaNode, regionalizedVariableMap);
+  }
+  else if (auto loopNode = dynamic_cast<const loopaggnode *>(&aggregationNode))
+  {
+    Convert(*loopNode, demandMap, lambdaNode, regionalizedVariableMap);
+  }
+  else
+  {
+    JLM_UNREACHABLE("Unhandled aggregation node type");
+  }
 }
 
 static void

--- a/jlm/llvm/ir/Annotation.cpp
+++ b/jlm/llvm/ir/Annotation.cpp
@@ -329,30 +329,40 @@ AnnotateReadWrite(const loopaggnode & loopAggregationNode, AnnotationMap & deman
   demandMap.Insert(loopAggregationNode, std::move(demandSet));
 }
 
-template<class T>
-static void
-AnnotateReadWrite(const aggnode & aggregationNode, AnnotationMap & DemandMap)
-{
-  JLM_ASSERT(is<T>(&aggregationNode));
-  AnnotateReadWrite(*static_cast<const T *>(&aggregationNode), DemandMap);
-}
-
 static void
 AnnotateReadWrite(const aggnode & aggregationNode, AnnotationMap & demandMap)
 {
-  static std::unordered_map<std::type_index, void (*)(const aggnode &, AnnotationMap &)> map(
-      { { typeid(entryaggnode), AnnotateReadWrite<entryaggnode> },
-        { typeid(exitaggnode), AnnotateReadWrite<exitaggnode> },
-        { typeid(blockaggnode), AnnotateReadWrite<blockaggnode> },
-        { typeid(linearaggnode), AnnotateReadWrite<linearaggnode> },
-        { typeid(branchaggnode), AnnotateReadWrite<branchaggnode> },
-        { typeid(loopaggnode), AnnotateReadWrite<loopaggnode> } });
-
   for (size_t n = 0; n < aggregationNode.nchildren(); n++)
     AnnotateReadWrite(*aggregationNode.child(n), demandMap);
 
-  JLM_ASSERT(map.find(typeid(aggregationNode)) != map.end());
-  return map[typeid(aggregationNode)](aggregationNode, demandMap);
+  if (auto entryNode = dynamic_cast<const entryaggnode *>(&aggregationNode))
+  {
+    AnnotateReadWrite(*entryNode, demandMap);
+  }
+  else if (auto exitNode = dynamic_cast<const exitaggnode *>(&aggregationNode))
+  {
+    AnnotateReadWrite(*exitNode, demandMap);
+  }
+  else if (auto blockNode = dynamic_cast<const blockaggnode *>(&aggregationNode))
+  {
+    AnnotateReadWrite(*blockNode, demandMap);
+  }
+  else if (auto linearNode = dynamic_cast<const linearaggnode *>(&aggregationNode))
+  {
+    AnnotateReadWrite(*linearNode, demandMap);
+  }
+  else if (auto branchNode = dynamic_cast<const branchaggnode *>(&aggregationNode))
+  {
+    AnnotateReadWrite(*branchNode, demandMap);
+  }
+  else if (auto loopNode = dynamic_cast<const loopaggnode *>(&aggregationNode))
+  {
+    AnnotateReadWrite(*loopNode, demandMap);
+  }
+  else
+  {
+    JLM_UNREACHABLE("Unhandled aggregation node type");
+  }
 }
 
 static void

--- a/jlm/llvm/ir/aggregation.hpp
+++ b/jlm/llvm/ir/aggregation.hpp
@@ -533,7 +533,7 @@ public:
  *
  * 2. Branch subgraphs, such as:
  * \dot
- * 	\digraph branches {
+ *   digraph branches {
  * 		Split -> A;
  * 		Split -> B;
  * 		Split -> C;

--- a/jlm/llvm/ir/operators/Phi.hpp
+++ b/jlm/llvm/ir/operators/Phi.hpp
@@ -47,7 +47,7 @@ class rvoutput;
 
 class node final : public jlm::rvsdg::structural_node
 {
-  friend phi::builder;
+  friend class phi::builder;
 
   class cvconstiterator final
   {
@@ -59,7 +59,7 @@ class node final : public jlm::rvsdg::structural_node
     using reference = const cvinput *&;
 
   private:
-    friend phi::node;
+    friend class phi::node;
 
     cvconstiterator(const cvinput * input)
         : input_(input)
@@ -122,7 +122,7 @@ class node final : public jlm::rvsdg::structural_node
     using reference = cvinput *&;
 
   private:
-    friend phi::node;
+    friend class phi::node;
 
     cviterator(cvinput * input)
         : input_(input)
@@ -184,7 +184,7 @@ class node final : public jlm::rvsdg::structural_node
     using pointer = const rvoutput **;
     using reference = const rvoutput *&;
 
-    friend phi::node;
+    friend class phi::node;
 
     rvconstiterator(const rvoutput * output)
         : output_(output)
@@ -247,7 +247,7 @@ class node final : public jlm::rvsdg::structural_node
     using reference = rvoutput *&;
 
   private:
-    friend phi::node;
+    friend class phi::node;
 
     rviterator(rvoutput * output)
         : output_(output)
@@ -549,7 +549,7 @@ private:
 
 class cvinput final : public jlm::rvsdg::structural_input
 {
-  friend phi::node;
+  friend class phi::node;
 
 public:
   ~cvinput() override;
@@ -594,7 +594,7 @@ class rvresult;
 
 class rvoutput final : public jlm::rvsdg::structural_output
 {
-  friend phi::builder;
+  friend class phi::builder;
 
 public:
   ~rvoutput() override;
@@ -647,8 +647,8 @@ class rvresult;
 
 class rvargument final : public jlm::rvsdg::argument
 {
-  friend phi::builder;
-  friend phi::rvoutput;
+  friend class phi::builder;
+  friend class phi::rvoutput;
 
 public:
   ~rvargument() override;
@@ -702,7 +702,7 @@ class node;
 
 class cvargument final : public jlm::rvsdg::argument
 {
-  friend phi::node;
+  friend class phi::node;
 
 public:
   ~cvargument() override;
@@ -742,7 +742,7 @@ public:
 
 class rvresult final : public jlm::rvsdg::result
 {
-  friend phi::builder;
+  friend class phi::builder;
 
 public:
   ~rvresult() override;

--- a/jlm/llvm/ir/operators/delta.hpp
+++ b/jlm/llvm/ir/operators/delta.hpp
@@ -274,7 +274,7 @@ public:
    * \param type The delta node's type.
    * \param name The delta node's name.
    * \param linkage The delta node's linkage.
-   * \param Section The delta node's section.
+   * \param section The delta node's section.
    * \param constant True, if the delta node is constant, otherwise false.
    *
    * \return A delta node without inputs or outputs.

--- a/jlm/llvm/ir/operators/lambda.hpp
+++ b/jlm/llvm/ir/operators/lambda.hpp
@@ -791,9 +791,9 @@ public:
   }
 
   /**
-   * Returns an \ref iterator_range for iterating through all direct call sites.
+   * Returns an \ref util::iterator_range for iterating through all direct call sites.
    *
-   * @return An \ref iterator_range of all direct call sites.
+   * @return An \ref util::iterator_range of all direct call sites.
    */
   [[nodiscard]] DirectCallsConstRange
   DirectCalls() const noexcept
@@ -802,9 +802,9 @@ public:
   }
 
   /**
-   * Returns an \ref iterator_range for iterating through all other usages.
+   * Returns an \ref util::iterator_range for iterating through all other usages.
    *
-   * @return An \ref iterator_range of all other usages.
+   * @return An \ref util::iterator_range of all other usages.
    */
   [[nodiscard]] OtherUsersConstRange
   OtherUsers() const noexcept

--- a/jlm/llvm/opt/alias-analyses/AgnosticMemoryNodeProvider.hpp
+++ b/jlm/llvm/opt/alias-analyses/AgnosticMemoryNodeProvider.hpp
@@ -82,7 +82,7 @@ public:
  *
  * The statistics collected when running the agnostic memory node provider.
  *
- * @See AgnosticMemoryNodeProvider
+ * @see AgnosticMemoryNodeProvider
  */
 class AgnosticMemoryNodeProvider::Statistics final : public util::Statistics
 {

--- a/jlm/llvm/opt/alias-analyses/PointsToGraph.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraph.hpp
@@ -951,7 +951,7 @@ public:
   using reference = NODETYPE *&;
 
 private:
-  friend PointsToGraph::Node;
+  friend class PointsToGraph::Node;
 
   explicit Iterator(const typename std::unordered_set<NODETYPE *>::iterator & it)
       : It_(it)

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
@@ -49,7 +49,7 @@ public:
   /**
    * \brief Analyze RVSDG module
    *
-   * \param module RVSDG module the analysis is performed on.
+   * \param rvsdgModule RVSDG module the analysis is performed on.
    *
    * \return A PointsTo graph.
    */

--- a/jlm/rvsdg/node.hpp
+++ b/jlm/rvsdg/node.hpp
@@ -34,8 +34,8 @@ class substitution_map;
 
 class input
 {
-  friend jlm::rvsdg::node;
-  friend jlm::rvsdg::region;
+  friend class jlm::rvsdg::node;
+  friend class jlm::rvsdg::region;
 
 public:
   virtual ~input() noexcept;
@@ -290,8 +290,8 @@ is(const jlm::rvsdg::input & input) noexcept
 class output
 {
   friend input;
-  friend jlm::rvsdg::node;
-  friend jlm::rvsdg::region;
+  friend class jlm::rvsdg::node;
+  friend class jlm::rvsdg::region;
 
   typedef std::unordered_set<jlm::rvsdg::input *>::const_iterator user_iterator;
 

--- a/jlm/rvsdg/simple-node.hpp
+++ b/jlm/rvsdg/simple-node.hpp
@@ -72,7 +72,7 @@ public:
 
 class simple_input final : public node_input
 {
-  friend jlm::rvsdg::output;
+  friend class jlm::rvsdg::output;
 
 public:
   virtual ~simple_input() noexcept;
@@ -91,7 +91,7 @@ public:
 
 class simple_output final : public node_output
 {
-  friend jlm::rvsdg::simple_input;
+  friend class jlm::rvsdg::simple_input;
 
 public:
   virtual ~simple_output() noexcept;


### PR DESCRIPTION
This PR does the following:
1. Fixes all warnings and errors that doxygen produces when creating the documentation
2. Configures doxygen to fail when it encounters an error or warning
3. Moves documentation creation into its own workflow