### PR TITLE
Add measurement/timer system and sourceFile to Statistics base class

### DIFF
--- a/jlm/llvm/backend/rvsdg2jlm/rvsdg2jlm.cpp
+++ b/jlm/llvm/backend/rvsdg2jlm/rvsdg2jlm.cpp
@@ -19,12 +19,12 @@
 namespace jlm::llvm
 {
 
-class rvsdg_destruction_stat final : public jlm::util::Statistics
+class rvsdg_destruction_stat final : public util::Statistics
 {
 public:
   ~rvsdg_destruction_stat() override = default;
 
-  explicit rvsdg_destruction_stat(const jlm::util::filepath & filename)
+  explicit rvsdg_destruction_stat(const util::filepath & filename)
       : Statistics(Statistics::Id::RvsdgDestruction, filename),
         ntacs_(0),
         nnodes_(0)
@@ -47,16 +47,11 @@ public:
   [[nodiscard]] std::string
   Serialize() const override
   {
-    return jlm::util::strfmt(
-        nnodes_,
-        " ",
-        ntacs_,
-        " ",
-        timer_.ns());
+    return jlm::util::strfmt(nnodes_, " ", ntacs_, " ", timer_.ns());
   }
 
   static std::unique_ptr<rvsdg_destruction_stat>
-  Create(const jlm::util::filepath & sourceFile)
+  Create(const util::filepath & sourceFile)
   {
     return std::make_unique<rvsdg_destruction_stat>(sourceFile);
   }
@@ -64,7 +59,7 @@ public:
 private:
   size_t ntacs_;
   size_t nnodes_;
-  jlm::util::timer timer_;
+  util::timer timer_;
 };
 
 namespace rvsdg2jlm

--- a/jlm/llvm/backend/rvsdg2jlm/rvsdg2jlm.cpp
+++ b/jlm/llvm/backend/rvsdg2jlm/rvsdg2jlm.cpp
@@ -22,14 +22,12 @@ namespace jlm::llvm
 class rvsdg_destruction_stat final : public jlm::util::Statistics
 {
 public:
-  virtual ~rvsdg_destruction_stat()
-  {}
+  ~rvsdg_destruction_stat() override = default;
 
-  rvsdg_destruction_stat(const jlm::util::filepath & filename)
-      : Statistics(Statistics::Id::RvsdgDestruction),
+  explicit rvsdg_destruction_stat(const jlm::util::filepath & filename)
+      : Statistics(Statistics::Id::RvsdgDestruction, filename),
         ntacs_(0),
-        nnodes_(0),
-        filename_(filename)
+        nnodes_(0)
   {}
 
   void
@@ -46,13 +44,10 @@ public:
     timer_.stop();
   }
 
-  virtual std::string
-  ToString() const override
+  [[nodiscard]] std::string
+  Serialize() const override
   {
     return jlm::util::strfmt(
-        "RVSDGDESTRUCTION ",
-        filename_.to_str(),
-        " ",
         nnodes_,
         " ",
         ntacs_,
@@ -70,7 +65,6 @@ private:
   size_t ntacs_;
   size_t nnodes_;
   jlm::util::timer timer_;
-  jlm::util::filepath filename_;
 };
 
 namespace rvsdg2jlm

--- a/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
+++ b/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
@@ -18,6 +18,7 @@
 #include <jlm/util/time.hpp>
 
 #include <stack>
+#include <utility>
 
 namespace jlm::llvm
 {
@@ -125,13 +126,15 @@ private:
   std::vector<rvsdg::region *> RegionStack_;
 };
 
-class ControlFlowRestructuringStatistics final : public jlm::util::Statistics
+class ControlFlowRestructuringStatistics final : public util::Statistics
 {
 public:
   ~ControlFlowRestructuringStatistics() override = default;
 
-  ControlFlowRestructuringStatistics(jlm::util::filepath sourceFileName, std::string functionName)
-      : Statistics(Statistics::Id::ControlFlowRecovery, std::move(sourceFileName)),
+  ControlFlowRestructuringStatistics(
+      const util::filepath & sourceFileName,
+      std::string functionName)
+      : Statistics(Statistics::Id::ControlFlowRecovery, sourceFileName),
         NumNodes_(0),
         FunctionName_(std::move(functionName))
   {}
@@ -163,26 +166,26 @@ public:
   }
 
   static std::unique_ptr<ControlFlowRestructuringStatistics>
-  Create(jlm::util::filepath sourceFileName, std::string functionName)
+  Create(const util::filepath & sourceFileName, std::string functionName)
   {
     return std::make_unique<ControlFlowRestructuringStatistics>(
-        std::move(sourceFileName),
+        sourceFileName,
         std::move(functionName));
   }
 
 private:
   size_t NumNodes_;
-  jlm::util::timer Timer_;
+  util::timer Timer_;
   std::string FunctionName_;
 };
 
-class AggregationStatistics final : public jlm::util::Statistics
+class AggregationStatistics final : public util::Statistics
 {
 public:
   ~AggregationStatistics() override = default;
 
-  AggregationStatistics(jlm::util::filepath sourceFileName, std::string functionName)
-      : Statistics(jlm::util::Statistics::Id::Aggregation, std::move(sourceFileName)),
+  AggregationStatistics(const util::filepath & sourceFileName, std::string functionName)
+      : Statistics(util::Statistics::Id::Aggregation, sourceFileName),
         NumNodes_(0),
         FunctionName_(std::move(functionName))
   {}
@@ -214,26 +217,24 @@ public:
   }
 
   static std::unique_ptr<AggregationStatistics>
-  Create(jlm::util::filepath sourceFileName, std::string functionName)
+  Create(const util::filepath & sourceFileName, std::string functionName)
   {
-    return std::make_unique<AggregationStatistics>(
-        std::move(sourceFileName),
-        std::move(functionName));
+    return std::make_unique<AggregationStatistics>(sourceFileName, std::move(functionName));
   }
 
 private:
   size_t NumNodes_;
-  jlm::util::timer Timer_;
+  util::timer Timer_;
   std::string FunctionName_;
 };
 
-class AnnotationStatistics final : public jlm::util::Statistics
+class AnnotationStatistics final : public util::Statistics
 {
 public:
   ~AnnotationStatistics() override = default;
 
-  AnnotationStatistics(jlm::util::filepath sourceFileName, std::string functionName)
-      : Statistics(jlm::util::Statistics::Id::Annotation, std::move(sourceFileName)),
+  AnnotationStatistics(const util::filepath & sourceFileName, std::string functionName)
+      : Statistics(util::Statistics::Id::Annotation, sourceFileName),
         NumThreeAddressCodes_(0),
         FunctionName_(std::move(functionName))
   {}
@@ -265,26 +266,24 @@ public:
   }
 
   static std::unique_ptr<AnnotationStatistics>
-  Create(jlm::util::filepath sourceFileName, std::string functionName)
+  Create(const util::filepath & sourceFileName, std::string functionName)
   {
-    return std::make_unique<AnnotationStatistics>(
-        std::move(sourceFileName),
-        std::move(functionName));
+    return std::make_unique<AnnotationStatistics>(sourceFileName, std::move(functionName));
   }
 
 private:
   size_t NumThreeAddressCodes_;
-  jlm::util::timer Timer_;
+  util::timer Timer_;
   std::string FunctionName_;
 };
 
-class AggregationTreeToLambdaStatistics final : public jlm::util::Statistics
+class AggregationTreeToLambdaStatistics final : public util::Statistics
 {
 public:
   ~AggregationTreeToLambdaStatistics() override = default;
 
-  AggregationTreeToLambdaStatistics(jlm::util::filepath sourceFileName, std::string functionName)
-      : Statistics(jlm::util::Statistics::Id::JlmToRvsdgConversion, std::move(sourceFileName)),
+  AggregationTreeToLambdaStatistics(const util::filepath & sourceFileName, std::string functionName)
+      : Statistics(util::Statistics::Id::JlmToRvsdgConversion, sourceFileName),
         FunctionName_(std::move(functionName))
   {}
 
@@ -303,33 +302,29 @@ public:
   [[nodiscard]] std::string
   Serialize() const override
   {
-    return jlm::util::strfmt(
-        FunctionName_,
-        " ",
-        "Time[ns]:",
-        Timer_.ns());
+    return jlm::util::strfmt(FunctionName_, " ", "Time[ns]:", Timer_.ns());
   }
 
   static std::unique_ptr<AggregationTreeToLambdaStatistics>
-  Create(jlm::util::filepath sourceFileName, std::string functionName)
+  Create(const util::filepath & sourceFileName, std::string functionName)
   {
     return std::make_unique<AggregationTreeToLambdaStatistics>(
-        std::move(sourceFileName),
+        sourceFileName,
         std::move(functionName));
   }
 
 private:
-  jlm::util::timer Timer_;
+  util::timer Timer_;
   std::string FunctionName_;
 };
 
