### PR TITLE
Add method for dumping the constraint set as a subset graph

### DIFF
--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -826,6 +826,9 @@ Andersen::AnalyzeModule(const RvsdgModule & module, Statistics & statistics)
 void
 Andersen::SolveConstraints(const Configuration & config, Statistics & statistics)
 {
+  jlm::util::GraphWriter writer;
+  Constraints_->DrawSubsetGraph(writer);
+
   if (config.GetSolver() == Configuration::Solver::Naive)
   {
     statistics.StartConstraintSolvingNaiveStatistics();
@@ -840,6 +843,12 @@ Andersen::SolveConstraints(const Configuration & config, Statistics & statistics
   }
   else
     JLM_UNREACHABLE("Unknown solver");
+
+  auto & graph = Constraints_->DrawSubsetGraph(writer);
+  graph.AppendToLabel("After Solving");
+
+  if (std::getenv(DUMP_SUBSET_GRAPH))
+    writer.OutputAllGraphs(std::cout, util::GraphOutputFormat::Dot);
 }
 
 std::unique_ptr<PointsToGraph>
@@ -853,6 +862,7 @@ Andersen::Analyze(const RvsdgModule & module, util::StatisticsCollector & statis
   // If double-checking against the naive solver is enabled, make a copy of the set and constraints
   const bool checkAgainstNaive = std::getenv(CHECK_AGAINST_NAIVE_SOLVER)
                               && Config_ != Configuration::NaiveSolverConfiguration();
+
   std::pair<std::unique_ptr<PointerObjectSet>, std::unique_ptr<PointerObjectConstraintSet>> copy;
   if (checkAgainstNaive)
     copy = Constraints_->Clone();

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -55,9 +55,9 @@ public:
   {}
 
   void
-  StartAndersenStatistics(const jlm::rvsdg::graph & graph) noexcept
+  StartAndersenStatistics(const rvsdg::graph & graph) noexcept
   {
-    AddMeasurement(Label::NumRvsdgNodes, jlm::rvsdg::nnodes(graph.root()));
+    AddMeasurement(Label::NumRvsdgNodes, rvsdg::nnodes(graph.root()));
     AddTimer(AnalysisTimer_).start();
   }
 
@@ -826,7 +826,7 @@ Andersen::AnalyzeModule(const RvsdgModule & module, Statistics & statistics)
 void
 Andersen::SolveConstraints(const Configuration & config, Statistics & statistics)
 {
-  jlm::util::GraphWriter writer;
+  util::GraphWriter writer;
   Constraints_->DrawSubsetGraph(writer);
 
   if (config.GetSolver() == Configuration::Solver::Naive)
@@ -1044,7 +1044,7 @@ std::unique_ptr<PointsToGraph>
 Andersen::ConstructPointsToGraphFromPointerObjectSet(const PointerObjectSet & set)
 {
   // Create a throwaway instance of statistics
-  Statistics statistics(jlm::util::filepath(""));
+  Statistics statistics(util::filepath(""));
   return ConstructPointsToGraphFromPointerObjectSet(set, statistics);
 }
 

--- a/jlm/llvm/opt/alias-analyses/Andersen.hpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Håvard Krogstie <krogstie.havard@gmail.com>
+ * Copyright 2023, 2024 Håvard Krogstie <krogstie.havard@gmail.com>
  * See COPYING for terms of redistribution.
  */
 
@@ -30,7 +30,12 @@ public:
    * by running analysis again with the naive solver and no extra processing.
    * Any differences in the produced PointsToGraph result in an error.
    */
-  static inline const char * CHECK_AGAINST_NAIVE_SOLVER = "JLM_ANDERSEN_COMPARE_SOLVE_NAIVE";
+  static inline const char * const CHECK_AGAINST_NAIVE_SOLVER = "JLM_ANDERSEN_COMPARE_SOLVE_NAIVE";
+
+  /**
+   * Environment variable that will trigger dumping the subset graph before and after solving.
+   */
+  static inline const char * const DUMP_SUBSET_GRAPH = "JLM_ANDERSEN_DUMP_SUBSET_GRAPH";
 
   /**
    * class for configuring the Andersen pass, such as what solver to use.

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
@@ -751,153 +751,209 @@ PointerObjectConstraintSet::GetConstraints() const noexcept
   return Constraints_;
 }
 
-jlm::util::Graph &
-PointerObjectConstraintSet::DrawSubsetGraph(jlm::util::GraphWriter & writer) const
+/**
+ * Creates a label describing the PointerObject with the given \p index in the given \p set.
+ * The label includes the index and the PointerObjectKind.
+ * The PointerObject's pointees are included, or a reference to the unification root.
+ * Helper function used by DrawSubsetGraph.
+ */
+static std::string
+CreateSubsetGraphNodeLabel(PointerObjectSet & set, PointerObjectIndex index)
 {
-  auto & graph = writer.CreateGraph();
-  graph.SetLabel("Andersen subset graph");
+  std::ostringstream label;
+  label << index;
+
+  auto kind = set.GetPointerObjectKind(index);
+  if (kind == PointerObjectKind::AllocaMemoryObject)
+    label << " A";
+  else if (kind == PointerObjectKind::MallocMemoryObject)
+    label << " M";
+  else if (kind == PointerObjectKind::FunctionMemoryObject)
+    label << " F";
+  else if (kind == PointerObjectKind::GlobalMemoryObject)
+    label << " G";
+  else if (kind == PointerObjectKind::ImportMemoryObject)
+    label << " I";
+  else if (kind != PointerObjectKind::Register)
+    JLM_UNREACHABLE("Unknown PointerObject kind");
+
+  label << "\n";
+
+  if (set.IsUnificationRoot(index))
+  {
+    label << "{";
+    bool sep = false;
+    for (auto pointee : set.GetPointsToSet(index).Items())
+    {
+      if (sep)
+        label << ", ";
+      sep = true;
+      label << pointee;
+    }
+    // Add a + if pointing to external
+    if (set.IsPointingToExternal(index))
+      label << (sep ? ", +" : "+");
+    label << "}";
+
+    if (set.HasPointeesEscaping(index))
+      label << "e";
+  }
+  else
+  {
+    label << "#" << set.GetUnificationRoot(index);
+  }
+
+  if (!set.ShouldTrackPointees(index))
+    label << "\nNOTRACK";
+
+  return label.str();
+}
+
+/**
+ * Creates GraphWriter nodes for each PointerObject in the set, with appropriate shape and label.
+ * Memory objects are rectangular, registers are oval. Escaped nodes have a yellow fill.
+ * Helper function used by DrawSubsetGraph.
+ */
+static void
+CreateSubsetGraphNodes(PointerObjectSet & set, util::Graph & graph)
+{
+  // Ensure the index of nodes line up with the index of the corresponding PointerObject
+  JLM_ASSERT(graph.NumNodes() == 0);
 
   // Create nodes for each PointerObject
-  std::vector<jlm::util::Node *> nodes(Set_.NumPointerObjects());
-  for (PointerObjectIndex i = 0; i < Set_.NumPointerObjects(); i++)
+  for (PointerObjectIndex i = 0; i < set.NumPointerObjects(); i++)
   {
     auto & node = graph.CreateNode();
-    nodes[i] = &node;
 
-    std::ostringstream label;
-    label << i;
+    node.SetLabel(CreateSubsetGraphNodeLabel(set, i));
 
-    auto kind = Set_.GetPointerObjectKind(i);
-    if (kind == PointerObjectKind::Register)
+    if (set.IsPointerObjectRegister(i))
       node.SetShape(util::Node::Shape::Oval);
     else
       node.SetShape(util::Node::Shape::Rectangle);
 
-    if (kind == PointerObjectKind::AllocaMemoryObject)
-      label << " A";
-    else if (kind == PointerObjectKind::MallocMemoryObject)
-      label << " M";
-    else if (kind == PointerObjectKind::FunctionMemoryObject)
-      label << " F";
-    else if (kind == PointerObjectKind::GlobalMemoryObject)
-      label << " G";
-    else if (kind == PointerObjectKind::ImportMemoryObject)
-      label << " I";
-
-    label << "\n";
-
-    if (Set_.IsUnificationRoot(i))
-    {
-      label << "{";
-      bool sep = false;
-      for (auto pointee : Set_.GetPointsToSet(i).Items())
-      {
-        if (sep)
-          label << ", ";
-        sep = true;
-        label << pointee;
-      }
-      // Add a + if pointing to external
-      if (Set_.IsPointingToExternal(i))
-        label << (sep ? ", +" : "+");
-      label << "}";
-
-      if (Set_.HasPointeesEscaping(i))
-        label << "e";
-    }
-    else
-    {
-      label << "#" << Set_.GetUnificationRoot(i);
-    }
-
-    if (!Set_.ShouldTrackPointees(i))
-      label << "\nNOTRACK";
-
-    node.SetLabel(label.str());
-
-    if (Set_.HasEscaped(i))
+    if (set.HasEscaped(i))
       node.SetFillColor("#FFFF99");
   }
+}
 
+/**
+ * Creates edges representing the different constraints in the subset graph.
+ * Subset constraints become normal edges.
+ * Load and store constraints become dashed edges with a circle on the end being dereferenced.
+ * Function call constraints append to the labels to the nodes involved in the function call.
+ * Helper function used by DrawSubsetGraph.
+ */
+static void
+CreateSubsetGraphEdges(
+    const PointerObjectSet & set,
+    const std::vector<PointerObjectConstraintSet::ConstraintVariant> & constraints,
+    util::Graph & graph)
+{
   // Draw edges for constraints
   size_t nextCallConstraintIndex = 0;
-  for (auto constraint : Constraints_)
+  for (auto & constraint : constraints)
   {
     if (auto * supersetConstraint = std::get_if<SupersetConstraint>(&constraint))
     {
       graph.CreateDirectedEdge(
-          *nodes[supersetConstraint->GetSubset()],
-          *nodes[supersetConstraint->GetSuperset()]);
+          graph.GetNode(supersetConstraint->GetSubset()),
+          graph.GetNode(supersetConstraint->GetSuperset()));
     }
     else if (auto * storeConstraint = std::get_if<StoreConstraint>(&constraint))
     {
       auto & edge = graph.CreateDirectedEdge(
-          *nodes[storeConstraint->GetValue()],
-          *nodes[storeConstraint->GetPointer()]);
+          graph.GetNode(storeConstraint->GetValue()),
+          graph.GetNode(storeConstraint->GetPointer()));
       edge.SetStyle(util::Edge::Style::Dashed);
-      edge.SetArrowhead("normalodot");
+      edge.SetArrowHead("normalodot");
     }
     else if (auto * loadConstraint = std::get_if<LoadConstraint>(&constraint))
     {
       auto & edge = graph.CreateDirectedEdge(
-          *nodes[loadConstraint->GetPointer()],
-          *nodes[loadConstraint->GetValue()]);
+          graph.GetNode(loadConstraint->GetPointer()),
+          graph.GetNode(loadConstraint->GetValue()));
       edge.SetStyle(util::Edge::Style::Dashed);
-      edge.SetArrowtail("odot");
+      edge.SetArrowTail("odot");
     }
     else if (auto * callConstraint = std::get_if<FunctionCallConstraint>(&constraint))
     {
       auto callConstraintIndex = nextCallConstraintIndex++;
-      auto & pointerNode = *nodes[callConstraint->GetPointer()];
+      auto & pointerNode = graph.GetNode(callConstraint->GetPointer());
       pointerNode.AppendToLabel(util::strfmt("call", callConstraintIndex, " target"));
 
       // Connect all registers that correspond to inputs and outputs of the call, to the call target
       auto & callNode = callConstraint->GetCallNode();
       for (size_t i = 0; i < callNode.NumArguments(); i++)
       {
-        if (auto inputRegister = Set_.TryGetRegisterPointerObject(*callNode.Argument(i)->origin()))
+        if (auto inputRegister = set.TryGetRegisterPointerObject(*callNode.Argument(i)->origin()))
         {
           const auto label = util::strfmt("call", callConstraintIndex, " input", i);
-          nodes[*inputRegister]->AppendToLabel(label);
+          graph.GetNode(*inputRegister).AppendToLabel(label);
         }
       }
       for (size_t i = 0; i < callNode.NumResults(); i++)
       {
-        if (auto outputRegister = Set_.TryGetRegisterPointerObject(*callNode.Result(i)))
+        if (auto outputRegister = set.TryGetRegisterPointerObject(*callNode.Result(i)))
         {
           const auto label = util::strfmt("call", callConstraintIndex, " output", i);
-          nodes[*outputRegister]->AppendToLabel(label);
+          graph.GetNode(*outputRegister).AppendToLabel(label);
         }
       }
     }
+    else
+    {
+      JLM_UNREACHABLE("Unknown constraint type");
+    }
   }
+}
 
