### PR TITLE
Fix handling of variadic arguments in Steensgaard

### DIFF
--- a/jlm/llvm/ir/operators/operators.hpp
+++ b/jlm/llvm/ir/operators/operators.hpp
@@ -1798,6 +1798,22 @@ public:
     ConstantArray op(*vt, elements.size());
     return tac::create(op, elements);
   }
+
+  static rvsdg::output *
+  Create(const std::vector<rvsdg::output *> & operands)
+  {
+    if (operands.empty())
+      throw util::error("Expected at least one element.\n");
+
+    auto valueType = dynamic_cast<const rvsdg::valuetype *>(&operands[0]->type());
+    if (!valueType)
+    {
+      throw util::error("Expected value type.\n");
+    }
+
+    ConstantArray operation(*valueType, operands.size());
+    return rvsdg::simple_node::create_normalized(operands[0]->region(), operation, operands)[0];
+  }
 };
 
 /* ConstantAggregateZero operator */

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -746,20 +746,26 @@ public:
         auto pointsToLabel = jlm::util::strfmt("{pt:", (intptr_t)location->GetPointsTo(), "}");
         auto locationLabel = jlm::util::strfmt((intptr_t)location, " : ", location->DebugString());
 
-        setLabel += location == rootLocation ? jlm::util::strfmt(
-                                                   "*",
-                                                   locationLabel,
-                                                   unknownLabel,
-                                                   pointsToEscapedMemoryLabel,
-                                                   escapesModuleLabel,
-                                                   pointsToLabel,
-                                                   "*\\n")
-                                             : jlm::util::strfmt(
-                                                   locationLabel,
-                                                   unknownLabel,
-                                                   pointsToEscapedMemoryLabel,
-                                                   escapesModuleLabel,
-                                                   "\\n");
+        if (location == rootLocation)
+        {
+          setLabel += jlm::util::strfmt(
+              "*",
+              locationLabel,
+              unknownLabel,
+              pointsToEscapedMemoryLabel,
+              escapesModuleLabel,
+              pointsToLabel,
+              "*\\n");
+        }
+        else
+        {
+          setLabel += jlm::util::strfmt(
+              locationLabel,
+              unknownLabel,
+              pointsToEscapedMemoryLabel,
+              escapesModuleLabel,
+              "\\n");
+        }
       }
 
       return jlm::util::strfmt("{ ", (intptr_t)&set, " [label = \"", setLabel, "\"]; }");

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
@@ -144,6 +144,9 @@ private:
   void
   AnalyzeExtractValue(const rvsdg::simple_node & node);
 
