### PR TITLE
Add support for volatile stores

### DIFF
--- a/jlm/llvm/Makefile.sub
+++ b/jlm/llvm/Makefile.sub
@@ -134,6 +134,7 @@ libllvm_TESTS += \
 	tests/jlm/llvm/backend/llvm/r2j/test-partial-gamma \
 	tests/jlm/llvm/backend/llvm/r2j/test-recursive-data \
 	tests/jlm/llvm/backend/llvm/jlm-llvm/LoadTests \
+    tests/jlm/llvm/backend/llvm/jlm-llvm/StoreTests \
 	tests/jlm/llvm/backend/llvm/jlm-llvm/TestAttributeConversion \
 	tests/jlm/llvm/backend/llvm/jlm-llvm/test-bitconstant \
 	tests/jlm/llvm/backend/llvm/jlm-llvm/test-function-calls \

--- a/jlm/llvm/Makefile.sub
+++ b/jlm/llvm/Makefile.sub
@@ -34,6 +34,7 @@ libllvm_SOURCES = \
     jlm/llvm/ir/operators/Phi.cpp \
     jlm/llvm/ir/operators/sext.cpp \
     jlm/llvm/ir/operators/store.cpp \
+    jlm/llvm/ir/operators/StoreVolatile.cpp \
     jlm/llvm/ir/print.cpp \
     jlm/llvm/ir/RvsdgModule.cpp \
     jlm/llvm/ir/ssa.cpp \
@@ -115,6 +116,7 @@ libllvm_HEADERS = \
 	jlm/llvm/ir/operators/theta.hpp \
 	jlm/llvm/ir/operators/delta.hpp \
 	jlm/llvm/ir/operators/store.hpp \
+	jlm/llvm/ir/operators/StoreVolatile.hpp \
 	jlm/llvm/ir/operators/alloca.hpp \
 	jlm/llvm/ir/operators/call.hpp \
 	jlm/llvm/ir/operators/sext.hpp \
@@ -157,6 +159,7 @@ libllvm_TESTS += \
 	tests/jlm/llvm/ir/operators/TestPhi \
 	tests/jlm/llvm/ir/operators/test-sext \
 	tests/jlm/llvm/ir/operators/TestStore \
+	tests/jlm/llvm/ir/operators/StoreVolatileTests \
 	tests/jlm/llvm/ir/test-aggregation \
 	tests/jlm/llvm/ir/test-cfg \
 	tests/jlm/llvm/ir/test-cfg-node \

--- a/jlm/llvm/Makefile.sub
+++ b/jlm/llvm/Makefile.sub
@@ -140,6 +140,7 @@ libllvm_TESTS += \
 	tests/jlm/llvm/backend/llvm/jlm-llvm/test-select-with-state \
 	tests/jlm/llvm/backend/llvm/jlm-llvm/test-type-conversion \
 	tests/jlm/llvm/frontend/llvm/LoadTests \
+    tests/jlm/llvm/frontend/llvm/StoreTests \
 	tests/jlm/llvm/frontend/llvm/TestAttributeConversion \
 	tests/jlm/llvm/frontend/llvm/test-endless-loop \
 	tests/jlm/llvm/frontend/llvm/test-export \

--- a/jlm/llvm/Makefile.sub
+++ b/jlm/llvm/Makefile.sub
@@ -134,14 +134,14 @@ libllvm_TESTS += \
 	tests/jlm/llvm/backend/llvm/r2j/test-partial-gamma \
 	tests/jlm/llvm/backend/llvm/r2j/test-recursive-data \
 	tests/jlm/llvm/backend/llvm/jlm-llvm/LoadTests \
-    tests/jlm/llvm/backend/llvm/jlm-llvm/StoreTests \
+	tests/jlm/llvm/backend/llvm/jlm-llvm/StoreTests \
 	tests/jlm/llvm/backend/llvm/jlm-llvm/TestAttributeConversion \
 	tests/jlm/llvm/backend/llvm/jlm-llvm/test-bitconstant \
 	tests/jlm/llvm/backend/llvm/jlm-llvm/test-function-calls \
 	tests/jlm/llvm/backend/llvm/jlm-llvm/test-select-with-state \
 	tests/jlm/llvm/backend/llvm/jlm-llvm/test-type-conversion \
 	tests/jlm/llvm/frontend/llvm/LoadTests \
