### PR TITLE
[Andersen] Add queue for new edges to the worklist, and enable picking worklist policy

### DIFF
--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -39,6 +39,8 @@ Andersen::Configuration::DefaultConfiguration()
     if (configStream.fail())
       break;
 
+    using Policy = PointerObjectConstraintSet::WorklistSolverPolicy;
+
     if (option == CONFIG_OVS_ON)
       config.EnableOfflineVariableSubstitution(true);
     else if (option == CONFIG_OVS_OFF)
@@ -55,11 +57,11 @@ Andersen::Configuration::DefaultConfiguration()
       config.SetSolver(Solver::Worklist);
 
     else if (option == CONFIG_WL_POLICY_LRF)
-      config.SetWorklistSolverPolicy(PointerObjectConstraintSet::WorklistSolverPolicy::LRF);
+      config.SetWorklistSolverPolicy(Policy::LeastRecentlyFired);
     else if (option == CONFIG_WL_POLICY_FIFO)
-      config.SetWorklistSolverPolicy(PointerObjectConstraintSet::WorklistSolverPolicy::FIFO);
+      config.SetWorklistSolverPolicy(Policy::FirstInFirstOut);
     else if (option == CONFIG_WL_POLICY_LIFO)
-      config.SetWorklistSolverPolicy(PointerObjectConstraintSet::WorklistSolverPolicy::LIFO);
+      config.SetWorklistSolverPolicy(Policy::LastInFirstOut);
 
     else
     {

--- a/jlm/llvm/opt/alias-analyses/Andersen.hpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.hpp
@@ -172,7 +172,7 @@ public:
     bool EnableOfflineConstraintNormalization_ = true;
     Solver Solver_ = Solver::Worklist;
     PointerObjectConstraintSet::WorklistSolverPolicy WorklistSolverPolicy_ =
-        PointerObjectConstraintSet::WorklistSolverPolicy::LRF;
+        PointerObjectConstraintSet::WorklistSolverPolicy::LeastRecentlyFired;
   };
 
   ~Andersen() noexcept override = default;

--- a/jlm/llvm/opt/alias-analyses/Andersen.hpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.hpp
@@ -30,18 +30,37 @@ public:
    * by running analysis again with the naive solver and no extra processing.
    * Any differences in the produced PointsToGraph result in an error.
    */
-  static inline const char * const CHECK_AGAINST_NAIVE_SOLVER = "JLM_ANDERSEN_COMPARE_SOLVE_NAIVE";
+  static inline const char * const ENV_COMPARE_SOLVE_NAIVE = "JLM_ANDERSEN_COMPARE_SOLVE_NAIVE";
 
   /**
    * Environment variable that will trigger dumping the subset graph before and after solving.
    */