-class DataNodeToDeltaStatistics final : public jlm::util::Statistics
+class DataNodeToDeltaStatistics final : public util::Statistics
 {
 public:
   ~DataNodeToDeltaStatistics() override = default;
 
-  DataNodeToDeltaStatistics(jlm::util::filepath sourceFileName, std::string dataNodeName)
-      : Statistics(jlm::util::Statistics::Id::DataNodeToDelta, std::move(sourceFileName)),
+  DataNodeToDeltaStatistics(const util::filepath & sourceFileName, std::string dataNodeName)
+      : Statistics(util::Statistics::Id::DataNodeToDelta, sourceFileName),
         NumInitializationThreeAddressCodes_(0),
         DataNodeName_(std::move(dataNodeName))
   {}
@@ -361,26 +356,24 @@ public:
   }
 
   static std::unique_ptr<DataNodeToDeltaStatistics>
-  Create(jlm::util::filepath sourceFileName, std::string dataNodeName)
+  Create(const util::filepath & sourceFileName, std::string dataNodeName)
   {
-    return std::make_unique<DataNodeToDeltaStatistics>(
-        std::move(sourceFileName),
-        std::move(dataNodeName));
+    return std::make_unique<DataNodeToDeltaStatistics>(sourceFileName, std::move(dataNodeName));
   }
 
 private:
-  jlm::util::timer Timer_;
+  util::timer Timer_;
   size_t NumInitializationThreeAddressCodes_;
   std::string DataNodeName_;
 };
 
-class InterProceduralGraphToRvsdgStatistics final : public jlm::util::Statistics
+class InterProceduralGraphToRvsdgStatistics final : public util::Statistics
 {
 public:
   ~InterProceduralGraphToRvsdgStatistics() override = default;
 
-  explicit InterProceduralGraphToRvsdgStatistics(jlm::util::filepath sourceFileName)
-      : Statistics(jlm::util::Statistics::Id::RvsdgConstruction, std::move(sourceFileName)),
+  explicit InterProceduralGraphToRvsdgStatistics(const util::filepath & sourceFileName)
+      : Statistics(util::Statistics::Id::RvsdgConstruction, sourceFileName),
         NumThreeAddressCodes_(0),
         NumRvsdgNodes_(0)
   {}
@@ -414,23 +407,23 @@ public:
   }
 
   static std::unique_ptr<InterProceduralGraphToRvsdgStatistics>
-  Create(jlm::util::filepath sourceFileName)
+  Create(const util::filepath & sourceFileName)
   {
-    return std::make_unique<InterProceduralGraphToRvsdgStatistics>(std::move(sourceFileName));
+    return std::make_unique<InterProceduralGraphToRvsdgStatistics>(sourceFileName);
   }
 
 private:
   size_t NumThreeAddressCodes_;
   size_t NumRvsdgNodes_;
-  jlm::util::timer Timer_;
+  util::timer Timer_;
 };
 
 class InterProceduralGraphToRvsdgStatisticsCollector final
 {
 public:
-  explicit InterProceduralGraphToRvsdgStatisticsCollector(
-      jlm::util::StatisticsCollector & statisticsCollector,
-      jlm::util::filepath sourceFileName)
+  InterProceduralGraphToRvsdgStatisticsCollector(
+      util::StatisticsCollector & statisticsCollector,
+      util::filepath sourceFileName)
       : SourceFileName_(std::move(sourceFileName)),
         StatisticsCollector_(statisticsCollector)
   {}
@@ -557,8 +550,8 @@ public:
   }
 
 private:
-  const jlm::util::filepath SourceFileName_;
-  jlm::util::StatisticsCollector & StatisticsCollector_;
+  const util::filepath SourceFileName_;
+  util::StatisticsCollector & StatisticsCollector_;
 };
 
 static bool
