### PR TITLE
Add support for volatile memory accesses

### DIFF
--- a/jlm/llvm/backend/jlm2llvm/instruction.cpp
+++ b/jlm/llvm/backend/jlm2llvm/instruction.cpp
@@ -305,7 +305,8 @@ convert_store(
   JLM_ASSERT(is<StoreOperation>(op) && args.size() >= 2);
   auto store = static_cast<const StoreOperation *>(&op);
 
-  auto i = builder.CreateStore(ctx.value(args[1]), ctx.value(args[0]));
+  auto isVolatile = store->IsVolatile();
+  auto i = builder.CreateStore(ctx.value(args[1]), ctx.value(args[0]), isVolatile);
   i->setAlignment(::llvm::Align(store->GetAlignment()));
   return nullptr;
 }

--- a/jlm/llvm/backend/jlm2llvm/instruction.cpp
+++ b/jlm/llvm/backend/jlm2llvm/instruction.cpp
@@ -288,8 +288,9 @@ convert(
     ::llvm::IRBuilder<> & builder,
     context & ctx)
 {
+  auto isVolatile = operation.IsVolatile();
   auto type = convert_type(operation.GetLoadedType(), ctx);
-  auto loadInstruction = builder.CreateLoad(type, ctx.value(args[0]));
+  auto loadInstruction = builder.CreateLoad(type, ctx.value(args[0]), isVolatile);
   loadInstruction->setAlignment(::llvm::Align(operation.GetAlignment()));
   return loadInstruction;
 }

--- a/jlm/llvm/frontend/LlvmInstructionConversion.cpp
+++ b/jlm/llvm/frontend/LlvmInstructionConversion.cpp
@@ -596,12 +596,13 @@ convert_load_instruction(::llvm::Instruction * i, tacsvector_t & tacs, context &
   JLM_ASSERT(i->getOpcode() == ::llvm::Instruction::Load);
   auto instruction = static_cast<::llvm::LoadInst *>(i);
 
-  /* FIXME: volatile */
+  auto isVolatile = instruction->isVolatile();
   auto alignment = instruction->getAlign().value();
   auto address = ConvertValue(instruction->getPointerOperand(), tacs, ctx);
   auto loadedType = ConvertType(instruction->getType(), ctx);
 
-  tacs.push_back(LoadOperation::Create(address, ctx.memory_state(), *loadedType, alignment));
+  tacs.push_back(
+      LoadOperation::Create(address, ctx.memory_state(), *loadedType, isVolatile, alignment));
   auto value = tacs.back()->result(0);
   auto state = tacs.back()->result(1);
 

--- a/jlm/llvm/frontend/LlvmInstructionConversion.cpp
+++ b/jlm/llvm/frontend/LlvmInstructionConversion.cpp
@@ -617,12 +617,12 @@ convert_store_instruction(::llvm::Instruction * i, tacsvector_t & tacs, context 
   JLM_ASSERT(i->getOpcode() == ::llvm::Instruction::Store);
   auto instruction = static_cast<::llvm::StoreInst *>(i);
 
-  /* FIXME: volatile */
+  auto isVolatile = instruction->isVolatile();
   auto alignment = instruction->getAlign().value();
   auto address = ConvertValue(instruction->getPointerOperand(), tacs, ctx);
   auto value = ConvertValue(instruction->getValueOperand(), tacs, ctx);
 
-  tacs.push_back(StoreOperation::Create(address, value, ctx.memory_state(), alignment));
+  tacs.push_back(StoreOperation::Create(address, value, ctx.memory_state(), isVolatile, alignment));
   tacs.push_back(assignment_op::create(tacs.back()->result(0), ctx.memory_state()));
 
   return nullptr;

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
@@ -666,6 +666,7 @@ MemoryStateEncoder::EncodeLoad(const LoadNode & loadNode)
       address,
       inStates,
       loadOperation.GetLoadedType(),
+      loadOperation.IsVolatile(),
       loadOperation.GetAlignment());
   oldResult->divert_users(outputs[0]);
 

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
@@ -689,7 +689,12 @@ MemoryStateEncoder::EncodeStore(const StoreNode & storeNode)
   auto memoryNodeStatePairs = stateMap.GetStates(*address);
   auto inStates = StateMap::MemoryNodeStatePair::States(memoryNodeStatePairs);
 
-  auto outStates = StoreNode::Create(address, value, inStates, storeOperation.GetAlignment());
+  auto outStates = StoreNode::Create(
+      address,
+      value,
+      inStates,
+      storeOperation.IsVolatile(),
+      storeOperation.GetAlignment());
 
   StateMap::MemoryNodeStatePair::ReplaceStates(memoryNodeStatePairs, outStates);
 }

--- a/jlm/llvm/opt/push.cpp
+++ b/jlm/llvm/opt/push.cpp
@@ -355,7 +355,8 @@ pushout_store(jlm::rvsdg::node * storenode)
   }
 
   /* create new store and redirect theta output users */
-  auto nstates = StoreNode::Create(address, nvalue, states, storeop->GetAlignment());
+  auto nstates =
+      StoreNode::Create(address, nvalue, states, storeop->IsVolatile(), storeop->GetAlignment());
   for (size_t n = 0; n < states.size(); n++)
   {
     std::unordered_set<jlm::rvsdg::input *> users;

--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -40,9 +40,9 @@ StoreTest1::SetupRvsdg()
   auto merge_a =
       MemStateMergeOperator::Create(std::vector<jlm::rvsdg::output *>({ a[1], merge_b }));
 
-  auto a_amp_b = StoreNode::Create(a[0], b[0], { merge_a }, 4);
-  auto b_amp_c = StoreNode::Create(b[0], c[0], { a_amp_b[0] }, 4);
-  auto c_amp_d = StoreNode::Create(c[0], d[0], { b_amp_c[0] }, 4);
+  auto a_amp_b = StoreNode::Create(a[0], b[0], { merge_a }, false, 4);
+  auto b_amp_c = StoreNode::Create(b[0], c[0], { a_amp_b[0] }, false, 4);
+  auto c_amp_d = StoreNode::Create(c[0], d[0], { b_amp_c[0] }, false, 4);
 
   fct->finalize({ c_amp_d[0] });
 
@@ -97,10 +97,10 @@ StoreTest2::SetupRvsdg()
   auto merge_p =
       MemStateMergeOperator::Create(std::vector<jlm::rvsdg::output *>({ p[1], merge_y }));
 
-  auto x_amp_a = StoreNode::Create(x[0], a[0], { merge_p }, 4);
-  auto y_amp_b = StoreNode::Create(y[0], b[0], { x_amp_a[0] }, 4);
-  auto p_amp_x = StoreNode::Create(p[0], x[0], { y_amp_b[0] }, 4);
-  auto p_amp_y = StoreNode::Create(p[0], y[0], { p_amp_x[0] }, 4);
+  auto x_amp_a = StoreNode::Create(x[0], a[0], { merge_p }, false, 4);
+  auto y_amp_b = StoreNode::Create(y[0], b[0], { x_amp_a[0] }, false, 4);
+  auto p_amp_x = StoreNode::Create(p[0], x[0], { y_amp_b[0] }, false, 4);
+  auto p_amp_y = StoreNode::Create(p[0], y[0], { p_amp_x[0] }, false, 4);
 
   fct->finalize({ p_amp_y[0] });
 
@@ -190,13 +190,13 @@ LoadTest2::SetupRvsdg()
   auto merge_p =
       MemStateMergeOperator::Create(std::vector<jlm::rvsdg::output *>({ p[1], merge_y }));
 
-  auto x_amp_a = StoreNode::Create(x[0], a[0], { merge_p }, 4);
-  auto y_amp_b = StoreNode::Create(y[0], b[0], x_amp_a, 4);
-  auto p_amp_x = StoreNode::Create(p[0], x[0], y_amp_b, 4);
+  auto x_amp_a = StoreNode::Create(x[0], a[0], { merge_p }, false, 4);
+  auto y_amp_b = StoreNode::Create(y[0], b[0], x_amp_a, false, 4);
+  auto p_amp_x = StoreNode::Create(p[0], x[0], y_amp_b, false, 4);
 
   auto ld1 = LoadNode::Create(p[0], p_amp_x, pointerType, false, 4);
   auto ld2 = LoadNode::Create(ld1[0], { ld1[1] }, pointerType, false, 4);
-  auto y_star_p = StoreNode::Create(y[0], ld2[0], { ld2[1] }, 4);
+  auto y_star_p = StoreNode::Create(y[0], ld2[0], { ld2[1] }, false, 4);
 
   fct->finalize({ y_star_p[0] });
 
@@ -431,8 +431,12 @@ ConstantPointerNullTest::SetupRvsdg()
 
   auto constantPointerNullResult =
       ConstantPointerNullOperation::Create(fct->subregion(), pointerType);
-  auto st =
-      StoreNode::Create(fct->fctargument(0), constantPointerNullResult, { fct->fctargument(1) }, 4);
+  auto st = StoreNode::Create(
+      fct->fctargument(0),
+      constantPointerNullResult,
+      { fct->fctargument(1) },
+      false,
+      4);
 
   fct->finalize({ st[0] });
 
@@ -546,9 +550,9 @@ CallTest1::SetupRvsdg()
     auto six = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 6);
     auto seven = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 7);
 