-  static inline const char * const DUMP_SUBSET_GRAPH = "JLM_ANDERSEN_DUMP_SUBSET_GRAPH";
+  static inline const char * const ENV_DUMP_SUBSET_GRAPH = "JLM_ANDERSEN_DUMP_SUBSET_GRAPH";
+
+  /**
+   * Environment variable for overriding the default configuration.
+   * The variable should something look like
+   * "+OVS +Normalize -OnlineCD Solver=Worklist WLPolicy=LRF"
+   */
+  static inline const char * const ENV_CONFIG_OVERRIDE = "JLM_ANDERSEN_CONFIG_OVERRIDE";
+  static inline const char * const CONFIG_OVS_ON = "+OVS";
+  static inline const char * const CONFIG_OVS_OFF = "-OVS";
+  static inline const char * const CONFIG_NORMALIZE_ON = "+Normalize";
+  static inline const char * const CONFIG_NORMALIZE_OFF = "-Normalize";
+  static inline const char * const CONFIG_SOLVER_WL = "Solver=Worklist";
+  static inline const char * const CONFIG_SOLVER_NAIVE = "Solver=Naive";
+  static inline const char * const CONFIG_WL_POLICY_LRF = "WLPolicy=LRF";
+  static inline const char * const CONFIG_WL_POLICY_FIFO = "WLPolicy=FIFO";
+  static inline const char * const CONFIG_WL_POLICY_LIFO = "WLPolicy=LIFO";
 
   /**
    * class for configuring the Andersen pass, such as what solver to use.
    */
   class Configuration
   {
+  private:
+    Configuration() = default;
+
   public:
     enum class Solver
     {
@@ -49,16 +68,12 @@ public:
       Worklist
     };
 
-    explicit Configuration(Solver solver)
-        : Solver_(solver)
-    {}
-
     [[nodiscard]] bool
     operator==(const Configuration & other) const
     {
       return EnableOfflineVariableSubstitution_ == other.EnableOfflineVariableSubstitution_
           && EnableOfflineConstraintNormalization_ == other.EnableOfflineConstraintNormalization_
-          && Solver_ == other.Solver_;
+          && Solver_ == other.Solver_ && WorklistSolverPolicy_ == other.WorklistSolverPolicy_;
     }
 
     [[nodiscard]] bool
@@ -81,6 +96,18 @@ public:
     GetSolver() const noexcept
     {
       return Solver_;
+    }
+
+    void
+    SetWorklistSolverPolicy(PointerObjectConstraintSet::WorklistSolverPolicy policy)
+    {
+      WorklistSolverPolicy_ = policy;
+    }
+
+    [[nodiscard]] PointerObjectConstraintSet::WorklistSolverPolicy
+    GetWorklistSoliverPolicy() const noexcept
+    {
+      return WorklistSolverPolicy_;
     }
 
     /**
@@ -119,15 +146,11 @@ public:
     }
 
     /**
-     * Creates a solver configuration using the worklist solver,
-     * with the default set of offline and online techniques enabled.
+     * Creates the default Andersen constraint set solver configuration
      * @return the solver configuration
      */
     [[nodiscard]] static Configuration
-    WorklistSolverConfiguration()
-    {
-      return Configuration(Solver::Worklist);
-    }
+    DefaultConfiguration();
 
     /**
      * Creates a solver configuration using the naive solver,
@@ -137,16 +160,19 @@ public:
     [[nodiscard]] static Configuration
     NaiveSolverConfiguration()
     {
-      auto config = Configuration(Solver::Naive);
+      auto config = Configuration();
       config.EnableOfflineVariableSubstitution(false);
       config.EnableOfflineConstraintNormalization(false);
+      config.SetSolver(Solver::Naive);
       return config;
     }
 
   private:
     bool EnableOfflineVariableSubstitution_ = true;
     bool EnableOfflineConstraintNormalization_ = true;
-    Solver Solver_;
+    Solver Solver_ = Solver::Worklist;
+    PointerObjectConstraintSet::WorklistSolverPolicy WorklistSolverPolicy_ =
+        PointerObjectConstraintSet::WorklistSolverPolicy::LRF;
   };
 
   ~Andersen() noexcept override = default;
@@ -311,7 +337,7 @@ private:
   void
   SolveConstraints(const Configuration & config, Statistics & statistics);
 
-  Configuration Config_ = Configuration::WorklistSolverConfiguration();
+  Configuration Config_ = Configuration::DefaultConfiguration();
 
   std::unique_ptr<PointerObjectSet> Set_;
   std::unique_ptr<PointerObjectConstraintSet> Constraints_;

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
@@ -1495,13 +1495,13 @@ PointerObjectConstraintSet::SolveUsingWorklist(WorklistSolverPolicy policy)
   WorklistStatistics statistics(policy);
   switch (policy)
   {
-  case WorklistSolverPolicy::LRF:
+  case WorklistSolverPolicy::LeastRecentlyFired:
     RunWorklistSolver<util::LrfWorklist<PointerObjectIndex>>(statistics);
     return statistics;
-  case WorklistSolverPolicy::FIFO:
+  case WorklistSolverPolicy::FirstInFirstOut:
     RunWorklistSolver<util::FifoWorklist<PointerObjectIndex>>(statistics);
     return statistics;
-  case WorklistSolverPolicy::LIFO:
+  case WorklistSolverPolicy::LastInFirstOut:
     RunWorklistSolver<util::LifoWorklist<PointerObjectIndex>>(statistics);
     return statistics;
   default:
@@ -1514,12 +1514,12 @@ PointerObjectConstraintSet::WorklistSolverPolicyToString(WorklistSolverPolicy po
 {
   switch (policy)
   {
-  case WorklistSolverPolicy::LRF:
-    return "LRF";
-  case WorklistSolverPolicy::FIFO:
-    return "FIFO";
-  case WorklistSolverPolicy::LIFO:
-    return "LIFO";
+  case WorklistSolverPolicy::LeastRecentlyFired:
+    return "LeastRecentlyFired";
+  case WorklistSolverPolicy::FirstInFirstOut:
+    return "FirstInFirstOut";
+  case WorklistSolverPolicy::LastInFirstOut:
+    return "LastInFirstOut";
   default:
     JLM_UNREACHABLE("Unknown WorklistSolverPolicy");
   }

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
@@ -1259,31 +1259,34 @@ PointerObjectConstraintSet::NormalizeConstraints()
   return reduction;
 }
 
-size_t
-PointerObjectConstraintSet::SolveUsingWorklist()
+template<typename Worklist>
+void
+PointerObjectConstraintSet::RunWorklistSolver(WorklistStatistics & statistics)
 {
-  // Create auxiliary superset graph.
-  // All edges must have their tail be a unification root.
+  // Create auxiliary subset graph.
+  // All edges must have their tail be a unification root (non-root nodes have no successors).
   // If supersetEdges[x] contains y, (x -> y), that means P(y) supseteq P(x)
   std::vector<util::HashSet<PointerObjectIndex>> supersetEdges(Set_.NumPointerObjects());
 
   // Create quick lookup tables for Load, Store and function call constraints.
-  // Lookup is indexed by the constraint's pointer
+  // Lookup is indexed by the constraint's pointer.
   // The constraints need to be added to the unification root, as only unification roots
-  // are allowed on the worklist.
+  // are allowed on the worklist. The sets are empty for all non-root nodes.
   std::vector<util::HashSet<PointerObjectIndex>> storeConstraints(Set_.NumPointerObjects());
   std::vector<util::HashSet<PointerObjectIndex>> loadConstraints(Set_.NumPointerObjects());
-  std::vector<std::vector<const jlm::llvm::CallNode *>> callConstraints(Set_.NumPointerObjects());
+  std::vector<util::HashSet<const jlm::llvm::CallNode *>> callConstraints(Set_.NumPointerObjects());
 
   for (const auto & constraint : Constraints_)
   {
     if (const auto * ssConstraint = std::get_if<SupersetConstraint>(&constraint))
     {
-      // Superset constraints become edges in the superset graph
+      // Superset constraints become edges in the subset graph
+      // When initializing the set of superset edges, normalize them as well
       auto superset = Set_.GetUnificationRoot(ssConstraint->GetSuperset());
       auto subset = Set_.GetUnificationRoot(ssConstraint->GetSubset());
 
-      supersetEdges[subset].Insert(superset);
+      if (superset != subset) // Ignore self-edges
+        supersetEdges[subset].Insert(superset);
     }
     else if (const auto * storeConstraint = std::get_if<StoreConstraint>(&constraint))
     {
@@ -1304,12 +1307,12 @@ PointerObjectConstraintSet::SolveUsingWorklist()
       auto pointer = Set_.GetUnificationRoot(callConstraint->GetPointer());
       const auto & callNode = callConstraint->GetCallNode();
 
-      callConstraints[pointer].push_back(&callNode);
+      callConstraints[pointer].Insert(&callNode);
     }
   }
 
   // The worklist, initialized with every unification root
-  util::LrfWorklist<PointerObjectIndex> worklist;
+  Worklist worklist;
   for (PointerObjectIndex i = 0; i < Set_.NumPointerObjects(); i++)
   {
     if (Set_.IsUnificationRoot(i))
@@ -1317,22 +1320,41 @@ PointerObjectConstraintSet::SolveUsingWorklist()
   }
 
   // Helper function for adding superset edges, propagating everything currently in the subset.
-  // The superset's root is added to the work list if its points-to set or flags are changed.
+  // The superset's root is added to the worklist if its points-to set or flags are changed.
   const auto AddSupersetEdge = [&](PointerObjectIndex superset, PointerObjectIndex subset)
   {
     superset = Set_.GetUnificationRoot(superset);
     subset = Set_.GetUnificationRoot(subset);
 
+    // If this is a self-edge, ignore
+    if (superset == subset)
+      return;
+
     // If the edge already exists, ignore
     if (!supersetEdges[subset].Insert(superset))
       return;
 
-    // A new edge was added, propagate points to-sets
-    if (!Set_.MakePointsToSetSuperset(superset, subset))
-      return;
+    // A new edge was added, propagate points to-sets. If the superset changes, add to the worklist
+    if (Set_.MakePointsToSetSuperset(superset, subset))
+      worklist.PushWorkItem(superset);
+  };
 
-    // pointees or the points-to-external flag were propagated to the superset, add to the worklist
-    worklist.PushWorkItem(superset);
+  // A temporary place to store new subset edges, to avoid modifying sets while they are iterated
+  util::HashSet<std::pair<PointerObjectIndex, PointerObjectIndex>> newSupersetEdges;
+  const auto QueueNewSupersetEdge = [&](PointerObjectIndex superset, PointerObjectIndex subset)
+  {
+    superset = Set_.GetUnificationRoot(superset);
+    subset = Set_.GetUnificationRoot(subset);
+    if (superset == subset || supersetEdges[subset].Contains(superset))
+      return;
+    newSupersetEdges.Insert({ superset, subset });
+  };
+
+  const auto FlushNewSupersetEdges = [&]()
+  {
+    for (auto [superset, subset] : newSupersetEdges.Items())
+      AddSupersetEdge(superset, subset);
+    newSupersetEdges.Clear();
   };
 
   // Helper function for marking a PointerObject such that all its pointees will escape
@@ -1355,57 +1377,51 @@ PointerObjectConstraintSet::SolveUsingWorklist()
   // The worklist will only inform functions if their HasEscaped flag changes
   EscapedFunctionConstraint::PropagateEscapedFunctionsDirectly(Set_);
 
-  // Count of the total number of work items fired
-  size_t numWorkItems = 0;
-
-  // The main worklist loop. A work item can be in the worklist for the following reasons:
+  // The main work item handler. A work item can be in the worklist for the following reasons:
   // - It has never been fired
   // - It has pointees added since the last time it was fired
   // - It has been marked as pointing to external since last time it was fired
   // - It has been marked as escaping all pointees since last time it was fired
-  // All work items are unification roots, or were unification roots when added
-  while (worklist.HasMoreWorkItems())
+  // - It is the unification root of a new unification
+  // Work items should be unification roots. If a work item is not a root when popped, it is skipped
+  const auto HandleWorkItem = [&](PointerObjectIndex node)
   {
-    const auto n = worklist.PopWorkItem();
-    numWorkItems++;
+    statistics.NumWorkItemsPopped++;
 
-    // Only visit unification roots
-    const auto root = Set_.GetUnificationRoot(n);
-    if (n != root)
-    {
-      worklist.PushWorkItem(root);
-      continue;
-    }
+    // Skip visiting unification roots.
+    // All unification operations are responsible for adding the new root to the worklist if needed
+    if (!Set_.IsUnificationRoot(node))
+      return;
 
     // Stores on the form *n = value.
-    for (const auto value : storeConstraints[n].Items())
+    for (const auto value : storeConstraints[node].Items())
     {
       // This loop ensures *P(n) supseteq P(value)
-      for (const auto pointee : Set_.GetPointsToSet(n).Items())
-        AddSupersetEdge(pointee, value);
+      for (const auto pointee : Set_.GetPointsToSet(node).Items())
+        QueueNewSupersetEdge(pointee, value);
 
       // If P(n) contains "external", the contents of the written value escapes
-      if (Set_.IsPointingToExternal(n))
+      if (Set_.IsPointingToExternal(node))
         MarkAsPointeesEscaping(value);
     }
 
     // Loads on the form value = *n.
-    for (const auto value : loadConstraints[n].Items())
+    for (const auto value : loadConstraints[node].Items())
     {
       // This loop ensures P(value) supseteq *P(n)
-      for (const auto pointee : Set_.GetPointsToSet(n).Items())
-        AddSupersetEdge(value, pointee);
+      for (const auto pointee : Set_.GetPointsToSet(node).Items())
+        QueueNewSupersetEdge(value, pointee);
 
       // If P(n) contains "external", the loaded value may also point to external
-      if (Set_.IsPointingToExternal(n))
+      if (Set_.IsPointingToExternal(node))
         MarkAsPointsToExternal(value);
     }
 
     // Function calls on the form (*n)()
-    for (const auto callNode : callConstraints[n])
+    for (const auto callNode : callConstraints[node].Items())
     {
       // Connect the inputs and outputs of the callNode to every possible function pointee
-      for (const auto pointee : Set_.GetPointsToSet(n).Items())
+      for (const auto pointee : Set_.GetPointsToSet(node).Items())
       {
         const auto kind = Set_.GetPointerObjectKind(pointee);
         if (kind == PointerObjectKind::ImportMemoryObject)
@@ -1416,11 +1432,11 @@ PointerObjectConstraintSet::SolveUsingWorklist()
               MarkAsPointeesEscaping,
               MarkAsPointsToExternal);
         else if (kind == PointerObjectKind::FunctionMemoryObject)
-          HandleCallingLambdaFunction(Set_, *callNode, pointee, AddSupersetEdge);
+          HandleCallingLambdaFunction(Set_, *callNode, pointee, QueueNewSupersetEdge);
       }
 
       // If P(n) contains "external", handle calling external functions
-      if (Set_.IsPointingToExternal(n))
+      if (Set_.IsPointingToExternal(node))
         HandleCallingExternalFunction(
             Set_,
             *callNode,
@@ -1429,18 +1445,18 @@ PointerObjectConstraintSet::SolveUsingWorklist()
     }
 
     // Propagate P(n) along all edges n -> superset
-    for (auto superset : supersetEdges[n].Items())
+    for (const auto superset : supersetEdges[node].Items())
     {
-      // FIXME: Replace edges going to non-roots
-      superset = Set_.GetUnificationRoot(superset);
-      if (Set_.MakePointsToSetSuperset(superset, n))
-        worklist.PushWorkItem(superset);
+      // FIXME: replace supersets by their unification root, to remove duplicate edges
+      const auto supersetParent = Set_.GetUnificationRoot(superset);
+      if (Set_.MakePointsToSetSuperset(supersetParent, node))
+        worklist.PushWorkItem(supersetParent);
     }
 
     // If n is marked as PointeesEscaping, add the escaped flag to all pointees
-    if (Set_.HasPointeesEscaping(n))
+    if (Set_.HasPointeesEscaping(node))
     {
-      for (const auto pointee : Set_.GetPointsToSet(n).Items())
+      for (const auto pointee : Set_.GetPointsToSet(node).Items())
       {
         const auto pointeeRoot = Set_.GetUnificationRoot(pointee);
         const bool prevPointeesEscaping = Set_.HasPointeesEscaping(pointeeRoot);
@@ -1462,9 +1478,51 @@ PointerObjectConstraintSet::SolveUsingWorklist()
         }
       }
     }
-  }
 
-  return numWorkItems;
+    // Add all new superset edges, which also propagates points-to sets immediately
+    // and possibly performs unifications to eliminate cycles.
+    // Any unified nodes, or nodes with updated points-to sets, are added to the worklist.
+    FlushNewSupersetEdges();
+  };
+
+  while (worklist.HasMoreWorkItems())
+    HandleWorkItem(worklist.PopWorkItem());
+}
+
+PointerObjectConstraintSet::WorklistStatistics
+PointerObjectConstraintSet::SolveUsingWorklist(WorklistSolverPolicy policy)
+{
+  WorklistStatistics statistics(policy);
+  switch (policy)
+  {
+  case WorklistSolverPolicy::LRF:
+    RunWorklistSolver<util::LrfWorklist<PointerObjectIndex>>(statistics);
+    return statistics;
+  case WorklistSolverPolicy::FIFO:
+    RunWorklistSolver<util::FifoWorklist<PointerObjectIndex>>(statistics);
+    return statistics;
+  case WorklistSolverPolicy::LIFO:
+    RunWorklistSolver<util::LifoWorklist<PointerObjectIndex>>(statistics);
+    return statistics;
+  default:
+    JLM_UNREACHABLE("Unknown WorklistSolverPolicy");
+  }
+}
+
+const char *
+PointerObjectConstraintSet::WorklistSolverPolicyToString(WorklistSolverPolicy policy)
+{
+  switch (policy)
+  {
+  case WorklistSolverPolicy::LRF:
+    return "LRF";
+  case WorklistSolverPolicy::FIFO:
+    return "FIFO";
+  case WorklistSolverPolicy::LIFO:
+    return "LIFO";
+  default:
+    JLM_UNREACHABLE("Unknown WorklistSolverPolicy");
+  }
 }
 
 size_t

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
@@ -731,16 +731,6 @@ public:
      * The number of items that were popped from the worklist before the solution converged.
      */
     size_t NumWorkItemsPopped{};
-
-    /**
-     * The number of cycles detected by online cycle detection, if enabled.
-     */
-    std::optional<size_t> NumOnlineCyclesDetected{};
-
-    /**
-     * The number of unifications made by online cycle detection, if enabled.
-     */
-    std::optional<size_t> NumOnlineCycleUnifications{};
   };
 
   explicit PointerObjectConstraintSet(PointerObjectSet & set)