@@ -1299,7 +1292,7 @@ ConvertInterProceduralGraphModule(
 std::unique_ptr<RvsdgModule>
 ConvertInterProceduralGraphModule(
     ipgraph_module & interProceduralGraphModule,
-    jlm::util::StatisticsCollector & statisticsCollector)
+    util::StatisticsCollector & statisticsCollector)
 {
   InterProceduralGraphToRvsdgStatisticsCollector interProceduralGraphToRvsdgStatisticsCollector(
       statisticsCollector,

--- a/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
+++ b/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
@@ -131,10 +131,9 @@ public:
   ~ControlFlowRestructuringStatistics() override = default;
 
   ControlFlowRestructuringStatistics(jlm::util::filepath sourceFileName, std::string functionName)
-      : Statistics(Statistics::Id::ControlFlowRecovery),
+      : Statistics(Statistics::Id::ControlFlowRecovery, std::move(sourceFileName)),
         NumNodes_(0),
-        FunctionName_(std::move(functionName)),
-        SourceFileName_(std::move(sourceFileName))
+        FunctionName_(std::move(functionName))
   {}
 
   void
@@ -150,13 +149,10 @@ public:
     Timer_.stop();
   }
 
-  std::string
-  ToString() const override
+  [[nodiscard]] std::string
+  Serialize() const override
   {
     return jlm::util::strfmt(
-        "ControlFlowRestructuring ",
-        SourceFileName_.to_str(),
-        " ",
         FunctionName_,
         " ",
         "#Nodes:",
@@ -178,7 +174,6 @@ private:
   size_t NumNodes_;
   jlm::util::timer Timer_;
   std::string FunctionName_;
-  jlm::util::filepath SourceFileName_;
 };
 
 class AggregationStatistics final : public jlm::util::Statistics
@@ -187,10 +182,9 @@ public:
   ~AggregationStatistics() override = default;
 
   AggregationStatistics(jlm::util::filepath sourceFileName, std::string functionName)
-      : Statistics(jlm::util::Statistics::Id::Aggregation),
+      : Statistics(jlm::util::Statistics::Id::Aggregation, std::move(sourceFileName)),
         NumNodes_(0),
-        FunctionName_(std::move(functionName)),
-        SourceFileName_(std::move(sourceFileName))
+        FunctionName_(std::move(functionName))
   {}
 
   void
@@ -206,13 +200,10 @@ public:
     Timer_.stop();
   }
 
-  std::string
-  ToString() const override
+  [[nodiscard]] std::string
+  Serialize() const override
   {
     return jlm::util::strfmt(
-        "Aggregation ",
-        SourceFileName_.to_str(),
-        " ",
         FunctionName_,
         " ",
         "#Nodes:",
@@ -234,7 +225,6 @@ private:
   size_t NumNodes_;
   jlm::util::timer Timer_;
   std::string FunctionName_;
-  jlm::util::filepath SourceFileName_;
 };
 
 class AnnotationStatistics final : public jlm::util::Statistics
@@ -243,10 +233,9 @@ public:
   ~AnnotationStatistics() override = default;
 
   AnnotationStatistics(jlm::util::filepath sourceFileName, std::string functionName)
-      : Statistics(jlm::util::Statistics::Id::Annotation),
+      : Statistics(jlm::util::Statistics::Id::Annotation, std::move(sourceFileName)),
         NumThreeAddressCodes_(0),
-        FunctionName_(std::move(functionName)),
-        SourceFileName_(std::move(sourceFileName))
+        FunctionName_(std::move(functionName))
   {}
 
   void
@@ -262,13 +251,10 @@ public:
     Timer_.stop();
   }
 
-  std::string
-  ToString() const override
+  [[nodiscard]] std::string
+  Serialize() const override
   {
     return jlm::util::strfmt(
-        "Annotation ",
-        SourceFileName_.to_str(),
-        " ",
         FunctionName_,
         " ",
         "#ThreeAddressCodes:",
@@ -290,7 +276,6 @@ private:
   size_t NumThreeAddressCodes_;
   jlm::util::timer Timer_;
   std::string FunctionName_;
-  jlm::util::filepath SourceFileName_;
 };
 
 class AggregationTreeToLambdaStatistics final : public jlm::util::Statistics
@@ -299,9 +284,8 @@ public:
   ~AggregationTreeToLambdaStatistics() override = default;
 
   AggregationTreeToLambdaStatistics(jlm::util::filepath sourceFileName, std::string functionName)
-      : Statistics(jlm::util::Statistics::Id::JlmToRvsdgConversion),
-        FunctionName_(std::move(functionName)),
-        SourceFileName_(std::move(sourceFileName))
+      : Statistics(jlm::util::Statistics::Id::JlmToRvsdgConversion, std::move(sourceFileName)),
+        FunctionName_(std::move(functionName))
   {}
 
   void
@@ -316,13 +300,10 @@ public:
     Timer_.stop();
   }
 
-  std::string
-  ToString() const override
+  [[nodiscard]] std::string
+  Serialize() const override
   {
     return jlm::util::strfmt(
-        "ControlFlowGraphToLambda ",
-        SourceFileName_.to_str(),
-        " ",
         FunctionName_,
         " ",
         "Time[ns]:",
@@ -340,7 +321,6 @@ public:
 private:
   jlm::util::timer Timer_;
   std::string FunctionName_;
-  jlm::util::filepath SourceFileName_;
 };
 
 class DataNodeToDeltaStatistics final : public jlm::util::Statistics
@@ -349,10 +329,9 @@ public:
   ~DataNodeToDeltaStatistics() override = default;
 
   DataNodeToDeltaStatistics(jlm::util::filepath sourceFileName, std::string dataNodeName)
-      : Statistics(jlm::util::Statistics::Id::DataNodeToDelta),
+      : Statistics(jlm::util::Statistics::Id::DataNodeToDelta, std::move(sourceFileName)),
         NumInitializationThreeAddressCodes_(0),
-        DataNodeName_(std::move(dataNodeName)),
-        SourceFileName_(std::move(sourceFileName))
+        DataNodeName_(std::move(dataNodeName))
   {}
 
   void
@@ -368,13 +347,10 @@ public:
     Timer_.stop();
   }
 
-  std::string
-  ToString() const override
+  [[nodiscard]] std::string
+  Serialize() const override
   {
     return jlm::util::strfmt(
-        "DataNodeToDeltaStatistics ",
-        SourceFileName_.to_str(),
-        " ",
         DataNodeName_,
         " ",
         "#InitializationThreeAddressCodes:",
@@ -396,7 +372,6 @@ private:
   jlm::util::timer Timer_;
   size_t NumInitializationThreeAddressCodes_;
   std::string DataNodeName_;
-  jlm::util::filepath SourceFileName_;
 };
 
 class InterProceduralGraphToRvsdgStatistics final : public jlm::util::Statistics
@@ -405,10 +380,9 @@ public:
   ~InterProceduralGraphToRvsdgStatistics() override = default;
 
   explicit InterProceduralGraphToRvsdgStatistics(jlm::util::filepath sourceFileName)
-      : Statistics(jlm::util::Statistics::Id::RvsdgConstruction),
+      : Statistics(jlm::util::Statistics::Id::RvsdgConstruction, std::move(sourceFileName)),
         NumThreeAddressCodes_(0),
-        NumRvsdgNodes_(0),
-        SourceFileName_(std::move(sourceFileName))
+        NumRvsdgNodes_(0)
   {}
 
   void
@@ -425,13 +399,10 @@ public:
     NumRvsdgNodes_ = rvsdg::nnodes(graph.root());
   }
 
-  std::string
-  ToString() const override
+  [[nodiscard]] std::string
+  Serialize() const override
   {
     return jlm::util::strfmt(
-        "InterProceduralGraphToRvsdg ",
-        SourceFileName_.to_str(),
-        " ",
         "#ThreeAddressCodes:",
         NumThreeAddressCodes_,
         " ",
@@ -452,7 +423,6 @@ private:
   size_t NumThreeAddressCodes_;
   size_t NumRvsdgNodes_;
   jlm::util::timer Timer_;
-  jlm::util::filepath SourceFileName_;
 };
 
 class InterProceduralGraphToRvsdgStatisticsCollector final

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -101,8 +101,7 @@ public:
   ~Statistics() override = default;
 
   explicit Statistics(util::filepath sourceFile)
-      : util::Statistics(Statistics::Id::DeadNodeElimination),
-        SourceFile_(std::move(sourceFile)),
+      : util::Statistics(Statistics::Id::DeadNodeElimination, std::move(sourceFile)),
         NumRvsdgNodesBefore_(0),
         NumRvsdgNodesAfter_(0),
         NumInputsBefore_(0),
@@ -138,12 +137,9 @@ public:
   }
 
   [[nodiscard]] std::string
-  ToString() const override
+  Serialize() const override
   {
     return util::strfmt(
-        "DeadNodeElimination ",
-        SourceFile_.to_str(),
-        " ",
         "#RvsdgNodesBeforeDNE:",
         NumRvsdgNodesBefore_,
         " ",
@@ -170,8 +166,6 @@ public:
   }
 
 private:
-  util::filepath SourceFile_;
-
   size_t NumRvsdgNodesBefore_;
   size_t NumRvsdgNodesAfter_;
   size_t NumInputsBefore_;

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -100,8 +100,8 @@ class DeadNodeElimination::Statistics final : public util::Statistics
 public:
   ~Statistics() override = default;
 
-  explicit Statistics(util::filepath sourceFile)
-      : util::Statistics(Statistics::Id::DeadNodeElimination, std::move(sourceFile)),
+  explicit Statistics(const util::filepath & sourceFile)
+      : util::Statistics(Statistics::Id::DeadNodeElimination, sourceFile),
         NumRvsdgNodesBefore_(0),
         NumRvsdgNodesAfter_(0),
         NumInputsBefore_(0),

--- a/jlm/llvm/opt/InvariantValueRedirection.cpp
+++ b/jlm/llvm/opt/InvariantValueRedirection.cpp
@@ -19,8 +19,8 @@ class InvariantValueRedirection::Statistics final : public util::Statistics
 public:
   ~Statistics() override = default;
 
-  Statistics()
-      : util::Statistics(Statistics::Id::InvariantValueRedirection)
+  Statistics(util::filepath sourceFile)
+      : util::Statistics(Statistics::Id::InvariantValueRedirection, std::move(sourceFile))
   {}
 
   void
@@ -36,15 +36,15 @@ public:
   }
 
   [[nodiscard]] std::string
-  ToString() const override
+  Serialize() const override
   {
-    return util::strfmt("InvariantValueRedirection ", "Time[ns]:", Timer_.ns());
+    return util::strfmt("Time[ns]:", Timer_.ns());
   }
 
   static std::unique_ptr<Statistics>
-  Create()
+  Create(util::filepath sourceFile)
   {
-    return std::make_unique<Statistics>();
+    return std::make_unique<Statistics>(std::move(sourceFile));
   }
 
 private:
@@ -59,7 +59,7 @@ InvariantValueRedirection::run(
     util::StatisticsCollector & statisticsCollector)
 {
   auto & rvsdg = rvsdgModule.Rvsdg();
-  auto statistics = Statistics::Create();
+  auto statistics = Statistics::Create(rvsdgModule.SourceFileName());
 
   statistics->Start();
   RedirectInvariantValues(*rvsdg.root());

--- a/jlm/llvm/opt/InvariantValueRedirection.cpp
+++ b/jlm/llvm/opt/InvariantValueRedirection.cpp
@@ -19,8 +19,8 @@ class InvariantValueRedirection::Statistics final : public util::Statistics
 public:
   ~Statistics() override = default;
 
-  Statistics(util::filepath sourceFile)
-      : util::Statistics(Statistics::Id::InvariantValueRedirection, std::move(sourceFile))
+  explicit Statistics(const util::filepath & sourceFile)
+      : util::Statistics(Statistics::Id::InvariantValueRedirection, sourceFile)
   {}
 
   void
@@ -42,9 +42,9 @@ public:
   }
 
   static std::unique_ptr<Statistics>
-  Create(util::filepath sourceFile)
+  Create(const util::filepath & sourceFile)
   {
-    return std::make_unique<Statistics>(std::move(sourceFile));
+    return std::make_unique<Statistics>(sourceFile);
   }
 
 private:

--- a/jlm/llvm/opt/OptimizationSequence.cpp
+++ b/jlm/llvm/opt/OptimizationSequence.cpp
@@ -16,8 +16,8 @@ class OptimizationSequence::Statistics final : public util::Statistics
 public:
   ~Statistics() noexcept override = default;
 
-  explicit Statistics(util::filepath sourceFile)
-      : util::Statistics(Statistics::Id::RvsdgOptimization, std::move(sourceFile)),
+  explicit Statistics(const util::filepath & sourceFile)
+      : util::Statistics(Statistics::Id::RvsdgOptimization, sourceFile),
         NumNodesBefore_(0),
         NumNodesAfter_(0)
   {}
@@ -39,12 +39,7 @@ public:
   [[nodiscard]] std::string
   Serialize() const override
   {
-    return util::strfmt(
-        NumNodesBefore_,
-        " ",
-        NumNodesAfter_,
-        " ",
-        Timer_.ns());
+    return util::strfmt(NumNodesBefore_, " ", NumNodesAfter_, " ", Timer_.ns());
   }
 
   static std::unique_ptr<Statistics>

--- a/jlm/llvm/opt/OptimizationSequence.cpp
+++ b/jlm/llvm/opt/OptimizationSequence.cpp
@@ -17,8 +17,7 @@ public:
   ~Statistics() noexcept override = default;
 
   explicit Statistics(util::filepath sourceFile)
-      : util::Statistics(Statistics::Id::RvsdgOptimization),
-        SourceFile_(std::move(sourceFile)),
+      : util::Statistics(Statistics::Id::RvsdgOptimization, std::move(sourceFile)),
         NumNodesBefore_(0),
         NumNodesAfter_(0)
   {}
@@ -38,12 +37,9 @@ public:
   }
 
   [[nodiscard]] std::string
-  ToString() const override
+  Serialize() const override
   {
     return util::strfmt(
-        "RVSDGOPTIMIZATION ",
-        SourceFile_.to_str(),
-        " ",
         NumNodesBefore_,
         " ",
         NumNodesAfter_,
@@ -59,7 +55,6 @@ public:
 
 private:
   util::timer Timer_;
-  util::filepath SourceFile_;
   size_t NumNodesBefore_;
   size_t NumNodesAfter_;
 };

--- a/jlm/llvm/opt/alias-analyses/AgnosticMemoryNodeProvider.hpp
+++ b/jlm/llvm/opt/alias-analyses/AgnosticMemoryNodeProvider.hpp
@@ -91,8 +91,7 @@ public:
       util::filepath sourceFile,
       const util::StatisticsCollector & statisticsCollector,
       const PointsToGraph & pointsToGraph)
