### PR TITLE
Fix three address code conversion for volatile loads and stores

### DIFF
--- a/jlm/llvm/Makefile.sub
+++ b/jlm/llvm/Makefile.sub
@@ -150,6 +150,7 @@ libllvm_TESTS += \
 	tests/jlm/llvm/frontend/llvm/test-recursive-data \
 	tests/jlm/llvm/frontend/llvm/test-restructuring \
 	tests/jlm/llvm/frontend/llvm/test-select \
+	tests/jlm/llvm/frontend/llvm/ThreeAddressCodeConversionTests \
 	tests/jlm/llvm/ir/operators/LoadTests \
 	tests/jlm/llvm/ir/operators/MemCpyTests \
 	tests/jlm/llvm/ir/operators/MemoryStateOperationTests \

--- a/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
+++ b/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
@@ -561,8 +561,7 @@ ConvertThreeAddressCode(
   {
     Convert<StoreNonVolatileNode, StoreNonVolatileOperation>(threeAddressCode, region, variableMap);
   }
-  else // FiXME: I would rather have all operations explicitly checked and a JLM_UNREACHABLE() as
-       // else case.
+  else
   {
     std::vector<rvsdg::output *> operands;
     for (size_t n = 0; n < threeAddressCode.noperands(); n++)

--- a/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
+++ b/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
@@ -501,7 +501,7 @@ ConvertBranch(
    */
 }
 
-template<class NODE, class OPERATION>
+template<class TNode, class TOperation>
 static void
 Convert(const llvm::tac & threeAddressCode, rvsdg::region & region, llvm::VariableMap & variableMap)
 {
@@ -512,8 +512,8 @@ Convert(const llvm::tac & threeAddressCode, rvsdg::region & region, llvm::Variab
     operands.push_back(variableMap.lookup(operand));
   }
 
-  auto operation = jlm::util::AssertedCast<const OPERATION>(&threeAddressCode.operation());
-  auto results = NODE::Create(region, *operation, operands);
+  auto operation = util::AssertedCast<const TOperation>(&threeAddressCode.operation());
+  auto results = TNode::Create(region, *operation, operands);
 
   JLM_ASSERT(results.size() == threeAddressCode.nresults());
   for (size_t n = 0; n < threeAddressCode.nresults(); n++)
@@ -529,32 +529,52 @@ ConvertThreeAddressCode(
     rvsdg::region & region,
     llvm::VariableMap & variableMap)
 {
-  static std::unordered_map<
-      std::type_index,
-      std::function<void(const llvm::tac &, rvsdg::region &, llvm::VariableMap &)>>
-      map({ { typeid(assignment_op), ConvertAssignment },
-            { typeid(select_op), ConvertSelect },
-            { typeid(branch_op), ConvertBranch },
-            { typeid(CallOperation), Convert<CallNode, CallOperation> },
-            { typeid(LoadNonVolatileOperation),
-              Convert<LoadNonVolatileNode, LoadNonVolatileOperation> },
-            { typeid(StoreNonVolatileOperation),
-              Convert<StoreNonVolatileNode, StoreNonVolatileOperation> } });
+  if (is<assignment_op>(&threeAddressCode))
+  {
+    ConvertAssignment(threeAddressCode, region, variableMap);
+  }
+  else if (is<select_op>(&threeAddressCode))
+  {
+    ConvertSelect(threeAddressCode, region, variableMap);
+  }
+  else if (is<branch_op>(&threeAddressCode))
+  {
+    ConvertBranch(threeAddressCode, region, variableMap);
+  }
+  else if (is<CallOperation>(&threeAddressCode))
+  {
+    Convert<CallNode, CallOperation>(threeAddressCode, region, variableMap);
+  }
+  else if (is<LoadVolatileOperation>(&threeAddressCode))
+  {
+    Convert<LoadVolatileNode, LoadVolatileOperation>(threeAddressCode, region, variableMap);
+  }
+  else if (is<LoadNonVolatileOperation>(&threeAddressCode))
+  {
+    Convert<LoadNonVolatileNode, LoadNonVolatileOperation>(threeAddressCode, region, variableMap);
+  }
+  else if (is<StoreVolatileOperation>(&threeAddressCode))
+  {
+    Convert<StoreVolatileNode, StoreVolatileOperation>(threeAddressCode, region, variableMap);
+  }
+  else if (is<StoreNonVolatileOperation>(&threeAddressCode))
+  {
+    Convert<StoreNonVolatileNode, StoreNonVolatileOperation>(threeAddressCode, region, variableMap);
+  }
+  else // FiXME: I would rather have all operations explicitly checked and a JLM_UNREACHABLE() as
+       // else case.
+  {
+    std::vector<rvsdg::output *> operands;
+    for (size_t n = 0; n < threeAddressCode.noperands(); n++)
+      operands.push_back(variableMap.lookup(threeAddressCode.operand(n)));
 
-  auto & op = threeAddressCode.operation();
-  if (map.find(typeid(op)) != map.end())
-    return map[typeid(op)](threeAddressCode, region, variableMap);
+    auto & simpleOperation = static_cast<const rvsdg::simple_op &>(threeAddressCode.operation());
+    auto results = rvsdg::simple_node::create_normalized(&region, simpleOperation, operands);
 
-  std::vector<rvsdg::output *> operands;
-  for (size_t n = 0; n < threeAddressCode.noperands(); n++)
-    operands.push_back(variableMap.lookup(threeAddressCode.operand(n)));
-
-  auto & simpleOperation = static_cast<const rvsdg::simple_op &>(threeAddressCode.operation());
-  auto results = rvsdg::simple_node::create_normalized(&region, simpleOperation, operands);
-
-  JLM_ASSERT(results.size() == threeAddressCode.nresults());
-  for (size_t n = 0; n < threeAddressCode.nresults(); n++)
-    variableMap.insert(threeAddressCode.result(n), results[n]);
+    JLM_ASSERT(results.size() == threeAddressCode.nresults());
+    for (size_t n = 0; n < threeAddressCode.nresults(); n++)
+      variableMap.insert(threeAddressCode.result(n), results[n]);
+  }
 }
 
 static void

--- a/jlm/llvm/ir/operators/Load.hpp
+++ b/jlm/llvm/ir/operators/Load.hpp
@@ -390,6 +390,15 @@ public:
     LoadVolatileOperation operation(loadedType, memoryStates.size(), alignment);
     return CreateNode(*address.region(), operation, operands);
   }
+
+  static std::vector<rvsdg::output *>
+  Create(
+      rvsdg::region & region,
+      const LoadVolatileOperation & loadOperation,
+      const std::vector<rvsdg::output *> & operands)
+  {
+    return rvsdg::outputs(&CreateNode(region, loadOperation, operands));
+  }
 };
 
 /**

--- a/jlm/llvm/ir/operators/Store.hpp
+++ b/jlm/llvm/ir/operators/Store.hpp
@@ -516,6 +516,15 @@ public:
     return CreateNode(*address.region(), storeOperation, operands);
   }
 
+  static std::vector<rvsdg::output *>
+  Create(
+      rvsdg::region & region,
+      const StoreVolatileOperation & loadOperation,
+      const std::vector<rvsdg::output *> & operands)
+  {
+    return rvsdg::outputs(&CreateNode(region, loadOperation, operands));
+  }
+
 private:
   static const rvsdg::valuetype &
   CheckAndExtractStoredType(const rvsdg::type & type)

--- a/tests/jlm/llvm/frontend/llvm/ThreeAddressCodeConversionTests.cpp
+++ b/tests/jlm/llvm/frontend/llvm/ThreeAddressCodeConversionTests.cpp
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2024 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <test-registry.hpp>
+#include <test-types.hpp>
+
+#include <jlm/llvm/frontend/InterProceduralGraphConversion.hpp>
+#include <jlm/llvm/ir/ipgraph-module.hpp>
+#include <jlm/llvm/ir/operators/lambda.hpp>
+#include <jlm/llvm/ir/operators/Load.hpp>
+#include <jlm/llvm/ir/operators/Store.hpp>
+#include <jlm/llvm/ir/RvsdgModule.hpp>
+
+#include <jlm/rvsdg/view.hpp>
+
+#include <jlm/util/Statistics.hpp>
+
+static std::unique_ptr<jlm::llvm::cfg>
+SetupControlFlowGraph(
+    jlm::llvm::ipgraph_module & ipgModule,
+    const jlm::rvsdg::simple_op & operation)
+{
+  using namespace jlm::llvm;
+
+  auto cfg = jlm::llvm::cfg::create(ipgModule);
+
+  std::vector<const variable *> operands;
+  for (size_t n = 0; n < operation.narguments(); n++)
+  {
+    auto & operandType = operation.argument(n).type();
+    auto operand = cfg->entry()->append_argument(argument::create("", operandType));
+    operands.emplace_back(operand);
+  }
+
+  auto basicBlock = basic_block::create(*cfg);
+  auto threeAddressCode = basicBlock->append_last(tac::create(operation, operands));
+
+  for (size_t n = 0; n < threeAddressCode->nresults(); n++)
+  {
+    auto result = threeAddressCode->result(n);
+    cfg->exit()->append_result(result);
+  }
+
+  cfg->exit()->divert_inedges(basicBlock);
+  basicBlock->add_outedge(cfg->exit());
+
+  return cfg;
+}
+
+static std::unique_ptr<jlm::llvm::ipgraph_module>
+SetupFunctionWithThreeAddressCode(const jlm::rvsdg::simple_op & operation)
+{
+  using namespace jlm::llvm;
+
+  auto ipgModule = ipgraph_module::create(jlm::util::filepath(""), "", "");
+  auto & ipgraph = ipgModule->ipgraph();
+
+  std::vector<const jlm::rvsdg::type *> operandTypes;
+  for (size_t n = 0; n < operation.narguments(); n++)
+  {
+    auto & operandType = operation.argument(n).type();
+    operandTypes.emplace_back(&operandType);
+  }
+
+  std::vector<const jlm::rvsdg::type *> resultTypes;
+  for (size_t n = 0; n < operation.nresults(); n++)
+  {
+    auto & resultType = operation.result(n).type();
+    resultTypes.emplace_back(&resultType);
+  }
+
+  FunctionType functionType(operandTypes, resultTypes);
+
+  auto functionNode =
+      function_node::create(ipgraph, "test", functionType, linkage::external_linkage);
+  auto cfg = SetupControlFlowGraph(*ipgModule, operation);
+  functionNode->add_cfg(std::move(cfg));
+  ipgModule->create_variable(functionNode);
+
+  return ipgModule;
+}
+
+static int
+LoadVolatileConversion()
+{
+  using namespace jlm::llvm;
+
+  // Arrange
+  jlm::tests::valuetype valueType;
+  LoadVolatileOperation operation(valueType, 3, 4);
+  auto ipgModule = SetupFunctionWithThreeAddressCode(operation);
+
+  // Act
+  jlm::util::StatisticsCollector statisticsCollector;
+  auto rvsdgModule = ConvertInterProceduralGraphModule(*ipgModule, statisticsCollector);
+  std::cout << jlm::rvsdg::view(rvsdgModule->Rvsdg().root()) << std::flush;
+
+  // Assert
+  auto lambdaOutput = rvsdgModule->Rvsdg().root()->result(0)->origin();
+  auto lambda = dynamic_cast<const lambda::node *>(jlm::rvsdg::node_output::node(lambdaOutput));
+
+  auto loadVolatileNode = lambda->subregion()->nodes.first();
+  assert(dynamic_cast<const LoadVolatileNode *>(loadVolatileNode));
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER(
+    "jlm/llvm/frontend/llvm/ThreeAddressCodeConversionTests-LoadVolatileConversion",
+    LoadVolatileConversion)
+
+static int
+StoreVolatileConversion()
+{
+  using namespace jlm::llvm;
+
+  // Arrange
+  jlm::tests::valuetype valueType;
+  StoreVolatileOperation operation(valueType, 3, 4);
+  auto ipgModule = SetupFunctionWithThreeAddressCode(operation);
+
+  // Act
+  jlm::util::StatisticsCollector statisticsCollector;
+  auto rvsdgModule = ConvertInterProceduralGraphModule(*ipgModule, statisticsCollector);
+  std::cout << jlm::rvsdg::view(rvsdgModule->Rvsdg().root()) << std::flush;
+
+  // Assert
+  auto lambdaOutput = rvsdgModule->Rvsdg().root()->result(0)->origin();
+  auto lambda = dynamic_cast<const lambda::node *>(jlm::rvsdg::node_output::node(lambdaOutput));
+
+  auto storeVolatileNode = lambda->subregion()->nodes.first();
+  assert(dynamic_cast<const StoreVolatileNode *>(storeVolatileNode));
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER(
+    "jlm/llvm/frontend/llvm/ThreeAddressCodeConversionTests-StoreVolatileConversion",
+    StoreVolatileConversion)


### PR DESCRIPTION
The three address code conversion for volatile loads and stores did not create the correct LoadVolatileNode and StoreVolatileNode classes, but simple_node classes.

This PR does the following:
1. Fix the three address code conversion for volatile loads
2. Fix the three address code conversion for volatile stores
3. Refactors the conversion to be better readable
4. Adds unit tests for the conversions
5. Adds support functions to easier test other conversions in the future