### PR TITLE
Remove load-store-alloca reduction

### DIFF
--- a/jlm/llvm/ir/operators/load.hpp
+++ b/jlm/llvm/ir/operators/load.hpp
@@ -85,18 +85,6 @@ public:
   }
 
   inline void
-  set_load_store_alloca_reducible(bool enable) noexcept
-  {
-    enable_load_store_alloca_ = enable;
-  }
-
-  inline bool
-  get_load_store_alloca_reducible() const noexcept
-  {
-    return enable_load_store_alloca_;
-  }
-
-  inline void
   set_load_store_reducible(bool enable) noexcept
   {
     enable_load_store_ = enable;
@@ -127,7 +115,6 @@ private:
   bool enable_load_load_state_;
   bool enable_multiple_origin_;
   bool enable_load_store_state_;
-  bool enable_load_store_alloca_;
 };
 
 /** \brief LoadOperation class

--- a/jlm/llvm/opt/reduction.cpp
+++ b/jlm/llvm/opt/reduction.cpp
@@ -76,7 +76,6 @@ enable_load_reductions(jlm::rvsdg::graph & graph)
   nf->set_load_alloca_reducible(true);
   nf->set_multiple_origin_reducible(true);
   nf->set_load_store_state_reducible(true);
-  nf->set_load_store_alloca_reducible(true);
   // set_load_load_state_reducible throws a type_error
   // github issue #307
   nf->set_load_load_state_reducible(false);

--- a/tests/jlm/llvm/ir/operators/TestLoad.cpp
+++ b/tests/jlm/llvm/ir/operators/TestLoad.cpp
@@ -169,43 +169,6 @@ TestLoadStoreStateReduction()
 }
 
 static void
-TestLoadStoreAllocaReduction()
-{
-  using namespace jlm::llvm;
-
-  // Arrange
-  MemoryStateType mt;
-  jlm::rvsdg::bittype bt(32);
-
-  jlm::rvsdg::graph graph;
-  auto nf = LoadOperation::GetNormalForm(&graph);
-  nf->set_mutable(false);
-  nf->set_load_store_alloca_reducible(false);
-
-  auto size = graph.add_import({ bt, "v" });
-
-  auto alloca = alloca_op::create(bt, size, 4);
-  auto store = StoreNode::Create(alloca[0], size, { alloca[1] }, 4);
-  auto load = LoadNode::Create(alloca[0], store, bt, 4);
-
-  auto value = graph.add_export(load[0], { load[0]->type(), "l" });
-  auto rstate = graph.add_export(load[1], { mt, "s" });
-
-  //	jlm::rvsdg::view(graph.root(), stdout);
-
-  // Act
-  nf->set_mutable(true);
-  nf->set_load_store_alloca_reducible(true);
-  graph.normalize();
-
-  //	jlm::rvsdg::view(graph.root(), stdout);
-
-  // Assert
-  assert(value->origin() == graph.root()->argument(0));
-  assert(rstate->origin() == alloca[1]);
-}
-
-static void
 TestLoadStoreReduction()
 {
   using namespace jlm::llvm;
@@ -312,7 +275,6 @@ TestLoad()
   TestLoadAllocaReduction();
   TestMultipleOriginReduction();
   TestLoadStoreStateReduction();
-  TestLoadStoreAllocaReduction();
   TestLoadStoreReduction();
   TestLoadLoadReduction();
 


### PR DESCRIPTION
This PR removes the load-store-alloca reduction.

The reduction was buggy (it failed when the stored and loaded value was of a different type) and it is also just a more specific version of the [load-store reduction](https://github.com/phate/jlm/blob/86d9af20fef46935ab31ae4fbcb840eed9f50180/jlm/llvm/ir/operators/load.cpp#L205C1-L213C25). Since the load-store reduction is more general, we can just remove this reduction instead of fixing it.

Closes #341 