### PR TITLE
Fix various issues in Steensgaard

### DIFF
--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -986,6 +986,10 @@ Steensgaard::AnalyzeSimpleNode(const jlm::rvsdg::simple_node & node)
   {
     AnalyzeBits2ptr(node);
   }
+  else if (is<ptr2bits_op>(&node))
+  {
+    AnalyzePtr2Bits(node);
+  }
   else if (is<ConstantPointerNullOperation>(&node))
   {
     AnalyzeConstantPointerNull(node);
@@ -1262,6 +1266,14 @@ Steensgaard::AnalyzeBits2ptr(const jlm::rvsdg::simple_node & node)
       // The register location already points to unknown memory. Unknown memory is a superset of
       // escaped memory, and therefore we can simply set escaped memory to false.
       PointsToFlags::PointsToUnknownMemory | PointsToFlags::PointsToExternalMemory);
+}
+
+void
+Steensgaard::AnalyzePtr2Bits(const rvsdg::simple_node & node)
+{
+  JLM_ASSERT(is<ptr2bits_op>(&node));
+
+  MarkAsEscaped(*node.input(0)->origin());
 }
 
 void

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -628,7 +628,6 @@ public:
    * Otherwise creates a new location for register \p output with PointsToFlags::PointsToNone.
    *
    * @param output A register.
-   * @param pointsToFlags The points-to flags associated with the newly created location.
    * @return A Location.
    *
    * \note It is deliberate that only GetOrInsertRegisterLocation() instead of also

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
@@ -124,6 +124,9 @@ private:
   AnalyzeBits2ptr(const rvsdg::simple_node & node);
 
   void
+  AnalyzePtr2Bits(const rvsdg::simple_node & node);
+
+  void
   AnalyzeConstantPointerNull(const rvsdg::simple_node & node);
 
   void


### PR DESCRIPTION
The PR fixes the following issues:

1. Added handling of missing ptr2bits operation
2. Fix handling of ConstantArray and ConstantStruct. The insertion of the output location was performed in the loop for the nodes' inputs. This would lead to multiple creation attempts in case of multiple pointer inputs and therefore fail. Moreover, the handling of the nodes was changed by analyzing types instead of checking for previously created locations. This is more intuitive and in line with the handling of all other nodes.
3. Utilize GetOrInsertRegisterLocation() everywhere instead of InsertRegisterLocation(). The opposite was done in a recent PR, i.e., utilize InsertRegisterLocation() instead of the more general GetOrInsertRegisterLocation(), but this was simply incorrect and leads to bugs in case of recursive functions. I also added some documentation of why simply using InsertRegisterLocation() is incorrect such that I won't forget it again and make the same mistake in future.

I provided no unit tests for this PR as these problems were discovered with the LLVM test suite. I will provide another PR soon where I add a check for the SteengaardAgnostic pass to the CI. The above issues would be discovered in this check if they would reappear.