### PR TITLE
Rename MemCpyOperation class to MemCpyNonVolatile

### DIFF
--- a/jlm/llvm/backend/jlm2llvm/instruction.cpp
+++ b/jlm/llvm/backend/jlm2llvm/instruction.cpp
@@ -903,7 +903,7 @@ convert(
 
 static ::llvm::Value *
 convert(
-    const MemCpyOperation &,
+    const MemCpyNonVolatileOperation &,
     const std::vector<const variable *> & operands,
     ::llvm::IRBuilder<> & builder,
     context & ctx)
@@ -1070,7 +1070,7 @@ convert_operation(
             { typeid(CallOperation), convert<CallOperation> },
             { typeid(malloc_op), convert<malloc_op> },
             { typeid(FreeOperation), convert<FreeOperation> },
-            { typeid(MemCpyOperation), convert<MemCpyOperation> },
+            { typeid(MemCpyNonVolatileOperation), convert<MemCpyNonVolatileOperation> },
             { typeid(MemCpyVolatileOperation), convert<MemCpyVolatileOperation> },
             { typeid(fpneg_op), convert_fpneg },
             { typeid(bitcast_op), convert_cast<::llvm::Instruction::BitCast> },

--- a/jlm/llvm/frontend/LlvmInstructionConversion.cpp
+++ b/jlm/llvm/frontend/LlvmInstructionConversion.cpp
@@ -782,7 +782,8 @@ convert_memcpy_call(const ::llvm::CallInst * instruction, tacsvector_t & tacs, c
   }
   else
   {
-    tacs.push_back(MemCpyOperation::create(destination, source, length, { memoryState }));
+    tacs.push_back(
+        MemCpyNonVolatileOperation::create(destination, source, length, { memoryState }));
     tacs.push_back(assignment_op::create(tacs.back()->result(0), memoryState));
   }
 

--- a/jlm/llvm/ir/operators/MemCpy.cpp
+++ b/jlm/llvm/ir/operators/MemCpy.cpp
@@ -8,26 +8,26 @@
 namespace jlm::llvm
 {
 
-MemCpyOperation::~MemCpyOperation() = default;
+MemCpyNonVolatileOperation::~MemCpyNonVolatileOperation() = default;
 
 bool
-MemCpyOperation::operator==(const operation & other) const noexcept
+MemCpyNonVolatileOperation::operator==(const operation & other) const noexcept
 {
-  auto operation = dynamic_cast<const MemCpyOperation *>(&other);
+  auto operation = dynamic_cast<const MemCpyNonVolatileOperation *>(&other);
   return operation && operation->LengthType() == LengthType()
       && operation->NumMemoryStates() == NumMemoryStates();
 }
 
 std::string
-MemCpyOperation::debug_string() const
+MemCpyNonVolatileOperation::debug_string() const
 {
   return "MemCpy";
 }
 
 std::unique_ptr<rvsdg::operation>
-MemCpyOperation::copy() const
+MemCpyNonVolatileOperation::copy() const
 {
-  return std::unique_ptr<rvsdg::operation>(new MemCpyOperation(*this));
+  return std::unique_ptr<rvsdg::operation>(new MemCpyNonVolatileOperation(*this));
 }
 
 MemCpyVolatileOperation::~MemCpyVolatileOperation() noexcept = default;

--- a/jlm/llvm/ir/operators/MemCpy.hpp
+++ b/jlm/llvm/ir/operators/MemCpy.hpp
@@ -15,16 +15,16 @@ namespace jlm::llvm
 {
 
 /**
- * Represents an LLVM memcpy intrinsic.
+ * Represents a non-volatile LLVM memcpy intrinsic.
  *
  * @see MemCpyVolatileOperation
  */
-class MemCpyOperation final : public rvsdg::simple_op
+class MemCpyNonVolatileOperation final : public rvsdg::simple_op
 {
 public:
-  ~MemCpyOperation() override;
+  ~MemCpyNonVolatileOperation() override;
 
-  MemCpyOperation(const rvsdg::type & lengthType, size_t numMemoryStates)
+  MemCpyNonVolatileOperation(const rvsdg::type & lengthType, size_t numMemoryStates)
       : simple_op(
           CheckAndCreateOperandPorts(lengthType, numMemoryStates),
           CreateResultPorts(numMemoryStates))
@@ -63,7 +63,7 @@ public:
     std::vector<const variable *> operands = { destination, source, length };
     operands.insert(operands.end(), memoryStates.begin(), memoryStates.end());
 
-    MemCpyOperation operation(length->type(), memoryStates.size());
+    MemCpyNonVolatileOperation operation(length->type(), memoryStates.size());
     return tac::create(operation, operands);
   }
 
@@ -77,7 +77,7 @@ public:
     std::vector<rvsdg::output *> operands = { destination, source, length };
     operands.insert(operands.end(), memoryStates.begin(), memoryStates.end());
 
-    MemCpyOperation operation(length->type(), memoryStates.size());
+    MemCpyNonVolatileOperation operation(length->type(), memoryStates.size());
     return rvsdg::simple_node::create_normalized(destination->region(), operation, operands);
   }
 
@@ -112,9 +112,9 @@ private:
  * incorporates externally visible side-effects. This I/O state allows the volatile memcpy operation
  * to be sequentialized with respect to other volatile memory accesses and I/O operations. This
  * additional I/O state is the main reason why volatile memcpys are modeled as its own operation and
- * volatile is not just a flag at the normal \ref MemCpyOperation.
+ * volatile is not just a flag at the normal \ref MemCpyNonVolatileOperation.
  *
- * @see MemCpyOperation
+ * @see MemCpyNonVolatileOperation
  */
 class MemCpyVolatileOperation final : public rvsdg::simple_op
 {

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -234,7 +234,7 @@ Andersen::AnalyzeSimpleNode(const rvsdg::simple_node & node)
     AnalyzeConstantPointerNull(node);
   else if (is<UndefValueOperation>(op))
     AnalyzeUndef(node);
-  else if (is<MemCpyOperation>(op))
+  else if (is<MemCpyNonVolatileOperation>(op))
     AnalyzeMemcpy(node);
   else if (is<ConstantArray>(op))
     AnalyzeConstantArray(node);

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
@@ -598,7 +598,7 @@ MemoryStateEncoder::EncodeSimpleNode(const jlm::rvsdg::simple_node & be)
               { typeid(StoreOperation), EncodeStore },
               { typeid(CallOperation), EncodeCall },
               { typeid(FreeOperation), EncodeFree },
-              { typeid(MemCpyOperation), EncodeMemcpy } });
+              { typeid(MemCpyNonVolatileOperation), EncodeMemcpy } });
 
   auto & operation = be.operation();
   if (nodes.find(typeid(operation)) == nodes.end())
