### PR TITLE
Add Statistics tracking to Andersen

### DIFF
--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -43,7 +43,7 @@ public:
         NumSupersetOfAllPointeesConstraints_(0),
         NumHandleEscapingFunctionConstraints_(0),
         NumFunctionCallConstraints_(0),
-        ConstraintSolvingIterations_(0),
+        NumConstraintSolvingIterations_(0),
         NumPointsToGraphNodes_(0),
         NumRegisterNodes_(0),
         NumAllocaNodes_(0),
@@ -97,13 +97,15 @@ public:
   }
 
   void
-  StartPointsToGraphConstructionStatistics(
-      const PointerObjectSet & set,
-      size_t constraintSolvingIterations)
+  StopConstraintSolvingStatistics(size_t numConstraintSolvingIterations) noexcept
   {
     ConstraintSolvingTimer_.stop();
-    ConstraintSolvingIterations_ = constraintSolvingIterations;
+    NumConstraintSolvingIterations_ = numConstraintSolvingIterations;
+  }
 
+  void
+  StartPointsToGraphConstructionStatistics()
+  {
     PointsToGraphConstructionTimer_.start();
   }
 
@@ -176,7 +178,7 @@ public:
         NumFunctionCallConstraints_,
         " ",
         "#ConstraintSolvingIterations:",
-        ConstraintSolvingIterations_,
+        NumConstraintSolvingIterations_,
         " ",
         "#PointsToGraphNodes:",
         NumPointsToGraphNodes_,
@@ -243,7 +245,7 @@ private:
   size_t NumFunctionCallConstraints_;
 
   // How many iterations constraint solving used before a fixed point was established
-  size_t ConstraintSolvingIterations_;
+  size_t NumConstraintSolvingIterations_;
 
   // Counts of nodes in the final PointsToGraph
   size_t NumPointsToGraphNodes_;
@@ -913,9 +915,10 @@ Andersen::Analyze(const RvsdgModule & module, util::StatisticsCollector & statis
   AnalyzeRvsdg(module.Rvsdg());
 
   statistics->StartConstraintSolvingStatistics(*Set_, *Constraints_);
-  size_t iterations = Constraints_->Solve();
+  size_t numIterations = Constraints_->Solve();
+  statistics->StopConstraintSolvingStatistics(numIterations);
 
-  statistics->StartPointsToGraphConstructionStatistics(*Set_, iterations);
+  statistics->StartPointsToGraphConstructionStatistics();
   auto result = ConstructPointsToGraphFromPointerObjectSet(*Set_, *statistics);
   statistics->StopPointsToGraphConstructionStatistics(*result);
 

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -37,6 +37,7 @@ public:
       : jlm::util::Statistics(Statistics::Id::AndersenAnalysis),
         SourceFile_(std::move(sourceFile)),
         NumRvsdgNodes_(0),
+        NumPointerObjects_(0),
         NumRegistersMappedToPointerObject_(0),
         NumSupersetConstraints_(0),
         NumAllPointeesPointToSupersetConstraints_(0),
@@ -71,6 +72,7 @@ public:
   {
     SetAndConstraintBuildingTimer_.stop();
 
+    NumPointerObjects_ = set.NumPointerObjects();
     NumRegistersMappedToPointerObject_ = set.GetRegisterMap().size();
     for (const auto & constraint : constraints.GetConstraints())
     {
@@ -155,6 +157,9 @@ public:
         "AliasAnalysisTime[ns]:",
         AnalysisTimer_.ns(),
         " ",
+        "#PointerObjects:",
+        NumPointerObjects_,
+        " ",
         "#RegistersMappedToPointerObject:",
         NumRegistersMappedToPointerObject_,
         " ",
@@ -229,6 +234,7 @@ private:
   jlm::util::filepath SourceFile_;
   size_t NumRvsdgNodes_;
 
+  size_t NumPointerObjects_;
   // The number of RVSDG outputs and arguments that are associated with a PointerObject
   size_t NumRegistersMappedToPointerObject_;
 

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -81,16 +81,14 @@ public:
             using ConstraintType = std::decay_t<decltype(c)>;
             if constexpr (std::is_same_v<ConstraintType, SupersetConstraint>)
               NumSupersetConstraints_++;
-            else if constexpr (std::is_same_v<ConstraintType, AllPointeesPointToSupersetConstraint>)
+            if constexpr (std::is_same_v<ConstraintType, AllPointeesPointToSupersetConstraint>)
               NumAllPointeesPointToSupersetConstraints_++;
-            else if constexpr (std::is_same_v<ConstraintType, SupersetOfAllPointeesConstraint>)
+            if constexpr (std::is_same_v<ConstraintType, SupersetOfAllPointeesConstraint>)
               NumSupersetOfAllPointeesConstraints_++;
-            else if constexpr (std::is_same_v<ConstraintType, HandleEscapingFunctionConstraint>)
+            if constexpr (std::is_same_v<ConstraintType, HandleEscapingFunctionConstraint>)
               NumHandleEscapingFunctionConstraints_++;
-            else if constexpr (std::is_same_v<ConstraintType, FunctionCallConstraint>)
+            if constexpr (std::is_same_v<ConstraintType, FunctionCallConstraint>)
               NumFunctionCallConstraints_++;
-            else
-              static_assert(false, "Unknown ConstraintType");
           },
           constraint);
     }

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -8,7 +8,6 @@
 #include <jlm/rvsdg/traverser.hpp>
 #include <jlm/util/Statistics.hpp>
 #include <jlm/util/time.hpp>
