### PR TITLE
Update InstallPackages composite action

### DIFF
--- a/.github/actions/InstallPackages/action.yml
+++ b/.github/actions/InstallPackages/action.yml
@@ -36,8 +36,12 @@ runs:
         || inputs.install-mlir == 'true'
         || inputs.install-clang-format == 'true'}}
       run: |
-        wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-        sudo add-apt-repository deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main
+        HAS_LLVM_REPOSITORY=`find /etc/apt/ -name *.list | xargs cat | grep llvm-toolchain-jammy-16`
+        echo $HAS_LLVM_REPOSITORY
+        if [[ -z $HAS_LLVM_REPOSITORY ]]; then
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          sudo add-apt-repository deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main
+        fi
       shell: bash
 
     - name: "Install LLVM package"

--- a/.github/actions/InstallPackages/action.yml
+++ b/.github/actions/InstallPackages/action.yml
@@ -36,7 +36,7 @@ runs:
         || inputs.install-mlir == 'true'
         || inputs.install-clang-format == 'true'}}
       run: |
-        HAS_LLVM_REPOSITORY=`find /etc/apt/ -name *.list | xargs cat | grep llvm-toolchain-jammy-16`
+        HAS_LLVM_REPOSITORY=$(find /etc/apt/ -name *.list | xargs cat | grep llvm-toolchain-jammy-16)
         echo $HAS_LLVM_REPOSITORY
         if [[ -z $HAS_LLVM_REPOSITORY ]]; then
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc

--- a/.github/actions/InstallPackages/action.yml
+++ b/.github/actions/InstallPackages/action.yml
@@ -38,7 +38,7 @@ runs:
       run: |
         export HAS_LLVM_REPOSITORY=$(find /etc/apt/ -name *.list | xargs cat | grep llvm-toolchain-jammy-16)
         echo $HAS_LLVM_REPOSITORY
-        if [[ -z HAS_LLVM_REPOSITORY ]]; then
+        if [[ -z $HAS_LLVM_REPOSITORY ]]; then
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
           sudo add-apt-repository deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main
         fi

--- a/.github/actions/InstallPackages/action.yml
+++ b/.github/actions/InstallPackages/action.yml
@@ -38,10 +38,8 @@ runs:
       run: |
         HAS_LLVM_REPOSITORY=$(find /etc/apt/ -name *.list | xargs cat | grep llvm-toolchain-jammy-16)
         echo $HAS_LLVM_REPOSITORY
-        if [[ -z $HAS_LLVM_REPOSITORY ]]; then
-          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-          sudo add-apt-repository deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main
-        fi
+        wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+        sudo add-apt-repository deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main
       shell: bash
 
     - name: "Install LLVM package"

--- a/.github/actions/InstallPackages/action.yml
+++ b/.github/actions/InstallPackages/action.yml
@@ -37,7 +37,6 @@ runs:
         || inputs.install-clang-format == 'true'}}
       run: |
         export HAS_LLVM_REPOSITORY=$(find /etc/apt/ -name *.list | xargs cat | grep llvm-toolchain-jammy-16)
-        echo $HAS_LLVM_REPOSITORY
         if [[ -z $HAS_LLVM_REPOSITORY ]]; then
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
           sudo add-apt-repository deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main

--- a/.github/actions/InstallPackages/action.yml
+++ b/.github/actions/InstallPackages/action.yml
@@ -43,19 +43,19 @@ runs:
     - name: "Install LLVM package"
       if: ${{inputs.install-llvm == 'true'}}
       run: |
-        sudo apt-get update && sudo apt-get install llvm-16-dev
+        sudo apt-get install llvm-16-dev
         sudo python3 /usr/lib/llvm-16/build/utils/lit/setup.py install
       shell: bash
 
     - name: "Install clang package"
       if: ${{inputs.install-clang == 'true'}}
-      run: sudo apt-get update && sudo apt-get install clang-16
+      run: sudo apt-get install clang-16
       shell: bash
 
     - name: "Install MLIR packages"
       if: ${{inputs.install-mlir == 'true'}}
       run: |
-        sudo apt-get update && sudo apt-get install libmlir-16-dev mlir-16-tools
+        sudo apt-get install libmlir-16-dev mlir-16-tools
         if ! [ -f /usr/lib/x86_64-linux-gnu/libMLIR.so ]; then
           sudo ln -s /usr/lib/llvm-16/lib/libMLIR.so.16 /usr/lib/x86_64-linux-gnu/
           sudo ln -s /usr/lib/llvm-16/lib/libMLIR.so.16 /usr/lib/x86_64-linux-gnu/libMLIR.so
@@ -64,10 +64,10 @@ runs:
 
     - name: "Install clang-format package"
       if: ${{inputs.install-clang-format == 'true'}}
-      run: sudo apt-get update && sudo apt-get install clang-format-16
+      run: sudo apt-get install clang-format-16
       shell: bash
 
     - name: "Install ninja package"
       if: ${{inputs.install-ninja == 'true'}}
