### PR TITLE
Fail the build on unit test failure

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -127,7 +127,9 @@ $(RUNTESTS): run-% : %
 	if $^ >$^.log 2>&1 ; then \
 		echo "success" ; \
 	else \
+		EXIT_CODE="$$?" ; \
 		echo "failed. See $^.log:" ; cat $^.log ; \
+		exit "$$EXIT_CODE" ; \
 	fi
 
 $(VALGRINDTESTS): valgrind-% : %

--- a/tests/Makefile.sub
+++ b/tests/Makefile.sub
@@ -59,7 +59,9 @@ $(patsubst %, run-%, $(JLC_COMPILE_TESTS)): run-%: $(BUILD_OUT_PREFIX)%.jlm
 	if $^ >$^.log 2>&1 ; then \
 		echo "success" ; \
 	else \
+		EXIT_CODE="$$?" ; \
 		echo "failed. See $^.log:" ; cat $^.log ; \
+		exit "$$EXIT_CODE" ; \
 	fi
 
 # Run the jlc-compiled binaries as part of tests. This may


### PR DESCRIPTION
With this change, a unit test failure is no longer "silent" but fails the entire build. It is user's choice if they want to abort on first failure (default invocation of make), or run all tests and have all failing ones reports (invoke as "make -k").

Closes #388 