### PR TITLE
Use clone of Andersen's variable and constraint set when double checking

### DIFF
--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -824,7 +824,7 @@ Andersen::AnalyzeModule(const RvsdgModule & module, Statistics & statistics)
 }
 
 void
-Andersen::SolveConstraints(Configuration config, Statistics & statistics)
+Andersen::SolveConstraints(const Configuration & config, Statistics & statistics)
 {
   if (config.GetSolver() == Configuration::Solver::Naive)
   {

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -742,7 +742,6 @@ Andersen::AnalyzeRegion(rvsdg::region & region)
   // PointerObjects for any of the node's outputs of pointer type
   for (const auto node : traverser)
   {
-
     if (auto simpleNode = dynamic_cast<const rvsdg::simple_node *>(node))
       AnalyzeSimpleNode(*simpleNode);
     else if (auto structuralNode = dynamic_cast<const rvsdg::structural_node *>(node))

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -36,9 +36,6 @@ class Andersen::Statistics final : public util::Statistics
   inline static const char * NumLoadConstraints_ = "#LoadConstraints";
   inline static const char * NumFunctionCallConstraints_ = "#FunctionCallConstraints";
 
-  inline static const char * NumUnificationsOVS_ = "#Unifications(OVS)";
-  inline static const char * NumConstraintsRemovedOfflineNorm_ = "#ConstraintsRemoved(OfflineNorm)";
-
   inline static const char * NumNaiveSolverIterations_ = "#NaiveSolverIterations";
   inline static const char * NumWorklistSolverWorkItems_ = "#WorklistSolverWorkItems";
 
@@ -100,32 +97,6 @@ public:
     AddMeasurement(NumStoreConstraints_, numStoreConstraints);
     AddMeasurement(NumLoadConstraints_, numLoadConstraints);
     AddMeasurement(NumFunctionCallConstraints_, numFunctionCallConstraints);
-  }
-
-  void
-  StartOfflineVariableSubstitution() noexcept
-  {
-    AddTimer(OfflineVariableSubstitutionTimer_).start();
-  }
-
-  void
-  StopOfflineVariableSubstitution(size_t numUnifications) noexcept
-  {
-    GetTimer(OfflineVariableSubstitutionTimer_).stop();
-    AddMeasurement(NumUnificationsOVS_, numUnifications);
-  }
-
-  void
-  StartOfflineConstraintNormalization() noexcept
-  {
-    AddTimer(OfflineConstraintNormalizationTimer_).start();
-  }
-
-  void
-  StopOfflineConstraintNormalization(size_t numConstraintsRemoved) noexcept
-  {
-    GetTimer(OfflineConstraintNormalizationTimer_).stop();
-    AddMeasurement(NumConstraintsRemovedOfflineNorm_, numConstraintsRemoved);
   }
 
   void

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -41,8 +41,6 @@ class Andersen::Statistics final : public util::Statistics
 
   inline static const char * AnalysisTimer_ = "AnalysisTimer";
   inline static const char * SetAndConstraintBuildingTimer_ = "SetAndConstraintBuildingTimer";
-  inline static const char * OfflineVariableSubstitutionTimer_ = "OVSTimer";
-  inline static const char * OfflineConstraintNormalizationTimer_ = "OfflineNormTimer";
   inline static const char * ConstraintSolvingNaiveTimer_ = "ConstraintSolvingNaiveTimer";
   inline static const char * ConstraintSolvingWorklistTimer_ = "ConstraintSolvingWorklistTimer";
   inline static const char * PointsToGraphConstructionTimer_ = "PointsToGraphConstructionTimer";

--- a/jlm/llvm/opt/alias-analyses/Andersen.hpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.hpp
@@ -48,18 +48,6 @@ public:
         : Solver_(solver)
     {}
 
-    void
-    SetSolver(Solver solver)
-    {
-      Solver_ = solver;
-    }
-
-    [[nodiscard]] Solver
-    GetSolver() const
-    {
-      return Solver_;
-    }
-
     [[nodiscard]] bool
     operator==(const Configuration & other) const
     {
@@ -72,12 +60,38 @@ public:
       return !operator==(other);
     }
 
+    /**
+     * Sets which solver algorithm to use.
+     * Not all solvers are compatible with all online techniques.
+     */
+    void
+    SetSolver(Solver solver)
+    {
+      Solver_ = solver;
+    }
+
+    [[nodiscard]] Solver
+    GetSolver() const noexcept
+    {
+      return Solver_;
+    }
+
+    /**
+     * Creates a solver configuration using the worklist solver,
+     * with the default set of offline and online techniques enabled.
+     * @return the solver configuration
+     */
     [[nodiscard]] static Configuration
     WorklistSolverConfiguration()
     {
       return Configuration(Solver::Worklist);
     }
 
+    /**
+     * Creates a solver configuration using the naive solver,
+     * with all offline and online speedup techniques disabled.
+     * @return the solver configuration
+     */
     [[nodiscard]] static Configuration
     NaiveSolverConfiguration()
     {
@@ -85,7 +99,7 @@ public:
     }
 
   private:
-    Solver Solver_;
+    Solver Solver_ = Solver::Worklist;
   };
 
   ~Andersen() noexcept override = default;
@@ -232,8 +246,23 @@ private:
   void
   AnalyzeRvsdg(const rvsdg::graph & graph);
 
-  std::unique_ptr<PointsToGraph>
-  AnalyzeModule(const RvsdgModule & module, util::StatisticsCollector & statisticsCollector);
+  /**
+   * Traverses the given module, and initializes the members Set_ and Constraints_ with
+   * PointerObjects and constraints corresponding to the module.
+   * @param module the module to analyze
+   * @param statistics the Statistics instance used to track info about the analysis
+   */
+  void
+  AnalyzeModule(const RvsdgModule & module, Statistics & statistics);
+
+  /**
+   * Works with the members Set_ and Constraints_, and solves the constraint problem
+   * using the techniques and solver specified in the given configuration
+   * @param config settings for the solving
+   * @param statistics the Statistics instance used to track info about the analysis
+   */
+  void
+  SolveConstraints(Configuration config, Statistics & statistics);
 
   Configuration Config_ = Configuration::WorklistSolverConfiguration();
 

--- a/jlm/llvm/opt/alias-analyses/Andersen.hpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.hpp
@@ -99,7 +99,7 @@ public:
     }
 
   private:
