### PR TITLE
Perf: Avoid visiting nodes for a "second" time multiple times in TarjanSCC

### DIFF
--- a/jlm/util/TarjanScc.hpp
+++ b/jlm/util/TarjanScc.hpp
@@ -59,7 +59,8 @@ FindStronglyConnectedComponents(
   // The lowest order seen through any path of edges that do not enter finished SCCs
   std::vector<int64_t> lowLink(numNodes);
 
-  // The DFS stack is a regular DFS traversal stack
+  // The DFS stack is a regular DFS traversal stack.
+  // Note that the same element can be pushed many times, but will only be visited twice
   std::stack<size_t> dfsStack;
   // The SCC stack is only popped once an SCC is found
   std::stack<size_t> sccStack;
@@ -89,8 +90,9 @@ FindStronglyConnectedComponents(
             dfsStack.push(next);
         }
       }
-      else // This is the second time node is visited, all children have been processed
+      else if (order[node] != SCC_FINISHED)
       {
+        // This is the second time node is visited, all children have been processed
         dfsStack.pop();
         for (auto next : successors(node))
         {

--- a/jlm/util/TarjanScc.hpp
+++ b/jlm/util/TarjanScc.hpp
@@ -90,10 +90,14 @@ FindStronglyConnectedComponents(
             dfsStack.push(next);
         }
       }
-      else if (order[node] != SCC_FINISHED)
+      else
       {
-        // This is the second time node is visited, all children have been processed
+        // This node has been visited before, so all children have been processed
         dfsStack.pop();
+
+        if (order[node] == SCC_FINISHED)
+          continue;
+
         for (auto next : successors(node))
         {
           // Ignore edges to nodes that are already part of a finished SCC

--- a/jlm/util/TarjanScc.hpp
+++ b/jlm/util/TarjanScc.hpp
@@ -90,13 +90,13 @@ FindStronglyConnectedComponents(
             dfsStack.push(next);
         }
       }
-      else
+      else if (order[node] == SCC_FINISHED) // This node has already been fully processed
       {
-        // This node has been visited before, so all children have been processed
         dfsStack.pop();
-
-        if (order[node] == SCC_FINISHED)
-          continue;
+      }
+      else // This node is being visited for the second time, i.e., the dfs post-visit
+      {
+        dfsStack.pop();
 
         for (auto next : successors(node))
         {


### PR DESCRIPTION
This does not affect correctness, but should boost performance by avoiding unnecessary visits of nodes that are already parts of finished SCCs.

When implementing DFS using a stack, I had forgotten that the same node can be added multiple times before it actually gets visited. In a graph like
```
A -------> B
 \         ^
  --> C --/
```
Visiting node A will push B and C. Since we then visit C first, it will also have to push B to process B before C can be popped. The edge `A->B` should then be ignored when popping B the second time.