-    tests/jlm/llvm/frontend/llvm/StoreTests \
+	tests/jlm/llvm/frontend/llvm/StoreTests \
 	tests/jlm/llvm/frontend/llvm/TestAttributeConversion \
 	tests/jlm/llvm/frontend/llvm/test-endless-loop \
 	tests/jlm/llvm/frontend/llvm/test-export \

--- a/jlm/llvm/ir/operators.hpp
+++ b/jlm/llvm/ir/operators.hpp
@@ -18,6 +18,7 @@
 #include <jlm/llvm/ir/operators/Phi.hpp>
 #include <jlm/llvm/ir/operators/sext.hpp>
 #include <jlm/llvm/ir/operators/store.hpp>
+#include <jlm/llvm/ir/operators/StoreVolatile.hpp>
 #include <jlm/llvm/ir/operators/theta.hpp>
 
 #endif

--- a/jlm/llvm/ir/operators/LoadVolatile.hpp
+++ b/jlm/llvm/ir/operators/LoadVolatile.hpp
@@ -21,6 +21,8 @@ namespace jlm::llvm
  * sequentialized with respect to other volatile memory accesses and I/O operations. This additional
  * I/O state is the main reason why volatile loads are modeled as its own operation and volatile is
  * not just a flag at the normal \ref LoadOperation.
