### PR TITLE
[Andersen] change the PointerObjectSet interface to enable unification

### DIFF
--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
@@ -141,7 +141,12 @@ PointerObjectIndex
 PointerObjectSet::CreateImportMemoryObject(const rvsdg::argument & importNode)
 {
   JLM_ASSERT(ImportMap_.count(&importNode) == 0);
-  return ImportMap_[&importNode] = AddPointerObject(PointerObjectKind::ImportMemoryObject);
+  auto importMemoryObject = AddPointerObject(PointerObjectKind::ImportMemoryObject);
+  ImportMap_[&importNode] = importMemoryObject;
+
+  // Memory objects defined in other modules are definitely not private to this module
+  MarkAsEscaped(importMemoryObject);
+  return importMemoryObject;
 }
 
 const std::unordered_map<const rvsdg::output *, PointerObjectIndex> &

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
@@ -14,12 +14,26 @@
 namespace jlm::llvm::aa
 {
 
-PointerObject::Index
+/**
+ * Flag that enables unification logic.
+ * When enabled, each points-to set lookup needs to perform a find operation.
+ * When disabled, attempting to call UnifyPointerObjects panics.
+ */
+static constexpr bool ENABLE_UNIFICATION = true;
+
+PointerObjectIndex
 PointerObjectSet::AddPointerObject(PointerObjectKind kind)
 {
-  JLM_ASSERT(PointerObjects_.size() < std::numeric_limits<PointerObject::Index>::max());
+  JLM_ASSERT(PointerObjects_.size() < std::numeric_limits<PointerObjectIndex>::max());
+  PointerObjectIndex index = PointerObjects_.size();
+
   PointerObjects_.emplace_back(kind);
-  PointsToSets_.emplace_back(); // Add empty points-to-set
+  if constexpr (ENABLE_UNIFICATION)
+  {
+    PointerObjectParents_.push_back(index);
+    PointerObjectRank_.push_back(0);
+  }
+  PointsToSets_.emplace_back(); // Add empty points-to set
   return PointerObjects_.size() - 1;
 }
 
@@ -35,33 +49,19 @@ PointerObjectSet::NumPointerObjectsOfKind(PointerObjectKind kind) const noexcept
   size_t count = 0;
   for (auto & pointerObject : PointerObjects_)
   {
-    count += pointerObject.GetKind() == kind;
+    count += pointerObject.Kind == kind;
   }
   return count;
 }
 
-PointerObject &
-PointerObjectSet::GetPointerObject(PointerObject::Index index)
-{
-  JLM_ASSERT(index < NumPointerObjects());
-  return PointerObjects_[index];
-}
-
-const PointerObject &
-PointerObjectSet::GetPointerObject(PointerObject::Index index) const
-{
-  JLM_ASSERT(index < NumPointerObjects());
-  return PointerObjects_[index];
-}
-
-PointerObject::Index
+PointerObjectIndex
 PointerObjectSet::CreateRegisterPointerObject(const rvsdg::output & rvsdgOutput)
 {
   JLM_ASSERT(RegisterMap_.count(&rvsdgOutput) == 0);
   return RegisterMap_[&rvsdgOutput] = AddPointerObject(PointerObjectKind::Register);
 }
 
-PointerObject::Index
+PointerObjectIndex
 PointerObjectSet::GetRegisterPointerObject(const rvsdg::output & rvsdgOutput) const
 {
   const auto it = RegisterMap_.find(&rvsdgOutput);
@@ -69,7 +69,7 @@ PointerObjectSet::GetRegisterPointerObject(const rvsdg::output & rvsdgOutput) co
   return it->second;
 }
 
-std::optional<PointerObject::Index>
+std::optional<PointerObjectIndex>
 PointerObjectSet::TryGetRegisterPointerObject(const rvsdg::output & rvsdgOutput) const
 {
   if (const auto it = RegisterMap_.find(&rvsdgOutput); it != RegisterMap_.end())
@@ -80,41 +80,41 @@ PointerObjectSet::TryGetRegisterPointerObject(const rvsdg::output & rvsdgOutput)
 void
 PointerObjectSet::MapRegisterToExistingPointerObject(
     const rvsdg::output & rvsdgOutput,
-    PointerObject::Index pointerObject)
+    PointerObjectIndex pointerObject)
 {
   JLM_ASSERT(RegisterMap_.count(&rvsdgOutput) == 0);
-  JLM_ASSERT(GetPointerObject(pointerObject).GetKind() == PointerObjectKind::Register);
+  JLM_ASSERT(GetPointerObjectKind(pointerObject) == PointerObjectKind::Register);
   RegisterMap_[&rvsdgOutput] = pointerObject;
 }
 
-PointerObject::Index
+PointerObjectIndex
 PointerObjectSet::CreateDummyRegisterPointerObject()
 {
   return AddPointerObject(PointerObjectKind::Register);
 }
 
-PointerObject::Index
+PointerObjectIndex
 PointerObjectSet::CreateAllocaMemoryObject(const rvsdg::node & allocaNode)
 {
   JLM_ASSERT(AllocaMap_.count(&allocaNode) == 0);
   return AllocaMap_[&allocaNode] = AddPointerObject(PointerObjectKind::AllocaMemoryObject);
 }
 
-PointerObject::Index
+PointerObjectIndex
 PointerObjectSet::CreateMallocMemoryObject(const rvsdg::node & mallocNode)
 {
   JLM_ASSERT(MallocMap_.count(&mallocNode) == 0);
   return MallocMap_[&mallocNode] = AddPointerObject(PointerObjectKind::MallocMemoryObject);
 }
 
-PointerObject::Index
+PointerObjectIndex
 PointerObjectSet::CreateGlobalMemoryObject(const delta::node & deltaNode)
 {
   JLM_ASSERT(GlobalMap_.count(&deltaNode) == 0);
   return GlobalMap_[&deltaNode] = AddPointerObject(PointerObjectKind::GlobalMemoryObject);
 }
 
-PointerObject::Index
+PointerObjectIndex
 PointerObjectSet::CreateFunctionMemoryObject(const lambda::node & lambdaNode)
 {
   JLM_ASSERT(!FunctionMap_.HasKey(&lambdaNode));
@@ -123,7 +123,7 @@ PointerObjectSet::CreateFunctionMemoryObject(const lambda::node & lambdaNode)
   return pointerObject;
 }
 
-PointerObject::Index
+PointerObjectIndex
 PointerObjectSet::GetFunctionMemoryObject(const lambda::node & lambdaNode) const
 {
   JLM_ASSERT(FunctionMap_.HasKey(&lambdaNode));
@@ -131,114 +131,229 @@ PointerObjectSet::GetFunctionMemoryObject(const lambda::node & lambdaNode) const
 }
 
 const lambda::node &
-PointerObjectSet::GetLambdaNodeFromFunctionMemoryObject(PointerObject::Index index) const
+PointerObjectSet::GetLambdaNodeFromFunctionMemoryObject(PointerObjectIndex index) const
 {
   JLM_ASSERT(FunctionMap_.HasValue(index));
   return *FunctionMap_.LookupValue(index);
 }
 
-PointerObject::Index
+PointerObjectIndex
 PointerObjectSet::CreateImportMemoryObject(const rvsdg::argument & importNode)
 {
   JLM_ASSERT(ImportMap_.count(&importNode) == 0);
   return ImportMap_[&importNode] = AddPointerObject(PointerObjectKind::ImportMemoryObject);
 }
 