-    auto stx = StoreNode::Create(x[0], five, { mz }, 4);
-    auto sty = StoreNode::Create(y[0], six, { stx[0] }, 4);
-    auto stz = StoreNode::Create(z[0], seven, { sty[0] }, 4);
+    auto stx = StoreNode::Create(x[0], five, { mz }, false, 4);
+    auto sty = StoreNode::Create(y[0], six, { stx[0] }, false, 4);
+    auto stz = StoreNode::Create(z[0], seven, { sty[0] }, false, 4);
 
     auto callFResults = CallNode::Create(
         cvf,
@@ -974,7 +978,7 @@ IndirectCallTest2::SetupRvsdg()
     auto argumentFunctionCv = lambda->add_ctxvar(&argumentFunction);
 
     auto five = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, n);
-    auto storeNode = StoreNode::Create(pointerArgument, five, { memoryStateArgument }, 4);
+    auto storeNode = StoreNode::Create(pointerArgument, five, { memoryStateArgument }, false, 4);
 
     auto call = CallNode::Create(
         functionICv,
@@ -1171,8 +1175,8 @@ ExternalCallTest1::SetupRvsdg()
     auto mergeMode = MemStateMergeOperator::Create(
         std::vector<jlm::rvsdg::output *>({ allocaMode[1], mergePath }));
 
-    auto storePath = StoreNode::Create(allocaPath[0], pathArgument, { mergeMode }, 4);
-    auto storeMode = StoreNode::Create(allocaMode[0], modeArgument, { storePath[0] }, 4);
+    auto storePath = StoreNode::Create(allocaPath[0], pathArgument, { mergeMode }, false, 4);
+    auto storeMode = StoreNode::Create(allocaMode[0], modeArgument, { storePath[0] }, false, 4);
 
     auto loadPath = LoadNode::Create(allocaPath[0], storeMode, pointerType, false, 4);
     auto loadMode = LoadNode::Create(allocaMode[0], { loadPath[1] }, pointerType, false, 4);
@@ -1279,10 +1283,12 @@ ExternalCallTest2::SetupRvsdg()
   auto loadResults3 = LoadNode::Create(gepResult2, { loadResults2[1] }, pointerType, false, 8);
   auto loadResults4 = LoadNode::Create(loadResults1[0], { loadResults3[1] }, pointerType, false, 8);
 
-  auto storeResults1 = StoreNode::Create(loadResults1[0], loadResults4[0], { loadResults4[1] }, 8);
+  auto storeResults1 =
+      StoreNode::Create(loadResults1[0], loadResults4[0], { loadResults4[1] }, false, 8);
 
   auto loadResults5 = LoadNode::Create(gepResult2, { storeResults1[0] }, pointerType, false, 8);
-  auto storeResults2 = StoreNode::Create(loadResults5[0], loadResults2[0], { loadResults5[1] }, 8);
+  auto storeResults2 =
+      StoreNode::Create(loadResults5[0], loadResults2[0], { loadResults5[1] }, false, 8);
 
   auto callLLvmLifetimeEndResults = CallNode::Create(
       llvmLifetimeEndArgument,
@@ -1381,7 +1387,7 @@ GammaTest2::SetupRvsdg()
 
       auto one = rvsdg::create_bitconstant(gammaNode->subregion(0), 32, 1);
       auto storeZRegion0Results =
-          StoreNode::Create(gammaInputZ->argument(0), one, { loadXResults[1] }, 4);
+          StoreNode::Create(gammaInputZ->argument(0), one, { loadXResults[1] }, false, 4);
 
       // gamma subregion 1
       auto loadYResults = LoadNode::Create(
@@ -1393,7 +1399,7 @@ GammaTest2::SetupRvsdg()
 
       auto two = rvsdg::create_bitconstant(gammaNode->subregion(1), 32, 2);
       auto storeZRegion1Results =
-          StoreNode::Create(gammaInputZ->argument(1), two, { loadYResults[1] }, 4);
+          StoreNode::Create(gammaInputZ->argument(1), two, { loadYResults[1] }, false, 4);
 
       // finalize gamma
       auto gammaOutputA = gammaNode->add_exitvar({ loadXResults[0], loadYResults[0] });
@@ -1431,7 +1437,8 @@ GammaTest2::SetupRvsdg()
     auto memoryState = MemStateMergeOperator::Create({ allocaZResults[1], memoryStateArgument });
 
     auto nullPointer = ConstantPointerNullOperation::Create(lambda->subregion(), pointerType);
-    auto storeZResults = StoreNode::Create(allocaZResults[0], nullPointer, { memoryState }, 4);
+    auto storeZResults =
+        StoreNode::Create(allocaZResults[0], nullPointer, { memoryState }, false, 4);
 
     auto zero = rvsdg::create_bitconstant(lambda->subregion(), 32, 0);
     auto bitEq = rvsdg::biteq_op::create(32, cArgument, zero);
@@ -1491,9 +1498,9 @@ GammaTest2::SetupRvsdg()
     auto x = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, xValue);
     auto y = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, yValue);
 
-    auto storeXResults = StoreNode::Create(allocaXResults[0], x, { allocaXResults[1] }, 4);
+    auto storeXResults = StoreNode::Create(allocaXResults[0], x, { allocaXResults[1] }, false, 4);
 
-    auto storeYResults = StoreNode::Create(allocaYResults[0], y, { storeXResults[0] }, 4);
+    auto storeYResults = StoreNode::Create(allocaYResults[0], y, { storeXResults[0] }, false, 4);
 
     auto callResults = CallNode::Create(
         lambdaFArgument,
@@ -1570,7 +1577,7 @@ ThetaTest::SetupRvsdg()
       { n->argument() },
       jlm::rvsdg::bit32,
       pointerType);
-  auto store = StoreNode::Create(gepnode, c->argument(), { s->argument() }, 4);
+  auto store = StoreNode::Create(gepnode, c->argument(), { s->argument() }, false, 4);
 
   auto one = jlm::rvsdg::create_bitconstant(thetanode->subregion(), 32, 1);
   auto sum = jlm::rvsdg::bitadd_op::create(32, n->argument(), one);
@@ -1660,7 +1667,7 @@ DeltaTest1::SetupRvsdg()
     auto cvg = lambda->add_ctxvar(g);
 
     auto five = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 5);
-    auto st = StoreNode::Create(cvf, five, { memoryStateArgument }, 4);
+    auto st = StoreNode::Create(cvf, five, { memoryStateArgument }, false, 4);
     auto callg = CallNode::Create(
         cvg,
         g->node()->type(),
@@ -1751,7 +1758,7 @@ DeltaTest2::SetupRvsdg()
 
     auto cvd1 = lambda->add_ctxvar(d1);
     auto b2 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 2);
-    auto st = StoreNode::Create(cvd1, b2, { memoryStateArgument }, 4);
+    auto st = StoreNode::Create(cvd1, b2, { memoryStateArgument }, false, 4);
 
     return lambda->finalize({ iOStateArgument, st[0], loopStateArgument });
   };
@@ -1777,10 +1784,10 @@ DeltaTest2::SetupRvsdg()
 
     auto b5 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 5);
     auto b42 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 42);
-    auto st = StoreNode::Create(cvd1, b5, { memoryStateArgument }, 4);
+    auto st = StoreNode::Create(cvd1, b5, { memoryStateArgument }, false, 4);
     auto callResults =
         CallNode::Create(cvf1, f1->node()->type(), { iOStateArgument, st[0], loopStateArgument });
-    st = StoreNode::Create(cvd2, b42, { callResults[1] }, 4);
+    st = StoreNode::Create(cvd2, b42, { callResults[1] }, false, 4);
 
     auto lambdaOutput = lambda->finalize(callResults);
     graph->add_export(lambdaOutput, { PointerType(), "f2" });
@@ -1864,7 +1871,7 @@ DeltaTest3::SetupRvsdg()
     auto g2CtxVar = lambda->add_ctxvar(&g2);
 
     auto loadResults = LoadNode::Create(g2CtxVar, { memoryStateArgument }, PointerType(), false, 8);
-    auto storeResults = StoreNode::Create(g2CtxVar, loadResults[0], { loadResults[1] }, 8);
+    auto storeResults = StoreNode::Create(g2CtxVar, loadResults[0], { loadResults[1] }, false, 8);
 
     loadResults = LoadNode::Create(g1CtxVar, storeResults, jlm::rvsdg::bit32, false, 8);
     auto truncResult = trunc_op::create(16, loadResults[0]);
