### PR TITLE
Add custom Hash functor for HashSet, with overload for std::pair

### DIFF
--- a/tests/jlm/util/TestHashSet.cpp
+++ b/tests/jlm/util/TestHashSet.cpp
@@ -63,6 +63,30 @@ TestUniquePointer()
 }
 
 static void
+TestPair()
+{
+  jlm::util::HashSet<std::pair<int, int>> hashSet{ { 1, 10 }, { 5, 50 } };
+
+  // Inserting new value
+  auto result = hashSet.Insert({ 7, 70 });
+  assert(result && hashSet.Size() == 3);
+
+  // Try inserting already inserted
+  result = hashSet.Insert({ 1, 10 });
+  assert(!result && hashSet.Size() == 3);
+
+  // Contains is only true in the correct order
+  assert(hashSet.Contains({ 5, 50 }));
+  assert(!hashSet.Contains({ 50, 5 }));
+
+  // Removing works
+  result = hashSet.Remove({ 5, 50 });
+  assert(result && hashSet.Size() == 2);
+  result = hashSet.Remove({ 5, 50 });
+  assert(!result && hashSet.Size() == 2);
+}
+
+static void
 TestIsSubsetOf()
 {
   jlm::util::HashSet<int> set12({ 1, 2 });
@@ -120,6 +144,7 @@ TestHashSet()
 {
   TestInt();
   TestUniquePointer();
+  TestPair();
   TestIsSubsetOf();
   TestUnionWith();
   TestIntersectWith();

--- a/tests/jlm/util/TestHashSet.cpp
+++ b/tests/jlm/util/TestHashSet.cpp
@@ -10,7 +10,7 @@
 #include <cassert>
 #include <memory>
 
-static void
+static int
 TestInt()
 {
   jlm::util::HashSet<int> hashSet({ 0, 1, 2, 3, 4, 5, 6, 7 });
@@ -45,9 +45,13 @@ TestInt()
 
   hashSet.Clear();
   assert(hashSet.Size() == 0);
+
+  return 0;
 }
 
-static void
+JLM_UNIT_TEST_REGISTER("jlm/util/TestHashSet-TestInt", TestInt)
+
+static int
 TestUniquePointer()
 {
   jlm::util::HashSet<std::unique_ptr<int>> hashSet;
@@ -60,9 +64,13 @@ TestUniquePointer()
 
   hashSet.Clear();
   assert(hashSet.Size() == 0);
+
+  return 0;
 }
 
-static void
+JLM_UNIT_TEST_REGISTER("jlm/util/TestHashSet-TestUniquePointer", TestUniquePointer)
+
+static int
 TestPair()
 {
   jlm::util::HashSet<std::pair<int, int>> hashSet{ { 1, 10 }, { 5, 50 } };
@@ -84,9 +92,13 @@ TestPair()
   assert(result && hashSet.Size() == 2);
   result = hashSet.Remove({ 5, 50 });
   assert(!result && hashSet.Size() == 2);
+
+  return 0;
 }
 
-static void
+JLM_UNIT_TEST_REGISTER("jlm/util/TestHashSet-TestPair", TestPair)
+
+static int
 TestIsSubsetOf()
 {
   jlm::util::HashSet<int> set12({ 1, 2 });
@@ -100,9 +112,13 @@ TestIsSubsetOf()
   assert(set123.IsSubsetOf(set1234));
   assert(!set1234.IsSubsetOf(set12));
   assert(!set1234.IsSubsetOf(set123));
+
+  return 0;
 }
 
-static void
+JLM_UNIT_TEST_REGISTER("jlm/util/TestHashSet-TestIsSubsetOf", TestIsSubsetOf)
+
+static int
 TestUnionWith()
 {
   using namespace jlm::util;
@@ -121,9 +137,13 @@ TestUnionWith()
 
   assert(set45.UnionWith(set123));
   assert(set45.Size() == 5);
+
+  return 0;
 }
 
-static void
+JLM_UNIT_TEST_REGISTER("jlm/util/TestHashSet-TestUnionWith", TestUnionWith)
+
+static int
 TestIntersectWith()
 {
   using namespace jlm::util;
@@ -137,19 +157,7 @@ TestIntersectWith()
 
   set123.IntersectWith(set45);
   assert(set123.Size() == 0);
-}
-
-static int
-TestHashSet()
-{
-  TestInt();
-  TestUniquePointer();
-  TestPair();
-  TestIsSubsetOf();
-  TestUnionWith();
-  TestIntersectWith();
-
   return 0;
 }
 
-JLM_UNIT_TEST_REGISTER("jlm/util/TestHashSet", TestHashSet)
+JLM_UNIT_TEST_REGISTER("jlm/util/TestHashSet-TestIntersectWith", TestIntersectWith)


### PR DESCRIPTION
@phate's comment about using `std::set` instead of `util::HashSet` made me remember why I picked `set` in the first place: `std::pair` doesn't have a specialization of `std::hash`. Since we have our own `HashSet` class that we like to use, I thought it would be fun to see what it would look like to add support for `std::pair`without requiring the user to specify a custom hash function for it.

I also added some constructors to be able to initialize the set with sets that do not have the same hash functor.

If we prefer to not go this route that is of course completely OK. I do enjoy being able to place `std::pair` in HashSets without any extra hassle, though.