### PR TITLE
Ensure phi nodes containing delta nodes are properly handled in the ReginAwareMemoryNodeProvider

### DIFF
--- a/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.hpp
+++ b/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.hpp
@@ -164,6 +164,19 @@ private:
   PropagatePhi(const phi::node & phiNode);
 
   /**
+   * Assigns and propagates memory nodes as well as unknown memory node references in a phi::node.
+   *
+   * @param region The phi::node subregion.
+   * @param memoryNodes The memory nodes to propagate.
+   * @param unknownMemoryNodeReferences The unknown memory node references to propagate.
+   */
+  void
+  AssignAndPropagateMemoryNodes(
+      const rvsdg::region & region,
+      const util::HashSet<const PointsToGraph::MemoryNode *> & memoryNodes,
+      const util::HashSet<const rvsdg::simple_node *> & unknownMemoryNodeReferences);
+
+  /**
    * Resolves all references to unknown memory locations.
    *
    * After the propagation phase, the tail lambda regions contain all memory locations and simple

--- a/tests/TestRvsdgs.hpp
+++ b/tests/TestRvsdgs.hpp
@@ -1623,6 +1623,38 @@ private:
   jlm::rvsdg::simple_node * PdAlloca_;
 };
 
+/**
+ * This function sets up an RVSDG representing the following code snippet:
+ *
+ * \code{.c}
+ *   #include <stdlib.h>
+ *
+ *   struct myStruct {
+ *     struct myStruct *other;
+ *   };
+ *
+ *   struct myStruct myArray[] = {
+ *     {NULL},
+ *     {&myArray[0]}
+ *   };
+ * \endcode
+ */
+class PhiWithDeltaTest final : public RvsdgTest
+{
+  [[nodiscard]] const jlm::llvm::delta::node &
+  GetDelta() const noexcept
+  {
+    JLM_ASSERT(Delta_ != nullptr);
+    return *Delta_;
+  }
+
+private:
+  std::unique_ptr<jlm::llvm::RvsdgModule>
+  SetupRvsdg() override;
+
+  jlm::llvm::delta::node * Delta_ = {};
+};
+
 /** \brief ExternalMemoryTest class
  *
  * This function sets up an RVSDG representing the following code snippet:

--- a/tests/jlm/llvm/opt/alias-analyses/TestRegionAwareMemoryNodeProvider.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestRegionAwareMemoryNodeProvider.cpp
@@ -9,6 +9,7 @@
 
 #include <jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.hpp>
 #include <jlm/llvm/opt/alias-analyses/Steensgaard.hpp>
+#include <jlm/rvsdg/view.hpp>
 #include <jlm/util/Statistics.hpp>
 
 static std::unique_ptr<jlm::llvm::aa::PointsToGraph>
@@ -1163,6 +1164,25 @@ TestPhi2()
 }
 
 static void
+TestPhiWithDelta()
+{
+  // Assert
+  jlm::tests::PhiWithDeltaTest test;
+  std::unordered_map<const jlm::rvsdg::output *, std::string> outputMap;
+  std::cout << jlm::rvsdg::view(test.graph().root(), outputMap) << std::flush;
+
+  auto pointsToGraph = RunSteensgaard(test.module());
+  std::cout << jlm::llvm::aa::PointsToGraph::ToDot(*pointsToGraph, outputMap) << std::flush;
+
+  // Act
+  auto provisioning =
+      jlm::llvm::aa::RegionAwareMemoryNodeProvider::Create(test.module(), *pointsToGraph);
+
+  // Assert
+  // Nothing needs to be validated as there are only phi and delta nodes in the RVSDG.
+}
+
+static void
 TestMemcpy()
 {
   /*
@@ -1482,6 +1502,7 @@ TestRegionAwareMemoryNodeProvider()
 
   TestPhi1();
   TestPhi2();
+  TestPhiWithDelta();
 
   TestEscapedMemory1();
   TestEscapedMemory2();


### PR DESCRIPTION
This PR fixes a bug where phi nodes containing delta nodes were not properly handled in the RegionAwareMemoryNodeProvider. The PR contains the following:

1. A creator for the ConstantStruct opertion to conveniently create it in an RVSDG.
2. Makes AssignAndPropagateMemoryNodes a proper method instead of having it as a lambda.
3. Adds an RVSDG test that exposes the problem.
4. Fixes the issue in the RegionAwareMemoryNodeProvider by simply not adding delta nodes to the created region summaries. This is achieved by simply moving code around, making the overall code also more intuitive and easier to follow.

Closes #439  