### PR TITLE
Add measurements and timers to the Statistics base class

### DIFF
--- a/jlm/util/Makefile.sub
+++ b/jlm/util/Makefile.sub
@@ -12,6 +12,7 @@ libutil_TESTS += \
 	tests/jlm/util/TestHashSet \
 	tests/jlm/util/TestMath \
 	tests/jlm/util/TestStatistics \
+	tests/jlm/util/TestTimer \
 
 libutil_TEST_LIBS = \
 	libjlmtest \

--- a/jlm/util/Statistics.cpp
+++ b/jlm/util/Statistics.cpp
@@ -1,14 +1,114 @@
 /*
  * Copyright 2020 Nico Reißmann <nico.reissmann@gmail.com>
+ * Copyright 2024 Håvard Krogstie <krogstie.havard@gmail.com>
  * See COPYING for terms of redistribution.
  */
 
 #include <jlm/util/Statistics.hpp>
 
+#include <jlm/util/strfmt.hpp>
+
 namespace jlm::util
 {
 
 Statistics::~Statistics() = default;
+
+std::string
+Statistics::Serialize() const
+{
+  std::ostringstream ss;
+  for (const auto & [mName, measurement] : Measurements_)
+  {
+    if (ss.tellp() != 0)
+      ss << " ";
+
+    ss << mName << ":";
+    std::visit(
+        [&](const auto & value)
+        {
+          ss << value;
+        },
+        measurement);
+  }
+  for (const auto & [mName, timer] : Timers_)
+  {
+    if (ss.tellp() != 0)
+      ss << " ";
+
+    ss << mName << "[ns]:" << timer.ns();
+  }
+
+  return ss.str();
+}
+
+bool
+Statistics::HasMeasurement(const std::string & name) const noexcept
+{
+  for (const auto & [mName, _] : Measurements_)
+    if (mName == name)
+      return true;
+  return false;
+}
+
+Statistics::Measurement &
+Statistics::GetMeasurement(const std::string & name)
+{
+  for (auto & [mName, measurement] : Measurements_)
+    if (mName == name)
+      return measurement;
+  throw util::error(util::strfmt("Unknown measurement: ", name));
+}
+
+const Statistics::Measurement &
+Statistics::GetMeasurement(const std::string & name) const
+{
+  return const_cast<Statistics *>(this)->GetMeasurement(name);
+}
+
+util::iterator_range<Statistics::MeasurementList::const_iterator>
+Statistics::GetMeasurements() const
+{
+  return {Measurements_.begin(), Measurements_.end()};
+}
+
+bool
+Statistics::HasTimer(const std::string & name) const noexcept
+{
+  for (const auto & [mName, _] : Timers_)
+    if (mName == name)
+      return true;
+  return false;
+}
+
+util::timer &
+Statistics::GetTimer(const std::string & name)
+{
+  for (auto & [mName, timer] : Timers_)
+    if (mName == name)
+      return timer;
+  throw util::error(util::strfmt("Unknown timer: ", name));
+}
+
+const util::timer &
+Statistics::GetTimer(const std::string & name) const
+{
+  return const_cast<Statistics *>(this)->GetTimer(name);
+}
+
+util::iterator_range<Statistics::TimerList::const_iterator>
+Statistics::GetTimers() const
+{
+  return Timers_;
+}
+
+util::timer &
+Statistics::AddTimer(std::string name)
+{
+  JLM_ASSERT(!HasTimer(name));
+  Timers_.emplace_back(std::make_pair(std::move(name), util::timer()));
+  auto & timer = Timers_.back().second;
+  return timer;
+}
 
 void
 StatisticsCollector::PrintStatistics() const

--- a/tests/jlm/util/TestTimer.cpp
+++ b/tests/jlm/util/TestTimer.cpp
@@ -1,7 +1,7 @@
 /*
-* Copyright 2024 Håvard Krogstie <krogstie.havard@gmail.com>
-* See COPYING for terms of redistribution.
-*/
+ * Copyright 2024 Håvard Krogstie <krogstie.havard@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
 
 #include <test-registry.hpp>
 

--- a/tests/jlm/util/TestTimer.cpp
+++ b/tests/jlm/util/TestTimer.cpp
@@ -1,0 +1,75 @@
+/*
+* Copyright 2024 Håvard Krogstie <krogstie.havard@gmail.com>
+* See COPYING for terms of redistribution.
+*/
+
+#include <test-registry.hpp>
+
+#include <jlm/util/time.hpp>
+
+#include <cassert>
+#include <chrono>
+#include <thread>
+
+using namespace jlm::util;
+
+static void
+sleepUs(int us)
+{
+  std::this_thread::sleep_for(std::chrono::duration<int, std::micro>(us));
+}
+
+static void
+TestStartStop()
+{
+  timer t;
+  assert(t.ns() == 0);
+  assert(!t.IsRunning());
+
+  t.start();
+  assert(t.IsRunning());
+  sleepUs(10);
+  t.stop();
+  assert(!t.IsRunning());
+  auto ns = t.ns();
+  assert(ns >= 10000);
+
+  // Add more time
+  t.start();
+  sleepUs(1);
+  t.stop();
+  assert(t.ns() >= ns + 1000);
+}
+
+static void
+TestReset()
+{
+  timer t;
+  assert(t.ns() == 0);
+  assert(!t.IsRunning());
+
+  t.start();
+  sleepUs(1);
+  t.stop();
+
+  assert(t.ns() != 0);
+  t.reset();
+  assert(t.ns() == 0);
+  assert(!t.IsRunning());
+
+  // Resetting while running
+  t.start();
+  t.reset();
+  assert(t.ns() == 0);
+  assert(!t.IsRunning());
+}
+
+static int
+TestTimer()
+{
+  TestStartStop();
+  TestReset();
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER("jlm/util/TestTimer", TestTimer)


### PR DESCRIPTION
While modifying Andersen, I tried to evolve the `Andersen::Statistics` class with the changes, and was annoyed by two things:

 - Modifying the set of tracked measurements required 4 changes to the code (ctor init, field, assigning the value and serializing the value)
 - There was no nice way of making certain fields optional
 - Also, tests don't have access to statistics

In this PR is a suggestion for a modified base class for `Statistics`. I also modified `Andersen::Statistics` to make use of it. This PR should of course also have tests added, but I'm putting it up now to get feedback.

This PR should correspond to #361