### PR TITLE
Changed CI actions to v4

### DIFF
--- a/.github/actions/BuildCirct/action.yml
+++ b/.github/actions/BuildCirct/action.yml
@@ -12,7 +12,7 @@ runs:
 
     - name: "Try to fetch CIRCT from the cache"
       id: cache-circt
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ${{ github.workspace }}/build-circt/circt

--- a/.github/workflows/hls.yml
+++ b/.github/workflows/hls.yml
@@ -11,7 +11,7 @@ jobs:
   hls-test-suite:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: '0'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
   ClangFormat:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Install clang format"
         uses: ./.github/actions/InstallLlvmDependencies
       - name: Find source files
@@ -19,10 +19,10 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Cache build
       id: cache-build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/*
         key: ${{ runner.os }}-${{ github.sha }}-jlm
@@ -38,7 +38,7 @@ jobs:
   gcc:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: "Install LLVM and Clang"
       uses: ./.github/actions/InstallLlvmDependencies
     - name: Configure jlm
@@ -53,7 +53,7 @@ jobs:
     needs: build
     steps:
     - name: Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/*
         key: ${{ runner.os }}-${{ github.sha }}-jlm
@@ -69,7 +69,7 @@ jobs:
     needs: build
     steps:
     - name: Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/*
         key: ${{ runner.os }}-${{ github.sha }}-jlm
@@ -87,7 +87,7 @@ jobs:
     needs: build
     steps:
     - name: Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/*
         key: ${{ runner.os }}-${{ github.sha }}-jlm


### PR DESCRIPTION
Changed actions/checkout and actions/cache from v3 to v4, since v3 uses deprecated Node.js version.