@@ -898,7 +888,7 @@ private:
    * The worklist solver, with configuration passed at compile time as templates.
    * @param statistics the WorklistStatistics instance that will get information about this run.
    * @tparam worklist a type supporting the worklist interface with PointerObjectIndex as work items
-   * @See SolveUsingWorklist() for the public interface.
+   * @see SolveUsingWorklist() for the public interface.
    */
   template<typename Worklist>
   void

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
@@ -705,9 +705,24 @@ public:
 
   enum class WorklistSolverPolicy
   {
-    LRF,
-    FIFO,
-    LIFO
+    /**
+     * A worklist policy based on selecting the work item that was least recently selected. From:
+     *   A. Kanamori and D. Weise "Worklist management strategies for Dataflow Analysis" (1994)
+     * @see jlm::util::LrfWorklist
+     */
+    LeastRecentlyFired,
+
+    /**
+     * A worklist policy based on a queue.
+     * @see jlm::util::FifoWorklist
+     */
+    FirstInFirstOut,
+
+    /**
+     * A worklist policy based on a stack.
+     * @see jlm::util::LifoWorklist
+     */
+    LastInFirstOut
   };
 
   [[nodiscard]] static const char *

--- a/jlm/rvsdg/graph.cpp
+++ b/jlm/rvsdg/graph.cpp
@@ -9,6 +9,8 @@
 #include <jlm/rvsdg/graph.hpp>
 #include <jlm/rvsdg/substitution.hpp>
 
