### PR TITLE
Fix memory state operation equality

### DIFF
--- a/jlm/llvm/Makefile.sub
+++ b/jlm/llvm/Makefile.sub
@@ -152,6 +152,7 @@ libllvm_TESTS += \
 	tests/jlm/llvm/frontend/llvm/test-select \
 	tests/jlm/llvm/ir/operators/LoadTests \
 	tests/jlm/llvm/ir/operators/MemCpyTests \
+	tests/jlm/llvm/ir/operators/MemoryStateOperationTests \
 	tests/jlm/llvm/ir/operators/TestCall \
 	tests/jlm/llvm/ir/operators/test-ConstantFP \
 	tests/jlm/llvm/ir/operators/test-delta \

--- a/jlm/llvm/Makefile.sub
+++ b/jlm/llvm/Makefile.sub
@@ -173,6 +173,7 @@ libllvm_TESTS += \
 	tests/jlm/llvm/ir/test-domtree \
 	tests/jlm/llvm/ir/test-ssa-destruction \
 	tests/jlm/llvm/ir/TestAnnotation \
+	tests/jlm/llvm/opt/alias-analyses/MemoryStateOperationTests \
 	tests/jlm/llvm/opt/alias-analyses/TestAgnosticMemoryNodeProvider \
 	tests/jlm/llvm/opt/alias-analyses/TestAndersen \
 	tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder \

--- a/jlm/llvm/ir/operators/operators.cpp
+++ b/jlm/llvm/ir/operators/operators.cpp
@@ -1186,7 +1186,8 @@ MemStateMergeOperator::~MemStateMergeOperator()
 bool
 MemStateMergeOperator::operator==(const rvsdg::operation & other) const noexcept
 {
-  return is<MemStateMergeOperator>(other);
+  auto operation = dynamic_cast<const MemStateMergeOperator *>(&other);
+  return operation && operation->narguments() == narguments();
 }
 
 std::string
@@ -1209,7 +1210,8 @@ MemStateSplitOperator::~MemStateSplitOperator()
 bool
 MemStateSplitOperator::operator==(const rvsdg::operation & other) const noexcept
 {
-  return is<MemStateSplitOperator>(other);
+  auto operation = dynamic_cast<const MemStateSplitOperator *>(&other);
+  return operation && operation->nresults() == nresults();
 }
 
 std::string

--- a/jlm/llvm/opt/alias-analyses/Operators.cpp
+++ b/jlm/llvm/opt/alias-analyses/Operators.cpp
@@ -18,7 +18,8 @@ LambdaEntryMemStateOperator::~LambdaEntryMemStateOperator() = default;
 bool
 LambdaEntryMemStateOperator::operator==(const jlm::rvsdg::operation & other) const noexcept
 {
-  return is<LambdaEntryMemStateOperator>(other);
+  auto operation = dynamic_cast<const LambdaEntryMemStateOperator *>(&other);
+  return operation && operation->nresults() == nresults();
 }
 
 std::string
@@ -40,7 +41,8 @@ LambdaExitMemStateOperator::~LambdaExitMemStateOperator() = default;
 bool
 LambdaExitMemStateOperator::operator==(const jlm::rvsdg::operation & other) const noexcept
 {
-  return is<LambdaExitMemStateOperator>(other);
+  auto operation = dynamic_cast<const LambdaExitMemStateOperator *>(&other);
+  return operation && operation->narguments() == narguments();
 }
 
 std::string
@@ -62,7 +64,8 @@ CallEntryMemStateOperator::~CallEntryMemStateOperator() = default;
 bool
 CallEntryMemStateOperator::operator==(const jlm::rvsdg::operation & other) const noexcept
 {
-  return is<CallEntryMemStateOperator>(other);
+  auto operation = dynamic_cast<const CallEntryMemStateOperator *>(&other);
+  return operation && operation->narguments() == narguments();
 }
 
 std::string
@@ -84,7 +87,8 @@ CallExitMemStateOperator::~CallExitMemStateOperator() = default;
 bool
 CallExitMemStateOperator::operator==(const jlm::rvsdg::operation & other) const noexcept
 {
-  return is<CallExitMemStateOperator>(other);
+  auto operation = dynamic_cast<const CallExitMemStateOperator *>(&other);
+  return operation && operation->nresults() == nresults();
 }
 
 std::string

--- a/jlm/llvm/opt/alias-analyses/Operators.hpp
+++ b/jlm/llvm/opt/alias-analyses/Operators.hpp
@@ -21,12 +21,11 @@ class LambdaEntryMemStateOperator final : public MemStateOperator
 public:
   ~LambdaEntryMemStateOperator() override;
 
-private:
+public:
   explicit LambdaEntryMemStateOperator(size_t nresults)
       : MemStateOperator(1, nresults)
   {}
 
-public:
   bool
   operator==(const operation & other) const noexcept override;
 
@@ -52,12 +51,11 @@ class LambdaExitMemStateOperator final : public MemStateOperator
 public:
   ~LambdaExitMemStateOperator() override;
 
-private:
+public:
   explicit LambdaExitMemStateOperator(size_t noperands)
       : MemStateOperator(noperands, 1)
   {}
 
-public:
   bool
   operator==(const operation & other) const noexcept override;
 
@@ -82,12 +80,11 @@ class CallEntryMemStateOperator final : public MemStateOperator
 public:
   ~CallEntryMemStateOperator() override;
 
-private:
+public:
   explicit CallEntryMemStateOperator(size_t noperands)
       : MemStateOperator(noperands, 1)
   {}
 
-public:
   bool
   operator==(const operation & other) const noexcept override;
 
