### PR TITLE
Add IsInvariant() to gamma output class

### DIFF
--- a/jlm/llvm/ir/operators/gamma.hpp
+++ b/jlm/llvm/ir/operators/gamma.hpp
@@ -52,26 +52,4 @@ is_gamma_result(const rvsdg::input * input)
 
 }
 
-/*
-  FIXME: This function should be defined in librvsdg.
-*/
-static inline jlm::rvsdg::output *
-is_invariant(const jlm::rvsdg::gamma_output * output)
-{
-  auto argument = dynamic_cast<const jlm::rvsdg::argument *>(output->result(0)->origin());
-  if (!argument)
-    return nullptr;
-
-  size_t n;
-  auto origin = argument->input()->origin();
-  for (n = 1; n < output->nresults(); n++)
-  {
-    auto argument = dynamic_cast<const jlm::rvsdg::argument *>(output->result(n)->origin());
-    if (argument == nullptr || argument->input()->origin() != origin)
-      break;
-  }
-
-  return n == output->nresults() ? origin : nullptr;
-}
-
 #endif

--- a/jlm/llvm/opt/InvariantValueRedirection.cpp
+++ b/jlm/llvm/opt/InvariantValueRedirection.cpp
@@ -92,8 +92,11 @@ InvariantValueRedirection::RedirectInvariantGammaOutputs(jlm::rvsdg::gamma_node 
   {
     auto & gammaOutput = *it;
 
-    if (auto origin = is_invariant(&gammaOutput))
-      it->divert_users(origin);
+    rvsdg::output * invariantOrigin = nullptr;
+    if (gammaOutput.IsInvariant(&invariantOrigin))
+    {
+      it->divert_users(invariantOrigin);
+    }
   }
 }
 

--- a/jlm/rvsdg/gamma.cpp
+++ b/jlm/rvsdg/gamma.cpp
@@ -276,6 +276,33 @@ gamma_input::~gamma_input() noexcept
 gamma_output::~gamma_output() noexcept
 {}
 
+bool
+gamma_output::IsInvariant(rvsdg::output ** invariantOrigin) const noexcept
+{
+  auto argument = dynamic_cast<const rvsdg::argument *>(result(0)->origin());
+  if (!argument)
+  {
+    return false;
+  }
+
+  size_t n;
+  auto origin = argument->input()->origin();
+  for (n = 1; n < nresults(); n++)
+  {
+    argument = dynamic_cast<const rvsdg::argument *>(result(n)->origin());
+    if (argument == nullptr || argument->input()->origin() != origin)
+      break;
+  }
+
+  auto isInvariant = (n == nresults());
+  if (isInvariant && invariantOrigin != nullptr)
+  {
+    *invariantOrigin = origin;
+  }
+
+  return isInvariant;
+}
+
 /* gamma node */
 
 gamma_node::~gamma_node()

--- a/jlm/rvsdg/gamma.hpp
+++ b/jlm/rvsdg/gamma.hpp
@@ -442,12 +442,12 @@ public:
   }
 
   /**
-   * Determines whether the gamma output is invariant.
+   * Determines whether a gamma output is invariant.
    *
    * A gamma output is invariant if its value directly originates from gamma inputs and the origin
-   * for all these inputs is the same.
+   * of all these inputs is the same.
    *
-   * @param invariantOrigin The invariant value if the gamma output is invariant and \p
+   * @param invariantOrigin The origin of the gamma inputs if the gamma output is invariant and \p
    * invariantOrigin is unequal NULL.
    * @return True if the gamma output is invariant, otherwise false.
    */

--- a/jlm/rvsdg/gamma.hpp
+++ b/jlm/rvsdg/gamma.hpp
@@ -440,6 +440,19 @@ public:
     JLM_ASSERT(result->output() == this);
     return result;
   }
+
+  /**
+   * Determines whether the gamma output is invariant.
+   *
+   * A gamma output is invariant if its value directly originates from gamma inputs and the origin
+   * for all these inputs is the same.
+   *
+   * @param invariantOrigin The invariant value if the gamma output is invariant and \p
+   * invariantOrigin is unequal NULL.
+   * @return True if the gamma output is invariant, otherwise false.
+   */
+  bool
+  IsInvariant(rvsdg::output ** invariantOrigin = nullptr) const noexcept;
 };
 
 static inline bool


### PR DESCRIPTION
This PR does the following:

1. Adds IsInvariant() method to gamma output class.
2. Replaces all usages of old is_invariant() function.
3. Removes is_invariant() function.