+#include <algorithm>
+
 namespace jlm::rvsdg
 {
 

--- a/tests/jlm/llvm/opt/alias-analyses/TestPointerObjectSet.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestPointerObjectSet.cpp
@@ -8,6 +8,7 @@
 #include <test-registry.hpp>
 
 #include <jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp>
+#include <jlm/util/Worklist.hpp>
 
 #include <cassert>
 
@@ -690,8 +691,9 @@ TestDrawSubsetGraph()
 }
 
 // Tests crating a ConstraintSet with multiple different constraints and calling Solve()
+template<bool useWorklist, typename... Args>
 static void
-TestPointerObjectConstraintSetSolve(bool useWorklist)
+TestPointerObjectConstraintSetSolve(Args... args)
 {
   using namespace jlm::llvm::aa;
 
@@ -757,10 +759,15 @@ TestPointerObjectConstraintSetSolve(bool useWorklist)
   constraints.AddConstraint(LoadConstraint(reg[10], reg[8]));
 
   // Find a solution to all the constraints
-  if (useWorklist)
-    constraints.SolveUsingWorklist();
+  if constexpr (useWorklist)
+  {
+    constraints.SolveUsingWorklist(args...);
+  }
   else
+  {
+    static_assert(sizeof...(args) == 0, "The naive solver takes no arguments");
     constraints.SolveNaively();
+  }
 
   // alloca1 should point to alloca2, etc
   assert(set.GetPointsToSet(alloca1).Size() == 1);
@@ -867,8 +874,11 @@ TestPointerObjectSet()
   TestAddPointsToExternalConstraint();
   TestAddRegisterContentEscapedConstraint();
   TestDrawSubsetGraph();
-  TestPointerObjectConstraintSetSolve(false);
-  TestPointerObjectConstraintSetSolve(true);
+  TestPointerObjectConstraintSetSolve<false>();
+  using Policy = jlm::llvm::aa::PointerObjectConstraintSet::WorklistSolverPolicy;
+  TestPointerObjectConstraintSetSolve<true>(Policy::LRF);
+  TestPointerObjectConstraintSetSolve<true>(Policy::FIFO);
+  TestPointerObjectConstraintSetSolve<true>(Policy::LIFO);
   TestClonePointerObjectConstraintSet();
   return 0;
 }