-  // Add labels to indicate registers that are arguments and results of functions
+/**
+ * Appends to the labels of all nodes that represent parts of functions.
+ * This includes nodes representing the function itself, e.g. "function4",
+ * nodes representing the functions arguments, e.g. "function4 arg2",
+ * and nodes representing values returned from the function, e.g. "function4 res0".
+ * Helper function used by DrawSubsetGraph.
+ */
+static void
+LabelFunctionsArgumentsAndReturnValues(PointerObjectSet & set, util::Graph & graph)
+{
   size_t nextFunctionIndex = 0;
-  for (auto [function, pointerObject] : Set_.GetFunctionMap())
+  for (auto [function, pointerObject] : set.GetFunctionMap())
   {
-    JLM_ASSERT(Set_.GetPointerObjectKind(pointerObject) == PointerObjectKind::FunctionMemoryObject);
+    JLM_ASSERT(set.GetPointerObjectKind(pointerObject) == PointerObjectKind::FunctionMemoryObject);
     const auto functionIndex = nextFunctionIndex++;
-    nodes[pointerObject]->AppendToLabel(util::strfmt("function", functionIndex));
+    graph.GetNode(pointerObject).AppendToLabel(util::strfmt("function", functionIndex));
 
     // Add labels to registers corresponding to arguments and results of the function
     for (size_t i = 0; i < function->nfctarguments(); i++)
     {
-      if (auto argumentRegister = Set_.TryGetRegisterPointerObject(*function->fctargument(i)))
+      if (auto argumentRegister = set.TryGetRegisterPointerObject(*function->fctargument(i)))
       {
         const auto label = util::strfmt("function", functionIndex, " arg", i);
-        nodes[*argumentRegister]->AppendToLabel(label);
+        graph.GetNode(*argumentRegister).AppendToLabel(label);
       }
     }
     for (size_t i = 0; i < function->nfctresults(); i++)
     {
-      if (auto resultRegister = Set_.TryGetRegisterPointerObject(*function->fctresult(i)->origin()))
+      if (auto resultRegister = set.TryGetRegisterPointerObject(*function->fctresult(i)->origin()))
       {
         const auto label = util::strfmt("function", functionIndex, " res", i);
-        nodes[*resultRegister]->AppendToLabel(label);
+        graph.GetNode(*resultRegister).AppendToLabel(label);
       }
     }
   }
+}
+
+util::Graph &
+PointerObjectConstraintSet::DrawSubsetGraph(util::GraphWriter & writer) const
+{
+  auto & graph = writer.CreateGraph();
+  graph.SetLabel("Andersen subset graph");
+
+  CreateSubsetGraphNodes(Set_, graph);
+  CreateSubsetGraphEdges(Set_, Constraints_, graph);
+  LabelFunctionsArgumentsAndReturnValues(Set_, graph);
 
   return graph;
 }

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
@@ -10,6 +10,7 @@
 #include <jlm/llvm/ir/operators/lambda.hpp>
 #include <jlm/util/BijectiveMap.hpp>
 #include <jlm/util/common.hpp>