@@ -1950,7 +1957,7 @@ ImportTest::SetupRvsdg()
     auto cvd1 = lambda->add_ctxvar(d1);
 
     auto b5 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 5);
-    auto st = StoreNode::Create(cvd1, b5, { memoryStateArgument }, 4);
+    auto st = StoreNode::Create(cvd1, b5, { memoryStateArgument }, false, 4);
 
     return lambda->finalize({ iOStateArgument, st[0], loopStateArgument });
   };
@@ -1975,10 +1982,10 @@ ImportTest::SetupRvsdg()
     auto cvf1 = lambda->add_ctxvar(f1);
     auto b2 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 2);
     auto b21 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 21);
-    auto st = StoreNode::Create(cvd1, b2, { memoryStateArgument }, 4);
+    auto st = StoreNode::Create(cvd1, b2, { memoryStateArgument }, false, 4);
     auto callResults =
         CallNode::Create(cvf1, f1->node()->type(), { iOStateArgument, st[0], loopStateArgument });
-    st = StoreNode::Create(cvd2, b21, { callResults[1] }, 4);
+    st = StoreNode::Create(cvd2, b21, { callResults[1] }, false, 4);
 
     auto lambdaOutput = lambda->finalize(callResults);
     graph->add_export(lambda->output(), { PointerType(), "f2" });
@@ -2102,7 +2109,7 @@ PhiTest1::SetupRvsdg()
         { valueArgument },
         jlm::rvsdg::bit64,
         pbit64);
-    auto store = StoreNode::Create(gepn, sumex, { gOMemoryState }, 8);
+    auto store = StoreNode::Create(gepn, sumex, { gOMemoryState }, false, 8);
 
     auto lambdaOutput = lambda->finalize({ gOIoState, store[0], gOLoopState });
 
@@ -2261,7 +2268,7 @@ PhiTest2::SetupRvsdg()
     auto functionDCv = lambda->add_ctxvar(&functionD);
 
     auto one = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 1);
-    auto storeNode = StoreNode::Create(pointerArgument, one, { memoryStateArgument }, 4);
+    auto storeNode = StoreNode::Create(pointerArgument, one, { memoryStateArgument }, false, 4);
 
     auto four = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
     auto paAlloca = alloca_op::create(jlm::rvsdg::bit32, four, 4);
@@ -2306,7 +2313,7 @@ PhiTest2::SetupRvsdg()
     auto functionEightCv = lambda->add_ctxvar(&functionEight);
 
     auto two = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 2);
-    auto storeNode = StoreNode::Create(pointerArgument, two, { memoryStateArgument }, 4);
+    auto storeNode = StoreNode::Create(pointerArgument, two, { memoryStateArgument }, false, 4);
 
     auto four = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
     auto pbAlloca = alloca_op::create(jlm::rvsdg::bit32, four, 4);
@@ -2346,7 +2353,7 @@ PhiTest2::SetupRvsdg()
     auto functionACv = lambda->add_ctxvar(&functionA);
 
     auto three = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 3);
-    auto storeNode = StoreNode::Create(xArgument, three, { memoryStateArgument }, 4);
+    auto storeNode = StoreNode::Create(xArgument, three, { memoryStateArgument }, false, 4);
 
     auto four = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
     auto pcAlloca = alloca_op::create(jlm::rvsdg::bit32, four, 4);
@@ -2382,7 +2389,7 @@ PhiTest2::SetupRvsdg()
     auto functionACv = lambda->add_ctxvar(&functionA);
 
     auto four = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
-    auto storeNode = StoreNode::Create(xArgument, four, { memoryStateArgument }, 4);
+    auto storeNode = StoreNode::Create(xArgument, four, { memoryStateArgument }, false, 4);
 
     auto pdAlloca = alloca_op::create(jlm::rvsdg::bit32, four, 4);
     auto pdMerge = MemStateMergeOperator::Create(
@@ -2610,8 +2617,8 @@ ExternalMemoryTest::SetupRvsdg()
   auto one = jlm::rvsdg::create_bitconstant(LambdaF->subregion(), 32, 1);
   auto two = jlm::rvsdg::create_bitconstant(LambdaF->subregion(), 32, 2);
 
-  auto storeOne = StoreNode::Create(x, one, { state }, 4);
-  auto storeTwo = StoreNode::Create(y, two, { storeOne[0] }, 4);
+  auto storeOne = StoreNode::Create(x, one, { state }, false, 4);
+  auto storeTwo = StoreNode::Create(y, two, { storeOne[0] }, false, 4);
 
   LambdaF->finalize(storeTwo);
   graph->add_export(LambdaF->output(), { pointerType, "f" });
@@ -2712,7 +2719,7 @@ EscapedMemoryTest1::SetupRvsdg()
         LoadNode::Create(loadResults1[0], { loadResults1[1] }, jlm::rvsdg::bit32, false, 4);
 
     auto five = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 5);
-    auto storeResults = StoreNode::Create(contextVariableB, five, { loadResults2[1] }, 4);
+    auto storeResults = StoreNode::Create(contextVariableB, five, { loadResults2[1] }, false, 4);
 
     auto lambdaOutput =
         lambda->finalize({ loadResults2[0], iOStateArgument, storeResults[0], loopStateArgument });
@@ -3104,7 +3111,7 @@ MemcpyTest::SetupRvsdg()
         arrayType,
         PointerType());
 
-    auto storeResults = StoreNode::Create(gep, six, { memoryStateArgument }, 8);
+    auto storeResults = StoreNode::Create(gep, six, { memoryStateArgument }, false, 8);
 
     auto loadResults = LoadNode::Create(gep, { storeResults[0] }, jlm::rvsdg::bit32, false, 8);
 
@@ -3398,13 +3405,13 @@ LinkedListTest::SetupRvsdg()
     auto mergedMemoryState = MemStateMergeOperator::Create({ alloca[1], memoryStateArgument });
 
     auto load1 = LoadNode::Create(myListArgument, { mergedMemoryState }, pointerType, false, 4);
-    auto store1 = StoreNode::Create(alloca[0], load1[0], { load1[1] }, 4);
+    auto store1 = StoreNode::Create(alloca[0], load1[0], { load1[1] }, false, 4);
 
     auto load2 = LoadNode::Create(alloca[0], { store1[0] }, pointerType, false, 4);
     auto gep = GetElementPtrOperation::Create(load2[0], { zero, zero }, *structType, pointerType);
 
     auto load3 = LoadNode::Create(gep, { load2[1] }, pointerType, false, 4);
-    auto store2 = StoreNode::Create(alloca[0], load3[0], { load3[1] }, 4);
+    auto store2 = StoreNode::Create(alloca[0], load3[0], { load3[1] }, false, 4);
 
     auto load4 = LoadNode::Create(alloca[0], { store2[0] }, pointerType, false, 4);
 
@@ -3482,7 +3489,7 @@ AllMemoryNodesTest::SetupRvsdg()
 
   // Store the result of malloc into the alloca'd memory
   auto storeAllocaOutputs =
-      StoreNode::Create(allocaOutputs[0], mallocOutputs[0], { afterMallocMemoryState }, 8);
+      StoreNode::Create(allocaOutputs[0], mallocOutputs[0], { afterMallocMemoryState }, false, 8);
 
   // load the value in the alloca again
   auto loadAllocaOutputs =
@@ -3498,11 +3505,16 @@ AllMemoryNodesTest::SetupRvsdg()
       loadAllocaOutputs[0],
       loadImportedOutputs[0],
       { loadImportedOutputs[1] },
+      false,
       4);
 
   // store the loaded alloca value in the global variable
-  auto storeOutputs =
-      StoreNode::Create(deltaContextVar, loadAllocaOutputs[0], { storeImportedOutputs[0] }, 8);
+  auto storeOutputs = StoreNode::Create(
+      deltaContextVar,
+      loadAllocaOutputs[0],
+      { storeImportedOutputs[0] },
+      false,
+      8);
 
   Lambda_->finalize({ storeOutputs[0] });
 
@@ -3595,7 +3607,7 @@ EscapingLocalFunctionTest::SetupRvsdg()
 
   // Store the function parameter into the alloca node
   auto storeOutputs =
-      StoreNode::Create(allocaOutputs[0], LocalFuncParam_, { mergedMemoryState }, 4);
+      StoreNode::Create(allocaOutputs[0], LocalFuncParam_, { mergedMemoryState }, false, 4);
 
   // Bring in deltaOuput as a context variable
   const auto deltaOutputCtxVar = LocalFunc_->add_ctxvar(deltaOutput);
