### PR TITLE
[Andersen] Make InterProceduralGraphConversion emit the _VolatileNode varieties

### DIFF
--- a/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
+++ b/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
@@ -538,8 +538,11 @@ ConvertThreeAddressCode(
             { typeid(CallOperation), Convert<CallNode, CallOperation> },
             { typeid(LoadNonVolatileOperation),
               Convert<LoadNonVolatileNode, LoadNonVolatileOperation> },
+            { typeid(LoadVolatileOperation), Convert<LoadVolatileNode, LoadVolatileOperation> },
             { typeid(StoreNonVolatileOperation),
-              Convert<StoreNonVolatileNode, StoreNonVolatileOperation> } });
+              Convert<StoreNonVolatileNode, StoreNonVolatileOperation> },
+            { typeid(StoreVolatileOperation),
+              Convert<StoreVolatileNode, StoreVolatileOperation> } });
 
   auto & op = threeAddressCode.operation();
   if (map.find(typeid(op)) != map.end())

--- a/jlm/llvm/ir/operators/Load.cpp
+++ b/jlm/llvm/ir/operators/Load.cpp
@@ -76,6 +76,18 @@ LoadNonVolatileNode::copy(rvsdg::region * region, const std::vector<rvsdg::outpu
   return &CreateNode(*region, GetOperation(), operands);
 }
 
+LoadNode &
+LoadNonVolatileNode::ReplaceWithNewMemoryStates(std::vector<rvsdg::output *> & memoryStates) const
+{
+  auto & newNode = CreateNode(
+      GetAddressInput().origin(),
+      memoryStates,
+      GetOperation().GetLoadedType(),
+      GetOperation().GetAlignment());
+  GetLoadedValueOutput().divert_users(&newNode.GetLoadedValueOutput());
+  return newNode;
+}
+
 LoadVolatileOperation::~LoadVolatileOperation() noexcept = default;
 
 bool
@@ -138,6 +150,20 @@ rvsdg::node *
 LoadVolatileNode::copy(rvsdg::region * region, const std::vector<rvsdg::output *> & operands) const
 {
   return &CreateNode(*region, GetOperation(), operands);
+}
+
+LoadNode &
+LoadVolatileNode::ReplaceWithNewMemoryStates(std::vector<rvsdg::output *> & memoryStates) const
+{
+  auto & newNode = CreateNode(
+      *GetAddressInput().origin(),
+      *GetIoStateInput().origin(),
+      memoryStates,
+      GetOperation().GetLoadedType(),
+      GetOperation().GetAlignment());
+  GetLoadedValueOutput().divert_users(&newNode.GetLoadedValueOutput());
+  GetIoStateOutput().divert_users(&newNode.GetIoStateOutput());
+  return newNode;
 }
 
 /* load normal form */

--- a/jlm/llvm/ir/operators/Load.hpp
+++ b/jlm/llvm/ir/operators/Load.hpp
@@ -367,6 +367,15 @@ public:
   [[nodiscard]] MemoryStateOutputRange
   MemoryStateOutputs() const noexcept override;
 
+  static std::vector<rvsdg::output *>
+  Create(
+      rvsdg::region & region,
+      const LoadVolatileOperation & loadOperation,
+      const std::vector<rvsdg::output *> & operands)
+  {
+    return rvsdg::outputs(&CreateNode(region, loadOperation, operands));
+  }
+
   static LoadVolatileNode &
   CreateNode(
       rvsdg::region & region,

--- a/jlm/llvm/ir/operators/MemCpy.hpp
+++ b/jlm/llvm/ir/operators/MemCpy.hpp
@@ -184,6 +184,17 @@ public:
     return tac::create(operation, operands);
   }
 
