### PR TITLE
Moved output files from /tmp to output path

### DIFF
--- a/jlm/tooling/Command.hpp
+++ b/jlm/tooling/Command.hpp
@@ -555,19 +555,19 @@ public:
   [[nodiscard]] util::filepath
   FirrtlFile() const noexcept
   {
-    return OutputFolder_.to_str() + "/jlm_hls.fir";
+    return OutputFolder_.to_str() + ".fir";
   }
 
   [[nodiscard]] util::filepath
   LlvmFile() const noexcept
   {
-    return OutputFolder_.to_str() + "/jlm_hls_rest.ll";
+    return OutputFolder_.to_str() + ".rest.ll";
   }
 
   [[nodiscard]] util::filepath
   HarnessFile() const noexcept
   {
-    return OutputFolder_.to_str() + "/jlm_hls_harness.cpp";
+    return OutputFolder_.to_str() + ".harness.cpp";
   }
 
   [[nodiscard]] const util::filepath &
@@ -620,13 +620,13 @@ public:
   [[nodiscard]] util::filepath
   HlsFunctionFile() const noexcept
   {
-    return OutputFolder_.to_str() + "/jlm_hls_function.ll";
+    return OutputFolder_.to_str() + ".function.ll";
   }
 
   [[nodiscard]] util::filepath
   LlvmFile() const noexcept
   {
-    return OutputFolder_.to_str() + "/jlm_hls_rest.ll";
+    return OutputFolder_.to_str() + ".rest.ll";
   }
 
   [[nodiscard]] const util::filepath &

--- a/jlm/tooling/CommandGraphGenerator.cpp
+++ b/jlm/tooling/CommandGraphGenerator.cpp
@@ -341,9 +341,9 @@ JhlsCommandGraphGenerator::GenerateCommandGraph(const JhlsCommandLineOptions & c
       *commandGraph,
       dynamic_cast<LlvmOptCommand *>(&m2r1.GetCommand())->OutputFile(),
       commandLineOptions.HlsFunctionRegex_,
-      tmp_folder.to_str());
+      commandLineOptions.OutputFile_);
   m2r1.AddEdge(extract);
