### PR TITLE
Propagate points-to flags between sets in Steensgaard

### DIFF
--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -1730,7 +1730,7 @@ Steensgaard::Analyze(
   // std::cout << LocationSet_->ToDot() << std::flush;
   statistics->StopSteensgaardStatistics();
 
-  // Propagate points-to flags in disjoint location set
+  // Propagate points-to flags in disjoint location set graph
   statistics->StartPointsToFlagsPropagationStatistics(*LocationSet_);
   PropagatePointsToFlags();
   statistics->StopPointsToFlagsPropagationStatistics();

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
@@ -145,7 +145,7 @@ private:
   AnalyzeExtractValue(const rvsdg::simple_node & node);
 
   /**
-   * \brief Propagates the points-to flags throughout the disjoint set location graph.
+   * Propagates the points-to flags throughout the disjoint set location graph.
    *
    * AnalyzeRvsdg builds a disjoint set location graph, where each set is annotated with points-to
    * flags. This method propagates these points-to flags throughout the graph as all of these flags

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
@@ -147,7 +147,7 @@ private:
   /**
    * Propagates the points-to flags throughout the disjoint set location graph.
    *
-   * AnalyzeRvsdg builds a disjoint set location graph, where each set is annotated with points-to
+   * AnalyzeRvsdg() builds a disjoint set location graph, where each set is annotated with points-to
    * flags. This method propagates these points-to flags throughout the graph as all of these flags
    * are contagious. An example would be a set A that is marked as PointsToEscapedMemory and points
    * to another set B. As set B would "originate" from a load operation from "set A", the

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
@@ -145,6 +145,18 @@ private:
   AnalyzeExtractValue(const rvsdg::simple_node & node);
 
   /**
+   * \brief Propagates the points-to flags throughout the disjoint set location graph.
+   *
+   * Analyze builds a disjoint set location graph, where each set is annotated with points-to flags.
+   * This method propagates these points-to flags throughout the graph as all of these flags are
+   * contagious. An example would be a set A that is marked as PointsToEscapedMemory and points to
+   * another set B. As set B would "originate" from a load operation from "set A", the consequence
+   * would be that set B must be marked as PointsToEscapedMemory as well.
+   */
+  void
+  PropagatePointsToFlags();
+
+  /**
    * Construct a points-to graph from the Steensgaard analysis result.
    *
    * @return A points-to graph.

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
@@ -147,11 +147,11 @@ private:
   /**
    * \brief Propagates the points-to flags throughout the disjoint set location graph.
    *
-   * Analyze builds a disjoint set location graph, where each set is annotated with points-to flags.
-   * This method propagates these points-to flags throughout the graph as all of these flags are
-   * contagious. An example would be a set A that is marked as PointsToEscapedMemory and points to
-   * another set B. As set B would "originate" from a load operation from "set A", the consequence
-   * would be that set B must be marked as PointsToEscapedMemory as well.
+   * AnalyzeRvsdg builds a disjoint set location graph, where each set is annotated with points-to
+   * flags. This method propagates these points-to flags throughout the graph as all of these flags
+   * are contagious. An example would be a set A that is marked as PointsToEscapedMemory and points
+   * to another set B. As set B would "originate" from a load operation from "set A", the
+   * consequence would be that set B must be marked as PointsToEscapedMemory as well.
    */
   void
   PropagatePointsToFlags();

--- a/tests/TestRvsdgs.hpp
+++ b/tests/TestRvsdgs.hpp
@@ -1795,6 +1795,79 @@ private:
   jlm::rvsdg::node * Memcpy_;
 };
 
+/**
+ * This class sets up an RVSDG representing the following code snippet:
+ *
+ * \code{.c}
+ *   #include <string.h>
+ *
+ *   typedef struct structB
+ *   {
+ *     int * array[32];
+ *   } structB;
+ *
+ *   typedef struct structA
+ *   {
+ *     int x;
+ *     structB * b;
+ *   } structA;
+ *
+ *   static void
+ *   g(structB * s1, structB * s2)
+ *   {
+ *     memcpy(*s2->array, *s1->array, sizeof(int) * 32);
+ *   }
+ *
+ *   void
+ *   f(structA * s1, structA * s2)
+ *   {
+ *     g(s1->b, s2->b);
+ *   }
+ * \endcode
+ */
+class MemcpyTest2 final : public RvsdgTest
+{
+public:
+  [[nodiscard]] const jlm::llvm::lambda::node &
+  LambdaF() const noexcept
+  {
+    JLM_ASSERT(LambdaF_ != nullptr);
+    return *LambdaF_;
+  }
+
+  [[nodiscard]] const jlm::llvm::lambda::node &
+  LambdaG() const noexcept
+  {
+    JLM_ASSERT(LambdaG_ != nullptr);
+    return *LambdaG_;
+  }
+
+  [[nodiscard]] const jlm::llvm::CallNode &
+  CallG() const noexcept
+  {
+    JLM_ASSERT(CallG_ != nullptr);
+    return *CallG_;
+  }
+
+  [[nodiscard]] const jlm::rvsdg::node &
+  Memcpy() const noexcept
+  {
+    JLM_ASSERT(Memcpy_ != nullptr);
+    return *Memcpy_;
+  }
+
+private:
+  std::unique_ptr<jlm::llvm::RvsdgModule>
+  SetupRvsdg() override;
+
+  jlm::llvm::lambda::node * LambdaF_ = {};
+  jlm::llvm::lambda::node * LambdaG_ = {};
+
+  jlm::llvm::CallNode * CallG_ = {};
+
+  jlm::rvsdg::node * Memcpy_ = {};
+};
+
 /** \brief LinkedListTest class
  *
  * This class sets up an RVSDG representing the following code snippet:


### PR DESCRIPTION
This PR introduces a points-to flag propagation pass in the Steensgaard alias analysis such that the points-to flags are properly propagated in the disjoint location set graph. So far, the points-to flags were only annotated for each disjoint location set, but were not propagated to the points-to set. However, all of the points-to flags are contagious, i.e., if a set is marked with a flag, then the points-to set must also be marked with it.

This should put the points-to flags on solid footing as:
1. The points-to flags are added for each location on creation time.
2. The flags are propagated to the root element of a set when a location is joined to a set.
3. The flags are propagated between sets with the just introduced propagation pass.

This PR introduces the third point from above. The first and second point are already present in the code.

Closes #335 