### PR TITLE
Rework bitstring ops using templates instead of macros

### DIFF
--- a/jlm/rvsdg/Makefile.sub
+++ b/jlm/rvsdg/Makefile.sub
@@ -36,6 +36,7 @@ librvsdg_HEADERS = \
 	jlm/rvsdg/notifiers.hpp \
 	jlm/rvsdg/bitstring/constant.hpp \
 	jlm/rvsdg/bitstring/slice.hpp \
+	jlm/rvsdg/bitstring/arithmetic-impl.hpp \
 	jlm/rvsdg/bitstring/arithmetic.hpp \
 	jlm/rvsdg/bitstring/type.hpp \
 	jlm/rvsdg/bitstring/value-representation.hpp \

--- a/jlm/rvsdg/bitstring/arithmetic-impl.hpp
+++ b/jlm/rvsdg/bitstring/arithmetic-impl.hpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024 Helge Bahmann <hcb@chaoticmind.net>
+ * See COPYING for terms of redistribution.
+ */
+
+#ifndef JLM_RVSDG_BITSTRING_ARITHMETIC_IMPL_HPP
+#define JLM_RVSDG_BITSTRING_ARITHMETIC_IMPL_HPP
+
+#include <jlm/rvsdg/bitstring/arithmetic.hpp>
+#include <jlm/rvsdg/simple-node.hpp>
+
+namespace jlm::rvsdg
+{
+
+template<typename reduction, const char * name>
+MakeBitUnaryOperation<reduction, name>::~MakeBitUnaryOperation() noexcept
+{}
+
+template<typename reduction, const char * name>
+bool
+MakeBitUnaryOperation<reduction, name>::operator==(const operation & other) const noexcept
+{
+  auto op = dynamic_cast<const MakeBitUnaryOperation *>(&other);
+  return op && op->type() == type();
+}
+
+template<typename reduction, const char * name>
+bitvalue_repr
+MakeBitUnaryOperation<reduction, name>::reduce_constant(const bitvalue_repr & arg) const
+{
+  return reduction{}(arg);
+}
+
+template<typename reduction, const char * name>
+std::string
+MakeBitUnaryOperation<reduction, name>::debug_string() const
+{
+  return jlm::util::strfmt(name, type().nbits());
+}
+
+template<typename reduction, const char * name>
+std::unique_ptr<operation>
+MakeBitUnaryOperation<reduction, name>::copy() const
+{
+  return std::unique_ptr<operation>(new MakeBitUnaryOperation(*this));
+}
+
+template<typename reduction, const char * name>
+std::unique_ptr<bitunary_op>
+MakeBitUnaryOperation<reduction, name>::create(size_t nbits) const
+{
+  return std::unique_ptr<bitunary_op>(new MakeBitUnaryOperation(nbits));
+}
+
+template<typename reduction, const char * name, enum binary_op::flags opflags>
+MakeBitBinaryOperation<reduction, name, opflags>::~MakeBitBinaryOperation() noexcept
+{}
+
+template<typename reduction, const char * name, enum binary_op::flags opflags>
+bool
+MakeBitBinaryOperation<reduction, name, opflags>::operator==(const operation & other) const noexcept
+{
+  auto op = dynamic_cast<const MakeBitBinaryOperation *>(&other);
+  return op && op->type() == type();
+}
+
+template<typename reduction, const char * name, enum binary_op::flags opflags>
+bitvalue_repr
+MakeBitBinaryOperation<reduction, name, opflags>::reduce_constants(
+    const bitvalue_repr & arg1,
+    const bitvalue_repr & arg2) const
+{
+  return reduction{}(arg1, arg2);
+}
+
+template<typename reduction, const char * name, enum binary_op::flags opflags>
+enum binary_op::flags
+MakeBitBinaryOperation<reduction, name, opflags>::flags() const noexcept
+{
+  return opflags;
+}
+
+template<typename reduction, const char * name, enum binary_op::flags opflags>
+std::string
+MakeBitBinaryOperation<reduction, name, opflags>::debug_string() const
+{
+  return jlm::util::strfmt(name, type().nbits());
+}
+
+template<typename reduction, const char * name, enum binary_op::flags opflags>
+std::unique_ptr<operation>
+MakeBitBinaryOperation<reduction, name, opflags>::copy() const
+{
+  return std::make_unique<MakeBitBinaryOperation>(*this);
+}
+
+template<typename reduction, const char * name, enum binary_op::flags opflags>
+std::unique_ptr<bitbinary_op>
+MakeBitBinaryOperation<reduction, name, opflags>::create(size_t nbits) const
+{
+  return std::make_unique<MakeBitBinaryOperation>(nbits);
+}
+
+}
+
+#endif

