### PR TITLE
Clean up common_executable build macro

### DIFF
--- a/Makefile.macros
+++ b/Makefile.macros
@@ -102,7 +102,7 @@ endef
 #   - foo_LIBS:
 #     extra libraries built in this project linked into the binary
 #     (just specify the name without extension)
-#   - foo_EXTRA_LDFLAGS:
+#   - foo_LDFLAGS:
 #     additional LDFLAGS to be passed to link the executable
 #     use this to pull in external libraries (not built in this project)
 define common_executable

--- a/Makefile.macros
+++ b/Makefile.macros
@@ -102,7 +102,7 @@ endef
 #   - foo_LIBS:
 #     extra libraries built in this project linked into the binary
 #     (just specify the name without extension)
-#   - foo_LDFLAGS:
+#   - foo_EXTRA_LDFLAGS:
 #     additional LDFLAGS to be passed to link the executable
 #     use this to pull in external libraries (not built in this project)
 define common_executable
@@ -110,7 +110,7 @@ SOURCES += $$($1_SOURCES)
 HEADERS += $$($1_HEADERS)
 
 $$(BUILD_OUT_PREFIX)$1: $$(patsubst %.cpp, $$(BUILD_OUT_PREFIX)%.la, $$($1_SOURCES)) $$(patsubst %, $$(BUILD_OUT_PREFIX)%.a, $$($1_LIBS))
-$$(BUILD_OUT_PREFIX)$1: LDFLAGS+=$$(patsubst %, $$(BUILD_OUT_PREFIX)%.a, $$($1_LIBS)) $$($1_LDFLAGS)
+$$(BUILD_OUT_PREFIX)$1: LDFLAGS+=$$(patsubst %, $$(BUILD_OUT_PREFIX)%.a, $$($1_LIBS)) $$($1_EXTRA_LDFLAGS)
 EXECUTABLES += $$(BUILD_OUT_PREFIX)$1
 
 # alias rule to allow issuing "make foo" instead of "make build/foo"

--- a/tools/Makefile.sub
+++ b/tools/Makefile.sub
@@ -11,7 +11,7 @@ jlc_LIBS += \
 	librvsdg \
 	libutil \
 
-jlc_LDFLAGS += $(shell $(LLVMCONFIG) --libs core irReader) $(shell $(LLVMCONFIG) --ldflags) $(shell $(LLVMCONFIG) --system-libs)
+jlc_EXTRA_LDFLAGS += $(shell $(LLVMCONFIG) --libs core irReader) $(shell $(LLVMCONFIG) --ldflags) $(shell $(LLVMCONFIG) --system-libs)
 
 $(eval $(call common_executable,jlc))
 
@@ -24,6 +24,6 @@ jlm-opt_LIBS = \
 	librvsdg \
 	libutil \
 
-jlm-opt_LDFLAGS = $(shell $(LLVMCONFIG) --libs core irReader) $(shell $(LLVMCONFIG) --ldflags) $(shell $(LLVMCONFIG) --system-libs)
+jlm-opt_EXTRA_LDFLAGS = $(shell $(LLVMCONFIG) --libs core irReader) $(shell $(LLVMCONFIG) --ldflags) $(shell $(LLVMCONFIG) --system-libs)
 
 $(eval $(call common_executable,jlm-opt))

--- a/tools/Makefile.sub
+++ b/tools/Makefile.sub
@@ -11,8 +11,6 @@ jlc_LIBS += \
 	librvsdg \
 	libutil \
 
-jlc_EXTRA_CPPFLAGS += -I$(shell $(LLVMCONFIG) --includedir)
-
 jlc_LDFLAGS += $(shell $(LLVMCONFIG) --libs core irReader) $(shell $(LLVMCONFIG) --ldflags) $(shell $(LLVMCONFIG) --system-libs)
 
 $(eval $(call common_executable,jlc))
