### PR TITLE
Mark variadic arguments of external calls as escaped in Steensgaard

### DIFF
--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -1004,9 +1004,11 @@ Steensgaard::AnalyzeSimpleNode(const jlm::rvsdg::simple_node & node)
   {
     AnalyzeExtractValue(node);
   }
-  else if (is<FreeOperation>(&node) || is<ptrcmp_op>(&node))
+  else if (is<FreeOperation>(&node) || is<ptrcmp_op>(&node) || is<valist_op>(&node))
   {
-    // Nothing needs to be done as these operations do not affect points-to sets
+    // Nothing needs to be done:
+    // 1. FreeOperation and ptrcmp_op do not affect points-to sets
+    // 2. valist_op are handled along with call nodes
   }
   else
   {

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -17,10 +17,10 @@ namespace jlm::llvm::aa
  * Determines whether \p output%s type is or contains a pointer type.
  *
  * @param output An rvsdg::output.
- * @return True if \p output is or contains a pointer type, otherwise false.
+ * @return True if \p output%s type is or contains a pointer type, otherwise false.
  */
 static bool
-IsOrContainsPointerType(const rvsdg::output & output)
+HasOrContainsPointerType(const rvsdg::output & output)
 {
   return IsOrContains<PointerType>(output.type());
 }
@@ -37,7 +37,7 @@ ShouldHandle(const rvsdg::simple_node & node)
   for (size_t n = 0; n < node.ninputs(); n++)
   {
     auto & origin = *node.input(n)->origin();
-    if (IsOrContainsPointerType(origin))
+    if (HasOrContainsPointerType(origin))
     {
       return true;
     }
@@ -1080,7 +1080,7 @@ Steensgaard::AnalyzeLoad(const LoadNode & loadNode)
   auto & result = *loadNode.GetValueOutput();
   auto & address = *loadNode.GetAddressInput()->origin();
 
-  if (!IsOrContainsPointerType(result))
+  if (!HasOrContainsPointerType(result))
     return;
 
   auto & addressLocation = Context_->GetLocation(address);
@@ -1103,7 +1103,7 @@ Steensgaard::AnalyzeStore(const StoreNode & storeNode)
   auto & address = *storeNode.GetAddressInput()->origin();
   auto & value = *storeNode.GetValueInput()->origin();
 
-  if (!IsOrContainsPointerType(value))
+  if (!HasOrContainsPointerType(value))
     return;
 
   auto & addressLocation = Context_->GetLocation(address);
@@ -1163,7 +1163,7 @@ Steensgaard::AnalyzeDirectCall(const CallNode & callNode, const lambda::node & l
     auto & callArgument = *callNode.input(n)->origin();
     auto & lambdaArgument = *lambdaNode.fctargument(n - 1);
 
-    if (IsOrContainsPointerType(callArgument))
+    if (HasOrContainsPointerType(callArgument))
     {
       auto & callArgumentLocation = Context_->GetLocation(callArgument);
       auto & lambdaArgumentLocation =
@@ -1181,7 +1181,7 @@ Steensgaard::AnalyzeDirectCall(const CallNode & callNode, const lambda::node & l
     auto & callResult = *callNode.output(n);
     auto & lambdaResult = *subregion->result(n)->origin();
 
-    if (IsOrContainsPointerType(callResult))
+    if (HasOrContainsPointerType(callResult))
     {
       auto & callResultLocation =
           Context_->GetOrInsertRegisterLocation(callResult, PointsToFlags::PointsToNone);
@@ -1201,7 +1201,7 @@ Steensgaard::AnalyzeExternalCall(const CallNode & callNode)
   {
     auto & callArgument = *callNode.input(n)->origin();
 
-    if (IsOrContainsPointerType(callArgument))
+    if (HasOrContainsPointerType(callArgument))
     {
       MarkAsEscaped(callArgument);
     }
@@ -1211,7 +1211,7 @@ Steensgaard::AnalyzeExternalCall(const CallNode & callNode)
   {
     auto & callResult = *callNode.Result(n);
 
-    if (IsOrContainsPointerType(callResult))
+    if (HasOrContainsPointerType(callResult))
     {
       Context_->GetOrInsertRegisterLocation(
           callResult,
@@ -1231,7 +1231,7 @@ Steensgaard::AnalyzeIndirectCall(const CallNode & callNode)
   {
     auto & callResult = *callNode.output(n);
 
-    if (IsOrContainsPointerType(callResult))
+    if (HasOrContainsPointerType(callResult))
     {
       Context_->GetOrInsertRegisterLocation(
           callResult,
@@ -1260,7 +1260,7 @@ Steensgaard::AnalyzeBitcast(const jlm::rvsdg::simple_node & node)
   auto & operand = *node.input(0)->origin();
   auto & result = *node.output(0);
 
-  if (IsOrContainsPointerType(operand))
+  if (HasOrContainsPointerType(operand))
   {
     auto & operandLocation = Context_->GetLocation(operand);
     auto & resultLocation = Context_->InsertRegisterLocation(result, PointsToFlags::PointsToNone);
@@ -1288,7 +1288,7 @@ Steensgaard::AnalyzeExtractValue(const jlm::rvsdg::simple_node & node)
 
   auto & result = *node.output(0);
 
-  if (IsOrContainsPointerType(result))
+  if (HasOrContainsPointerType(result))
   {
     // FIXME: Have a look at this operation again to ensure that the flags add up.
     Context_->InsertRegisterLocation(
@@ -1313,7 +1313,7 @@ Steensgaard::AnalyzeConstantAggregateZero(const jlm::rvsdg::simple_node & node)
   JLM_ASSERT(is<ConstantAggregateZero>(&node));
   auto & output = *node.output(0);
 
-  if (IsOrContainsPointerType(output))
+  if (HasOrContainsPointerType(output))
   {
     // ConstantAggregateZero cannot point to any memory location. We therefore only insert a
     // register node for it, but let this node not point to anything.
@@ -1327,7 +1327,7 @@ Steensgaard::AnalyzeUndef(const jlm::rvsdg::simple_node & node)
   JLM_ASSERT(is<UndefValueOperation>(&node));
   auto & output = *node.output(0);
 
-  if (IsOrContainsPointerType(output))
+  if (HasOrContainsPointerType(output))
   {
     // UndefValue cannot point to any memory location. We therefore only insert a register node for
     // it, but let this node not point to anything.
@@ -1421,7 +1421,7 @@ Steensgaard::AnalyzeLambda(const lambda::node & lambda)
   {
     auto & origin = *cv.origin();
 
-    if (IsOrContainsPointerType(origin))
+    if (HasOrContainsPointerType(origin))
     {
       auto & originLocation = Context_->GetLocation(origin);
       auto & argumentLocation =
@@ -1436,7 +1436,7 @@ Steensgaard::AnalyzeLambda(const lambda::node & lambda)
   {
     for (auto & argument : lambda.fctarguments())
     {
-      if (IsOrContainsPointerType(argument))
+      if (HasOrContainsPointerType(argument))
       {
         Context_->GetOrInsertRegisterLocation(argument, PointsToFlags::PointsToNone);
       }
@@ -1447,7 +1447,7 @@ Steensgaard::AnalyzeLambda(const lambda::node & lambda)
     // FIXME: We also end up in this case when the lambda has only direct calls, but is exported.
     for (auto & argument : lambda.fctarguments())
     {
-      if (IsOrContainsPointerType(argument))
+      if (HasOrContainsPointerType(argument))
         Context_->GetOrInsertRegisterLocation(
             argument,
             PointsToFlags::PointsToExternalMemory | PointsToFlags::PointsToEscapedMemory);
@@ -1463,7 +1463,7 @@ Steensgaard::AnalyzeLambda(const lambda::node & lambda)
     {
       auto & operand = *result.origin();
 
-      if (IsOrContainsPointerType(operand))
+      if (HasOrContainsPointerType(operand))
       {
         MarkAsEscaped(operand);
       }
@@ -1485,7 +1485,7 @@ Steensgaard::AnalyzeDelta(const delta::node & delta)
   {
     auto & origin = *input.origin();
 
-    if (IsOrContainsPointerType(origin))
+    if (HasOrContainsPointerType(origin))
     {
       auto & originLocation = Context_->GetLocation(origin);
       auto & argumentLocation =
@@ -1517,7 +1517,7 @@ Steensgaard::AnalyzePhi(const phi::node & phi)
   {
     auto & origin = *cv->origin();
 
-    if (IsOrContainsPointerType(origin))
+    if (HasOrContainsPointerType(origin))
     {
       auto & originLocation = Context_->GetLocation(origin);
       auto & argumentLocation =
@@ -1531,7 +1531,7 @@ Steensgaard::AnalyzePhi(const phi::node & phi)
   {
     auto & argument = *rv->argument();
 
-    if (IsOrContainsPointerType(argument))
+    if (HasOrContainsPointerType(argument))
     {
       Context_->InsertRegisterLocation(argument, PointsToFlags::PointsToNone);
     }
@@ -1546,7 +1546,7 @@ Steensgaard::AnalyzePhi(const phi::node & phi)
     auto & output = *rv.output();
     auto & result = *rv->result();
 
-    if (IsOrContainsPointerType(argument))
+    if (HasOrContainsPointerType(argument))
     {
       auto & originLocation = Context_->GetLocation(*result.origin());
       auto & argumentLocation = Context_->GetLocation(argument);
@@ -1566,7 +1566,7 @@ Steensgaard::AnalyzeGamma(const jlm::rvsdg::gamma_node & node)
   {
     auto & origin = *ev->origin();
 
-    if (IsOrContainsPointerType(origin))
+    if (HasOrContainsPointerType(origin))
     {
       auto & originLocation = Context_->GetLocation(*ev->origin());
       for (auto & argument : *ev)
@@ -1587,7 +1587,7 @@ Steensgaard::AnalyzeGamma(const jlm::rvsdg::gamma_node & node)
   {
     auto & output = *ex.output();
 
-    if (IsOrContainsPointerType(output))
+    if (HasOrContainsPointerType(output))
     {
       auto & outputLocation = Context_->InsertRegisterLocation(output, PointsToFlags::PointsToNone);
       for (auto & result : *ex)
@@ -1604,7 +1604,7 @@ Steensgaard::AnalyzeTheta(const jlm::rvsdg::theta_node & theta)
 {
   for (auto thetaOutput : theta)
   {
-    if (IsOrContainsPointerType(*thetaOutput))
+    if (HasOrContainsPointerType(*thetaOutput))
     {
       auto & originLocation = Context_->GetLocation(*thetaOutput->input()->origin());
       auto & argumentLocation =
@@ -1618,7 +1618,7 @@ Steensgaard::AnalyzeTheta(const jlm::rvsdg::theta_node & theta)
 
   for (auto thetaOutput : theta)
   {
-    if (IsOrContainsPointerType(*thetaOutput))
+    if (HasOrContainsPointerType(*thetaOutput))
     {
       auto & originLocation = Context_->GetLocation(*thetaOutput->result()->origin());
       auto & argumentLocation = Context_->GetLocation(*thetaOutput->argument());
@@ -1667,7 +1667,7 @@ Steensgaard::AnalyzeRegion(jlm::rvsdg::region & region)
   for (size_t n = 0; n < region.narguments(); n++)
   {
     auto & argument = *region.argument(n);
-    if (IsOrContainsPointerType(argument))
+    if (HasOrContainsPointerType(argument))
     {
       JLM_ASSERT(Context_->HasRegisterLocation(argument));
     }
@@ -1709,7 +1709,7 @@ Steensgaard::AnalyzeImports(const rvsdg::graph & graph)
   {
     auto & argument = *rootRegion->argument(n);
 
-    if (IsOrContainsPointerType(argument))
+    if (HasOrContainsPointerType(argument))
     {
       auto & importLocation = Context_->InsertImportLocation(argument);
       auto & registerLocation =

--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -3746,7 +3746,7 @@ VariadicFunctionTest1::SetupRvsdg()
     auto five = jlm::rvsdg::create_bitconstant(LambdaG_->subregion(), 32, 5);
 
     auto allocaResults = alloca_op::create(rvsdg::bit32, one, 4);
-    auto merge = MemStateMergeOperator::Create({ allocaResults[1], LambdaG_->fctargument(1) });
+    auto merge = MemStateMergeOperator::Create({ allocaResults[1], memoryStateArgument });
 
     auto storeResults = StoreNode::Create(allocaResults[0], five, { merge }, 4);
 

--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -3728,6 +3728,7 @@ VariadicFunctionTest1::SetupRvsdg()
         lambdaHArgument,
         lambdaHType,
         { one, varArgList, iOStateArgument, memoryStateArgument, loopStateArgument });
+    CallH_ = util::AssertedCast<llvm::CallNode>(rvsdg::node_output::node(callHResults[0]));
 
     auto storeResults = StoreNode::Create(callHResults[0], three, { callHResults[2] }, 4);
 
@@ -3747,6 +3748,7 @@ VariadicFunctionTest1::SetupRvsdg()
 
     auto allocaResults = alloca_op::create(rvsdg::bit32, one, 4);
     auto merge = MemStateMergeOperator::Create({ allocaResults[1], memoryStateArgument });
+    AllocaNode_ = rvsdg::node_output::node(allocaResults[0]);
 
     auto storeResults = StoreNode::Create(allocaResults[0], five, { merge }, 4);
 

--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -3683,4 +3683,82 @@ LambdaCallArgumentMismatch::SetupRvsdg()
   return rvsdgModule;
 }
 
+std::unique_ptr<llvm::RvsdgModule>
+VariadicFunctionTest1::SetupRvsdg()
+{
+  using namespace jlm::llvm;
+
+  auto rvsdgModule = RvsdgModule::Create(util::filepath(""), "", "");
+  auto & rvsdg = rvsdgModule->Rvsdg();
+  rvsdg.node_normal_form(typeid(rvsdg::operation))->set_mutable(false);
+
+  PointerType pointerType;
+  iostatetype iOStateType;
+  MemoryStateType memoryStateType;
+  loopstatetype loopStateType;
+  varargtype varArgType;
+  FunctionType lambdaHType(
+      { &jlm::rvsdg::bit32, &varArgType, &iOStateType, &memoryStateType, &loopStateType },
+      { &pointerType, &iOStateType, &memoryStateType, &loopStateType });
+  FunctionType lambdaFType(
+      { &pointerType, &iOStateType, &memoryStateType, &loopStateType },
+      { &iOStateType, &memoryStateType, &loopStateType });
+  FunctionType lambdaGType(
+      { &iOStateType, &memoryStateType, &loopStateType },
+      { &iOStateType, &memoryStateType, &loopStateType });
+
+  // Setup h()
+  ImportH_ = rvsdg.add_import(impport(lambdaHType, "h", linkage::external_linkage));
+
+  // Setup f()
+  {
+    LambdaF_ = lambda::node::create(rvsdg.root(), lambdaFType, "f", linkage::internal_linkage);
+    auto iArgument = LambdaF_->fctargument(0);
+    auto iOStateArgument = LambdaF_->fctargument(1);
+    auto memoryStateArgument = LambdaF_->fctargument(2);
+    auto loopStateArgument = LambdaF_->fctargument(3);
+    auto lambdaHArgument = LambdaF_->add_ctxvar(ImportH_);
+
+    auto one = jlm::rvsdg::create_bitconstant(LambdaF_->subregion(), 32, 1);
+    auto three = jlm::rvsdg::create_bitconstant(LambdaF_->subregion(), 32, 3);
+
+    auto varArgList = valist_op::Create(*LambdaF_->subregion(), { iArgument });
+
+    auto callHResults = CallNode::Create(
+        lambdaHArgument,
+        lambdaHType,
+        { one, varArgList, iOStateArgument, memoryStateArgument, loopStateArgument });
+
+    auto storeResults = StoreNode::Create(callHResults[0], three, { callHResults[2] }, 4);
+
+    LambdaF_->finalize({ callHResults[1], storeResults[0], callHResults[3] });
+  }
+
+  // Setup g()
+  {
+    LambdaG_ = lambda::node::create(rvsdg.root(), lambdaGType, "g", linkage::external_linkage);
+    auto iOStateArgument = LambdaG_->fctargument(0);
+    auto memoryStateArgument = LambdaG_->fctargument(1);
+    auto loopStateArgument = LambdaG_->fctargument(2);
+    auto lambdaFArgument = LambdaG_->add_ctxvar(LambdaF_->output());
+
+    auto one = jlm::rvsdg::create_bitconstant(LambdaG_->subregion(), 32, 1);
+    auto five = jlm::rvsdg::create_bitconstant(LambdaG_->subregion(), 32, 5);
+
+    auto allocaResults = alloca_op::create(rvsdg::bit32, one, 4);
+    auto merge = MemStateMergeOperator::Create({ allocaResults[1], LambdaG_->fctargument(1) });
+
+    auto storeResults = StoreNode::Create(allocaResults[0], five, { merge }, 4);
+
+    auto callFResults = CallNode::Create(
+        lambdaFArgument,
+        lambdaFType,
+        { allocaResults[0], iOStateArgument, storeResults[0], loopStateArgument });
+
+    LambdaG_->finalize(callFResults);
+  }
+
+  return rvsdgModule;
+}
+
 }

--- a/tests/TestRvsdgs.hpp
+++ b/tests/TestRvsdgs.hpp
@@ -2362,4 +2362,64 @@ private:
   llvm::lambda::node * LambdaMain_;
 };
 
+/**
+ * The class sets up an RVSDG module corresponding to the code:
+ *
+ * \code{.c}
+ *   #include <stdint.h>
+ *
+ *   uint32_t* h(uint32_t, ...);
+ *
+ *
+ *   static void
+ *   f(uint32_t * i)
+ *   {
+ *     uint32_t* x = h(1, i);
+ *     *x = 3;
+ *   }
+ *
+ *   void
+ *   g()
+ *   {
+ *     uint32_t i = 5;
+ *     f(&i);
+ *   }
+ * \endcode
+ *
+ * It uses a single memory state to sequentialize the respective memory operations.
+ */
+class VariadicFunctionTest1 final : public RvsdgTest
+{
+public:
+  [[nodiscard]] llvm::lambda::node &
+  LambdaF() const noexcept
+  {
+    JLM_ASSERT(LambdaF_ != nullptr);
+    return *LambdaF_;
+  }
+
+  [[nodiscard]] llvm::lambda::node &
+  LambdaG() const noexcept
+  {
+    JLM_ASSERT(LambdaG_ != nullptr);
+    return *LambdaG_;
+  }
+
+  [[nodiscard]] rvsdg::argument &
+  ImportH() const noexcept
+  {
+    JLM_ASSERT(ImportH_ != nullptr);
+    return *ImportH_;
+  }
+
+private:
+  std::unique_ptr<llvm::RvsdgModule>
+  SetupRvsdg() override;
+
+  llvm::lambda::node * LambdaF_ = {};
+  llvm::lambda::node * LambdaG_ = {};
+
+  rvsdg::argument * ImportH_ = {};
+};
+
 }

--- a/tests/TestRvsdgs.hpp
+++ b/tests/TestRvsdgs.hpp
@@ -2392,24 +2392,38 @@ class VariadicFunctionTest1 final : public RvsdgTest
 {
 public:
   [[nodiscard]] llvm::lambda::node &
-  LambdaF() const noexcept
+  GetLambdaF() const noexcept
   {
     JLM_ASSERT(LambdaF_ != nullptr);
     return *LambdaF_;
   }
 
   [[nodiscard]] llvm::lambda::node &
-  LambdaG() const noexcept
+  GetLambdaG() const noexcept
   {
     JLM_ASSERT(LambdaG_ != nullptr);
     return *LambdaG_;
   }
 
   [[nodiscard]] rvsdg::argument &
-  ImportH() const noexcept
+  GetImportH() const noexcept
   {
     JLM_ASSERT(ImportH_ != nullptr);
     return *ImportH_;
+  }
+
+  [[nodiscard]] llvm::CallNode &
+  GetCallH() const noexcept
+  {
+    JLM_ASSERT(CallH_ != nullptr);
+    return *CallH_;
+  }
+
+  [[nodiscard]] rvsdg::node &
+  GetAllocaNode() const noexcept
+  {
+    JLM_ASSERT(AllocaNode_ != nullptr);
+    return *AllocaNode_;
   }
 
 private:
@@ -2420,6 +2434,10 @@ private:
   llvm::lambda::node * LambdaG_ = {};
 
   rvsdg::argument * ImportH_ = {};
+
+  llvm::CallNode * CallH_ = {};
+
+  rvsdg::node * AllocaNode_ = {};
 };
 
 }

--- a/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
@@ -1232,6 +1232,31 @@ TestLambdaCallArgumentMismatch()
 }
 
 static void
+TestVariadicFunction1()
+{
+  // Arrange and Act
+  jlm::tests::VariadicFunctionTest1 test;
+  auto pointsToGraph = RunSteensgaard(test.module());
+
+  // Assert
+  assert(pointsToGraph->NumAllocaNodes() == 1);
+  assert(pointsToGraph->NumLambdaNodes() == 2);
+  assert(pointsToGraph->NumImportNodes() == 1);
+  assert(pointsToGraph->NumRegisterNodes() == 5);
+
+  auto & allocaMemoryNode = pointsToGraph->GetAllocaNode(test.GetAllocaNode());
+  auto & externalMemoryNode = pointsToGraph->GetExternalMemoryNode();
+
+  auto & callOutput = pointsToGraph->GetRegisterNode(*test.GetCallH().output(0));
+
+  auto & escapedMemoryNodes = pointsToGraph->GetEscapedMemoryNodes();
+  assert(escapedMemoryNodes.Size() == 1);
+  assert(escapedMemoryNodes.Contains(&allocaMemoryNode));
+
+  assertTargets(callOutput, { &allocaMemoryNode, &externalMemoryNode });
+}
+
+static void
 TestStatistics()
 {
   // Arrange
@@ -1303,6 +1328,8 @@ TestSteensgaardAnalysis()
   TestLinkedList();
 
   TestLambdaCallArgumentMismatch();
+
+  TestVariadicFunction1();
 
   TestStatistics();
 


### PR DESCRIPTION
The variadic arguments of external function calls were so far not handled and marked as escaped in Steensgaard. This PR fixes this.