+#include <jlm/util/GraphWriter.hpp>
 #include <jlm/util/HashSet.hpp>
 #include <jlm/util/Math.hpp>
 
@@ -383,7 +384,6 @@ public:
    * @param subset the index of the PointerObject whose pointees shall all be pointed to by superset
    * as well
    *
-   *
    * @return true if P(\p superset) or any flags were modified by this operation
    */
   bool
@@ -751,6 +751,13 @@ public:
    */
   [[nodiscard]] const std::vector<ConstraintVariant> &
   GetConstraints() const noexcept;
+
+  /**
+   * Creates a subset graph containing all PointerObjects, their current points-to sets,
+   * and edges representing the current set of constraints.
+   */
+  jlm::util::Graph &
+  DrawSubsetGraph(jlm::util::GraphWriter & writer) const;
 
   /**
    * Finds a least solution satisfying all constraints, using the Worklist algorithm.

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
@@ -756,8 +756,8 @@ public:
    * Creates a subset graph containing all PointerObjects, their current points-to sets,
    * and edges representing the current set of constraints.
    */
-  jlm::util::Graph &
-  DrawSubsetGraph(jlm::util::GraphWriter & writer) const;
+  util::Graph &
+  DrawSubsetGraph(util::GraphWriter & writer) const;
 
   /**
    * Finds a least solution satisfying all constraints, using the Worklist algorithm.

--- a/jlm/util/GraphWriter.hpp
+++ b/jlm/util/GraphWriter.hpp
@@ -93,6 +93,13 @@ public:
   SetLabel(std::string label);
 
   /**
+   * Appends the given \p text to the element's label.
+   * If the current label is non-empty, the separator string \p sep in inserted between them.
+   */
+  void
+  AppendToLabel(const std::string_view text, const char * sep = "\n");
+
+  /**
    * @return true if this graph element has a non-empty label
    */
   [[nodiscard]] bool
