### PR TITLE
Enable load-load-state reduction again

### DIFF
--- a/jlm/llvm/opt/reduction.cpp
+++ b/jlm/llvm/opt/reduction.cpp
@@ -76,9 +76,7 @@ enable_load_reductions(jlm::rvsdg::graph & graph)
   nf->set_load_alloca_reducible(true);
   nf->set_multiple_origin_reducible(true);
   nf->set_load_store_state_reducible(true);
-  // set_load_load_state_reducible throws a type_error
-  // github issue #307
-  nf->set_load_load_state_reducible(false);
+  nf->set_load_load_state_reducible(true);
 }
 
 static void


### PR DESCRIPTION
I could not reproduce the problem from #307 any longer. Looking at the input program and the reported error, I suspect that this optimization was just the trigger, but not the actual cause. I believe that the cause was the missing loaded type in the equality operator of the LoadOperation. It was fixed in #456.

Closes #307 