+ *
+ * @see StoreVolatileOperation
  */
 class LoadVolatileOperation final : public rvsdg::simple_op
 {

--- a/jlm/llvm/ir/operators/StoreVolatile.cpp
+++ b/jlm/llvm/ir/operators/StoreVolatile.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <jlm/llvm/ir/operators/StoreVolatile.hpp>
+
+namespace jlm::llvm
+{
+
+StoreVolatileOperation::~StoreVolatileOperation() noexcept = default;
+
+bool
+StoreVolatileOperation::operator==(const operation & other) const noexcept
+{
+  auto operation = dynamic_cast<const StoreVolatileOperation *>(&other);
+  return operation && operation->NumMemoryStates() == NumMemoryStates()
+      && operation->GetStoredType() == GetStoredType()
+      && operation->GetAlignment() == GetAlignment();
+}
+
+std::string
+StoreVolatileOperation::debug_string() const
+{
+  return "StoreVolatile";
+}
+
+std::unique_ptr<rvsdg::operation>
+StoreVolatileOperation::copy() const
+{
+  return std::unique_ptr<rvsdg::operation>(new StoreVolatileOperation(*this));
+}
+
+rvsdg::node *
+StoreVolatileNode::copy(rvsdg::region * region, const std::vector<rvsdg::output *> & operands) const
+{
+  return &CreateNode(*region, GetOperation(), operands);
+}
+
+}

--- a/jlm/llvm/ir/operators/StoreVolatile.hpp
+++ b/jlm/llvm/ir/operators/StoreVolatile.hpp
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2024 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#ifndef JLM_LLVM_IR_OPERATORS_STOREVOLATILE_HPP
+#define JLM_LLVM_IR_OPERATORS_STOREVOLATILE_HPP
+
+#include <jlm/llvm/ir/tac.hpp>
+#include <jlm/llvm/ir/types.hpp>
+#include <jlm/rvsdg/simple-node.hpp>
+
+namespace jlm::llvm
+{
+
+/**
+ * Represents a volatile LLVM store instruction.
+ *
+ * In contrast to LLVM, a volatile store requires in an RVSDG setting an I/O state as it
+ * incorporates externally visible side-effects. This I/O state allows the volatile store operation
+ * to be sequentialized with respect to other volatile memory accesses and I/O operations. This
+ * additional I/O state is the main reason why volatile stores are modeled as its own operation and
+ * volatile is not just a flag at the normal \ref StoreOperation.
+ *
+ * @see LoadVolatileOperation
+ */
+class StoreVolatileOperation final : public rvsdg::simple_op
+{
+public:
+  ~StoreVolatileOperation() noexcept override;
+
+  StoreVolatileOperation(
+      const rvsdg::valuetype & storedType,
+      size_t numMemoryStates,
+      size_t alignment)
+      : simple_op(
+            CreateOperandPorts(storedType, numMemoryStates),
+            CreateResultPorts(numMemoryStates)),
+        Alignment_(alignment)
+  {}
+
+  bool
+  operator==(const operation & other) const noexcept override;
+
+  [[nodiscard]] std::string
+  debug_string() const override;
+
+  [[nodiscard]] std::unique_ptr<rvsdg::operation>
+  copy() const override;
+
+  [[nodiscard]] const jlm::rvsdg::valuetype &
+  GetStoredType() const noexcept
+  {
+    return *util::AssertedCast<const jlm::rvsdg::valuetype>(&argument(1).type());
+  }
+
+  [[nodiscard]] size_t
+  NumMemoryStates() const noexcept
+  {
+    return nresults() - 1;
+  }
+
+  [[nodiscard]] size_t
+  GetAlignment() const noexcept
+  {
+    return Alignment_;
+  }
+
+  static std::unique_ptr<llvm::tac>
+  Create(
+      const variable * address,
+      const variable * value,
+      const variable * ioState,
+      const variable * memoryState,
+      size_t alignment)
+  {
+    auto & storedType = CheckAndExtractStoredType(value->type());
+
+    StoreVolatileOperation op(storedType, 1, alignment);
+    return tac::create(op, { address, value, ioState, memoryState });
+  }
+
+private:
+  static const rvsdg::valuetype &
+  CheckAndExtractStoredType(const rvsdg::type & type)
+  {
+    if (auto storedType = dynamic_cast<const rvsdg::valuetype *>(&type))
+      return *storedType;
+
+    throw jlm::util::error("Expected value type");
+  }
+
+  static std::vector<rvsdg::port>
+  CreateOperandPorts(const rvsdg::valuetype & storedType, size_t numStates)
+  {
+    std::vector<rvsdg::port> ports({ PointerType(), storedType, iostatetype() });
+    std::vector<rvsdg::port> states(numStates, { MemoryStateType() });
+    ports.insert(ports.end(), states.begin(), states.end());
+    return ports;
+  }
+
+  static std::vector<rvsdg::port>
+  CreateResultPorts(size_t numMemoryStates)
+  {
+    std::vector<rvsdg::port> ports({ iostatetype() });
+    std::vector<rvsdg::port> memoryStates(numMemoryStates, { MemoryStateType() });
+    ports.insert(ports.end(), memoryStates.begin(), memoryStates.end());
+    return ports;
+  }
+
+  size_t Alignment_;
+};
+
+/**
+ * Represents a StoreVolatileOperation in an RVSDG.
+ */
+class StoreVolatileNode final : public rvsdg::simple_node
+{
+  StoreVolatileNode(
+      rvsdg::region & region,
+      const StoreVolatileOperation & operation,
+      const std::vector<rvsdg::output *> & operands)
+      : simple_node(&region, operation, operands)
+  {}
+
+public:
+  [[nodiscard]] const StoreVolatileOperation &
+  GetOperation() const noexcept
+  {
+    return *util::AssertedCast<const StoreVolatileOperation>(&operation());
+  }
+
+  [[nodiscard]] size_t
+  NumMemoryStates() const noexcept
+  {
+    return GetOperation().NumMemoryStates();
+  }
+
+  [[nodiscard]] size_t
+  GetAlignment() const noexcept
+  {
+    return GetOperation().GetAlignment();
+  }
+
+  [[nodiscard]] rvsdg::input &
+  GetAddressInput() const noexcept
+  {
+    auto addressInput = input(0);
+    JLM_ASSERT(is<PointerType>(addressInput->type()));
+    return *addressInput;
+  }
+
+  [[nodiscard]] rvsdg::input &
+  GetValueInput() const noexcept
+  {
+    auto valueInput = input(1);
+    JLM_ASSERT(is<rvsdg::valuetype>(valueInput->type()));
+    return *valueInput;
+  }
+
+  [[nodiscard]] rvsdg::input &
+  GetIoStateInput() const noexcept
+  {
+    auto ioStateInput = input(2);
+    JLM_ASSERT(is<iostatetype>(ioStateInput->type()));
+    return *ioStateInput;
+  }
+
+  [[nodiscard]] rvsdg::output &
+  GetIoStateOutput() const noexcept
+  {
+    auto ioStateOutput = output(0);
+    JLM_ASSERT(is<iostatetype>(ioStateOutput->type()));
+    return *ioStateOutput;
+  }
+
+  rvsdg::node *
+  copy(rvsdg::region * region, const std::vector<rvsdg::output *> & operands) const override;
+
+  static StoreVolatileNode &
+  CreateNode(
+      rvsdg::region & region,
+      const StoreVolatileOperation & storeOperation,
+      const std::vector<rvsdg::output *> & operands)
+  {
+    return *(new StoreVolatileNode(region, storeOperation, operands));
+  }
+
+  static StoreVolatileNode &
+  CreateNode(
+      rvsdg::output & address,
+      rvsdg::output & value,
+      rvsdg::output & ioState,
+      const std::vector<rvsdg::output *> & memoryStates,
+      size_t alignment)
+  {
+    auto & storedType = CheckAndExtractStoredType(value.type());
+
+    std::vector<rvsdg::output *> operands({ &address, &value, &ioState });
+    operands.insert(operands.end(), memoryStates.begin(), memoryStates.end());
+
+    StoreVolatileOperation storeOperation(storedType, memoryStates.size(), alignment);
+    return CreateNode(*address.region(), storeOperation, operands);
+  }
+
+private:
+  static const rvsdg::valuetype &
+  CheckAndExtractStoredType(const rvsdg::type & type)
+  {
+    if (auto storedType = dynamic_cast<const rvsdg::valuetype *>(&type))
+      return *storedType;
+
+    throw jlm::util::error("Expected value type.");
+  }
+};
+
+}
+
+#endif // JLM_LLVM_IR_OPERATORS_STOREVOLATILE_HPP

--- a/jlm/llvm/ir/operators/StoreVolatile.hpp
+++ b/jlm/llvm/ir/operators/StoreVolatile.hpp
@@ -34,8 +34,8 @@ public:
       size_t numMemoryStates,
       size_t alignment)
       : simple_op(
-            CreateOperandPorts(storedType, numMemoryStates),
-            CreateResultPorts(numMemoryStates)),
+          CreateOperandPorts(storedType, numMemoryStates),
+          CreateResultPorts(numMemoryStates)),
         Alignment_(alignment)
   {}
 