@@ -164,6 +171,19 @@ public:
    */
   void
   SetAttributeGraphElement(const std::string & attribute, const GraphElement & element);
+
+  /**
+   * @return true if an attribute with the given name \p attribute is defined
+   */
+  [[nodiscard]] bool
+  HasAttribute(const std::string & attribute) const;
+
+  /**
+   * Removes the attribute with the given name \p attribute, if it exists.
+   * @return true if the attribute existed, and was removed, false otherwise
+   */
+  bool
+  RemoveAttribute(const std::string & attribute);
 
   /**
    * Claims a unique id suffix for the element, if it doesn't already have one.
@@ -308,6 +328,29 @@ public:
   Graph &
   GetGraph() override;
 
+  /**
+   * Sets the shape to be used when rendering the node
+   * @see Node::Shape
+   */
+  virtual void
+  SetShape(std::string shape);
+
+  /**
+   * A collection of common GraphViz node shapes.
+   * See https://graphviz.org/doc/info/shapes.html for more.
+   */
+  struct Shape
+  {
+    static inline const char * const Rectangle = "rect";
+    static inline const char * const Circle = "circle";
+    static inline const char * const Oval = "oval";
+    static inline const char * const Point = "point";
+    static inline const char * const Plain = "plain";
+    static inline const char * const Plaintext = "plaintext";
+    static inline const char * const Triangle = "triangle";
+    static inline const char * const DoubleCircle = "doublecircle";
+  };
+
   void
   SetFillColor(std::string color) override;
 