-const std::unordered_map<const rvsdg::output *, PointerObject::Index> &
+const std::unordered_map<const rvsdg::output *, PointerObjectIndex> &
 PointerObjectSet::GetRegisterMap() const noexcept
 {
   return RegisterMap_;
 }
 
-const std::unordered_map<const rvsdg::node *, PointerObject::Index> &
+const std::unordered_map<const rvsdg::node *, PointerObjectIndex> &
 PointerObjectSet::GetAllocaMap() const noexcept
 {
   return AllocaMap_;
 }
 
-const std::unordered_map<const rvsdg::node *, PointerObject::Index> &
+const std::unordered_map<const rvsdg::node *, PointerObjectIndex> &
 PointerObjectSet::GetMallocMap() const noexcept
 {
   return MallocMap_;
 }
 
-const std::unordered_map<const delta::node *, PointerObject::Index> &
+const std::unordered_map<const delta::node *, PointerObjectIndex> &
 PointerObjectSet::GetGlobalMap() const noexcept
 {
   return GlobalMap_;
 }
 
-const util::BijectiveMap<const lambda::node *, PointerObject::Index> &
+const util::BijectiveMap<const lambda::node *, PointerObjectIndex> &
 PointerObjectSet::GetFunctionMap() const noexcept
 {
   return FunctionMap_;
 }
 
-const std::unordered_map<const rvsdg::argument *, PointerObject::Index> &
+const std::unordered_map<const rvsdg::argument *, PointerObjectIndex> &
 PointerObjectSet::GetImportMap() const noexcept
 {
   return ImportMap_;
 }
 
-const util::HashSet<PointerObject::Index> &
-PointerObjectSet::GetPointsToSet(PointerObject::Index idx) const
+PointerObjectKind
+PointerObjectSet::GetPointerObjectKind(PointerObjectIndex index) const noexcept
 {
-  JLM_ASSERT(idx < NumPointerObjects());
-  return PointsToSets_[idx];
+  JLM_ASSERT(index < NumPointerObjects());
+  return PointerObjects_[index].Kind;
+}
+
+bool
+PointerObjectSet::CanPointerObjectPoint(PointerObjectIndex index) const noexcept
+{
+  JLM_ASSERT(index < NumPointerObjects());
+  return PointerObjects_[index].CanPoint();
+}
+
+bool
+PointerObjectSet::CanPointerObjectBePointee(PointerObjectIndex index) const noexcept
+{
+  JLM_ASSERT(index < NumPointerObjects());
+  return PointerObjects_[index].CanBePointee();
+}
+
+bool
+PointerObjectSet::HasEscaped(PointerObjectIndex index) const noexcept
+{
+  JLM_ASSERT(index < NumPointerObjects());
+  return PointerObjects_[index].HasEscaped;
+}
+
+bool
+PointerObjectSet::MarkAsEscaped(PointerObjectIndex index)
+{
+  JLM_ASSERT(index < NumPointerObjects());
+  if (PointerObjects_[index].HasEscaped)
+    return false;
+  PointerObjects_[index].HasEscaped = true;
+
+  // Pointer objects that have addresses can be written to from outside the module
+  if (CanPointerObjectBePointee(index))
+    MarkAsPointingToExternal(index);
+
+  return true;
+}
+
+bool
+PointerObjectSet::IsPointingToExternal(PointerObjectIndex index) const noexcept
+{
+  return PointerObjects_[GetUnificationRoot(index)].PointsToExternal;
+}
+
+bool
+PointerObjectSet::MarkAsPointingToExternal(PointerObjectIndex index)
+{
+  if (!CanPointerObjectPoint(index))
+    return false;
+
+  auto parent = GetUnificationRoot(index);
+  if (PointerObjects_[parent].PointsToExternal)
+    return false;
+  PointerObjects_[parent].PointsToExternal = true;
+  return true;
+}
+
+PointerObjectIndex
+PointerObjectSet::GetUnificationRoot(PointerObjectIndex index) const noexcept
+{
+  if constexpr (ENABLE_UNIFICATION)
+  {
+    JLM_ASSERT(index < NumPointerObjects());
+
+    // Technique known as path halving, gives same asymptotic performance as full path compression
+    while (PointerObjectParents_[index] != index)
+    {
+      auto & parent = PointerObjectParents_[index];
+      auto grandparent = PointerObjectParents_[parent];
+      index = parent = grandparent;
+    }
+  }
+
+  return index;
+}
+
+PointerObjectIndex
+PointerObjectSet::UnifyPointerObjects(PointerObjectIndex object1, PointerObjectIndex object2)
+{
+  if constexpr (!ENABLE_UNIFICATION)
+    JLM_UNREACHABLE("Unification is not enabled");
+
+  JLM_ASSERT(CanPointerObjectPoint(object1));
+  JLM_ASSERT(CanPointerObjectPoint(object2));
+
+  PointerObjectIndex newRoot = GetUnificationRoot(object1);
+  PointerObjectIndex oldRoot = GetUnificationRoot(object2);
+
+  if (newRoot == oldRoot)
+    return newRoot;
+
+  // Make sure the rank continues to be an upper bound for height.
+  // If they have different rank, the root should be the one with the highest rank.
+  // Equal rank forces the new root to increase its rank
+  if (PointerObjectRank_[newRoot] < PointerObjectRank_[oldRoot])
+    std::swap(newRoot, oldRoot);
+  else if (PointerObjectRank_[newRoot] == PointerObjectRank_[oldRoot])
+    PointerObjectRank_[newRoot]++;
+
+  PointerObjectParents_[oldRoot] = newRoot;
+
+  PointsToSets_[newRoot].UnionWith(PointsToSets_[oldRoot]);
+  PointsToSets_[oldRoot].Clear();
+
+  if (IsPointingToExternal(oldRoot))
+    MarkAsPointingToExternal(newRoot);
+
+  return newRoot;
+}
+
+const util::HashSet<PointerObjectIndex> &
+PointerObjectSet::GetPointsToSet(PointerObjectIndex index) const
+{
+  return PointsToSets_[GetUnificationRoot(index)];
 }
 
 // Makes pointee a member of P(pointer)
 bool
-PointerObjectSet::AddToPointsToSet(PointerObject::Index pointer, PointerObject::Index pointee)
+PointerObjectSet::AddToPointsToSet(PointerObjectIndex pointer, PointerObjectIndex pointee)
 {
   JLM_ASSERT(pointer < NumPointerObjects());
   JLM_ASSERT(pointee < NumPointerObjects());
   // Assert the pointer object is a possible pointee
-  JLM_ASSERT(GetPointerObject(pointee).CanBePointee());
+  JLM_ASSERT(CanPointerObjectBePointee(pointee));
 
   // If the pointer PointerObject can not point to anything, silently ignore
-  if (!GetPointerObject(pointer).CanPoint())
+  if (!CanPointerObjectPoint(pointer))
     return false;
 
-  return PointsToSets_[pointer].Insert(pointee);
+  return PointsToSets_[GetUnificationRoot(pointer)].Insert(pointee);
 }
 
 // Makes P(superset) a superset of P(subset)
 bool
