### PR TITLE
Add support for volatile loads

### DIFF
--- a/jlm/llvm/Makefile.sub
+++ b/jlm/llvm/Makefile.sub
@@ -131,6 +131,7 @@ libllvm_TESTS += \
 	tests/jlm/llvm/backend/llvm/r2j/test-empty-gamma \
 	tests/jlm/llvm/backend/llvm/r2j/test-partial-gamma \
 	tests/jlm/llvm/backend/llvm/r2j/test-recursive-data \
+	tests/jlm/llvm/backend/llvm/jlm-llvm/LoadTests \
 	tests/jlm/llvm/backend/llvm/jlm-llvm/TestAttributeConversion \
 	tests/jlm/llvm/backend/llvm/jlm-llvm/test-bitconstant \
 	tests/jlm/llvm/backend/llvm/jlm-llvm/test-function-calls \

--- a/jlm/llvm/Makefile.sub
+++ b/jlm/llvm/Makefile.sub
@@ -29,6 +29,7 @@ libllvm_SOURCES = \
     jlm/llvm/ir/operators/GetElementPtr.cpp \
     jlm/llvm/ir/operators/lambda.cpp \
     jlm/llvm/ir/operators/load.cpp \
+    jlm/llvm/ir/operators/LoadVolatile.cpp \
     jlm/llvm/ir/operators/operators.cpp \
     jlm/llvm/ir/operators/Phi.cpp \
     jlm/llvm/ir/operators/sext.cpp \
@@ -108,6 +109,7 @@ libllvm_HEADERS = \
 	jlm/llvm/ir/operators/operators.hpp \
 	jlm/llvm/ir/operators/Phi.hpp \
 	jlm/llvm/ir/operators/load.hpp \
+	jlm/llvm/ir/operators/LoadVolatile.hpp \
 	jlm/llvm/ir/operators/gamma.hpp \
 	jlm/llvm/ir/operators/GetElementPtr.hpp \
 	jlm/llvm/ir/operators/theta.hpp \
@@ -142,6 +144,7 @@ libllvm_TESTS += \
 	tests/jlm/llvm/frontend/llvm/test-recursive-data \
 	tests/jlm/llvm/frontend/llvm/test-restructuring \
 	tests/jlm/llvm/frontend/llvm/test-select \
+	tests/jlm/llvm/ir/operators/LoadVolatileTests \
 	tests/jlm/llvm/ir/operators/TestCall \
 	tests/jlm/llvm/ir/operators/test-ConstantFP \
 	tests/jlm/llvm/ir/operators/test-delta \

--- a/jlm/llvm/Makefile.sub
+++ b/jlm/llvm/Makefile.sub
@@ -136,6 +136,7 @@ libllvm_TESTS += \
 	tests/jlm/llvm/backend/llvm/jlm-llvm/test-function-calls \
 	tests/jlm/llvm/backend/llvm/jlm-llvm/test-select-with-state \
 	tests/jlm/llvm/backend/llvm/jlm-llvm/test-type-conversion \
+	tests/jlm/llvm/frontend/llvm/LoadTests \
 	tests/jlm/llvm/frontend/llvm/TestAttributeConversion \
 	tests/jlm/llvm/frontend/llvm/test-endless-loop \
 	tests/jlm/llvm/frontend/llvm/test-export \

--- a/jlm/llvm/ir/operators.hpp
+++ b/jlm/llvm/ir/operators.hpp
@@ -13,6 +13,7 @@
 #include <jlm/llvm/ir/operators/GetElementPtr.hpp>
 #include <jlm/llvm/ir/operators/lambda.hpp>
 #include <jlm/llvm/ir/operators/load.hpp>
+#include <jlm/llvm/ir/operators/LoadVolatile.hpp>
 #include <jlm/llvm/ir/operators/operators.hpp>
 #include <jlm/llvm/ir/operators/Phi.hpp>
 #include <jlm/llvm/ir/operators/sext.hpp>