-      : util::Statistics(Statistics::Id::AgnosticMemoryNodeProvisioning),
-        SourceFile_(std::move(sourceFile)),
+      : util::Statistics(Statistics::Id::AgnosticMemoryNodeProvisioning, std::move(sourceFile)),
         NumPointsToGraphMemoryNodes_(0),
         StatisticsCollector_(statisticsCollector)
   {
@@ -114,12 +113,6 @@ public:
     return Timer_.ns();
   }
 
-  [[nodiscard]] const util::filepath &
-  GetSourceFile() const noexcept
-  {
-    return SourceFile_;
-  }
-
   void
   StartCollecting() noexcept
   {
@@ -139,12 +132,9 @@ public:
   }
 
   [[nodiscard]] std::string
-  ToString() const override
+  Serialize() const override
   {
     return util::strfmt(
-        "AgnosticMemoryNodeProvider ",
-        SourceFile_.to_str(),
-        " ",
         "#PointsToGraphMemoryNodes:",
         NumPointsToGraphMemoryNodes_,
         " ",
@@ -163,7 +153,6 @@ public:
 
 private:
   util::timer Timer_;
-  util::filepath SourceFile_;
   size_t NumPointsToGraphMemoryNodes_;
   const util::StatisticsCollector & StatisticsCollector_;
 };

--- a/jlm/llvm/opt/alias-analyses/AgnosticMemoryNodeProvider.hpp
+++ b/jlm/llvm/opt/alias-analyses/AgnosticMemoryNodeProvider.hpp
@@ -88,10 +88,10 @@ class AgnosticMemoryNodeProvider::Statistics final : public util::Statistics
 {
 public:
   Statistics(
-      util::filepath sourceFile,
+      const util::filepath & sourceFile,
       const util::StatisticsCollector & statisticsCollector,
       const PointsToGraph & pointsToGraph)
-      : util::Statistics(Statistics::Id::AgnosticMemoryNodeProvisioning, std::move(sourceFile)),
+      : util::Statistics(Statistics::Id::AgnosticMemoryNodeProvisioning, sourceFile),
         NumPointsToGraphMemoryNodes_(0),
         StatisticsCollector_(statisticsCollector)
   {

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -33,8 +33,7 @@ public:
   ~Statistics() override = default;
 
   explicit Statistics(jlm::util::filepath sourceFile)
-      : jlm::util::Statistics(Statistics::Id::AndersenAnalysis),
-        SourceFile_(std::move(sourceFile)),
+      : jlm::util::Statistics(Statistics::Id::AndersenAnalysis, std::move(sourceFile)),
         NumRvsdgNodes_(0),
         NumPointerObjects_(0),
         NumRegistersMappedToPointerObject_(0),
@@ -144,12 +143,9 @@ public:
   }
 
   [[nodiscard]] std::string
-  ToString() const override
+  Serialize() const override
   {
     return jlm::util::strfmt(
-        "AndersenAnalysis ",
-        SourceFile_.to_str(),
-        " ",
         "#RvsdgNodes:",
         NumRvsdgNodes_,
         " ",
@@ -230,7 +226,6 @@ public:
   }
 
 private:
-  jlm::util::filepath SourceFile_;
   size_t NumRvsdgNodes_;
 
   size_t NumPointerObjects_;

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -27,13 +27,13 @@ IsOrContainsPointerType(const rvsdg::type & type)
 /**
  * Class collecting statistics from a pass of Andersen's alias analysis
  */
-class Andersen::Statistics final : public jlm::util::Statistics
+class Andersen::Statistics final : public util::Statistics
 {
 public:
   ~Statistics() override = default;
 
-  explicit Statistics(jlm::util::filepath sourceFile)
-      : jlm::util::Statistics(Statistics::Id::AndersenAnalysis, std::move(sourceFile)),
+  explicit Statistics(const util::filepath & sourceFile)
+      : util::Statistics(Statistics::Id::AndersenAnalysis, sourceFile),
         NumRvsdgNodes_(0),
         NumPointerObjects_(0),
         NumRegistersMappedToPointerObject_(0),
@@ -220,7 +220,7 @@ public:
   }
 
   static std::unique_ptr<Statistics>
-  Create(const jlm::util::filepath & sourceFile)
+  Create(const util::filepath & sourceFile)
   {
     return std::make_unique<Statistics>(sourceFile);
   }

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
@@ -24,9 +24,8 @@ public:
   ~EncodingStatistics() override = default;
 
   explicit EncodingStatistics(jlm::util::filepath sourceFile)
-      : Statistics(Statistics::Id::MemoryStateEncoder),
-        NumNodesBefore_(0),
-        SourceFile_(std::move(sourceFile))
+      : Statistics(Statistics::Id::MemoryStateEncoder, std::move(sourceFile)),
+        NumNodesBefore_(0)
   {}
 
   void
@@ -43,12 +42,9 @@ public:
   }
 
   [[nodiscard]] std::string
-  ToString() const override
+  Serialize() const override
   {
     return jlm::util::strfmt(
-        "MemoryStateEncoder ",
-        SourceFile_.to_str(),
-        " ",
         "#RvsdgNodes:",
         NumNodesBefore_,
         " ",
@@ -65,7 +61,6 @@ public:
 private:
   jlm::util::timer Timer_;
   size_t NumNodesBefore_;
-  jlm::util::filepath SourceFile_;
 };
 
 static jlm::rvsdg::argument *

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
@@ -18,13 +18,13 @@ namespace jlm::llvm::aa
 /** \brief Statistics class for memory state encoder encoding
  *
  */
-class EncodingStatistics final : public jlm::util::Statistics
+class EncodingStatistics final : public util::Statistics
 {
 public:
   ~EncodingStatistics() override = default;
 
-  explicit EncodingStatistics(jlm::util::filepath sourceFile)
-      : Statistics(Statistics::Id::MemoryStateEncoder, std::move(sourceFile)),
+  explicit EncodingStatistics(const util::filepath & sourceFile)
+      : Statistics(Statistics::Id::MemoryStateEncoder, sourceFile),
         NumNodesBefore_(0)
   {}
 
@@ -44,12 +44,7 @@ public:
   [[nodiscard]] std::string
   Serialize() const override
   {
-    return jlm::util::strfmt(
-        "#RvsdgNodes:",
-        NumNodesBefore_,
-        " ",
-        "Time[ns]:",
-        Timer_.ns());
+    return jlm::util::strfmt("#RvsdgNodes:", NumNodesBefore_, " ", "Time[ns]:", Timer_.ns());
   }
 
   static std::unique_ptr<EncodingStatistics>
@@ -59,7 +54,7 @@ public:
   }
 
 private:
-  jlm::util::timer Timer_;
+  util::timer Timer_;
   size_t NumNodesBefore_;
 };
 

--- a/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.hpp
+++ b/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.hpp
@@ -193,7 +193,7 @@ private:
  *
  * @see RegionAwareMemoryNodeProvider
  */
-class RegionAwareMemoryNodeProvider::Statistics final : public jlm::util::Statistics
+class RegionAwareMemoryNodeProvider::Statistics final : public util::Statistics
 {
 public:
   ~Statistics() override = default;
@@ -202,9 +202,9 @@ public:
       const util::StatisticsCollector & statisticsCollector,
       const RvsdgModule & rvsdgModule,
       const PointsToGraph & pointsToGraph)
-      : jlm::util::Statistics(
-            Statistics::Id::RegionAwareMemoryNodeProvisioning,
-            rvsdgModule.SourceFileName()),
+      : util::Statistics(
+          Statistics::Id::RegionAwareMemoryNodeProvisioning,
+          rvsdgModule.SourceFileName()),
         NumRvsdgNodes_(0),
         NumRvsdgRegions_(0),
         NumPointsToGraphMemoryNodes_(0),

--- a/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.hpp
+++ b/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.hpp
@@ -202,7 +202,9 @@ public:
       const util::StatisticsCollector & statisticsCollector,
       const RvsdgModule & rvsdgModule,
       const PointsToGraph & pointsToGraph)
-      : jlm::util::Statistics(Statistics::Id::RegionAwareMemoryNodeProvisioning),
+      : jlm::util::Statistics(
+            Statistics::Id::RegionAwareMemoryNodeProvisioning,
+            rvsdgModule.SourceFileName()),
         NumRvsdgNodes_(0),
         NumRvsdgRegions_(0),
         NumPointsToGraphMemoryNodes_(0),
@@ -331,10 +333,9 @@ public:
   }
 
   [[nodiscard]] std::string
-  ToString() const override
+  Serialize() const override
   {
     return util::strfmt(
-        "RegionAwareMemoryNodeProvision ",
         "#RvsdgNodes:",
         NumRvsdgNodes_,
         " ",
@@ -354,8 +355,7 @@ public:
         ResolveUnknownMemoryReferencesTimer_.ns(),
         " ",
         "PropagationPass2Time[ns]:",
-        PropagationPass2Timer_.ns(),
-        " ");
+        PropagationPass2Timer_.ns());
   }
 
   static std::unique_ptr<Statistics>

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -783,9 +783,8 @@ public:
   ~Statistics() override = default;
 
   explicit Statistics(jlm::util::filepath sourceFile)
