### PR TITLE
Enable Control Constant Reduction again

### DIFF
--- a/jlm/llvm/opt/reduction.cpp
+++ b/jlm/llvm/opt/reduction.cpp
@@ -85,9 +85,7 @@ enable_gamma_reductions(jlm::rvsdg::graph & graph)
   auto nf = jlm::rvsdg::gamma_op::normal_form(&graph);
   nf->set_mutable(true);
   nf->set_predicate_reduction(true);
-  // set_control_constante_reduction cause a PHI node input type error
-  // github issue #303
-  nf->set_control_constant_reduction(false);
+  nf->set_control_constant_reduction(true);
 }
 
 static void

--- a/jlm/rvsdg/control.cpp
+++ b/jlm/rvsdg/control.cpp
@@ -110,6 +110,7 @@ std::string
 match_op::debug_string() const
 {
   std::string str("[");
+  str += util::strfmt(nalternatives(), ", ");
   for (const auto & pair : mapping_)
     str += jlm::util::strfmt(pair.first, " -> ", pair.second, ", ");
   str += jlm::util::strfmt(default_alternative_, "]");

--- a/jlm/rvsdg/control.hpp
+++ b/jlm/rvsdg/control.hpp
@@ -106,7 +106,12 @@ struct ctlformat_value
   std::string
   operator()(const ctlvalue_repr & repr) const
   {
-    return jlm::util::strfmt("CTL(", repr.alternative(), ")");
+    return jlm::util::strfmt(
+        "ControlConstant[",
+        repr.nalternatives(),
+        "](",
+        repr.alternative(),
+        ")");
   }
 };
 


### PR DESCRIPTION
This PR enables control constant reduction again. It does the following:

1. Improves debug output of the match and control constant operations
2. Handles the case were all the constants in every branch are the same specifically

The problem arises because match operations are either mapped to integer types of bit width 1 or 32 in the back-end, depending on the nature of the match operation. This all works fine as long as the match operation is directly consumed by an LLVM terminator instruction. If that is not the case any longer, then we might end up with the problem where we have input values of differing type to an operation (i32 vs. i1), such as a SSA phi. The control constant reduction is an optimization that can trigger this problem.

This PR does not resolve the underlying problem (mismatching type translation), but only provides a band-aid such that the problem is less likely to reappear. I currently have no idea how to satisfactorily resolve the underlying problem.

Closes #303 