### PR TITLE
Add ascii output format option to jlm-opt

### DIFF
--- a/jlm/tooling/Command.cpp
+++ b/jlm/tooling/Command.cpp
@@ -20,14 +20,13 @@
 #endif
 
 #include <llvm/IR/LLVMContext.h>
-#include <llvm/IR/Module.h>
 #include <llvm/IRReader/IRReader.h>
 #include <llvm/Support/raw_os_ostream.h>
 #include <llvm/Support/SourceMgr.h>
 
 #include <sys/stat.h>
 
-#include <filesystem>
+#include <fstream>
 #include <unordered_map>
 
 namespace jlm::tooling
@@ -398,6 +397,26 @@ JlmOptCommand::ParseInputFile(
 }
 
 void
+JlmOptCommand::PrintAsAscii(
+    const llvm::RvsdgModule & rvsdgModule,
+    const util::filepath & outputFile,
+    util::StatisticsCollector &)
+{
+  auto ascii = rvsdg::view(rvsdgModule.Rvsdg().root());
+
+  if (outputFile == "")
+  {
+    std::cout << ascii << std::flush;
+  }
+  else
+  {
+    std::ofstream fileStream(outputFile.to_str());
+    fileStream << ascii;
+    fileStream.close();
+  }
+}
+
+void
 JlmOptCommand::PrintAsXml(
     const llvm::RvsdgModule & rvsdgModule,
     const util::filepath & outputFile,
@@ -458,7 +477,11 @@ JlmOptCommand::PrintRvsdgModule(
     const JlmOptCommandLineOptions::OutputFormat & outputFormat,
     util::StatisticsCollector & statisticsCollector)
 {
-  if (outputFormat == tooling::JlmOptCommandLineOptions::OutputFormat::Xml)
+  if (outputFormat == tooling::JlmOptCommandLineOptions::OutputFormat::Ascii)
+  {
+    PrintAsAscii(rvsdgModule, outputFile, statisticsCollector);
+  }
+  else if (outputFormat == tooling::JlmOptCommandLineOptions::OutputFormat::Xml)
   {
     PrintAsXml(rvsdgModule, outputFile, statisticsCollector);
   }

--- a/jlm/tooling/Command.hpp
+++ b/jlm/tooling/Command.hpp
@@ -392,6 +392,12 @@ private:
       util::StatisticsCollector & statisticsCollector);
 
   static void
+  PrintAsAscii(
+      const llvm::RvsdgModule & rvsdgModule,
+      const util::filepath & outputFile,
+      util::StatisticsCollector & statisticsCollector);
+
+  static void
   PrintAsXml(
       const llvm::RvsdgModule & rvsdgModule,
       const util::filepath & outputFile,

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -220,10 +220,7 @@ const char *
 JlmOptCommandLineOptions::ToCommandLineArgument(OutputFormat outputFormat)
 {
   auto & mapping = GetOutputFormatCommandLineArguments();
-  if (mapping.find(outputFormat) != mapping.end())
-    return mapping.at(outputFormat).data();
-
-  throw util::error("Unknown output format");
+  return mapping.at(outputFormat).data();
 }
 
 llvm::optimization *

--- a/jlm/tooling/CommandLine.hpp
+++ b/jlm/tooling/CommandLine.hpp
@@ -49,9 +49,14 @@ public:
 
   enum class OutputFormat
   {
+    FirstEnumValue, // must always be the first enum value, used for iteration
+
+    Ascii,
     Llvm,
     Mlir,
-    Xml
+    Xml,
+
+    LastEnumValue // must always be the last enum value, used for iteration
   };
 
   enum class OptimizationId
@@ -198,6 +203,9 @@ private:
 
   static const util::BijectiveMap<util::Statistics::Id, std::string_view> &
   GetStatisticsIdCommandLineArguments();
+
+  static const std::unordered_map<OutputFormat, std::string_view> &
+  GetOutputFormatCommandLineArguments();
 };
 
 class JlcCommandLineOptions final : public CommandLineOptions

--- a/tests/jlm/tooling/TestJlmOptCommandLineParser.cpp
+++ b/tests/jlm/tooling/TestJlmOptCommandLineParser.cpp
@@ -76,7 +76,7 @@ TestOutputFormatToCommandLineArgument()
   {
     auto outputFormat = static_cast<JlmOptCommandLineOptions::OutputFormat>(n);
 
-    // throws exception on failure
+    // throws exception / asserts on failure
     JlmOptCommandLineOptions::ToCommandLineArgument(outputFormat);
   }
 

--- a/tests/jlm/tooling/TestJlmOptCommandLineParser.cpp
+++ b/tests/jlm/tooling/TestJlmOptCommandLineParser.cpp
@@ -63,6 +63,30 @@ TestOptimizationIdToOptimizationTranslation()
 }
 
 static int
+TestOutputFormatToCommandLineArgument()
+{
+  using namespace jlm::tooling;
+
+  // Arrange
+  auto start = static_cast<std::size_t>(JlmOptCommandLineOptions::OutputFormat::FirstEnumValue) + 1;
+  auto end = static_cast<std::size_t>(JlmOptCommandLineOptions::OutputFormat::LastEnumValue);
+
+  // Act & Assert
+  for (size_t n = start; n != end; n++)
+  {
+    auto outputFormat = static_cast<JlmOptCommandLineOptions::OutputFormat>(n);
+
+    // throws exception on failure
+    JlmOptCommandLineOptions::ToCommandLineArgument(outputFormat);
+  }
+
+  return 0;
+}
+JLM_UNIT_TEST_REGISTER(
+    "jlm/tooling/TestJlmOptCommandLineParser-TestOutputFormatToCommandLineArgument",
+    TestOutputFormatToCommandLineArgument)
+
+static int
 Test()
 {
   TestOptimizationCommandLineArgumentConversion();


### PR DESCRIPTION
Adds an option to jlm-opt for printing an RVSDG in ASCII format.