--- a/jlm/llvm/ir/operators/LoadVolatile.cpp
+++ b/jlm/llvm/ir/operators/LoadVolatile.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <jlm/llvm/ir/operators/LoadVolatile.hpp>
+
+namespace jlm::llvm
+{
+
+LoadVolatileOperation::~LoadVolatileOperation() noexcept = default;
+
+bool
+LoadVolatileOperation::operator==(const operation & other) const noexcept
+{
+  auto operation = dynamic_cast<const LoadVolatileOperation *>(&other);
+  return operation && operation->narguments() == narguments()
+      && operation->GetLoadedType() == GetLoadedType()
+      && operation->GetAlignment() == GetAlignment();
+}
+
+std::string
+LoadVolatileOperation::debug_string() const
+{
+  return "LoadVolatile";
+}
+
+std::unique_ptr<rvsdg::operation>
+LoadVolatileOperation::copy() const
+{
+  return std::unique_ptr<rvsdg::operation>(new LoadVolatileOperation(*this));
+}
+
+rvsdg::node *
+LoadVolatileNode::copy(rvsdg::region * region, const std::vector<rvsdg::output *> & operands) const
+{
+  return &CreateNode(*region, GetOperation(), operands);
+}
+
+}

--- a/jlm/llvm/ir/operators/LoadVolatile.hpp
+++ b/jlm/llvm/ir/operators/LoadVolatile.hpp
@@ -20,7 +20,7 @@ namespace jlm::llvm
  * externally visible side-effects. This I/O state allows the volatile load operation to be
  * sequentialized with respect to other volatile memory accesses and I/O operations. This additional
  * I/O state is the main reason why volatile loads are modeled as its own operation and volatile is
- * not just a flag at the normal @see{LoadOperation}.
+ * not just a flag at the normal \ref LoadOperation.
  */
 class LoadVolatileOperation final : public rvsdg::simple_op
 {

--- a/jlm/llvm/ir/operators/LoadVolatile.hpp
+++ b/jlm/llvm/ir/operators/LoadVolatile.hpp
@@ -81,7 +81,7 @@ private:
   CreateOperandPorts(size_t numStates)
   {
     std::vector<rvsdg::port> ports({ PointerType(), iostatetype() });
-    std::vector<rvsdg::port> states(numStates, { MemoryStateType::Create() });
+    std::vector<rvsdg::port> states(numStates, { MemoryStateType() });
     ports.insert(ports.end(), states.begin(), states.end());
     return ports;
   }
@@ -90,7 +90,7 @@ private:
   CreateResultPorts(const rvsdg::valuetype & loadedType, size_t numStates)
   {
     std::vector<rvsdg::port> ports({ loadedType, iostatetype() });
-    std::vector<rvsdg::port> states(numStates, { MemoryStateType::Create() });
+    std::vector<rvsdg::port> states(numStates, { MemoryStateType() });
     ports.insert(ports.end(), states.begin(), states.end());
     return ports;
   }

--- a/jlm/llvm/ir/operators/LoadVolatile.hpp
+++ b/jlm/llvm/ir/operators/LoadVolatile.hpp
@@ -32,8 +32,8 @@ public:
       size_t numMemoryStates,
       size_t alignment)
       : simple_op(
-            CreateOperandPorts(numMemoryStates),
-            CreateResultPorts(loadedType, numMemoryStates)),
+          CreateOperandPorts(numMemoryStates),
+          CreateResultPorts(loadedType, numMemoryStates)),
         Alignment_(alignment)
   {}
 