-    Solver Solver_ = Solver::Worklist;
+    Solver Solver_;
   };
 
   ~Andersen() noexcept override = default;
@@ -262,7 +262,7 @@ private:
    * @param statistics the Statistics instance used to track info about the analysis
    */
   void
-  SolveConstraints(Configuration config, Statistics & statistics);
+  SolveConstraints(const Configuration & config, Statistics & statistics);
 
   Configuration Config_ = Configuration::WorklistSolverConfiguration();
 

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
@@ -363,6 +363,12 @@ PointerObjectSet::MarkAllPointeesAsEscaped(PointerObjectIndex pointer)
   return modified;
 }
 
+std::unique_ptr<PointerObjectSet>
+PointerObjectSet::Clone() const
+{
+  return std::make_unique<PointerObjectSet>(*this);
+}
+
 // Makes P(superset) a superset of P(subset)
 bool
 SupersetConstraint::ApplyDirectly(PointerObjectSet & set)
@@ -906,6 +912,16 @@ PointerObjectConstraintSet::SolveNaively()
   }
 
   return numIterations;
+}
+
+std::pair<std::unique_ptr<PointerObjectSet>, std::unique_ptr<PointerObjectConstraintSet>>
+PointerObjectConstraintSet::Clone() const
+{
+  auto setClone = Set_.Clone();
+  auto constraintClone = std::make_unique<PointerObjectConstraintSet>(*setClone);
+  for (auto constraint : Constraints_)
+    constraintClone->AddConstraint(constraint);
+  return std::make_pair(std::move(setClone), std::move(constraintClone));
 }
 
 } // namespace jlm::llvm::aa

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Håvard Krogstie <krogstie.havard@gmail.com>
+ * Copyright 2023, 2024 Håvard Krogstie <krogstie.havard@gmail.com>
  * See COPYING for terms of redistribution.
  */
 
@@ -349,6 +349,14 @@ public:
    */
   bool
   MarkAllPointeesAsEscaped(PointerObjectIndex pointer);
+
+  /**
+   * Creates a clone of this PointerObjectSet, with all the same PointerObjects,
+   * flags, unifications and points-to sets.
+   * @return an owned clone of this
+   */
+  [[nodiscard]] std::unique_ptr<PointerObjectSet>
+  Clone() const;
 };
 
 /**
@@ -722,6 +730,14 @@ public:
    */
   size_t
   SolveNaively();
+
+  /**
+   * Creates a clone of this constraint set, and the underlying PointerObjectSet.
+   * The result is an identical copy, containing no references to the original.
+   * @return the cloned PointerObjectSet and PointerObjectConstraintSet
+   */
+  std::pair<std::unique_ptr<PointerObjectSet>, std::unique_ptr<PointerObjectConstraintSet>>
+  Clone() const;
 
 private:
   // The PointerObjectSet being built upon


### PR DESCRIPTION
I had some issues where the order nodes were traversed seemed different in the "main" analysis and the "double check" analysis. To make debugging easier, the double check now makes use of a copy of the constraint set, instead of creating the constraint set again.

@phate I tried looking into the `rvsdg::topdown_traverser`, and realized I might have misunderstood it. I initially thought it traversed the region in a topological order (all predecessors of X are visited before X), but now I'm not quite sure, as it kind of looks like "at least one predecessor of X has been visited before X". My analysis has however assumed the order to be topological, without any issues. Do you know if that's just been luck, or if it is somehow guaranteed?