-      : jlm::util::Statistics(Statistics::Id::SteensgaardAnalysis),
+      : jlm::util::Statistics(Statistics::Id::SteensgaardAnalysis, std::move(sourceFile)),
         NumRvsdgNodes_(0),
-        SourceFile_(std::move(sourceFile)),
         NumDisjointSets_(0),
         NumLocations_(0),
         NumPointsToGraphNodes_(0),
@@ -860,12 +859,9 @@ public:
   }
 
   [[nodiscard]] std::string
-  ToString() const override
+  Serialize() const override
   {
     return jlm::util::strfmt(
-        "SteensgaardAnalysis ",
-        SourceFile_.to_str(),
-        " ",
         "#RvsdgNodes:",
         NumRvsdgNodes_,
         " ",
@@ -923,7 +919,6 @@ public:
 
 private:
   size_t NumRvsdgNodes_;
-  jlm::util::filepath SourceFile_;
 
   size_t NumDisjointSets_;
   size_t NumLocations_;

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -777,13 +777,13 @@ private:
 /** \brief Collect statistics about Steensgaard alias analysis pass
  *
  */
-class Steensgaard::Statistics final : public jlm::util::Statistics
+class Steensgaard::Statistics final : public util::Statistics
 {
 public:
   ~Statistics() override = default;
 
-  explicit Statistics(jlm::util::filepath sourceFile)
-      : jlm::util::Statistics(Statistics::Id::SteensgaardAnalysis, std::move(sourceFile)),
+  explicit Statistics(const util::filepath & sourceFile)
+      : util::Statistics(Statistics::Id::SteensgaardAnalysis, sourceFile),
         NumRvsdgNodes_(0),
         NumDisjointSets_(0),
         NumLocations_(0),
@@ -912,7 +912,7 @@ public:
   }
 
   static std::unique_ptr<Statistics>
-  Create(const jlm::util::filepath & sourceFile)
+  Create(const util::filepath & sourceFile)
   {
     return std::make_unique<Statistics>(sourceFile);
   }

--- a/jlm/llvm/opt/cne.cpp
+++ b/jlm/llvm/opt/cne.cpp
@@ -18,8 +18,8 @@ class cnestat final : public util::Statistics
 public:
   ~cnestat() override = default;
 
-  cnestat(util::filepath sourceFile)
-      : Statistics(Statistics::Id::CommonNodeElimination, std::move(sourceFile)),
+  explicit cnestat(const util::filepath & sourceFile)
+      : Statistics(Statistics::Id::CommonNodeElimination, sourceFile),
         nnodes_before_(0),
         nnodes_after_(0),
         ninputs_before_(0),
@@ -72,9 +72,9 @@ public:
   }
 
   static std::unique_ptr<cnestat>
-  Create(util::filepath sourceFile)
+  Create(const util::filepath & sourceFile)
   {
-    return std::make_unique<cnestat>(std::move(sourceFile));
+    return std::make_unique<cnestat>(sourceFile);
   }
 
 private:

--- a/jlm/llvm/opt/cne.cpp
+++ b/jlm/llvm/opt/cne.cpp
@@ -16,11 +16,10 @@ namespace jlm::llvm
 class cnestat final : public util::Statistics
 {
 public:
-  virtual ~cnestat()
-  {}
+  ~cnestat() override = default;
 
-  cnestat()
-      : Statistics(Statistics::Id::CommonNodeElimination),
+  cnestat(util::filepath sourceFile)
+      : Statistics(Statistics::Id::CommonNodeElimination, std::move(sourceFile)),
         nnodes_before_(0),
         nnodes_after_(0),
         ninputs_before_(0),
@@ -55,11 +54,10 @@ public:
     diverttimer_.stop();
   }
 
-  virtual std::string
-  ToString() const override
+  [[nodiscard]] std::string
+  Serialize() const override
   {
     return util::strfmt(
-        "CNE ",
         nnodes_before_,
         " ",
         nnodes_after_,
@@ -74,9 +72,9 @@ public:
   }
 
   static std::unique_ptr<cnestat>
-  Create()
+  Create(util::filepath sourceFile)
   {
-    return std::make_unique<cnestat>();
+    return std::make_unique<cnestat>(std::move(sourceFile));
   }
 
 private:
@@ -580,7 +578,7 @@ cne(RvsdgModule & rm, util::StatisticsCollector & statisticsCollector)
   auto & graph = rm.Rvsdg();
 
   cnectx ctx;
-  auto statistics = cnestat::Create();
+  auto statistics = cnestat::Create(rm.SourceFileName());
 
   statistics->start_mark_stat(graph);
   mark(graph.root(), ctx);

--- a/jlm/llvm/opt/inlining.cpp
+++ b/jlm/llvm/opt/inlining.cpp
@@ -18,8 +18,8 @@ class ilnstat final : public util::Statistics
 public:
   ~ilnstat() override = default;
 
-  ilnstat(util::filepath sourceFile)
-      : Statistics(Statistics::Id::FunctionInlining, std::move(sourceFile)),
+  explicit ilnstat(const util::filepath & sourceFile)
+      : Statistics(Statistics::Id::FunctionInlining, sourceFile),
         nnodes_before_(0),
         nnodes_after_(0)
   {}
@@ -45,9 +45,9 @@ public:
   }
 
   static std::unique_ptr<ilnstat>
-  Create(util::filepath sourceFile)
+  Create(const util::filepath & sourceFile)
   {
-    return std::make_unique<ilnstat>(std::move(sourceFile));
+    return std::make_unique<ilnstat>(sourceFile);
   }
 
 private:

--- a/jlm/llvm/opt/inlining.cpp
+++ b/jlm/llvm/opt/inlining.cpp
@@ -16,11 +16,10 @@ namespace jlm::llvm
 class ilnstat final : public util::Statistics
 {
 public:
-  virtual ~ilnstat()
-  {}
+  ~ilnstat() override = default;
 
-  ilnstat()
-      : Statistics(Statistics::Id::FunctionInlining),
+  ilnstat(util::filepath sourceFile)
+      : Statistics(Statistics::Id::FunctionInlining, std::move(sourceFile)),
         nnodes_before_(0),
         nnodes_after_(0)
   {}
@@ -40,15 +39,15 @@ public:
   }
 
   virtual std::string
-  ToString() const override
+  Serialize() const override
   {
-    return util::strfmt("ILN ", nnodes_before_, " ", nnodes_after_, " ", timer_.ns());
+    return util::strfmt(nnodes_before_, " ", nnodes_after_, " ", timer_.ns());
   }
 
   static std::unique_ptr<ilnstat>
-  Create()
+  Create(util::filepath sourceFile)
   {
-    return std::make_unique<ilnstat>();
+    return std::make_unique<ilnstat>(std::move(sourceFile));
   }
 
 private:
@@ -173,7 +172,7 @@ static void
 inlining(RvsdgModule & rm, util::StatisticsCollector & statisticsCollector)
 {
   auto & graph = rm.Rvsdg();
-  auto statistics = ilnstat::Create();
+  auto statistics = ilnstat::Create(rm.SourceFileName());
 
   statistics->start(graph);
   inlining(graph);

--- a/jlm/llvm/opt/inversion.cpp
+++ b/jlm/llvm/opt/inversion.cpp
@@ -14,13 +14,13 @@
 namespace jlm::llvm
 {
 
-class ivtstat final : public jlm::util::Statistics
+class ivtstat final : public util::Statistics
 {
 public:
   ~ivtstat() override = default;
 
-  explicit ivtstat(util::filepath sourceFile)
-      : Statistics(Statistics::Id::ThetaGammaInversion, std::move(sourceFile)),
+  explicit ivtstat(const util::filepath & sourceFile)
+      : Statistics(Statistics::Id::ThetaGammaInversion, sourceFile),
         nnodes_before_(0),
         nnodes_after_(0),
         ninputs_before_(0),
@@ -59,9 +59,9 @@ public:
   }
 
   static std::unique_ptr<ivtstat>
-  Create(util::filepath sourceFile)
+  Create(const util::filepath & sourceFile)
   {
-    return std::make_unique<ivtstat>(std::move(sourceFile));
+    return std::make_unique<ivtstat>(sourceFile);
   }
 
 private:

--- a/jlm/llvm/opt/inversion.cpp
+++ b/jlm/llvm/opt/inversion.cpp
@@ -17,11 +17,10 @@ namespace jlm::llvm
 class ivtstat final : public jlm::util::Statistics
 {
 public:
-  virtual ~ivtstat()
-  {}
+  ~ivtstat() override = default;
 
-  ivtstat()
-      : Statistics(Statistics::Id::ThetaGammaInversion),
+  explicit ivtstat(util::filepath sourceFile)
+      : Statistics(Statistics::Id::ThetaGammaInversion, std::move(sourceFile)),
         nnodes_before_(0),
         nnodes_after_(0),
         ninputs_before_(0),
@@ -44,11 +43,10 @@ public:
     timer_.stop();
   }
 
-  virtual std::string
-  ToString() const override
+  [[nodiscard]] std::string
+  Serialize() const override
   {
     return jlm::util::strfmt(
-        "IVT ",
         nnodes_before_,
         " ",
         nnodes_after_,
@@ -61,9 +59,9 @@ public:
   }
 
   static std::unique_ptr<ivtstat>
-  Create()
+  Create(util::filepath sourceFile)
   {
-    return std::make_unique<ivtstat>();
+    return std::make_unique<ivtstat>(std::move(sourceFile));
   }
 
 private:
@@ -330,7 +328,7 @@ invert(jlm::rvsdg::region * region)
 static void
 invert(RvsdgModule & rm, util::StatisticsCollector & statisticsCollector)
 {
-  auto statistics = ivtstat::Create();
+  auto statistics = ivtstat::Create(rm.SourceFileName());
 
   statistics->start(rm.Rvsdg());
   invert(rm.Rvsdg().root());

--- a/jlm/llvm/opt/pull.cpp
+++ b/jlm/llvm/opt/pull.cpp
@@ -16,11 +16,10 @@ namespace jlm::llvm
 class pullstat final : public util::Statistics
 {
 public:
-  virtual ~pullstat()
-  {}
+  ~pullstat() override = default;
 
-  pullstat()
-      : Statistics(Statistics::Id::PullNodes),
+  explicit pullstat(util::filepath sourceFile)
+      : Statistics(Statistics::Id::PullNodes, std::move(sourceFile)),
         ninputs_before_(0),
         ninputs_after_(0)
   {}
@@ -39,16 +38,16 @@ public:
     timer_.stop();
   }
 
-  virtual std::string
-  ToString() const override
+  [[nodiscard]] std::string
+  Serialize() const override
   {
-    return util::strfmt("PULL ", ninputs_before_, " ", ninputs_after_, " ", timer_.ns());
+    return util::strfmt(ninputs_before_, " ", ninputs_after_, " ", timer_.ns());
   }
 
   static std::unique_ptr<pullstat>
-  Create()
+  Create(util::filepath sourceFile)
   {
-    return std::make_unique<pullstat>();
+    return std::make_unique<pullstat>(std::move(sourceFile));
   }
 
 private:
@@ -313,7 +312,7 @@ pull(jlm::rvsdg::region * region)
 static void
 pull(RvsdgModule & rm, util::StatisticsCollector & statisticsCollector)
 {
-  auto statistics = pullstat::Create();
+  auto statistics = pullstat::Create(rm.SourceFileName());
 
   statistics->start(rm.Rvsdg());
   pull(rm.Rvsdg().root());

--- a/jlm/llvm/opt/pull.cpp
+++ b/jlm/llvm/opt/pull.cpp
@@ -18,8 +18,8 @@ class pullstat final : public util::Statistics
 public:
   ~pullstat() override = default;
 
-  explicit pullstat(util::filepath sourceFile)
-      : Statistics(Statistics::Id::PullNodes, std::move(sourceFile)),
+  explicit pullstat(const util::filepath & sourceFile)
+      : Statistics(Statistics::Id::PullNodes, sourceFile),
         ninputs_before_(0),
         ninputs_after_(0)
   {}
@@ -45,9 +45,9 @@ public:
   }
 
   static std::unique_ptr<pullstat>
-  Create(util::filepath sourceFile)
+  Create(const util::filepath & sourceFile)
   {
-    return std::make_unique<pullstat>(std::move(sourceFile));
+    return std::make_unique<pullstat>(sourceFile);
   }
 
 private:

--- a/jlm/llvm/opt/push.cpp
+++ b/jlm/llvm/opt/push.cpp
@@ -20,8 +20,8 @@ class pushstat final : public util::Statistics
 public:
   ~pushstat() override = default;
 
-  explicit pushstat(util::filepath sourceFile)
-      : Statistics(Statistics::Id::PushNodes, std::move(sourceFile)),
+  explicit pushstat(const util::filepath & sourceFile)
+      : Statistics(Statistics::Id::PushNodes, sourceFile),
         ninputs_before_(0),
         ninputs_after_(0)
   {}
@@ -47,9 +47,9 @@ public:
   }
 
   static std::unique_ptr<pushstat>
-  Create(util::filepath sourceFile)
+  Create(const util::filepath & sourceFile)
   {
-    return std::make_unique<pushstat>(std::move(sourceFile));
+    return std::make_unique<pushstat>(sourceFile);
   }
 
 private:

--- a/jlm/llvm/opt/push.cpp
+++ b/jlm/llvm/opt/push.cpp
@@ -18,11 +18,10 @@ namespace jlm::llvm
 class pushstat final : public util::Statistics
 {
 public:
-  virtual ~pushstat()
-  {}
+  ~pushstat() override = default;
 
-  pushstat()
-      : Statistics(Statistics::Id::PushNodes),
+  explicit pushstat(util::filepath sourceFile)
+      : Statistics(Statistics::Id::PushNodes, std::move(sourceFile)),
         ninputs_before_(0),
         ninputs_after_(0)
   {}
@@ -41,16 +40,16 @@ public:
     timer_.stop();
   }
 
-  virtual std::string
-  ToString() const override
+  [[nodiscard]] std::string
+  Serialize() const override
   {
-    return util::strfmt("PUSH ", ninputs_before_, " ", ninputs_after_, " ", timer_.ns());
+    return util::strfmt(ninputs_before_, " ", ninputs_after_, " ", timer_.ns());
   }
 
   static std::unique_ptr<pushstat>
-  Create()
+  Create(util::filepath sourceFile)
   {
-    return std::make_unique<pushstat>();
+    return std::make_unique<pushstat>(std::move(sourceFile));
   }
 
 private:
@@ -435,7 +434,7 @@ push(jlm::rvsdg::region * region)
 static void
 push(RvsdgModule & rm, util::StatisticsCollector & statisticsCollector)
 {
-  auto statistics = pushstat::Create();
+  auto statistics = pushstat::Create(rm.SourceFileName());
 
   statistics->start(rm.Rvsdg());
   push(rm.Rvsdg().root());

--- a/jlm/llvm/opt/reduction.cpp
+++ b/jlm/llvm/opt/reduction.cpp
@@ -18,8 +18,8 @@ class redstat final : public util::Statistics
 public:
   ~redstat() override = default;
 
-  explicit redstat(util::filepath sourceFile)
-      : Statistics(Statistics::Id::ReduceNodes, std::move(sourceFile)),
+  explicit redstat(const util::filepath & sourceFile)
+      : Statistics(Statistics::Id::ReduceNodes, sourceFile),
         nnodes_before_(0),
         nnodes_after_(0),
         ninputs_before_(0),
@@ -58,9 +58,9 @@ public:
   }
 
   static std::unique_ptr<redstat>
-  Create(util::filepath sourceFile)
+  Create(const util::filepath & sourceFile)
   {
-    return std::make_unique<redstat>(std::move(sourceFile));
+    return std::make_unique<redstat>(sourceFile);
   }
 
 private:

--- a/jlm/llvm/opt/reduction.cpp
+++ b/jlm/llvm/opt/reduction.cpp
@@ -16,11 +16,10 @@ namespace jlm::llvm
 class redstat final : public util::Statistics
 {
 public:
-  virtual ~redstat()
-  {}
+  ~redstat() override = default;
 
-  redstat()
-      : Statistics(Statistics::Id::ReduceNodes),
+  explicit redstat(util::filepath sourceFile)
+      : Statistics(Statistics::Id::ReduceNodes, std::move(sourceFile)),
         nnodes_before_(0),
         nnodes_after_(0),
         ninputs_before_(0),
@@ -43,11 +42,10 @@ public:
     timer_.stop();
   }
 
-  virtual std::string
-  ToString() const override
+  [[nodiscard]] std::string
+  Serialize() const override
   {
     return util::strfmt(
-        "RED ",
         nnodes_before_,
         " ",
         nnodes_after_,
@@ -60,9 +58,9 @@ public:
   }
 
   static std::unique_ptr<redstat>
-  Create()
+  Create(util::filepath sourceFile)
   {
-    return std::make_unique<redstat>();
+    return std::make_unique<redstat>(std::move(sourceFile));
   }
 
 private:
@@ -144,7 +142,7 @@ static void
 reduce(RvsdgModule & rm, util::StatisticsCollector & statisticsCollector)
 {
   auto & graph = rm.Rvsdg();
-  auto statistics = redstat::Create();
+  auto statistics = redstat::Create(rm.SourceFileName());
 
   statistics->start(graph);
 

--- a/jlm/llvm/opt/unroll.cpp
+++ b/jlm/llvm/opt/unroll.cpp
@@ -16,11 +16,10 @@ namespace jlm::llvm
 class unrollstat final : public util::Statistics
 {
 public:
-  virtual ~unrollstat()
-  {}
+  ~unrollstat() override = default;
 
-  unrollstat()
-      : Statistics(Statistics::Id::LoopUnrolling),
+  explicit unrollstat(util::filepath sourceFile)
+      : Statistics(Statistics::Id::LoopUnrolling, std::move(sourceFile)),
         nnodes_before_(0),
         nnodes_after_(0)
   {}
@@ -39,16 +38,16 @@ public:
     timer_.stop();
   }
 
-  virtual std::string
-  ToString() const override
+  [[nodiscard]] std::string
+  Serialize() const override
   {
-    return util::strfmt("UNROLL ", nnodes_before_, " ", nnodes_after_, " ", timer_.ns());
+    return util::strfmt(nnodes_before_, " ", nnodes_after_, " ", timer_.ns());
   }
 
   static std::unique_ptr<unrollstat>
-  Create()
+  Create(util::filepath sourceFile)
   {
-    return std::make_unique<unrollstat>();
+    return std::make_unique<unrollstat>(std::move(sourceFile));
   }
 
 private:
@@ -530,7 +529,7 @@ loopunroll::run(RvsdgModule & module, util::StatisticsCollector & statisticsColl
     return;
 
   auto & graph = module.Rvsdg();
-  auto statistics = unrollstat::Create();
+  auto statistics = unrollstat::Create(module.SourceFileName());
 
   statistics->start(module.Rvsdg());
   unroll(graph.root(), factor_);

--- a/jlm/llvm/opt/unroll.cpp
+++ b/jlm/llvm/opt/unroll.cpp
@@ -18,8 +18,8 @@ class unrollstat final : public util::Statistics
 public:
   ~unrollstat() override = default;
 
-  explicit unrollstat(util::filepath sourceFile)
-      : Statistics(Statistics::Id::LoopUnrolling, std::move(sourceFile)),
+  explicit unrollstat(const util::filepath & sourceFile)
+      : Statistics(Statistics::Id::LoopUnrolling, sourceFile),
         nnodes_before_(0),
         nnodes_after_(0)
   {}
@@ -45,9 +45,9 @@ public:
   }
 
   static std::unique_ptr<unrollstat>
-  Create(util::filepath sourceFile)
+  Create(const util::filepath & sourceFile)
   {
-    return std::make_unique<unrollstat>(std::move(sourceFile));
+    return std::make_unique<unrollstat>(sourceFile);
   }
 
 private:

--- a/jlm/util/Statistics.cpp
+++ b/jlm/util/Statistics.cpp
@@ -106,19 +106,13 @@ Statistics::HasMeasurement(const std::string & name) const noexcept
   return false;
 }
 
-Statistics::Measurement &
-Statistics::GetMeasurement(const std::string & name)
-{
-  for (auto & [mName, measurement] : Measurements_)
-    if (mName == name)
-      return measurement;
-  throw util::error(util::strfmt("Unknown measurement: ", name));
-}
-
 const Statistics::Measurement &
 Statistics::GetMeasurement(const std::string & name) const
 {
-  return const_cast<Statistics *>(this)->GetMeasurement(name);
+  for (const auto & [mName, measurement] : Measurements_)
+    if (mName == name)
+      return measurement;
+  JLM_UNREACHABLE("Unknown measurement");
 }
 
 util::iterator_range<Statistics::MeasurementList::const_iterator>
@@ -142,7 +136,7 @@ Statistics::GetTimer(const std::string & name)
   for (auto & [mName, timer] : Timers_)
     if (mName == name)
       return timer;
-  throw util::error(util::strfmt("Unknown timer: ", name));
+  JLM_UNREACHABLE("Unknown timer");
 }
 
 const util::timer &

--- a/jlm/util/Statistics.cpp
+++ b/jlm/util/Statistics.cpp
@@ -1,14 +1,170 @@
 /*
  * Copyright 2020 Nico Reißmann <nico.reissmann@gmail.com>
+ * Copyright 2024 Håvard Krogstie <krogstie.havard@gmail.com>
  * See COPYING for terms of redistribution.
  */
 
 #include <jlm/util/Statistics.hpp>
 
+#include <jlm/util/BijectiveMap.hpp>
+#include <jlm/util/strfmt.hpp>
+
+#include <string_view>
+
 namespace jlm::util
 {
 
+// Mapping between each statistics id and identifier used when serializing the statistic
+static const util::BijectiveMap<Statistics::Id, std::string_view> &
+GetStatisticsIdNames()
+{
+  static util::BijectiveMap<Statistics::Id, std::string_view> mapping = {
+    { Statistics::Id::Aggregation, "Aggregation" },
+    { Statistics::Id::AgnosticMemoryNodeProvisioning, "AgnosticMemoryNodeProvider" },
+    { Statistics::Id::AndersenAnalysis, "AndersenAnalysis" },
+    { Statistics::Id::Annotation, "Annotation" },
+    { Statistics::Id::CommonNodeElimination, "CNE" },
+    { Statistics::Id::ControlFlowRecovery, "ControlFlowRestructuring" },
+    { Statistics::Id::DataNodeToDelta, "DataNodeToDeltaStatistics" },
+    { Statistics::Id::DeadNodeElimination, "DeadNodeElimination" },
+    { Statistics::Id::FunctionInlining, "ILN" },
+    { Statistics::Id::JlmToRvsdgConversion, "ControlFlowGraphToLambda" },
+    { Statistics::Id::LoopUnrolling, "UNROLL" },
+    { Statistics::Id::InvariantValueRedirection, "InvariantValueRedirection" },
+    { Statistics::Id::MemoryStateEncoder, "MemoryStateEncoder" },
+    { Statistics::Id::PullNodes, "PULL" },
+    { Statistics::Id::PushNodes, "PUSH" },
+    { Statistics::Id::ReduceNodes, "RED" },
+    { Statistics::Id::RegionAwareMemoryNodeProvisioning, "RegionAwareMemoryNodeProvision" },
+    { Statistics::Id::RvsdgConstruction, "InterProceduralGraphToRvsdg" },
+    { Statistics::Id::RvsdgDestruction, "RVSDGDESTRUCTION" },
+    { Statistics::Id::RvsdgOptimization, "RVSDGOPTIMIZATION" },
+    { Statistics::Id::SteensgaardAnalysis, "SteensgaardAnalysis" },
+    { Statistics::Id::ThetaGammaInversion, "IVT" }
+  };
+  // Make sure every Statistic is mentioned in the mapping
+  auto lastIdx = static_cast<size_t>(Statistics::Id::LastEnumValue);
+  auto firstIdx = static_cast<size_t>(Statistics::Id::FirstEnumValue);
+  JLM_ASSERT(mapping.Size() == lastIdx - firstIdx - 1);
+  return mapping;
+}
+
 Statistics::~Statistics() = default;
+
+std::string_view
+Statistics::GetName() const
+{
+  return GetStatisticsIdNames().LookupKey(StatisticsId_);
+}
+
+const util::filepath &
+Statistics::GetSourceFile() const
+{
+  return SourceFile_;
+}
+
+std::string
+Statistics::ToString() const
+{
+  return util::strfmt(GetName(), " ", GetSourceFile().to_str(), " ", Serialize());
+}
+
+std::string
+Statistics::Serialize() const
+{
+  std::ostringstream ss;
+  for (const auto & [mName, measurement] : Measurements_)
+  {
+    if (ss.tellp() != 0)
+      ss << " ";
+
+    ss << mName << ":";
+    std::visit(
+        [&](const auto & value)
+        {
+          ss << value;
+        },
+        measurement);
+  }
+  for (const auto & [mName, timer] : Timers_)
+  {
+    if (ss.tellp() != 0)
+      ss << " ";
+
+    ss << mName << "[ns]:" << timer.ns();
+  }
+
+  return ss.str();
+}
+
+bool
+Statistics::HasMeasurement(const std::string & name) const noexcept
+{
+  for (const auto & [mName, _] : Measurements_)
+    if (mName == name)
+      return true;
+  return false;
+}
+
+Statistics::Measurement &
+Statistics::GetMeasurement(const std::string & name)
+{
+  for (auto & [mName, measurement] : Measurements_)
+    if (mName == name)
+      return measurement;
+  throw util::error(util::strfmt("Unknown measurement: ", name));
+}
+
+const Statistics::Measurement &
+Statistics::GetMeasurement(const std::string & name) const
+{
+  return const_cast<Statistics *>(this)->GetMeasurement(name);
+}
+
+util::iterator_range<Statistics::MeasurementList::const_iterator>
+Statistics::GetMeasurements() const
+{
+  return { Measurements_.begin(), Measurements_.end() };
+}
+
+bool
+Statistics::HasTimer(const std::string & name) const noexcept
+{
+  for (const auto & [mName, _] : Timers_)
+    if (mName == name)
+      return true;
+  return false;
+}
+
+util::timer &
+Statistics::GetTimer(const std::string & name)
+{
+  for (auto & [mName, timer] : Timers_)
+    if (mName == name)
+      return timer;
+  throw util::error(util::strfmt("Unknown timer: ", name));
+}
+
+const util::timer &
+Statistics::GetTimer(const std::string & name) const
+{
+  return const_cast<Statistics *>(this)->GetTimer(name);
+}
+
+util::iterator_range<Statistics::TimerList::const_iterator>
+Statistics::GetTimers() const
+{
+  return Timers_;
+}
+
+util::timer &
+Statistics::AddTimer(std::string name)
+{
+  JLM_ASSERT(!HasTimer(name));
+  Timers_.emplace_back(std::make_pair(std::move(name), util::timer()));
+  auto & timer = Timers_.back().second;
+  return timer;
+}
 
 void
 StatisticsCollector::PrintStatistics() const

--- a/jlm/util/Statistics.hpp
+++ b/jlm/util/Statistics.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017 Nico Reißmann <nico.reissmann@gmail.com>
+ * Copyright 2024 Håvard Krogstie <krogstie.havard@gmail.com>
  * See COPYING for terms of redistribution.
  */
 
@@ -8,8 +9,13 @@
 
 #include <jlm/util/file.hpp>
 #include <jlm/util/HashSet.hpp>
+#include <jlm/util/time.hpp>
 
+#include <cstdint>
+#include <list>
 #include <memory>
+#include <string>
+#include <variant>
 
 namespace jlm::util
 {
@@ -26,6 +32,7 @@ public:
 
     Aggregation,
     AgnosticMemoryNodeProvisioning,
+    AndersenAnalysis,
     Annotation,
     CommonNodeElimination,
     ControlFlowRecovery,
@@ -44,16 +51,21 @@ public:
     RvsdgDestruction,
     RvsdgOptimization,
     SteensgaardAnalysis,
-    AndersenAnalysis,
     ThetaGammaInversion,
 
     LastEnumValue // must always be the last enum value, used for iteration
   };
 
+  using Measurement = std::variant<std::string, int64_t, uint64_t, double>;
+  // Lists are used instead of vectors to give stable references to members
+  using MeasurementList = std::list<std::pair<std::string, Measurement>>;
+  using TimerList = std::list<std::pair<std::string, util::timer>>;
+
   virtual ~Statistics();
 
-  explicit Statistics(const Statistics::Id & statisticsId)
-      : StatisticsId_(statisticsId)
+  Statistics(const Statistics::Id & statisticsId, util::filepath sourceFile)
+      : StatisticsId_(statisticsId),
+        SourceFile_(std::move(sourceFile))
   {}
 
   [[nodiscard]] Statistics::Id
@@ -62,11 +74,123 @@ public:
     return StatisticsId_;
   }
 
+  /**
+   * @return a string identifying the type of this Statistics instance
+   */
+  [[nodiscard]] std::string_view
+  GetName() const;
+
+  /**
+   * @return the source file that was worked on while capturing these statistics
+   */
+  [[nodiscard]] const util::filepath &
+  GetSourceFile() const;
+
+  /**
+   * Converts the Statistics instance to a string containing all information it has
+   * @return a full serialized description of the Statistic instance
+   */
   [[nodiscard]] virtual std::string
-  ToString() const = 0;
+  ToString() const;
+
+  /**
+   * Creates a string containing all measurements and timers.
+   * Requires all timers to be stopped.
+   * @return the created string
+   */
+  [[nodiscard]] virtual std::string
+  Serialize() const;
+
+  /**
+   * Checks if a measurement with the given \p name exists.
+   * @return true if the measurement exists, false otherwise.
+   */
+  [[nodiscard]] bool
+  HasMeasurement(const std::string & name) const noexcept;
+
+  /**
+   * Gets the measurement with the given \p name, it must exist.
+   * @return a reference to the measurement.
+   */
+  [[nodiscard]] const Measurement &
+  GetMeasurement(const std::string & name) const;
+
+  /**
+   * Gets the value of the measurement with the given \p name.
+   * Requires the measurement to exist and have the given type \tparam T.
+   * @return the measurement's value.
+   */
+  template<typename T>
+  [[nodiscard]] const T &
+  GetMeasurementValue(const std::string & name) const
+  {
+    const auto & measurement = GetMeasurement(name);
+    return std::get<T>(measurement);
+  }
+
+  /**
+   * Retrieves the full list of measurements
+   */
+  [[nodiscard]] util::iterator_range<MeasurementList::const_iterator>
+  GetMeasurements() const;
+
+  /**
+   * Checks if a timer with the given \p name exists.
+   * @return true if the timer exists, false otherwise.
+   */
+  [[nodiscard]] bool
+  HasTimer(const std::string & name) const noexcept;
+
+  /**
+   * Gets the timer with the given \p name, it must exist.
+   * @return the timer.
+   */
+  [[nodiscard]] const util::timer &
+  GetTimer(const std::string & name) const;
+
+  /**
+   * Retrieves the full list of timers
+   */
+  [[nodiscard]] util::iterator_range<TimerList::const_iterator>
+  GetTimers() const;
+
+protected:
+  /**
+   * Adds a measurement, identified by \p name, with the given value.
+   * Requires that the measurement doesn't already exist.
+   * Measurements are listed in insertion order.
+   * @tparam T the type of the measurement, must be one of: std::string, int64_t, uint16_4, double
+   */
+  template<typename T>
+  void
+  AddMeasurement(std::string name, T value)
+  {
+    JLM_ASSERT(!HasMeasurement(name));
+    Measurements_.emplace_back(std::make_pair(std::move(name), std::move(value)));
+  }
+
+  // Mutable version of @see GetMeasurement
+  [[nodiscard]] Measurement &
+  GetMeasurement(const std::string & name);
+
+  /**
+   * Creates a new timer with the given \p name.
+   * Requires that the timer does not already exist.
+   * @return a reference to the timer
+   */
+  util::timer &
+  AddTimer(std::string name);
+
+  // Mutable version of @see GetTimer
+  [[nodiscard]] util::timer &
+  GetTimer(const std::string & name);
 
 private:
   Statistics::Id StatisticsId_;
+  jlm::util::filepath SourceFile_;
+
+  MeasurementList Measurements_;
+  TimerList Timers_;
 };
 
 /**

--- a/jlm/util/Statistics.hpp
+++ b/jlm/util/Statistics.hpp
@@ -142,11 +142,15 @@ public:
   HasTimer(const std::string & name) const noexcept;
 
   /**
-   * Gets the timer with the given \p name, it must exist.
-   * @return the timer.
+   * Retrieves the measured time passed on the timer with the given \p name.
+   * Requires the timer to exist, and not currently be running.
+   * @return the timer's elapsed time in nanoseconds
    */
-  [[nodiscard]] const util::timer &
-  GetTimer(const std::string & name) const;
+  [[nodiscard]] size_t
+  GetTimerElapsedNanoseconds(const std::string & name) const
+  {
+    return GetTimer(name).ns();
+  }
 
   /**
    * Retrieves the full list of timers
@@ -158,7 +162,6 @@ protected:
   /**
    * Adds a measurement, identified by \p name, with the given value.
    * Requires that the measurement doesn't already exist.
-   * Measurements are listed in insertion order.
    * @tparam T the type of the measurement, must be one of: std::string, int64_t, uint16_4, double
    */
   template<typename T>
@@ -169,10 +172,6 @@ protected:
     Measurements_.emplace_back(std::make_pair(std::move(name), std::move(value)));
   }
 
-  // Mutable version of @see GetMeasurement
-  [[nodiscard]] Measurement &
-  GetMeasurement(const std::string & name);
-
   /**
    * Creates a new timer with the given \p name.
    * Requires that the timer does not already exist.
@@ -181,13 +180,20 @@ protected:
   util::timer &
   AddTimer(std::string name);
 
-  // Mutable version of @see GetTimer
+  /**
+   * Retrieves the timer with the given \p name.
+   * Requires that the timer already exists.
+   * @return a reference to the timer
+   */
   [[nodiscard]] util::timer &
   GetTimer(const std::string & name);
 
+  [[nodiscard]] const util::timer &
+  GetTimer(const std::string & name) const;
+
 private:
   Statistics::Id StatisticsId_;
-  jlm::util::filepath SourceFile_;
+  util::filepath SourceFile_;
 
   MeasurementList Measurements_;
   TimerList Timers_;

--- a/tests/jlm/util/TestStatistics.cpp
+++ b/tests/jlm/util/TestStatistics.cpp
@@ -133,20 +133,24 @@ TestStatisticsPrinting()
   StatisticsCollector collector(std::move(settings));
 
   filepath path("file.ll");
-  std::unique_ptr<MyTestStatistics> testStatistics(
+  std::unique_ptr<MyTestStatistics> statistics(
       new MyTestStatistics(Statistics::Id::Aggregation, path));
+  statistics->Start(10, 6.0);
+  statistics->Stop(-400, "poor");
 
-  collector.CollectDemandedStatistics(std::move(testStatistics));
+  collector.CollectDemandedStatistics(std::move(statistics));
 
   // Act
   collector.PrintStatistics();
 
   // Assert
-  std::stringstream stringStream;
   std::ifstream file(filePath.to_str());
-  stringStream << file.rdbuf();
+  std::string name, fileName, measurement;
+  file >> name >> fileName >> measurement;
 
-  assert(stringStream.str() == "Aggregation file.ll");
+  assert(name == "Aggregation");
+  assert(fileName == path.to_str());
+  assert(measurement == "count:10");
 }
 
 static int


### PR DESCRIPTION
The Statistics part of #382. Modifies all existing Statistics to provide the sourceFile path.

The mapping from id to name is now in `Statistics.cpp`, but many of the existing statistics used names that were different from the C++ enums, so I tried to make the classes keep their old names.

It might be better to have `GetName()` be an abstract method, and let subclasses provide names that way, instead of a single BijectiveMap. Let me know!