@@ -3713,7 +3725,7 @@ LambdaCallArgumentMismatch::SetupRvsdg()
     auto memoryState = MemStateMergeOperator::Create(
         std::vector<rvsdg::output *>{ memoryStateArgument, allocaResults[1] });
 
-    auto storeResults = StoreNode::Create(allocaResults[0], six, { memoryState }, 4);
+    auto storeResults = StoreNode::Create(allocaResults[0], six, { memoryState }, false, 4);
 
     auto loadResults = LoadNode::Create(allocaResults[0], storeResults, rvsdg::bit32, false, 4);
 
@@ -3786,7 +3798,7 @@ VariadicFunctionTest1::SetupRvsdg()
         { one, varArgList, iOStateArgument, memoryStateArgument, loopStateArgument });
     CallH_ = util::AssertedCast<llvm::CallNode>(rvsdg::node_output::node(callHResults[0]));
 
-    auto storeResults = StoreNode::Create(callHResults[0], three, { callHResults[2] }, 4);
+    auto storeResults = StoreNode::Create(callHResults[0], three, { callHResults[2] }, false, 4);
 
     LambdaF_->finalize({ callHResults[1], storeResults[0], callHResults[3] });
   }
@@ -3806,7 +3818,7 @@ VariadicFunctionTest1::SetupRvsdg()
     auto merge = MemStateMergeOperator::Create({ allocaResults[1], memoryStateArgument });
     AllocaNode_ = rvsdg::node_output::node(allocaResults[0]);
 
-    auto storeResults = StoreNode::Create(allocaResults[0], five, { merge }, 4);
+    auto storeResults = StoreNode::Create(allocaResults[0], five, { merge }, false, 4);
 
     auto callFResults = CallNode::Create(
         lambdaFArgument,
@@ -3922,7 +3934,7 @@ VariadicFunctionTest2::SetupRvsdg()
     auto gepResult2 =
         GetElementPtrOperation::Create(loadResultsGamma0[0], { eight }, rvsdg::bit8, pointerType);
     auto storeResultsGamma0 =
-        StoreNode::Create(gepResult1, gepResult2, { loadResultsGamma0[1] }, 8);
+        StoreNode::Create(gepResult1, gepResult2, { loadResultsGamma0[1] }, false, 8);
 
     // gamma subregion 1
     zero = jlm::rvsdg::create_bitconstant(gammaNode->subregion(1), 64, 0);
@@ -3942,8 +3954,12 @@ VariadicFunctionTest2::SetupRvsdg()
         rvsdg::bit8,
         pointerType);
     auto addResult = rvsdg::bitadd_op::create(32, gammaLoadResult->argument(1), eightBit32);
-    auto storeResultsGamma1 =
-        StoreNode::Create(gammaVaAddress->argument(1), addResult, { loadResultsGamma1[1] }, 16);
+    auto storeResultsGamma1 = StoreNode::Create(
+        gammaVaAddress->argument(1),
+        addResult,
+        { loadResultsGamma1[1] },
+        false,
+        16);
 
     auto gammaAddress = gammaNode->add_exitvar({ loadResultsGamma0[0], gepResult2 });
     auto gammaOutputMemoryState =

--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -138,8 +138,8 @@ LoadTest1::SetupRvsdg()
 
   auto fct = lambda::node::create(graph->root(), fcttype, "f", linkage::external_linkage);
 
-  auto ld1 = LoadNode::Create(fct->fctargument(0), { fct->fctargument(1) }, pointerType, 4);
-  auto ld2 = LoadNode::Create(ld1[0], { ld1[1] }, jlm::rvsdg::bit32, 4);
+  auto ld1 = LoadNode::Create(fct->fctargument(0), { fct->fctargument(1) }, pointerType, false, 4);
+  auto ld2 = LoadNode::Create(ld1[0], { ld1[1] }, jlm::rvsdg::bit32, false, 4);
 
   fct->finalize(ld2);
 
@@ -194,8 +194,8 @@ LoadTest2::SetupRvsdg()
   auto y_amp_b = StoreNode::Create(y[0], b[0], x_amp_a, 4);
   auto p_amp_x = StoreNode::Create(p[0], x[0], y_amp_b, 4);
 
-  auto ld1 = LoadNode::Create(p[0], p_amp_x, pointerType, 4);
-  auto ld2 = LoadNode::Create(ld1[0], { ld1[1] }, pointerType, 4);
+  auto ld1 = LoadNode::Create(p[0], p_amp_x, pointerType, false, 4);
+  auto ld2 = LoadNode::Create(ld1[0], { ld1[1] }, pointerType, false, 4);
   auto y_star_p = StoreNode::Create(y[0], ld2[0], { ld2[1] }, 4);
 
   fct->finalize({ y_star_p[0] });
@@ -216,7 +216,6 @@ LoadTest2::SetupRvsdg()
 
   this->load_x = jlm::rvsdg::node_output::node(ld1[0]);
   this->load_a = jlm::rvsdg::node_output::node(ld2[0]);
-  ;
 
   return module;
 }
@@ -240,7 +239,7 @@ LoadFromUndefTest::SetupRvsdg()
 
   auto undefValue = UndefValueOperation::Create(*Lambda_->subregion(), pointerType);
   auto loadResults =
-      LoadNode::Create(undefValue, { Lambda_->fctargument(0) }, jlm::rvsdg::bit32, 4);
+      LoadNode::Create(undefValue, { Lambda_->fctargument(0) }, jlm::rvsdg::bit32, false, 4);
 
   Lambda_->finalize(loadResults);
   rvsdg.add_export(Lambda_->output(), { pointerType, "f" });
@@ -279,11 +278,11 @@ GetElementPtrTest::SetupRvsdg()
 
   auto gepx =
       GetElementPtrOperation::Create(fct->fctargument(0), { zero, zero }, structType, pointerType);
-  auto ldx = LoadNode::Create(gepx, { fct->fctargument(1) }, jlm::rvsdg::bit32, 4);
+  auto ldx = LoadNode::Create(gepx, { fct->fctargument(1) }, jlm::rvsdg::bit32, false, 4);
 
   auto gepy =
       GetElementPtrOperation::Create(fct->fctargument(0), { zero, one }, structType, pointerType);
-  auto ldy = LoadNode::Create(gepy, { ldx[1] }, jlm::rvsdg::bit32, 4);
+  auto ldy = LoadNode::Create(gepy, { ldx[1] }, jlm::rvsdg::bit32, false, 4);
 
   auto sum = jlm::rvsdg::bitadd_op::create(32, ldx[0], ldy[0]);
 
@@ -476,8 +475,9 @@ CallTest1::SetupRvsdg()
     auto memoryStateArgument = lambda->fctargument(3);
     auto loopStateArgument = lambda->fctargument(4);
 
-    auto ld1 = LoadNode::Create(pointerArgument1, { memoryStateArgument }, jlm::rvsdg::bit32, 4);
-    auto ld2 = LoadNode::Create(pointerArgument2, { ld1[1] }, jlm::rvsdg::bit32, 4);
+    auto ld1 =
+        LoadNode::Create(pointerArgument1, { memoryStateArgument }, jlm::rvsdg::bit32, false, 4);
+    auto ld2 = LoadNode::Create(pointerArgument2, { ld1[1] }, jlm::rvsdg::bit32, false, 4);
 
     auto sum = jlm::rvsdg::bitadd_op::create(32, ld1[0], ld2[0]);
 
@@ -503,8 +503,9 @@ CallTest1::SetupRvsdg()
     auto memoryStateArgument = lambda->fctargument(3);
     auto loopStateArgument = lambda->fctargument(4);
 
-    auto ld1 = LoadNode::Create(pointerArgument1, { memoryStateArgument }, jlm::rvsdg::bit32, 4);
-    auto ld2 = LoadNode::Create(pointerArgument2, { ld1[1] }, jlm::rvsdg::bit32, 4);
+    auto ld1 =
+        LoadNode::Create(pointerArgument1, { memoryStateArgument }, jlm::rvsdg::bit32, false, 4);
+    auto ld2 = LoadNode::Create(pointerArgument2, { ld1[1] }, jlm::rvsdg::bit32, false, 4);
 
     auto diff = jlm::rvsdg::bitsub_op::create(32, ld1[0], ld2[0]);
 
@@ -1026,8 +1027,8 @@ IndirectCallTest2::SetupRvsdg()
         functionY.node()->type(),
         { pyAlloca[0], iOStateArgument, callX[2], loopStateArgument });
 
-    auto loadG1 = LoadNode::Create(globalG1Cv, { callY[2] }, jlm::rvsdg::bit32, 4);
-    auto loadG2 = LoadNode::Create(globalG2Cv, { loadG1[1] }, jlm::rvsdg::bit32, 4);
+    auto loadG1 = LoadNode::Create(globalG1Cv, { callY[2] }, jlm::rvsdg::bit32, false, 4);
+    auto loadG2 = LoadNode::Create(globalG2Cv, { loadG1[1] }, jlm::rvsdg::bit32, false, 4);
 
     auto sum = jlm::rvsdg::bitadd_op::create(32, callX[0], callY[0]);
     sum = jlm::rvsdg::bitadd_op::create(32, sum, loadG1[0]);
