### PR TITLE
Ensure correct flags for escaping registers in Steensgaard

### DIFF
--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -10,6 +10,8 @@
 #include <jlm/rvsdg/traverser.hpp>
 #include <jlm/util/Statistics.hpp>
 
+#include <jlm/rvsdg/view.hpp>
+
 namespace jlm::llvm::aa
 {
 
@@ -1744,8 +1746,8 @@ Steensgaard::Analyze(
     const RvsdgModule & module,
     jlm::util::StatisticsCollector & statisticsCollector)
 {
-  // std::unordered_map<const rvsdg::output *, std::string> outputMap;
-  // std::cout << jlm::rvsdg::view(module.Rvsdg().root(), outputMap) << std::flush;
+  std::unordered_map<const rvsdg::output *, std::string> outputMap;
+  std::cout << jlm::rvsdg::view(module.Rvsdg().root(), outputMap) << std::flush;
 
   Context_ = Context::Create();
   auto statistics = Statistics::Create(module.SourceFileName());
@@ -1753,7 +1755,7 @@ Steensgaard::Analyze(
   // Perform Steensgaard analysis
   statistics->StartSteensgaardStatistics(module.Rvsdg());
   AnalyzeRvsdg(module.Rvsdg());
-  // std::cout << Context_->ToDot() << std::flush;
+  std::cout << Context_->ToDot() << std::flush;
   statistics->StopSteensgaardStatistics();
 
   // Propagate points-to flags in disjoint location set graph
@@ -1764,7 +1766,7 @@ Steensgaard::Analyze(
   // Construct PointsTo graph
   statistics->StartPointsToGraphConstructionStatistics();
   auto pointsToGraph = ConstructPointsToGraph();
-  // std::cout << PointsToGraph::ToDot(*pointsToGraph, outputMap) << std::flush;
+  std::cout << PointsToGraph::ToDot(*pointsToGraph, outputMap) << std::flush;
   statistics->StopPointsToGraphConstructionStatistics(*pointsToGraph);
 
   // Redirect unknown memory node sources

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -732,6 +732,24 @@ public:
     return it != LocationMap_.end();
   }
 
+  void
+  MarkAsEscaped(const rvsdg::output & output)
+  {
+    auto & outputLocation = GetRegisterLocation(output);
+    outputLocation.MarkAsEscaped();
+
+    auto & rootLocation = GetRootLocation(outputLocation);
+    if (!rootLocation.GetPointsTo())
+    {
+    }
+
+    if (rootLocation.GetPointsTo())
+    {
+      rootLocation.GetPointsTo()->SetPointsToFlags(
+          PointsToFlags::PointsToEscapedMemory | PointsToFlags::PointsToExternalMemory);
+    }
+  }
+
   std::string
   ToDot() const
   {

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -10,8 +10,6 @@
 #include <jlm/rvsdg/traverser.hpp>
 #include <jlm/util/Statistics.hpp>
 
-#include <jlm/rvsdg/view.hpp>
-
 namespace jlm::llvm::aa
 {
 
@@ -1743,8 +1741,8 @@ Steensgaard::Analyze(
     const RvsdgModule & module,
     jlm::util::StatisticsCollector & statisticsCollector)
 {
-  std::unordered_map<const rvsdg::output *, std::string> outputMap;
-  std::cout << jlm::rvsdg::view(module.Rvsdg().root(), outputMap) << std::flush;
+  // std::unordered_map<const rvsdg::output *, std::string> outputMap;
+  // std::cout << jlm::rvsdg::view(module.Rvsdg().root(), outputMap) << std::flush;
 
   Context_ = Context::Create();
   auto statistics = Statistics::Create(module.SourceFileName());
@@ -1752,7 +1750,7 @@ Steensgaard::Analyze(
   // Perform Steensgaard analysis
   statistics->StartSteensgaardStatistics(module.Rvsdg());
   AnalyzeRvsdg(module.Rvsdg());
-  std::cout << Context_->ToDot() << std::flush;
+  // std::cout << Context_->ToDot() << std::flush;
   statistics->StopSteensgaardStatistics();
 
   // Propagate points-to flags in disjoint location set graph
@@ -1763,7 +1761,7 @@ Steensgaard::Analyze(
   // Construct PointsTo graph
   statistics->StartPointsToGraphConstructionStatistics();
   auto pointsToGraph = ConstructPointsToGraph();
-  std::cout << PointsToGraph::ToDot(*pointsToGraph, outputMap) << std::flush;
+  // std::cout << PointsToGraph::ToDot(*pointsToGraph, outputMap) << std::flush;
   statistics->StopPointsToGraphConstructionStatistics(*pointsToGraph);
 
   // Redirect unknown memory node sources

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
@@ -145,6 +145,17 @@ private:
   AnalyzeExtractValue(const rvsdg::simple_node & node);
 
   /**
+   * Marks register \p output as escaping the module. This indicates that the pointer in \p output
+   * is going outside the module, where we do not know what happens with it. Consequently, the
+   * locations that \p output points to need to be marked as points-to-external and
+   * points-to-escaped.
+   *
+   * @param output The register that is marked as escaping.
+   */
+  void
+  MarkAsEscaped(const rvsdg::output & output);
+
+  /**
    * Propagates the points-to flags throughout the disjoint set location graph.
    *
    * AnalyzeRvsdg() builds a disjoint set location graph, where each set is annotated with points-to

--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -1199,6 +1199,10 @@ ExternalCallTest1::SetupRvsdg()
 }
 
 std::unique_ptr<jlm::llvm::RvsdgModule>
+ExternalCallTest2::SetupRvsdg()
+{}
+
+std::unique_ptr<jlm::llvm::RvsdgModule>
 GammaTest::SetupRvsdg()
 {
   using namespace jlm::llvm;

--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -1119,7 +1119,7 @@ IndirectCallTest2::SetupRvsdg()
 }
 
 std::unique_ptr<jlm::llvm::RvsdgModule>
-ExternalCallTest::SetupRvsdg()
+ExternalCallTest1::SetupRvsdg()
 {
   using namespace jlm::llvm;
 

--- a/tests/TestRvsdgs.hpp
+++ b/tests/TestRvsdgs.hpp
@@ -804,8 +804,7 @@ private:
   jlm::rvsdg::simple_node * AllocaPz_;
 };
 
-/** \brief ExternalCallTest
- *
+/**
  * This function sets up an RVSDG representing the following program:
  *
  * \code{.c}
@@ -822,7 +821,7 @@ private:
  * It uses a single memory state to sequentialize the respective memory operations within each
  * function.
  */
-class ExternalCallTest final : public RvsdgTest
+class ExternalCallTest1 final : public RvsdgTest
 {
 public:
   [[nodiscard]] const jlm::llvm::lambda::node &

--- a/tests/TestRvsdgs.hpp
+++ b/tests/TestRvsdgs.hpp
@@ -886,15 +886,36 @@ private:
 class ExternalCallTest2 final : public RvsdgTest
 {
 public:
+  [[nodiscard]] jlm::llvm::lambda::node &
+  LambdaG()
+  {
+    JLM_ASSERT(LambdaG_ != nullptr);
+    return *LambdaG_;
+  }
+
+  [[nodiscard]] jlm::llvm::CallNode &
+  CallF()
+  {
+    JLM_ASSERT(CallF_ != nullptr);
+    return *CallF_;
+  }
+
+  [[nodiscard]] jlm::rvsdg::argument &
+  ExternalF()
+  {
+    JLM_ASSERT(ExternalFArgument_ != nullptr);
+    return *ExternalFArgument_;
+  }
+
 private:
   std::unique_ptr<jlm::llvm::RvsdgModule>
   SetupRvsdg() override;
 
-  jlm::llvm::lambda::node * LambdaG_;
+  jlm::llvm::lambda::node * LambdaG_ = {};
 
-  jlm::llvm::CallNode * CallF_;
+  jlm::llvm::CallNode * CallF_ = {};
 
-  jlm::rvsdg::argument * ExternalFArgument_;
+  jlm::rvsdg::argument * ExternalFArgument_ = {};
 };
 
 /** \brief GammaTest class

--- a/tests/TestRvsdgs.hpp
+++ b/tests/TestRvsdgs.hpp
@@ -853,6 +853,50 @@ private:
   jlm::rvsdg::argument * ExternalGArgument_;
 };
 
+/**
+ * This function sets up an RVSDG representing the following program:
+ *
+ * \code{.c}
+ *   #include <stdint.h>
+ *
+ *   typedef struct myStruct
+ *   {
+ *     uint32_t i;
+ *     uint32_t ** p1;
+ *     uint32_t ** p2;
+ *   } myStruct;
+ *
+ *   extern void
+ *   f(myStruct * s);
+ *
+ *   void
+ *   g()
+ *   {
+ *     myStruct s;
+ *     f(&s);
+ *     uint32_t * tmp = *s.p1;
+ *     *s.p1 = *s.p2;
+ *     *s.p2 = tmp;
+ *   }
+ * \endcode
+ *
+ * It uses a single memory state to sequentialize the respective memory operations within each
+ * function.
+ */
+class ExternalCallTest2 final : public RvsdgTest
+{
+public:
+private:
+  std::unique_ptr<jlm::llvm::RvsdgModule>
+  SetupRvsdg() override;
+
+  jlm::llvm::lambda::node * LambdaG_;
+
+  jlm::llvm::CallNode * CallF_;
+
+  jlm::rvsdg::argument * ExternalFArgument_;
+};
+
 /** \brief GammaTest class
  *
  * This function sets up an RVSDG representing the following function:

--- a/tests/jlm/llvm/opt/alias-analyses/TestAndersen.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestAndersen.cpp
@@ -462,9 +462,9 @@ TestIndirectCall2()
 }
 
 static void
-TestExternalCall()
+TestExternalCall1()
 {
-  jlm::tests::ExternalCallTest test;
+  jlm::tests::ExternalCallTest1 test;
   const auto ptg = RunAndersen(test.module());
 
   assert(ptg->NumAllocaNodes() == 2);
@@ -909,7 +909,7 @@ TestAndersen()
   TestCall2();
   TestIndirectCall1();
   TestIndirectCall2();
-  TestExternalCall();
+  TestExternalCall1();
   TestGamma();
   TestTheta();
   TestDelta1();

--- a/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
@@ -1195,9 +1195,18 @@ TestLinkedList()
 
     auto & allocaNode = pointsToGraph.GetAllocaNode(test.GetAlloca());
     auto & deltaMyListNode = pointsToGraph.GetDeltaNode(test.GetDeltaMyList());
+    auto & lambdaNextNode = pointsToGraph.GetLambdaNode(test.GetLambdaNext());
+    auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
 
-    assertTargets(allocaNode, { &allocaNode, &deltaMyListNode });
-    assertTargets(deltaMyListNode, { &allocaNode, &deltaMyListNode });
+    std::unordered_set<const jlm::llvm::aa::PointsToGraph::Node *> expectedMemoryNodes = {
+      &allocaNode,
+      &deltaMyListNode,
+      &lambdaNextNode,
+      &externalMemoryNode
+    };
+
+    assertTargets(allocaNode, expectedMemoryNodes);
+    assertTargets(deltaMyListNode, expectedMemoryNodes);
   };
 
   jlm::tests::LinkedListTest test;

--- a/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
@@ -613,6 +613,22 @@ TestExternalCall1()
 }
 
 static void
+TestExternalCall2()
+{
+  // Arrange
+  jlm::tests::ExternalCallTest2 test;
+  std::unordered_map<const jlm::rvsdg::output *, std::string> outputMap;
+  std::cout << jlm::rvsdg::view(test.graph().root(), outputMap) << std::flush;
+
+  // Act
+  auto pointsToGraph = RunSteensgaard(test.module());
+  std::cout << jlm::llvm::aa::PointsToGraph::ToDot(*pointsToGraph, outputMap) << std::flush;
+
+  // Assert
+  assert(0);
+}
+
+static void
 TestGamma()
 {
   auto ValidatePointsToGraph =
@@ -1238,9 +1254,12 @@ TestSteensgaardAnalysis()
 
   TestCall1();
   TestCall2();
+
   TestIndirectCall();
   TestIndirectCall2();
+
   TestExternalCall1();
+  TestExternalCall2();
 
   TestGamma();
 

--- a/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
@@ -625,7 +625,15 @@ TestExternalCall2()
   std::cout << jlm::llvm::aa::PointsToGraph::ToDot(*pointsToGraph, outputMap) << std::flush;
 
   // Assert
-  assert(0);
+  assert(pointsToGraph->NumAllocaNodes() == 1);
+  assert(pointsToGraph->NumLambdaNodes() == 1);
+  assert(pointsToGraph->NumImportNodes() == 3);
+  assert(pointsToGraph->NumRegisterNodes() == 7);
+
+  for (auto & registerNode : pointsToGraph->RegisterNodes())
+  {
+    assert(registerNode.NumTargets() != 0);
+  }
 }
 
 static void

--- a/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
@@ -580,10 +580,10 @@ TestIndirectCall2()
 }
 
 static void
-TestExternalCall()
+TestExternalCall1()
 {
   auto validatePointsToGraph = [](const jlm::llvm::aa::PointsToGraph & pointsToGraph,
-                                  const jlm::tests::ExternalCallTest & test)
+                                  const jlm::tests::ExternalCallTest1 & test)
   {
     assert(pointsToGraph.NumAllocaNodes() == 2);
     assert(pointsToGraph.NumLambdaNodes() == 1);
@@ -603,7 +603,7 @@ TestExternalCall()
     assertTargets(callResult, { &lambdaF, &externalMemory });
   };
 
-  jlm::tests::ExternalCallTest test;
+  jlm::tests::ExternalCallTest1 test;
   // jlm::rvsdg::view(test.graph().root(), stdout);
 
   auto pointsToGraph = RunSteensgaard(test.module());
@@ -1240,7 +1240,7 @@ TestSteensgaardAnalysis()
   TestCall2();
   TestIndirectCall();
   TestIndirectCall2();
-  TestExternalCall();
+  TestExternalCall1();
 
   TestGamma();
 


### PR DESCRIPTION
The contents of registers that escape the module can point to external and all escaped memory, but they were not marked as points-to-external and points-to-escaped so far. This PR fixes this problem.