-  util::filepath ll_m2r2(tmp_folder.to_str() + "function.m2r.ll");
+  util::filepath ll_m2r2(tmp_folder.to_str() + "function.hls.ll");
   auto & m2r2 = LlvmOptCommand::Create(
       *commandGraph,
       dynamic_cast<JlmHlsExtractCommand *>(&extract.GetCommand())->HlsFunctionFile(),
@@ -355,7 +355,7 @@ JhlsCommandGraphGenerator::GenerateCommandGraph(const JhlsCommandLineOptions & c
   auto & hls = JlmHlsCommand::Create(
       *commandGraph,
       dynamic_cast<LlvmOptCommand *>(&m2r2.GetCommand())->OutputFile(),
-      tmp_folder.to_str(),
+      commandLineOptions.OutputFile_,
       commandLineOptions.UseCirct_);
   m2r2.AddEdge(hls);
 
@@ -364,10 +364,10 @@ JhlsCommandGraphGenerator::GenerateCommandGraph(const JhlsCommandLineOptions & c
     util::filepath verilogfile(tmp_folder.to_str() + "jlm_hls.v");
     auto & firrtl = FirtoolCommand::Create(
         *commandGraph,
-        dynamic_cast<JlmHlsCommand *>(&hls.GetCommand())->FirrtlFile(),
+        commandLineOptions.OutputFile_.to_str() + ".fir",
         verilogfile);
     hls.AddEdge(firrtl);
-    util::filepath assemblyFile(tmp_folder.to_str() + "hls.o");
+    util::filepath assemblyFile(commandLineOptions.OutputFile_.to_str() + ".o");
     auto inputFile = dynamic_cast<JlmHlsCommand *>(&hls.GetCommand())->LlvmFile();
     auto & asmnode = LlcCommand::Create(
         *commandGraph,

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -326,7 +326,7 @@ void
 JlmHlsCommandLineOptions::Reset() noexcept
 {
   InputFile_ = util::filepath("");
-  OutputFolder_ = util::filepath("");
+  OutputFiles_ = util::filepath("");
   OutputFormat_ = OutputFormat::Firrtl;
   HlsFunction_ = "";
   ExtractHlsFunction_ = false;
@@ -1064,7 +1064,7 @@ JlmHlsCommandLineParser::ParseCommandLineArguments(int argc, char ** argv)
 
   CommandLineOptions_.InputFile_ = inputFile;
   CommandLineOptions_.HlsFunction_ = std::move(hlsFunction);
-  CommandLineOptions_.OutputFolder_ = outputFolder;
+  CommandLineOptions_.OutputFiles_ = outputFolder;
   CommandLineOptions_.ExtractHlsFunction_ = extractHlsFunction;
   CommandLineOptions_.UseCirct_ = useCirct;
   CommandLineOptions_.OutputFormat_ = format;

--- a/jlm/tooling/CommandLine.hpp
+++ b/jlm/tooling/CommandLine.hpp
@@ -375,7 +375,7 @@ public:
 
   JlmHlsCommandLineOptions()
       : InputFile_(""),
-        OutputFolder_(""),
+        OutputFiles_(""),
         OutputFormat_(OutputFormat::Firrtl),
         ExtractHlsFunction_(false),
         UseCirct_(false)
@@ -385,7 +385,7 @@ public:
   Reset() noexcept override;
 
   util::filepath InputFile_;
-  util::filepath OutputFolder_;
+  util::filepath OutputFiles_;
   OutputFormat OutputFormat_;
   std::string HlsFunction_;
   bool ExtractHlsFunction_;

--- a/tools/jlm-hls/jlm-hls.cpp
+++ b/tools/jlm-hls/jlm-hls.cpp
@@ -49,7 +49,7 @@ main(int argc, char ** argv)
   llvm::LLVMContext ctx;
   llvm::SMDiagnostic err;
   auto llvmModule = llvm::parseIRFile(commandLineOptions.InputFile_.to_str(), err, ctx);
-  llvmModule->setSourceFileName(commandLineOptions.OutputFolder_.path() + "/jlm_hls");
+  llvmModule->setSourceFileName(commandLineOptions.OutputFiles_.path() + "/jlm_hls");
   if (!llvmModule)
   {
     err.print(argv[0], llvm::errs());
@@ -65,8 +65,8 @@ main(int argc, char ** argv)
   {
     auto hlsFunction = jlm::hls::split_hls_function(*rvsdgModule, commandLineOptions.HlsFunction_);
 
-    llvmToFile(*rvsdgModule, commandLineOptions.OutputFolder_.path() + "/jlm_hls_rest.ll");
-    llvmToFile(*hlsFunction, commandLineOptions.OutputFolder_.path() + "/jlm_hls_function.ll");
+    llvmToFile(*rvsdgModule, commandLineOptions.OutputFiles_.to_str() + ".rest.ll");
+    llvmToFile(*hlsFunction, commandLineOptions.OutputFiles_.to_str() + ".function.ll");
     return 0;
   }
 
@@ -86,12 +86,10 @@ main(int argc, char ** argv)
       jlm::hls::FirrtlHLS hls;
       output = hls.run(*rvsdgModule);
     }
-    stringToFile(output, commandLineOptions.OutputFolder_.path() + "/jlm_hls.fir");
+    stringToFile(output, commandLineOptions.OutputFiles_.to_str() + ".fir");
 
     jlm::hls::VerilatorHarnessHLS vhls;
-    stringToFile(
-        vhls.run(*rvsdgModule),
-        commandLineOptions.OutputFolder_.path() + "/jlm_hls_harness.cpp");
+    stringToFile(vhls.run(*rvsdgModule), commandLineOptions.OutputFiles_.to_str() + ".harness.cpp");
   }
   else if (
       commandLineOptions.OutputFormat_ == jlm::tooling::JlmHlsCommandLineOptions::OutputFormat::Dot)
@@ -99,7 +97,7 @@ main(int argc, char ** argv)
     jlm::hls::rvsdg2rhls(*rvsdgModule);
 
     jlm::hls::DotHLS dhls;
-    stringToFile(dhls.run(*rvsdgModule), commandLineOptions.OutputFolder_.path() + "/jlm_hls.dot");
+    stringToFile(dhls.run(*rvsdgModule), commandLineOptions.OutputFiles_.path() + "/jlm_hls.dot");
   }
   else
   {


### PR DESCRIPTION
This is the first step for eliminating the dependency on firtool and verilator by jhls.
To avoid this dependency the FIRRTL, harness, and remaning code is written to the specified output path.