### PR TITLE
Fix build of CIRCT dependency in CI pipeline

### DIFF
--- a/.github/actions/BuildCirct/action.yml
+++ b/.github/actions/BuildCirct/action.yml
@@ -31,5 +31,5 @@ runs:
         ./scripts/build-circt.sh \
           --build-path ${{ github.workspace }}/build-circt \
           --install-path ${{ github.workspace }}/build-circt/circt \
-          --llvm-lit-path ~/.local/bin
+          --llvm-lit-path ~/.local/bin/lit
       shell: bash

--- a/.github/actions/BuildCirct/action.yml
+++ b/.github/actions/BuildCirct/action.yml
@@ -30,5 +30,6 @@ runs:
       run: |
         ./scripts/build-circt.sh \
           --build-path ${{ github.workspace }}/build-circt \
-          --install-path ${{ github.workspace }}/build-circt/circt
+          --install-path ${{ github.workspace }}/build-circt/circt \
+          --llvm-lit-path ~/.local/bin
       shell: bash

--- a/.github/actions/BuildCirct/action.yml
+++ b/.github/actions/BuildCirct/action.yml
@@ -4,20 +4,20 @@ description: "Builds CIRCT, which is used for the HLS backend"
 runs:
   using: "composite"
   steps:
-    - name: "Get the commit used for building CIRCT and use it as the cache key"
-      id: get-circt-hash
-      run: |
-        echo "hash=$(./scripts/build-circt.sh --get-commit-hash)" >> $GITHUB_OUTPUT
-      shell: bash
-
-    - name: "Try to fetch CIRCT from the cache"
-      id: cache-circt
-      uses: actions/cache@v4
-      with:
-        path: |
-          ${{ github.workspace }}/build-circt/circt
-        key: ${{ runner.os }}-circt-${{ steps.get-circt-hash.outputs.hash }}
-
+    #    - name: "Get the commit used for building CIRCT and use it as the cache key"
+    #      id: get-circt-hash
+    #      run: |
+    #        echo "hash=$(./scripts/build-circt.sh --get-commit-hash)" >> $GITHUB_OUTPUT
+    #      shell: bash
+    #
+    #    - name: "Try to fetch CIRCT from the cache"
+    #      id: cache-circt
+    #      uses: actions/cache@v4
+    #      with:
+    #        path: |
+    #          ${{ github.workspace }}/build-circt/circt
+    #        key: ${{ runner.os }}-circt-${{ steps.get-circt-hash.outputs.hash }}
+    #
     - name: "Install LLVM, Clang, MLIR, and Ninja"
       uses: ./.github/actions/InstallPackages
       with:

--- a/.github/actions/BuildCirct/action.yml
+++ b/.github/actions/BuildCirct/action.yml
@@ -4,20 +4,20 @@ description: "Builds CIRCT, which is used for the HLS backend"
 runs:
   using: "composite"
   steps:
-    #    - name: "Get the commit used for building CIRCT and use it as the cache key"
-    #      id: get-circt-hash
-    #      run: |
-    #        echo "hash=$(./scripts/build-circt.sh --get-commit-hash)" >> $GITHUB_OUTPUT
-    #      shell: bash
-    #
-    #    - name: "Try to fetch CIRCT from the cache"
-    #      id: cache-circt
-    #      uses: actions/cache@v4
-    #      with:
-    #        path: |
-    #          ${{ github.workspace }}/build-circt/circt
-    #        key: ${{ runner.os }}-circt-${{ steps.get-circt-hash.outputs.hash }}
-    #
+    - name: "Get the commit used for building CIRCT and use it as the cache key"
+      id: get-circt-hash
+      run: |
+        echo "hash=$(./scripts/build-circt.sh --get-commit-hash)" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: "Try to fetch CIRCT from the cache"
+      id: cache-circt
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{ github.workspace }}/build-circt/circt
+        key: ${{ runner.os }}-circt-${{ steps.get-circt-hash.outputs.hash }}
+
     - name: "Install LLVM, Clang, MLIR, and Ninja"
       uses: ./.github/actions/InstallPackages
       with:

--- a/.github/actions/InstallPackages/action.yml
+++ b/.github/actions/InstallPackages/action.yml
@@ -57,7 +57,7 @@ runs:
       if: ${{inputs.install-llvm == 'true'}}
       run: |
         sudo apt-get install llvm-16-dev
-        pip install "lit~=16"
+        pip install "lit~=16.0"
       shell: bash
 
     - name: "Install clang package"

--- a/.github/actions/InstallPackages/action.yml
+++ b/.github/actions/InstallPackages/action.yml
@@ -58,6 +58,7 @@ runs:
       run: |
         sudo apt-get install llvm-16-dev
         pip install "lit~=16.0"
+        pip show lit
       shell: bash
 
     - name: "Install clang package"

