### PR TITLE
Add valgrind to install packages composite action

### DIFF
--- a/.github/actions/BuildJlm/action.yml
+++ b/.github/actions/BuildJlm/action.yml
@@ -42,11 +42,12 @@ runs:
         exit 1
       shell: bash
 
-    - name: "Install LLVM dependencies"
+    - name: "Install dependencies"
       uses: ./.github/actions/InstallPackages
       with:
         install-llvm: true
         install-clang: true
+        install-valgrind: true  # Required for make target valgrind-check
 
     - name: "Install HLS dialect dependencies"
       if: ${{inputs.enable-hls == 'true'}}

--- a/.github/actions/InstallPackages/action.yml
+++ b/.github/actions/InstallPackages/action.yml
@@ -32,15 +32,20 @@ inputs:
     default: "false"
     required: false
 
+  install-valgrind:
+    description: "Install valgrind package. Default is 'false'."
+    default: "false"
+    required: false
+
   install-verilator:
-    description: "Install varilator package. Default is 'false'."
+    description: "Install verilator package. Default is 'false'."
     default: "false"
     required: false
 
 runs:
   using: "composite"
   steps:
-    - name: "Get LLVM apt key and update apt sources"
+    - name: "Get LLVM apt key"
       if: ${{inputs.install-llvm == 'true'
         || inputs.install-clang == 'true'
         || inputs.install-mlir == 'true'
@@ -49,8 +54,12 @@ runs:
         export HAS_LLVM_REPOSITORY=$(find /etc/apt/ -name *.list | xargs cat | grep llvm-toolchain-jammy-16)
         if [[ -z $HAS_LLVM_REPOSITORY ]]; then
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-          sudo add-apt-repository deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main
+          sudo add-apt-repository --no-update deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main
         fi
+      shell: bash
+
+    - name: "Update apt sources"
+      run: sudo apt-get update
       shell: bash
 
     - name: "Install LLVM package"
@@ -89,6 +98,11 @@ runs:
     - name: "Install doxygen package"
       if: ${{inputs.install-doxygen == 'true'}}
       run: sudo apt-get install graphviz doxygen
+      shell: bash
+
+    - name: "Install valgrind package"
+      if: ${{inputs.install-valgrind == 'true'}}
+      run: sudo apt-get install valgrind
       shell: bash
 
     - name: "Install verilator package"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,10 +32,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: "Install valgrind"
-        uses: ./.github/actions/InstallPackages
-        with:
-          install-valgrind: true
       - name: "Build jlm"
         uses: ./.github/actions/BuildJlm
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,8 +32,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: Install valgrind
-        run: sudo apt-get install valgrind
+      - name: "Install valgrind"
+        uses: ./.github/actions/InstallPackages
+        with:
+          install-valgrind: true
       - name: "Build jlm"
         uses: ./.github/actions/BuildJlm
         with:


### PR DESCRIPTION
The valgrind jobs are currently failing in several PRs as fetching the mirrors fails. This is due to a missing `apt-get update` before installing the package. This PR does the following:

1. Adds the valgrind installation to the InstallPackages composite action
2. Ensures that an `apt-get update` is performed before packages are installed