-PointerObjectSet::MakePointsToSetSuperset(
-    PointerObject::Index superset,
-    PointerObject::Index subset)
+PointerObjectSet::MakePointsToSetSuperset(PointerObjectIndex superset, PointerObjectIndex subset)
 {
-  JLM_ASSERT(superset < NumPointerObjects());
-  JLM_ASSERT(subset < NumPointerObjects());
-
   // If the superset PointerObject can't point to anything, silently ignore
-  if (!GetPointerObject(superset).CanPoint())
+  if (!CanPointerObjectPoint(superset))
     return false;
 
-  // If the superset PointerObject can't point to anything, silently ignore
-  if (!GetPointerObject(superset).CanPoint())
+  // If the subset PointerObject can't point to anything, silently ignore
+  if (!CanPointerObjectPoint(subset))
     return false;
 
-  auto & P_super = PointsToSets_[superset];
-  const auto & P_sub = PointsToSets_[subset];
+  auto supersetParent = GetUnificationRoot(superset);
+  auto subsetParent = GetUnificationRoot(subset);
+
+  if (supersetParent == subsetParent)
+    return false;
+
+  auto & P_super = PointsToSets_[supersetParent];
+  auto & P_sub = PointsToSets_[subsetParent];
 
   bool modified = P_super.UnionWith(P_sub);
 
   // If the external node is in the subset, it must also be part of the superset
-  if (GetPointerObject(subset).PointsToExternal())
-    modified |= GetPointerObject(superset).MarkAsPointsToExternal();
+  if (IsPointingToExternal(subsetParent))
+    modified |= MarkAsPointingToExternal(supersetParent);
 
   return modified;
 }
 
-// Markes all x in P(pointer) as escaped
+// Marks all x in P(pointer) as escaped
 bool
-PointerObjectSet::MarkAllPointeesAsEscaped(PointerObject::Index pointer)
+PointerObjectSet::MarkAllPointeesAsEscaped(PointerObjectIndex pointer)
 {
   bool modified = false;
-  for (PointerObject::Index pointee : PointsToSets_[pointer].Items())
-    modified |= GetPointerObject(pointee).MarkAsEscaped();
+  for (PointerObjectIndex pointee : GetPointsToSet(pointer).Items())
+    modified |= MarkAsEscaped(pointee);
 
   return modified;
 }