@@ -429,6 +472,11 @@ class InOutNode : public Node
 
 public:
   ~InOutNode() override = default;
+
+  /**
+   * InOutNodes use HTML tables when rendering, so setting the shape is disabled
+   */
+  void SetShape(std::string) override;
 
   InputPort &
   CreateInputPort();
@@ -603,6 +651,45 @@ public:
    */
   [[nodiscard]] Port &
   GetOtherEnd(const Port & end);
+
+  /**
+   * Sets the style of the edge
+   * @see Edge::Style for a list of possible styles
+   */
+  void
+  SetStyle(std::string style);
+
+  /**
+   * The set of available edge styles in GraphViz.
+   */
+  struct Style
+  {
+    static inline const char * const Solid = "solid";
+    static inline const char * const Dashed = "dashed";
+    static inline const char * const Dotted = "dotted";
+    static inline const char * const Invisible = "invis";
+    static inline const char * const Bold = "bold";
+    static inline const char * const Tapered = "tapered";
+  };
+
+  /**
+   * Customizes the look of the edge at the head end.
+   * For a normal arrow, use "normal". Other common options are "box", "diamond" and "dot".
+   * Prefix the string with "o" to get outline only. Prefix with "l" or "r" to only get one half.
+   * Concatenate multiple strings to get longer arrows, with the tipmost arrow listed first.
+   * For full a description of the grammar, see https://graphviz.org/doc/info/arrows.html
+   * @param arrow a string describing the look of the edge head.
+   */
+  void
+  SetArrowhead(std::string arrow);
+
+  /**
+   * Customizes the look of the edge at the tail end.
+   * @param arrow a string describing the look of the edge tail.
+   * @see Edge::SetArrowhead() for a short description of the grammar
+   */
+  void
+  SetArrowtail(std::string arrow);
 
   /**
    * Outputs the edge in dot format. In ASCII, edges are not implicitly encoded by nodes/ports.
@@ -859,22 +946,22 @@ private:
  */
 namespace Colors
 {
-inline const char * Black = "#000000";
-inline const char * Blue = "#0000FF";
-inline const char * Coral = "#FF7F50";
-inline const char * CornflowerBlue = "#6495ED";
-inline const char * Firebrick = " #B22222";
-inline const char * Gold = "#FFD700";
-inline const char * Gray = "#BEBEBE";
-inline const char * Green = "#00FF00";
-inline const char * Orange = "#FFA500";
-inline const char * Purple = "#A020F0";
-inline const char * Red = "#FF0000";
-inline const char * Brown = "#8B4513"; // X11's Saddle Brown
-inline const char * SkyBlue = "#87CEEB";
-inline const char * White = "#FFFFFF";
-inline const char * Yellow = "#FFFF00";
-};
+inline const char * const Black = "#000000";
+inline const char * const Blue = "#0000FF";
+inline const char * const Coral = "#FF7F50";
+inline const char * const CornflowerBlue = "#6495ED";
+inline const char * const Firebrick = " #B22222";
+inline const char * const Gold = "#FFD700";
+inline const char * const Gray = "#BEBEBE";
+inline const char * const Green = "#00FF00";
+inline const char * const Orange = "#FFA500";
+inline const char * const Purple = "#A020F0";
+inline const char * const Red = "#FF0000";
+inline const char * const Brown = "#8B4513"; // X11's Saddle Brown
+inline const char * const SkyBlue = "#87CEEB";
+inline const char * const White = "#FFFFFF";
+inline const char * const Yellow = "#FFFF00";
+}
 
 }
 #endif // JLM_UTIL_GRAPHWRITER_HPP