-#include <variant>
 
 namespace jlm::llvm::aa
 {

--- a/jlm/llvm/opt/alias-analyses/Andersen.hpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.hpp
@@ -71,7 +71,7 @@ public:
    * @return the newly created PointsToGraph
    */
   static std::unique_ptr<PointsToGraph>
-  ConstructPointsToGraphFromPointerObjectSet(const PointerObjectSet & set);
+  ConstructPointsToGraphFromPointerObjectSet(const PointerObjectSet & set, Statistics & statistics);
 
 private:
   void

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
@@ -452,14 +452,14 @@ PointerObjectConstraintSet::GetConstraints() const noexcept
 size_t
 PointerObjectConstraintSet::Solve()
 {
-  size_t iterations = 0;
+  size_t numIterations = 0;
 
   // Keep applying constraints until no sets are modified
   bool modified = true;
 
   while (modified)
   {
-    iterations++;
+    numIterations++;
     modified = false;
 
     for (auto & constraint : Constraints_)
@@ -475,7 +475,7 @@ PointerObjectConstraintSet::Solve()
     modified |= PropagateEscapedFlag();
   }
 
-  return iterations;
+  return numIterations;
 }
 
 bool

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
@@ -443,14 +443,23 @@ PointerObjectConstraintSet::AddConstraint(ConstraintVariant c)
   Constraints_.push_back(c);
 }
 
-void
+const std::vector<PointerObjectConstraintSet::ConstraintVariant> &
+PointerObjectConstraintSet::GetConstraints() const noexcept
+{
+  return Constraints_;
+}
+
+size_t
 PointerObjectConstraintSet::Solve()
 {
+  size_t iterations = 0;
+
   // Keep applying constraints until no sets are modified
   bool modified = true;
 
   while (modified)
   {
+    iterations++;
     modified = false;
 
     for (auto & constraint : Constraints_)
@@ -465,6 +474,8 @@ PointerObjectConstraintSet::Solve()
 
     modified |= PropagateEscapedFlag();
   }
+
+  return iterations;
 }
 
 bool

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
@@ -571,10 +571,17 @@ public:
   AddConstraint(ConstraintVariant c);
 
   /**
+   * Retrieves all added constraints that were not simple one-off flag changes
+   */
+  const std::vector<ConstraintVariant> &
+  GetConstraints() const noexcept;
+
+  /**
    * Iterates over and applies constraints until all points-to-sets satisfy them.
    * This operation potentially has a long runtime, with an upper bound of O(n^3).
+   * @return the number of iterations until a fixed solution was established. At least 1.
    */