--- a/.github/actions/InstallPackages/action.yml
+++ b/.github/actions/InstallPackages/action.yml
@@ -57,7 +57,7 @@ runs:
       if: ${{inputs.install-llvm == 'true'}}
       run: |
         sudo apt-get install llvm-16-dev
-        pip install lit
+        pip install "lit~=16"
       shell: bash
 
     - name: "Install clang package"

--- a/scripts/build-circt.sh
+++ b/scripts/build-circt.sh
@@ -66,6 +66,7 @@ cmake -G Ninja \
 	-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 	-DLLVM_DIR=/usr/lib/llvm-16/cmake/ \
 	-DMLIR_DIR=/usr/lib/llvm-16/lib/cmake/mlir \
+	-DLLVM_EXTERNAL_LIT=/usr/local/bin/lit \
 	-DLLVM_LIT_ARGS="-v --show-unsupported" \
 	-DVERILATOR_DISABLE=ON \
 	-DCMAKE_INSTALL_PREFIX=${CIRCT_INSTALL}

--- a/scripts/build-circt.sh
+++ b/scripts/build-circt.sh
@@ -41,11 +41,11 @@ while [[ "$#" -ge 1 ]] ; do
 			CIRCT_INSTALL=$(readlink -m "$1")
 			shift
 			;;
-	  --llvm-lit-path)
-	    shift
-	    LLVM_LIT_PATH=$(readlink -m "$1")
-	    shift
-	    ;;
+    --llvm-lit-path)
+      shift
+      LLVM_LIT_PATH=$(readlink -m "$1")
+      shift
+      ;;
 		--get-commit-hash)
 			commit >&2
 			exit 1

--- a/scripts/build-circt.sh
+++ b/scripts/build-circt.sh
@@ -30,12 +30,12 @@ while [[ "$#" -ge 1 ]] ; do
 	case "$1" in
 		--build-path)
 			shift
-			CIRCT_BUILD="$1"
+			CIRCT_BUILD=$(readlink -m "$1")
 			shift
 			;;
 		--install-path)
 			shift
-			CIRCT_INSTALL="$1"
+			CIRCT_INSTALL=$(readlink -m "$1")
 			shift
 			;;
 		--get-commit-hash)

--- a/scripts/build-circt.sh
+++ b/scripts/build-circt.sh
@@ -71,8 +71,5 @@ cmake -G Ninja \
 	-DVERILATOR_DISABLE=ON \
 	-DCMAKE_INSTALL_PREFIX=${CIRCT_INSTALL}
 ninja -C ${CIRCT_BUILD_DIR}
-###
-# FIXME: This check lead to failing CI piplines
-###
 # ninja -C ${CIRCT_BUILD_DIR} check-circt
 ninja -C ${CIRCT_BUILD_DIR} install

--- a/scripts/build-circt.sh
+++ b/scripts/build-circt.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 JLM_ROOT_DIR=${SCRIPT_DIR}/..
 CIRCT_BUILD=${JLM_ROOT_DIR}/build-circt
 CIRCT_INSTALL=${JLM_ROOT_DIR}/usr
-LLVM_LIT_PATH=/usr/local/bin
+LLVM_LIT_PATH=/usr/local/bin/lit
 
 function commit()
 {

--- a/scripts/build-circt.sh
+++ b/scripts/build-circt.sh
@@ -66,7 +66,7 @@ cmake -G Ninja \
 	-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 	-DLLVM_DIR=/usr/lib/llvm-16/cmake/ \
 	-DMLIR_DIR=/usr/lib/llvm-16/lib/cmake/mlir \
-	-DLLVM_EXTERNAL_LIT=/usr/local/bin/lit \
+	-DLLVM_EXTERNAL_LIT=~/.local/bin \
 	-DLLVM_LIT_ARGS="-v --show-unsupported" \
 	-DVERILATOR_DISABLE=ON \
 	-DCMAKE_INSTALL_PREFIX=${CIRCT_INSTALL}

--- a/scripts/build-circt.sh
+++ b/scripts/build-circt.sh
@@ -23,7 +23,7 @@ function usage()
 	echo "                        [${CIRCT_BUILD}]"
 	echo "  --install-path PATH   The path where to install CIRCT."
 	echo "                        [${CIRCT_INSTALL}]"
-	echo "  --llvm-lit-path PATH  The path to LLVM lit tool."
+	echo "  --llvm-lit-path PATH  The path to the LLVM lit tool."
 	echo "                        [${LLVM_LIT_PATH}]"
 	echo "  --get-commit-hash     Prints the commit hash used for the build."
 	echo "  --help                Prints this message and stops."

--- a/scripts/build-circt.sh
+++ b/scripts/build-circt.sh
@@ -66,7 +66,6 @@ cmake -G Ninja \
 	-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 	-DLLVM_DIR=/usr/lib/llvm-16/cmake/ \
 	-DMLIR_DIR=/usr/lib/llvm-16/lib/cmake/mlir \
-	-DLLVM_EXTERNAL_LIT=/usr/local/bin/lit \
 	-DLLVM_LIT_ARGS="-v --show-unsupported" \
 	-DVERILATOR_DISABLE=ON \
 	-DCMAKE_INSTALL_PREFIX=${CIRCT_INSTALL}

--- a/scripts/build-circt.sh
+++ b/scripts/build-circt.sh
@@ -71,5 +71,8 @@ cmake -G Ninja \
 	-DVERILATOR_DISABLE=ON \
 	-DCMAKE_INSTALL_PREFIX=${CIRCT_INSTALL}
 ninja -C ${CIRCT_BUILD_DIR}
-ninja -C ${CIRCT_BUILD_DIR} check-circt
+###
+# FIXME: This check lead to failing CI piplines
+###
+# ninja -C ${CIRCT_BUILD_DIR} check-circt
 ninja -C ${CIRCT_BUILD_DIR} install

--- a/scripts/build-circt.sh
+++ b/scripts/build-circt.sh
@@ -41,11 +41,11 @@ while [[ "$#" -ge 1 ]] ; do
 			CIRCT_INSTALL=$(readlink -m "$1")
 			shift
 			;;
-    --llvm-lit-path)
-      shift
-      LLVM_LIT_PATH=$(readlink -m "$1")
-      shift
-      ;;
+		--llvm-lit-path)
+			shift
+			LLVM_LIT_PATH=$(readlink -m "$1")
+			shift
+			;;
 		--get-commit-hash)
 			commit >&2
 			exit 1