--- a/tests/jlm/llvm/opt/alias-analyses/TestPointerObjectSet.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestPointerObjectSet.cpp
@@ -681,6 +681,8 @@ TestDrawSubsetGraph()
   assert(StringContains(functionNode.GetLabel(), "function0"));
   // Since functions don't track pointees, they should have NOTRACK
   assert(StringContains(functionNode.GetLabel(), "NOTRACK"));
+  // They should also both point to external, and escape all pointees
+  assert(StringContains(functionNode.GetLabel(), "{+}e"));
 
   // Check that the import PointerObject has a fill color, since it has escaped
   auto & importNode = graph.GetNode(import0);

--- a/tests/jlm/llvm/opt/alias-analyses/TestPointerObjectSet.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestPointerObjectSet.cpp
@@ -11,6 +11,12 @@
 
 #include <cassert>
 
+static bool
+StringContains(std::string_view haystack, std::string_view needle)
+{
+  return haystack.find(needle) != std::string::npos;
+}
+
 // Test the flag functions on the PointerObject class
 static void
 TestFlagFunctions()
@@ -599,6 +605,88 @@ TestAddRegisterContentEscapedConstraint()
   assert(set.HasEscaped(alloca1));
 }
 
+static void
+TestDrawSubsetGraph()
+{
+  using namespace jlm::llvm::aa;
+  using namespace jlm::util;
+  jlm::tests::AllMemoryNodesTest rvsdg;
+  rvsdg.InitializeTest();
+
+  // Arrange
+  PointerObjectSet set;
+  const auto alloca0 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode());
+  const auto allocaReg0 = set.CreateRegisterPointerObject(rvsdg.GetAllocaOutput());
+
+  const auto dummy0 = set.CreateDummyRegisterPointerObject();
+  const auto dummy1 = set.CreateDummyRegisterPointerObject();
+  const auto root = set.UnifyPointerObjects(dummy0, dummy1);
+  const auto nonRoot = dummy0 + dummy1 - root;
+
+  const auto storeValue = set.CreateDummyRegisterPointerObject();
+  const auto storePointer = set.CreateDummyRegisterPointerObject();
+
+  const auto loadValue = set.CreateDummyRegisterPointerObject();
+  const auto loadPointer = set.CreateDummyRegisterPointerObject();
+
+  const auto function0 = set.CreateFunctionMemoryObject(rvsdg.GetLambdaNode());
+
+  const auto import0 = set.CreateImportMemoryObject(rvsdg.GetImportOutput());
+
+  PointerObjectConstraintSet constraints(set);
+  constraints.AddPointsToExternalConstraint(nonRoot);
+  constraints.AddPointerPointeeConstraint(allocaReg0, alloca0);
+  constraints.AddConstraint(SupersetConstraint(import0, allocaReg0));
+  constraints.AddConstraint(StoreConstraint(storePointer, storeValue));
+  constraints.AddConstraint(LoadConstraint(loadValue, loadPointer));
+
+  // Act
+  GraphWriter writer;
+  auto & graph = constraints.DrawSubsetGraph(writer);
+
+  // Assert
+  assert(graph.NumNodes() == set.NumPointerObjects());
+
+  // Check that the unified node that is not the root, contains the index of the root
+  assert(StringContains(graph.GetNode(nonRoot).GetLabel(), "#" + std::to_string(root)));
+
+  // Check that the unification root's label indicates pointing to external
+  assert(StringContains(graph.GetNode(root).GetLabel(), "{+}"));
+
+  // Check that allocaReg0 points to alloca0
+  assert(StringContains(graph.GetNode(allocaReg0).GetLabel(), strfmt("{", alloca0, "}")));
+
+  // Check that a regular edge connects allocaReg0 to the importNode
+  auto * supersetEdge = graph.GetEdgeBetween(graph.GetNode(allocaReg0), graph.GetNode(import0));
+  assert(supersetEdge);
+  assert(supersetEdge->IsDirected());
+  assert(supersetEdge->GetAttributeOr("style", "solid") == "solid");
+
+  // Check that a store edge connects storeValue to storePointer
+  auto * storeEdge = graph.GetEdgeBetween(graph.GetNode(storeValue), graph.GetNode(storePointer));
+  assert(storeEdge);
+  assert(storeEdge->IsDirected());
+  assert(storeEdge->GetAttributeOr("style", Edge::Style::Dashed) == Edge::Style::Dashed);
+  assert(StringContains(storeEdge->GetAttribute("arrowhead"), "dot"));
+
+  // Check that a load edge connects loadPointer to loadValue
+  auto * loadEdge = graph.GetEdgeBetween(graph.GetNode(loadPointer), graph.GetNode(loadValue));
+  assert(loadEdge);
+  assert(loadEdge->IsDirected());
+  assert(loadEdge->GetAttributeOr("style", Edge::Style::Dashed) == Edge::Style::Dashed);
+  assert(StringContains(loadEdge->GetAttribute("arrowtail"), "dot"));
+
+  // Check that the function contains the word "function0"
+  auto & functionNode = graph.GetNode(function0);
+  assert(StringContains(functionNode.GetLabel(), "function0"));
+  // Since functions don't track pointees, they should have NOTRACK
+  assert(StringContains(functionNode.GetLabel(), "NOTRACK"));
+
+  // Check that the import PointerObject has a fill color, since it has escaped
+  auto & importNode = graph.GetNode(import0);
+  assert(importNode.HasAttribute("fillcolor"));
+}
+
 // Tests crating a ConstraintSet with multiple different constraints and calling Solve()
 static void
 TestPointerObjectConstraintSetSolve(bool useWorklist)