--- a/tests/jlm/llvm/opt/alias-analyses/TestPointerObjectSet.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestPointerObjectSet.cpp
@@ -876,9 +876,9 @@ TestPointerObjectSet()
   TestDrawSubsetGraph();
   TestPointerObjectConstraintSetSolve<false>();
   using Policy = jlm::llvm::aa::PointerObjectConstraintSet::WorklistSolverPolicy;
-  TestPointerObjectConstraintSetSolve<true>(Policy::LRF);
-  TestPointerObjectConstraintSetSolve<true>(Policy::FIFO);
-  TestPointerObjectConstraintSetSolve<true>(Policy::LIFO);
+  TestPointerObjectConstraintSetSolve<true>(Policy::LeastRecentlyFired);
+  TestPointerObjectConstraintSetSolve<true>(Policy::FirstInFirstOut);
+  TestPointerObjectConstraintSetSolve<true>(Policy::LastInFirstOut);
   TestClonePointerObjectConstraintSet();
   return 0;
 }


### PR DESCRIPTION
This PR fixes a bug in the worklist solver where pointees could be added to `GetPointsToSet(node)`, while the points-to set was being iterated over.

Running the worklist is now divided into two functions, to convert runtime configuration into compile-time configuration through dispatching the corresponding templated version.

With this PR, the only configuration of the worklist solver is the worklist policy.

The default configuration checks an environment variable to be overridden. This is to make development easier, and not because I think environment variables are a good configuration interface :)