--- a/jlm/rvsdg/bitstring/arithmetic.hpp
+++ b/jlm/rvsdg/bitstring/arithmetic.hpp
@@ -12,91 +12,198 @@
 namespace jlm::rvsdg
 {
 
-#define DECLARE_BITUNARY_OPERATION(NAME)                                                \
-  class NAME##_op final : public bitunary_op                                            \
-  {                                                                                     \
-  public:                                                                               \
-    virtual ~NAME##_op() noexcept;                                                      \
-                                                                                        \
-    inline NAME##_op(const bittype & type) noexcept                                     \
-        : bitunary_op(type)                                                             \
-    {}                                                                                  \
-                                                                                        \
-    virtual bool                                                                        \
-    operator==(const operation & other) const noexcept override;                        \
-                                                                                        \
-    virtual bitvalue_repr                                                               \
-    reduce_constant(const bitvalue_repr & arg) const override;                          \
-                                                                                        \
-    virtual std::string                                                                 \
-    debug_string() const override;                                                      \
-                                                                                        \
-    virtual std::unique_ptr<operation>                                                  \
-    copy() const override;                                                              \
-                                                                                        \
-    virtual std::unique_ptr<bitunary_op>                                                \
-    create(size_t nbits) const override;                                                \
-                                                                                        \
-    static inline output *                                                              \
-    create(size_t nbits, output * op)                                                   \
-    {                                                                                   \
-      return simple_node::create_normalized(op->region(), NAME##_op(nbits), { op })[0]; \
-    }                                                                                   \
-  };
+template<typename reduction, const char * name>
+class MakeBitUnaryOperation final : public bitunary_op
+{
+public:
+  ~MakeBitUnaryOperation() noexcept override;
 
-#define DECLARE_BITBINARY_OPERATION(NAME)                                                      \
-  class NAME##_op final : public bitbinary_op                                                  \
-  {                                                                                            \
-  public:                                                                                      \
-    virtual ~NAME##_op() noexcept;                                                             \
-                                                                                               \
-    inline NAME##_op(const bittype & type) noexcept                                            \
-        : bitbinary_op(type)                                                                   \
-    {}                                                                                         \
-                                                                                               \
-    virtual bool                                                                               \
-    operator==(const operation & other) const noexcept override;                               \
-                                                                                               \
-    virtual enum binary_op::flags                                                              \
-    flags() const noexcept override;                                                           \
-                                                                                               \
-    virtual bitvalue_repr                                                                      \
-    reduce_constants(const bitvalue_repr & arg1, const bitvalue_repr & arg2) const override;   \
-                                                                                               \
-    virtual std::string                                                                        \
-    debug_string() const override;                                                             \
-                                                                                               \
-    virtual std::unique_ptr<operation>                                                         \
-    copy() const override;                                                                     \
-                                                                                               \
-    virtual std::unique_ptr<bitbinary_op>                                                      \
-    create(size_t nbits) const override;                                                       \
-                                                                                               \
-    static inline output *                                                                     \
-    create(size_t nbits, output * op1, output * op2)                                           \
-    {                                                                                          \
-      return simple_node::create_normalized(op1->region(), NAME##_op(nbits), { op1, op2 })[0]; \
-    }                                                                                          \
-  };
+  explicit MakeBitUnaryOperation(const bittype & type) noexcept
+      : bitunary_op(type)
+  {}
 
-DECLARE_BITUNARY_OPERATION(bitneg)
-DECLARE_BITUNARY_OPERATION(bitnot)
+  bool
+  operator==(const operation & other) const noexcept override;
 
-DECLARE_BITBINARY_OPERATION(bitadd)
-DECLARE_BITBINARY_OPERATION(bitand)
-DECLARE_BITBINARY_OPERATION(bitashr)
-DECLARE_BITBINARY_OPERATION(bitmul)
-DECLARE_BITBINARY_OPERATION(bitor)
-DECLARE_BITBINARY_OPERATION(bitsdiv)
-DECLARE_BITBINARY_OPERATION(bitshl)
-DECLARE_BITBINARY_OPERATION(bitshr)
-DECLARE_BITBINARY_OPERATION(bitsmod)
-DECLARE_BITBINARY_OPERATION(bitsmulh)
-DECLARE_BITBINARY_OPERATION(bitsub)
-DECLARE_BITBINARY_OPERATION(bitudiv)
-DECLARE_BITBINARY_OPERATION(bitumod)
-DECLARE_BITBINARY_OPERATION(bitumulh)
-DECLARE_BITBINARY_OPERATION(bitxor)
+  bitvalue_repr
+  reduce_constant(const bitvalue_repr & arg) const override;
+
+  std::string
+  debug_string() const override;
+
+  std::unique_ptr<operation>
+  copy() const override;
+
+  std::unique_ptr<bitunary_op>
+  create(size_t nbits) const override;
+
+  static output *
+  create(size_t nbits, output * op)
+  {
+    return simple_node::create_normalized(op->region(), MakeBitUnaryOperation(nbits), { op })[0];
+  }
+};
+
+template<typename reduction, const char * name, enum binary_op::flags opflags>
+class MakeBitBinaryOperation final : public bitbinary_op
+{
+public:
+  ~MakeBitBinaryOperation() noexcept override;
+
+  explicit MakeBitBinaryOperation(const bittype & type) noexcept
+      : bitbinary_op(type)
+  {}
+
+  bool
+  operator==(const operation & other) const noexcept override;
+
+  enum binary_op::flags
+  flags() const noexcept override;
+
+  bitvalue_repr
+  reduce_constants(const bitvalue_repr & arg1, const bitvalue_repr & arg2) const override;
+
+  std::string
+  debug_string() const override;
+
+  std::unique_ptr<operation>
+  copy() const override;
+
+  std::unique_ptr<bitbinary_op>
+  create(size_t nbits) const override;
+
+  static output *
+  create(size_t nbits, output * op1, output * op2)
+  {
+    return simple_node::create_normalized(
+        op1->region(),
+        MakeBitBinaryOperation(nbits),
+        { op1, op2 })[0];
+  }
+};
+
+struct reduce_neg;
+extern const char BitNegateLabel[];
+using bitneg_op = MakeBitUnaryOperation<reduce_neg, BitNegateLabel>;
+extern template class MakeBitUnaryOperation<reduce_neg, BitNegateLabel>;
+
+struct reduce_not;
+extern const char BitNotLabel[];
+using bitnot_op = MakeBitUnaryOperation<reduce_not, BitNotLabel>;
+extern template class MakeBitUnaryOperation<reduce_not, BitNotLabel>;
+
+struct reduce_add;
+extern const char BitAddLabel[];
+using bitadd_op = MakeBitBinaryOperation<
+    reduce_add,
+    BitAddLabel,
+    binary_op::flags::associative | binary_op::flags::commutative>;
+extern template class MakeBitBinaryOperation<
+    reduce_add,
+    BitAddLabel,
+    binary_op::flags::associative | binary_op::flags::commutative>;
+
+struct reduce_and;
+extern const char BitAndLabel[];
+using bitand_op = MakeBitBinaryOperation<
+    reduce_and,
+    BitAndLabel,
+    binary_op::flags::associative | binary_op::flags::commutative>;
+extern template class MakeBitBinaryOperation<
+    reduce_and,
+    BitAndLabel,
+    binary_op::flags::associative | binary_op::flags::commutative>;
+
+struct reduce_ashr;
+extern const char BitAShrLabel[];
+using bitashr_op = MakeBitBinaryOperation<reduce_ashr, BitAShrLabel, binary_op::flags::none>;
+extern template class MakeBitBinaryOperation<reduce_ashr, BitAShrLabel, binary_op::flags::none>;
+
+struct reduce_mul;
+extern const char BitMulLabel[];
+using bitmul_op = MakeBitBinaryOperation<
+    reduce_mul,
+    BitMulLabel,
+    binary_op::flags::associative | binary_op::flags::commutative>;
+extern template class MakeBitBinaryOperation<
+    reduce_mul,
+    BitMulLabel,
+    binary_op::flags::associative | binary_op::flags::commutative>;
+
+struct reduce_or;
+extern const char BitOrLabel[];
+using bitor_op = MakeBitBinaryOperation<
+    reduce_or,
+    BitOrLabel,
+    binary_op::flags::associative | binary_op::flags::commutative>;
+extern template class MakeBitBinaryOperation<
+    reduce_or,
+    BitOrLabel,
+    binary_op::flags::associative | binary_op::flags::commutative>;
+
+struct reduce_sdiv;
+extern const char BitSDivLabel[];
+using bitsdiv_op = MakeBitBinaryOperation<reduce_sdiv, BitSDivLabel, binary_op::flags::none>;
+extern template class MakeBitBinaryOperation<reduce_sdiv, BitSDivLabel, binary_op::flags::none>;
+
+struct reduce_shl;
+extern const char BitShlLabel[];
+using bitshl_op = MakeBitBinaryOperation<reduce_shl, BitShlLabel, binary_op::flags::none>;
+extern template class MakeBitBinaryOperation<reduce_shl, BitShlLabel, binary_op::flags::none>;
+
+struct reduce_shr;
+extern const char BitShrLabel[];
+using bitshr_op = MakeBitBinaryOperation<reduce_shr, BitShrLabel, binary_op::flags::none>;
+extern template class MakeBitBinaryOperation<reduce_shr, BitShrLabel, binary_op::flags::none>;
+
+struct reduce_smod;
+extern const char BitSModLabel[];
+using bitsmod_op = MakeBitBinaryOperation<reduce_smod, BitSModLabel, binary_op::flags::none>;
+extern template class MakeBitBinaryOperation<reduce_smod, BitSModLabel, binary_op::flags::none>;
+
+struct reduce_smulh;
+extern const char BitSMulHLabel[];
+using bitsmulh_op =
+    MakeBitBinaryOperation<reduce_smulh, BitSMulHLabel, binary_op::flags::commutative>;
+extern template class MakeBitBinaryOperation<
+    reduce_smulh,
+    BitSMulHLabel,
+    binary_op::flags::commutative>;
+
+struct reduce_sub;
+extern const char BitSubLabel[];
+using bitsub_op = MakeBitBinaryOperation<reduce_sub, BitSubLabel, binary_op::flags::none>;
+extern template class MakeBitBinaryOperation<reduce_sub, BitSubLabel, binary_op::flags::none>;
+
+struct reduce_udiv;
+extern const char BitUDivLabel[];
+using bitudiv_op = MakeBitBinaryOperation<reduce_udiv, BitUDivLabel, binary_op::flags::none>;
+extern template class MakeBitBinaryOperation<reduce_udiv, BitUDivLabel, binary_op::flags::none>;
+
+struct reduce_umod;
+extern const char BitUModLabel[];
+using bitumod_op = MakeBitBinaryOperation<reduce_umod, BitUModLabel, binary_op::flags::none>;
+extern template class MakeBitBinaryOperation<reduce_umod, BitUModLabel, binary_op::flags::none>;
+
+struct reduce_umulh;
+extern const char BitUMulHLabel[];
+using bitumulh_op =
+    MakeBitBinaryOperation<reduce_umulh, BitUMulHLabel, binary_op::flags::commutative>;
+extern template class MakeBitBinaryOperation<
+    reduce_umulh,
+    BitUMulHLabel,
+    binary_op::flags::commutative>;
+
+struct reduce_xor;
+extern const char BitXorLabel[];
+using bitxor_op = MakeBitBinaryOperation<
+    reduce_xor,
+    BitXorLabel,
+    binary_op::flags::associative | binary_op::flags::commutative>;
+extern template class MakeBitBinaryOperation<
+    reduce_xor,
+    BitXorLabel,
+    binary_op::flags::associative | binary_op::flags::commutative>;
 
 }
 


### PR DESCRIPTION
Remove all code generation macros for instantiating bitstring operation classes. Replace this with normal C++ template classes.