### PR TITLE
Add support for volatile operations to alias analyses pipeline [Andersen] [SteensgaardAgnostic]

### DIFF
--- a/jlm/llvm/ir/operators/Load.cpp
+++ b/jlm/llvm/ir/operators/Load.cpp
@@ -69,6 +69,17 @@ LoadNonVolatileNode::MemoryStateOutputs() const noexcept
   return { MemoryStateOutputIterator(output(1)), MemoryStateOutputIterator(nullptr) };
 }
 
+LoadNonVolatileNode &
+LoadNonVolatileNode::CopyWithNewMemoryStates(
+    const std::vector<rvsdg::output *> & memoryStates) const
+{
+  return CreateNode(
+      *GetAddressInput().origin(),
+      memoryStates,
+      GetOperation().GetLoadedType(),
+      GetAlignment());
+}
+
 rvsdg::node *
 LoadNonVolatileNode::copy(rvsdg::region * region, const std::vector<rvsdg::output *> & operands)
     const
@@ -132,6 +143,17 @@ LoadVolatileNode::MemoryStateOutputs() const noexcept
   }
 
   return { MemoryStateOutputIterator(output(2)), MemoryStateOutputIterator(nullptr) };
+}
+
+LoadVolatileNode &
+LoadVolatileNode::CopyWithNewMemoryStates(const std::vector<rvsdg::output *> & memoryStates) const
+{
+  return CreateNode(
+      *GetAddressInput().origin(),
+      *GetIoStateInput().origin(),
+      memoryStates,
+      GetOperation().GetLoadedType(),
+      GetAlignment());
 }
 
 rvsdg::node *

--- a/jlm/llvm/ir/operators/Load.hpp
+++ b/jlm/llvm/ir/operators/Load.hpp
@@ -361,6 +361,14 @@ public:
     return *ioInput;
   }
 
+  [[nodiscard]] rvsdg::output &
+  GetIoStateOutput() const noexcept
+  {
+    auto ioOutput = output(1);
+    JLM_ASSERT(is<iostatetype>(ioOutput->type()));
+    return *ioOutput;
+  }
+
   [[nodiscard]] MemoryStateInputRange
   MemoryStateInputs() const noexcept override;
 

--- a/jlm/llvm/ir/operators/Load.hpp
+++ b/jlm/llvm/ir/operators/Load.hpp
@@ -257,6 +257,7 @@ protected:
       : simple_node(&region, operation, operands)
   {}
 