+  static std::vector<rvsdg::output *>
+  Create(
+      rvsdg::output & destination,
+      rvsdg::output & source,
+      rvsdg::output & length,
+      rvsdg::output & ioState,
+      const std::vector<rvsdg::output *> & memoryStates)
+  {
+    return rvsdg::outputs(&CreateNode(destination, source, length, ioState, memoryStates));
+  }
+
   static rvsdg::simple_node &
   CreateNode(
       rvsdg::output & destination,

--- a/jlm/llvm/ir/operators/Store.cpp
+++ b/jlm/llvm/ir/operators/Store.cpp
@@ -74,6 +74,16 @@ StoreNonVolatileNode::copy(rvsdg::region * region, const std::vector<rvsdg::outp
   return &CreateNode(*region, GetOperation(), operands);
 }
 
+StoreNode &
+StoreNonVolatileNode::ReplaceWithNewMemoryStates(std::vector<rvsdg::output *> & memoryStates) const
+{
+  return CreateNode(
+      GetAddressInput().origin(),
+      GetStoredValueInput().origin(),
+      memoryStates,
+      GetOperation().GetAlignment());
+}
+
 StoreVolatileOperation::~StoreVolatileOperation() noexcept = default;
 
 bool
@@ -136,6 +146,19 @@ rvsdg::node *
 StoreVolatileNode::copy(rvsdg::region * region, const std::vector<rvsdg::output *> & operands) const
 {
   return &CreateNode(*region, GetOperation(), operands);
+}
+
+StoreNode &
+StoreVolatileNode::ReplaceWithNewMemoryStates(std::vector<rvsdg::output *> & memoryStates) const
+{
+  auto & newNode = CreateNode(
+      *GetAddressInput().origin(),
+      *GetStoredValueInput().origin(),
+      *GetIoStateInput().origin(),
+      memoryStates,
+      GetOperation().GetAlignment());
+  GetIoStateOutput().divert_users(&newNode.GetIoStateOutput());
+  return newNode;
 }
 
 /* store normal form */

--- a/jlm/llvm/ir/operators/Store.hpp
+++ b/jlm/llvm/ir/operators/Store.hpp
@@ -490,6 +490,15 @@ public:
   rvsdg::node *
   copy(rvsdg::region * region, const std::vector<rvsdg::output *> & operands) const override;
 
+  static std::vector<rvsdg::output *>
+  Create(
+      rvsdg::region & region,
+      const StoreVolatileOperation & storeOperation,
+      const std::vector<rvsdg::output *> & operands)
+  {
+    return rvsdg::outputs(&CreateNode(region, storeOperation, operands));
+  }
+
   static StoreVolatileNode &
   CreateNode(
       rvsdg::region & region,

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -216,9 +216,9 @@ Andersen::AnalyzeSimpleNode(const rvsdg::simple_node & node)
     AnalyzeAlloca(node);
   else if (is<malloc_op>(op))
     AnalyzeMalloc(node);
-  else if (const auto loadNode = dynamic_cast<const LoadNonVolatileNode *>(&node))
+  else if (const auto loadNode = dynamic_cast<const LoadNode *>(&node))
     AnalyzeLoad(*loadNode);
-  else if (const auto storeNode = dynamic_cast<const StoreNonVolatileNode *>(&node))
+  else if (const auto storeNode = dynamic_cast<const StoreNode *>(&node))
     AnalyzeStore(*storeNode);
   else if (const auto callNode = dynamic_cast<const CallNode *>(&node))
     AnalyzeCall(*callNode);
@@ -234,7 +234,7 @@ Andersen::AnalyzeSimpleNode(const rvsdg::simple_node & node)
     AnalyzeConstantPointerNull(node);
   else if (is<UndefValueOperation>(op))
     AnalyzeUndef(node);
-  else if (is<MemCpyNonVolatileOperation>(op))
+  else if (is<MemCpyOperation>(op))
     AnalyzeMemcpy(node);
   else if (is<ConstantArray>(op))
     AnalyzeConstantArray(node);
@@ -283,7 +283,7 @@ Andersen::AnalyzeMalloc(const rvsdg::simple_node & node)
 }
 
 void
-Andersen::AnalyzeLoad(const LoadNonVolatileNode & loadNode)
+Andersen::AnalyzeLoad(const LoadNode & loadNode)
 {
   const auto & addressRegister = *loadNode.GetAddressInput().origin();
   const auto & outputRegister = loadNode.GetLoadedValueOutput();
@@ -302,7 +302,7 @@ Andersen::AnalyzeLoad(const LoadNonVolatileNode & loadNode)
 }
 
 void
-Andersen::AnalyzeStore(const StoreNonVolatileNode & storeNode)
+Andersen::AnalyzeStore(const StoreNode & storeNode)
 {
   const auto & addressRegister = *storeNode.GetAddressInput().origin();
   const auto & valueRegister = *storeNode.GetStoredValueInput().origin();

--- a/jlm/llvm/opt/alias-analyses/Andersen.hpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.hpp
@@ -228,10 +228,10 @@ private:
   AnalyzeMalloc(const rvsdg::simple_node & node);
 
   void
-  AnalyzeLoad(const LoadNonVolatileNode & loadNode);
+  AnalyzeLoad(const LoadNode & loadNode);
 
   void
-  AnalyzeStore(const StoreNonVolatileNode & storeNode);
+  AnalyzeStore(const StoreNode & storeNode);
 
   void
   AnalyzeCall(const CallNode & callNode);

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp
@@ -34,8 +34,8 @@ namespace phi
 class node;
 }
 
-class LoadNonVolatileNode;
-class StoreNonVolatileNode;
+class LoadNode;
+class StoreNode;
 
 namespace aa
 {
@@ -98,10 +98,10 @@ private:
   EncodeMalloc(const rvsdg::simple_node & mallocNode);
 
   void
-  EncodeLoad(const LoadNonVolatileNode & loadNode);
+  EncodeLoad(const LoadNode & loadNode);
 
   void
-  EncodeStore(const StoreNonVolatileNode & storeNode);
+  EncodeStore(const StoreNode & storeNode);
 
   void
   EncodeFree(const rvsdg::simple_node & freeNode);

--- a/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.cpp
+++ b/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.cpp
@@ -694,11 +694,11 @@ RegionAwareMemoryNodeProvider::AnnotateRegion(rvsdg::region & region)
 void
 RegionAwareMemoryNodeProvider::AnnotateSimpleNode(const rvsdg::simple_node & simpleNode)
 {
-  if (auto loadNode = dynamic_cast<const LoadNonVolatileNode *>(&simpleNode))
+  if (auto loadNode = dynamic_cast<const LoadNode *>(&simpleNode))
   {
     AnnotateLoad(*loadNode);
   }
-  else if (auto storeNode = dynamic_cast<const StoreNonVolatileNode *>(&simpleNode))
+  else if (auto storeNode = dynamic_cast<const StoreNode *>(&simpleNode))
   {
     AnnotateStore(*storeNode);
   }
@@ -718,14 +718,14 @@ RegionAwareMemoryNodeProvider::AnnotateSimpleNode(const rvsdg::simple_node & sim
   {
     AnnotateFree(simpleNode);
   }
-  else if (is<MemCpyNonVolatileOperation>(&simpleNode))
+  else if (is<MemCpyOperation>(&simpleNode))
   {
     AnnotateMemcpy(simpleNode);
   }
 }
 
 void
-RegionAwareMemoryNodeProvider::AnnotateLoad(const LoadNonVolatileNode & loadNode)
+RegionAwareMemoryNodeProvider::AnnotateLoad(const LoadNode & loadNode)
 {
   auto memoryNodes = Provisioning_->GetOutputNodes(*loadNode.GetAddressInput().origin());
   auto & regionSummary = Provisioning_->GetRegionSummary(*loadNode.region());
@@ -733,7 +733,7 @@ RegionAwareMemoryNodeProvider::AnnotateLoad(const LoadNonVolatileNode & loadNode
 }
 
 void
-RegionAwareMemoryNodeProvider::AnnotateStore(const StoreNonVolatileNode & storeNode)
+RegionAwareMemoryNodeProvider::AnnotateStore(const StoreNode & storeNode)
 {
   auto memoryNodes = Provisioning_->GetOutputNodes(*storeNode.GetAddressInput().origin());
   auto & regionSummary = Provisioning_->GetRegionSummary(*storeNode.region());
@@ -817,7 +817,7 @@ RegionAwareMemoryNodeProvider::AnnotateCall(const CallNode & callNode)
 void
 RegionAwareMemoryNodeProvider::AnnotateMemcpy(const rvsdg::simple_node & memcpyNode)
 {
-  JLM_ASSERT(is<MemCpyNonVolatileOperation>(memcpyNode.operation()));
+  JLM_ASSERT(is<MemCpyOperation>(memcpyNode.operation()));
 
   auto & regionSummary = Provisioning_->GetRegionSummary(*memcpyNode.region());
 

--- a/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.hpp
+++ b/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.hpp
@@ -113,10 +113,10 @@ private:
   AnnotateStructuralNode(const rvsdg::structural_node & structuralNode);
 
   void
-  AnnotateLoad(const LoadNonVolatileNode & loadNode);
+  AnnotateLoad(const LoadNode & loadNode);
 
   void
-  AnnotateStore(const StoreNonVolatileNode & storeNode);
+  AnnotateStore(const StoreNode & storeNode);
 
   void
   AnnotateAlloca(const rvsdg::simple_node & allocaNode);

--- a/jlm/rvsdg/graph.cpp
+++ b/jlm/rvsdg/graph.cpp
@@ -9,6 +9,8 @@
 #include <jlm/rvsdg/graph.hpp>
 #include <jlm/rvsdg/substitution.hpp>
 
+#include <algorithm>
+
 namespace jlm::rvsdg
 {
 

--- a/jlm/rvsdg/node.hpp
+++ b/jlm/rvsdg/node.hpp
@@ -397,7 +397,7 @@ public:
     using value_type = T *;
     using difference_type = std::ptrdiff_t;
     using pointer = T **;
-    using rerefence = T *&;
+    using reference = T *&;
 
     static_assert(
         std::is_base_of<jlm::rvsdg::output, T>::value,


### PR DESCRIPTION
With this change, the `StoreVoltatileOperation` and `LoadVolatileOperation` are placed in `StoreVolatileNode` and `LoadVolatileNode`, respectively. I'm not sure how one would best test that you never place one of the operations in a regular `simple_node`.

Andersen is modified slightly, to use the superclasses.

I also had to add `#include <algorithm>` to `graph.cpp`, since `std::any_of` apparently isn't transitively included from any of the other headers anymore.