@@ -761,7 +761,7 @@ MemoryStateEncoder::EncodeCall(const CallNode & callNode)
 void
 MemoryStateEncoder::EncodeMemcpy(const jlm::rvsdg::simple_node & memcpyNode)
 {
-  JLM_ASSERT(is<MemCpyOperation>(&memcpyNode));
+  JLM_ASSERT(is<MemCpyNonVolatileOperation>(&memcpyNode));
   auto & stateMap = Context_->GetRegionalizedStateMap();
 
   auto destination = memcpyNode.input(0)->origin();
@@ -775,7 +775,7 @@ MemoryStateEncoder::EncodeMemcpy(const jlm::rvsdg::simple_node & memcpyNode)
   auto srcStates = StateMap::MemoryNodeStatePair::States(srcMemoryNodeStatePairs);
   inStates.insert(inStates.end(), srcStates.begin(), srcStates.end());
 
-  auto outStates = MemCpyOperation::create(destination, source, length, inStates);
+  auto outStates = MemCpyNonVolatileOperation::create(destination, source, length, inStates);
 
   auto end = std::next(outStates.begin(), (ssize_t)destMemoryNodeStatePairs.size());
   StateMap::MemoryNodeStatePair::ReplaceStates(

--- a/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.cpp
+++ b/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.cpp
@@ -718,7 +718,7 @@ RegionAwareMemoryNodeProvider::AnnotateSimpleNode(const rvsdg::simple_node & sim
   {
     AnnotateFree(simpleNode);
   }
-  else if (is<MemCpyOperation>(&simpleNode))
+  else if (is<MemCpyNonVolatileOperation>(&simpleNode))
   {
     AnnotateMemcpy(simpleNode);
   }
@@ -817,7 +817,7 @@ RegionAwareMemoryNodeProvider::AnnotateCall(const CallNode & callNode)
 void
 RegionAwareMemoryNodeProvider::AnnotateMemcpy(const rvsdg::simple_node & memcpyNode)
 {
-  JLM_ASSERT(is<MemCpyOperation>(memcpyNode.operation()));
+  JLM_ASSERT(is<MemCpyNonVolatileOperation>(memcpyNode.operation()));
 
   auto & regionSummary = Provisioning_->GetRegionSummary(*memcpyNode.region());
 

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -1034,7 +1034,7 @@ Steensgaard::AnalyzeSimpleNode(const jlm::rvsdg::simple_node & node)
   {
     AnalyzeUndef(node);
   }
-  else if (is<MemCpyOperation>(&node))
+  else if (is<MemCpyNonVolatileOperation>(&node))
   {
     AnalyzeMemcpy(node);
   }
@@ -1411,7 +1411,7 @@ Steensgaard::AnalyzeConstantStruct(const jlm::rvsdg::simple_node & node)
 void
 Steensgaard::AnalyzeMemcpy(const jlm::rvsdg::simple_node & node)
 {
-  JLM_ASSERT(is<MemCpyOperation>(&node));
+  JLM_ASSERT(is<MemCpyNonVolatileOperation>(&node));
 
   auto & dstAddress = Context_->GetLocation(*node.input(0)->origin());
   auto & srcAddress = Context_->GetLocation(*node.input(1)->origin());

--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -3001,8 +3001,11 @@ MemcpyTest::SetupRvsdg()
 
     auto twenty = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 20);
 
-    auto memcpyResults =
-        MemCpyOperation::create(bcGlobalArray, bcLocalArray, twenty, { memoryStateArgument });
+    auto memcpyResults = MemCpyNonVolatileOperation::create(
+        bcGlobalArray,
+        bcLocalArray,
+        twenty,
+        { memoryStateArgument });
 
     auto & call = CallNode::CreateNode(
         functionFArgument,
@@ -3076,7 +3079,7 @@ MemcpyTest2::SetupRvsdg()
     auto gepS12 = GetElementPtrOperation::Create(gepS11, { c0, c0 }, arrayType, pointerType);
     auto ldS1 = LoadNonVolatileNode::Create(gepS12, { ldS2[1] }, pointerType, 8);
 
-    auto memcpyResults = MemCpyOperation::create(ldS2[0], ldS1[0], c128, { ldS1[1] });
+    auto memcpyResults = MemCpyNonVolatileOperation::create(ldS2[0], ldS1[0], c128, { ldS1[1] });
 
     auto lambdaOutput = lambda->finalize({ iOStateArgument, memcpyResults[0] });
 
@@ -3165,7 +3168,8 @@ MemcpyTest3::SetupRvsdg()
   auto allocaResults = alloca_op::create(*structType, eight, 8);
   auto memoryState = MemStateMergeOperator::Create({ allocaResults[1], memoryStateArgument });
 
-  auto memcpyResults = MemCpyOperation::create(allocaResults[0], pArgument, eight, { memoryState });
+  auto memcpyResults =
+      MemCpyNonVolatileOperation::create(allocaResults[0], pArgument, eight, { memoryState });
 
   auto gep1 =
       GetElementPtrOperation::Create(allocaResults[0], { zero, zero }, *structType, pointerType);
@@ -3174,7 +3178,7 @@ MemcpyTest3::SetupRvsdg()
   auto gep2 =
       GetElementPtrOperation::Create(allocaResults[0], { minusFive }, *structType, pointerType);
 
-  memcpyResults = MemCpyOperation::create(ld[0], gep2, three, { ld[1] });
+  memcpyResults = MemCpyNonVolatileOperation::create(ld[0], gep2, three, { ld[1] });
 
   auto lambdaOutput = Lambda_->finalize({ iOStateArgument, memcpyResults[0] });
 

--- a/tests/jlm/llvm/backend/llvm/jlm-llvm/MemCpyTests.cpp
+++ b/tests/jlm/llvm/backend/llvm/jlm-llvm/MemCpyTests.cpp
@@ -37,7 +37,7 @@ MemCpyConversion()
       cfg->entry()->append_argument(argument::create("memoryState", memoryStateType));
 
   auto basicBlock = basic_block::create(*cfg);
-  auto memCpyTac = basicBlock->append_last(MemCpyOperation::create(
+  auto memCpyTac = basicBlock->append_last(MemCpyNonVolatileOperation::create(
       destinationArgument,
       sourceArgument,
       lengthArgument,

--- a/tests/jlm/llvm/frontend/llvm/MemCpyTests.cpp
+++ b/tests/jlm/llvm/frontend/llvm/MemCpyTests.cpp
@@ -75,7 +75,7 @@ MemCpyConversion()
         assert(is<assignment_op>(memoryStateAssignment->operation()));
         assert(is<MemoryStateType>(memoryStateAssignment->operand(0)->type()));
       }
-      else if (is<MemCpyOperation>(*it))
+      else if (is<MemCpyNonVolatileOperation>(*it))
       {
         numMemCpyThreeAddressCodes++;
         auto memoryStateAssignment = *std::next(it, 1);

--- a/tests/jlm/llvm/ir/operators/MemCpyTests.cpp
+++ b/tests/jlm/llvm/ir/operators/MemCpyTests.cpp
@@ -19,8 +19,8 @@ OperationEquality()
   jlm::rvsdg::bittype bit32Type(32);
   jlm::rvsdg::bittype bit64Type(64);
 
-  MemCpyOperation operation1(bit32Type, 1);
-  MemCpyOperation operation2(bit64Type, 4);
+  MemCpyNonVolatileOperation operation1(bit32Type, 1);
+  MemCpyNonVolatileOperation operation2(bit64Type, 4);
   jlm::tests::test_op operation3({ &valueType }, { &valueType });
 
   // Act & Assert
@@ -31,4 +31,6 @@ OperationEquality()
   return 0;
 }
 
-JLM_UNIT_TEST_REGISTER("jlm/llvm/ir/operators/MemCpyTests-OperationEquality", OperationEquality)
+JLM_UNIT_TEST_REGISTER(
+    "jlm/llvm/ir/operators/MemCpyNonVolatileTests-OperationEquality",
+    OperationEquality)

--- a/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
@@ -1957,11 +1957,11 @@ ValidateMemcpySteensgaardAgnostic(const jlm::tests::MemcpyTest & test)
     for (size_t n = 0; n < callEntryMerge->ninputs(); n++)
     {
       auto node = jlm::rvsdg::node_output::node(callEntryMerge->input(n)->origin());
-      if (is<MemCpyOperation>(node))
+      if (is<MemCpyNonVolatileOperation>(node))
         memcpy = node;
     }
     assert(memcpy != nullptr);
-    assert(is<MemCpyOperation>(*memcpy, 7, 4));
+    assert(is<MemCpyNonVolatileOperation>(*memcpy, 7, 4));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(memcpy->input(5)->origin());
     assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 5));
@@ -2004,7 +2004,7 @@ ValidateMemcpySteensgaardRegionAware(const jlm::tests::MemcpyTest & test)
     assert(is<aa::CallExitMemStateOperator>(*callExitSplit, 1, 2));
 
     auto memcpyNode = jlm::rvsdg::node_output::node(callEntryMerge->input(0)->origin());
-    assert(is<MemCpyOperation>(*memcpyNode, 7, 4));
+    assert(is<MemCpyNonVolatileOperation>(*memcpyNode, 7, 4));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(memcpyNode->input(4)->origin());
     assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 2));
@@ -2053,11 +2053,11 @@ ValidateMemcpyTestSteensgaardAgnosticTopDown(const jlm::tests::MemcpyTest & test
     for (size_t n = 0; n < callEntryMerge->ninputs(); n++)
     {
       auto node = jlm::rvsdg::node_output::node(callEntryMerge->input(n)->origin());
-      if (is<MemCpyOperation>(node))
+      if (is<MemCpyNonVolatileOperation>(node))
         memcpy = node;
     }
     assert(memcpy != nullptr);
-    assert(is<MemCpyOperation>(*memcpy, 7, 4));
+    assert(is<MemCpyNonVolatileOperation>(*memcpy, 7, 4));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(memcpy->input(5)->origin());
     assert(is<aa::LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 5));


### PR DESCRIPTION
The reason for this renaming is that a common operation will be introduced in order to:

1. Refactor out common properties between the volatile and non-volatile
operations/nodes.
2. Provide a common base class for passes, such as alias analysis, that
do not care about the volatile/non-volatile.