### PR TITLE
Ensure proper memory node propagation in RegionAwareMemoryNodeProvider

### DIFF
--- a/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.cpp
+++ b/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.cpp
@@ -898,8 +898,8 @@ RegionAwareMemoryNodeProvider::PropagatePhi(const phi::node & phiNode)
         {
           subregionSummary.AddMemoryNodes(memoryNodes);
           subregionSummary.AddUnknownMemoryNodeReferences(unknownMemoryNodeReferences);
-          RegionSummary::Propagate(regionSummary, subregionSummary);
         }
+        RegionSummary::Propagate(regionSummary, subregionSummary);
       }
     }
   };

--- a/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.hpp
+++ b/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.hpp
@@ -185,6 +185,18 @@ private:
   static bool
   ShouldCreateRegionSummary(const rvsdg::region & region);
 
+  /**
+   * Converts \p rvsdg to an annotated region tree. This method is very useful for debugging the
+   * RegionAwareMemoryNodeProvider.
+   *
+   * @param rvsdg The RVSDG that is converted to a region tree.
+   * @param provisioning The provisioning used for annotating the region tree.
+   *
+   * @return A string that contains the region tree.
+   */
+  static std::string
+  ToRegionTree(const rvsdg::graph & rvsdg, const RegionAwareMemoryNodeProvisioning & provisioning);
+
   std::unique_ptr<RegionAwareMemoryNodeProvisioning> Provisioning_;
 };
 


### PR DESCRIPTION
This PR does the following:

1. Fixes an issue where memory nodes assigned to the region of a recursive call were not properly propagated upwards in the region tree. The issue arose as the method execution in the code was only executed conditionally even though it should have been unconditionally.
2. Splits up the single invariant check to two checks such that it is easier to deduce problems in the future.
3. Adds a debug method for printing annotated region trees.

Closes #281
Closes #201 