+public:
   class MemoryStateInputIterator final : public rvsdg::input::iterator<rvsdg::simple_input>
   {
   public:
@@ -294,7 +295,6 @@ protected:
   using MemoryStateInputRange = util::iterator_range<MemoryStateInputIterator>;
   using MemoryStateOutputRange = util::iterator_range<MemoryStateOutputIterator>;
 
-public:
   [[nodiscard]] virtual const LoadOperation &
   GetOperation() const noexcept = 0;
 
@@ -331,6 +331,15 @@ public:
 
   [[nodiscard]] virtual MemoryStateOutputRange
   MemoryStateOutputs() const noexcept = 0;
+
+  /**
+   * Create a new copy of this LoadNode that consumes the provided \p memoryStates.
+   *
+   * @param memoryStates The memory states the newly created copy should consume.
+   * @return A newly created LoadNode.
+   */
+  [[nodiscard]] virtual LoadNode &
+  CopyWithNewMemoryStates(const std::vector<rvsdg::output *> & memoryStates) const = 0;
 };
 
 /**
@@ -374,6 +383,9 @@ public:
 
   [[nodiscard]] MemoryStateOutputRange
   MemoryStateOutputs() const noexcept override;
+
+  [[nodiscard]] LoadVolatileNode &
+  CopyWithNewMemoryStates(const std::vector<rvsdg::output *> & memoryStates) const override;
 
   static LoadVolatileNode &
   CreateNode(
@@ -493,21 +505,34 @@ public:
   [[nodiscard]] MemoryStateOutputRange
   MemoryStateOutputs() const noexcept override;
 
+  [[nodiscard]] LoadNonVolatileNode &
+  CopyWithNewMemoryStates(const std::vector<rvsdg::output *> & memoryStates) const override;
+
   rvsdg::node *
   copy(rvsdg::region * region, const std::vector<rvsdg::output *> & operands) const override;
 
   static std::vector<rvsdg::output *>
   Create(
       rvsdg::output * address,
-      const std::vector<rvsdg::output *> & states,
+      const std::vector<rvsdg::output *> & memoryStates,
       const rvsdg::valuetype & loadedType,
       size_t alignment)
   {
-    std::vector<rvsdg::output *> operands({ address });
-    operands.insert(operands.end(), states.begin(), states.end());
+    return rvsdg::outputs(&CreateNode(*address, memoryStates, loadedType, alignment));
+  }
 
-    LoadNonVolatileOperation loadOperation(loadedType, states.size(), alignment);
-    return Create(*address->region(), loadOperation, operands);
+  static LoadNonVolatileNode &
+  CreateNode(
+      rvsdg::output & address,
+      const std::vector<rvsdg::output *> & memoryStates,
+      const rvsdg::valuetype & loadedType,
+      size_t alignment)
+  {
+    std::vector<rvsdg::output *> operands({ &address });
+    operands.insert(operands.end(), memoryStates.begin(), memoryStates.end());
+
+    LoadNonVolatileOperation loadOperation(loadedType, memoryStates.size(), alignment);
+    return CreateNode(*address.region(), loadOperation, operands);
   }
 
   static std::vector<rvsdg::output *>

--- a/jlm/llvm/ir/operators/Store.cpp
+++ b/jlm/llvm/ir/operators/Store.cpp
@@ -67,6 +67,17 @@ StoreNonVolatileNode::MemoryStateOutputs() const noexcept
   return { MemoryStateOutputIterator(output(0)), MemoryStateOutputIterator(nullptr) };
 }
 
+StoreNonVolatileNode &
+StoreNonVolatileNode::CopyWithNewMemoryStates(
+    const std::vector<rvsdg::output *> & memoryStates) const
+{
+  return CreateNode(
+      *GetAddressInput().origin(),
+      *GetStoredValueInput().origin(),
+      memoryStates,
+      GetAlignment());
+}
+
 rvsdg::node *
 StoreNonVolatileNode::copy(rvsdg::region * region, const std::vector<rvsdg::output *> & operands)
     const
@@ -130,6 +141,17 @@ StoreVolatileNode::MemoryStateOutputs() const noexcept
   }
 
   return { MemoryStateOutputIterator(output(1)), MemoryStateOutputIterator(nullptr) };
+}
+
+StoreVolatileNode &
+StoreVolatileNode::CopyWithNewMemoryStates(const std::vector<rvsdg::output *> & memoryStates) const
+{
+  return CreateNode(
+      *GetAddressInput().origin(),
+      *GetStoredValueInput().origin(),
+      *GetIoStateInput().origin(),
+      memoryStates,
+      GetAlignment());
 }
 
 rvsdg::node *

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -216,9 +216,9 @@ Andersen::AnalyzeSimpleNode(const rvsdg::simple_node & node)
     AnalyzeAlloca(node);
   else if (is<malloc_op>(op))
     AnalyzeMalloc(node);
-  else if (const auto loadNode = dynamic_cast<const LoadNonVolatileNode *>(&node))
+  else if (const auto loadNode = dynamic_cast<const LoadNode *>(&node))
     AnalyzeLoad(*loadNode);
-  else if (const auto storeNode = dynamic_cast<const StoreNonVolatileNode *>(&node))
+  else if (const auto storeNode = dynamic_cast<const StoreNode *>(&node))
     AnalyzeStore(*storeNode);
   else if (const auto callNode = dynamic_cast<const CallNode *>(&node))
     AnalyzeCall(*callNode);
@@ -234,7 +234,7 @@ Andersen::AnalyzeSimpleNode(const rvsdg::simple_node & node)
     AnalyzeConstantPointerNull(node);
   else if (is<UndefValueOperation>(op))
     AnalyzeUndef(node);
-  else if (is<MemCpyNonVolatileOperation>(op))
+  else if (is<MemCpyOperation>(op))
     AnalyzeMemcpy(node);
   else if (is<ConstantArray>(op))
     AnalyzeConstantArray(node);
@@ -283,7 +283,7 @@ Andersen::AnalyzeMalloc(const rvsdg::simple_node & node)
 }
 
 void
-Andersen::AnalyzeLoad(const LoadNonVolatileNode & loadNode)
+Andersen::AnalyzeLoad(const LoadNode & loadNode)
 {
   const auto & addressRegister = *loadNode.GetAddressInput().origin();
   const auto & outputRegister = loadNode.GetLoadedValueOutput();
@@ -302,7 +302,7 @@ Andersen::AnalyzeLoad(const LoadNonVolatileNode & loadNode)
 }
 
 void
-Andersen::AnalyzeStore(const StoreNonVolatileNode & storeNode)
+Andersen::AnalyzeStore(const StoreNode & storeNode)
 {
   const auto & addressRegister = *storeNode.GetAddressInput().origin();
   const auto & valueRegister = *storeNode.GetStoredValueInput().origin();
@@ -431,6 +431,8 @@ Andersen::AnalyzeUndef(const rvsdg::simple_node & node)
 void
 Andersen::AnalyzeMemcpy(const rvsdg::simple_node & node)
 {
+  JLM_ASSERT(is<MemCpyOperation>(&node));
+
   auto & dstAddressRegister = *node.input(0)->origin();
   auto & srcAddressRegister = *node.input(1)->origin();
   JLM_ASSERT(is<PointerType>(dstAddressRegister.type()));

--- a/jlm/llvm/opt/alias-analyses/Andersen.hpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.hpp
@@ -228,10 +228,10 @@ private:
   AnalyzeMalloc(const rvsdg::simple_node & node);
 
   void
-  AnalyzeLoad(const LoadNonVolatileNode & loadNode);
+  AnalyzeLoad(const LoadNode & loadNode);
 
   void
-  AnalyzeStore(const StoreNonVolatileNode & storeNode);
+  AnalyzeStore(const StoreNode & storeNode);
 
   void
   AnalyzeCall(const CallNode & callNode);

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
@@ -757,7 +757,7 @@ MemoryStateEncoder::EncodeCallExit(const CallNode & callNode)
 void
 MemoryStateEncoder::EncodeMemcpy(const rvsdg::simple_node & memcpyNode)
 {
-  JLM_ASSERT(is<MemCpyNonVolatileOperation>(&memcpyNode));
+  JLM_ASSERT(is<MemCpyOperation>(&memcpyNode));
   auto & stateMap = Context_->GetRegionalizedStateMap();
 
   auto destination = memcpyNode.input(0)->origin();

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
@@ -557,7 +557,7 @@ MemoryStateEncoder::EncodeSimpleNode(const rvsdg::simple_node & simpleNode)
   }
   else if (auto storeNode = dynamic_cast<const StoreNonVolatileNode *>(&simpleNode))
   {
-    EncodeStore(*storeNode);
+    EncodeNonVolatileStore(*storeNode);
   }
   else if (auto callNode = dynamic_cast<const CallNode *>(&simpleNode))
   {
@@ -642,7 +642,7 @@ MemoryStateEncoder::EncodeNonVolatileLoad(const LoadNonVolatileNode & loadNode)
 }
 
 void
-MemoryStateEncoder::EncodeStore(const StoreNonVolatileNode & storeNode)
+MemoryStateEncoder::EncodeNonVolatileStore(const StoreNonVolatileNode & storeNode)
 {
   auto & storeOperation = storeNode.GetOperation();
   auto & stateMap = Context_->GetRegionalizedStateMap();

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
@@ -553,7 +553,7 @@ MemoryStateEncoder::EncodeSimpleNode(const rvsdg::simple_node & simpleNode)
   }
   else if (auto loadNode = dynamic_cast<const LoadNonVolatileNode *>(&simpleNode))
   {
-    EncodeLoad(*loadNode);
+    EncodeNonVolatileLoad(*loadNode);
   }
   else if (auto storeNode = dynamic_cast<const StoreNonVolatileNode *>(&simpleNode))
   {
@@ -616,7 +616,7 @@ MemoryStateEncoder::EncodeMalloc(const rvsdg::simple_node & mallocNode)
 }
 
 void
-MemoryStateEncoder::EncodeLoad(const LoadNonVolatileNode & loadNode)
+MemoryStateEncoder::EncodeNonVolatileLoad(const LoadNonVolatileNode & loadNode)
 {
   auto & loadOperation = loadNode.GetOperation();
   auto & stateMap = Context_->GetRegionalizedStateMap();

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp
@@ -101,7 +101,7 @@ private:
   EncodeNonVolatileLoad(const LoadNonVolatileNode & loadNode);
 
   void
-  EncodeStore(const StoreNonVolatileNode & storeNode);
+  EncodeNonVolatileStore(const StoreNonVolatileNode & storeNode);
 
   void
   EncodeFree(const rvsdg::simple_node & freeNode);

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp
@@ -98,10 +98,7 @@ private:
   EncodeMalloc(const rvsdg::simple_node & mallocNode);
 
   void
-  EncodeNonVolatileLoad(const LoadNonVolatileNode & loadNode);
-
-  void
-  EncodeVolatileLoad(const LoadVolatileNode & oldLoadNode);
+  EncodeLoad(const LoadNode & loadNode);
 
   void
   EncodeNonVolatileStore(const StoreNonVolatileNode & storeNode);
@@ -155,6 +152,27 @@ private:
   EncodeThetaExit(
       rvsdg::theta_node & thetaNode,
       const std::vector<rvsdg::theta_output *> & thetaStateOutputs);
+
+  /**
+   * Replace \p loadNode with a new copy that takes the provided \p memoryStates. All users of the
+   * outputs of \p loadNode are redirected to the respective outputs of the newly created copy.
+   *
+   * @param loadNode A LoadNode.
+   * @param memoryStates The memory states the new LoadNode should consume.
+   *
+   * @return The newly created LoadNode.
+   */
+  [[nodiscard]] static LoadNode &
+  ReplaceLoadNode(const LoadNode & loadNode, const std::vector<rvsdg::output *> & memoryStates);
+
+  /**
+   * Determines whether \p simpleNode should be handled by the MemoryStateEncoder.
+   *
+   * @param simpleNode A simple_node.
+   * @return True, if \p simpleNode should be handled, otherwise false.
+   */
+  [[nodiscard]] static bool
+  ShouldHandle(const rvsdg::simple_node & simpleNode) noexcept;
 
   std::unique_ptr<Context> Context_;
 };

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp
@@ -98,7 +98,7 @@ private:
   EncodeMalloc(const rvsdg::simple_node & mallocNode);
 
   void