@@ -112,12 +109,11 @@ class CallExitMemStateOperator final : public MemStateOperator
 public:
   ~CallExitMemStateOperator() override;
 
-private:
+public:
   explicit CallExitMemStateOperator(size_t nresults)
       : MemStateOperator(1, nresults)
   {}
 
-public:
   bool
   operator==(const operation & other) const noexcept override;
 

--- a/tests/jlm/llvm/ir/operators/MemoryStateOperationTests.cpp
+++ b/tests/jlm/llvm/ir/operators/MemoryStateOperationTests.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <test-operation.hpp>
+#include <test-registry.hpp>
+
+#include <jlm/llvm/ir/operators/operators.hpp>
+
+static int
+MemoryStateSplitEquality()
+{
+  using namespace jlm::llvm;
+
+  // Arrange
+  MemoryStateType memoryStateType;
+  MemStateSplitOperator operation1(2);
+  MemStateSplitOperator operation2(4);
+  jlm::tests::test_op operation3({ &memoryStateType }, { &memoryStateType, &memoryStateType });
+
+  // Act & Assert
+  assert(operation1 == operation1);
+  assert(operation1 != operation2); // Number of results differ
+  assert(operation1 != operation3); // Operation differs
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER(
+    "jlm/llvm/ir/operators/MemoryStateOperationTests-MemoryStateSplitEquality",
+    MemoryStateSplitEquality)
+
+static int
+MemoryStateMergeEquality()
+{
+  using namespace jlm::llvm;
+
+  // Arrange
+  MemoryStateType memoryStateType;
+  MemStateMergeOperator operation1(2);
+  MemStateMergeOperator operation2(4);
+  jlm::tests::test_op operation3({ &memoryStateType, &memoryStateType }, { &memoryStateType });
+
+  // Act & Assert
+  assert(operation1 == operation1);
+  assert(operation1 != operation2); // Number of operands differ
+  assert(operation1 != operation3); // Operation differs
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER(
+    "jlm/llvm/ir/operators/MemoryStateOperationTests-MemoryStateMergeEquality",
+    MemoryStateMergeEquality)

--- a/tests/jlm/llvm/opt/alias-analyses/MemoryStateOperationTests.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/MemoryStateOperationTests.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2024 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <test-operation.hpp>
+#include <test-registry.hpp>
+
+#include <jlm/llvm/opt/alias-analyses/Operators.hpp>
+
+static int
+LambdaEntryMemStateOperatorEquality()
+{
+  using namespace jlm::llvm::aa;
+
+  // Arrange
+  jlm::llvm::MemoryStateType memoryStateType;
+  LambdaEntryMemStateOperator operation1(2);
+  LambdaEntryMemStateOperator operation2(4);
+  jlm::tests::test_op operation3({ &memoryStateType }, { &memoryStateType, &memoryStateType });
+
+  // Act & Assert
+  assert(operation1 == operation1);
+  assert(operation1 != operation2); // Number of results differ
+  assert(operation1 != operation3); // Operation differs
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER(
+    "jlm/llvm/opt/alias-analyses/MemoryStateOperationTests-LambdaEntryMemStateOperatorEquality",
+    LambdaEntryMemStateOperatorEquality)
+
+static int
+LambdaExitMemStateOperatorEquality()
+{
+  using namespace jlm::llvm::aa;
+
+  // Arrange
+  jlm::llvm::MemoryStateType memoryStateType;
+  LambdaExitMemStateOperator operation1(2);
+  LambdaExitMemStateOperator operation2(4);
+  jlm::tests::test_op operation3({ &memoryStateType, &memoryStateType }, { &memoryStateType });
+
+  // Act & Assert
+  assert(operation1 == operation1);
+  assert(operation1 != operation2); // Number of operands differ
+  assert(operation1 != operation3); // Operation differs
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER(
+    "jlm/llvm/ir/operators/MemoryStateOperationTests-LambdaExitMemStateOperatorEquality",
+    LambdaExitMemStateOperatorEquality)
+
+static int
+CallEntryMemStateOperatorEquality()
+{
+  using namespace jlm::llvm::aa;
+
+  // Arrange
+  jlm::llvm::MemoryStateType memoryStateType;
+  CallEntryMemStateOperator operation1(2);
+  CallEntryMemStateOperator operation2(4);
+  jlm::tests::test_op operation3({ &memoryStateType, &memoryStateType }, { &memoryStateType });
+
+  // Act & Assert
+  assert(operation1 == operation1);
+  assert(operation1 != operation2); // Number of operands differ
+  assert(operation1 != operation3); // Operation differs
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER(
+    "jlm/llvm/opt/alias-analyses/MemoryStateOperationTests-CallEntryMemStateOperatorEquality",
+    CallEntryMemStateOperatorEquality)
+
+static int
+CallExitMemStateOperatorEquality()
+{
+  using namespace jlm::llvm::aa;
+
+  // Arrange
+  jlm::llvm::MemoryStateType memoryStateType;
+  CallExitMemStateOperator operation1(2);
+  CallExitMemStateOperator operation2(4);
+  jlm::tests::test_op operation3({ &memoryStateType }, { &memoryStateType, &memoryStateType });
+
+  // Act & Assert
+  assert(operation1 == operation1);
+  assert(operation1 != operation2); // Number of results differ
+  assert(operation1 != operation3); // Operation differs
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER(
+    "jlm/llvm/ir/operators/MemoryStateOperationTests-CallExitMemStateOperatorEquality",
+    CallExitMemStateOperatorEquality)


### PR DESCRIPTION
The equality operator of all memory state operations was not taking the number of operands/results into account. This PR fixes this issue. An upcoming PR will move them in the same file and overhaul their implementation.