### PR TITLE
Add Rvsdg module class

### DIFF
--- a/jlm/llvm/ir/RvsdgModule.hpp
+++ b/jlm/llvm/ir/RvsdgModule.hpp
@@ -92,6 +92,8 @@ is_export(const jlm::rvsdg::input * input)
 class RvsdgModule final : public rvsdg::RvsdgModule
 {
 public:
+  ~RvsdgModule() noexcept override = default;
+
   RvsdgModule(jlm::util::filepath sourceFileName, std::string targetTriple, std::string dataLayout)
       : DataLayout_(std::move(dataLayout)),
         TargetTriple_(std::move(targetTriple)),

--- a/jlm/llvm/ir/RvsdgModule.hpp
+++ b/jlm/llvm/ir/RvsdgModule.hpp
@@ -8,7 +8,7 @@
 
 #include <jlm/llvm/ir/linkage.hpp>
 #include <jlm/llvm/ir/types.hpp>
-#include <jlm/rvsdg/graph.hpp>
+#include <jlm/rvsdg/RvsdgModule.hpp>
 #include <jlm/util/file.hpp>
 
 namespace jlm::llvm
@@ -86,10 +86,10 @@ is_export(const jlm::rvsdg::input * input)
   return result && result->region() == graph->root();
 }
 
-/** \brief RVSDG module class
- *
+/**
+ * An LLVM module utilizing the RVSDG representation.
  */
-class RvsdgModule final
+class RvsdgModule final : public rvsdg::RvsdgModule
 {
 public:
   RvsdgModule(jlm::util::filepath sourceFileName, std::string targetTriple, std::string dataLayout)
@@ -108,31 +108,19 @@ public:
   RvsdgModule &
   operator=(RvsdgModule &&) = delete;
 
-  jlm::rvsdg::graph &
-  Rvsdg() noexcept
-  {
-    return Rvsdg_;
-  }
-
-  const jlm::rvsdg::graph &
-  Rvsdg() const noexcept
-  {
-    return Rvsdg_;
-  }
-
-  const jlm::util::filepath &
+  [[nodiscard]] const jlm::util::filepath &
   SourceFileName() const noexcept
   {
     return SourceFileName_;
   }
 
-  const std::string &
+  [[nodiscard]] const std::string &
   TargetTriple() const noexcept
   {
     return TargetTriple_;
   }
 
-  const std::string &
+  [[nodiscard]] const std::string &
   DataLayout() const noexcept
   {
     return DataLayout_;
@@ -148,7 +136,6 @@ public:
   }
 
 private:
-  jlm::rvsdg::graph Rvsdg_;
   std::string DataLayout_;
   std::string TargetTriple_;
   const jlm::util::filepath SourceFileName_;

--- a/jlm/rvsdg/Makefile.sub
+++ b/jlm/rvsdg/Makefile.sub
@@ -57,6 +57,7 @@ librvsdg_HEADERS = \
 	jlm/rvsdg/record.hpp \
 	jlm/rvsdg/structural-normal-form.hpp \
 	jlm/rvsdg/reduction-helpers.hpp \
+	jlm/rvsdg/RvsdgModule.hpp \
 	jlm/rvsdg/bitstring.hpp \
 	jlm/rvsdg/node.hpp \
 	jlm/rvsdg/node-normal-form.hpp \

--- a/jlm/rvsdg/RvsdgModule.hpp
+++ b/jlm/rvsdg/RvsdgModule.hpp
@@ -17,6 +17,8 @@ namespace jlm::rvsdg
 class RvsdgModule
 {
 public:
+  virtual ~RvsdgModule() noexcept = default;
+
   RvsdgModule() = default;
 
   RvsdgModule(const RvsdgModule &) = delete;

--- a/jlm/rvsdg/RvsdgModule.hpp
+++ b/jlm/rvsdg/RvsdgModule.hpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#ifndef JLM_RVSDG_RVSDGMODULE_HPP
+#define JLM_RVSDG_RVSDGMODULE_HPP
+
+#include <jlm/rvsdg/graph.hpp>
+
+namespace jlm::rvsdg
+{
+
+/**
+ * Top-level class for a module with an RVSDG.
+ */
+class RvsdgModule
+{
+public:
+  RvsdgModule() = default;
+
+  RvsdgModule(const RvsdgModule &) = delete;
+
+  RvsdgModule(RvsdgModule &&) = delete;
+
+  RvsdgModule &
+  operator=(const RvsdgModule &) = delete;
+
+  RvsdgModule &
+  operator=(RvsdgModule &&) = delete;
+
+  /**
+   *
+   * @return The RVSDG of the module.
+   */
+  jlm::rvsdg::graph &
+  Rvsdg() noexcept
+  {
+    return Rvsdg_;
+  }
+
+  /**
+   *
+   * @return The RVSDG of the module.
+   */
+  [[nodiscard]] const jlm::rvsdg::graph &
+  Rvsdg() const noexcept
+  {
+    return Rvsdg_;
+  }
+
+private:
+  graph Rvsdg_;
+};
+
+}
+
+#endif // JLM_RVSDG_RVSDGMODULE_HPP


### PR DESCRIPTION
This PR does the following:

1. Adds the RvsdgModule class. It should serve as top-level class for translation of modules in the future.
2. Utilize it as base class for the LLVM RVSDGModule class.