### PR TITLE
Add missing tests to Makefiles

### DIFF
--- a/jlm/rvsdg/Makefile.sub
+++ b/jlm/rvsdg/Makefile.sub
@@ -66,7 +66,7 @@ librvsdg_HEADERS = \
 	jlm/rvsdg/region.hpp \
 
 librvsdg_TESTS = \
-    tests/jlm/rvsdg/bitstring/bitstring \
+	tests/jlm/rvsdg/bitstring/bitstring \
 	tests/jlm/rvsdg/test-binary \
 	tests/jlm/rvsdg/test-bottomup \
 	tests/jlm/rvsdg/test-cse \

--- a/jlm/rvsdg/Makefile.sub
+++ b/jlm/rvsdg/Makefile.sub
@@ -66,6 +66,7 @@ librvsdg_HEADERS = \
 	jlm/rvsdg/region.hpp \
 
 librvsdg_TESTS = \
+    tests/jlm/rvsdg/bitstring/bitstring \
 	tests/jlm/rvsdg/test-binary \
 	tests/jlm/rvsdg/test-bottomup \
 	tests/jlm/rvsdg/test-cse \

--- a/jlm/tooling/Makefile.sub
+++ b/jlm/tooling/Makefile.sub
@@ -52,6 +52,8 @@ libtooling_HEADERS = \
 libtooling_TESTS = \
 	tests/jlm/tooling/TestJlcCommandGraphGenerator \
 	tests/jlm/tooling/TestJlcCommandLineParser \
+	tests/jlm/tooling/TestJlmOptCommand \
+	tests/jlm/tooling/TestJlmOptCommandLineParser \
 
 libtooling_TEST_LIBS = \
 	libtooling \


### PR DESCRIPTION
We had test files missing in the Makefiles. I went through all the test listings in the Makefiles and compared to the files in the test folder to ensure that everything was added.