@@ -1173,8 +1174,8 @@ ExternalCallTest1::SetupRvsdg()
     auto storePath = StoreNode::Create(allocaPath[0], pathArgument, { mergeMode }, 4);
     auto storeMode = StoreNode::Create(allocaMode[0], modeArgument, { storePath[0] }, 4);
 
-    auto loadPath = LoadNode::Create(allocaPath[0], storeMode, pointerType, 4);
-    auto loadMode = LoadNode::Create(allocaMode[0], { loadPath[1] }, pointerType, 4);
+    auto loadPath = LoadNode::Create(allocaPath[0], storeMode, pointerType, false, 4);
+    auto loadMode = LoadNode::Create(allocaMode[0], { loadPath[1] }, pointerType, false, 4);
 
     auto callGResults = CallNode::Create(
         functionGCv,
@@ -1270,17 +1271,17 @@ ExternalCallTest2::SetupRvsdg()
 
   auto gepResult1 =
       GetElementPtrOperation::Create(allocaResults[0], { zero, one }, *structType, pointerType);
-  auto loadResults1 = LoadNode::Create(gepResult1, { callFResults[1] }, pointerType, 8);
-  auto loadResults2 = LoadNode::Create(loadResults1[0], { loadResults1[1] }, pointerType, 8);
+  auto loadResults1 = LoadNode::Create(gepResult1, { callFResults[1] }, pointerType, false, 8);
+  auto loadResults2 = LoadNode::Create(loadResults1[0], { loadResults1[1] }, pointerType, false, 8);
 
   auto gepResult2 =
       GetElementPtrOperation::Create(allocaResults[0], { zero, two }, *structType, pointerType);
-  auto loadResults3 = LoadNode::Create(gepResult2, { loadResults2[1] }, pointerType, 8);
-  auto loadResults4 = LoadNode::Create(loadResults1[0], { loadResults3[1] }, pointerType, 8);
+  auto loadResults3 = LoadNode::Create(gepResult2, { loadResults2[1] }, pointerType, false, 8);
+  auto loadResults4 = LoadNode::Create(loadResults1[0], { loadResults3[1] }, pointerType, false, 8);
 
   auto storeResults1 = StoreNode::Create(loadResults1[0], loadResults4[0], { loadResults4[1] }, 8);
 
-  auto loadResults5 = LoadNode::Create(gepResult2, { storeResults1[0] }, pointerType, 8);
+  auto loadResults5 = LoadNode::Create(gepResult2, { storeResults1[0] }, pointerType, false, 8);
   auto storeResults2 = StoreNode::Create(loadResults5[0], loadResults2[0], { loadResults5[1] }, 8);
 
   auto callLLvmLifetimeEndResults = CallNode::Create(
@@ -1327,8 +1328,8 @@ GammaTest::SetupRvsdg()
   auto tmp1 = gammanode->add_exitvar({ p1ev->argument(0), p3ev->argument(1) });
   auto tmp2 = gammanode->add_exitvar({ p2ev->argument(0), p4ev->argument(1) });
 
-  auto ld1 = LoadNode::Create(tmp1, { fct->fctargument(5) }, jlm::rvsdg::bit32, 4);
-  auto ld2 = LoadNode::Create(tmp2, { ld1[1] }, jlm::rvsdg::bit32, 4);
+  auto ld1 = LoadNode::Create(tmp1, { fct->fctargument(5) }, jlm::rvsdg::bit32, false, 4);
+  auto ld2 = LoadNode::Create(tmp2, { ld1[1] }, jlm::rvsdg::bit32, false, 4);
   auto sum = jlm::rvsdg::bitadd_op::create(32, ld1[0], ld2[0]);
 
   fct->finalize({ sum, ld2[1] });
@@ -1375,6 +1376,7 @@ GammaTest2::SetupRvsdg()
           gammaInputX->argument(0),
           { gammaInputMemoryState->argument(0) },
           jlm::rvsdg::bit32,
+          false,
           4);
 
       auto one = rvsdg::create_bitconstant(gammaNode->subregion(0), 32, 1);
@@ -1386,6 +1388,7 @@ GammaTest2::SetupRvsdg()
           gammaInputY->argument(1),
           { gammaInputMemoryState->argument(1) },
           jlm::rvsdg::bit32,
+          false,
           4);
 
       auto two = rvsdg::create_bitconstant(gammaNode->subregion(1), 32, 2);
@@ -1437,8 +1440,12 @@ GammaTest2::SetupRvsdg()
     auto [gammaOutputA, gammaOutputMemoryState] =
         SetupGamma(predicate, xArgument, yArgument, allocaZResults[0], memoryState);
 
-    auto loadZResults =
-        LoadNode::Create(allocaZResults[0], { gammaOutputMemoryState }, jlm::rvsdg::bit32, 4);
+    auto loadZResults = LoadNode::Create(
+        allocaZResults[0],
+        { gammaOutputMemoryState },
+        jlm::rvsdg::bit32,
+        false,
+        4);
 
     auto sum = jlm::rvsdg::bitadd_op::create(32, gammaOutputA, loadZResults[0]);
 
@@ -1629,7 +1636,8 @@ DeltaTest1::SetupRvsdg()
     auto memoryStateArgument = lambda->fctargument(2);
     auto loopStateArgument = lambda->fctargument(3);
 
-    auto ld = LoadNode::Create(pointerArgument, { memoryStateArgument }, jlm::rvsdg::bit32, 4);
+    auto ld =
+        LoadNode::Create(pointerArgument, { memoryStateArgument }, jlm::rvsdg::bit32, false, 4);
 
     return lambda->finalize({ ld[0], iOStateArgument, ld[1], loopStateArgument });
   };
@@ -1855,10 +1863,10 @@ DeltaTest3::SetupRvsdg()
     auto g1CtxVar = lambda->add_ctxvar(&g1);
     auto g2CtxVar = lambda->add_ctxvar(&g2);
 
-    auto loadResults = LoadNode::Create(g2CtxVar, { memoryStateArgument }, PointerType(), 8);
+    auto loadResults = LoadNode::Create(g2CtxVar, { memoryStateArgument }, PointerType(), false, 8);
     auto storeResults = StoreNode::Create(g2CtxVar, loadResults[0], { loadResults[1] }, 8);
 
-    loadResults = LoadNode::Create(g1CtxVar, storeResults, jlm::rvsdg::bit32, 8);
+    loadResults = LoadNode::Create(g1CtxVar, storeResults, jlm::rvsdg::bit32, false, 8);
     auto truncResult = trunc_op::create(16, loadResults[0]);
 
     return lambda->finalize({ truncResult, iOStateArgument, loadResults[1], loopStateArgument });
@@ -2073,11 +2081,11 @@ PhiTest1::SetupRvsdg()
 
     auto gepnm1 =
         GetElementPtrOperation::Create(resultev->argument(0), { nm1 }, jlm::rvsdg::bit64, pbit64);
-    auto ldnm1 = LoadNode::Create(gepnm1, { callfibm2Results[1] }, jlm::rvsdg::bit64, 8);
+    auto ldnm1 = LoadNode::Create(gepnm1, { callfibm2Results[1] }, jlm::rvsdg::bit64, false, 8);
 
     auto gepnm2 =
         GetElementPtrOperation::Create(resultev->argument(0), { nm2 }, jlm::rvsdg::bit64, pbit64);
-    auto ldnm2 = LoadNode::Create(gepnm2, { ldnm1[1] }, jlm::rvsdg::bit64, 8);
+    auto ldnm2 = LoadNode::Create(gepnm2, { ldnm1[1] }, jlm::rvsdg::bit64, false, 8);
 
     auto sum = jlm::rvsdg::bitadd_op::create(64, ldnm1[0], ldnm2[0]);
 
@@ -2350,7 +2358,7 @@ PhiTest2::SetupRvsdg()
         recFunctionType,
         { pcAlloca[0], iOStateArgument, pcMerge, loopStateArgument });
 
-    auto loadX = LoadNode::Create(xArgument, { callA[2] }, jlm::rvsdg::bit32, 4);
+    auto loadX = LoadNode::Create(xArgument, { callA[2] }, jlm::rvsdg::bit32, false, 4);
 
     auto sum = jlm::rvsdg::bitadd_op::create(32, callA[0], loadX[0]);
 
@@ -2698,9 +2706,10 @@ EscapedMemoryTest1::SetupRvsdg()
 
     auto contextVariableB = lambda->add_ctxvar(&deltaB);
 