-  EncodeLoad(const LoadNonVolatileNode & loadNode);
+  EncodeNonVolatileLoad(const LoadNonVolatileNode & loadNode);
 
   void
   EncodeStore(const StoreNonVolatileNode & storeNode);

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp
@@ -101,7 +101,7 @@ private:
   EncodeLoad(const LoadNode & loadNode);
 
   void
-  EncodeNonVolatileStore(const StoreNonVolatileNode & storeNode);
+  EncodeStore(const StoreNode & storeNode);
 
   void
   EncodeFree(const rvsdg::simple_node & freeNode);
@@ -164,6 +164,18 @@ private:
    */
   [[nodiscard]] static LoadNode &
   ReplaceLoadNode(const LoadNode & loadNode, const std::vector<rvsdg::output *> & memoryStates);
+
+  /**
+   * Replace \p storeNode with a new copy that takes the provided \p memoryStates. All users of the
+   * outputs of \p storeNode are redirected to the respective outputs of the newly created copy.
+   *
+   * @param loadNode A StoreNode.
+   * @param memoryStates The memory states the new StoreNode should consume.
+   *
+   * @return The newly created StoreNode.
+   */
+  [[nodiscard]] static StoreNode &
+  ReplaceStoreNode(const StoreNode & storeNode, const std::vector<rvsdg::output *> & memoryStates);
 
   /**
    * Determines whether \p simpleNode should be handled by the MemoryStateEncoder.

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp
@@ -178,6 +178,21 @@ private:
   ReplaceStoreNode(const StoreNode & storeNode, const std::vector<rvsdg::output *> & memoryStates);
 
   /**
+   * Replace \p memcpyNode with a new copy that takes the provided \p memoryStates. All users of
+   * the outputs of \p memcpyNode are redirected to the respective outputs of the newly created
+   * copy.
+   *
+   * @param loadNode A rvsdg::simple_node representing a MemCpyOperation.
+   * @param memoryStates The memory states the new memcpy node should consume.
+   *
+   * @return A vector with the memory states of the newly created copy.
+   */
+  [[nodiscard]] static std::vector<rvsdg::output *>
+  ReplaceMemcpyNode(
+      const rvsdg::simple_node & memcpyNode,
+      const std::vector<rvsdg::output *> & memoryStates);
+
+  /**
    * Determines whether \p simpleNode should be handled by the MemoryStateEncoder.
    *
    * @param simpleNode A simple_node.

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp
@@ -34,8 +34,8 @@ namespace phi
 class node;
 }
 
-class LoadNonVolatileNode;
-class StoreNonVolatileNode;
+class LoadNode;
+class StoreNode;
 
 namespace aa
 {

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp
@@ -101,6 +101,9 @@ private:
   EncodeNonVolatileLoad(const LoadNonVolatileNode & loadNode);
 
   void
+  EncodeVolatileLoad(const LoadVolatileNode & oldLoadNode);
+
+  void
   EncodeNonVolatileStore(const StoreNonVolatileNode & storeNode);
 
   void

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp
@@ -169,7 +169,7 @@ private:
    * Replace \p storeNode with a new copy that takes the provided \p memoryStates. All users of the
    * outputs of \p storeNode are redirected to the respective outputs of the newly created copy.
    *
-   * @param loadNode A StoreNode.
+   * @param storeNode A StoreNode.
    * @param memoryStates The memory states the new StoreNode should consume.
    *
    * @return The newly created StoreNode.
@@ -182,7 +182,7 @@ private:
    * the outputs of \p memcpyNode are redirected to the respective outputs of the newly created
    * copy.
    *
-   * @param loadNode A rvsdg::simple_node representing a MemCpyOperation.
+   * @param memcpyNode A rvsdg::simple_node representing a MemCpyOperation.
    * @param memoryStates The memory states the new memcpy node should consume.
    *
    * @return A vector with the memory states of the newly created copy.

--- a/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.cpp
+++ b/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.cpp
@@ -694,11 +694,11 @@ RegionAwareMemoryNodeProvider::AnnotateRegion(rvsdg::region & region)
 void
 RegionAwareMemoryNodeProvider::AnnotateSimpleNode(const rvsdg::simple_node & simpleNode)
 {
-  if (auto loadNode = dynamic_cast<const LoadNonVolatileNode *>(&simpleNode))
+  if (auto loadNode = dynamic_cast<const LoadNode *>(&simpleNode))
   {
     AnnotateLoad(*loadNode);
   }
-  else if (auto storeNode = dynamic_cast<const StoreNonVolatileNode *>(&simpleNode))
+  else if (auto storeNode = dynamic_cast<const StoreNode *>(&simpleNode))
   {
     AnnotateStore(*storeNode);
   }
@@ -718,14 +718,14 @@ RegionAwareMemoryNodeProvider::AnnotateSimpleNode(const rvsdg::simple_node & sim
   {
     AnnotateFree(simpleNode);
   }
-  else if (is<MemCpyNonVolatileOperation>(&simpleNode))
+  else if (is<MemCpyOperation>(&simpleNode))
   {
     AnnotateMemcpy(simpleNode);
   }
 }
 
 void
-RegionAwareMemoryNodeProvider::AnnotateLoad(const LoadNonVolatileNode & loadNode)
+RegionAwareMemoryNodeProvider::AnnotateLoad(const LoadNode & loadNode)
 {
   auto memoryNodes = Provisioning_->GetOutputNodes(*loadNode.GetAddressInput().origin());
   auto & regionSummary = Provisioning_->GetRegionSummary(*loadNode.region());
@@ -733,7 +733,7 @@ RegionAwareMemoryNodeProvider::AnnotateLoad(const LoadNonVolatileNode & loadNode
 }
 
 void
-RegionAwareMemoryNodeProvider::AnnotateStore(const StoreNonVolatileNode & storeNode)
+RegionAwareMemoryNodeProvider::AnnotateStore(const StoreNode & storeNode)
 {
   auto memoryNodes = Provisioning_->GetOutputNodes(*storeNode.GetAddressInput().origin());
   auto & regionSummary = Provisioning_->GetRegionSummary(*storeNode.region());
@@ -817,7 +817,7 @@ RegionAwareMemoryNodeProvider::AnnotateCall(const CallNode & callNode)
 void
 RegionAwareMemoryNodeProvider::AnnotateMemcpy(const rvsdg::simple_node & memcpyNode)
 {
-  JLM_ASSERT(is<MemCpyNonVolatileOperation>(memcpyNode.operation()));
+  JLM_ASSERT(is<MemCpyOperation>(memcpyNode.operation()));
 
   auto & regionSummary = Provisioning_->GetRegionSummary(*memcpyNode.region());
 

--- a/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.hpp
+++ b/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.hpp
@@ -113,10 +113,10 @@ private:
   AnnotateStructuralNode(const rvsdg::structural_node & structuralNode);
 
   void
-  AnnotateLoad(const LoadNonVolatileNode & loadNode);
+  AnnotateLoad(const LoadNode & loadNode);
 
   void
-  AnnotateStore(const StoreNonVolatileNode & storeNode);
+  AnnotateStore(const StoreNode & storeNode);
 
   void
   AnnotateAlloca(const rvsdg::simple_node & allocaNode);

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -998,11 +998,11 @@ Steensgaard::AnalyzeSimpleNode(const jlm::rvsdg::simple_node & node)
   {
     AnalyzeMalloc(node);
   }
-  else if (auto loadNode = dynamic_cast<const LoadNonVolatileNode *>(&node))
+  else if (auto loadNode = dynamic_cast<const LoadNode *>(&node))
   {
     AnalyzeLoad(*loadNode);
   }
-  else if (auto storeNode = dynamic_cast<const StoreNonVolatileNode *>(&node))
+  else if (auto storeNode = dynamic_cast<const StoreNode *>(&node))
   {
     AnalyzeStore(*storeNode);
   }
@@ -1034,7 +1034,7 @@ Steensgaard::AnalyzeSimpleNode(const jlm::rvsdg::simple_node & node)
   {
     AnalyzeUndef(node);
   }
-  else if (is<MemCpyNonVolatileOperation>(&node))
+  else if (is<MemCpyOperation>(&node))
   {
     AnalyzeMemcpy(node);
   }
@@ -1090,7 +1090,7 @@ Steensgaard::AnalyzeMalloc(const jlm::rvsdg::simple_node & node)
 }
 
 void
-Steensgaard::AnalyzeLoad(const LoadNonVolatileNode & loadNode)
+Steensgaard::AnalyzeLoad(const LoadNode & loadNode)
 {
   auto & result = loadNode.GetLoadedValueOutput();
   auto & address = *loadNode.GetAddressInput().origin();
@@ -1114,7 +1114,7 @@ Steensgaard::AnalyzeLoad(const LoadNonVolatileNode & loadNode)
 }
 
 void
-Steensgaard::AnalyzeStore(const StoreNonVolatileNode & storeNode)
+Steensgaard::AnalyzeStore(const StoreNode & storeNode)
 {
   auto & address = *storeNode.GetAddressInput().origin();
   auto & value = *storeNode.GetStoredValueInput().origin();
@@ -1411,7 +1411,7 @@ Steensgaard::AnalyzeConstantStruct(const jlm::rvsdg::simple_node & node)
 void
 Steensgaard::AnalyzeMemcpy(const jlm::rvsdg::simple_node & node)
 {
-  JLM_ASSERT(is<MemCpyNonVolatileOperation>(&node));
+  JLM_ASSERT(is<MemCpyOperation>(&node));
 
   auto & dstAddress = Context_->GetLocation(*node.input(0)->origin());
   auto & srcAddress = Context_->GetLocation(*node.input(1)->origin());

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
@@ -97,10 +97,10 @@ private:
   AnalyzeMalloc(const rvsdg::simple_node & node);
 
   void
-  AnalyzeLoad(const LoadNonVolatileNode & loadNode);
+  AnalyzeLoad(const LoadNode & loadNode);
 
   void
-  AnalyzeStore(const StoreNonVolatileNode & storeNode);
+  AnalyzeStore(const StoreNode & storeNode);
 
   void
   AnalyzeCall(const CallNode & callNode);


### PR DESCRIPTION
This PR does the following:
1. Adds support for volatile load, store, and memcpy nodes to memory state encoder
2. Adds support for volatile load, store, and memcpy nodes to Steensgaard alias analysis
3. Adds support for volatile load, store, and memcpy nodes to Andersen alias analysis
4. Adds support for volatile load, store, and memcpy nodes to region-aware memory node provider
5. Tighten the handling of simple nodes in the memory state encoder