### PR TITLE
Enable load-store reduction again

### DIFF
--- a/jlm/llvm/Makefile.sub
+++ b/jlm/llvm/Makefile.sub
@@ -175,6 +175,7 @@ libllvm_TESTS += \
 	tests/jlm/llvm/opt/TestInvariantValueRedirection \
 	tests/jlm/llvm/opt/test-inversion \
 	tests/jlm/llvm/opt/TestLoadMuxReduction \
+	tests/jlm/llvm/opt/TestLoadStoreReduction \
 	tests/jlm/llvm/opt/test-pull \
 	tests/jlm/llvm/opt/test-push \
 	tests/jlm/llvm/opt/test-unroll \

--- a/jlm/llvm/ir/operators/load.cpp
+++ b/jlm/llvm/ir/operators/load.cpp
@@ -221,7 +221,7 @@ is_load_store_reducible(
     return false;
   }
 
-  // Check that all states to the load originate from the same store
+  // Check that all state edges to the load originate from the same store
   if (storeNode->NumStates() != loadOperation.NumStates())
   {
     return false;

--- a/jlm/llvm/ir/operators/load.cpp
+++ b/jlm/llvm/ir/operators/load.cpp
@@ -213,7 +213,7 @@ is_load_store_reducible(
     return false;
   }
 
-  // Check that the first state originates from a store
+  // Check that the first state edge originates from a store
   auto firstState = operands[1];
   auto storeNode = dynamic_cast<const StoreNode *>(rvsdg::node_output::node(firstState));
   if (!storeNode)

--- a/jlm/llvm/ir/operators/load.cpp
+++ b/jlm/llvm/ir/operators/load.cpp
@@ -201,6 +201,7 @@ is_multiple_origin_reducible(const std::vector<rvsdg::output *> & operands)
 // v2 s3 = load_op a s2
 // ... = any_op v2
 // =>
+// s2 = store_op a v1 s1
 // ... = any_op v1
 static bool
 is_load_store_reducible(

--- a/jlm/llvm/ir/operators/load.cpp
+++ b/jlm/llvm/ir/operators/load.cpp
@@ -198,7 +198,7 @@ is_multiple_origin_reducible(const std::vector<rvsdg::output *> & operands)
 }
 
 // s2 = store_op a v1 s1
-// v2 = load_op a s2
+// v2 s3 = load_op a s2
 // ... = any_op v2
 // =>
 // ... = any_op v1

--- a/jlm/llvm/ir/operators/load.cpp
+++ b/jlm/llvm/ir/operators/load.cpp
@@ -248,8 +248,7 @@ is_load_store_reducible(
   //
   // FIXME: This is too restrictive and can be improved upon by inserting truncation or narrowing
   // operations instead. For example, a store of a 32 bit integer followed by a load of a 8 bit
-  // integer can be converted to a trunc operation. Similarly, a store of a floating point
-  // value followed by a load of a 32 bit integer can be converted to a fp2ui operation.
+  // integer can be converted to a trunc operation.
   auto & loadedValueType = loadOperation.GetLoadedType();
   auto & storedValueType = storeNode->GetValueInput()->type();
   if (loadedValueType != storedValueType)

--- a/jlm/llvm/ir/operators/load.cpp
+++ b/jlm/llvm/ir/operators/load.cpp
@@ -197,30 +197,67 @@ is_multiple_origin_reducible(const std::vector<rvsdg::output *> & operands)
   return states.size() != operands.size() - 1;
 }
 
+// s2 = store_op a v1 s1
+// v2 = load_op a s2
+// ... = any_op v2
+// =>
+// ... = any_op v1
 static bool
-is_load_store_reducible(const LoadOperation & op, const std::vector<rvsdg::output *> & operands)
+is_load_store_reducible(
+    const LoadOperation & loadOperation,
+    const std::vector<rvsdg::output *> & operands)
 {
-  JLM_ASSERT(operands.size() > 1);
-
-  auto storenode = rvsdg::node_output::node(operands[1]);
-  if (!is<StoreOperation>(storenode))
-    return false;
-
-  auto sop = static_cast<const StoreOperation *>(&storenode->operation());
-  if (sop->NumStates() != op.NumStates())
-    return false;
-
-  /* check for same address */
-  if (operands[0] != storenode->input(0)->origin())
-    return false;
-
-  for (size_t n = 1; n < operands.size(); n++)
+  // We do not need to check further if no state edge is provided to the load
+  if (operands.size() < 2)
   {
-    if (rvsdg::node_output::node(operands[n]) != storenode)
-      return false;
+    return false;
   }
 
-  JLM_ASSERT(op.GetAlignment() == sop->GetAlignment());
+  // Check that the first state originates from a store
+  auto firstState = operands[1];
+  auto storeNode = dynamic_cast<const StoreNode *>(rvsdg::node_output::node(firstState));
+  if (!storeNode)
+  {
+    return false;
+  }
+
+  // Check that all states to the load originate from the same store
+  if (storeNode->NumStates() != loadOperation.NumStates())
+  {
+    return false;
+  }
+  for (size_t n = 1; n < operands.size(); n++)
+  {
+    auto state = operands[n];
+    auto node = rvsdg::node_output::node(state);
+    if (node != storeNode)
+    {
+      return false;
+    }
+  }
+
+  // Check that the address to the load and store originate from the same value
+  auto loadAddress = operands[0];
+  auto storeAddress = storeNode->GetAddressInput()->origin();
+  if (loadAddress != storeAddress)
+  {
+    return false;
+  }
+
+  // Check that the loaded and stored value type are the same
+  //
+  // FIXME: This is too restrictive and can be improved upon by inserting truncation or narrowing
+  // operations instead. For example, a store of a 32 bit integer followed by a load of a 8 bit
+  // integer can be converted to a trunc operation. Similarly, a store of a floating point
+  // value followed by a load of a 32 bit integer can be converted to a fp2ui operation.
+  auto & loadedValueType = loadOperation.GetLoadedType();
+  auto & storedValueType = storeNode->GetValueInput()->type();
+  if (loadedValueType != storedValueType)
+  {
+    return false;
+  }
+
+  JLM_ASSERT(loadOperation.GetAlignment() == storeNode->GetAlignment());
   return true;
 }
 

--- a/jlm/llvm/opt/reduction.cpp
+++ b/jlm/llvm/opt/reduction.cpp
@@ -98,10 +98,7 @@ enable_load_reductions(jlm::rvsdg::graph & graph)
   auto nf = LoadOperation::GetNormalForm(&graph);
   nf->set_mutable(true);
   nf->set_load_mux_reducible(true);
-  // set_load_store_reducible throws a type_error when the optimization
-  // is applied twice
-  // github issue #302
-  nf->set_load_store_reducible(false);
+  nf->set_load_store_reducible(true);
   nf->set_load_alloca_reducible(true);
   nf->set_multiple_origin_reducible(true);
   nf->set_load_store_state_reducible(true);

--- a/tests/jlm/llvm/opt/TestLoadStoreReduction.cpp
+++ b/tests/jlm/llvm/opt/TestLoadStoreReduction.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <test-registry.hpp>
+
+#include <jlm/llvm/ir/operators/load.hpp>
+#include <jlm/llvm/ir/operators/store.hpp>
+#include <jlm/rvsdg/bitstring.hpp>
+#include <jlm/rvsdg/view.hpp>
+
+/**
+ * Tests the load-store reduction with the value type of the store being different than the
+ * value type of the load.
+ */
+static int
+TestLoadStoreReductionWithDifferentValueOperandType()
+{
+  using namespace jlm::llvm;
+
+  // Arrange
+  PointerType pointerType;
+  MemoryStateType memoryStateType;
+
+  jlm::rvsdg::graph graph;
+  auto nf = LoadOperation::GetNormalForm(&graph);
+  nf->set_mutable(false);
+  nf->set_load_store_reducible(false);
+
+  auto address = graph.add_import({ pointerType, "address" });
+  auto value = graph.add_import({ jlm::rvsdg::bit32, "value" });
+  auto memoryState = graph.add_import({ memoryStateType, "memoryState" });
+
+  auto storeResults = StoreNode::Create(address, value, { memoryState }, 4);
+  auto loadResults = LoadNode::Create(address, storeResults, jlm::rvsdg::bit8, 4);
+
+  auto exportedValue = graph.add_export(loadResults[0], { jlm::rvsdg::bit8, "v" });
+  graph.add_export(loadResults[1], { memoryStateType, "s" });
+
+  jlm::rvsdg::view(graph.root(), stdout);
+
+  // Act
+  nf->set_mutable(true);
+  nf->set_load_store_reducible(true);
+  graph.normalize();
+  graph.prune();
+
+  jlm::rvsdg::view(graph.root(), stdout);
+
+  // Assert
+  auto load = jlm::rvsdg::node_output::node(exportedValue->origin());
+  assert(is<LoadOperation>(load));
+  assert(load->ninputs() == 2);
+  auto store = jlm::rvsdg::node_output::node(load->input(1)->origin());
+  assert(is<StoreOperation>(store));
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER(
+    "jlm/llvm/opt/TestLoadStoreReductionWithDifferentValueOperandType",
+    TestLoadStoreReductionWithDifferentValueOperandType)


### PR DESCRIPTION
1. Fixes the load-store reduction. The problem was a missing check for the stored and loaded value type being the same. If they are not the same, then we might have to insert a truncation or conversion operation instead of just bypassing the load and store. I marked the place in the code with a FIXME such that we can improve upon it in the future.
2. Adds a unit test that exposes the problem.

Closes #302 