### PR TITLE
More expressive bitvalue comparison error messages

### DIFF
--- a/jlm/rvsdg/bitstring/value-representation.hpp
+++ b/jlm/rvsdg/bitstring/value-representation.hpp
@@ -169,7 +169,7 @@ private:
     JLM_ASSERT(remainder == 0);
 
     if (divisor.nbits() != nbits())
-      throw jlm::util::error("Unequal number of bits.");
+      throw jlm::util::error("Unequal number of bits in udiv.");
 
     /*
       FIXME: This should check whether divisor is zero, not whether nbits() is zero.
@@ -382,7 +382,7 @@ public:
   ult(const bitvalue_repr & other) const
   {
     if (nbits() != other.nbits())
-      throw jlm::util::error("Unequal number of bits.");
+      throw jlm::util::error("Unequal number of bits in ult.");
 
     char v = land(lnot(data_[0]), other[0]);
     for (size_t n = 1; n < nbits(); n++)
@@ -404,7 +404,7 @@ public:
   ule(const bitvalue_repr & other) const
   {
     if (nbits() != other.nbits())
-      throw jlm::util::error("Unequal number of bits.");
+      throw jlm::util::error("Unequal number of bits in ule.");
 
     char v = '1';
     for (size_t n = 0; n < nbits(); n++)
@@ -426,7 +426,10 @@ public:
   ne(const bitvalue_repr & other) const
   {
     if (nbits() != other.nbits())
-      throw jlm::util::error("Unequal number of bits.");
+    {
+      const std::string & msg = "Unequal number of bits in ne, " + std::to_string(nbits()) + " != " + std::to_string(other.nbits());
+      throw jlm::util::error(msg);
+    }
 
     char v = '0';
     for (size_t n = 0; n < nbits(); n++)
@@ -468,7 +471,7 @@ public:
   add(const bitvalue_repr & other) const
   {
     if (nbits() != other.nbits())
-      throw jlm::util::error("Unequal number of bits.");
+      throw jlm::util::error("Unequal number of bits in add.");
 
     char c = '0';
     bitvalue_repr sum = repeat(nbits(), 'X');
@@ -485,7 +488,7 @@ public:
   land(const bitvalue_repr & other) const
   {
     if (nbits() != other.nbits())
-      throw jlm::util::error("Unequal number of bits.");
+      throw jlm::util::error("Unequal number of bits in land.");
 
     bitvalue_repr result = repeat(nbits(), 'X');
     for (size_t n = 0; n < nbits(); n++)
@@ -498,7 +501,7 @@ public:
   lor(const bitvalue_repr & other) const
   {
     if (nbits() != other.nbits())
-      throw jlm::util::error("Unequal number of bits.");
+      throw jlm::util::error("Unequal number of bits in lor.");
 
     bitvalue_repr result = repeat(nbits(), 'X');
     for (size_t n = 0; n < nbits(); n++)
@@ -511,7 +514,7 @@ public:
   lxor(const bitvalue_repr & other) const
   {
     if (nbits() != other.nbits())
-      throw jlm::util::error("Unequal number of bits.");
+      throw jlm::util::error("Unequal number of bits in lxor.");
 
     bitvalue_repr result = repeat(nbits(), 'X');
     for (size_t n = 0; n < nbits(); n++)
@@ -644,7 +647,7 @@ public:
   mul(const bitvalue_repr & other) const
   {
     if (nbits() != other.nbits())
-      throw jlm::util::error("Unequal number of bits.");
+      throw jlm::util::error("Unequal number of bits in mul.");
 
     bitvalue_repr product(2 * nbits(), 0);
     mul(*this, other, product);
@@ -655,7 +658,7 @@ public:
   umulh(const bitvalue_repr & other) const
   {
     if (nbits() != other.nbits())
-      throw jlm::util::error("Unequal number of bits.");
+      throw jlm::util::error("Unequal number of bits in umulh.");
 
     bitvalue_repr product(4 * nbits(), 0);
     bitvalue_repr factor1 = this->zext(nbits());
@@ -668,7 +671,7 @@ public:
   smulh(const bitvalue_repr & other) const
   {
     if (nbits() != other.nbits())
-      throw jlm::util::error("Unequal number of bits.");
+      throw jlm::util::error("Unequal number of bits in smulh.");
 
     bitvalue_repr product(4 * nbits(), 0);
     bitvalue_repr factor1 = this->sext(nbits());


### PR DESCRIPTION
Really small pull request that changes error messages in `rvsdg/bitstring/value-representation.hpp` to specify operation name in "Unequal number of bits" errors.