### PR TITLE
Add IsSupergraphOf to PointsToGraph

### DIFF
--- a/jlm/llvm/opt/alias-analyses/PointsToGraph.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraph.cpp
@@ -161,6 +161,135 @@ PointsToGraph::AddImportNode(std::unique_ptr<PointsToGraph::ImportNode> node)
   return *tmp;
 }
 
+bool
+PointsToGraph::IsSupergraphOf(const jlm::llvm::aa::PointsToGraph & subgraph) const
+{
+  // Given a memory node representing a memory object in an RVSDG module, this function finds
+  // a memory node representing the same memory object in a different PointsToGraph.
+  // If no corresponding memory node exists in the graph, nullptr is returned
+  const auto GetCorrespondingMemoryNode =
+      [](const PointsToGraph::MemoryNode & node,
+         const PointsToGraph & graph) -> const PointsToGraph::MemoryNode *
+  {
+    if (auto allocaNode = dynamic_cast<const AllocaNode *>(&node))
+    {
+      if (auto it = graph.AllocaNodes_.find(&allocaNode->GetAllocaNode());
+          it != graph.AllocaNodes_.end())
+        return it->second.get();
+    }
+    else if (auto deltaNode = dynamic_cast<const DeltaNode *>(&node))
+    {
+      if (auto it = graph.DeltaNodes_.find(&deltaNode->GetDeltaNode());
+          it != graph.DeltaNodes_.end())
+        return it->second.get();
+    }
+    else if (auto importNode = dynamic_cast<const ImportNode *>(&node))
+    {
+      if (auto it = graph.ImportNodes_.find(&importNode->GetArgument());
+          it != graph.ImportNodes_.end())
+        return it->second.get();
+    }
+    else if (auto lambdaNode = dynamic_cast<const LambdaNode *>(&node))
+    {
+      if (auto it = graph.LambdaNodes_.find(&lambdaNode->GetLambdaNode());
+          it != graph.LambdaNodes_.end())
+        return it->second.get();
+    }
+    else if (auto mallocNode = dynamic_cast<const MallocNode *>(&node))
+    {
+      if (auto it = graph.MallocNodes_.find(&mallocNode->GetMallocNode());
+          it != graph.MallocNodes_.end())
+        return it->second.get();
+    }
+    else if (MemoryNode::Is<UnknownMemoryNode>(node))
+    {
+      return &graph.GetUnknownMemoryNode();
+    }
+    else if (MemoryNode::Is<ExternalMemoryNode>(node))
+    {
+      return &graph.GetExternalMemoryNode();
+    }
+    else
+      JLM_UNREACHABLE("Unknown type of MemoryNode");
+
+    return nullptr;
+  };
+
+  // Given two nodes, checks if the first node points to everything the second points to.
+  // The nodes can belong to different PointsToGraphs.
+  const auto HasSupersetOfPointees = [&GetCorrespondingMemoryNode](
+                                         const PointsToGraph::Node & superset,
+                                         const PointsToGraph::Node & subset)
+  {
+    for (const auto & subsetTarget : subset.Targets())
+    {
+      auto correspondingTarget = GetCorrespondingMemoryNode(subsetTarget, superset.Graph());
+
+      // Check if the superset is pointing to the target
+      if (correspondingTarget == nullptr || !superset.HasTarget(*correspondingTarget))
+        return false;
+    }
+    return true;
+  };
+
+  // Given a memory node from the subgraph, check that a corresponding node exists in this graph.
+  // All edges the other node has, must have corresponding edges in this graph.
+  // If the other node is marked as escaping, the corresponding node must be as well.
+  const auto HasSuperOfMemoryNode = [&](const PointsToGraph::MemoryNode & subNode)
+  {
+    const auto thisNode = GetCorrespondingMemoryNode(subNode, *this);
+    if (thisNode == nullptr)
+      return false;
+
+    if (subNode.IsModuleEscaping() && !thisNode->IsModuleEscaping())
+      return false;
+
+    return HasSupersetOfPointees(*thisNode, subNode);
+  };
+
+  // Iterate through all memory nodes in the subgraph, and make sure we have corresponding nodes
+  for (const auto & node : subgraph.AllocaNodes())
+  {
+    if (!HasSuperOfMemoryNode(node))
+      return false;
+  }
+  for (const auto & node : subgraph.DeltaNodes())
+  {
+    if (!HasSuperOfMemoryNode(node))
+      return false;
+  }
+  for (const auto & node : subgraph.ImportNodes())
+  {
+    if (!HasSuperOfMemoryNode(node))
+      return false;
+  }
+  for (const auto & node : subgraph.LambdaNodes())
+  {
+    if (!HasSuperOfMemoryNode(node))
+      return false;
+  }
+  for (const auto & node : subgraph.MallocNodes())
+  {
+    if (!HasSuperOfMemoryNode(node))
+      return false;
+  }
+
+  // For each register mapped to a RegisterNode in the subgraph, this graph must also have mapped
+  // the same register to be a supergraph. The RegisterNode must point to a superset of what
+  // the subgraph's RegisterNode points to.
+  for (const auto [rvsdgOutput, subNode] : subgraph.RegisterNodeMap_)
+  {
+    auto correspondingRegisterNode = RegisterNodeMap_.find(rvsdgOutput);
+    if (correspondingRegisterNode == RegisterNodeMap_.end())
+      return false;
+
+    if (!HasSupersetOfPointees(*correspondingRegisterNode->second, *subNode))
+      return false;
+  }
+
+  return true;
+}
+
 std::string
 PointsToGraph::ToDot(
     const PointsToGraph & pointsToGraph,
@@ -293,6 +422,12 @@ PointsToGraph::Node::Targets() const
   return { TargetConstIterator(Targets_.begin()), TargetConstIterator(Targets_.end()) };
 }
 
