### PR TITLE
Make unified register PointerObjects share RegisterNode in the PointsToGraph

### DIFF
--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -1010,8 +1010,8 @@ std::unique_ptr<PointsToGraph>
 Andersen::ConstructPointsToGraphFromPointerObjectSet(const PointerObjectSet & set)
 {
   // Create a throwaway instance of statistics
-  auto statistics = Statistics::Create(jlm::util::filepath(""));
-  return ConstructPointsToGraphFromPointerObjectSet(set, *statistics);
+  Statistics statistics(jlm::util::filepath(""));
+  return ConstructPointsToGraphFromPointerObjectSet(set, statistics);
 }
 
 }

--- a/jlm/llvm/opt/alias-analyses/Andersen.hpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.hpp
@@ -138,17 +138,19 @@ public:
    * Converts a PointerObjectSet into PointsToGraph nodes,
    * and points-to-graph set memberships into edges.
    *
-   * Note that registers sharing PointerObject, become separate PointsToGraph nodes.
-   *
    * In the PointerObjectSet, the PointsToExternal flag encodes pointing to an address available
    * outside the module. This may however be the address of a memory object within the module, that
    * has escaped. In the final PointsToGraph, any node marked as pointing to external, will get an
    * edge to the special "external" node, as well as to every memory object node marked as escaped.
    *
+   * @param set the PointerObjectSet to convert
+   * @param statistics if not null, it will collect statistics about the process
    * @return the newly created PointsToGraph
    */
   static std::unique_ptr<PointsToGraph>
-  ConstructPointsToGraphFromPointerObjectSet(const PointerObjectSet & set, Statistics & statistics);
+  ConstructPointsToGraphFromPointerObjectSet(
+      const PointerObjectSet & set,
+      Statistics * statistics = nullptr);
 
 private:
   void

--- a/jlm/llvm/opt/alias-analyses/Andersen.hpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.hpp
@@ -144,13 +144,14 @@ public:
    * edge to the special "external" node, as well as to every memory object node marked as escaped.
    *
    * @param set the PointerObjectSet to convert
-   * @param statistics if not null, it will collect statistics about the process
+   * @param statistics the statistics instance used to collect statistics about the process
    * @return the newly created PointsToGraph
    */
-  static std::unique_ptr<PointsToGraph>
-  ConstructPointsToGraphFromPointerObjectSet(
-      const PointerObjectSet & set,
-      Statistics * statistics = nullptr);
+  [[nodiscard]] static std::unique_ptr<PointsToGraph>
+  ConstructPointsToGraphFromPointerObjectSet(const PointerObjectSet & set, Statistics & statistics);
+
+  [[nodiscard]] static std::unique_ptr<PointsToGraph>
+  ConstructPointsToGraphFromPointerObjectSet(const PointerObjectSet & set);
 
 private:
   void


### PR DESCRIPTION
Since `RegisterNode`s support mapping multiple RVSDG outputs to a single `PointsToGraph` node, when they all share pointees, it makes sense to use this for unified `PointerObject`s of Register kind.

This PR also adds a test of `Andersen::ConstructPointsToGraphFromPointerObjectSet`, which was missing.

Just for fun, here is the PointsToGraph being built in the test:

![ptg](https://github.com/phate/jlm/assets/3748845/79a31b17-2ffa-4c16-8613-76b87f9189ab)
