### PR TITLE
Fix non-quoted html attributes in dot output

### DIFF
--- a/jlm/util/GraphWriter.cpp
+++ b/jlm/util/GraphWriter.cpp
@@ -259,20 +259,18 @@ GraphElement::OutputAttributes(std::ostream & out, AttributeOutputFormat format)
       JLM_UNREACHABLE("Unknown AttributeOutputFormat");
 
     out << "=";
+    if (format == AttributeOutputFormat::HTMLAttributes)
+      out << '"'; // HTML attributes must be quoted
+
     if (auto string = std::get_if<std::string>(&value))
     {
       if (format == AttributeOutputFormat::SpaceSeparatedList)
         PrintIdentifierSafe(out, *string);
       else
-      {
-        out << '"';
         PrintStringAsHtmlText(out, *string);
-        out << '"';
-      }
     }
     else if (auto graphElement = std::get_if<const GraphElement *>(&value))
     {
-      // HTML allows unquoted attribute values when they are single words with no special characters
       out << (*graphElement)->GetFullId();
     }
     else if (auto ptr = std::get_if<uintptr_t>(&value))
@@ -291,6 +289,8 @@ GraphElement::OutputAttributes(std::ostream & out, AttributeOutputFormat format)
         out << "ptr" << ptr;
       }
     }
+    if (format == AttributeOutputFormat::HTMLAttributes)
+      out << '"'; // Closing quote
     out << " ";
   }
 }

--- a/tests/jlm/util/TestGraphWriter.cpp
+++ b/tests/jlm/util/TestGraphWriter.cpp
@@ -62,7 +62,7 @@ TestGraphElement()
   graph.OutputAttributes(out, AttributeOutputFormat::HTMLAttributes);
   attributes = out.str();
   assert(StringContains(attributes, "color=\"&quot;brown&quot;\""));
-  assert(StringContains(attributes, "another-graph=graph0"));
+  assert(StringContains(attributes, "another-graph=\"graph0\""));
 }
 
 static void


### PR DESCRIPTION
Apologies, but I realized I had mis-read the dot language spec. Unlike in HTML/XML, all attribute values must always be quoted. This PR fixes this. It is part of #308 