### PR TITLE
Simplify jlc and jlm-opt command line option setup

### DIFF
--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -275,6 +275,15 @@ JhlsCommandLineOptions::Reset() noexcept
   *this = JhlsCommandLineOptions();
 }
 
+static ::llvm::cl::OptionEnumValue
+CreateStatisticsOption(util::Statistics::Id statisticsId, const char * description)
+{
+  return ::clEnumValN(
+      statisticsId,
+      JlmOptCommandLineOptions::ToCommandLineArgument(statisticsId),
+      description);
+}
+
 CommandLineParser::~CommandLineParser() noexcept = default;
 
 CommandLineParser::Exception::~Exception() noexcept = default;
@@ -445,124 +454,74 @@ JlcCommandLineParser::ParseCommandLineArguments(int argc, char ** argv)
       cl::desc("Specify name of main file output in depfile."),
       cl::value_desc("value"));
 
-  auto aggregationStatisticsId = util::Statistics::Id::Aggregation;
-  auto agnosticMemoryNodeProvisioningStatisticsId =
-      util::Statistics::Id::AgnosticMemoryNodeProvisioning;
-  auto andersenAnalysisStatisticsId = util::Statistics::Id::AndersenAnalysis;
-  auto annotationStatisticsId = util::Statistics::Id::Annotation;
-  auto commonNodeEliminationStatisticsId = util::Statistics::Id::CommonNodeElimination;
-  auto controlFlowRecoveryStatisticsId = util::Statistics::Id::ControlFlowRecovery;
-  auto dataNodeToDeltaStatisticsId = util::Statistics::Id::DataNodeToDelta;
-  auto deadNodeEliminationStatisticsId = util::Statistics::Id::DeadNodeElimination;
-  auto functionInliningStatisticsId = util::Statistics::Id::FunctionInlining;
-  auto invariantValueRedirectionStatisticsId = util::Statistics::Id::InvariantValueRedirection;
-  auto jlmToRvsdgConversionStatisticsId = util::Statistics::Id::JlmToRvsdgConversion;
-  auto loopUnrollingStatisticsId = util::Statistics::Id::LoopUnrolling;
-  auto memoryStateEncoderStatisticsId = util::Statistics::Id::MemoryStateEncoder;
-  auto pullNodesStatisticsId = util::Statistics::Id::PullNodes;
-  auto pushNodesStatisticsId = util::Statistics::Id::PushNodes;
-  auto reduceNodesStatisticsId = util::Statistics::Id::ReduceNodes;
-  auto regionAwareMemoryNodeProvisioningStatisticsId =
-      util::Statistics::Id::RegionAwareMemoryNodeProvisioning;
-  auto rvsdgConstructionStatisticsId = util::Statistics::Id::RvsdgConstruction;
-  auto rvsdgDestructionStatisticsId = util::Statistics::Id::RvsdgDestruction;
-  auto rvsdgOptimizationStatisticsId = util::Statistics::Id::RvsdgOptimization;
-  auto steensgaardAnalysisStatisticsId = util::Statistics::Id::SteensgaardAnalysis;
-  auto thetaGammaInversionStatisticsId = util::Statistics::Id::ThetaGammaInversion;
-
   cl::list<util::Statistics::Id> jlmOptPassStatistics(
       "JlmOptPassStatistics",
       cl::values(
-          ::clEnumValN(
-              aggregationStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(aggregationStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::Aggregation,
               "Collect control flow graph aggregation pass statistics."),
-          ::clEnumValN(
-              agnosticMemoryNodeProvisioningStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(
-                  agnosticMemoryNodeProvisioningStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::AgnosticMemoryNodeProvisioning,
               "Collect agnostic memory node provisioning pass statistics."),
-          ::clEnumValN(
-              andersenAnalysisStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(andersenAnalysisStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::AndersenAnalysis,
               "Collect Andersen alias analysis pass statistics."),
-          ::clEnumValN(
-              annotationStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(annotationStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::Annotation,
               "Collect aggregation tree annotation pass statistics."),
-          ::clEnumValN(
-              memoryStateEncoderStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(memoryStateEncoderStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::MemoryStateEncoder,
               "Collect memory state encoding pass statistics."),
-          ::clEnumValN(
-              commonNodeEliminationStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(commonNodeEliminationStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::CommonNodeElimination,
               "Collect common node elimination pass statistics."),
-          ::clEnumValN(
-              controlFlowRecoveryStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(controlFlowRecoveryStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::ControlFlowRecovery,
               "Collect control flow recovery pass statistics."),
-          ::clEnumValN(
-              dataNodeToDeltaStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(dataNodeToDeltaStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::DataNodeToDelta,
               "Collect data node to delta node conversion pass statistics."),
-          ::clEnumValN(
-              deadNodeEliminationStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(deadNodeEliminationStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::DeadNodeElimination,
               "Collect dead node elimination pass statistics."),
-          ::clEnumValN(
-              functionInliningStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(functionInliningStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::FunctionInlining,
               "Collect function inlining pass statistics."),
-          ::clEnumValN(
-              invariantValueRedirectionStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(
-                  invariantValueRedirectionStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::InvariantValueRedirection,
               "Collect invariant value redirection pass statistics."),
-          ::clEnumValN(
-              jlmToRvsdgConversionStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(jlmToRvsdgConversionStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::JlmToRvsdgConversion,
               "Collect Jlm to RVSDG conversion pass statistics."),
-          ::clEnumValN(
-              loopUnrollingStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(loopUnrollingStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::LoopUnrolling,
               "Collect loop unrolling pass statistics."),
-          ::clEnumValN(
-              pullNodesStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(pullNodesStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::PullNodes,
               "Collect node pull pass statistics."),
-          ::clEnumValN(
-              pushNodesStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(pushNodesStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::PushNodes,
               "Collect node push pass statistics."),
-          ::clEnumValN(
-              reduceNodesStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(reduceNodesStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::ReduceNodes,
               "Collect node reduction pass statistics."),
-          ::clEnumValN(
-              regionAwareMemoryNodeProvisioningStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(
-                  regionAwareMemoryNodeProvisioningStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::RegionAwareMemoryNodeProvisioning,
               "Collect memory node provisioning pass statistics."),
-          ::clEnumValN(
-              rvsdgConstructionStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(rvsdgConstructionStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::RvsdgConstruction,
               "Collect RVSDG construction pass statistics."),
-          ::clEnumValN(
-              rvsdgDestructionStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(rvsdgDestructionStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::RvsdgDestruction,
               "Collect RVSDG destruction pass statistics."),
-          ::clEnumValN(
-              rvsdgOptimizationStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(rvsdgOptimizationStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::RvsdgOptimization,
               "Collect RVSDG optimization pass statistics."),
-          ::clEnumValN(
-              steensgaardAnalysisStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(steensgaardAnalysisStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::SteensgaardAnalysis,
               "Collect Steensgaard alias analysis pass statistics."),
-          ::clEnumValN(
-              thetaGammaInversionStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(thetaGammaInversionStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::ThetaGammaInversion,
               "Collect theta-gamma inversion pass statistics.")),
       cl::desc("Collect jlm-opt pass statistics"));
 
@@ -713,123 +672,73 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, char ** argv)
       cl::desc(statisticDirectoryDescription),
       cl::value_desc("dir"));
 
-  auto aggregationStatisticsId = util::Statistics::Id::Aggregation;
-  auto agnosticMemoryNodeProvisioningStatisticsId =
-      util::Statistics::Id::AgnosticMemoryNodeProvisioning;
-  auto andersenAnalysisStatisticsId = util::Statistics::Id::AndersenAnalysis;
-  auto annotationStatisticsId = util::Statistics::Id::Annotation;
-  auto commonNodeEliminationStatisticsId = util::Statistics::Id::CommonNodeElimination;
-  auto controlFlowRecoveryStatisticsId = util::Statistics::Id::ControlFlowRecovery;
-  auto dataNodeToDeltaStatisticsId = util::Statistics::Id::DataNodeToDelta;
-  auto deadNodeEliminationStatisticsId = util::Statistics::Id::DeadNodeElimination;
-  auto functionInliningStatisticsId = util::Statistics::Id::FunctionInlining;
-  auto invariantValueRedirectionStatisticsId = util::Statistics::Id::InvariantValueRedirection;
-  auto jlmToRvsdgConversionStatisticsId = util::Statistics::Id::JlmToRvsdgConversion;
-  auto loopUnrollingStatisticsId = util::Statistics::Id::LoopUnrolling;
-  auto memoryStateEncoderStatisticsId = util::Statistics::Id::MemoryStateEncoder;
-  auto pullNodesStatisticsId = util::Statistics::Id::PullNodes;
-  auto pushNodesStatisticsId = util::Statistics::Id::PushNodes;
-  auto reduceNodesStatisticsId = util::Statistics::Id::ReduceNodes;
-  auto regionAwareMemoryNodeProvisioningStatisticsId =
-      util::Statistics::Id::RegionAwareMemoryNodeProvisioning;
-  auto rvsdgConstructionStatisticsId = util::Statistics::Id::RvsdgConstruction;
-  auto rvsdgDestructionStatisticsId = util::Statistics::Id::RvsdgDestruction;
-  auto rvsdgOptimizationStatisticsId = util::Statistics::Id::RvsdgOptimization;
-  auto steensgaardAnalysisStatisticsId = util::Statistics::Id::SteensgaardAnalysis;
-  auto thetaGammaInversionStatisticsId = util::Statistics::Id::ThetaGammaInversion;
-
   cl::list<util::Statistics::Id> printStatistics(
       cl::values(
-          ::clEnumValN(
-              aggregationStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(aggregationStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::Aggregation,
               "Write aggregation statistics to file."),
-          ::clEnumValN(
-              agnosticMemoryNodeProvisioningStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(
-                  agnosticMemoryNodeProvisioningStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::AgnosticMemoryNodeProvisioning,
               "Collect agnostic memory node provisioning pass statistics."),
-          ::clEnumValN(
-              andersenAnalysisStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(andersenAnalysisStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::AndersenAnalysis,
               "Collect Andersen alias analysis pass statistics."),
-          ::clEnumValN(
-              annotationStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(annotationStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::Annotation,
               "Write annotation statistics to file."),
-          ::clEnumValN(
-              memoryStateEncoderStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(memoryStateEncoderStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::MemoryStateEncoder,
               "Write encoding statistics of basic encoder to file."),
-          ::clEnumValN(
-              commonNodeEliminationStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(commonNodeEliminationStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::CommonNodeElimination,
               "Write common node elimination statistics to file."),
-          ::clEnumValN(
-              controlFlowRecoveryStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(controlFlowRecoveryStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::ControlFlowRecovery,
               "Write control flow recovery statistics to file."),
-          ::clEnumValN(
-              dataNodeToDeltaStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(dataNodeToDeltaStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::DataNodeToDelta,
               "Write data node to delta node conversion statistics to file."),
-          ::clEnumValN(
-              deadNodeEliminationStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(deadNodeEliminationStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::DeadNodeElimination,
               "Write dead node elimination statistics to file."),
-          ::clEnumValN(
-              functionInliningStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(functionInliningStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::FunctionInlining,
               "Write function inlining statistics to file."),
-          ::clEnumValN(
-              invariantValueRedirectionStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(
-                  invariantValueRedirectionStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::InvariantValueRedirection,
               "Write invariant value redirection statistics to file."),
-          ::clEnumValN(
-              jlmToRvsdgConversionStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(jlmToRvsdgConversionStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::JlmToRvsdgConversion,
               "Write Jlm to RVSDG conversion statistics to file."),
-          ::clEnumValN(
-              loopUnrollingStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(loopUnrollingStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::LoopUnrolling,
               "Write loop unrolling statistics to file."),
-          ::clEnumValN(
-              pullNodesStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(pullNodesStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::PullNodes,
               "Write node pull statistics to file."),
-          ::clEnumValN(
-              pushNodesStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(pushNodesStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::PushNodes,
               "Write node push statistics to file."),
-          ::clEnumValN(
-              reduceNodesStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(reduceNodesStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::ReduceNodes,
               "Write node reduction statistics to file."),
-          ::clEnumValN(
-              regionAwareMemoryNodeProvisioningStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(
-                  regionAwareMemoryNodeProvisioningStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::RegionAwareMemoryNodeProvisioning,
               "Write memory node provisioning statistics to file."),
-          ::clEnumValN(
-              rvsdgConstructionStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(rvsdgConstructionStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::RvsdgConstruction,
               "Write RVSDG construction statistics to file."),
-          ::clEnumValN(
-              rvsdgDestructionStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(rvsdgDestructionStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::RvsdgDestruction,
               "Write RVSDG destruction statistics to file."),
-          ::clEnumValN(
-              rvsdgOptimizationStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(rvsdgOptimizationStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::RvsdgOptimization,
               "Write RVSDG optimization statistics to file."),
-          ::clEnumValN(
-              steensgaardAnalysisStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(steensgaardAnalysisStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::SteensgaardAnalysis,
               "Write Steensgaard analysis statistics to file."),
-          ::clEnumValN(
-              thetaGammaInversionStatisticsId,
-              JlmOptCommandLineOptions::ToCommandLineArgument(thetaGammaInversionStatisticsId),
+          CreateStatisticsOption(
+              util::Statistics::Id::ThetaGammaInversion,
               "Write theta-gamma inversion statistics to file.")),
       cl::desc("Write statistics"));
 

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -183,7 +183,7 @@ JlmOptCommandLineOptions::FromCommandLineArgumentToStatisticsId(
 {
   try
   {
-    return StatisticsIdCommandLineArguments_.LookupValue(commandLineArgument);
+    return GetStatisticsIdCommandLineArguments().LookupValue(commandLineArgument);
   }
   catch (...)
   {
@@ -196,7 +196,7 @@ JlmOptCommandLineOptions::ToCommandLineArgument(util::Statistics::Id statisticsI
 {
   try
   {
-    return StatisticsIdCommandLineArguments_.LookupKey(statisticsId).c_str();
+    return GetStatisticsIdCommandLineArguments().LookupKey(statisticsId).data();
   }
   catch (...)
   {
@@ -256,6 +256,41 @@ JlmOptCommandLineOptions::GetOptimization(enum OptimizationId id)
     return map[id];
 
   throw util::error("Unknown optimization identifier");
+}
+
+const util::BijectiveMap<util::Statistics::Id, std::string_view> &
+JlmOptCommandLineOptions::GetStatisticsIdCommandLineArguments()
+{
+  static util::BijectiveMap<util::Statistics::Id, std::string_view> mapping = {
+    { util::Statistics::Id::Aggregation, "print-aggregation-time" },
+    { util::Statistics::Id::AgnosticMemoryNodeProvisioning,
+      "print-agnostic-memory-node-provisioning" },
+    { util::Statistics::Id::AndersenAnalysis, "print-andersen-analysis" },
+    { util::Statistics::Id::Annotation, "print-annotation-time" },
+    { util::Statistics::Id::CommonNodeElimination, "print-cne-stat" },
+    { util::Statistics::Id::ControlFlowRecovery, "print-cfr-time" },
+    { util::Statistics::Id::DataNodeToDelta, "printDataNodeToDelta" },
+    { util::Statistics::Id::DeadNodeElimination, "print-dne-stat" },
+    { util::Statistics::Id::FunctionInlining, "print-iln-stat" },
+    { util::Statistics::Id::InvariantValueRedirection, "printInvariantValueRedirection" },
+    { util::Statistics::Id::JlmToRvsdgConversion, "print-jlm-rvsdg-conversion" },
+    { util::Statistics::Id::LoopUnrolling, "print-unroll-stat" },
+    { util::Statistics::Id::MemoryStateEncoder, "print-basicencoder-encoding" },
+    { util::Statistics::Id::PullNodes, "print-pull-stat" },
+    { util::Statistics::Id::PushNodes, "print-push-stat" },
+    { util::Statistics::Id::ReduceNodes, "print-reduction-stat" },
+    { util::Statistics::Id::RegionAwareMemoryNodeProvisioning, "print-memory-node-provisioning" },
+    { util::Statistics::Id::RvsdgConstruction, "print-rvsdg-construction" },
+    { util::Statistics::Id::RvsdgDestruction, "print-rvsdg-destruction" },
+    { util::Statistics::Id::RvsdgOptimization, "print-rvsdg-optimization" },
+    { util::Statistics::Id::SteensgaardAnalysis, "print-steensgaard-analysis" },
+    { util::Statistics::Id::ThetaGammaInversion, "print-ivt-stat" }
+  };
+
+  auto firstIndex = static_cast<size_t>(util::Statistics::Id::FirstEnumValue);
+  auto lastIndex = static_cast<size_t>(util::Statistics::Id::LastEnumValue);
+  JLM_ASSERT(mapping.Size() == lastIndex - firstIndex - 1);
+  return mapping;
 }
 
 void

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -181,95 +181,27 @@ util::Statistics::Id
 JlmOptCommandLineOptions::FromCommandLineArgumentToStatisticsId(
     const std::string & commandLineArgument)
 {
-  static std::unordered_map<std::string, util::Statistics::Id> map(
-      { { StatisticsCommandLineArgument::Aggregation_, util::Statistics::Id::Aggregation },
-        { StatisticsCommandLineArgument::AgnosticMemoryNodeProvisioning_,
-          util::Statistics::Id::AgnosticMemoryNodeProvisioning },
-        { StatisticsCommandLineArgument::Annotation_, util::Statistics::Id::Annotation },
-        { StatisticsCommandLineArgument::CommonNodeElimination_,
-          util::Statistics::Id::CommonNodeElimination },
-        { StatisticsCommandLineArgument::ControlFlowRecovery_,
-          util::Statistics::Id::ControlFlowRecovery },
-        { StatisticsCommandLineArgument::DataNodeToDelta_, util::Statistics::Id::DataNodeToDelta },
-        { StatisticsCommandLineArgument::DeadNodeElimination_,
-          util::Statistics::Id::DeadNodeElimination },
-        { StatisticsCommandLineArgument::FunctionInlining_,
-          util::Statistics::Id::FunctionInlining },
-        { StatisticsCommandLineArgument::InvariantValueRedirection_,
-          util::Statistics::Id::InvariantValueRedirection },
-        { StatisticsCommandLineArgument::JlmToRvsdgConversion_,
-          util::Statistics::Id::JlmToRvsdgConversion },
-        { StatisticsCommandLineArgument::LoopUnrolling_, util::Statistics::Id::LoopUnrolling },
-        { StatisticsCommandLineArgument::MemoryStateEncoder_,
-          util::Statistics::Id::MemoryStateEncoder },
-        { StatisticsCommandLineArgument::PullNodes_, util::Statistics::Id::PullNodes },
-        { StatisticsCommandLineArgument::PushNodes_, util::Statistics::Id::PushNodes },
-        { StatisticsCommandLineArgument::ReduceNodes_, util::Statistics::Id::ReduceNodes },
-        { StatisticsCommandLineArgument::RegionAwareMemoryNodeProvisioning_,
-          util::Statistics::Id::RegionAwareMemoryNodeProvisioning },
-        { StatisticsCommandLineArgument::RvsdgConstruction_,
-          util::Statistics::Id::RvsdgConstruction },
-        { StatisticsCommandLineArgument::RvsdgDestruction_,
-          util::Statistics::Id::RvsdgDestruction },
-        { StatisticsCommandLineArgument::RvsdgOptimization_,
-          util::Statistics::Id::RvsdgOptimization },
-        { StatisticsCommandLineArgument::SteensgaardAnalysis_,
-          util::Statistics::Id::SteensgaardAnalysis },
-        { StatisticsCommandLineArgument::ThetaGammaInversion_,
-          util::Statistics::Id::ThetaGammaInversion } });
-
-  if (map.find(commandLineArgument) != map.end())
-    return map[commandLineArgument];
-
-  throw util::error("Unknown command line argument: " + commandLineArgument);
+  try
+  {
+    return StatisticsIdCommandLineArguments_.LookupValue(commandLineArgument);
+  }
+  catch (...)
+  {
+    throw util::error("Unknown command line argument: " + commandLineArgument);
+  }
 }
 
 const char *
-JlmOptCommandLineOptions::ToCommandLineArgument(jlm::util::Statistics::Id statisticsId)
+JlmOptCommandLineOptions::ToCommandLineArgument(util::Statistics::Id statisticsId)
 {
-  static std::unordered_map<util::Statistics::Id, const char *> map(
-      { { util::Statistics::Id::Aggregation, StatisticsCommandLineArgument::Aggregation_ },
-        { util::Statistics::Id::AgnosticMemoryNodeProvisioning,
-          StatisticsCommandLineArgument::AgnosticMemoryNodeProvisioning_ },
-        { util::Statistics::Id::AndersenAnalysis,
-          StatisticsCommandLineArgument::AndersenAnalysis_ },
-        { util::Statistics::Id::Annotation, StatisticsCommandLineArgument::Annotation_ },
-        { util::Statistics::Id::CommonNodeElimination,
-          StatisticsCommandLineArgument::CommonNodeElimination_ },
-        { util::Statistics::Id::ControlFlowRecovery,
-          StatisticsCommandLineArgument::ControlFlowRecovery_ },
-        { util::Statistics::Id::DataNodeToDelta, StatisticsCommandLineArgument::DataNodeToDelta_ },
-        { util::Statistics::Id::DeadNodeElimination,
-          StatisticsCommandLineArgument::DeadNodeElimination_ },
-        { util::Statistics::Id::FunctionInlining,
-          StatisticsCommandLineArgument::FunctionInlining_ },
-        { util::Statistics::Id::InvariantValueRedirection,
-          StatisticsCommandLineArgument::InvariantValueRedirection_ },
-        { util::Statistics::Id::JlmToRvsdgConversion,
-          StatisticsCommandLineArgument::JlmToRvsdgConversion_ },
-        { util::Statistics::Id::LoopUnrolling, StatisticsCommandLineArgument::LoopUnrolling_ },
-        { util::Statistics::Id::MemoryStateEncoder,
-          StatisticsCommandLineArgument::MemoryStateEncoder_ },
-        { util::Statistics::Id::PullNodes, StatisticsCommandLineArgument::PullNodes_ },
-        { util::Statistics::Id::PushNodes, StatisticsCommandLineArgument::PushNodes_ },
-        { util::Statistics::Id::ReduceNodes, StatisticsCommandLineArgument::ReduceNodes_ },
-        { util::Statistics::Id::RegionAwareMemoryNodeProvisioning,
-          StatisticsCommandLineArgument::RegionAwareMemoryNodeProvisioning_ },
-        { util::Statistics::Id::RvsdgConstruction,
-          StatisticsCommandLineArgument::RvsdgConstruction_ },
-        { util::Statistics::Id::RvsdgDestruction,
-          StatisticsCommandLineArgument::RvsdgDestruction_ },
-        { util::Statistics::Id::RvsdgOptimization,
-          StatisticsCommandLineArgument::RvsdgOptimization_ },
-        { util::Statistics::Id::SteensgaardAnalysis,
-          StatisticsCommandLineArgument::SteensgaardAnalysis_ },
-        { util::Statistics::Id::ThetaGammaInversion,
-          StatisticsCommandLineArgument::ThetaGammaInversion_ } });
-
-  if (map.find(statisticsId) != map.end())
-    return map[statisticsId];
-
-  throw util::error("Unknown statistics identifier");
+  try
+  {
+    return StatisticsIdCommandLineArguments_.LookupKey(statisticsId).c_str();
+  }
+  catch (...)
+  {
+    throw util::error("Unknown statistics identifier");
+  }
 }
 
 const char *

--- a/jlm/tooling/CommandLine.hpp
+++ b/jlm/tooling/CommandLine.hpp
@@ -175,33 +175,11 @@ private:
     inline static const char * NodeReduction_ = "NodeReduction";
   };
 
-  static inline const util::BijectiveMap<util::Statistics::Id, std::string>
-      StatisticsIdCommandLineArguments_ = {
-        { util::Statistics::Id::Aggregation, "print-aggregation-time" },
-        { util::Statistics::Id::AgnosticMemoryNodeProvisioning,
-          "print-agnostic-memory-node-provisioning" },
-        { util::Statistics::Id::AndersenAnalysis, "print-andersen-analysis" },
-        { util::Statistics::Id::Annotation, "print-annotation-time" },
-        { util::Statistics::Id::CommonNodeElimination, "print-cne-stat" },
-        { util::Statistics::Id::ControlFlowRecovery, "print-cfr-time" },
-        { util::Statistics::Id::DataNodeToDelta, "printDataNodeToDelta" },
-        { util::Statistics::Id::DeadNodeElimination, "print-dne-stat" },
-        { util::Statistics::Id::FunctionInlining, "print-iln-stat" },
-        { util::Statistics::Id::InvariantValueRedirection, "printInvariantValueRedirection" },
-        { util::Statistics::Id::JlmToRvsdgConversion, "print-jlm-rvsdg-conversion" },
-        { util::Statistics::Id::LoopUnrolling, "print-unroll-stat" },
-        { util::Statistics::Id::MemoryStateEncoder, "print-basicencoder-encoding" },
-        { util::Statistics::Id::PullNodes, "print-pull-stat" },
-        { util::Statistics::Id::PushNodes, "print-push-stat" },
-        { util::Statistics::Id::ReduceNodes, "print-reduction-stat" },
-        { util::Statistics::Id::RegionAwareMemoryNodeProvisioning,
-          "print-memory-node-provisioning" },
-        { util::Statistics::Id::RvsdgConstruction, "print-rvsdg-construction" },
-        { util::Statistics::Id::RvsdgDestruction, "print-rvsdg-destruction" },
-        { util::Statistics::Id::RvsdgOptimization, "print-rvsdg-optimization" },
-        { util::Statistics::Id::SteensgaardAnalysis, "print-steensgaard-analysis" },
-        { util::Statistics::Id::ThetaGammaInversion, "print-ivt-stat" }
-      };
+  static const util::BijectiveMap<util::Statistics::Id, std::string_view>
+      StatisticsIdCommandLineArguments_;
+
+  static const util::BijectiveMap<util::Statistics::Id, std::string_view> &
+  GetStatisticsIdCommandLineArguments();
 };
 
 class JlcCommandLineOptions final : public CommandLineOptions

--- a/jlm/tooling/CommandLine.hpp
+++ b/jlm/tooling/CommandLine.hpp
@@ -7,6 +7,7 @@
 #define JLM_TOOLING_COMMANDLINE_HPP
 
 #include <jlm/llvm/opt/optimization.hpp>
+#include <jlm/util/BijectiveMap.hpp>
 #include <jlm/util/file.hpp>
 #include <jlm/util/Statistics.hpp>
 
@@ -174,33 +175,33 @@ private:
     inline static const char * NodeReduction_ = "NodeReduction";
   };
 
-  struct StatisticsCommandLineArgument
-  {
-    inline static const char * Aggregation_ = "print-aggregation-time";
-    inline static const char * AgnosticMemoryNodeProvisioning_ =
-        "print-agnostic-memory-node-provisioning";
-    inline static const char * AndersenAnalysis_ = "print-andersen-analysis";
-    inline static const char * Annotation_ = "print-annotation-time";
-    inline static const char * CommonNodeElimination_ = "print-cne-stat";
-    inline static const char * ControlFlowRecovery_ = "print-cfr-time";
-    inline static const char * DataNodeToDelta_ = "printDataNodeToDelta";
-    inline static const char * DeadNodeElimination_ = "print-dne-stat";
-    inline static const char * FunctionInlining_ = "print-iln-stat";
-    inline static const char * InvariantValueRedirection_ = "printInvariantValueRedirection";
-    inline static const char * JlmToRvsdgConversion_ = "print-jlm-rvsdg-conversion";
-    inline static const char * LoopUnrolling_ = "print-unroll-stat";
-    inline static const char * MemoryStateEncoder_ = "print-basicencoder-encoding";
-    inline static const char * PullNodes_ = "print-pull-stat";
-    inline static const char * PushNodes_ = "print-push-stat";
-    inline static const char * ReduceNodes_ = "print-reduction-stat";
-    inline static const char * RegionAwareMemoryNodeProvisioning_ =
-        "print-memory-node-provisioning";
-    inline static const char * RvsdgConstruction_ = "print-rvsdg-construction";
-    inline static const char * RvsdgDestruction_ = "print-rvsdg-destruction";
-    inline static const char * RvsdgOptimization_ = "print-rvsdg-optimization";
-    inline static const char * SteensgaardAnalysis_ = "print-steensgaard-analysis";
-    inline static const char * ThetaGammaInversion_ = "print-ivt-stat";
-  };
+  static inline const util::BijectiveMap<util::Statistics::Id, std::string>
+      StatisticsIdCommandLineArguments_ = {
+        { util::Statistics::Id::Aggregation, "print-aggregation-time" },
+        { util::Statistics::Id::AgnosticMemoryNodeProvisioning,
+          "print-agnostic-memory-node-provisioning" },
+        { util::Statistics::Id::AndersenAnalysis, "print-andersen-analysis" },
+        { util::Statistics::Id::Annotation, "print-annotation-time" },
+        { util::Statistics::Id::CommonNodeElimination, "print-cne-stat" },
+        { util::Statistics::Id::ControlFlowRecovery, "print-cfr-time" },
+        { util::Statistics::Id::DataNodeToDelta, "printDataNodeToDelta" },
+        { util::Statistics::Id::DeadNodeElimination, "print-dne-stat" },
+        { util::Statistics::Id::FunctionInlining, "print-iln-stat" },
+        { util::Statistics::Id::InvariantValueRedirection, "printInvariantValueRedirection" },
+        { util::Statistics::Id::JlmToRvsdgConversion, "print-jlm-rvsdg-conversion" },
+        { util::Statistics::Id::LoopUnrolling, "print-unroll-stat" },
+        { util::Statistics::Id::MemoryStateEncoder, "print-basicencoder-encoding" },
+        { util::Statistics::Id::PullNodes, "print-pull-stat" },
+        { util::Statistics::Id::PushNodes, "print-push-stat" },
+        { util::Statistics::Id::ReduceNodes, "print-reduction-stat" },
+        { util::Statistics::Id::RegionAwareMemoryNodeProvisioning,
+          "print-memory-node-provisioning" },
+        { util::Statistics::Id::RvsdgConstruction, "print-rvsdg-construction" },
+        { util::Statistics::Id::RvsdgDestruction, "print-rvsdg-destruction" },
+        { util::Statistics::Id::RvsdgOptimization, "print-rvsdg-optimization" },
+        { util::Statistics::Id::SteensgaardAnalysis, "print-steensgaard-analysis" },
+        { util::Statistics::Id::ThetaGammaInversion, "print-ivt-stat" }
+      };
 };
 
 class JlcCommandLineOptions final : public CommandLineOptions

--- a/jlm/tooling/CommandLine.hpp
+++ b/jlm/tooling/CommandLine.hpp
@@ -175,9 +175,6 @@ private:
     inline static const char * NodeReduction_ = "NodeReduction";
   };
 
-  static const util::BijectiveMap<util::Statistics::Id, std::string_view>
-      StatisticsIdCommandLineArguments_;
-
   static const util::BijectiveMap<util::Statistics::Id, std::string_view> &
   GetStatisticsIdCommandLineArguments();
 };


### PR DESCRIPTION
We had a lot of unnecessary code for setting up the statistics command line options of jlm-opt and jlc. This PR simplifies it. It is part of #357.