@@ -776,6 +864,7 @@ TestPointerObjectSet()
   TestFunctionCallConstraint();
   TestAddPointsToExternalConstraint();
   TestAddRegisterContentEscapedConstraint();
+  TestDrawSubsetGraph();
   TestPointerObjectConstraintSetSolve(false);
   TestPointerObjectConstraintSetSolve(true);
   TestClonePointerObjectConstraintSet();


### PR DESCRIPTION
Also adds some utility functions to the GraphWriter classes, to make it nicer to use. At first I was surprised that `arrowtail` is completely ignored when edges have their default `dir=forward`, so it now selects a `dir` that makes manually specified arrow heads visible.

The subset graphs produced look like
![image](https://github.com/phate/jlm/assets/3748845/f7c48558-1f50-4368-903f-e8df11343551)

Regular edges are superset constraints, dashed edges are complex constraints (dereference the side with the circle to convert it into a regular superset constraint edge).
The + means points to escaped, e means all the pointees in the set should escape. NOTRACK is for PointerObjects where the final PointsToGraph node doesn't get any pointees. Function call constraints don't use edges, so they are a bit harder to read.

For this PR, I have added another temporary environment variable `JLM_ANDERSEN_DUMP_SUBSET_GRAPH`, to enable dumping of the subset graph before and after solving. I don't imagine it will ever make sense to make it a proper command line option, so taking the ENV approach seemed the most sensible.