--- a/jlm/llvm/ir/operators/LoadVolatile.hpp
+++ b/jlm/llvm/ir/operators/LoadVolatile.hpp
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2024 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#ifndef JLM_LLVM_IR_OPERATORS_LOADVOLATILE_HPP
+#define JLM_LLVM_IR_OPERATORS_LOADVOLATILE_HPP
+
+#include <jlm/llvm/ir/tac.hpp>
+#include <jlm/llvm/ir/types.hpp>
+#include <jlm/rvsdg/simple-node.hpp>
+
+namespace jlm::llvm
+{
+
+/**
+ * Represents a volatile LLVM load instruction.
+ *
+ * In contrast to LLVM, a volatile load requires in an RVSDG setting an I/O state as it incorporates
+ * externally visible side-effects. This I/O state allows the volatile load operation to be
+ * sequentialized with respect to other volatile memory accesses and I/O operations. This additional
+ * I/O state is the main reason why volatile loads are modeled as its own operation and volatile is
+ * not just a flag at the normal @see{LoadOperation}.
+ */
+class LoadVolatileOperation final : public rvsdg::simple_op
+{
+public:
+  ~LoadVolatileOperation() noexcept override;
+
+  LoadVolatileOperation(
+      const rvsdg::valuetype & loadedType,
+      size_t numMemoryStates,
+      size_t alignment)
+      : simple_op(
+            CreateOperandPorts(numMemoryStates),
+            CreateResultPorts(loadedType, numMemoryStates)),
+        Alignment_(alignment)
+  {}
+
+  bool
+  operator==(const operation & other) const noexcept override;
+
+  [[nodiscard]] std::string
+  debug_string() const override;
+
+  [[nodiscard]] std::unique_ptr<rvsdg::operation>
+  copy() const override;
+
+  [[nodiscard]] size_t
+  GetAlignment() const noexcept
+  {
+    return Alignment_;
+  }
+
+  [[nodiscard]] const rvsdg::valuetype &
+  GetLoadedType() const noexcept
+  {
+    return *util::AssertedCast<const rvsdg::valuetype>(&result(0).type());
+  }
+
+  [[nodiscard]] size_t
+  NumMemoryStates() const noexcept
+  {
+    return narguments() - 2;
+  }
+
+  static std::unique_ptr<llvm::tac>
+  Create(
+      const variable * address,
+      const variable * iOState,
+      const variable * memoryState,
+      const rvsdg::valuetype & loadedType,
+      size_t alignment)
+  {
+    LoadVolatileOperation operation(loadedType, 1, alignment);
+    return tac::create(operation, { address, iOState, memoryState });
+  }
+
+private:
+  static std::vector<rvsdg::port>
+  CreateOperandPorts(size_t numStates)
+  {
+    std::vector<rvsdg::port> ports({ PointerType(), iostatetype() });
+    std::vector<rvsdg::port> states(numStates, { MemoryStateType::Create() });
+    ports.insert(ports.end(), states.begin(), states.end());
+    return ports;
+  }
+
+  static std::vector<rvsdg::port>
+  CreateResultPorts(const rvsdg::valuetype & loadedType, size_t numStates)
+  {
+    std::vector<rvsdg::port> ports({ loadedType, iostatetype() });
+    std::vector<rvsdg::port> states(numStates, { MemoryStateType::Create() });
+    ports.insert(ports.end(), states.begin(), states.end());
+    return ports;
+  }
+
+  size_t Alignment_;
+};
+
+/**
+ * Represents a LoadVolatileOperation in an RVSDG.
+ */
+class LoadVolatileNode final : public rvsdg::simple_node
+{
+private:
+  LoadVolatileNode(
+      rvsdg::region & region,
+      const LoadVolatileOperation & operation,
+      const std::vector<rvsdg::output *> & operands)
+      : simple_node(&region, operation, operands)
+  {}
+
+public:
+  rvsdg::node *
+  copy(rvsdg::region * region, const std::vector<rvsdg::output *> & operands) const override;
+
+  [[nodiscard]] const LoadVolatileOperation &
+  GetOperation() const noexcept
+  {
+    return *util::AssertedCast<const LoadVolatileOperation>(&operation());
+  }
+
+  [[nodiscard]] rvsdg::input &
+  GetAddressInput() const noexcept
+  {
+    auto addressInput = input(0);
+    JLM_ASSERT(is<PointerType>(addressInput->type()));
+    return *addressInput;
+  }
+
+  [[nodiscard]] rvsdg::input &
+  GetIoStateInput() const noexcept
+  {
+    auto ioInput = input(1);
+    JLM_ASSERT(is<iostatetype>(ioInput->type()));
+    return *ioInput;
+  }
+
+  [[nodiscard]] rvsdg::output &
+  GetLoadedValueOutput() const noexcept
+  {
+    auto valueOutput = output(0);
+    JLM_ASSERT(is<rvsdg::valuetype>(valueOutput->type()));
+    return *valueOutput;
+  }
+
+  static LoadVolatileNode &
+  CreateNode(
+      rvsdg::region & region,
+      const LoadVolatileOperation & loadOperation,
+      const std::vector<rvsdg::output *> & operands)
+  {
+    return *(new LoadVolatileNode(region, loadOperation, operands));
+  }
+
+  static LoadVolatileNode &
+  CreateNode(
+      rvsdg::output & address,
+      rvsdg::output & iOState,
+      const std::vector<rvsdg::output *> & memoryStates,
+      const rvsdg::valuetype & loadedType,
+      size_t alignment)
+  {
+    std::vector<rvsdg::output *> operands({ &address, &iOState });
+    operands.insert(operands.end(), memoryStates.begin(), memoryStates.end());
+
+    LoadVolatileOperation operation(loadedType, memoryStates.size(), alignment);
+    return CreateNode(*address.region(), operation, operands);
+  }
+};
+
+}
+
+#endif // JLM_LLVM_IR_OPERATORS_LOADVOLATILE_HPP