-      run: sudo apt-get update && sudo apt-get install ninja-build
+      run: sudo apt-get install ninja-build
       shell: bash

--- a/.github/actions/InstallPackages/action.yml
+++ b/.github/actions/InstallPackages/action.yml
@@ -27,6 +27,16 @@ inputs:
     default: "false"
     required: false
 
+  install-doxygen:
+    description: "Install doxygen package. Default is 'false'."
+    default: "false"
+    required: false
+
+  install-verilator:
+    description: "Install varilator package. Default is 'false'."
+    default: "false"
+    required: false
+
 runs:
   using: "composite"
   steps:
@@ -73,4 +83,14 @@ runs:
     - name: "Install ninja package"
       if: ${{inputs.install-ninja == 'true'}}
       run: sudo apt-get install ninja-build
+      shell: bash
+
+    - name: "Install doxygen package"
+      if: ${{inputs.install-doxygen == 'true'}}
+      run: sudo apt-get graphviz doxygen
+      shell: bash
+
+    - name: "Install verilator package"
+      if: ${{inputs.install-verilator == 'true'}}
+      run: sudo apt-get verilator
       shell: bash

--- a/.github/actions/InstallPackages/action.yml
+++ b/.github/actions/InstallPackages/action.yml
@@ -36,7 +36,7 @@ runs:
         || inputs.install-mlir == 'true'
         || inputs.install-clang-format == 'true'}}
       run: |
-        HAS_LLVM_REPOSITORY=$(find /etc/apt/ -name *.list | xargs cat | grep llvm-toolchain-jammy-16)
+        export HAS_LLVM_REPOSITORY=$(find /etc/apt/ -name *.list | xargs cat | grep llvm-toolchain-jammy-16)
         echo $HAS_LLVM_REPOSITORY
         wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
         sudo add-apt-repository deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main

--- a/.github/actions/InstallPackages/action.yml
+++ b/.github/actions/InstallPackages/action.yml
@@ -38,8 +38,10 @@ runs:
       run: |
         export HAS_LLVM_REPOSITORY=$(find /etc/apt/ -name *.list | xargs cat | grep llvm-toolchain-jammy-16)
         echo $HAS_LLVM_REPOSITORY
-        wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-        sudo add-apt-repository deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main
+        if [[ -z HAS_LLVM_REPOSITORY ]]; then
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          sudo add-apt-repository deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main
+        fi
       shell: bash
 
     - name: "Install LLVM package"

--- a/.github/actions/InstallPackages/action.yml
+++ b/.github/actions/InstallPackages/action.yml
@@ -44,7 +44,7 @@ runs:
       if: ${{inputs.install-llvm == 'true'}}
       run: |
         sudo apt-get install llvm-16-dev
-        sudo pip install lit
+        pip install lit
       shell: bash
 
     - name: "Install clang package"

--- a/.github/actions/InstallPackages/action.yml
+++ b/.github/actions/InstallPackages/action.yml
@@ -44,7 +44,7 @@ runs:
       if: ${{inputs.install-llvm == 'true'}}
       run: |
         sudo apt-get install llvm-16-dev
-        sudo python3 /usr/lib/llvm-16/build/utils/lit/setup.py install
+        sudo pip install lit
       shell: bash
 
     - name: "Install clang package"

--- a/.github/actions/InstallPackages/action.yml
+++ b/.github/actions/InstallPackages/action.yml
@@ -87,10 +87,10 @@ runs:
 
     - name: "Install doxygen package"
       if: ${{inputs.install-doxygen == 'true'}}
-      run: sudo apt-get graphviz doxygen
+      run: sudo apt-get install graphviz doxygen
       shell: bash
 
     - name: "Install verilator package"
       if: ${{inputs.install-verilator == 'true'}}
-      run: sudo apt-get verilator
+      run: sudo apt-get install verilator
       shell: bash

--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -9,8 +9,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: Install doxygen and graphviz
-        run: sudo apt-get install graphviz doxygen
+      - name: "Install doxygen"
+        uses: ./.github/actions/InstallPackages
+        with:
+          install-doxygen: true
       - name: "Build documentation"
         uses: ./.github/actions/BuildJlm
         with:

--- a/.github/workflows/hls.yml
+++ b/.github/workflows/hls.yml
@@ -23,6 +23,9 @@ jobs:
     # --------
 
     - name: "Install verilator"
+      uses: ./.github/actions/InstallPackages
+      with:
+        install-verilator: true
       run: sudo apt-get install verilator
     - name: "Clone jlm-test-suite"
       run: git clone https://github.com/phate/jlm-eval-suite.git


### PR DESCRIPTION
The PR does the following:

1. Removes `sudo apt-get update`. It was unnecessary
2. Uses pip install lit instead of setup.py. Using setup.py is deprecated.
3. Only adds the llvm repository when it is not already present (multiple invocations of the script can lead to it)
4. Adds the possibility for installing doxygen and verilator to the script.