-    auto loadResults1 = LoadNode::Create(pointerArgument, { memoryStateArgument }, pointerType, 4);
+    auto loadResults1 =
+        LoadNode::Create(pointerArgument, { memoryStateArgument }, pointerType, false, 4);
     auto loadResults2 =
-        LoadNode::Create(loadResults1[0], { loadResults1[1] }, jlm::rvsdg::bit32, 4);
+        LoadNode::Create(loadResults1[0], { loadResults1[1] }, jlm::rvsdg::bit32, false, 4);
 
     auto five = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 5);
     auto storeResults = StoreNode::Create(contextVariableB, five, { loadResults2[1] }, 4);
@@ -2871,7 +2880,8 @@ EscapedMemoryTest2::SetupRvsdg()
         externalFunction2Type,
         { iOStateArgument, memoryStateArgument, loopStateArgument });
 
-    auto loadResults = LoadNode::Create(callResults[0], { callResults[2] }, jlm::rvsdg::bit32, 4);
+    auto loadResults =
+        LoadNode::Create(callResults[0], { callResults[2] }, jlm::rvsdg::bit32, false, 4);
 
     auto lambdaOutput =
         lambda->finalize({ loadResults[0], callResults[1], loadResults[1], callResults[3] });
@@ -2980,7 +2990,8 @@ EscapedMemoryTest3::SetupRvsdg()
         externalFunctionType,
         { iOStateArgument, memoryStateArgument, loopStateArgument });
 
-    auto loadResults = LoadNode::Create(callResults[0], { callResults[2] }, jlm::rvsdg::bit32, 4);
+    auto loadResults =
+        LoadNode::Create(callResults[0], { callResults[2] }, jlm::rvsdg::bit32, false, 4);
 
     auto lambdaOutput =
         lambda->finalize({ loadResults[0], callResults[1], loadResults[1], callResults[3] });
@@ -3095,7 +3106,7 @@ MemcpyTest::SetupRvsdg()
 
     auto storeResults = StoreNode::Create(gep, six, { memoryStateArgument }, 8);
 
-    auto loadResults = LoadNode::Create(gep, { storeResults[0] }, jlm::rvsdg::bit32, 8);
+    auto loadResults = LoadNode::Create(gep, { storeResults[0] }, jlm::rvsdg::bit32, false, 8);
 
     auto lambdaOutput =
         lambda->finalize({ loadResults[0], iOStateArgument, loadResults[1], loopStateArgument });
@@ -3205,11 +3216,11 @@ MemcpyTest2::SetupRvsdg()
 
     auto gepS21 = GetElementPtrOperation::Create(s2Argument, { c0, c0 }, *structTypeB, pointerType);
     auto gepS22 = GetElementPtrOperation::Create(gepS21, { c0, c0 }, arrayType, pointerType);
-    auto ldS2 = LoadNode::Create(gepS22, { memoryStateArgument }, pointerType, 8);
+    auto ldS2 = LoadNode::Create(gepS22, { memoryStateArgument }, pointerType, false, 8);
 
     auto gepS11 = GetElementPtrOperation::Create(s1Argument, { c0, c0 }, *structTypeB, pointerType);
     auto gepS12 = GetElementPtrOperation::Create(gepS11, { c0, c0 }, arrayType, pointerType);
-    auto ldS1 = LoadNode::Create(gepS12, { ldS2[1] }, pointerType, 8);
+    auto ldS1 = LoadNode::Create(gepS12, { ldS2[1] }, pointerType, false, 8);
 
     auto memcpyResults = Memcpy::create(ldS2[0], ldS1[0], c128, cFalse, { ldS1[1] });
 
@@ -3239,10 +3250,10 @@ MemcpyTest2::SetupRvsdg()
     auto c0 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 0);
 
     auto gepS1 = GetElementPtrOperation::Create(s1Argument, { c0, c0 }, *structTypeB, pointerType);
-    auto ldS1 = LoadNode::Create(gepS1, { memoryStateArgument }, pointerType, 8);
+    auto ldS1 = LoadNode::Create(gepS1, { memoryStateArgument }, pointerType, false, 8);
 
     auto gepS2 = GetElementPtrOperation::Create(s2Argument, { c0, c0 }, *structTypeB, pointerType);
-    auto ldS2 = LoadNode::Create(gepS2, { ldS1[1] }, pointerType, 8);
+    auto ldS2 = LoadNode::Create(gepS2, { ldS1[1] }, pointerType, false, 8);
 
     auto callResults = CallNode::Create(
         functionFArgument,
@@ -3311,7 +3322,7 @@ MemcpyTest3::SetupRvsdg()
 
   auto gep1 =
       GetElementPtrOperation::Create(allocaResults[0], { zero, zero }, *structType, pointerType);
-  auto ld = LoadNode::Create(gep1, { memcpyResults[0] }, pointerType, 8);
+  auto ld = LoadNode::Create(gep1, { memcpyResults[0] }, pointerType, false, 8);
 
   auto gep2 =
       GetElementPtrOperation::Create(allocaResults[0], { minusFive }, *structType, pointerType);
@@ -3386,16 +3397,16 @@ LinkedListTest::SetupRvsdg()
     auto alloca = alloca_op::create(pointerType, size, 4);
     auto mergedMemoryState = MemStateMergeOperator::Create({ alloca[1], memoryStateArgument });
 
-    auto load1 = LoadNode::Create(myListArgument, { mergedMemoryState }, pointerType, 4);
+    auto load1 = LoadNode::Create(myListArgument, { mergedMemoryState }, pointerType, false, 4);
     auto store1 = StoreNode::Create(alloca[0], load1[0], { load1[1] }, 4);
 
-    auto load2 = LoadNode::Create(alloca[0], { store1[0] }, pointerType, 4);
+    auto load2 = LoadNode::Create(alloca[0], { store1[0] }, pointerType, false, 4);
     auto gep = GetElementPtrOperation::Create(load2[0], { zero, zero }, *structType, pointerType);
 
-    auto load3 = LoadNode::Create(gep, { load2[1] }, pointerType, 4);
+    auto load3 = LoadNode::Create(gep, { load2[1] }, pointerType, false, 4);
     auto store2 = StoreNode::Create(alloca[0], load3[0], { load3[1] }, 4);
 
-    auto load4 = LoadNode::Create(alloca[0], { store2[0] }, pointerType, 4);
+    auto load4 = LoadNode::Create(alloca[0], { store2[0] }, pointerType, false, 4);
 
     auto lambdaOutput =
         lambda->finalize({ load4[0], iOStateArgument, load4[1], loopStateArgument });
@@ -3475,11 +3486,11 @@ AllMemoryNodesTest::SetupRvsdg()
 
   // load the value in the alloca again
   auto loadAllocaOutputs =
-      LoadNode::Create(allocaOutputs[0], { storeAllocaOutputs[0] }, pointerType, 8);
+      LoadNode::Create(allocaOutputs[0], { storeAllocaOutputs[0] }, pointerType, false, 8);
 
   // Load the value of the imported symbol "imported"
   auto loadImportedOutputs =
-      LoadNode::Create(importContextVar, { loadAllocaOutputs[1] }, jlm::rvsdg::bit32, 4);
+      LoadNode::Create(importContextVar, { loadAllocaOutputs[1] }, jlm::rvsdg::bit32, false, 4);
 
   // Store the loaded value from imported, into the address loaded from the alloca (aka. the malloc
   // result)
@@ -3704,7 +3715,7 @@ LambdaCallArgumentMismatch::SetupRvsdg()
 
     auto storeResults = StoreNode::Create(allocaResults[0], six, { memoryState }, 4);
 
-    auto loadResults = LoadNode::Create(allocaResults[0], storeResults, rvsdg::bit32, 4);
+    auto loadResults = LoadNode::Create(allocaResults[0], storeResults, rvsdg::bit32, false, 4);
 
     auto callResults = CallNode::Create(
         lambdaGArgument,
@@ -3888,7 +3899,7 @@ VariadicFunctionTest2::SetupRvsdg()
           callLLvmLifetimeStartResults[2] });
 
     auto loadResults =
-        LoadNode::Create(allocaResults[0], { callVaStartResults[1] }, rvsdg::bit32, 16);
+        LoadNode::Create(allocaResults[0], { callVaStartResults[1] }, rvsdg::bit32, false, 16);
     auto icmpResult = rvsdg::bitult_op::create(32, loadResults[0], fortyOne);
     auto matchResult = rvsdg::match_op::Create(*icmpResult, { { 1, 1 } }, 0, 2);
 
@@ -3907,7 +3918,7 @@ VariadicFunctionTest2::SetupRvsdg()
         *structType,
         pointerType);
     auto loadResultsGamma0 =