--- a/tests/jlm/llvm/backend/llvm/jlm-llvm/StoreTests.cpp
+++ b/tests/jlm/llvm/backend/llvm/jlm-llvm/StoreTests.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2024 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <test-registry.hpp>
+#include <test-types.hpp>
+#include <test-util.hpp>
+
+#include <jlm/llvm/backend/jlm2llvm/jlm2llvm.hpp>
+#include <jlm/llvm/ir/ipgraph-module.hpp>
+#include <jlm/llvm/ir/operators.hpp>
+#include <jlm/llvm/ir/print.hpp>
+#include <llvm/IR/Instructions.h>
+
+static int
+StoreConversion()
+{
+  using namespace jlm::llvm;
+
+  // Arrange
+  PointerType pointerType;
+  MemoryStateType memoryStateType;
+  jlm::rvsdg::bittype bit64Type(64);
+  FunctionType functionType({ &pointerType, &bit64Type, &memoryStateType }, { &memoryStateType });
+
+  ipgraph_module ipgModule(jlm::util::filepath(""), "", "");
+
+  auto cfg = cfg::create(ipgModule);
+  auto addressArgument = cfg->entry()->append_argument(argument::create("address", pointerType));
+  auto valueArgument = cfg->entry()->append_argument(argument::create("value", bit64Type));
+  auto memoryStateArgument =
+      cfg->entry()->append_argument(argument::create("memoryState", memoryStateType));
+
+  auto basicBlock = basic_block::create(*cfg);
+  size_t alignment = 4;
+  auto storeTac = basicBlock->append_last(
+      StoreOperation::Create(addressArgument, valueArgument, memoryStateArgument, alignment));
+
+  cfg->exit()->divert_inedges(basicBlock);
+  basicBlock->add_outedge(cfg->exit());
+  cfg->exit()->append_result(storeTac->result(0));
+
+  auto f = function_node::create(ipgModule.ipgraph(), "f", functionType, linkage::external_linkage);
+  f->add_cfg(std::move(cfg));
+
+  print(ipgModule, stdout);
+
+  // Act
+  llvm::LLVMContext ctx;
+  auto llvmModule = jlm2llvm::convert(ipgModule, ctx);
+  jlm::tests::print(*llvmModule);
+
+  // Assert
+  {
+    auto llvmFunction = llvmModule->getFunction("f");
+    auto & basicBlock = llvmFunction->back();
+    auto & instruction = basicBlock.front();
+
+    auto storeInstruction = ::llvm::dyn_cast<::llvm::StoreInst>(&instruction);
+    assert(storeInstruction != nullptr);
+    assert(storeInstruction->isVolatile() == false);
+    assert(storeInstruction->getAlign().value() == alignment);
+  }
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER("jlm/llvm/backend/llvm/jlm-llvm/StoreTests-StoreConversion", StoreConversion)
+
+static int
+StoreVolatileConversion()
+{
+  using namespace jlm::llvm;
+
+  // Arrange
+  PointerType pointerType;
+  iostatetype ioStateType;
+  MemoryStateType memoryStateType;
+  jlm::rvsdg::bittype bit64Type(64);
+  FunctionType functionType(
+      { &pointerType, &bit64Type, &ioStateType, &memoryStateType },
+      { &ioStateType, &memoryStateType });
+
+  ipgraph_module ipgModule(jlm::util::filepath(""), "", "");
+
+  auto cfg = cfg::create(ipgModule);
+  auto addressArgument = cfg->entry()->append_argument(argument::create("address", pointerType));
+  auto valueArgument = cfg->entry()->append_argument(argument::create("value", bit64Type));
+  auto ioStateArgument = cfg->entry()->append_argument(argument::create("ioState", ioStateType));
+  auto memoryStateArgument =
+      cfg->entry()->append_argument(argument::create("memoryState", memoryStateType));
+
+  auto basicBlock = basic_block::create(*cfg);
+  size_t alignment = 4;
+  auto storeTac = basicBlock->append_last(StoreVolatileOperation::Create(
+      addressArgument,
+      valueArgument,
+      ioStateArgument,
+      memoryStateArgument,
+      alignment));
+
+  cfg->exit()->divert_inedges(basicBlock);
+  basicBlock->add_outedge(cfg->exit());
+  cfg->exit()->append_result(storeTac->result(0));
+  cfg->exit()->append_result(storeTac->result(1));
+
+  auto f = function_node::create(ipgModule.ipgraph(), "f", functionType, linkage::external_linkage);
+  f->add_cfg(std::move(cfg));
+
+  print(ipgModule, stdout);
+
+  // Act
+  llvm::LLVMContext ctx;
+  auto llvmModule = jlm2llvm::convert(ipgModule, ctx);
+  jlm::tests::print(*llvmModule);
+
+  // Assert
+  {
+    auto llvmFunction = llvmModule->getFunction("f");
+    auto & basicBlock = llvmFunction->back();
+    auto & instruction = basicBlock.front();
+
+    auto storeInstruction = ::llvm::dyn_cast<::llvm::StoreInst>(&instruction);
+    assert(storeInstruction != nullptr);
+    assert(storeInstruction->isVolatile() == true);
+    assert(storeInstruction->getAlign().value() == alignment);
+  }
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER(
+    "jlm/llvm/backend/llvm/jlm-llvm/StoreTests-StoreVolatileConversion",
+    StoreVolatileConversion)

--- a/tests/jlm/llvm/frontend/llvm/StoreTests.cpp
+++ b/tests/jlm/llvm/frontend/llvm/StoreTests.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <test-registry.hpp>
+#include <test-util.hpp>
+
+#include <jlm/llvm/frontend/LlvmModuleConversion.hpp>
+#include <jlm/llvm/ir/operators/operators.hpp>
+#include <jlm/llvm/ir/operators/store.hpp>
+#include <jlm/llvm/ir/operators/StoreVolatile.hpp>
+#include <jlm/llvm/ir/print.hpp>
+
+#include <llvm/IR/BasicBlock.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Module.h>
+
+static int
+StoreConversion()
+{
+  using namespace llvm;
+
+  // Arrange
+  llvm::LLVMContext context;
+  std::unique_ptr<Module> llvmModule(new Module("module", context));
+
+  auto int64Type = Type::getInt64Ty(context);
+  auto pointerType = Type::getInt64PtrTy(context);
+  auto voidType = Type::getVoidTy(context);
+
+  auto functionType =
+      FunctionType::get(voidType, ArrayRef<Type *>({ int64Type, pointerType }), false);
+  auto function =
+      Function::Create(functionType, GlobalValue::ExternalLinkage, "f", llvmModule.get());
+  auto valueArgument = function->getArg(0);
+  auto addressArgument = function->getArg(1);
+
+  auto basicBlock = BasicBlock::Create(context, "BasicBlock", function);
+
+  IRBuilder<> builder(basicBlock);
+  builder.CreateStore(valueArgument, addressArgument, true);
+  builder.CreateStore(valueArgument, addressArgument, false);
+  builder.CreateStore(valueArgument, addressArgument, true);
+  builder.CreateRetVoid();
+
+  jlm::tests::print(*llvmModule);
+
+  // Act
+  auto ipgModule = jlm::llvm::ConvertLlvmModule(*llvmModule);
+  print(*ipgModule, stdout);
+
+  // Assert
+  {
+    using namespace jlm::llvm;
+
+    auto controlFlowGraph =
+        dynamic_cast<const function_node *>(ipgModule->ipgraph().find("f"))->cfg();
+    auto basicBlock =
+        dynamic_cast<const basic_block *>(controlFlowGraph->entry()->outedge(0)->sink());
+
+    size_t numStoreThreeAddressCodes = 0;
+    size_t numStoreVolatileThreeAddressCodes = 0;
+    for (auto it = basicBlock->begin(); it != basicBlock->end(); it++)
+    {
+      if (is<StoreVolatileOperation>(*it))
+      {
+        numStoreVolatileThreeAddressCodes++;
+        auto ioStateAssignment = *std::next(it);
+        auto memoryStateAssignment = *std::next(it, 2);
+
+        assert(is<assignment_op>(ioStateAssignment->operation()));
+        assert(is<iostatetype>(ioStateAssignment->operand(0)->type()));
+
+        assert(is<assignment_op>(memoryStateAssignment->operation()));
+        assert(is<MemoryStateType>(memoryStateAssignment->operand(0)->type()));
+      }
+      else if (is<StoreOperation>(*it))
+      {
+        numStoreThreeAddressCodes++;
+        auto memoryStateAssignment = *std::next(it, 1);
+
+        assert(is<assignment_op>(memoryStateAssignment->operation()));
+        assert(is<MemoryStateType>(memoryStateAssignment->operand(0)->type()));
+      }
+    }
+
+    assert(numStoreThreeAddressCodes == 1);
+    assert(numStoreVolatileThreeAddressCodes == 2);
+  }
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER("jlm/llvm/frontend/llvm/StoreTests-StoreConversion", StoreConversion)

--- a/tests/jlm/llvm/ir/operators/StoreVolatileTests.cpp
+++ b/tests/jlm/llvm/ir/operators/StoreVolatileTests.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2024 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <test-operation.hpp>
+#include <test-registry.hpp>
+#include <test-types.hpp>
+
+#include <jlm/llvm/ir/operators/StoreVolatile.hpp>
+
+static int
+OperationEquality()
+{
+  using namespace jlm::llvm;
+
+  // Arrange
+  MemoryStateType memoryType;
+  jlm::tests::valuetype valueType;
+  PointerType pointerType;
+
+  StoreVolatileOperation operation1(valueType, 2, 4);
+  StoreVolatileOperation operation2(pointerType, 2, 4);
+  StoreVolatileOperation operation3(valueType, 4, 4);
+  StoreVolatileOperation operation4(valueType, 2, 8);
+  jlm::tests::test_op operation5({ &pointerType }, { &pointerType });
+
+  // Assert
+  assert(operation1 == operation1);
+  assert(operation1 != operation2); // stored type differs
+  assert(operation1 != operation3); // number of memory states differs
+  assert(operation1 != operation4); // alignment differs
+  assert(operation1 != operation5); // operation differs
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER(
+    "jlm/llvm/ir/operators/StoreVolatileTests-OperationEquality",
+    OperationEquality)
+
+static int
+OperationCopy()
+{
+  using namespace jlm::llvm;
+
+  // Arrange
+  MemoryStateType memoryType;
+  jlm::tests::valuetype valueType;
+  PointerType pointerType;
+
+  StoreVolatileOperation operation(valueType, 2, 4);
+
+  // Act
+  auto copiedOperation = operation.copy();
+
+  // Assert
+  assert(*copiedOperation == operation);
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER("jlm/llvm/ir/operators/StoreVolatileTests-OperationCopy", OperationCopy)
+
+static int
+OperationAccessors()
+{
+  using namespace jlm::llvm;
+
+  // Arrange
+  MemoryStateType memoryType;
+  jlm::tests::valuetype valueType;
+  PointerType pointerType;
+
+  size_t alignment = 4;
+  size_t numMemoryStates = 2;
+  StoreVolatileOperation operation(valueType, numMemoryStates, alignment);
+
+  // Assert
+  assert(operation.GetStoredType() == valueType);
+  assert(operation.NumMemoryStates() == numMemoryStates);
+  assert(operation.GetAlignment() == alignment);
+  assert(
+      operation.narguments()
+      == numMemoryStates + 3); // [address, storedValue, ioState, memoryStates]
+  assert(operation.nresults() == numMemoryStates + 1); // [ioState, memoryStates]
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER(
+    "jlm/llvm/ir/operators/StoreVolatileTests-OperationAccessors",
+    OperationAccessors)
+
+static int
+NodeCopy()
+{
+  using namespace jlm::llvm;
+
+  // Arrange
+  PointerType pointerType;
+  iostatetype ioStateType;
+  MemoryStateType memoryType;
+  jlm::tests::valuetype valueType;
+
+  jlm::rvsdg::graph graph;
+  auto & address1 = *graph.add_import({ pointerType, "address1" });
+  auto & value1 = *graph.add_import({ valueType, "value1" });
+  auto & ioState1 = *graph.add_import({ ioStateType, "ioState1" });
+  auto & memoryState1 = *graph.add_import({ memoryType, "memoryState1" });
+
+  auto & address2 = *graph.add_import({ pointerType, "address2" });
+  auto & value2 = *graph.add_import({ valueType, "value2" });
+  auto & ioState2 = *graph.add_import({ ioStateType, "ioState2" });
+  auto & memoryState2 = *graph.add_import({ memoryType, "memoryState2" });
+
+  auto & storeNode =
+      StoreVolatileNode::CreateNode(address1, value1, ioState1, { &memoryState1 }, 4);
+
+  // Act
+  auto copiedNode = storeNode.copy(graph.root(), { &address2, &value2, &ioState2, &memoryState2 });
+
+  // Assert
+  auto copiedStoreNode = dynamic_cast<const StoreVolatileNode *>(copiedNode);
+  assert(storeNode.GetOperation() == copiedStoreNode->GetOperation());
+  assert(copiedStoreNode->GetAddressInput().origin() == &address2);
+  assert(copiedStoreNode->GetValueInput().origin() == &value2);
+  assert(copiedStoreNode->GetIoStateInput().origin() == &ioState2);
+  assert(copiedStoreNode->GetIoStateOutput().type() == ioStateType);
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER("jlm/llvm/ir/operators/StoreVolatileTests-NodeCopy", NodeCopy)


### PR DESCRIPTION
This PR does the following:

    Add StoreOperation and StoreNode class for volatile load operations.
    Adds conversion support for LLVM -> RVSDG
    Adds conversion support for RVSDG -> LLVM