+bool
+PointsToGraph::Node::HasTarget(const PointsToGraph::MemoryNode & target) const
+{
+  return Targets_.find(const_cast<MemoryNode *>(&target)) != Targets_.end();
+}
+
 PointsToGraph::Node::SourceRange
 PointsToGraph::Node::Sources()
 {
@@ -303,6 +438,12 @@ PointsToGraph::Node::SourceConstRange
 PointsToGraph::Node::Sources() const
 {
   return { SourceConstIterator(Sources_.begin()), SourceConstIterator(Sources_.end()) };
+}
+
+bool
+PointsToGraph::Node::HasSource(const PointsToGraph::Node & source) const
+{
+  return Sources_.find(const_cast<Node *>(&source)) != Sources_.end();
 }
 
 void

--- a/jlm/llvm/opt/alias-analyses/PointsToGraph.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraph.hpp
@@ -351,6 +351,17 @@ public:
   AddImportNode(std::unique_ptr<PointsToGraph::ImportNode> node);
 
   /**
+   * Checks if this PointsToGraph is a supergraph of the given PointsToGraph.
+   * Every node and every edge in the subgraph needs to have corresponding nodes and edges
+   * present in this graph, defined by nodes representing the same registers and memory objects.
+   * All nodes marked as escaping in the subgraph must also be marked as escaping in this graph.
+   * @param subgraph the graph to compare against
+   * @return true if this graph is a supergraph of the given subgraph, false otherwise
+   */
+  [[nodiscard]] bool
+  IsSupergraphOf(const PointsToGraph & subgraph) const;
+
+  /**
    * Creates a GraphViz description of the given \p pointsToGraph,
    * including the names given to rvsdg::outputs by the \p outputMap,
    * for all RegisterNodes that correspond to names rvsdg::outputs.
@@ -448,11 +459,17 @@ public:
   TargetConstRange
   Targets() const;
 
+  [[nodiscard]] bool
+  HasTarget(const PointsToGraph::MemoryNode & target) const;
+
   SourceRange
   Sources();
 
   SourceConstRange
   Sources() const;
+
+  [[nodiscard]] bool
+  HasSource(const PointsToGraph::Node & source) const;
 
   PointsToGraph &
   Graph() const noexcept
@@ -553,6 +570,15 @@ public:
   MarkAsModuleEscaping()
   {
     Graph().AddEscapedMemoryNode(*this);
+  }
+
+  /**
+   * @return true if this memory node is marked as escaping the module.
+   */
+  bool
+  IsModuleEscaping() const
+  {
+    return Graph().GetEscapedMemoryNodes().Contains(this);
   }
 
 protected:

--- a/jlm/llvm/opt/alias-analyses/PointsToGraph.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraph.hpp
@@ -351,7 +351,7 @@ public:
   AddImportNode(std::unique_ptr<PointsToGraph::ImportNode> node);
 
   /**
-   * Checks if this PointsToGraph is a supergraph of the given PointsToGraph.
+   * Checks if this PointsToGraph is a supergraph of \p subgraph.
    * Every node and every edge in the subgraph needs to have corresponding nodes and edges
    * present in this graph, defined by nodes representing the same registers and memory objects.
    * All nodes marked as escaping in the subgraph must also be marked as escaping in this graph.

--- a/tests/jlm/llvm/opt/alias-analyses/TestPointsToGraph.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestPointsToGraph.cpp
@@ -210,11 +210,122 @@ TestRegisterNodeIteration()
   assert(numIteratedRegisterNodes == pointsToGraph->NumRegisterNodes());
 }
 
+static void
+TestIsSupergraphOf()
+{
+  using namespace jlm::llvm::aa;
+  auto graph0 = PointsToGraph::Create();
+  auto graph1 = PointsToGraph::Create();
+
+  // Empty graphs are identical, and are both subgraphs of each other
+  assert(graph0->IsSupergraphOf(*graph1));
+  assert(graph1->IsSupergraphOf(*graph0));
+
+  jlm::tests::AllMemoryNodesTest rvsdg;
+  rvsdg.InitializeTest();
+
+  // Adding an alloca node to only graph0, makes graph1 NOT a subgraph
+  auto & alloca0 = PointsToGraph::AllocaNode::Create(*graph0, rvsdg.GetAllocaNode());
+  assert(graph0->IsSupergraphOf(*graph1));
+  assert(!graph1->IsSupergraphOf(*graph0));
+
+  // Adding a corresponding alloca node to graph1, they are now equal
+  auto & alloca1 = PointsToGraph::AllocaNode::Create(*graph1, rvsdg.GetAllocaNode());
+  assert(graph0->IsSupergraphOf(*graph1));
+  assert(graph1->IsSupergraphOf(*graph0));
+
+  // Marking alloca0 as escaping, makes graph1 NOT a subgraph
+  alloca0.MarkAsModuleEscaping();
+  assert(graph0->IsSupergraphOf(*graph1));
+  assert(!graph1->IsSupergraphOf(*graph0));
+
+  // Now both alloca0 and alloca1 is marked as escaping
+  alloca1.MarkAsModuleEscaping();
+  assert(graph0->IsSupergraphOf(*graph1));
+  assert(graph1->IsSupergraphOf(*graph0));
+
+  // Adding register0 makes graph1 NOT a subgraph
+  auto & register0 = PointsToGraph::RegisterNode::Create(*graph0, { &rvsdg.GetAllocaOutput() });
+  assert(graph0->IsSupergraphOf(*graph1));
+  assert(!graph1->IsSupergraphOf(*graph0));
+
+  // Adding register1 that covers both the alloca and delta outputs makes graph0 NOT a subgraph
+  auto & register1 = PointsToGraph::RegisterNode::Create(
+      *graph1,
+      { &rvsdg.GetAllocaOutput(), &rvsdg.GetDeltaOutput() });
+  assert(!graph0->IsSupergraphOf(*graph1));
+  assert(graph1->IsSupergraphOf(*graph0));
+
+  // Adding a deltaRegister0 to make the graphs identical again
+  auto & deltaRegister0 = PointsToGraph::RegisterNode::Create(*graph0, { &rvsdg.GetDeltaOutput() });
+  assert(graph0->IsSupergraphOf(*graph1));
+  assert(graph1->IsSupergraphOf(*graph0));
+
+  // Adding an edge from register0 to the alloca makes graph1 NOT a subgraph
+  register0.AddEdge(alloca0);
+  assert(graph0->IsSupergraphOf(*graph1));
+  assert(!graph1->IsSupergraphOf(*graph0));
+
+  // By adding an edge from register1 (delta+alloca output), graph0 is now a subgraph of graph1
+  register1.AddEdge(alloca1);
+  assert(!graph0->IsSupergraphOf(*graph1));
+  assert(graph1->IsSupergraphOf(*graph0));
+
+  // To make them identical, the both the delta and alloca registers must point to the alloca
+  deltaRegister0.AddEdge(alloca0);
+  assert(graph0->IsSupergraphOf(*graph1));
+  assert(graph1->IsSupergraphOf(*graph0));
+
+  // Adding an edge from alloca0 to external that is NOT in graph1
+  alloca0.AddEdge(graph0->GetExternalMemoryNode());
+  assert(graph0->IsSupergraphOf(*graph1));
+  assert(!graph1->IsSupergraphOf(*graph0));
+
+  // Adding the same edge to alloca1 makes the graphs identical again
+  alloca1.AddEdge(graph1->GetExternalMemoryNode());
+  assert(graph0->IsSupergraphOf(*graph1));
+  assert(graph1->IsSupergraphOf(*graph0));
+
+  // Finally test all the other memory node types
+  auto & delta0 = PointsToGraph::DeltaNode::Create(*graph0, rvsdg.GetDeltaNode());
+  auto & delta1 = PointsToGraph::DeltaNode::Create(*graph1, rvsdg.GetDeltaNode());
+  auto & import0 = PointsToGraph::ImportNode::Create(*graph0, rvsdg.GetImportOutput());
+  auto & import1 = PointsToGraph::ImportNode::Create(*graph1, rvsdg.GetImportOutput());
+  auto & lambda0 = PointsToGraph::LambdaNode::Create(*graph0, rvsdg.GetLambdaNode());
+  auto & lambda1 = PointsToGraph::LambdaNode::Create(*graph1, rvsdg.GetLambdaNode());
+  auto & malloc0 = PointsToGraph::MallocNode::Create(*graph0, rvsdg.GetMallocNode());
+  auto & malloc1 = PointsToGraph::MallocNode::Create(*graph1, rvsdg.GetMallocNode());
+  assert(graph0->IsSupergraphOf(*graph1));
+  assert(graph1->IsSupergraphOf(*graph0));
+
+  // Add edges to unknown in one graph at a time
+  delta0.AddEdge(graph0->GetUnknownMemoryNode());
+  assert(graph0->IsSupergraphOf(*graph1));
+  assert(!graph1->IsSupergraphOf(*graph0));
+  delta1.AddEdge(graph1->GetUnknownMemoryNode());
+  assert(graph1->IsSupergraphOf(*graph0));
+
+  // Add some arbitrary edges between memory nodes
+  malloc0.AddEdge(import0);
+  assert(graph0->IsSupergraphOf(*graph1));
+  assert(!graph1->IsSupergraphOf(*graph0));
+
+  import1.AddEdge(lambda1);
+  assert(!graph0->IsSupergraphOf(*graph1));
+
+  // Make them equal again by adding the same edges to the opposite graph
+  malloc1.AddEdge(import1);
+  import0.AddEdge(lambda0);
+  assert(graph0->IsSupergraphOf(*graph1));
+  assert(graph1->IsSupergraphOf(*graph0));
+}
+
 static int
 TestPointsToGraph()
 {
   TestNodeIterators();
   TestRegisterNodeIteration();
+  TestIsSupergraphOf();
 
   return 0;
 }


### PR DESCRIPTION
This is used as part of double checking PointsToGraphs created by the naive constraint solver and more sophisticated solvers. If you think some of the lambdas should be available as separate public methods (or private methods) let me know.