@@ -255,12 +370,12 @@ bool
 StoreConstraint::ApplyDirectly(PointerObjectSet & set)
 {
   bool modified = false;
-  for (PointerObject::Index x : set.GetPointsToSet(Pointer_).Items())
+  for (PointerObjectIndex x : set.GetPointsToSet(Pointer_).Items())
     modified |= set.MakePointsToSetSuperset(x, Value_);
 
   // If external in P(Pointer1_), P(external) should become a superset of P(Pointer2)
   // In practice, this means everything in P(Pointer2) escapes
-  if (set.GetPointerObject(Pointer_).PointsToExternal())
+  if (set.IsPointingToExternal(Pointer_))
     modified |= set.MarkAllPointeesAsEscaped(Value_);
 
   return modified;
@@ -271,12 +386,12 @@ bool
 LoadConstraint::ApplyDirectly(PointerObjectSet & set)
 {
   bool modified = false;
-  for (PointerObject::Index x : set.GetPointsToSet(Pointer_).Items())
+  for (PointerObjectIndex x : set.GetPointsToSet(Pointer_).Items())
     modified |= set.MakePointsToSetSuperset(Value_, x);
 
   // P(pointer) "contains" external, then P(loaded) should also "contain" it
-  if (set.GetPointerObject(Pointer_).PointsToExternal())
-    modified |= set.GetPointerObject(Value_).MarkAsPointsToExternal();
+  if (set.IsPointingToExternal(Pointer_))
+    modified |= set.MarkAsPointingToExternal(Value_);
 
   return modified;
 }
@@ -331,7 +446,7 @@ static void
 HandleCallingImportedFunction(
     PointerObjectSet & set,
     const jlm::llvm::CallNode & callNode,
-    [[maybe_unused]] PointerObject::Index imported,
+    [[maybe_unused]] PointerObjectIndex imported,
     MarkAsEscaped & markAsEscaped,
     MarkAsPointsToExternal & markAsPointsToExternal)
 {
@@ -345,7 +460,7 @@ HandleCallingImportedFunction(
  * Passes the points-to-sets of the arguments into the function subregion,
  * and passes the points-to-sets of the function's return values back to the CallNode's outputs.
  * Passing pointees is performed by calling the provided \p makeSuperset functor, with signature
- *   void(PointerObject::Index superset, PointerObject::Index subset)
+ *   void(PointerObjectIndex superset, PointerObjectIndex subset)
  * @param set the PointerObjectSet representing this module.
  * @param callNode the RVSDG CallNode that represents the function call itself
  * @param lambda the PointerObject of FunctionMemoryObject kind that might be called.
@@ -356,7 +471,7 @@ static void
 HandleCallingLambdaFunction(
     PointerObjectSet & set,
     const jlm::llvm::CallNode & callNode,
-    PointerObject::Index lambda,
+    PointerObjectIndex lambda,
     MakeSuperset & makeSuperset)
 {
   auto & lambdaNode = set.GetLambdaNodeFromFunctionMemoryObject(lambda);
@@ -404,25 +519,25 @@ FunctionCallConstraint::ApplyDirectly(PointerObjectSet & set)
 {
   bool modified = false;
 
-  const auto MakeSuperset = [&](PointerObject::Index superset, PointerObject::Index subset)
+  const auto MakeSuperset = [&](PointerObjectIndex superset, PointerObjectIndex subset)
   {
     modified |= set.MakePointsToSetSuperset(superset, subset);
   };
 
-  const auto MarkAsEscaped = [&](PointerObject::Index index)
+  const auto MarkAsEscaped = [&](PointerObjectIndex index)
   {
-    modified |= set.GetPointerObject(index).MarkAsEscaped();
+    modified |= set.MarkAsEscaped(index);
   };
 
-  const auto MarkAsPointsToExternal = [&](PointerObject::Index index)
+  const auto MarkAsPointsToExternal = [&](PointerObjectIndex index)
   {
-    modified |= set.GetPointerObject(index).MarkAsPointsToExternal();
+    modified |= set.MarkAsPointingToExternal(index);
   };
 
   // For each possible function target, connect parameters and return values to the call node
   for (const auto target : set.GetPointsToSet(Pointer_).Items())
   {
-    const auto kind = set.GetPointerObject(target).GetKind();
+    const auto kind = set.GetPointerObjectKind(target);
     if (kind == PointerObjectKind::ImportMemoryObject)
       HandleCallingImportedFunction(set, CallNode_, target, MarkAsEscaped, MarkAsPointsToExternal);
     else if (kind == PointerObjectKind::FunctionMemoryObject)
@@ -430,7 +545,7 @@ FunctionCallConstraint::ApplyDirectly(PointerObjectSet & set)
   }
 
   // If we might be calling an external function
-  if (set.GetPointerObject(Pointer_).PointsToExternal())
+  if (set.IsPointingToExternal(Pointer_))
     HandleCallingExternalFunction(set, CallNode_, MarkAsEscaped, MarkAsPointsToExternal);
 
   return modified;
@@ -439,12 +554,12 @@ FunctionCallConstraint::ApplyDirectly(PointerObjectSet & set)
 bool
 EscapeFlagConstraint::PropagateEscapedFlagsDirectly(PointerObjectSet & set)
 {
-  std::queue<PointerObject::Index> escapers;
+  std::queue<PointerObjectIndex> escapers;
 
   // First add all already escaped PointerObjects to the queue
-  for (PointerObject::Index idx = 0; idx < set.NumPointerObjects(); idx++)
+  for (PointerObjectIndex idx = 0; idx < set.NumPointerObjects(); idx++)
   {
-    if (set.GetPointerObject(idx).HasEscaped())
+    if (set.HasEscaped(idx))
       escapers.push(idx);
   }
 
@@ -453,12 +568,12 @@ EscapeFlagConstraint::PropagateEscapedFlagsDirectly(PointerObjectSet & set)
   // For all escapers, check if they point to any PointerObjects not marked as escaped
   while (!escapers.empty())
   {
-    const PointerObject::Index escaper = escapers.front();
+    const PointerObjectIndex escaper = escapers.front();
     escapers.pop();
 
-    for (PointerObject::Index pointee : set.GetPointsToSet(escaper).Items())
+    for (PointerObjectIndex pointee : set.GetPointsToSet(escaper).Items())
     {
-      if (set.GetPointerObject(pointee).MarkAsEscaped())
+      if (set.MarkAsEscaped(pointee))
       {
         // Add the newly marked PointerObject to the queue, in case the flag can be propagated
         escapers.push(pointee);
@@ -485,12 +600,12 @@ template<typename MarkAsEscapedFunctor, typename MarkAsPointsToExternalFunctor>
 static void
 HandleEscapedFunction(
     PointerObjectSet & set,
-    PointerObject::Index lambda,
+    PointerObjectIndex lambda,
     MarkAsEscapedFunctor & markAsEscaped,
     MarkAsPointsToExternalFunctor & markAsPointsToExternal)
 {
-  JLM_ASSERT(set.GetPointerObject(lambda).GetKind() == PointerObjectKind::FunctionMemoryObject);
-  JLM_ASSERT(set.GetPointerObject(lambda).HasEscaped());
+  JLM_ASSERT(set.GetPointerObjectKind(lambda) == PointerObjectKind::FunctionMemoryObject);
+  JLM_ASSERT(set.HasEscaped(lambda));
 
   // We now go through the lambda's inner region and apply the necessary flags
   auto & lambdaNode = set.GetLambdaNodeFromFunctionMemoryObject(lambda);
@@ -504,7 +619,7 @@ HandleEscapedFunction(
       continue;
 
     // Nothing to be done if it is already marked as points to external
-    if (set.GetPointerObject(argumentPO.value()).PointsToExternal())
+    if (set.IsPointingToExternal(argumentPO.value()))
       continue;
 
     markAsPointsToExternal(argumentPO.value());
@@ -518,7 +633,7 @@ HandleEscapedFunction(
       continue;
 
     // Nothing to be done if it is already marked as escaped
-    if (set.GetPointerObject(resultPO.value()).HasEscaped())
+    if (set.HasEscaped(resultPO.value()))
       continue;
 
     // Mark the result register as escaped
@@ -531,21 +646,21 @@ EscapedFunctionConstraint::PropagateEscapedFunctionsDirectly(PointerObjectSet & 
 {
   bool modified = false;
 
-  const auto markAsEscaped = [&](PointerObject::Index index)
+  const auto markAsEscaped = [&](PointerObjectIndex index)
   {
-    set.GetPointerObject(index).MarkAsEscaped();
+    set.MarkAsEscaped(index);
     modified = true;
   };
 
-  const auto markAsPointsToExternal = [&](PointerObject::Index index)
+  const auto markAsPointsToExternal = [&](PointerObjectIndex index)
   {
-    set.GetPointerObject(index).MarkAsPointsToExternal();
+    set.MarkAsPointingToExternal(index);
     modified = true;
   };
 
   for (const auto [lambda, lambdaPO] : set.GetFunctionMap())
   {
-    if (set.GetPointerObject(lambdaPO).HasEscaped())
+    if (set.HasEscaped(lambdaPO))
       HandleEscapedFunction(set, lambdaPO, markAsEscaped, markAsPointsToExternal);
   }
 
@@ -554,30 +669,29 @@ EscapedFunctionConstraint::PropagateEscapedFunctionsDirectly(PointerObjectSet & 
 
 void
 PointerObjectConstraintSet::AddPointerPointeeConstraint(
-    PointerObject::Index pointer,
-    PointerObject::Index pointee)
+    PointerObjectIndex pointer,
+    PointerObjectIndex pointee)
 {
   // All set constraints are additive, so simple constraints like this can be directly applied.
   Set_.AddToPointsToSet(pointer, pointee);
 }
 
 void
-PointerObjectConstraintSet::AddPointsToExternalConstraint(PointerObject::Index pointer)
+PointerObjectConstraintSet::AddPointsToExternalConstraint(PointerObjectIndex pointer)
 {
   // Flags are never removed, so adding the flag now ensures it will be included.
-  Set_.GetPointerObject(pointer).MarkAsPointsToExternal();
+  Set_.MarkAsPointingToExternal(pointer);
 }
 
 void
-PointerObjectConstraintSet::AddRegisterContentEscapedConstraint(PointerObject::Index registerIndex)
+PointerObjectConstraintSet::AddRegisterContentEscapedConstraint(PointerObjectIndex registerIndex)
 {
   // Registers themselves can't escape in the classical sense, since they don't have an address.
   // (CanBePointee() is false)
   // When marked as Escaped, it instead means that the contents of the register has escaped.
   // This allows Escaped-flag propagation to mark any pointee the register might hold as escaped.
-  auto & registerPointerObject = Set_.GetPointerObject(registerIndex);
-  JLM_ASSERT(registerPointerObject.GetKind() == PointerObjectKind::Register);
-  registerPointerObject.MarkAsEscaped();
+  JLM_ASSERT(Set_.GetPointerObjectKind(registerIndex) == PointerObjectKind::Register);
+  Set_.MarkAsEscaped(registerIndex);
 }
 
 void
@@ -597,12 +711,12 @@ PointerObjectConstraintSet::SolveUsingWorklist()
 {
   // Create auxiliary superset graph.
   // If supersetEdges[x] contains y, (x -> y), that means P(y) supseteq P(x)
-  std::vector<util::HashSet<PointerObject::Index>> supersetEdges(Set_.NumPointerObjects());
+  std::vector<util::HashSet<PointerObjectIndex>> supersetEdges(Set_.NumPointerObjects());
 
   // Create quick lookup tables for Load, Store and function call constraints.
   // Lookup is indexed by the constraint's pointer
-  std::vector<std::vector<PointerObject::Index>> storeConstraints(Set_.NumPointerObjects());
-  std::vector<std::vector<PointerObject::Index>> loadConstraints(Set_.NumPointerObjects());
+  std::vector<std::vector<PointerObjectIndex>> storeConstraints(Set_.NumPointerObjects());
+  std::vector<std::vector<PointerObjectIndex>> loadConstraints(Set_.NumPointerObjects());
   std::vector<std::vector<const jlm::llvm::CallNode *>> callConstraints(Set_.NumPointerObjects());
 
   for (const auto & constraint : Constraints_)
@@ -643,13 +757,13 @@ PointerObjectConstraintSet::SolveUsingWorklist()
   }
 
   // The worklist, initialized with every object
-  util::LrfWorklist<PointerObject::Index> worklist;
-  for (PointerObject::Index i = 0; i < Set_.NumPointerObjects(); i++)
+  util::LrfWorklist<PointerObjectIndex> worklist;
+  for (PointerObjectIndex i = 0; i < Set_.NumPointerObjects(); i++)
     worklist.PushWorkItem(i);
 
   // Helper function for adding superset edges, propagating everything currently in the subset.
   // The superset is added to the work list if its points-to set or flags are changed.
-  const auto AddSupersetEdge = [&](PointerObject::Index superset, PointerObject::Index subset)
+  const auto AddSupersetEdge = [&](PointerObjectIndex superset, PointerObjectIndex subset)
   {
     // If the edge already exists, ignore
     if (!supersetEdges[subset].Insert(superset))
@@ -664,16 +778,16 @@ PointerObjectConstraintSet::SolveUsingWorklist()
   };
 
   // Helper function for flagging a pointer object as escaped. Adds to the worklist if changed
-  const auto MarkAsEscaped = [&](PointerObject::Index index)
+  const auto MarkAsEscaped = [&](PointerObjectIndex index)
   {
-    if (Set_.GetPointerObject(index).MarkAsEscaped())
+    if (Set_.MarkAsEscaped(index))
       worklist.PushWorkItem(index);
   };
 
   // Helper function for flagging a pointer as pointing to external. Adds to the worklist if changed
-  const auto MarkAsPointsToExternal = [&](PointerObject::Index index)
+  const auto MarkAsPointsToExternal = [&](PointerObjectIndex index)
   {
-    if (Set_.GetPointerObject(index).MarkAsPointsToExternal())
+    if (Set_.MarkAsPointingToExternal(index))
       worklist.PushWorkItem(index);
   };
 
@@ -698,7 +812,7 @@ PointerObjectConstraintSet::SolveUsingWorklist()
         AddSupersetEdge(pointee, value);
 
       // If P(n) contains "external", the contents of the written value escapes
-      if (Set_.GetPointerObject(n).PointsToExternal())
+      if (Set_.IsPointingToExternal(n))
         MarkAsEscaped(value);
     }
 
@@ -710,7 +824,7 @@ PointerObjectConstraintSet::SolveUsingWorklist()
         AddSupersetEdge(value, pointee);
 
       // If P(n) contains "external", the loaded value may also point to external
-      if (Set_.GetPointerObject(n).PointsToExternal())
+      if (Set_.IsPointingToExternal(n))
         MarkAsPointsToExternal(value);
     }
 
@@ -720,7 +834,7 @@ PointerObjectConstraintSet::SolveUsingWorklist()
       // Connect the inputs and outputs of the callNode to every possible function pointee
       for (const auto pointee : Set_.GetPointsToSet(n).Items())
       {
-        const auto kind = Set_.GetPointerObject(pointee).GetKind();
+        const auto kind = Set_.GetPointerObjectKind(pointee);
         if (kind == PointerObjectKind::ImportMemoryObject)
           HandleCallingImportedFunction(
               Set_,
@@ -733,7 +847,7 @@ PointerObjectConstraintSet::SolveUsingWorklist()
       }
 
       // If P(n) contains "external", handle calling external functions
-      if (Set_.GetPointerObject(n).PointsToExternal())
+      if (Set_.IsPointingToExternal(n))
         HandleCallingExternalFunction(Set_, *callNode, MarkAsEscaped, MarkAsPointsToExternal);
     }
 
@@ -745,13 +859,13 @@ PointerObjectConstraintSet::SolveUsingWorklist()
     }
 
     // If escaped, propagate escaped flag to all pointees
-    if (Set_.GetPointerObject(n).HasEscaped())
+    if (Set_.HasEscaped(n))
     {
       for (const auto pointee : Set_.GetPointsToSet(n).Items())
         MarkAsEscaped(pointee);
 
       // Escaped functions also need to flag arguments and results in the function body
-      if (Set_.GetPointerObject(n).GetKind() == PointerObjectKind::FunctionMemoryObject)
+      if (Set_.GetPointerObjectKind(n) == PointerObjectKind::FunctionMemoryObject)
         HandleEscapedFunction(Set_, n, MarkAsEscaped, MarkAsPointsToExternal);
     }
   }

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
@@ -71,10 +71,6 @@ class PointerObjectSet final
           PointsToExternal(0)
     {
       JLM_ASSERT(kind != PointerObjectKind::COUNT);
-
-      // Memory objects from other modules are definitely not private to this module
-      if (kind == PointerObjectKind::ImportMemoryObject)
-        HasEscaped = 1;
     }
 
     /**

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
@@ -38,128 +38,7 @@ enum class PointerObjectKind : uint8_t
   COUNT
 };
 
-/**
- * Class representing a single entry in the PointerObjectSet.
- */
-class PointerObject final
-{
-  PointerObjectKind Kind_ : util::BitWidthOfEnum(PointerObjectKind::COUNT);
-
-  // May point to a memory object defined outside the module, or any escaped memory object
-  uint8_t PointsToExternal_ : 1;
-
-  // This memory object's address is known outside the module.
-  // If set and Kind_ is Register, it only means the pointees of the Reigister have escaped.
-  uint8_t HasEscaped_ : 1;
-
-public:
-  using Index = std::uint32_t;
-
-  explicit PointerObject(PointerObjectKind kind)
-      : Kind_(kind),
-        PointsToExternal_(0),
-        HasEscaped_(0)
-  {
-    JLM_ASSERT(kind != PointerObjectKind::COUNT);
-
-    // Memory objects from other modules are definitely not private to this module
-    if (kind == PointerObjectKind::ImportMemoryObject)
-      MarkAsEscaped();
-  }
-
-  [[nodiscard]] PointerObjectKind
-  GetKind() const noexcept
-  {
-    return Kind_;
-  }
-
-  /**
-   * Some PointerObjects are not capable of pointing to anything else.
-   * Their points-to-set will always be empty, and constraints that attempt
-   * to add pointees should be no-ops that are silently ignored.
-   * The same applies to attempts at setting the PointsToExternal-flag.
-   * @return true if this PointerObject can point to other PointerObjects
-   */
-  [[nodiscard]] bool
-  CanPoint() const noexcept
-  {
-    return Kind_ != PointerObjectKind::FunctionMemoryObject;
-  }
-
-  /**
-   * Some PointerObjects don't have addresses, and can as such not be pointed to.
-   * Any attempt at adding them to a points-to-set is a fatal error.
-   * @return true if this PointerObject can be pointed to by another PointerObject
-   */
-  [[nodiscard]] bool
-  CanBePointee() const noexcept
-  {
-    return Kind_ != PointerObjectKind::Register;
-  }
-
-  /**
-   * When the PointsToExternal-flag is set, the PointerObject possibly points to a storage
-   * instance declared outside to module, or to a memory object from this same module, that has
-   * escaped.
-   * @return true if the PointsToExternal flag is set.
-   */
-  [[nodiscard]] bool
-  PointsToExternal() const noexcept
-  {
-    return PointsToExternal_;
-  }
-
-  /**
-   * Sets the PointsToExternal-flag, if possible.
-   * If CanPoint() is false, this is a no-op.
-   * @return true if the PointsToExternal flag was modified, otherwise false
-   */
-  bool
-  MarkAsPointsToExternal() noexcept
-  {
-    if (!CanPoint())
-      return false;
-
-    bool modified = !PointsToExternal_;
-    PointsToExternal_ = 1;
-    return modified;
-  }
-
-  /**
-   * When set, the PointerObject's value is accessible from outside the module.
-   * Anything it points to can also be accessed outside the module, and should also be marked as
-   * escaped.
-   *
-   * If CanBePointee() is true, this PointerObjects's address is available outside the module,
-   * and can potentially be written to. Therefore, HasEscaped implies the PointsToEscaped flag,
-   * if it is possible to set it.
-   *
-   * @return true if the PointerObject is marked as having escaped
-   */
-  [[nodiscard]] bool
-  HasEscaped() const noexcept
-  {
-    return HasEscaped_;
-  }
-
-  /**
-   * Sets the HasEscaped-flag, indicating that this PointerObject's value is available outside
-   * the module. If CanBePointee() is true, its address is also escaped, and PointsToExternal
-   * will be set as well, if possible.
-   *
-   * @see HasEscaped()
-   * @return true if the HasEscaped or PointsToExternal flags were modified, otherwise false.
-   */
-  bool
-  MarkAsEscaped() noexcept
-  {
-    bool modified = !HasEscaped_;
-    HasEscaped_ = 1;
-    if (CanBePointee())
-      modified |= MarkAsPointsToExternal();
-    return modified;
-  }
-};
+using PointerObjectIndex = uint32_t;
 
 /**
  * A class containing a set of PointerObjects, and their points-to-sets,
@@ -168,30 +47,95 @@ public:
  */
 class PointerObjectSet final
 {
+  /**
+   * Struct used internally to store information about each PointerObject.
+   * When PointerObjects are unified, some flags are shared.
+   * This is handled by the accessor methods defined on PointerObjectSet
+   */
+  struct PointerObject final
+  {
+    // The kind of pointer object
+    PointerObjectKind Kind : util::BitWidthOfEnum(PointerObjectKind::COUNT);
+
+    // This memory object's address is known outside the module.
+    // If CanBePointee() is false, this object has no address, but its value has escaped.
+    uint8_t HasEscaped : 1;
+
+    // If this PointerObject is the parent of its own unification,
+    // and this flag is set, this pointer object is pointing to external.
+    uint8_t PointsToExternal : 1;
+
+    explicit PointerObject(PointerObjectKind kind)
+        : Kind(kind),
+          HasEscaped(0),
+          PointsToExternal(0)
+    {
+      JLM_ASSERT(kind != PointerObjectKind::COUNT);
+
+      // Memory objects from other modules are definitely not private to this module
+      if (kind == PointerObjectKind::ImportMemoryObject)
+        HasEscaped = 1;
+    }
+
+    /**
+     * Some PointerObjects are not capable of pointing to anything else.
+     * Their points-to-set will always be empty, and constraints that attempt
+     * to add pointees should be no-ops that are silently ignored.
+     * The same applies to attempts at setting the PointsToExternal-flag.
+     * @return true if this PointerObject can point to other PointerObjects
+     */
+    [[nodiscard]] bool
+    CanPoint() const noexcept
+    {
+      return Kind != PointerObjectKind::FunctionMemoryObject;
+    }
+
+    /**
+     * Some PointerObjects don't have addresses, and can as such not be pointed to.
+     * Any attempt at adding them to a points-to-set is a fatal error.
+     * @return true if this PointerObject can be pointed to by another PointerObject
+     */
+    [[nodiscard]] bool
+    CanBePointee() const noexcept
+    {
+      return Kind != PointerObjectKind::Register;
+    }
+  };
+
   // All PointerObjects in the set
   std::vector<PointerObject> PointerObjects_;
 
+  // The parent of each PointerObject in the disjoint-set forest. Roots are their own parent.
+  // Marked as mutable to allow path compression in const qualified methods.
+  mutable std::vector<PointerObjectIndex> PointerObjectParents_;
+
+  // Metadata enabling union by rank, where rank is an upper bound for tree height
+  // Size of a disjoint set is at least 2^rank, making a uint8_t plenty big enough.
+  std::vector<uint8_t> PointerObjectRank_;
+
   // For each PointerObject, a set of the other PointerObjects it points to
-  std::vector<util::HashSet<PointerObject::Index>> PointsToSets_;
+  // Only unification roots may have a non-empty set,
+  // other PointerObjects refer to their root's set.
+  std::vector<util::HashSet<PointerObjectIndex>> PointsToSets_;
 
   // Mapping from register to PointerObject
   // Unlike the other maps, several rvsdg::output* can share register PointerObject
-  std::unordered_map<const rvsdg::output *, PointerObject::Index> RegisterMap_;
+  std::unordered_map<const rvsdg::output *, PointerObjectIndex> RegisterMap_;
 
-  std::unordered_map<const rvsdg::node *, PointerObject::Index> AllocaMap_;
+  std::unordered_map<const rvsdg::node *, PointerObjectIndex> AllocaMap_;
 
-  std::unordered_map<const rvsdg::node *, PointerObject::Index> MallocMap_;
+  std::unordered_map<const rvsdg::node *, PointerObjectIndex> MallocMap_;
 
-  std::unordered_map<const delta::node *, PointerObject::Index> GlobalMap_;
+  std::unordered_map<const delta::node *, PointerObjectIndex> GlobalMap_;
 
-  util::BijectiveMap<const lambda::node *, PointerObject::Index> FunctionMap_;
+  util::BijectiveMap<const lambda::node *, PointerObjectIndex> FunctionMap_;
 
-  std::unordered_map<const rvsdg::argument *, PointerObject::Index> ImportMap_;
+  std::unordered_map<const rvsdg::argument *, PointerObjectIndex> ImportMap_;
 
   /**
    * Internal helper function for adding PointerObjects, use the Create* methods instead
    */
-  [[nodiscard]] PointerObject::Index
+  [[nodiscard]] PointerObjectIndex
   AddPointerObject(PointerObjectKind kind);
 
 public:
@@ -199,21 +143,10 @@ public:
   NumPointerObjects() const noexcept;
 
   /**
-   * Returns the number of PointerObjects in the set matching the specified \p kind.
-   * @return the number of matches
+   * @return the number of PointerObjects in the set matching the specified \p kind.
    */
   [[nodiscard]] size_t
   NumPointerObjectsOfKind(PointerObjectKind kind) const noexcept;
-
-  /**
-   * Gets the PointerObject associated with the given \p index
-   * @return a reference to the PointerObject with the given index
-   */
-  [[nodiscard]] PointerObject &
-  GetPointerObject(PointerObject::Index index);
-
-  [[nodiscard]] const PointerObject &
-  GetPointerObject(PointerObject::Index index) const;
 
   /**
    * Creates a PointerObject of Register kind and maps the rvsdg output to the new PointerObject.
@@ -221,7 +154,7 @@ public:
    * @param rvsdgOutput the rvsdg output associated with the register PointerObject
    * @return the index of the new PointerObject in the PointerObjectSet
    */
-  [[nodiscard]] PointerObject::Index
+  [[nodiscard]] PointerObjectIndex
   CreateRegisterPointerObject(const rvsdg::output & rvsdgOutput);
 
   /**
@@ -229,7 +162,7 @@ public:
    * @param rvsdgOutput an rvsdg::output that already corresponds to a PointerObject in the set
    * @return the index of the PointerObject associated with the rvsdg::output
    */
-  [[nodiscard]] PointerObject::Index
+  [[nodiscard]] PointerObjectIndex
   GetRegisterPointerObject(const rvsdg::output & rvsdgOutput) const;
 
   /**
@@ -238,7 +171,7 @@ public:
    * @param rvsdgOutput the rvsdg::output that might correspond to a PointerObject in the set
    * @return the index of the PointerObject associated with rvsdgOutput, if it exists
    */
-  [[nodiscard]] std::optional<PointerObject::Index>
+  [[nodiscard]] std::optional<PointerObjectIndex>
   TryGetRegisterPointerObject(const rvsdg::output & rvsdgOutput) const;
 
   /**
@@ -250,7 +183,7 @@ public:
   void
   MapRegisterToExistingPointerObject(
       const rvsdg::output & rvsdgOutput,
-      PointerObject::Index pointerObject);
+      PointerObjectIndex pointerObject);
 
   /**
    * Creates a PointerObject of Register kind, without any association to any node in the program.
@@ -259,16 +192,16 @@ public:
    * @see Andersen::AnalyzeMemcpy.
    * @return the index of the new PointerObject
    */
-  [[nodiscard]] PointerObject::Index
+  [[nodiscard]] PointerObjectIndex
   CreateDummyRegisterPointerObject();
 
-  [[nodiscard]] PointerObject::Index
+  [[nodiscard]] PointerObjectIndex
   CreateAllocaMemoryObject(const rvsdg::node & allocaNode);
 
-  [[nodiscard]] PointerObject::Index
+  [[nodiscard]] PointerObjectIndex
   CreateMallocMemoryObject(const rvsdg::node & mallocNode);
 
-  [[nodiscard]] PointerObject::Index
+  [[nodiscard]] PointerObjectIndex
   CreateGlobalMemoryObject(const delta::node & deltaNode);
 
   /**
@@ -277,7 +210,7 @@ public:
    * @param lambdaNode the RVSDG node defining the function,
    * @return the index of the new PointerObject in the PointerObjectSet
    */
-  [[nodiscard]] PointerObject::Index
+  [[nodiscard]] PointerObjectIndex
   CreateFunctionMemoryObject(const lambda::node & lambdaNode);
 
   /**
@@ -285,7 +218,7 @@ public:
    * @param lambdaNode the lambda node associated with the existing PointerObject
    * @return the index of the associated PointerObject
    */
-  [[nodiscard]] PointerObject::Index
+  [[nodiscard]] PointerObjectIndex
   GetFunctionMemoryObject(const lambda::node & lambdaNode) const;
 
   /**
@@ -294,31 +227,99 @@ public:
    * @return the lambda node associated with the PointerObject
    */
   [[nodiscard]] const lambda::node &
-  GetLambdaNodeFromFunctionMemoryObject(PointerObject::Index index) const;
+  GetLambdaNodeFromFunctionMemoryObject(PointerObjectIndex index) const;
 
-  [[nodiscard]] PointerObject::Index
+  [[nodiscard]] PointerObjectIndex
   CreateImportMemoryObject(const rvsdg::argument & importNode);
 
-  const std::unordered_map<const rvsdg::output *, PointerObject::Index> &
+  const std::unordered_map<const rvsdg::output *, PointerObjectIndex> &
   GetRegisterMap() const noexcept;
 
-  const std::unordered_map<const rvsdg::node *, PointerObject::Index> &
+  const std::unordered_map<const rvsdg::node *, PointerObjectIndex> &
   GetAllocaMap() const noexcept;
 
-  const std::unordered_map<const rvsdg::node *, PointerObject::Index> &
+  const std::unordered_map<const rvsdg::node *, PointerObjectIndex> &
   GetMallocMap() const noexcept;
 
-  const std::unordered_map<const delta::node *, PointerObject::Index> &
+  const std::unordered_map<const delta::node *, PointerObjectIndex> &
   GetGlobalMap() const noexcept;
 
-  const util::BijectiveMap<const lambda::node *, PointerObject::Index> &
+  const util::BijectiveMap<const lambda::node *, PointerObjectIndex> &
   GetFunctionMap() const noexcept;
 
-  const std::unordered_map<const rvsdg::argument *, PointerObject::Index> &
+  const std::unordered_map<const rvsdg::argument *, PointerObjectIndex> &
   GetImportMap() const noexcept;
 
-  [[nodiscard]] const util::HashSet<PointerObject::Index> &
-  GetPointsToSet(PointerObject::Index idx) const;
+  /**
+   * @return the kind of the PointerObject with the given \p index
+   */
+  [[nodiscard]] PointerObjectKind
+  GetPointerObjectKind(PointerObjectIndex index) const noexcept;
+
+  /**
+   * @return true if the PointerObject with the given \p index can point, otherwise false
+   */
+  [[nodiscard]] bool
+  CanPointerObjectPoint(PointerObjectIndex index) const noexcept;
+
+  /**
+   * @return true if the PointerObject with the given \p index can be a pointee, otherwise false
+   */
+  [[nodiscard]] bool
+  CanPointerObjectBePointee(PointerObjectIndex index) const noexcept;
+
+  /**
+   * @return true if the PointerObject with the given \p index has escaped, otherwise false
+   */
+  [[nodiscard]] bool
+  HasEscaped(PointerObjectIndex index) const noexcept;
+
+  /**
+   * Marks the PointerObject with the given \p index as having escaped the module.
+   * @return true if the flag was changed by this operation
+   */
+  bool
+  MarkAsEscaped(PointerObjectIndex index);
+
+  /**
+   * @return true if the PointerObject with the given \p index points to external, otherwise false
+   */
+  [[nodiscard]] bool
+  IsPointingToExternal(PointerObjectIndex index) const noexcept;
+
+  /**
+   * Marks the PointerObject with the given \p index as pointing to external.
+   * If the PointerObject has CanPoint() = false, this is a no-op.
+   * @return true if the flag was changed by this operation
+   */
+  bool
+  MarkAsPointingToExternal(PointerObjectIndex index);
+
+  /**
+   * @return the root in the unification the PointerObject with the given \p index belongs to.
+   * PointerObjects that have not been unified will always be their own root.
+   */
+  [[nodiscard]] PointerObjectIndex
+  GetUnificationRoot(PointerObjectIndex index) const noexcept;
+
+  /**
+   * Unifies two PointerObjects, such that they will forever share their set of pointees.
+   * If any object in the unification points to external, they will all point to external.
+   * The HasEscaped flags are not shared, and can still be set individually.
+   * Only PointerObjects where CanPoint() is true may be unified.
+   * If the objects already belong to the same disjoint set, this is a no-op.
+   * @param object1 the index of the first PointerObject to unify
+   * @param object2 the index of the second PointerObject to unify
+   * @return the index of the root PointerObject in the unification
+   */
+  PointerObjectIndex
+  UnifyPointerObjects(PointerObjectIndex object1, PointerObjectIndex object2);
+
+  /**
+   * @return the PointsToSet of the PointerObject with the given \p index.
+   */
+  [[nodiscard]] const util::HashSet<PointerObjectIndex> &
+  GetPointsToSet(PointerObjectIndex index) const;
 
   /**
    * Adds \p pointee to P(\p pointer)
@@ -330,7 +331,7 @@ public:
    * @return true if P(\p pointer) was changed by this operation
    */
   bool
-  AddToPointsToSet(PointerObject::Index pointer, PointerObject::Index pointee);
+  AddToPointsToSet(PointerObjectIndex pointer, PointerObjectIndex pointee);
 
   /**
    * Makes P(\p superset) a superset of P(\p subset), by adding any elements in the set difference
@@ -343,7 +344,7 @@ public:
    * @return true if P(\p superset) was modified by this operation
    */
   bool
-  MakePointsToSetSuperset(PointerObject::Index superset, PointerObject::Index subset);
+  MakePointsToSetSuperset(PointerObjectIndex superset, PointerObjectIndex subset);
 
   /**
    * Adds the Escaped flag to all PointerObjects in the P(\p pointer) set
@@ -351,7 +352,7 @@ public:
    * @return true if any PointerObjects had their flag modified by this operation
    */
   bool
-  MarkAllPointeesAsEscaped(PointerObject::Index pointer);
+  MarkAllPointeesAsEscaped(PointerObjectIndex pointer);
 };
 
 /**
@@ -361,11 +362,11 @@ public:
  */
 class SupersetConstraint final
 {
-  PointerObject::Index Superset_;
-  PointerObject::Index Subset_;
+  PointerObjectIndex Superset_;
+  PointerObjectIndex Subset_;
 
 public:
-  SupersetConstraint(PointerObject::Index superset, PointerObject::Index subset)
+  SupersetConstraint(PointerObjectIndex superset, PointerObjectIndex subset)
       : Superset_(superset),
         Subset_(subset)
   {}
@@ -373,7 +374,7 @@ public:
   /**
    * @return the PointerObject that should point to everything the subset points to
    */
-  [[nodiscard]] PointerObject::Index
+  [[nodiscard]] PointerObjectIndex
   GetSuperset() const noexcept
   {
     return Superset_;
@@ -383,7 +384,7 @@ public:
    * @param superset the new PointerObject that should point to everything the subset points to
    */
   void
-  SetSuperset(PointerObject::Index superset)
+  SetSuperset(PointerObjectIndex superset)
   {
     Superset_ = superset;
   }
@@ -391,7 +392,7 @@ public:
   /**
    * @return the PointerObject whose points-to set should be contained within the superset
    */
-  [[nodiscard]] PointerObject::Index
+  [[nodiscard]] PointerObjectIndex
   GetSubset() const noexcept
   {
     return Subset_;
@@ -401,7 +402,7 @@ public:
    * @param subset the new PointerObject whose points-to set should be contained within the superset
    */
   void
-  SetSubset(PointerObject::Index subset)
+  SetSubset(PointerObjectIndex subset)
   {
     Subset_ = subset;
   }
@@ -423,11 +424,11 @@ public:
  */
 class StoreConstraint final
 {
-  PointerObject::Index Pointer_;
-  PointerObject::Index Value_;
+  PointerObjectIndex Pointer_;
+  PointerObjectIndex Value_;
 
 public:
-  StoreConstraint(PointerObject::Index pointer, PointerObject::Index value)
+  StoreConstraint(PointerObjectIndex pointer, PointerObjectIndex value)
       : Pointer_(pointer),
         Value_(value)
   {}
@@ -435,7 +436,7 @@ public:
   /**
    * @return the PointerObject representing the value written by the store instruction
    */
-  [[nodiscard]] PointerObject::Index
+  [[nodiscard]] PointerObjectIndex
   GetValue() const noexcept
   {
     return Value_;
@@ -445,7 +446,7 @@ public:
    * @param value the new PointerObject representing the value written by the store instruction
    */
   void
-  SetValue(PointerObject::Index value)
+  SetValue(PointerObjectIndex value)
   {
     Value_ = value;
   }
@@ -453,7 +454,7 @@ public:
   /**
    * @return the PointerObject representing the pointer written to by the store instruction
    */
-  [[nodiscard]] PointerObject::Index
+  [[nodiscard]] PointerObjectIndex
   GetPointer() const noexcept
   {
     return Pointer_;
@@ -463,7 +464,7 @@ public:
    * @param pointer the new PointerObject representing the pointer written to by the store.
    */
   void
-  SetPointer(PointerObject::Index pointer)
+  SetPointer(PointerObjectIndex pointer)
   {
     Pointer_ = pointer;
   }
@@ -485,11 +486,11 @@ public:
  */
 class LoadConstraint final
 {
-  PointerObject::Index Value_;
-  PointerObject::Index Pointer_;
+  PointerObjectIndex Value_;
+  PointerObjectIndex Pointer_;
 
 public:
-  LoadConstraint(PointerObject::Index value, PointerObject::Index pointer)
+  LoadConstraint(PointerObjectIndex value, PointerObjectIndex pointer)
       : Value_(value),
         Pointer_(pointer)
   {}
@@ -497,7 +498,7 @@ public:
   /**
    * @return the PointerObject representing the value returned by the load instruction
    */
-  [[nodiscard]] PointerObject::Index
+  [[nodiscard]] PointerObjectIndex
   GetValue() const noexcept
   {
     return Value_;
@@ -507,7 +508,7 @@ public:
    * @param value the new PointerObject representing the value returned by the load instruction
    */
   void
-  SetValue(PointerObject::Index value)
+  SetValue(PointerObjectIndex value)
   {
     Value_ = value;
   }
@@ -515,7 +516,7 @@ public:
   /**
    * @return the PointerObject representing the pointer loaded by the load instruction
    */
-  [[nodiscard]] PointerObject::Index
+  [[nodiscard]] PointerObjectIndex
   GetPointer() const noexcept
   {
     return Pointer_;
@@ -525,7 +526,7 @@ public:
    * @param pointer the new PointerObject representing the pointer loaded by the load instruction.
    */
   void
-  SetPointer(PointerObject::Index pointer)
+  SetPointer(PointerObjectIndex pointer)
   {
     Pointer_ = pointer;
   }
@@ -559,7 +560,7 @@ class FunctionCallConstraint final
   /**
    * A PointerObject of Register kind, representing the function pointer being called
    */
-  PointerObject::Index Pointer_;
+  PointerObjectIndex Pointer_;
 
   /**
    * The RVSDG node representing the function call
@@ -567,7 +568,7 @@ class FunctionCallConstraint final
   const jlm::llvm::CallNode & CallNode_;
 
 public:
-  FunctionCallConstraint(PointerObject::Index pointer, const jlm::llvm::CallNode & callNode)
+  FunctionCallConstraint(PointerObjectIndex pointer, const jlm::llvm::CallNode & callNode)
       : Pointer_(pointer),
         CallNode_(callNode)
   {}
@@ -575,7 +576,7 @@ public:
   /**
    * @return the PointerObject representing the function pointer being called
    */
-  [[nodiscard]] PointerObject::Index
+  [[nodiscard]] PointerObjectIndex
   GetPointer() const noexcept
   {
     return Pointer_;
@@ -585,7 +586,7 @@ public:
    * @param pointer the new PointerObject representing the function pointer being called
    */
   void
-  SetPointer(PointerObject::Index pointer)
+  SetPointer(PointerObjectIndex pointer)
   {
     Pointer_ = pointer;
   }
@@ -677,14 +678,14 @@ public:
    * @param pointee the PointerObject that should be in the points-to-set
    */
   void
-  AddPointerPointeeConstraint(PointerObject::Index pointer, PointerObject::Index pointee);
+  AddPointerPointeeConstraint(PointerObjectIndex pointer, PointerObjectIndex pointee);
 
   /**
    * Adds a constraint making \p pointer flagged as pointing to external
    * @param pointer the PointerObject that should be marked as pointing to external
    */
   void
-  AddPointsToExternalConstraint(PointerObject::Index pointer);
+  AddPointsToExternalConstraint(PointerObjectIndex pointer);
 
   /**
    * Ensures that any PointerObject in P(registerIndex) will be marked as escaped.
@@ -692,7 +693,7 @@ public:
    * may point to
    */
   void
-  AddRegisterContentEscapedConstraint(PointerObject::Index registerIndex);
+  AddRegisterContentEscapedConstraint(PointerObjectIndex registerIndex);
 
   /**
    * Generic add function for all struct based constraints


### PR DESCRIPTION
This is the first step in enabling both offline and online variable unification. You no longer have access to `PointerObeject`s directly, so all access goes through the set.

The global `constexpr bool ENABLE_UNIFICATION` allows quickly disabling unification logic, to check how much performance is lost due to extra lookups associated with the disjoint-set data structure, when unification isn't being used. I'm fairly confident that unification enables net performance gains. (Solvers that maintain their own unification invariants can get direct access to points-to sets to avoid the penalty, if it is too great).

Variables are not fully unified, they only start sharing points-to set. The old variables still exist, since other points-to sets may still contain only some of the variables in the unification, or only a subset of the variables have the escaped flag.

Variables where `CanPoint()` is false may not be part of unifications, since they have special meaning. (I'll probably want to rename `CanPoint()` to `TracksPointees()`, as that is a more descriptive name. If you have a variable with `TracksPointees()=false` in your SCC I have other ideas for handling that)