### PR TITLE
[Andersen] Split HasEscaped into two flags

### DIFF
--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -774,8 +774,8 @@ Andersen::AnalyzeRvsdg(const rvsdg::graph & graph)
       continue;
 
     // TODO: Mark the created ImportMemoryObject based on it being a function or a variable
-    // Functions and non-pointer typed globals can not point to other MemoryObjects, so CanPoint()
-    // should be false
+    // Functions and non-pointer typed globals can not point to other MemoryObjects,
+    // so letting them be ShouldTrackPointees() == false aids analysis.
 
     // Create a memory PointerObject representing the target of the external symbol
     // We can assume that two external symbols don't alias, clang does.
@@ -964,6 +964,10 @@ Andersen::ConstructPointsToGraphFromPointerObjectSet(
   // PointerObject's points-to set.
   auto applyPointsToSet = [&](PointsToGraph::Node & node, PointerObjectIndex index)
   {
+    // PointerObjects marked as not tracking pointees should not point to anything
+    if (!set.ShouldTrackPointees(index))
+      return;
+
     // Add all PointsToGraph nodes who should point to external to the list
     if (set.IsPointingToExternal(index))
       pointsToExternal.push_back(&node);

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
@@ -193,17 +193,17 @@ PointerObjectSet::GetPointerObjectKind(PointerObjectIndex index) const noexcept
 }
 
 bool
-PointerObjectSet::CanPointerObjectPoint(PointerObjectIndex index) const noexcept
+PointerObjectSet::ShouldTrackPointees(PointerObjectIndex index) const noexcept
 {
   JLM_ASSERT(index < NumPointerObjects());
-  return PointerObjects_[index].CanPoint();
+  return PointerObjects_[index].ShouldTrackPointees();
 }
 
 bool
-PointerObjectSet::CanPointerObjectBePointee(PointerObjectIndex index) const noexcept
+PointerObjectSet::IsPointerObjectRegister(PointerObjectIndex index) const noexcept
 {
   JLM_ASSERT(index < NumPointerObjects());
-  return PointerObjects_[index].CanBePointee();
+  return PointerObjects_[index].IsRegister();
 }
 
 bool
@@ -216,15 +216,33 @@ PointerObjectSet::HasEscaped(PointerObjectIndex index) const noexcept
 bool
 PointerObjectSet::MarkAsEscaped(PointerObjectIndex index)
 {
-  JLM_ASSERT(index < NumPointerObjects());
+  // Registers do not have addresses, and can as such not escape
+  JLM_ASSERT(!IsPointerObjectRegister(index));
   if (PointerObjects_[index].HasEscaped)
     return false;
+
   PointerObjects_[index].HasEscaped = true;
 
-  // Pointer objects that have addresses can be written to from outside the module
-  if (CanPointerObjectBePointee(index))
-    MarkAsPointingToExternal(index);
+  // Flags implied by escaping
+  MarkAsPointeesEscaping(index);
+  MarkAsPointingToExternal(index);
 
+  return true;
+}
+
+[[nodiscard]] bool
+PointerObjectSet::HasPointeesEscaping(PointerObjectIndex index) const noexcept
+{
+  return PointerObjects_[GetUnificationRoot(index)].PointeesEscaping;
+}
+
+bool
+PointerObjectSet::MarkAsPointeesEscaping(PointerObjectIndex index)
+{
+  auto root = GetUnificationRoot(index);
+  if (PointerObjects_[root].PointeesEscaping)
+    return false;
+  PointerObjects_[root].PointeesEscaping = true;
   return true;
 }
 
@@ -237,23 +255,20 @@ PointerObjectSet::IsPointingToExternal(PointerObjectIndex index) const noexcept
 bool
 PointerObjectSet::MarkAsPointingToExternal(PointerObjectIndex index)
 {
-  if (!CanPointerObjectPoint(index))
+  auto root = GetUnificationRoot(index);
+  if (PointerObjects_[root].PointsToExternal)
     return false;
-
-  auto parent = GetUnificationRoot(index);
-  if (PointerObjects_[parent].PointsToExternal)
-    return false;
-  PointerObjects_[parent].PointsToExternal = true;
+  PointerObjects_[root].PointsToExternal = true;
   return true;
 }
 
 PointerObjectIndex
 PointerObjectSet::GetUnificationRoot(PointerObjectIndex index) const noexcept
 {
+  JLM_ASSERT(index < NumPointerObjects());
+
   if constexpr (ENABLE_UNIFICATION)
   {
-    JLM_ASSERT(index < NumPointerObjects());
-
     // Technique known as path halving, gives same asymptotic performance as full path compression
     while (PointerObjectParents_[index] != index)
     {
@@ -271,9 +286,6 @@ PointerObjectSet::UnifyPointerObjects(PointerObjectIndex object1, PointerObjectI
 {
   if constexpr (!ENABLE_UNIFICATION)
     JLM_UNREACHABLE("Unification is not enabled");
-
-  JLM_ASSERT(CanPointerObjectPoint(object1));
-  JLM_ASSERT(CanPointerObjectPoint(object2));
 
   PointerObjectIndex newRoot = GetUnificationRoot(object1);
   PointerObjectIndex oldRoot = GetUnificationRoot(object2);
@@ -294,8 +306,11 @@ PointerObjectSet::UnifyPointerObjects(PointerObjectIndex object1, PointerObjectI
   PointsToSets_[newRoot].UnionWith(PointsToSets_[oldRoot]);
   PointsToSets_[oldRoot].Clear();
 
+  // Ensure any flags set on the points-to set continue to be set in the new unification
   if (IsPointingToExternal(oldRoot))
     MarkAsPointingToExternal(newRoot);
+  if (HasPointeesEscaping(oldRoot))
+    MarkAsPointeesEscaping(newRoot);
 
   return newRoot;
 }
@@ -312,53 +327,32 @@ PointerObjectSet::AddToPointsToSet(PointerObjectIndex pointer, PointerObjectInde
 {
   JLM_ASSERT(pointer < NumPointerObjects());
   JLM_ASSERT(pointee < NumPointerObjects());
-  // Assert the pointer object is a possible pointee
-  JLM_ASSERT(CanPointerObjectBePointee(pointee));
+  // Assert we are not trying to point to a register
+  JLM_ASSERT(!IsPointerObjectRegister(pointee));
 
-  // If the pointer PointerObject can not point to anything, silently ignore
-  if (!CanPointerObjectPoint(pointer))
-    return false;
+  const auto pointerRoot = GetUnificationRoot(pointer);
 
-  return PointsToSets_[GetUnificationRoot(pointer)].Insert(pointee);
+  return PointsToSets_[pointerRoot].Insert(pointee);
 }
 
 // Makes P(superset) a superset of P(subset)
 bool
 PointerObjectSet::MakePointsToSetSuperset(PointerObjectIndex superset, PointerObjectIndex subset)
 {
-  // If the superset PointerObject can't point to anything, silently ignore
-  if (!CanPointerObjectPoint(superset))
+  auto supersetRoot = GetUnificationRoot(superset);
+  auto subsetRoot = GetUnificationRoot(subset);
+
+  if (supersetRoot == subsetRoot)
     return false;
 
-  // If the subset PointerObject can't point to anything, silently ignore
-  if (!CanPointerObjectPoint(subset))
-    return false;
-
-  auto supersetParent = GetUnificationRoot(superset);
-  auto subsetParent = GetUnificationRoot(subset);
-
-  if (supersetParent == subsetParent)
-    return false;
-
-  auto & P_super = PointsToSets_[supersetParent];
-  auto & P_sub = PointsToSets_[subsetParent];
+  auto & P_super = PointsToSets_[supersetRoot];
+  auto & P_sub = PointsToSets_[subsetRoot];
 
   bool modified = P_super.UnionWith(P_sub);
 
   // If the external node is in the subset, it must also be part of the superset
-  if (IsPointingToExternal(subsetParent))
-    modified |= MarkAsPointingToExternal(supersetParent);
-
-  return modified;
-}
-
-// Marks all x in P(pointer) as escaped
-bool
-PointerObjectSet::MarkAllPointeesAsEscaped(PointerObjectIndex pointer)
-{
-  bool modified = false;
-  for (PointerObjectIndex pointee : GetPointsToSet(pointer).Items())
-    modified |= MarkAsEscaped(pointee);
+  if (IsPointingToExternal(subsetRoot))
+    modified |= MarkAsPointingToExternal(supersetRoot);
 
   return modified;
 }
@@ -384,10 +378,10 @@ StoreConstraint::ApplyDirectly(PointerObjectSet & set)
   for (PointerObjectIndex x : set.GetPointsToSet(Pointer_).Items())
     modified |= set.MakePointsToSetSuperset(x, Value_);
 
-  // If external in P(Pointer1_), P(external) should become a superset of P(Pointer2)
-  // In practice, this means everything in P(Pointer2) escapes
+  // If external in P(pointer), P(external) should become a superset of P(value)
+  // In practice, this means everything in P(value) escapes
   if (set.IsPointingToExternal(Pointer_))
-    modified |= set.MarkAllPointeesAsEscaped(Value_);
+    modified |= set.MarkAsPointeesEscaping(Value_);
 
   return modified;
 }
@@ -412,15 +406,15 @@ LoadConstraint::ApplyDirectly(PointerObjectSet & set)
  * possibly being sent to and retrieved from unknown code.
  * @param set the PointerObjectSet representing this module.
  * @param callNode the RVSDG CallNode that represents the function call itself
- * @param markAsEscaped the function to call when a PointerObject should be marked as escaped
+ * @param markAsPointeesEscaping the function to call when marking a register as pointees escaping
  * @param markAsPointsToExternal called to flag a PointerObject as pointing to external
  */
-template<typename MarkAsEscaped, typename MarkAsPointsToExternal>
+template<typename MarkAsPointeesEscaping, typename MarkAsPointsToExternal>
 void
 HandleCallingExternalFunction(
     PointerObjectSet & set,
     const jlm::llvm::CallNode & callNode,
-    MarkAsEscaped & markAsEscaped,
+    MarkAsPointeesEscaping & markAsPointeesEscaping,
     MarkAsPointsToExternal & markAsPointsToExternal)
 {
 
@@ -431,7 +425,7 @@ HandleCallingExternalFunction(
     const auto inputRegisterPO = set.TryGetRegisterPointerObject(inputRegister);
 
     if (inputRegisterPO)
-      markAsEscaped(inputRegisterPO.value());
+      markAsPointeesEscaping(inputRegisterPO.value());
   }
 
   for (size_t n = 0; n < callNode.NumResults(); n++)
@@ -449,21 +443,77 @@ HandleCallingExternalFunction(
  * @param set the PointerObjectSet representing this module.
  * @param callNode the RVSDG CallNode that represents the function call itself
  * @param imported the PointerObject of ImportMemoryObject kind that might be called.
- * @param markAsEscaped the function to call when a PointerObject should be marked as escaped
+ * @param markAsPointeesEscaping the function to call when marking a register as pointees escaping
  * @param markAsPointsToExternal called to flag a PointerObject as pointing to external
  */
-template<typename MarkAsEscaped, typename MarkAsPointsToExternal>
+template<typename MarkAsPointeesEscaping, typename MarkAsPointsToExternal>
 static void
 HandleCallingImportedFunction(
     PointerObjectSet & set,
     const jlm::llvm::CallNode & callNode,
     [[maybe_unused]] PointerObjectIndex imported,
-    MarkAsEscaped & markAsEscaped,
+    MarkAsPointeesEscaping & markAsPointeesEscaping,
     MarkAsPointsToExternal & markAsPointsToExternal)
 {
   // FIXME: Add special handling of common library functions
   // Otherwise we don't know anything about the function
-  return HandleCallingExternalFunction(set, callNode, markAsEscaped, markAsPointsToExternal);
+  return HandleCallingExternalFunction(
+      set,
+      callNode,
+      markAsPointeesEscaping,
+      markAsPointsToExternal);
+}
+
+/**
+ * Pairs up call node inputs and function body argument, and calls the provided \p makeSuperset
+ * to make the function body arguments include all pointees the call node may pass in.
+ */
+template<typename MakeSupersetFunctor>
+static void
+HandleLambdaCallParameters(
+    PointerObjectSet & set,
+    const jlm::llvm::CallNode & callNode,
+    const lambda::node & lambdaNode,
+    MakeSupersetFunctor & makeSuperset)
+{
+  for (size_t n = 0; n < callNode.NumArguments() && n < lambdaNode.nfctarguments(); n++)
+  {
+    const auto & inputRegister = *callNode.Argument(n)->origin();
+    const auto & argumentRegister = *lambdaNode.fctargument(n);
+
+    const auto inputRegisterPO = set.TryGetRegisterPointerObject(inputRegister);
+    const auto argumentRegisterPO = set.TryGetRegisterPointerObject(argumentRegister);
+    if (!inputRegisterPO || !argumentRegisterPO)
+      continue;
+
+    makeSuperset(*argumentRegisterPO, *inputRegisterPO);
+  }
+}
+
+/**
+ * Pairs up function body results and call node outputs, and calls the provided \p makeSuperset
+ * to make the call node output include all possible returned pointees.
+ */
+template<typename MakeSupersetFunctor>
+static void
+HandleLambdaCallReturnValues(
+    PointerObjectSet & set,
+    const jlm::llvm::CallNode & callNode,
+    const lambda::node & lambdaNode,
+    MakeSupersetFunctor & makeSuperset)
+{
+  for (size_t n = 0; n < callNode.NumResults() && n < lambdaNode.nfctresults(); n++)
+  {
+    const auto & outputRegister = *callNode.Result(n);
+    const auto & resultRegister = *lambdaNode.fctresult(n)->origin();
+
+    const auto outputRegisterPO = set.TryGetRegisterPointerObject(outputRegister);
+    const auto resultRegisterPO = set.TryGetRegisterPointerObject(resultRegister);
+    if (!outputRegisterPO || !resultRegisterPO)
+      continue;
+
+    makeSuperset(*outputRegisterPO, *resultRegisterPO);
+  }
 }
 
 /**
@@ -477,51 +527,24 @@ HandleCallingImportedFunction(
  * @param lambda the PointerObject of FunctionMemoryObject kind that might be called.
  * @param makeSuperset the function to call to make one points-to set a superset of another
  */
-template<typename MakeSuperset>
+template<typename MakeSupersetFunctor>
 static void
 HandleCallingLambdaFunction(
     PointerObjectSet & set,
     const jlm::llvm::CallNode & callNode,
     PointerObjectIndex lambda,
-    MakeSuperset & makeSuperset)
+    MakeSupersetFunctor & makeSuperset)
 {
   auto & lambdaNode = set.GetLambdaNodeFromFunctionMemoryObject(lambda);
 
-  // If the number of parameters or number of results doesn't line up,
-  // assume this is not the function we are calling.
-  // Note that the number of arguments and results include 3 state edges: memory, loop and IO.
-  // Varargs are properly handled, since they get merged by a valist_op node before the CallNode.
-  if (lambdaNode.nfctarguments() != callNode.NumArguments()
-      || lambdaNode.nfctresults() != callNode.NumResults())
-    return;
+  // LLVM allows calling functions even when the number of arguments don't match,
+  // so we instead pair up as many parameters and return values as possible
 
   // Pass all call node inputs to the function's subregion
-  for (size_t n = 0; n < callNode.NumArguments(); n++)
-  {
-    const auto & inputRegister = *callNode.Argument(n)->origin();
-    const auto & argumentRegister = *lambdaNode.fctargument(n);
-
-    const auto inputRegisterPO = set.TryGetRegisterPointerObject(inputRegister);
-    const auto argumentRegisterPO = set.TryGetRegisterPointerObject(argumentRegister);
-    if (!inputRegisterPO || !argumentRegisterPO)
-      continue;
-
-    makeSuperset(argumentRegisterPO.value(), inputRegisterPO.value());
-  }
+  HandleLambdaCallParameters(set, callNode, lambdaNode, makeSuperset);
 
   // Pass the function's subregion results to the output of the call node
-  for (size_t n = 0; n < callNode.NumResults(); n++)
-  {
-    const auto & outputRegister = *callNode.Result(n);
-    const auto & resultRegister = *lambdaNode.fctresult(n)->origin();
-
-    const auto outputRegisterPO = set.TryGetRegisterPointerObject(outputRegister);
-    const auto resultRegisterPO = set.TryGetRegisterPointerObject(resultRegister);
-    if (!outputRegisterPO || !resultRegisterPO)
-      continue;
-
-    makeSuperset(outputRegisterPO.value(), resultRegisterPO.value());
-  }
+  HandleLambdaCallReturnValues(set, callNode, lambdaNode, makeSuperset);
 }
 
 // Connects function calls to every possible target function
@@ -535,9 +558,9 @@ FunctionCallConstraint::ApplyDirectly(PointerObjectSet & set)
     modified |= set.MakePointsToSetSuperset(superset, subset);
   };
 
-  const auto MarkAsEscaped = [&](PointerObjectIndex index)
+  const auto MarkAsPointeesEscaping = [&](PointerObjectIndex index)
   {
-    modified |= set.MarkAsEscaped(index);
+    modified |= set.MarkAsPointeesEscaping(index);
   };
 
   const auto MarkAsPointsToExternal = [&](PointerObjectIndex index)
@@ -550,14 +573,19 @@ FunctionCallConstraint::ApplyDirectly(PointerObjectSet & set)
   {
     const auto kind = set.GetPointerObjectKind(target);
     if (kind == PointerObjectKind::ImportMemoryObject)
-      HandleCallingImportedFunction(set, CallNode_, target, MarkAsEscaped, MarkAsPointsToExternal);
+      HandleCallingImportedFunction(
+          set,
+          CallNode_,
+          target,
+          MarkAsPointeesEscaping,
+          MarkAsPointsToExternal);
     else if (kind == PointerObjectKind::FunctionMemoryObject)
       HandleCallingLambdaFunction(set, CallNode_, target, MakeSuperset);
   }
 
   // If we might be calling an external function
   if (set.IsPointingToExternal(Pointer_))
-    HandleCallingExternalFunction(set, CallNode_, MarkAsEscaped, MarkAsPointsToExternal);
+    HandleCallingExternalFunction(set, CallNode_, MarkAsPointeesEscaping, MarkAsPointsToExternal);
 
   return modified;
 }
@@ -565,30 +593,36 @@ FunctionCallConstraint::ApplyDirectly(PointerObjectSet & set)
 bool
 EscapeFlagConstraint::PropagateEscapedFlagsDirectly(PointerObjectSet & set)
 {
-  std::queue<PointerObjectIndex> escapers;
+  std::queue<PointerObjectIndex> pointeeEscapers;
 
-  // First add all already escaped PointerObjects to the queue
+  // First add all unification roots marked as PointeesEscaping
   for (PointerObjectIndex idx = 0; idx < set.NumPointerObjects(); idx++)
   {
-    if (set.HasEscaped(idx))
-      escapers.push(idx);
+    if (set.GetUnificationRoot(idx) == idx && set.HasPointeesEscaping(idx))
+      pointeeEscapers.push(idx);
   }
 
   bool modified = false;
 
-  // For all escapers, check if they point to any PointerObjects not marked as escaped
-  while (!escapers.empty())
+  // For all pointee escapers, check if they point to any PointerObjects not marked as escaped
+  while (!pointeeEscapers.empty())
   {
-    const PointerObjectIndex escaper = escapers.front();
-    escapers.pop();
+    const PointerObjectIndex pointeeEscaper = pointeeEscapers.front();
+    pointeeEscapers.pop();
 
-    for (PointerObjectIndex pointee : set.GetPointsToSet(escaper).Items())
+    for (PointerObjectIndex pointee : set.GetPointsToSet(pointeeEscaper).Items())
     {
-      if (set.MarkAsEscaped(pointee))
+      const auto unificationRoot = set.GetUnificationRoot(pointee);
+      const bool prevHasPointeesEscaping = set.HasPointeesEscaping(unificationRoot);
+
+      modified |= set.MarkAsEscaped(pointee);
+
+      // If the pointee's unification root previously didn't have the PointeesEscaping flag,
+      // add it to the queue
+      if (!prevHasPointeesEscaping)
       {
-        // Add the newly marked PointerObject to the queue, in case the flag can be propagated
-        escapers.push(pointee);
-        modified = true;
+        JLM_ASSERT(set.HasPointeesEscaping(unificationRoot));
+        pointeeEscapers.push(unificationRoot);
       }
     }
   }
@@ -597,22 +631,22 @@ EscapeFlagConstraint::PropagateEscapedFlagsDirectly(PointerObjectSet & set)
 }
 
 /**
- * Given an escaped function, the results should be marked as escaped,
+ * Given an escaped function, the results registers should be marked as escaping pointees,
  * and all arguments as pointing to external, provided they are of types we track the pointees of.
  * The modifications are made using the provided functors, which are called only if any flags are
  * missing. Each functor takes a single parameter:
  *   The index of a PointerObject of Register kind that is missing the specified flag.
  * @param set the PointerObjectSet representing this module
  * @param lambda the escaped PointerObject of function kind
- * @param markAsEscaped the function to call when a PointerObject should be marked as escaped
+ * @param markAsPointeesEscaping the function to call when marking a register as pointees escaping
  * @param markAsPointsToExternal called to flag a PointerObject as pointing to external
  */
-template<typename MarkAsEscapedFunctor, typename MarkAsPointsToExternalFunctor>
+template<typename MarkAsPointeesEscapingFunctor, typename MarkAsPointsToExternalFunctor>
 static void
 HandleEscapedFunction(
     PointerObjectSet & set,
     PointerObjectIndex lambda,
-    MarkAsEscapedFunctor & markAsEscaped,
+    MarkAsPointeesEscapingFunctor & markAsPointeesEscaping,
     MarkAsPointsToExternalFunctor & markAsPointsToExternal)
 {
   JLM_ASSERT(set.GetPointerObjectKind(lambda) == PointerObjectKind::FunctionMemoryObject);
@@ -647,8 +681,8 @@ HandleEscapedFunction(
     if (set.HasEscaped(resultPO.value()))
       continue;
 
-    // Mark the result register as escaped
-    markAsEscaped(resultPO.value());
+    // Mark the result register as escaping any pointees it may have
+    markAsPointeesEscaping(resultPO.value());
   }
 }
 
@@ -657,22 +691,20 @@ EscapedFunctionConstraint::PropagateEscapedFunctionsDirectly(PointerObjectSet & 
 {
   bool modified = false;
 
-  const auto markAsEscaped = [&](PointerObjectIndex index)
+  const auto markAsPointeesEscaping = [&](PointerObjectIndex index)
   {
-    set.MarkAsEscaped(index);
-    modified = true;
+    modified |= set.MarkAsPointeesEscaping(index);
   };
 
   const auto markAsPointsToExternal = [&](PointerObjectIndex index)
   {
-    set.MarkAsPointingToExternal(index);
-    modified = true;
+    modified |= set.MarkAsPointingToExternal(index);
   };
 
   for (const auto [lambda, lambdaPO] : set.GetFunctionMap())
   {
     if (set.HasEscaped(lambdaPO))
-      HandleEscapedFunction(set, lambdaPO, markAsEscaped, markAsPointsToExternal);
+      HandleEscapedFunction(set, lambdaPO, markAsPointeesEscaping, markAsPointsToExternal);
   }
 
   return modified;
@@ -697,12 +729,8 @@ PointerObjectConstraintSet::AddPointsToExternalConstraint(PointerObjectIndex poi
 void
 PointerObjectConstraintSet::AddRegisterContentEscapedConstraint(PointerObjectIndex registerIndex)
 {
-  // Registers themselves can't escape in the classical sense, since they don't have an address.
-  // (CanBePointee() is false)
-  // When marked as Escaped, it instead means that the contents of the register has escaped.
-  // This allows Escaped-flag propagation to mark any pointee the register might hold as escaped.
-  JLM_ASSERT(Set_.GetPointerObjectKind(registerIndex) == PointerObjectKind::Register);
-  Set_.MarkAsEscaped(registerIndex);
+  JLM_ASSERT(Set_.IsPointerObjectRegister(registerIndex));
+  Set_.MarkAsPointeesEscaping(registerIndex);
 }
 
 void
@@ -721,13 +749,16 @@ size_t
 PointerObjectConstraintSet::SolveUsingWorklist()
 {
   // Create auxiliary superset graph.
+  // All edges must have their tail be a unification root.
   // If supersetEdges[x] contains y, (x -> y), that means P(y) supseteq P(x)
   std::vector<util::HashSet<PointerObjectIndex>> supersetEdges(Set_.NumPointerObjects());
 
   // Create quick lookup tables for Load, Store and function call constraints.
   // Lookup is indexed by the constraint's pointer
-  std::vector<std::vector<PointerObjectIndex>> storeConstraints(Set_.NumPointerObjects());
-  std::vector<std::vector<PointerObjectIndex>> loadConstraints(Set_.NumPointerObjects());
+  // The constraints need to be added to the unification root, as only unification roots
+  // are allowed on the worklist.
+  std::vector<util::HashSet<PointerObjectIndex>> storeConstraints(Set_.NumPointerObjects());
+  std::vector<util::HashSet<PointerObjectIndex>> loadConstraints(Set_.NumPointerObjects());
   std::vector<std::vector<const jlm::llvm::CallNode *>> callConstraints(Set_.NumPointerObjects());
 
   for (const auto & constraint : Constraints_)
@@ -735,47 +766,49 @@ PointerObjectConstraintSet::SolveUsingWorklist()
     if (const auto * ssConstraint = std::get_if<SupersetConstraint>(&constraint))
     {
       // Superset constraints become edges in the superset graph
-      const auto superset = ssConstraint->GetSuperset();
-      const auto subset = ssConstraint->GetSubset();
-      JLM_ASSERT(superset < Set_.NumPointerObjects() && subset < Set_.NumPointerObjects());
+      auto superset = Set_.GetUnificationRoot(ssConstraint->GetSuperset());
+      auto subset = Set_.GetUnificationRoot(ssConstraint->GetSubset());
 
       supersetEdges[subset].Insert(superset);
     }
     else if (const auto * storeConstraint = std::get_if<StoreConstraint>(&constraint))
     {
-      const auto pointer = storeConstraint->GetPointer();
-      const auto value = storeConstraint->GetValue();
-      JLM_ASSERT(pointer < Set_.NumPointerObjects() && value < Set_.NumPointerObjects());
+      auto pointer = Set_.GetUnificationRoot(storeConstraint->GetPointer());
+      auto value = Set_.GetUnificationRoot(storeConstraint->GetValue());
 
-      storeConstraints[pointer].push_back(value);
+      storeConstraints[pointer].Insert(value);
     }
     else if (const auto * loadConstraint = std::get_if<LoadConstraint>(&constraint))
     {
-      const auto pointer = loadConstraint->GetPointer();
-      const auto value = loadConstraint->GetValue();
-      JLM_ASSERT(pointer < Set_.NumPointerObjects() && value < Set_.NumPointerObjects());
+      auto pointer = Set_.GetUnificationRoot(loadConstraint->GetPointer());
+      auto value = Set_.GetUnificationRoot(loadConstraint->GetValue());
 
-      loadConstraints[pointer].push_back(value);
+      loadConstraints[pointer].Insert(value);
     }
     else if (const auto * callConstraint = std::get_if<FunctionCallConstraint>(&constraint))
     {
-      const auto pointer = callConstraint->GetPointer();
+      auto pointer = Set_.GetUnificationRoot(callConstraint->GetPointer());
       const auto & callNode = callConstraint->GetCallNode();
-      JLM_ASSERT(pointer < Set_.NumPointerObjects());
 
       callConstraints[pointer].push_back(&callNode);
     }
   }
 
-  // The worklist, initialized with every object
+  // The worklist, initialized with every unification root
   util::LrfWorklist<PointerObjectIndex> worklist;
   for (PointerObjectIndex i = 0; i < Set_.NumPointerObjects(); i++)
-    worklist.PushWorkItem(i);
+  {
+    if (Set_.GetUnificationRoot(i) == i)
+      worklist.PushWorkItem(i);
+  }
 
   // Helper function for adding superset edges, propagating everything currently in the subset.
-  // The superset is added to the work list if its points-to set or flags are changed.
+  // The superset's root is added to the work list if its points-to set or flags are changed.
   const auto AddSupersetEdge = [&](PointerObjectIndex superset, PointerObjectIndex subset)
   {
+    superset = Set_.GetUnificationRoot(superset);
+    subset = Set_.GetUnificationRoot(subset);
+
     // If the edge already exists, ignore
     if (!supersetEdges[subset].Insert(superset))
       return;
@@ -788,19 +821,25 @@ PointerObjectConstraintSet::SolveUsingWorklist()
     worklist.PushWorkItem(superset);
   };
 
-  // Helper function for flagging a pointer object as escaped. Adds to the worklist if changed
-  const auto MarkAsEscaped = [&](PointerObjectIndex index)
+  // Helper function for marking a PointerObject such that all its pointees will escape
+  const auto MarkAsPointeesEscaping = [&](PointerObjectIndex index)
   {
-    if (Set_.MarkAsEscaped(index))
+    index = Set_.GetUnificationRoot(index);
+    if (Set_.MarkAsPointeesEscaping(index))
       worklist.PushWorkItem(index);
   };
 
   // Helper function for flagging a pointer as pointing to external. Adds to the worklist if changed
   const auto MarkAsPointsToExternal = [&](PointerObjectIndex index)
   {
+    index = Set_.GetUnificationRoot(index);
     if (Set_.MarkAsPointingToExternal(index))
       worklist.PushWorkItem(index);
   };
+
+  // Ensure that all functions that have already escaped have informed their arguments and results
+  // The worklist will only inform functions if their HasEscaped flag changes
+  EscapedFunctionConstraint::PropagateEscapedFunctionsDirectly(Set_);
 
   // Count of the total number of work items fired
   size_t numWorkItems = 0;
@@ -809,14 +848,23 @@ PointerObjectConstraintSet::SolveUsingWorklist()
   // - It has never been fired
   // - It has pointees added since the last time it was fired
   // - It has been marked as pointing to external since last time it was fired
-  // - It has been marked as escaping since the last time it was fired
+  // - It has been marked as escaping all pointees since last time it was fired
+  // All work items are unification roots, or were unification roots when added
   while (worklist.HasMoreWorkItems())
   {
     const auto n = worklist.PopWorkItem();
     numWorkItems++;
 
+    // Only visit unification roots
+    const auto root = Set_.GetUnificationRoot(n);
+    if (n != root)
+    {
+      worklist.PushWorkItem(root);
+      continue;
+    }
+
     // Stores on the form *n = value.
-    for (const auto value : storeConstraints[n])
+    for (const auto value : storeConstraints[n].Items())
     {
       // This loop ensures *P(n) supseteq P(value)
       for (const auto pointee : Set_.GetPointsToSet(n).Items())
@@ -824,11 +872,11 @@ PointerObjectConstraintSet::SolveUsingWorklist()
 
       // If P(n) contains "external", the contents of the written value escapes
       if (Set_.IsPointingToExternal(n))
-        MarkAsEscaped(value);
+        MarkAsPointeesEscaping(value);
     }
 
     // Loads on the form value = *n.
-    for (const auto value : loadConstraints[n])
+    for (const auto value : loadConstraints[n].Items())
     {
       // This loop ensures P(value) supseteq *P(n)
       for (const auto pointee : Set_.GetPointsToSet(n).Items())
@@ -851,7 +899,7 @@ PointerObjectConstraintSet::SolveUsingWorklist()
               Set_,
               *callNode,
               pointee,
-              MarkAsEscaped,
+              MarkAsPointeesEscaping,
               MarkAsPointsToExternal);
         else if (kind == PointerObjectKind::FunctionMemoryObject)
           HandleCallingLambdaFunction(Set_, *callNode, pointee, AddSupersetEdge);
@@ -859,25 +907,46 @@ PointerObjectConstraintSet::SolveUsingWorklist()
 
       // If P(n) contains "external", handle calling external functions
       if (Set_.IsPointingToExternal(n))
-        HandleCallingExternalFunction(Set_, *callNode, MarkAsEscaped, MarkAsPointsToExternal);
+        HandleCallingExternalFunction(
+            Set_,
+            *callNode,
+            MarkAsPointeesEscaping,
+            MarkAsPointsToExternal);
     }
 
     // Propagate P(n) along all edges n -> superset
-    for (const auto superset : supersetEdges[n].Items())
+    for (auto superset : supersetEdges[n].Items())
     {
+      // FIXME: Replace edges going to non-roots
+      superset = Set_.GetUnificationRoot(superset);
       if (Set_.MakePointsToSetSuperset(superset, n))
         worklist.PushWorkItem(superset);
     }
 
-    // If escaped, propagate escaped flag to all pointees
-    if (Set_.HasEscaped(n))
+    // If n is marked as PointeesEscaping, add the escaped flag to all pointees
+    if (Set_.HasPointeesEscaping(n))
     {
       for (const auto pointee : Set_.GetPointsToSet(n).Items())
-        MarkAsEscaped(pointee);
+      {
+        const auto pointeeRoot = Set_.GetUnificationRoot(pointee);
+        const bool prevPointeesEscaping = Set_.HasPointeesEscaping(pointeeRoot);
 
-      // Escaped functions also need to flag arguments and results in the function body
-      if (Set_.GetPointerObjectKind(n) == PointerObjectKind::FunctionMemoryObject)
-        HandleEscapedFunction(Set_, n, MarkAsEscaped, MarkAsPointsToExternal);
+        // Mark the pointee itself as escaped, not the pointee's unifiction root!
+        if (!Set_.MarkAsEscaped(pointee))
+          continue;
+
+        // If the PointerObject we just marked as escaped is a function, inform it about escaping
+        if (Set_.GetPointerObjectKind(pointee) == PointerObjectKind::FunctionMemoryObject)
+          HandleEscapedFunction(Set_, pointee, MarkAsPointeesEscaping, MarkAsPointsToExternal);
+
+        // If the pointee's unification root previously didn't have the PointeesEscaping flag,
+        // add the unification root to the worklist
+        if (!prevPointeesEscaping)
+        {
+          JLM_ASSERT(Set_.HasPointeesEscaping(pointeeRoot));
+          worklist.PushWorkItem(pointeeRoot);
+        }
+      }
     }
   }
 

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
@@ -281,6 +281,12 @@ PointerObjectSet::GetUnificationRoot(PointerObjectIndex index) const noexcept
   return index;
 }
 
+bool
+PointerObjectSet::IsUnificationRoot(PointerObjectIndex index) const noexcept
+{
+  return GetUnificationRoot(index) == index;
+}
+
 PointerObjectIndex
 PointerObjectSet::UnifyPointerObjects(PointerObjectIndex object1, PointerObjectIndex object2)
 {
@@ -598,7 +604,7 @@ EscapeFlagConstraint::PropagateEscapedFlagsDirectly(PointerObjectSet & set)
   // First add all unification roots marked as PointeesEscaping
   for (PointerObjectIndex idx = 0; idx < set.NumPointerObjects(); idx++)
   {
-    if (set.GetUnificationRoot(idx) == idx && set.HasPointeesEscaping(idx))
+    if (set.IsUnificationRoot(idx) && set.HasPointeesEscaping(idx))
       pointeeEscapers.push(idx);
   }
 
@@ -798,7 +804,7 @@ PointerObjectConstraintSet::SolveUsingWorklist()
   util::LrfWorklist<PointerObjectIndex> worklist;
   for (PointerObjectIndex i = 0; i < Set_.NumPointerObjects(); i++)
   {
-    if (Set_.GetUnificationRoot(i) == i)
+    if (Set_.IsUnificationRoot(i))
       worklist.PushWorkItem(i);
   }
 

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
@@ -58,43 +58,70 @@ class PointerObjectSet final
     PointerObjectKind Kind : util::BitWidthOfEnum(PointerObjectKind::COUNT);
 
     // This memory object's address is known outside the module.
-    // If CanBePointee() is false, this object has no address, but its value has escaped.
+    // Can only be true on memory objects.
     uint8_t HasEscaped : 1;
 
-    // If this PointerObject is the parent of its own unification,
-    // and this flag is set, this pointer object is pointing to external.
+    // Any pointee of this PointerObject has its address escaped.
+    // The unification root is the source of truth for this flag!
+    // This flag is implied by HasEscaped
+    uint8_t PointeesEscaping : 1;
+
+    // If set, this pointer object is pointing to external.
+    // The unification root is the source of truth for this flag!
+    // This flag is implied by HasEscaped
     uint8_t PointsToExternal : 1;
 
     explicit PointerObject(PointerObjectKind kind)
         : Kind(kind),
           HasEscaped(0),
+          PointeesEscaping(0),
           PointsToExternal(0)
     {
       JLM_ASSERT(kind != PointerObjectKind::COUNT);
+
+      if (!ShouldTrackPointees())
+      {
+        // No attempt is made at tracking pointees, so use these flags to inform others
+        PointeesEscaping = 1;
+        PointsToExternal = 1;
+      }
     }
 
     /**
-     * Some PointerObjects are not capable of pointing to anything else.
-     * Their points-to-set will always be empty, and constraints that attempt
-     * to add pointees should be no-ops that are silently ignored.
-     * The same applies to attempts at setting the PointsToExternal-flag.
-     * @return true if this PointerObject can point to other PointerObjects
+     * If a PointerObject is marked with both PointsToExternal and PointeesEscaping,
+     * its final points-to set will be identical to the set of escaped memory objects.
+     * There is no need to track its pointees, since all pointees can be marked as HasEscaped,
+     * and instead be an implicit pointee.
+     * @return true if this PointerObject's points-to set can be tracked fully implicitly.
      */
     [[nodiscard]] bool
-    CanPoint() const noexcept
+    CanTrackPointeesImplicitly() const noexcept
+    {
+      return PointsToExternal && PointeesEscaping;
+    }
+
+    /**
+     * Some memory objects can only be pointed to, but never themselves contain pointers.
+     * To avoid tracking their pointees, they are instead marked as both PointsToExternal and
+     * PointeesEscaping. This makes their points-to set equivalent to the set of all escaped
+     * memory objects, which means the set of explicit pointees can be empty.
+     * When converting the analysis result to a PointsToGraph, these PointerObjects get no pointees.
+     * @return true if the analysis should attempt track the points-to set of this PointerObject.
+     */
+    [[nodiscard]] bool
+    ShouldTrackPointees() const noexcept
     {
       return Kind != PointerObjectKind::FunctionMemoryObject;
     }
 
     /**
-     * Some PointerObjects don't have addresses, and can as such not be pointed to.
-     * Any attempt at adding them to a points-to-set is a fatal error.
-     * @return true if this PointerObject can be pointed to by another PointerObject
+     * Registers are the only PointerObjects that may not be pointed to, only point.
+     * @return true if the kind of this PointerObject is Register, false otherwise
      */
     [[nodiscard]] bool
-    CanBePointee() const noexcept
+    IsRegister() const noexcept
     {
-      return Kind != PointerObjectKind::Register;
+      return Kind == PointerObjectKind::Register;
     }
   };
 
@@ -256,26 +283,42 @@ public:
    * @return true if the PointerObject with the given \p index can point, otherwise false
    */
   [[nodiscard]] bool
-  CanPointerObjectPoint(PointerObjectIndex index) const noexcept;
+  ShouldTrackPointees(PointerObjectIndex index) const noexcept;
 
   /**
-   * @return true if the PointerObject with the given \p index can be a pointee, otherwise false
+   * @return true if the PointerObject with the given \p index is a Register
    */
   [[nodiscard]] bool
-  CanPointerObjectBePointee(PointerObjectIndex index) const noexcept;
+  IsPointerObjectRegister(PointerObjectIndex index) const noexcept;
 
   /**
-   * @return true if the PointerObject with the given \p index has escaped, otherwise false
+   * @return true if the PointerObject with the given \p index has its address escaped
    */
   [[nodiscard]] bool
   HasEscaped(PointerObjectIndex index) const noexcept;
 
   /**
    * Marks the PointerObject with the given \p index as having escaped the module.
-   * @return true if the flag was changed by this operation
+   * Can only be called on non-register PointerObjects.
+   * Implies both the PointeesEscaping flag, and the PointsToExternal flag.
+   * @return true if the flag was changed by this operation, false otherwise
    */
   bool
   MarkAsEscaped(PointerObjectIndex index);
+
+  /**
+   * @return true if the PointerObject with the given \p index makes all its pointees escape
+   */
+  [[nodiscard]] bool
+  HasPointeesEscaping(PointerObjectIndex index) const noexcept;
+
+  /**
+   * Marks the PointerObject with the given \p index as having all pointees escaping.
+   * The flag is applied to the unification root.
+   * @return true if the flag was changed by this operation, false otherwise
+   */
+  bool
+  MarkAsPointeesEscaping(PointerObjectIndex index);
 
   /**
    * @return true if the PointerObject with the given \p index points to external, otherwise false
@@ -285,8 +328,8 @@ public:
 
   /**
    * Marks the PointerObject with the given \p index as pointing to external.
-   * If the PointerObject has CanPoint() = false, this is a no-op.
-   * @return true if the flag was changed by this operation
+   * The flag is applied to the unification root.
+   * @return true if the flag was changed by this operation, false otherwise
    */
   bool
   MarkAsPointingToExternal(PointerObjectIndex index);
@@ -302,7 +345,6 @@ public:
    * Unifies two PointerObjects, such that they will forever share their set of pointees.
    * If any object in the unification points to external, they will all point to external.
    * The HasEscaped flags are not shared, and can still be set individually.
-   * Only PointerObjects where CanPoint() is true may be unified.
    * If the objects already belong to the same disjoint set, this is a no-op.
    * @param object1 the index of the first PointerObject to unify
    * @param object2 the index of the second PointerObject to unify
@@ -335,20 +377,11 @@ public:
    * @param subset the index of the PointerObject whose pointees shall all be pointed to by superset
    * as well
    *
-   * If the superset is of a PointerObjectKind that can't point, this is a no-op.
    *
-   * @return true if P(\p superset) was modified by this operation
+   * @return true if P(\p superset) or any flags were modified by this operation
    */
   bool
   MakePointsToSetSuperset(PointerObjectIndex superset, PointerObjectIndex subset);
-
-  /**
-   * Adds the Escaped flag to all PointerObjects in the P(\p pointer) set
-   * @param pointer the pointer whose pointees should be marked as escaped
-   * @return true if any PointerObjects had their flag modified by this operation
-   */
-  bool
-  MarkAllPointeesAsEscaped(PointerObjectIndex pointer);
 
   /**
    * Creates a clone of this PointerObjectSet, with all the same PointerObjects,
@@ -548,7 +581,7 @@ public:
  *
  * It follows the given pseudocode:
  * for f in P(CallTarget):
- *   if f is not a lambda, or the signature doesn't match:
+ *   if f is not a lambda:
  *     continue
  *   for each function argument/input pair (a, i):
  *     make P(a) a superset of P(i)
@@ -614,7 +647,7 @@ public:
 
 /**
  * Helper class representing the global constraint:
- *   For all PointerObjects x marked as escaping, all pointees in P(x) are escaping
+ *   For all PointerObjects x marked as PointeesEscaping, all pointees in P(x) are escaping
  */
 class EscapeFlagConstraint final
 {
@@ -652,7 +685,7 @@ public:
 /**
  * A class for adding and applying constraints to the points-to-sets of the PointerObjectSet.
  * Unlike the set modification methods on PointerObjectSet, constraints can be added in any order,
- * with the same result. Use SolveNaively() to calculate the final points-to-sets.
+ * with the same result. Multiple solvers can be used to solve for the final points-to sets.
  *
  * Some additional constraints on the PointerObject flags are built in.
  */
@@ -663,7 +696,8 @@ public:
       std::variant<SupersetConstraint, StoreConstraint, LoadConstraint, FunctionCallConstraint>;
 
   explicit PointerObjectConstraintSet(PointerObjectSet & set)
-      : Set_(set)
+      : Set_(set),
+        Constraints_()
   {}
 
   PointerObjectConstraintSet(const PointerObjectConstraintSet & other) = delete;
@@ -716,7 +750,7 @@ public:
    * Finds a least solution satisfying all constraints, using the Worklist algorithm.
    * Descriptions of the algorithm can be found in
    *  - Pearce et al. 2003: "Online cycle detection and difference propagation for pointer analysis"
-   *  - Hardekopf et al. 2007, "The Ant and the Grasshopper".
+   *  - Hardekopf et al. 2007: "The Ant and the Grasshopper".
    * @return the total number of work items handled by the WorkList algorithm
    */
   size_t

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
@@ -342,6 +342,12 @@ public:
   GetUnificationRoot(PointerObjectIndex index) const noexcept;
 
   /**
+   * @return true if the PointerObject with the given \p index is its own unification root
+   */
+  [[nodiscard]] bool
+  IsUnificationRoot(PointerObjectIndex index) const noexcept;
+
+  /**
    * Unifies two PointerObjects, such that they will forever share their set of pointees.
    * If any object in the unification points to external, they will all point to external.
    * The HasEscaped flags are not shared, and can still be set individually.

--- a/tests/jlm/llvm/opt/alias-analyses/TestAndersen.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestAndersen.cpp
@@ -8,7 +8,6 @@
 #include <test-registry.hpp>
 
 #include <jlm/llvm/opt/alias-analyses/Andersen.hpp>
-#include <jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp>
 #include <jlm/llvm/opt/alias-analyses/PointsToGraph.hpp>
 #include <jlm/util/Statistics.hpp>
 

--- a/tests/jlm/llvm/opt/alias-analyses/TestPointerObjectSet.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestPointerObjectSet.cpp
@@ -134,12 +134,21 @@ TestPointerObjectUnification()
   PointerObjectSet set;
   auto dummy0 = set.CreateDummyRegisterPointerObject();
   auto dummy1 = set.CreateDummyRegisterPointerObject();
-  assert(set.GetUnificationRoot(dummy0) == dummy0);
+  assert(set.IsUnificationRoot(dummy0));
 
   auto root = set.UnifyPointerObjects(dummy0, dummy1);
   assert(set.GetUnificationRoot(dummy0) == root);
   assert(set.GetUnificationRoot(dummy1) == root);
+
+  // Exactly one of the PointerObjects is the root
+  assert((root == dummy0) != (root == dummy1));
+  assert(set.IsUnificationRoot(root));
+
+  // Trying to unify again gives the same root
   assert(set.UnifyPointerObjects(dummy0, dummy1) == root);
+
+  auto notRoot = dummy0 + dummy1 - root;
+  assert(!set.IsUnificationRoot(notRoot));
 
   auto dummy2 = set.CreateDummyRegisterPointerObject();
   auto dummy3 = set.CreateDummyRegisterPointerObject();

--- a/tests/jlm/llvm/opt/alias-analyses/TestPointerObjectSet.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestPointerObjectSet.cpp
@@ -23,17 +23,16 @@ TestFlagFunctions()
   PointerObjectSet set;
   auto registerPO = set.CreateRegisterPointerObject(rvsdg.GetAllocaOutput());
 
-  // Registers may only point, not be pointee
-  assert(set.CanPointerObjectPoint(registerPO));
-  assert(!set.CanPointerObjectBePointee(registerPO));
+  assert(set.ShouldTrackPointees(registerPO));
+  assert(set.IsPointerObjectRegister(registerPO));
 
-  // Escaping flag
-  assert(!set.HasEscaped(registerPO));
-  assert(set.MarkAsEscaped(registerPO));
-  assert(set.HasEscaped(registerPO));
+  // PointeesEscaping flag
+  assert(!set.HasPointeesEscaping(registerPO));
+  assert(set.MarkAsPointeesEscaping(registerPO));
+  assert(set.HasPointeesEscaping(registerPO));
   // Trying to set the flag again returns false
-  assert(!set.MarkAsEscaped(registerPO));
-  assert(set.HasEscaped(registerPO));
+  assert(!set.MarkAsPointeesEscaping(registerPO));
+  assert(set.HasPointeesEscaping(registerPO));
 
   // PointsToExternal flag. For registers, the two flags are completely independent.
   assert(!set.IsPointingToExternal(registerPO));
@@ -46,27 +45,25 @@ TestFlagFunctions()
   // Test that Escaped implies PointsToExternal, for memory objects
   auto allocaPO = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode());
 
-  // alloca may both point and be a pointee
-  assert(set.CanPointerObjectPoint(allocaPO));
-  assert(set.CanPointerObjectBePointee(allocaPO));
+  // alloca may both point
+  assert(set.ShouldTrackPointees(allocaPO));
+  assert(!set.IsPointerObjectRegister(allocaPO));
 
-  // Escaping means another module can write a pointer to you -> set the points to external flag
+  // Escaping means another module can write a pointer to you.
+  // This implies another module might override it with pointers to external.
+  // It also implies any pointees should also escape
   assert(!set.IsPointingToExternal(allocaPO));
+  assert(!set.HasPointeesEscaping(allocaPO));
   assert(set.MarkAsEscaped(allocaPO));
   assert(set.IsPointingToExternal(allocaPO));
-  // Already marked as pointing to external
+  assert(set.HasPointeesEscaping(allocaPO));
+  // Already marked with these flags, trying to set them again makes no difference
   assert(!set.MarkAsPointingToExternal(allocaPO));
+  assert(!set.MarkAsPointeesEscaping(allocaPO));
 
-  // Test that Functions, who have CanPoint() == false, can not be made to PointToExternal
+  // The analysis should not bother tracking the pointees of lambdas
   auto lambdaPO = set.CreateFunctionMemoryObject(rvsdg.GetLambdaNode());
-
-  // functions may only be pointees
-  assert(!set.CanPointerObjectPoint(lambdaPO));
-  assert(set.CanPointerObjectBePointee(lambdaPO));
-
-  // Adding the points to external flag does not work
-  assert(!set.MarkAsPointingToExternal(lambdaPO));
-  assert(!set.IsPointingToExternal(lambdaPO));
+  assert(!set.ShouldTrackPointees(lambdaPO));
 }
 
 // Test creating pointer objects for each type of memory node
@@ -107,7 +104,6 @@ TestCreatePointerObjects()
   assert(!set.HasEscaped(alloca0) && !set.IsPointingToExternal(alloca0));
   assert(!set.HasEscaped(malloc0) && !set.IsPointingToExternal(malloc0));
   assert(!set.HasEscaped(delta0) && !set.IsPointingToExternal(delta0));
-  assert(!set.HasEscaped(lambda0) && !set.IsPointingToExternal(lambda0));
   // But import memory objects have always escaped
   assert(set.HasEscaped(import0) && set.IsPointingToExternal(import0));
 
@@ -183,6 +179,11 @@ TestPointerObjectUnificationPointees()
   assert(set.IsPointingToExternal(alloca0));
   assert(set.IsPointingToExternal(delta0));
 
+  // Marking one as pointees escaping marks all as pointees escaping
+  assert(set.MarkAsPointeesEscaping(delta0));
+  assert(set.HasPointeesEscaping(alloca0));
+  assert(set.HasPointeesEscaping(delta0));
+
   // Adding a new pointee adds it to all members
   auto import0 = set.CreateImportMemoryObject(rvsdg.GetImportOutput());
   assert(set.AddToPointsToSet(delta0, import0));
@@ -216,11 +217,6 @@ TestAddToPointsToSet()
 
   // Trying to add it again returns false
   assert(!set.AddToPointsToSet(reg0, alloca0));
-
-  // Trying to make a function (CanPoint() == false) point to something is a no-op
-  const auto function0 = set.CreateFunctionMemoryObject(rvsdg.GetFunction());
-  assert(!set.AddToPointsToSet(function0, alloca0));
-  assert(set.GetPointsToSet(function0).Size() == 0);
 }
 
 // Test the PointerObjectSet method for making one points-to-set a superset of another
@@ -257,37 +253,6 @@ TestMakePointsToSetSuperset()
   set.AddToPointsToSet(reg1, alloca2);
   assert(set.MakePointsToSetSuperset(reg0, reg1));
   assert(set.GetPointsToSet(reg0).Contains(alloca2));
-
-  // Trying to make a function's points-to-set a superset is a no-op
-  // Since functions have CanPoint() == false.
-  const auto function0 = set.CreateFunctionMemoryObject(rvsdg.GetFunction());
-  assert(!set.MakePointsToSetSuperset(function0, reg0));
-  assert(set.GetPointsToSet(function0).IsEmpty());
-}
-
-// Test the PointerObjectSet method for marking all pointees of the given pointer as escaped
-static void
-TestMarkAllPointeesAsEscaped()
-{
-  using namespace jlm::llvm::aa;
-
-  jlm::tests::NAllocaNodesTest rvsdg(3);
-  rvsdg.InitializeTest();
-
-  PointerObjectSet set;
-  const auto alloca0 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(0));
-  const auto reg0 = set.CreateRegisterPointerObject(rvsdg.GetAllocaOutput(0));
-  const auto alloca1 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(1));
-  const auto alloca2 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(2));
-
-  set.AddToPointsToSet(reg0, alloca0);
-  set.AddToPointsToSet(reg0, alloca1);
-  assert(set.MarkAllPointeesAsEscaped(reg0));
-
-  assert(set.HasEscaped(alloca0));
-  assert(set.HasEscaped(alloca1));
-  assert(!set.HasEscaped(reg0));
-  assert(!set.HasEscaped(alloca2));
 }
 
 static void
@@ -502,11 +467,14 @@ TestEscapedFunctionConstraint()
   assert(!set.HasEscaped(exportedFunctionPO));
 
   set.MarkAsEscaped(exportedFunctionPO);
+
+  // Use both EscapedFunctionConstraint and EscapeFlagConstraint to propagate flags
   result = EscapedFunctionConstraint::PropagateEscapedFunctionsDirectly(set);
+  result &= EscapeFlagConstraint::PropagateEscapedFlagsDirectly(set);
 
   // Now the local function has been marked as escaped as well, since it is the return value
   assert(result);
-  assert(set.HasEscaped(localFunctionRegisterPO));
+  assert(set.HasEscaped(localFunctionPO));
 }
 
 static void
@@ -791,7 +759,6 @@ TestPointerObjectSet()
   TestPointerObjectUnificationPointees();
   TestAddToPointsToSet();
   TestMakePointsToSetSuperset();
-  TestMarkAllPointeesAsEscaped();
   TestClonePointerObjectSet();
   TestSupersetConstraint();
   TestStoreConstraintDirectly();


### PR DESCRIPTION
The flag `HasEscaped` is now reserved for memory objects only. It implies the `PointeesEscaping` flag. The latter flag can be applied to registers, and it is also shared between all PointerObjects in a unification.
This allows the worklist to properly handle unification.