### PR TITLE
Correctly detect exported lambda nodes in Steensgaard

### DIFF
--- a/jlm/llvm/ir/operators/lambda.cpp
+++ b/jlm/llvm/ir/operators/lambda.cpp
@@ -350,6 +350,13 @@ node::ComputeCallSummary() const
   return CallSummary::Create(rvsdgExport, std::move(directCalls), std::move(otherUsers));
 }
 
+bool
+node::IsExported(const lambda::node & lambdaNode)
+{
+  auto callSummary = lambdaNode.ComputeCallSummary();
+  return callSummary->IsExported();
+}
+
 /* lambda context variable input class */
 
 cvinput::~cvinput() = default;

--- a/jlm/llvm/ir/operators/lambda.hpp
+++ b/jlm/llvm/ir/operators/lambda.hpp
@@ -879,16 +879,4 @@ lambda::node::RemoveLambdaInputsWhere(const F & match)
 }
 }
 
-static inline bool
-is_exported(const jlm::llvm::lambda::node & lambda)
-{
-  for (auto & user : *lambda.output())
-  {
-    if (dynamic_cast<const jlm::rvsdg::expport *>(&user->port()))
-      return true;
-  }
-
-  return false;
-}
-
 #endif

--- a/jlm/llvm/ir/operators/lambda.hpp
+++ b/jlm/llvm/ir/operators/lambda.hpp
@@ -373,6 +373,17 @@ public:
    */
   [[nodiscard]] std::unique_ptr<CallSummary>
   ComputeCallSummary() const;
+
+  /**
+   * Determines whether \p lambdaNode is exported from the module.
+   *
+   * @param lambdaNode The lambda node to be checked.
+   * @return True if \p lambdaNode is exported, otherwise false.
+   *
+   * \Note This method is equivalent to invoking CallSummary::IsExported().
+   */
+  [[nodiscard]] static bool
+  IsExported(const lambda::node & lambdaNode);
 };
 
 /** \brief Lambda context variable input

--- a/jlm/llvm/ir/operators/lambda.hpp
+++ b/jlm/llvm/ir/operators/lambda.hpp
@@ -380,7 +380,7 @@ public:
    * @param lambdaNode The lambda node to be checked.
    * @return True if \p lambdaNode is exported, otherwise false.
    *
-   * \Note This method is equivalent to invoking CallSummary::IsExported().
+   * \note This method is equivalent to invoking CallSummary::IsExported().
    */
   [[nodiscard]] static bool
   IsExported(const lambda::node & lambdaNode);

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -1456,7 +1456,7 @@ Steensgaard::AnalyzeLambda(const lambda::node & lambda)
   AnalyzeRegion(*lambda.subregion());
 
   // Handle function results
-  if (is_exported(lambda))
+  if (lambda::node::IsExported(lambda))
   {
     for (auto & result : lambda.fctresults())
     {


### PR DESCRIPTION
This PR does the following:

1. Introduces the IsExported() method to lambda nodes.
2. Utilizes this method in the Steensgaard analysis
3. Removes the old and incorrect is_exported() method.

The old method was not handling phi nodes correctly.