+  void
+  AnalyzeVaList(const rvsdg::simple_node & node);
+
   /**
    * Marks register \p output as escaping the module. This indicates that the pointer in \p output
    * is going outside the module, where we do not know what happens with it. Consequently, the

--- a/jlm/rvsdg/control.hpp
+++ b/jlm/rvsdg/control.hpp
@@ -195,7 +195,31 @@ public:
     return mapping_.end();
   }
 
+  static output *
+  Create(
+      output & predicate,
+      const std::unordered_map<uint64_t, uint64_t> & mapping,
+      uint64_t defaultAlternative,
+      size_t numAlternatives)
+  {
+    auto bitType = CheckAndExtractBitType(predicate.type());
+
+    match_op operation(bitType.nbits(), mapping, defaultAlternative, numAlternatives);
+    return rvsdg::simple_node::create_normalized(predicate.region(), operation, { &predicate })[0];
+  }
+
 private:
+  static const bittype &
+  CheckAndExtractBitType(const rvsdg::type & type)
+  {
+    if (auto bitType = dynamic_cast<const bittype *>(&type))
+    {
+      return *bitType;
+    }
+
+    throw util::type_error("bittype", type.debug_string());
+  }
+
   uint64_t default_alternative_;
   std::unordered_map<uint64_t, uint64_t> mapping_;
 };

--- a/tests/TestRvsdgs.hpp
+++ b/tests/TestRvsdgs.hpp
@@ -2440,4 +2440,68 @@ private:
   rvsdg::node * AllocaNode_ = {};
 };
 
+/**
+ * This class sets up an RVSDG representing the following code:
+ *
+ * \code{.c}
+ *   #include <stdarg.h>
+ *   #include <stdio.h>
+ *   #include <stdint.h>
+ *
+ *   static int
+ *   fst(int n, ...)
+ *   {
+ *     va_list arguments;
+ *     va_start(arguments, n);
+ *     int tmp = va_arg(arguments, int);
+ *     va_end(arguments);
+ *
+ *     return tmp;
+ *   }
+ *
+ *   int
+ *   g()
+ *   {
+ *     return fst(3, 0, 1, 2);
+ *   }
+ * \endcode
+ *
+ * It uses a single memory state to sequentialize the respective memory operations within each
+ * function. The code produced by the compiler for variadic functions is architecture specific. This
+ * function sets up the code that was produced for x64.
+ */
+class VariadicFunctionTest2 final : public RvsdgTest
+{
+public:
+  [[nodiscard]] const jlm::llvm::lambda::node &
+  GetLambdaFst() const noexcept
+  {
+    JLM_ASSERT(LambdaFst_ != nullptr);
+    return *LambdaFst_;
+  }
+
+  [[nodiscard]] const jlm::llvm::lambda::node &
+  GetLambdaG() const noexcept
+  {
+    JLM_ASSERT(LambdaG_ != nullptr);
+    return *LambdaG_;
+  }
+
+  [[nodiscard]] rvsdg::node &
+  GetAllocaNode() const noexcept
+  {
+    JLM_ASSERT(AllocaNode_ != nullptr);
+    return *AllocaNode_;
+  }
+
+private:
+  std::unique_ptr<jlm::llvm::RvsdgModule>
+  SetupRvsdg() override;
+
+  jlm::llvm::lambda::node * LambdaFst_ = {};
+  jlm::llvm::lambda::node * LambdaG_ = {};
+
+  rvsdg::node * AllocaNode_ = {};
+};
+
 }

--- a/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
@@ -1257,6 +1257,32 @@ TestVariadicFunction1()
 }
 
 static void
+TestVariadicFunction2()
+{
+  std::unordered_map<const jlm::rvsdg::output *, std::string> outputMap;
+
+  // Arrange
+  jlm::tests::VariadicFunctionTest2 test;
+  std::cout << jlm::rvsdg::view(test.module().Rvsdg().root(), outputMap) << std::flush;
+
+  // Act
+  auto pointsToGraph = RunSteensgaard(test.module());
+  std::cout << jlm::llvm::aa::PointsToGraph::ToDot(*pointsToGraph, outputMap);
+
+  // Assert
+  assert(pointsToGraph->NumAllocaNodes() == 1);
+  assert(pointsToGraph->NumLambdaNodes() == 2);
+  assert(pointsToGraph->NumImportNodes() == 4);
+  assert(pointsToGraph->NumRegisterNodes() == 8);
+
+  auto & allocaMemoryNode = pointsToGraph->GetAllocaNode(test.GetAllocaNode());
+
+  auto escapedMemoryNodes = pointsToGraph->GetEscapedMemoryNodes();
+  assert(escapedMemoryNodes.Size() == 1);
+  assert(escapedMemoryNodes.Contains(&allocaMemoryNode));
+}
+
+static void
 TestStatistics()
 {
   // Arrange
@@ -1330,6 +1356,7 @@ TestSteensgaardAnalysis()
   TestLambdaCallArgumentMismatch();
 
   TestVariadicFunction1();
+  TestVariadicFunction2();
 
   TestStatistics();
 

--- a/tests/test-util.hpp
+++ b/tests/test-util.hpp
@@ -30,10 +30,10 @@ namespace jlm::tests
 {
 
 static inline void
-print(const llvm::Module & module)
+print(const ::llvm::Module & module)
 {
-  llvm::raw_os_ostream os(std::cout);
-  module.print(os, NULL);
+  ::llvm::raw_os_ostream os(std::cout);
+  module.print(os, nullptr);
 }
 
 }


### PR DESCRIPTION
This PR does the following:

1. Fixes the handling of variadic arguments in Steensgaard for good.
2. Adds some RVSDG creators for different operations such that they are easier to create in the added unit test
3. Fixes the LLVM print function in test-util.hpp
4. Adds a variadic argument unit test. 