--- a/tests/jlm/llvm/backend/llvm/jlm-llvm/LoadTests.cpp
+++ b/tests/jlm/llvm/backend/llvm/jlm-llvm/LoadTests.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2020 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <test-registry.hpp>
+#include <test-util.hpp>
+
+#include <jlm/llvm/backend/jlm2llvm/jlm2llvm.hpp>
+#include <jlm/llvm/ir/ipgraph-module.hpp>
+#include <jlm/llvm/ir/operators.hpp>
+#include <jlm/llvm/ir/print.hpp>
+#include <llvm/IR/Instructions.h>
+
+static int
+LoadConversion()
+{
+  using namespace jlm::llvm;
+
+  // Arrange
+  PointerType pointerType;
+  MemoryStateType memoryStateType;
+  jlm::rvsdg::bittype bit64Type(64);
+  FunctionType functionType({ &pointerType, &memoryStateType }, { &bit64Type, &memoryStateType });
+
+  ipgraph_module ipgModule(jlm::util::filepath(""), "", "");
+
+  auto cfg = cfg::create(ipgModule);
+  auto addressArgument = cfg->entry()->append_argument(argument::create("address", pointerType));
+  auto memoryStateArgument =
+      cfg->entry()->append_argument(argument::create("memoryState", memoryStateType));
+
+  auto basicBlock = basic_block::create(*cfg);
+  size_t alignment = 4;
+  auto loadTac = basicBlock->append_last(
+      LoadOperation::Create(addressArgument, memoryStateArgument, bit64Type, alignment));
+
+  cfg->exit()->divert_inedges(basicBlock);
+  basicBlock->add_outedge(cfg->exit());
+  cfg->exit()->append_result(loadTac->result(0));
+  cfg->exit()->append_result(loadTac->result(1));
+
+  auto f = function_node::create(ipgModule.ipgraph(), "f", functionType, linkage::external_linkage);
+  f->add_cfg(std::move(cfg));
+
+  print(ipgModule, stdout);
+
+  // Act
+  llvm::LLVMContext ctx;
+  auto llvmModule = jlm2llvm::convert(ipgModule, ctx);
+  jlm::tests::print(*llvmModule);
+
+  // Assert
+  {
+    auto llvmFunction = llvmModule->getFunction("f");
+    auto & basicBlock = llvmFunction->back();
+    auto & instruction = basicBlock.front();
+
+    auto loadInstruction = ::llvm::dyn_cast<::llvm::LoadInst>(&instruction);
+    assert(loadInstruction != nullptr);
+    assert(loadInstruction->isVolatile() == false);
+    assert(loadInstruction->getAlign().value() == alignment);
+  }
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER("jlm/llvm/backend/llvm/jlm-llvm/LoadTests-LoadConversion", LoadConversion)
+
+static int
+LoadVolatileConversion()
+{
+  using namespace jlm::llvm;
+
+  // Arrange
+  PointerType pointerType;
+  iostatetype ioStateType;
+  MemoryStateType memoryStateType;
+  jlm::rvsdg::bittype bit64Type(64);
+  FunctionType functionType(
+      { &pointerType, &ioStateType, &memoryStateType },
+      { &bit64Type, &ioStateType, &memoryStateType });
+
+  ipgraph_module ipgModule(jlm::util::filepath(""), "", "");
+
+  auto cfg = cfg::create(ipgModule);
+  auto addressArgument = cfg->entry()->append_argument(argument::create("address", pointerType));
+  auto ioStateArgument = cfg->entry()->append_argument(argument::create("ioState", ioStateType));
+  auto memoryStateArgument =
+      cfg->entry()->append_argument(argument::create("memoryState", memoryStateType));
+
+  auto basicBlock = basic_block::create(*cfg);
+  size_t alignment = 4;
+  auto loadTac = basicBlock->append_last(LoadVolatileOperation::Create(
+      addressArgument,
+      ioStateArgument,
+      memoryStateArgument,
+      bit64Type,
+      alignment));
+
+  cfg->exit()->divert_inedges(basicBlock);
+  basicBlock->add_outedge(cfg->exit());
+  cfg->exit()->append_result(loadTac->result(0));
+  cfg->exit()->append_result(loadTac->result(1));
+  cfg->exit()->append_result(loadTac->result(2));
+
+  auto f = function_node::create(ipgModule.ipgraph(), "f", functionType, linkage::external_linkage);
+  f->add_cfg(std::move(cfg));
+
+  print(ipgModule, stdout);
+
+  // Act
+  llvm::LLVMContext ctx;
+  auto llvmModule = jlm2llvm::convert(ipgModule, ctx);
+  jlm::tests::print(*llvmModule);
+
+  // Assert
+  {
+    auto llvmFunction = llvmModule->getFunction("f");
+    auto & basicBlock = llvmFunction->back();
+    auto & instruction = basicBlock.front();
+
+    auto loadInstruction = ::llvm::dyn_cast<::llvm::LoadInst>(&instruction);
+    assert(loadInstruction != nullptr);
+    assert(loadInstruction->isVolatile() == true);
+    assert(loadInstruction->getAlign().value() == alignment);
+  }
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER(
+    "jlm/llvm/backend/llvm/jlm-llvm/LoadTests-LoadVolatileConversion",
+    LoadVolatileConversion)

--- a/tests/jlm/llvm/backend/llvm/jlm-llvm/LoadTests.cpp
+++ b/tests/jlm/llvm/backend/llvm/jlm-llvm/LoadTests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Nico Reißmann <nico.reissmann@gmail.com>
+ * Copyright 2024 Nico Reißmann <nico.reissmann@gmail.com>
  * See COPYING for terms of redistribution.
  */
 

--- a/tests/jlm/llvm/frontend/llvm/LoadTests.cpp
+++ b/tests/jlm/llvm/frontend/llvm/LoadTests.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <test-registry.hpp>
+#include <test-util.hpp>
+
+#include <jlm/llvm/frontend/LlvmModuleConversion.hpp>
+#include <jlm/llvm/ir/operators/load.hpp>
+#include <jlm/llvm/ir/operators/LoadVolatile.hpp>
+#include <jlm/llvm/ir/operators/operators.hpp>
+#include <jlm/llvm/ir/print.hpp>
+
+#include <llvm/IR/BasicBlock.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Module.h>
+
+static int
+LoadConversion()
+{
+  using namespace llvm;
+
+  // Arrange
+  llvm::LLVMContext context;
+  std::unique_ptr<Module> llvmModule(new Module("module", context));
+
+  auto int64Type = Type::getInt64Ty(context);
+  auto pointerType = Type::getInt64PtrTy(context);
+
+  auto functionType = FunctionType::get(int64Type, ArrayRef<Type *>({ pointerType }), false);
+  auto function =
+      Function::Create(functionType, GlobalValue::ExternalLinkage, "f", llvmModule.get());
+
+  auto basicBlock = BasicBlock::Create(context, "BasicBlock", function);
+
+  IRBuilder<> builder(basicBlock);
+  auto loadedValue1 = builder.CreateLoad(int64Type, function->arg_begin(), true);
+  auto loadedValue2 = builder.CreateLoad(int64Type, function->arg_begin(), false);
+  auto loadedValue3 = builder.CreateLoad(int64Type, function->arg_begin(), true);
+  auto sum1 = builder.CreateAdd(loadedValue1, loadedValue2);
+  auto sum2 = builder.CreateAdd(sum1, loadedValue3);
+  builder.CreateRet(sum2);
+
+  jlm::tests::print(*llvmModule);
+
+  // Act
+  auto ipgModule = jlm::llvm::ConvertLlvmModule(*llvmModule);
+  print(*ipgModule, stdout);
+
+  // Assert
+  {
+    using namespace jlm::llvm;
+
+    auto controlFlowGraph =
+        dynamic_cast<const function_node *>(ipgModule->ipgraph().find("f"))->cfg();
+    auto basicBlock =
+        dynamic_cast<const basic_block *>(controlFlowGraph->entry()->outedge(0)->sink());
+
+    size_t numLoadThreeAddressCodes = 0;
+    size_t numLoadVolatileThreeAddressCodes = 0;
+    for (auto it = basicBlock->begin(); it != basicBlock->end(); it++)
+    {
+      if (is<LoadVolatileOperation>(*it))
+      {
+        numLoadVolatileThreeAddressCodes++;
+        auto ioStateAssignment = *std::next(it);
+        auto memoryStateAssignment = *std::next(it, 2);
+
+        assert(is<assignment_op>(ioStateAssignment->operation()));
+        assert(is<iostatetype>(ioStateAssignment->operand(0)->type()));
+
+        assert(is<assignment_op>(memoryStateAssignment->operation()));
+        assert(is<MemoryStateType>(memoryStateAssignment->operand(0)->type()));
+      }
+      else if (is<LoadOperation>(*it))
+      {
+        numLoadThreeAddressCodes++;
+        auto memoryStateAssignment = *std::next(it, 1);
+
+        assert(is<assignment_op>(memoryStateAssignment->operation()));
+        assert(is<MemoryStateType>(memoryStateAssignment->operand(0)->type()));
+      }
+    }
+
+    assert(numLoadThreeAddressCodes == 1);
+    assert(numLoadVolatileThreeAddressCodes == 2);
+  }
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER("jlm/llvm/frontend/llvm/LoadTests-LoadConversion", LoadConversion)

--- a/tests/jlm/llvm/frontend/llvm/LoadTests.cpp
+++ b/tests/jlm/llvm/frontend/llvm/LoadTests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Nico Reißmann <nico.reissmann@gmail.com>
+ * Copyright 2024 Nico Reißmann <nico.reissmann@gmail.com>
  * See COPYING for terms of redistribution.
  */
 

--- a/tests/jlm/llvm/ir/operators/LoadVolatileTests.cpp
+++ b/tests/jlm/llvm/ir/operators/LoadVolatileTests.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2024 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <test-operation.hpp>
+#include <test-registry.hpp>
+#include <test-types.hpp>
+
+#include <jlm/llvm/ir/operators/LoadVolatile.hpp>
+
+static int
+OperationEquality()
+{
+  using namespace jlm::llvm;
+
+  // Arrange
+  MemoryStateType memoryType;
+  jlm::tests::valuetype valueType;
+  PointerType pointerType;
+
+  LoadVolatileOperation operation1(valueType, 2, 4);
+  LoadVolatileOperation operation2(pointerType, 2, 4);
+  LoadVolatileOperation operation3(valueType, 4, 4);
+  LoadVolatileOperation operation4(valueType, 2, 8);
+  jlm::tests::test_op operation5({ &pointerType }, { &pointerType });
+
+  // Assert
+  assert(operation1 == operation1);
+  assert(operation1 != operation2); // loaded type differs
+  assert(operation1 != operation3); // number of memory states differs
+  assert(operation1 != operation4); // alignment differs
+  assert(operation1 != operation5); // operation differs
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER(
+    "jlm/llvm/ir/operators/LoadVolatileTests-OperationEquality",
+    OperationEquality)
+
+static int
+OperationCopy()
+{
+  using namespace jlm::llvm;
+
+  // Arrange
+  MemoryStateType memoryType;
+  jlm::tests::valuetype valueType;
+  PointerType pointerType;
+
+  LoadVolatileOperation operation(valueType, 2, 4);
+
+  // Act
+  auto copiedOperation = operation.copy();
+
+  // Assert
+  assert(*copiedOperation == operation);
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER("jlm/llvm/ir/operators/LoadVolatileTests-OperationCopy", OperationCopy)
+
+static int
+OperationAccessors()
+{
+  using namespace jlm::llvm;
+
+  // Arrange
+  MemoryStateType memoryType;
+  jlm::tests::valuetype valueType;
+  PointerType pointerType;
+
+  size_t alignment = 4;
+  size_t numMemoryStates = 2;
+  LoadVolatileOperation operation(valueType, numMemoryStates, alignment);
+
+  // Assert
+  assert(operation.GetLoadedType() == valueType);
+  assert(operation.NumMemoryStates() == numMemoryStates);
+  assert(operation.GetAlignment() == alignment);
+  assert(operation.narguments() == numMemoryStates + 2); // [address, ioState, memoryStates]
+  assert(operation.nresults() == numMemoryStates + 2);   // [loadedValue, ioState, memoryStates]
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER(
+    "jlm/llvm/ir/operators/LoadVolatileTests-OperationAccessors",
+    OperationAccessors)
+
+static int
+NodeCopy()
+{
+  using namespace jlm::llvm;
+
+  // Arrange
+  PointerType pointerType;
+  iostatetype iOStateType;
+  MemoryStateType memoryType;
+  jlm::tests::valuetype valueType;
+
+  jlm::rvsdg::graph graph;
+  auto & address1 = *graph.add_import({ pointerType, "address1" });
+  auto & iOState1 = *graph.add_import({ iOStateType, "iOState1" });
+  auto & memoryState1 = *graph.add_import({ memoryType, "memoryState1" });
+
+  auto & address2 = *graph.add_import({ pointerType, "address2" });
+  auto & iOState2 = *graph.add_import({ iOStateType, "iOState2" });
+  auto & memoryState2 = *graph.add_import({ memoryType, "memoryState2" });
+
+  auto & loadNode =
+      LoadVolatileNode::CreateNode(address1, iOState1, { &memoryState1 }, valueType, 4);
+
+  // Act
+  auto copiedNode = loadNode.copy(graph.root(), { &address2, &iOState2, &memoryState2 });
+
+  // Assert
+  auto copiedLoadNode = dynamic_cast<const LoadVolatileNode *>(copiedNode);
+  assert(loadNode.GetOperation() == copiedLoadNode->GetOperation());
+  assert(copiedLoadNode->GetAddressInput().origin() == &address2);
+  assert(copiedLoadNode->GetIoStateInput().origin() == &iOState2);
+  assert(copiedLoadNode->GetLoadedValueOutput().type() == valueType);
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER("jlm/llvm/ir/operators/LoadVolatileTests-NodeCopy", NodeCopy)


### PR DESCRIPTION
This PR does the following:

1. Add LoadOperation and LoadNode class for volatile load operations.
2. Adds conversion support for LLVM -> RVSDG
3. Adds conversion support for RVSDG -> LLVM