-        LoadNode::Create(gepResult1, { gammaMemoryState->argument(0) }, pointerType, 8);
+        LoadNode::Create(gepResult1, { gammaMemoryState->argument(0) }, pointerType, false, 8);
     auto gepResult2 =
         GetElementPtrOperation::Create(loadResultsGamma0[0], { eight }, rvsdg::bit8, pointerType);
     auto storeResultsGamma0 =
@@ -3923,7 +3934,7 @@ VariadicFunctionTest2::SetupRvsdg()
         *structType,
         pointerType);
     auto loadResultsGamma1 =
-        LoadNode::Create(gepResult1, { gammaMemoryState->argument(1) }, pointerType, 16);
+        LoadNode::Create(gepResult1, { gammaMemoryState->argument(1) }, pointerType, false, 16);
     auto & zextResult = zext_op::Create(*gammaLoadResult->argument(1), rvsdg::bit64);
     gepResult2 = GetElementPtrOperation::Create(
         loadResultsGamma1[0],
@@ -3938,7 +3949,8 @@ VariadicFunctionTest2::SetupRvsdg()
     auto gammaOutputMemoryState =
         gammaNode->add_exitvar({ storeResultsGamma0[0], storeResultsGamma1[0] });
 
-    loadResults = LoadNode::Create(gammaAddress, { gammaOutputMemoryState }, rvsdg::bit32, 4);
+    loadResults =
+        LoadNode::Create(gammaAddress, { gammaOutputMemoryState }, rvsdg::bit32, false, 4);
     auto callVaEndResults = CallNode::Create(
         llvmVaEndArgument,
         lambdaVaEndType,

--- a/tests/jlm/llvm/ir/operators/TestCall.cpp
+++ b/tests/jlm/llvm/ir/operators/TestCall.cpp
@@ -142,7 +142,7 @@ TestCallTypeClassifierIndirectCall()
 
     auto store = StoreNode::Create(alloca[0], lambda->fctargument(0), { alloca[1] }, 8);
 
-    auto load = LoadNode::Create(alloca[0], store, pt, 8);
+    auto load = LoadNode::Create(alloca[0], store, pt, false, 8);
 
     auto callResults = CallNode::Create(
         load[0],
@@ -487,11 +487,11 @@ TestCallTypeClassifierRecursiveDirectCall()
 
     auto gepnm1 =
         GetElementPtrOperation::Create(resultev->argument(0), { nm1 }, jlm::rvsdg::bit64, pbit64);
-    auto ldnm1 = LoadNode::Create(gepnm1, { callfibm2Results[1] }, jlm::rvsdg::bit64, 8);
+    auto ldnm1 = LoadNode::Create(gepnm1, { callfibm2Results[1] }, jlm::rvsdg::bit64, false, 8);
 
     auto gepnm2 =
         GetElementPtrOperation::Create(resultev->argument(0), { nm2 }, jlm::rvsdg::bit64, pbit64);
-    auto ldnm2 = LoadNode::Create(gepnm2, { ldnm1[1] }, jlm::rvsdg::bit64, 8);
+    auto ldnm2 = LoadNode::Create(gepnm2, { ldnm1[1] }, jlm::rvsdg::bit64, false, 8);
 
     auto sum = jlm::rvsdg::bitadd_op::create(64, ldnm1[0], ldnm2[0]);
 

--- a/tests/jlm/llvm/ir/operators/TestCall.cpp
+++ b/tests/jlm/llvm/ir/operators/TestCall.cpp
@@ -140,7 +140,7 @@ TestCallTypeClassifierIndirectCall()
 
     auto alloca = alloca_op::create(pt, one, 8);
 
-    auto store = StoreNode::Create(alloca[0], lambda->fctargument(0), { alloca[1] }, 8);
+    auto store = StoreNode::Create(alloca[0], lambda->fctargument(0), { alloca[1] }, false, 8);
 
     auto load = LoadNode::Create(alloca[0], store, pt, false, 8);
 
@@ -508,7 +508,7 @@ TestCallTypeClassifierRecursiveDirectCall()
         { valueArgument },
         jlm::rvsdg::bit64,
         pbit64);
-    auto store = StoreNode::Create(gepn, sumex, { gOMemoryState }, 8);
+    auto store = StoreNode::Create(gepn, sumex, { gOMemoryState }, false, 8);
 
     auto lambdaOutput = lambda->finalize({ gOIoState, store[0], gOLoopState });
 

--- a/tests/jlm/llvm/ir/operators/TestLoad.cpp
+++ b/tests/jlm/llvm/ir/operators/TestLoad.cpp
@@ -139,8 +139,8 @@ TestLoadStoreStateReduction()
 
   auto alloca1 = alloca_op::create(bt, size, 4);
   auto alloca2 = alloca_op::create(bt, size, 4);
-  auto store1 = StoreNode::Create(alloca1[0], size, { alloca1[1] }, 4);
-  auto store2 = StoreNode::Create(alloca2[0], size, { alloca2[1] }, 4);
+  auto store1 = StoreNode::Create(alloca1[0], size, { alloca1[1] }, false, 4);
+  auto store2 = StoreNode::Create(alloca2[0], size, { alloca2[1] }, false, 4);
 
   auto value1 = LoadNode::Create(alloca1[0], { store1[0], store2[0] }, bt, false, 4)[0];
   auto value2 = LoadNode::Create(alloca1[0], { store1[0] }, bt, false, 8)[0];
@@ -187,7 +187,7 @@ TestLoadStoreReduction()
   auto v = graph.add_import({ vt, "value" });
   auto s = graph.add_import({ mt, "state" });
 
-  auto s1 = StoreNode::Create(a, v, { s }, 4)[0];
+  auto s1 = StoreNode::Create(a, v, { s }, false, 4)[0];
   auto load = LoadNode::Create(a, { s1 }, vt, false, 4);
 
   auto x1 = graph.add_export(load[0], { load[0]->type(), "value" });
@@ -230,7 +230,7 @@ TestLoadLoadReduction()
   auto s1 = graph.add_import({ mt, "s1" });
   auto s2 = graph.add_import({ mt, "s2" });
 
-  auto st1 = StoreNode::Create(a1, v1, { s1 }, 4);
+  auto st1 = StoreNode::Create(a1, v1, { s1 }, false, 4);
   auto ld1 = LoadNode::Create(a2, { s1 }, vt, false, 4);
   auto ld2 = LoadNode::Create(a3, { s2 }, vt, false, 4);
 

--- a/tests/jlm/llvm/ir/operators/TestLoad.cpp
+++ b/tests/jlm/llvm/ir/operators/TestLoad.cpp
@@ -31,7 +31,7 @@ TestCopy()
   auto address2 = graph.add_import({ pointerType, "address2" });
   auto memoryState2 = graph.add_import({ memoryType, "memoryState2" });
 
-  auto loadResults = LoadNode::Create(address1, { memoryState1 }, valueType, 4);
+  auto loadResults = LoadNode::Create(address1, { memoryState1 }, valueType, false, 4);
 
   // Act
   auto node = jlm::rvsdg::node_output::node(loadResults[0]);
@@ -63,7 +63,7 @@ TestLoadAllocaReduction()
   auto alloca1 = alloca_op::create(bt, size, 4);
   auto alloca2 = alloca_op::create(bt, size, 4);
   auto mux = jlm::rvsdg::create_state_mux(mt, { alloca1[1] }, 1);
-  auto value = LoadNode::Create(alloca1[0], { alloca1[1], alloca2[1], mux[0] }, bt, 4)[0];
+  auto value = LoadNode::Create(alloca1[0], { alloca1[1], alloca2[1], mux[0] }, bt, false, 4)[0];
 
   auto ex = graph.add_export(value, { value->type(), "l" });
 
@@ -103,7 +103,7 @@ TestMultipleOriginReduction()
   auto a = graph.add_import({ pt, "a" });
   auto s = graph.add_import({ mt, "s" });
 
-  auto load = LoadNode::Create(a, { s, s, s, s }, vt, 4)[0];
+  auto load = LoadNode::Create(a, { s, s, s, s }, vt, false, 4)[0];
 
   auto ex = graph.add_export(load, { load->type(), "l" });
 
@@ -142,8 +142,8 @@ TestLoadStoreStateReduction()
   auto store1 = StoreNode::Create(alloca1[0], size, { alloca1[1] }, 4);
   auto store2 = StoreNode::Create(alloca2[0], size, { alloca2[1] }, 4);
 
-  auto value1 = LoadNode::Create(alloca1[0], { store1[0], store2[0] }, bt, 4)[0];
-  auto value2 = LoadNode::Create(alloca1[0], { store1[0] }, bt, 8)[0];
+  auto value1 = LoadNode::Create(alloca1[0], { store1[0], store2[0] }, bt, false, 4)[0];
+  auto value2 = LoadNode::Create(alloca1[0], { store1[0] }, bt, false, 8)[0];
 
   auto ex1 = graph.add_export(value1, { value1->type(), "l1" });
   auto ex2 = graph.add_export(value2, { value2->type(), "l2" });
@@ -188,7 +188,7 @@ TestLoadStoreReduction()
   auto s = graph.add_import({ mt, "state" });
 
   auto s1 = StoreNode::Create(a, v, { s }, 4)[0];
-  auto load = LoadNode::Create(a, { s1 }, vt, 4);
+  auto load = LoadNode::Create(a, { s1 }, vt, false, 4);
 
   auto x1 = graph.add_export(load[0], { load[0]->type(), "value" });
   auto x2 = graph.add_export(load[1], { load[1]->type(), "state" });
@@ -231,10 +231,10 @@ TestLoadLoadReduction()
   auto s2 = graph.add_import({ mt, "s2" });
 
   auto st1 = StoreNode::Create(a1, v1, { s1 }, 4);
-  auto ld1 = LoadNode::Create(a2, { s1 }, vt, 4);
-  auto ld2 = LoadNode::Create(a3, { s2 }, vt, 4);
+  auto ld1 = LoadNode::Create(a2, { s1 }, vt, false, 4);
+  auto ld2 = LoadNode::Create(a3, { s2 }, vt, false, 4);
 
-  auto ld3 = LoadNode::Create(a4, { st1[0], ld1[1], ld2[1] }, vt, 4);
+  auto ld3 = LoadNode::Create(a4, { st1[0], ld1[1], ld2[1] }, vt, false, 4);
 
   auto x1 = graph.add_export(ld3[1], { mt, "s" });
   auto x2 = graph.add_export(ld3[2], { mt, "s" });

--- a/tests/jlm/llvm/ir/operators/TestStore.cpp
+++ b/tests/jlm/llvm/ir/operators/TestStore.cpp
@@ -32,7 +32,7 @@ TestCopy()
   auto value2 = graph.add_import({ valueType, "value2" });
   auto memoryState2 = graph.add_import({ memoryStateType, "state2" });
 
-  auto storeResults = StoreNode::Create(address1, value1, { memoryState1 }, 4);
+  auto storeResults = StoreNode::Create(address1, value1, { memoryState1 }, false, 4);
 
   // Act
   auto node = jlm::rvsdg::node_output::node(storeResults[0]);
@@ -68,7 +68,7 @@ TestStoreMuxReduction()
   auto s3 = graph.add_import({ mt, "s3" });
 
   auto mux = MemStateMergeOperator::Create({ s1, s2, s3 });
-  auto state = StoreNode::Create(a, v, { mux }, 4);
+  auto state = StoreNode::Create(a, v, { mux }, false, 4);
 
   auto ex = graph.add_export(state[0], { state[0]->type(), "s" });
 
@@ -114,7 +114,7 @@ TestMultipleOriginReduction()
   auto v = graph.add_import({ vt, "v" });
   auto s = graph.add_import({ mt, "s" });
 
-  auto states = StoreNode::Create(a, v, { s, s, s, s }, 4);
+  auto states = StoreNode::Create(a, v, { s, s, s, s }, false, 4);
 
   auto ex = graph.add_export(states[0], { states[0]->type(), "s" });
 
@@ -155,8 +155,8 @@ TestStoreAllocaReduction()
 
   auto alloca1 = alloca_op::create(vt, size, 4);
   auto alloca2 = alloca_op::create(vt, size, 4);
-  auto states1 = StoreNode::Create(alloca1[0], value, { alloca1[1], alloca2[1], s }, 4);
-  auto states2 = StoreNode::Create(alloca2[0], value, states1, 4);
+  auto states1 = StoreNode::Create(alloca1[0], value, { alloca1[1], alloca2[1], s }, false, 4);
+  auto states2 = StoreNode::Create(alloca2[0], value, states1, false, 4);
 
   graph.add_export(states2[0], { states2[0]->type(), "s1" });
   graph.add_export(states2[1], { states2[1]->type(), "s2" });
@@ -198,8 +198,8 @@ TestStoreStoreReduction()
   auto v2 = graph.add_import({ vt, "value" });
   auto s = graph.add_import({ mt, "state" });
 
-  auto s1 = StoreNode::Create(a, v1, { s }, 4)[0];
-  auto s2 = StoreNode::Create(a, v2, { s1 }, 4)[0];
+  auto s1 = StoreNode::Create(a, v1, { s }, false, 4)[0];
+  auto s2 = StoreNode::Create(a, v2, { s1 }, false, 4)[0];
 
   auto ex = graph.add_export(s2, { s2->type(), "state" });
 

--- a/tests/jlm/llvm/opt/TestLoadMuxReduction.cpp
+++ b/tests/jlm/llvm/opt/TestLoadMuxReduction.cpp
@@ -32,7 +32,7 @@ TestSuccess()
   auto s3 = graph.add_import({ mt, "s3" });
 
   auto mux = MemStateMergeOperator::Create({ s1, s2, s3 });
-  auto ld = LoadNode::Create(a, { mux }, vt, 4);
+  auto ld = LoadNode::Create(a, { mux }, vt, false, 4);
 
   auto ex1 = graph.add_export(ld[0], { ld[0]->type(), "v" });
   auto ex2 = graph.add_export(ld[1], { ld[1]->type(), "s" });
@@ -85,7 +85,7 @@ TestWrongNumberOfOperands()
   auto s2 = graph.add_import({ mt, "s2" });
 
   auto merge = MemStateMergeOperator::Create(std::vector<jlm::rvsdg::output *>{ s1, s2 });
-  auto ld = LoadNode::Create(a, { merge, merge }, vt, 4);
+  auto ld = LoadNode::Create(a, { merge, merge }, vt, false, 4);
 
   auto ex1 = graph.add_export(ld[0], { ld[0]->type(), "v" });
   auto ex2 = graph.add_export(ld[1], { ld[1]->type(), "s1" });
@@ -127,7 +127,7 @@ TestLoadWithoutStates()
 
   auto address = graph.add_import({ pointerType, "address" });
 
-  auto loadResults = LoadNode::Create(address, {}, valueType, 4);
+  auto loadResults = LoadNode::Create(address, {}, valueType, false, 4);
 
   auto ex = graph.add_export(loadResults[0], { valueType, "v" });
 

--- a/tests/jlm/llvm/opt/TestLoadStoreReduction.cpp
+++ b/tests/jlm/llvm/opt/TestLoadStoreReduction.cpp
@@ -32,7 +32,7 @@ TestLoadStoreReductionWithDifferentValueOperandType()
   auto value = graph.add_import({ jlm::rvsdg::bit32, "value" });
   auto memoryState = graph.add_import({ memoryStateType, "memoryState" });
 
-  auto storeResults = StoreNode::Create(address, value, { memoryState }, 4);
+  auto storeResults = StoreNode::Create(address, value, { memoryState }, false, 4);
   auto loadResults = LoadNode::Create(address, storeResults, jlm::rvsdg::bit8, false, 4);
 
   auto exportedValue = graph.add_export(loadResults[0], { jlm::rvsdg::bit8, "v" });

--- a/tests/jlm/llvm/opt/TestLoadStoreReduction.cpp
+++ b/tests/jlm/llvm/opt/TestLoadStoreReduction.cpp
@@ -33,7 +33,7 @@ TestLoadStoreReductionWithDifferentValueOperandType()
   auto memoryState = graph.add_import({ memoryStateType, "memoryState" });
 
   auto storeResults = StoreNode::Create(address, value, { memoryState }, 4);
-  auto loadResults = LoadNode::Create(address, storeResults, jlm::rvsdg::bit8, 4);
+  auto loadResults = LoadNode::Create(address, storeResults, jlm::rvsdg::bit8, false, 4);
 
   auto exportedValue = graph.add_export(loadResults[0], { jlm::rvsdg::bit8, "v" });
   graph.add_export(loadResults[1], { memoryStateType, "s" });

--- a/tests/jlm/llvm/opt/test-push.cpp
+++ b/tests/jlm/llvm/opt/test-push.cpp
@@ -125,7 +125,7 @@ test_push_theta_bottom()
   auto lvv = theta->add_loopvar(v);
   auto lvs = theta->add_loopvar(s);
 
-  auto s1 = StoreNode::Create(lva->argument(), lvv->argument(), { lvs->argument() }, 4)[0];
+  auto s1 = StoreNode::Create(lva->argument(), lvv->argument(), { lvs->argument() }, false, 4)[0];
 
   lvs->result()->divert_to(s1);
   theta->set_predicate(lvc->argument());


### PR DESCRIPTION
This PR adds support for volatile memory accesses. Concretely, it does the following:

1. Add volatile support to load operations.
2. Add volatile support to store operations.
3. Adjust load reductions to handle volatile.
4. Adjust store reductions to handle volatile.

We do not need to do anything for the memcpy operation as it already supported volatile.