@@ -27,7 +25,5 @@ jlm-opt_LIBS = \
 	libutil \
 
 jlm-opt_LDFLAGS = $(shell $(LLVMCONFIG) --libs core irReader) $(shell $(LLVMCONFIG) --ldflags) $(shell $(LLVMCONFIG) --system-libs)
-
-jlm-opt_CPPFLAGS = -I$(shell $(LLVMCONFIG) --includedir)
 
 $(eval $(call common_executable,jlm-opt))

--- a/tools/jhls/Makefile.sub
+++ b/tools/jhls/Makefile.sub
@@ -12,8 +12,6 @@ jhls_LIBS = \
 	librvsdg \
 	libutil \
 
-jhls_EXTRA_CPPFLAGS = -I$(shell $(LLVMCONFIG) --includedir)
-
 jhls_LDFLAGS = $(shell $(LLVMCONFIG) --libs core irReader) $(shell $(LLVMCONFIG) --ldflags) \
 
 $(eval $(call common_executable,jhls))

--- a/tools/jhls/Makefile.sub
+++ b/tools/jhls/Makefile.sub
@@ -12,6 +12,6 @@ jhls_LIBS = \
 	librvsdg \
 	libutil \
 
-jhls_LDFLAGS = $(shell $(LLVMCONFIG) --libs core irReader) $(shell $(LLVMCONFIG) --ldflags) \
+jhls_EXTRA_LDFLAGS = $(shell $(LLVMCONFIG) --libs core irReader) $(shell $(LLVMCONFIG) --ldflags) \
 
 $(eval $(call common_executable,jhls))

--- a/tools/jlm-hls/Makefile.sub
+++ b/tools/jlm-hls/Makefile.sub
@@ -5,8 +5,6 @@
 jlm-hls_SOURCES = \
     tools/jlm-hls/jlm-hls.cpp \
 
-jlm-hls_EXTRA_CPPFLAGS = -I$(shell $(LLVMCONFIG) --includedir)
-
 jlm-hls_LDFLAGS = $(shell $(LLVMCONFIG) --libs core irReader) $(shell $(LLVMCONFIG) --ldflags) $(shell $(LLVMCONFIG) --system-libs)
 
 jlm-hls_LIBS = \
@@ -15,9 +13,6 @@ jlm-hls_LIBS = \
 	libllvm \
 	librvsdg \
 	libutil \
-
-jlm-hls_EXTRA_CPPFLAGS += \
-        -I$(CIRCT_PATH)/include \
 
 jlm-hls_LDFLAGS += \
         -L$(CIRCT_PATH)/lib \

--- a/tools/jlm-hls/Makefile.sub
+++ b/tools/jlm-hls/Makefile.sub
@@ -5,8 +5,6 @@
 jlm-hls_SOURCES = \
     tools/jlm-hls/jlm-hls.cpp \
 
-jlm-hls_LDFLAGS = $(shell $(LLVMCONFIG) --libs core irReader) $(shell $(LLVMCONFIG) --ldflags) $(shell $(LLVMCONFIG) --system-libs)
-
 jlm-hls_LIBS = \
 	libtooling \
 	libhls \
@@ -14,7 +12,9 @@ jlm-hls_LIBS = \
 	librvsdg \
 	libutil \
 
-jlm-hls_LDFLAGS += \
+jlm-hls_EXTRA_LDFLAGS = $(shell $(LLVMCONFIG) --libs core irReader) $(shell $(LLVMCONFIG) --ldflags) $(shell $(LLVMCONFIG) --system-libs)
+
+jlm-hls_EXTRA_LDFLAGS += \
         -L$(CIRCT_PATH)/lib \
         -lMLIR \
         -lCIRCTAnalysisTestPasses \


### PR DESCRIPTION
This PR does the following:

1. Removes all extra CPPFLAGS from the executables in the project. These extra CPPFLAGS were never handled in the common_executable macro and are not necessary for a successful compilation.
2. Ensure consistent naming of EXTRA_LDFLAGS of the common_executable macro.

Closes #353 