--- a/scripts/build-circt.sh
+++ b/scripts/build-circt.sh
@@ -8,6 +8,7 @@ SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 JLM_ROOT_DIR=${SCRIPT_DIR}/..
 CIRCT_BUILD=${JLM_ROOT_DIR}/build-circt
 CIRCT_INSTALL=${JLM_ROOT_DIR}/usr
+LLVM_LIT_PATH=/usr/local/bin
 
 function commit()
 {
@@ -22,6 +23,8 @@ function usage()
 	echo "                        [${CIRCT_BUILD}]"
 	echo "  --install-path PATH   The path where to install CIRCT."
 	echo "                        [${CIRCT_INSTALL}]"
+	echo "  --llvm-lit-path PATH  The path to LLVM lit tool."
+	echo "                        [${LLVM_LIT_PATH}]"
 	echo "  --get-commit-hash     Prints the commit hash used for the build."
 	echo "  --help                Prints this message and stops."
 }
@@ -38,6 +41,11 @@ while [[ "$#" -ge 1 ]] ; do
 			CIRCT_INSTALL=$(readlink -m "$1")
 			shift
 			;;
+	  --llvm-lit-path)
+	    shift
+	    LLVM_LIT_PATH=$(readlink -m "$1")
+	    shift
+	    ;;
 		--get-commit-hash)
 			commit >&2
 			exit 1
@@ -66,7 +74,7 @@ cmake -G Ninja \
 	-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 	-DLLVM_DIR=/usr/lib/llvm-16/cmake/ \
 	-DMLIR_DIR=/usr/lib/llvm-16/lib/cmake/mlir \
-	-DLLVM_EXTERNAL_LIT=~/.local/bin \
+	-DLLVM_EXTERNAL_LIT="${LLVM_LIT_PATH}" \
 	-DLLVM_LIT_ARGS="-v --show-unsupported" \
 	-DVERILATOR_DISABLE=ON \
 	-DCMAKE_INSTALL_PREFIX=${CIRCT_INSTALL}

--- a/scripts/build-circt.sh
+++ b/scripts/build-circt.sh
@@ -30,12 +30,12 @@ while [[ "$#" -ge 1 ]] ; do
 	case "$1" in
 		--build-path)
 			shift
-			CIRCT_BUILD="${PWD}/$1"
+			CIRCT_BUILD="$1"
 			shift
 			;;
 		--install-path)
 			shift
-			CIRCT_INSTALL="${PWD}/$1"
+			CIRCT_INSTALL="$1"
 			shift
 			;;
 		--get-commit-hash)

--- a/scripts/build-circt.sh
+++ b/scripts/build-circt.sh
@@ -71,5 +71,5 @@ cmake -G Ninja \
 	-DVERILATOR_DISABLE=ON \
 	-DCMAKE_INSTALL_PREFIX=${CIRCT_INSTALL}
 ninja -C ${CIRCT_BUILD_DIR}
-# ninja -C ${CIRCT_BUILD_DIR} check-circt
+ninja -C ${CIRCT_BUILD_DIR} check-circt
 ninja -C ${CIRCT_BUILD_DIR} install


### PR DESCRIPTION
This PR does the following:

1. Fixes the version of LLVM lit.
2. Fixes a bug in the provided paths to build-circt.sh.
3. Adds llvm-lit-path to build-circt.sh script.

Closes #423 