### PR TITLE
CI HLS workflow uses specific jlm-eval-suite commit

### DIFF
--- a/.github/workflows/hls.yml
+++ b/.github/workflows/hls.yml
@@ -28,6 +28,10 @@ jobs:
         install-verilator: true
     - name: "Clone jlm-test-suite"
       run: git clone https://github.com/phate/jlm-eval-suite.git
+    - name: "Checkout specific version of jlm-eval-suite"
+      run: |
+        cd jlm-eval-suite
+        git checkout d91d42359ae7cfb261b76a36da9c532ac65e89a5
     - name: "Link the build output directory to where it is expected by jlm-eval-suite"
       run: ln -s ${{ github.workspace }}/build jlm-eval-suite/jlm/build
     - name: "Run hls-test-suite"


### PR DESCRIPTION
The HLS workflow performs a checkout of a specific jlm-eval-suite commit. This makes it possible to make updates to the jlm-eval-suite independently of jlm, and that later can be used by the jlm CI. This avoids breaking the CI until pull requests have been approved for both the jlm-eval-suite and jlm repositories.