-  void
+  size_t
   Solve();
 
 private:

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -227,9 +227,11 @@ JlmOptCommandLineOptions::ToCommandLineArgument(jlm::util::Statistics::Id statis
 {
   static std::unordered_map<util::Statistics::Id, const char *> map(
       { { util::Statistics::Id::Aggregation, StatisticsCommandLineArgument::Aggregation_ },
+        { util::Statistics::Id::AndersenAnalysis,
+          StatisticsCommandLineArgument::AndersenAnalysis_ },
+        { util::Statistics::Id::Annotation, StatisticsCommandLineArgument::Annotation_ },
         { util::Statistics::Id::BasicEncoderEncoding,
           StatisticsCommandLineArgument::BasicEncoderEncoding_ },
-        { util::Statistics::Id::Annotation, StatisticsCommandLineArgument::Annotation_ },
         { util::Statistics::Id::CommonNodeElimination,
           StatisticsCommandLineArgument::CommonNodeElimination_ },
         { util::Statistics::Id::ControlFlowRecovery,
@@ -508,6 +510,7 @@ JlcCommandLineParser::ParseCommandLineArguments(int argc, char ** argv)
       cl::value_desc("value"));
 
   auto aggregationStatisticsId = util::Statistics::Id::Aggregation;
+  auto andersenAnalysisStatisticsId = util::Statistics::Id::AndersenAnalysis;
   auto annotationStatisticsId = util::Statistics::Id::Annotation;
   auto basicEncoderEncodingStatisticsId = util::Statistics::Id::BasicEncoderEncoding;
   auto commonNodeEliminationStatisticsId = util::Statistics::Id::CommonNodeElimination;
@@ -535,6 +538,10 @@ JlcCommandLineParser::ParseCommandLineArguments(int argc, char ** argv)
               aggregationStatisticsId,
               JlmOptCommandLineOptions::ToCommandLineArgument(aggregationStatisticsId),
               "Collect control flow graph aggregation pass statistics."),
+          ::clEnumValN(
+              andersenAnalysisStatisticsId,
+              JlmOptCommandLineOptions::ToCommandLineArgument(andersenAnalysisStatisticsId),
+              "Collect Andersen alias analysis pass statistics."),
           ::clEnumValN(
               annotationStatisticsId,
               JlmOptCommandLineOptions::ToCommandLineArgument(annotationStatisticsId),
@@ -762,6 +769,7 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, char ** argv)
       cl::value_desc("dir"));
 
   auto aggregationStatisticsId = util::Statistics::Id::Aggregation;
+  auto andersenAnalysisStatisticsId = util::Statistics::Id::AndersenAnalysis;
   auto annotationStatisticsId = util::Statistics::Id::Annotation;
   auto basicEncoderEncodingStatisticsId = util::Statistics::Id::BasicEncoderEncoding;
   auto commonNodeEliminationStatisticsId = util::Statistics::Id::CommonNodeElimination;
@@ -788,6 +796,10 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, char ** argv)
               aggregationStatisticsId,
               JlmOptCommandLineOptions::ToCommandLineArgument(aggregationStatisticsId),
               "Write aggregation statistics to file."),
+          ::clEnumValN(
+              andersenAnalysisStatisticsId,
+              JlmOptCommandLineOptions::ToCommandLineArgument(andersenAnalysisStatisticsId),
+              "Collect Andersen alias analysis pass statistics."),
           ::clEnumValN(
               annotationStatisticsId,
               JlmOptCommandLineOptions::ToCommandLineArgument(annotationStatisticsId),

--- a/jlm/tooling/CommandLine.hpp
+++ b/jlm/tooling/CommandLine.hpp
@@ -177,6 +177,7 @@ private:
   struct StatisticsCommandLineArgument
   {
     inline static const char * Aggregation_ = "print-aggregation-time";
+    inline static const char * AndersenAnalysis_ = "print-andersen-analysis";
     inline static const char * Annotation_ = "print-annotation-time";
     inline static const char * BasicEncoderEncoding_ = "print-basicencoder-encoding";
     inline static const char * CommonNodeElimination_ = "print-cne-stat";

--- a/jlm/util/Statistics.hpp
+++ b/jlm/util/Statistics.hpp
@@ -43,6 +43,7 @@ public:
     RvsdgDestruction,
     RvsdgOptimization,
     SteensgaardAnalysis,
+    AndersenAnalysis,
     ThetaGammaInversion,
 
     LastEnumValue // must always be the last enum value, used for iteration

--- a/tests/jlm/llvm/opt/alias-analyses/TestAndersen.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestAndersen.cpp
@@ -869,6 +869,24 @@ TestLinkedList()
       TargetsExactly(deltaMyListNode, { &deltaMyListNode, &lambdaNextNode, &externalMemoryNode }));
 }
 
+static void
+TestStatistics()
+{
+  // Arrange
+  jlm::tests::LoadTest1 test;
+  jlm::util::StatisticsCollectorSettings statisticsCollectorSettings(
+      jlm::util::filepath("/tmp/stats.txt"),
+      { jlm::util::Statistics::Id::AndersenAnalysis });
+  jlm::util::StatisticsCollector statisticsCollector(statisticsCollectorSettings);
+
+  // Act
+  jlm::llvm::aa::Andersen andersen;
+  andersen.Analyze(test.module(), statisticsCollector);
+
+  // Assert
+  assert(statisticsCollector.NumCollectedStatistics() == 1);
+}
+
 static int
 TestAndersen()
 {
@@ -898,6 +916,7 @@ TestAndersen()
   TestEscapedMemory3();
   TestMemcpy();
   TestLinkedList();
+  TestStatistics();
 
   return 0;
 }


### PR DESCRIPTION
Fixes #352

The tracked statistics have the same names as Steensgaard where applicable, but there are of course some differences.

`NumUnknownMemorySources_` became `NumExternalMemorySources_`, since Andersen only uses external.

Note that time spent connecting all PointingToExternal nodes to all Escaped nodes, is called `PointsToGraphConstructionExternalToEscapedTime[ns]`, since it is a subslice of  `PointsToGraphConstructionTime[ns]`.

The papers I've been reading about optimizing Andersen can have quite different internal representations for sets and set constraints, which means some of these statistics might change, but I will of course try to keep things stable when possible, to make comparisons possible.