### PR TITLE
Clean up memory state operations

### DIFF
--- a/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.cpp
+++ b/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.cpp
@@ -232,7 +232,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::simple_node * node)
     auto inData = GetSubfield(body, inBundles[0], "data");
     Connect(body, outData, inData);
   }
-  else if (dynamic_cast<const llvm::MemStateMergeOperator *>(&(node->operation())))
+  else if (dynamic_cast<const llvm::MemoryStateMergeOperation *>(&(node->operation())))
   {
     auto inData = GetSubfield(body, inBundles[0], "data");
     Connect(body, outData, inData);

--- a/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.cpp
+++ b/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.cpp
@@ -227,7 +227,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::simple_node * node)
     int outSize = JlmSize(&node->output(0)->type());
     Connect(body, outData, AddBitsOp(body, inData, outSize - 1, 0));
   }
-  else if (dynamic_cast<const llvm::LambdaExitMemStateOperator *>(&(node->operation())))
+  else if (dynamic_cast<const llvm::LambdaExitMemoryStateMergeOperation *>(&(node->operation())))
   {
     auto inData = GetSubfield(body, inBundles[0], "data");
     Connect(body, outData, inData);

--- a/jlm/hls/backend/rvsdg2rhls/alloca-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/alloca-conv.cpp
@@ -200,7 +200,7 @@ alloca_conv(jlm::rvsdg::region * region)
       JLM_ASSERT(node->output(1)->nusers() == 1);
       auto merge_in = *node->output(1)->begin();
       auto merge_node = llvm::input_node(merge_in);
-      if (dynamic_cast<const jlm::llvm::MemStateMergeOperator *>(&merge_node->operation()))
+      if (dynamic_cast<const llvm::MemoryStateMergeOperation *>(&merge_node->operation()))
       {
         // merge after alloca -> remove merge
         JLM_ASSERT(merge_node->ninputs() == 2);

--- a/jlm/hls/backend/rvsdg2rhls/mem-queue.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-queue.cpp
@@ -533,8 +533,8 @@ jlm::hls::mem_queue(jlm::rvsdg::region * region)
   auto entry_input = dynamic_cast<jlm::rvsdg::simple_input *>(state_user);
   JLM_ASSERT(entry_input);
   auto entry_node = entry_input->node();
-  JLM_ASSERT(
-      dynamic_cast<const jlm::llvm::LambdaEntryMemStateOperator *>(&entry_node->operation()));
+  JLM_ASSERT(dynamic_cast<const jlm::llvm::LambdaEntryMemoryStateSplitOperation *>(
+      &entry_node->operation()));
   // for each state edge:
   //    for each outer loop (theta/loop in lambda region):
   //        split state edge before the loop

--- a/jlm/hls/backend/rvsdg2rhls/mem-queue.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-queue.cpp
@@ -381,7 +381,7 @@ separate_load_edge(
       {
         JLM_ASSERT("Decoupled nodes not implemented yet");
       }
-      else if (dynamic_cast<const jlm::llvm::MemStateMergeOperator *>(op))
+      else if (dynamic_cast<const jlm::llvm::MemoryStateMergeOperation *>(op))
       {
         auto si_load_user = dynamic_cast<jlm::rvsdg::simple_input *>(addr_edge_user);
         if (si_load_user && si->node() == sn)
@@ -474,7 +474,7 @@ process_loops(jlm::rvsdg::output * state_edge)
       auto mem_edge = split_states[0];
       sti->divert_to(mem_edge);
       split_states[0] = mem_edge_after_loop;
-      state_edge = jlm::llvm::MemStateMergeOperator::Create(split_states);
+      state_edge = jlm::llvm::MemoryStateMergeOperation::Create(split_states);
       common_user->divert_to(state_edge);
       for (size_t i = 0; i < load_nodes.size(); ++i)
       {

--- a/jlm/hls/backend/rvsdg2rhls/mem-queue.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-queue.cpp
@@ -314,14 +314,15 @@ separate_load_edge(
         JLM_ASSERT(mem_edge->nusers() == 1);
         user = *mem_edge->begin();
         auto ui = dynamic_cast<jlm::rvsdg::simple_input *>(user);
-        if (ui && dynamic_cast<const jlm::llvm::MemStateSplitOperator *>(&ui->node()->operation()))
+        if (ui
+            && dynamic_cast<const jlm::llvm::MemoryStateSplitOperation *>(&ui->node()->operation()))
         {
           auto msso =
-              dynamic_cast<const jlm::llvm::MemStateSplitOperator *>(&ui->node()->operation());
+              dynamic_cast<const jlm::llvm::MemoryStateSplitOperation *>(&ui->node()->operation());
           // handle case where output of store is already connected to a MemStateSplit by adding an
           // output
           auto store_split =
-              jlm::llvm::MemStateSplitOperator::Create(mem_edge, msso->nresults() + 1);
+              jlm::llvm::MemoryStateSplitOperation::Create(*mem_edge, msso->nresults() + 1);
           for (size_t i = 0; i < msso->nresults(); ++i)
           {
             ui->node()->output(i)->divert_users(store_split[i]);
@@ -332,7 +333,7 @@ separate_load_edge(
         }
         else
         {
-          auto store_split = jlm::llvm::MemStateSplitOperator::Create(mem_edge, 2);
+          auto store_split = jlm::llvm::MemoryStateSplitOperation::Create(*mem_edge, 2);
           mem_edge = store_split[0];
           user->divert_to(mem_edge);
           store_dequeues.push_back(route_to_region((*load)->region(), store_split[1]));
@@ -469,7 +470,7 @@ process_loops(jlm::rvsdg::output * state_edge)
       visited.insert(mem_edge_after_loop);
       find_load_store(&*sti->arguments.begin(), load_nodes, store_nodes, visited);
       auto split_states =
-          jlm::llvm::MemStateSplitOperator::Create(sti->origin(), load_nodes.size() + 1);
+          jlm::llvm::MemoryStateSplitOperation::Create(*sti->origin(), load_nodes.size() + 1);
       // handle common edge
       auto mem_edge = split_states[0];
       sti->divert_to(mem_edge);

--- a/jlm/hls/backend/rvsdg2rhls/mem-queue.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-queue.cpp
@@ -436,7 +436,7 @@ process_loops(jlm::rvsdg::output * state_edge)
         JLM_ASSERT(sn->noutputs() == 1);
         return sn->output(0);
       }
-      else if (dynamic_cast<const jlm::llvm::LambdaExitMemStateOperator *>(op))
+      else if (dynamic_cast<const jlm::llvm::LambdaExitMemoryStateMergeOperation *>(op))
       {
         // end of lambda
         JLM_ASSERT(sn->noutputs() == 1);

--- a/jlm/hls/backend/rvsdg2rhls/mem-sep.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-sep.cpp
@@ -149,9 +149,10 @@ mem_sep_independent(jlm::rvsdg::region * region)
   state_user->divert_to(entry_states.back());
   entry_states.pop_back();
   entry_states.push_back(state_result->origin());
-  auto merged_state = jlm::llvm::LambdaExitMemStateOperator::Create(lambda_region, entry_states);
+  auto & merged_state =
+      jlm::llvm::LambdaExitMemoryStateMergeOperation::Create(*lambda_region, entry_states);
   entry_states.pop_back();
-  state_result->divert_to(merged_state);
+  state_result->divert_to(&merged_state);
   for (auto node : mem_nodes)
   {
     auto in_state = route_through(node->region(), entry_states.back());
@@ -293,9 +294,10 @@ mem_sep_argument(jlm::rvsdg::region * region)
   entry_states.pop_back();
   state_user->divert_to(common_edge);
   entry_states.push_back(state_result->origin());
-  auto merged_state = jlm::llvm::LambdaExitMemStateOperator::Create(lambda_region, entry_states);
+  auto & merged_state =
+      jlm::llvm::LambdaExitMemoryStateMergeOperation::Create(*lambda_region, entry_states);
   entry_states.pop_back();
-  state_result->divert_to(merged_state);
+  state_result->divert_to(&merged_state);
   for (auto tp : port_nodes)
   {
     auto new_edge = entry_states.back();

--- a/jlm/hls/backend/rvsdg2rhls/mem-sep.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-sep.cpp
@@ -143,7 +143,7 @@ mem_sep_independent(jlm::rvsdg::region * region)
   std::vector<jlm::rvsdg::simple_node *> mem_nodes;
   gather_mem_nodes(lambda_region, mem_nodes);
   auto entry_states =
-      jlm::llvm::LambdaEntryMemStateOperator::Create(state_arg, 1 + mem_nodes.size());
+      jlm::llvm::LambdaEntryMemoryStateSplitOperation::Create(*state_arg, 1 + mem_nodes.size());
   auto state_result = GetMemoryStateResult(*lambda);
   // handle existing state edge - TODO: remove entirely?
   state_user->divert_to(entry_states.back());
@@ -286,7 +286,7 @@ mem_sep_argument(jlm::rvsdg::region * region)
   port_load_store_decouple port_nodes;
   trace_pointer_arguments(lambda, port_nodes);
   auto entry_states =
-      jlm::llvm::LambdaEntryMemStateOperator::Create(state_arg, 1 + port_nodes.size());
+      jlm::llvm::LambdaEntryMemoryStateSplitOperation::Create(*state_arg, 1 + port_nodes.size());
   auto state_result = GetMemoryStateResult(*lambda);
   // handle existing state edge - TODO: remove entirely?
   auto common_edge = entry_states.back();

--- a/jlm/hls/backend/rvsdg2rhls/memstate-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/memstate-conv.cpp
@@ -37,7 +37,7 @@ memstate_conv(jlm::rvsdg::region * region)
     else if (auto simplenode = dynamic_cast<jlm::rvsdg::simple_node *>(node))
     {
       if (dynamic_cast<const llvm::LambdaEntryMemStateOperator *>(&simplenode->operation())
-          || dynamic_cast<const jlm::llvm::MemStateSplitOperator *>(&simplenode->operation()))
+          || dynamic_cast<const jlm::llvm::MemoryStateSplitOperation *>(&simplenode->operation()))
       {
         auto new_outs =
             hls::fork_op::create(simplenode->noutputs(), *simplenode->input(0)->origin());

--- a/jlm/hls/backend/rvsdg2rhls/memstate-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/memstate-conv.cpp
@@ -36,7 +36,7 @@ memstate_conv(jlm::rvsdg::region * region)
     }
     else if (auto simplenode = dynamic_cast<jlm::rvsdg::simple_node *>(node))
     {
-      if (dynamic_cast<const llvm::LambdaEntryMemStateOperator *>(&simplenode->operation())
+      if (dynamic_cast<const llvm::LambdaEntryMemoryStateSplitOperation *>(&simplenode->operation())
           || dynamic_cast<const jlm::llvm::MemoryStateSplitOperation *>(&simplenode->operation()))
       {
         auto new_outs =

--- a/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
@@ -46,7 +46,7 @@ remove_unused_state(jlm::rvsdg::region * region, bool can_remove_arguments)
   {
     if (auto simplenode = dynamic_cast<jlm::rvsdg::simple_node *>(node))
     {
-      if (dynamic_cast<const llvm::LambdaExitMemStateOperator *>(&node->operation()))
+      if (dynamic_cast<const llvm::LambdaExitMemoryStateMergeOperation *>(&node->operation()))
       {
         std::vector<jlm::rvsdg::output *> nv;
         for (size_t i = 0; i < simplenode->ninputs(); ++i)
@@ -75,8 +75,8 @@ remove_unused_state(jlm::rvsdg::region * region, bool can_remove_arguments)
         }
         else if (nv.size() != simplenode->ninputs())
         {
-          auto new_state = llvm::LambdaExitMemStateOperator::Create(region, nv);
-          simplenode->output(0)->divert_users(new_state);
+          auto & new_state = llvm::LambdaExitMemoryStateMergeOperation::Create(*region, nv);
+          simplenode->output(0)->divert_users(&new_state);
           remove(simplenode);
         }
       }

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -223,7 +223,7 @@ convert_alloca(jlm::rvsdg::region * region)
       JLM_ASSERT(node->output(1)->nusers() == 1);
       auto mux_in = *node->output(1)->begin();
       auto mux_node = llvm::input_node(mux_in);
-      if (dynamic_cast<const llvm::MemStateMergeOperator *>(&mux_node->operation()))
+      if (dynamic_cast<const llvm::MemoryStateMergeOperation *>(&mux_node->operation()))
       {
         // merge after alloca -> remove merge
         JLM_ASSERT(mux_node->ninputs() == 2);

--- a/jlm/llvm/backend/jlm2llvm/instruction.cpp
+++ b/jlm/llvm/backend/jlm2llvm/instruction.cpp
@@ -953,7 +953,7 @@ convert(
 
 static ::llvm::Value *
 convert(
-    const MemStateSplitOperator &,
+    const MemoryStateSplitOperation &,
     const std::vector<const variable *> &,
     ::llvm::IRBuilder<> &,
     context &)
@@ -1086,7 +1086,7 @@ convert_operation(
             { typeid(uitofp_op), convert_cast<::llvm::Instruction::UIToFP> },
             { typeid(zext_op), convert_cast<::llvm::Instruction::ZExt> },
             { typeid(MemoryStateMergeOperation), convert<MemoryStateMergeOperation> },
-            { typeid(MemStateSplitOperator), convert<MemStateSplitOperator> },
+            { typeid(MemoryStateSplitOperation), convert<MemoryStateSplitOperation> },
             { typeid(LambdaEntryMemStateOperator), convert<LambdaEntryMemStateOperator> },
             { typeid(LambdaExitMemStateOperator), convert<LambdaExitMemStateOperator> },
             { typeid(CallEntryMemStateOperator), convert<CallEntryMemStateOperator> },

--- a/jlm/llvm/backend/jlm2llvm/instruction.cpp
+++ b/jlm/llvm/backend/jlm2llvm/instruction.cpp
@@ -993,7 +993,7 @@ convert(
 
 static ::llvm::Value *
 convert(
-    const CallExitMemStateOperator &,
+    const CallExitMemoryStateSplitOperation &,
     const std::vector<const variable *> &,
     ::llvm::IRBuilder<> &,
     context &)
@@ -1093,7 +1093,8 @@ convert_operation(
               convert<LambdaExitMemoryStateMergeOperation> },
             { typeid(CallEntryMemoryStateMergeOperation),
               convert<CallEntryMemoryStateMergeOperation> },
-            { typeid(CallExitMemStateOperator), convert<CallExitMemStateOperator> } });
+            { typeid(CallExitMemoryStateSplitOperation),
+              convert<CallExitMemoryStateSplitOperation> } });
   /* FIXME: AddrSpaceCast instruction is not supported */
 
   JLM_ASSERT(map.find(std::type_index(typeid(op))) != map.end());

--- a/jlm/llvm/backend/jlm2llvm/instruction.cpp
+++ b/jlm/llvm/backend/jlm2llvm/instruction.cpp
@@ -973,7 +973,7 @@ convert(
 
 static ::llvm::Value *
 convert(
-    const LambdaExitMemStateOperator &,
+    const LambdaExitMemoryStateMergeOperation &,
     const std::vector<const variable *> &,
     ::llvm::IRBuilder<> &,
     context &)
@@ -1089,7 +1089,8 @@ convert_operation(
             { typeid(MemoryStateSplitOperation), convert<MemoryStateSplitOperation> },
             { typeid(LambdaEntryMemoryStateSplitOperation),
               convert<LambdaEntryMemoryStateSplitOperation> },
-            { typeid(LambdaExitMemStateOperator), convert<LambdaExitMemStateOperator> },
+            { typeid(LambdaExitMemoryStateMergeOperation),
+              convert<LambdaExitMemoryStateMergeOperation> },
             { typeid(CallEntryMemStateOperator), convert<CallEntryMemStateOperator> },
             { typeid(CallExitMemStateOperator), convert<CallExitMemStateOperator> } });
   /* FIXME: AddrSpaceCast instruction is not supported */

--- a/jlm/llvm/backend/jlm2llvm/instruction.cpp
+++ b/jlm/llvm/backend/jlm2llvm/instruction.cpp
@@ -983,7 +983,7 @@ convert(
 
 static ::llvm::Value *
 convert(
-    const CallEntryMemStateOperator &,
+    const CallEntryMemoryStateMergeOperation &,
     const std::vector<const variable *> &,
     ::llvm::IRBuilder<> &,
     context &)
@@ -1091,7 +1091,8 @@ convert_operation(
               convert<LambdaEntryMemoryStateSplitOperation> },
             { typeid(LambdaExitMemoryStateMergeOperation),
               convert<LambdaExitMemoryStateMergeOperation> },
-            { typeid(CallEntryMemStateOperator), convert<CallEntryMemStateOperator> },
+            { typeid(CallEntryMemoryStateMergeOperation),
+              convert<CallEntryMemoryStateMergeOperation> },
             { typeid(CallExitMemStateOperator), convert<CallExitMemStateOperator> } });
   /* FIXME: AddrSpaceCast instruction is not supported */
 

--- a/jlm/llvm/backend/jlm2llvm/instruction.cpp
+++ b/jlm/llvm/backend/jlm2llvm/instruction.cpp
@@ -943,7 +943,7 @@ convert(
 
 static ::llvm::Value *
 convert(
-    const MemStateMergeOperator &,
+    const MemoryStateMergeOperation &,
     const std::vector<const variable *> &,
     ::llvm::IRBuilder<> &,
     context &)
@@ -1085,7 +1085,7 @@ convert_operation(
             { typeid(trunc_op), convert_cast<::llvm::Instruction::Trunc> },
             { typeid(uitofp_op), convert_cast<::llvm::Instruction::UIToFP> },
             { typeid(zext_op), convert_cast<::llvm::Instruction::ZExt> },
-            { typeid(MemStateMergeOperator), convert<MemStateMergeOperator> },
+            { typeid(MemoryStateMergeOperation), convert<MemoryStateMergeOperation> },
             { typeid(MemStateSplitOperator), convert<MemStateSplitOperator> },
             { typeid(LambdaEntryMemStateOperator), convert<LambdaEntryMemStateOperator> },
             { typeid(LambdaExitMemStateOperator), convert<LambdaExitMemStateOperator> },

--- a/jlm/llvm/backend/jlm2llvm/instruction.cpp
+++ b/jlm/llvm/backend/jlm2llvm/instruction.cpp
@@ -963,7 +963,7 @@ convert(
 
 static ::llvm::Value *
 convert(
-    const LambdaEntryMemStateOperator &,
+    const LambdaEntryMemoryStateSplitOperation &,
     const std::vector<const variable *> &,
     ::llvm::IRBuilder<> &,
     context &)
@@ -1087,7 +1087,8 @@ convert_operation(
             { typeid(zext_op), convert_cast<::llvm::Instruction::ZExt> },
             { typeid(MemoryStateMergeOperation), convert<MemoryStateMergeOperation> },
             { typeid(MemoryStateSplitOperation), convert<MemoryStateSplitOperation> },
-            { typeid(LambdaEntryMemStateOperator), convert<LambdaEntryMemStateOperator> },
+            { typeid(LambdaEntryMemoryStateSplitOperation),
+              convert<LambdaEntryMemoryStateSplitOperation> },
             { typeid(LambdaExitMemStateOperator), convert<LambdaExitMemStateOperator> },
             { typeid(CallEntryMemStateOperator), convert<CallEntryMemStateOperator> },
             { typeid(CallExitMemStateOperator), convert<CallExitMemStateOperator> } });

--- a/jlm/llvm/frontend/LlvmInstructionConversion.cpp
+++ b/jlm/llvm/frontend/LlvmInstructionConversion.cpp
@@ -716,7 +716,7 @@ convert_malloc_call(const ::llvm::CallInst * i, tacsvector_t & tacs, context & c
   auto result = tacs.back()->result(0);
   auto mstate = tacs.back()->result(1);
 
-  tacs.push_back(MemStateMergeOperator::Create({ mstate, memstate }));
+  tacs.push_back(MemoryStateMergeOperation::Create({ mstate, memstate }));
   tacs.push_back(assignment_op::create(tacs.back()->result(0), memstate));
 
   return result;
@@ -1033,7 +1033,7 @@ convert_alloca_instruction(::llvm::Instruction * instruction, tacsvector_t & tac
   auto result = tacs.back()->result(0);
   auto astate = tacs.back()->result(1);
 
-  tacs.push_back(MemStateMergeOperator::Create({ astate, memstate }));
+  tacs.push_back(MemoryStateMergeOperation::Create({ astate, memstate }));
   tacs.push_back(assignment_op::create(tacs.back()->result(0), memstate));
 
   return result;

--- a/jlm/llvm/ir/operators/Load.cpp
+++ b/jlm/llvm/ir/operators/Load.cpp
@@ -186,7 +186,7 @@ is_load_mux_reducible(const std::vector<rvsdg::output *> & operands)
     return false;
 
   auto memStateMergeNode = rvsdg::node_output::node(operands[1]);
-  if (!is<MemStateMergeOperator>(memStateMergeNode))
+  if (!is<MemoryStateMergeOperation>(memStateMergeNode))
     return false;
 
   return true;
@@ -375,7 +375,7 @@ perform_load_mux_reduction(
       op.GetAlignment());
 
   std::vector<rvsdg::output *> states = { std::next(ld.begin()), ld.end() };
-  auto mx = MemStateMergeOperator::Create(states);
+  auto mx = MemoryStateMergeOperation::Create(states);
 
   return { ld[0], mx };
 }
@@ -551,7 +551,7 @@ perform_load_load_state_reduction(
     if (!states.empty())
     {
       states.push_back(ld[n + 1]);
-      ld[n + 1] = MemStateMergeOperator::Create(states);
+      ld[n + 1] = MemoryStateMergeOperation::Create(states);
     }
   }
 

--- a/jlm/llvm/ir/operators/MemoryStateOperations.cpp
+++ b/jlm/llvm/ir/operators/MemoryStateOperations.cpp
@@ -92,27 +92,25 @@ LambdaExitMemoryStateMergeOperation::copy() const
   return std::unique_ptr<rvsdg::operation>(new LambdaExitMemoryStateMergeOperation(*this));
 }
 
-/* CallEntryMemStateOperator class */
-
-CallEntryMemStateOperator::~CallEntryMemStateOperator() = default;
+CallEntryMemoryStateMergeOperation::~CallEntryMemoryStateMergeOperation() = default;
 
 bool
-CallEntryMemStateOperator::operator==(const jlm::rvsdg::operation & other) const noexcept
+CallEntryMemoryStateMergeOperation::operator==(const rvsdg::operation & other) const noexcept
 {
-  auto operation = dynamic_cast<const CallEntryMemStateOperator *>(&other);
+  auto operation = dynamic_cast<const CallEntryMemoryStateMergeOperation *>(&other);
   return operation && operation->narguments() == narguments();
 }
 
 std::string
-CallEntryMemStateOperator::debug_string() const
+CallEntryMemoryStateMergeOperation::debug_string() const
 {
-  return "CallEntryMemState";
+  return "CallEntryMemoryStateMerge";
 }
 
-std::unique_ptr<jlm::rvsdg::operation>
-CallEntryMemStateOperator::copy() const
+std::unique_ptr<rvsdg::operation>
+CallEntryMemoryStateMergeOperation::copy() const
 {
-  return std::unique_ptr<jlm::rvsdg::operation>(new CallEntryMemStateOperator(*this));
+  return std::unique_ptr<rvsdg::operation>(new CallEntryMemoryStateMergeOperation(*this));
 }
 
 /* CallExitMemStateOperator class */

--- a/jlm/llvm/ir/operators/MemoryStateOperations.cpp
+++ b/jlm/llvm/ir/operators/MemoryStateOperations.cpp
@@ -50,7 +50,7 @@ MemoryStateSplitOperation::copy() const
   return std::unique_ptr<rvsdg::operation>(new MemoryStateSplitOperation(*this));
 }
 
-LambdaEntryMemoryStateSplitOperation::~LambdaEntryMemoryStateSplitOperation() = default;
+LambdaEntryMemoryStateSplitOperation::~LambdaEntryMemoryStateSplitOperation() noexcept = default;
 
 bool
 LambdaEntryMemoryStateSplitOperation::operator==(const rvsdg::operation & other) const noexcept
@@ -71,7 +71,7 @@ LambdaEntryMemoryStateSplitOperation::copy() const
   return std::unique_ptr<rvsdg::operation>(new LambdaEntryMemoryStateSplitOperation(*this));
 }
 
-LambdaExitMemoryStateMergeOperation::~LambdaExitMemoryStateMergeOperation() = default;
+LambdaExitMemoryStateMergeOperation::~LambdaExitMemoryStateMergeOperation() noexcept = default;
 
 bool
 LambdaExitMemoryStateMergeOperation::operator==(const rvsdg::operation & other) const noexcept
@@ -92,7 +92,7 @@ LambdaExitMemoryStateMergeOperation::copy() const
   return std::unique_ptr<rvsdg::operation>(new LambdaExitMemoryStateMergeOperation(*this));
 }
 
-CallEntryMemoryStateMergeOperation::~CallEntryMemoryStateMergeOperation() = default;
+CallEntryMemoryStateMergeOperation::~CallEntryMemoryStateMergeOperation() noexcept = default;
 
 bool
 CallEntryMemoryStateMergeOperation::operator==(const rvsdg::operation & other) const noexcept
@@ -113,27 +113,25 @@ CallEntryMemoryStateMergeOperation::copy() const
   return std::unique_ptr<rvsdg::operation>(new CallEntryMemoryStateMergeOperation(*this));
 }
 
-/* CallExitMemStateOperator class */
-
-CallExitMemStateOperator::~CallExitMemStateOperator() = default;
+CallExitMemoryStateSplitOperation::~CallExitMemoryStateSplitOperation() noexcept = default;
 
 bool
-CallExitMemStateOperator::operator==(const jlm::rvsdg::operation & other) const noexcept
+CallExitMemoryStateSplitOperation::operator==(const rvsdg::operation & other) const noexcept
 {
-  auto operation = dynamic_cast<const CallExitMemStateOperator *>(&other);
+  auto operation = dynamic_cast<const CallExitMemoryStateSplitOperation *>(&other);
   return operation && operation->nresults() == nresults();
 }
 
 std::string
-CallExitMemStateOperator::debug_string() const
+CallExitMemoryStateSplitOperation::debug_string() const
 {
-  return "CallExitMemState";
+  return "CallExitMemoryStateSplit";
 }
 
-std::unique_ptr<jlm::rvsdg::operation>
-CallExitMemStateOperator::copy() const
+std::unique_ptr<rvsdg::operation>
+CallExitMemoryStateSplitOperation::copy() const
 {
-  return std::unique_ptr<jlm::rvsdg::operation>(new CallExitMemStateOperator(*this));
+  return std::unique_ptr<rvsdg::operation>(new CallExitMemoryStateSplitOperation(*this));
 }
 
 }

--- a/jlm/llvm/ir/operators/MemoryStateOperations.cpp
+++ b/jlm/llvm/ir/operators/MemoryStateOperations.cpp
@@ -29,28 +29,25 @@ MemoryStateMergeOperation::copy() const
   return std::unique_ptr<rvsdg::operation>(new MemoryStateMergeOperation(*this));
 }
 
-/* MemStateSplit operator */
-
-MemStateSplitOperator::~MemStateSplitOperator()
-{}
+MemoryStateSplitOperation::~MemoryStateSplitOperation() noexcept = default;
 
 bool
-MemStateSplitOperator::operator==(const rvsdg::operation & other) const noexcept
+MemoryStateSplitOperation::operator==(const rvsdg::operation & other) const noexcept
 {
-  auto operation = dynamic_cast<const MemStateSplitOperator *>(&other);
+  auto operation = dynamic_cast<const MemoryStateSplitOperation *>(&other);
   return operation && operation->nresults() == nresults();
 }
 
 std::string
-MemStateSplitOperator::debug_string() const
+MemoryStateSplitOperation::debug_string() const
 {
-  return "MemStateSplit";
+  return "MemoryStateSplit";
 }
 
 std::unique_ptr<rvsdg::operation>
-MemStateSplitOperator::copy() const
+MemoryStateSplitOperation::copy() const
 {
-  return std::unique_ptr<rvsdg::operation>(new MemStateSplitOperator(*this));
+  return std::unique_ptr<rvsdg::operation>(new MemoryStateSplitOperation(*this));
 }
 
 /* LambdaEntryMemStateOperator class */

--- a/jlm/llvm/ir/operators/MemoryStateOperations.cpp
+++ b/jlm/llvm/ir/operators/MemoryStateOperations.cpp
@@ -50,27 +50,25 @@ MemoryStateSplitOperation::copy() const
   return std::unique_ptr<rvsdg::operation>(new MemoryStateSplitOperation(*this));
 }
 
-/* LambdaEntryMemStateOperator class */
-
-LambdaEntryMemStateOperator::~LambdaEntryMemStateOperator() = default;
+LambdaEntryMemoryStateSplitOperation::~LambdaEntryMemoryStateSplitOperation() = default;
 
 bool
-LambdaEntryMemStateOperator::operator==(const jlm::rvsdg::operation & other) const noexcept
+LambdaEntryMemoryStateSplitOperation::operator==(const rvsdg::operation & other) const noexcept
 {
-  auto operation = dynamic_cast<const LambdaEntryMemStateOperator *>(&other);
+  auto operation = dynamic_cast<const LambdaEntryMemoryStateSplitOperation *>(&other);
   return operation && operation->nresults() == nresults();
 }
 
 std::string
-LambdaEntryMemStateOperator::debug_string() const
+LambdaEntryMemoryStateSplitOperation::debug_string() const
 {
-  return "LambdaEntryMemState";
+  return "LambdaEntryMemoryStateSplit";
 }
 
 std::unique_ptr<jlm::rvsdg::operation>
-LambdaEntryMemStateOperator::copy() const
+LambdaEntryMemoryStateSplitOperation::copy() const
 {
-  return std::unique_ptr<jlm::rvsdg::operation>(new LambdaEntryMemStateOperator(*this));
+  return std::unique_ptr<rvsdg::operation>(new LambdaEntryMemoryStateSplitOperation(*this));
 }
 
 /* LambdaExitMemStateOperator class */

--- a/jlm/llvm/ir/operators/MemoryStateOperations.cpp
+++ b/jlm/llvm/ir/operators/MemoryStateOperations.cpp
@@ -71,27 +71,25 @@ LambdaEntryMemoryStateSplitOperation::copy() const
   return std::unique_ptr<rvsdg::operation>(new LambdaEntryMemoryStateSplitOperation(*this));
 }
 
-/* LambdaExitMemStateOperator class */
-
-LambdaExitMemStateOperator::~LambdaExitMemStateOperator() = default;
+LambdaExitMemoryStateMergeOperation::~LambdaExitMemoryStateMergeOperation() = default;
 
 bool
-LambdaExitMemStateOperator::operator==(const jlm::rvsdg::operation & other) const noexcept
+LambdaExitMemoryStateMergeOperation::operator==(const rvsdg::operation & other) const noexcept
 {
-  auto operation = dynamic_cast<const LambdaExitMemStateOperator *>(&other);
+  auto operation = dynamic_cast<const LambdaExitMemoryStateMergeOperation *>(&other);
   return operation && operation->narguments() == narguments();
 }
 
 std::string
-LambdaExitMemStateOperator::debug_string() const
+LambdaExitMemoryStateMergeOperation::debug_string() const
 {
-  return "LambdaExitMemState";
+  return "LambdaExitMemoryStateMerge";
 }
 
-std::unique_ptr<jlm::rvsdg::operation>
-LambdaExitMemStateOperator::copy() const
+std::unique_ptr<rvsdg::operation>
+LambdaExitMemoryStateMergeOperation::copy() const
 {
-  return std::unique_ptr<jlm::rvsdg::operation>(new LambdaExitMemStateOperator(*this));
+  return std::unique_ptr<rvsdg::operation>(new LambdaExitMemoryStateMergeOperation(*this));
 }
 
 /* CallEntryMemStateOperator class */

--- a/jlm/llvm/ir/operators/MemoryStateOperations.cpp
+++ b/jlm/llvm/ir/operators/MemoryStateOperations.cpp
@@ -8,28 +8,25 @@
 namespace jlm::llvm
 {
 
-/* MemStateMerge operator */
-
-MemStateMergeOperator::~MemStateMergeOperator()
-{}
+MemoryStateMergeOperation::~MemoryStateMergeOperation() noexcept = default;
 
 bool
-MemStateMergeOperator::operator==(const rvsdg::operation & other) const noexcept
+MemoryStateMergeOperation::operator==(const rvsdg::operation & other) const noexcept
 {
-  auto operation = dynamic_cast<const MemStateMergeOperator *>(&other);
+  auto operation = dynamic_cast<const MemoryStateMergeOperation *>(&other);
   return operation && operation->narguments() == narguments();
 }
 
 std::string
-MemStateMergeOperator::debug_string() const
+MemoryStateMergeOperation::debug_string() const
 {
-  return "MemStateMerge";
+  return "MemoryStateMerge";
 }
 
 std::unique_ptr<rvsdg::operation>
-MemStateMergeOperator::copy() const
+MemoryStateMergeOperation::copy() const
 {
-  return std::unique_ptr<rvsdg::operation>(new MemStateMergeOperator(*this));
+  return std::unique_ptr<rvsdg::operation>(new MemoryStateMergeOperation(*this));
 }
 
 /* MemStateSplit operator */

--- a/jlm/llvm/ir/operators/MemoryStateOperations.hpp
+++ b/jlm/llvm/ir/operators/MemoryStateOperations.hpp
@@ -185,32 +185,39 @@ public:
   }
 };
 
-/** \brief CallEntryMemStateOperator class
+/**
+ * A call entry memory state merge operation takes multiple states as input and merges them together
+ * to a single output state. In contrast to the MemoryStateMergeOperation, this operation is allowed
+ * to have zero input states. The operation's output is required to be connected to the memory state
+ * argument of a call.
+ *
+ * The operation has no equivalent LLVM instruction.
+ *
+ * @see CallExitMemStateOperator
  */
-class CallEntryMemStateOperator final : public MemoryStateOperation
+class CallEntryMemoryStateMergeOperation final : public MemoryStateOperation
 {
 public:
-  ~CallEntryMemStateOperator() override;
+  ~CallEntryMemoryStateMergeOperation() override;
 
-public:
-  explicit CallEntryMemStateOperator(size_t noperands)
-      : MemoryStateOperation(noperands, 1)
+  explicit CallEntryMemoryStateMergeOperation(size_t numOperands)
+      : MemoryStateOperation(numOperands, 1)
   {}
 
   bool
   operator==(const operation & other) const noexcept override;
 
-  std::string
+  [[nodiscard]] std::string
   debug_string() const override;
 
-  std::unique_ptr<jlm::rvsdg::operation>
+  [[nodiscard]] std::unique_ptr<rvsdg::operation>
   copy() const override;
 
-  static jlm::rvsdg::output *
-  Create(jlm::rvsdg::region * region, const std::vector<jlm::rvsdg::output *> & operands)
+  static rvsdg::output &
+  Create(rvsdg::region & region, const std::vector<rvsdg::output *> & operands)
   {
-    CallEntryMemStateOperator op(operands.size());
-    return jlm::rvsdg::simple_node::create_normalized(region, op, operands)[0];
+    CallEntryMemoryStateMergeOperation operation(operands.size());
+    return *rvsdg::simple_node::create_normalized(&region, operation, operands)[0];
   }
 };
 

--- a/jlm/llvm/ir/operators/MemoryStateOperations.hpp
+++ b/jlm/llvm/ir/operators/MemoryStateOperations.hpp
@@ -120,7 +120,7 @@ public:
  *
  * The operation has no equivalent LLVM instruction.
  *
- * @see LambdaExitMemStateOperator
+ * @see LambdaExitMemoryStateMergeOperation
  */
 class LambdaEntryMemoryStateSplitOperation final : public MemoryStateOperation
 {
@@ -149,32 +149,39 @@ public:
   }
 };
 
-/** \brief LambdaExitMemStateOperator class
+/**
+ * A lambda exit memory state merge operation takes multiple states as input and merges them
+ * together to a single output state. In contrast to the MemoryStateMergeOperation, this operation
+ * is allowed to have zero input states. The operation's output is required to be connected to the
+ * memory state result of a lambda.
+ *
+ * The operation has no equivalent LLVM instruction.
+ *
+ * @see LambdaEntryMemoryStateMergeOperation
  */
-class LambdaExitMemStateOperator final : public MemoryStateOperation
+class LambdaExitMemoryStateMergeOperation final : public MemoryStateOperation
 {
 public:
-  ~LambdaExitMemStateOperator() override;
+  ~LambdaExitMemoryStateMergeOperation() override;
 
-public:
-  explicit LambdaExitMemStateOperator(size_t noperands)
-      : MemoryStateOperation(noperands, 1)
+  explicit LambdaExitMemoryStateMergeOperation(size_t numOperands)
+      : MemoryStateOperation(numOperands, 1)
   {}
 
   bool
   operator==(const operation & other) const noexcept override;
 
-  std::string
+  [[nodiscard]] std::string
   debug_string() const override;
 
-  std::unique_ptr<jlm::rvsdg::operation>
+  [[nodiscard]] std::unique_ptr<jlm::rvsdg::operation>
   copy() const override;
 
-  static jlm::rvsdg::output *
-  Create(jlm::rvsdg::region * region, const std::vector<jlm::rvsdg::output *> & operands)
+  static rvsdg::output &
+  Create(rvsdg::region & region, const std::vector<jlm::rvsdg::output *> & operands)
   {
-    LambdaExitMemStateOperator op(operands.size());
-    return jlm::rvsdg::simple_node::create_normalized(region, op, operands)[0];
+    LambdaExitMemoryStateMergeOperation operation(operands.size());
+    return *rvsdg::simple_node::create_normalized(&region, operation, operands)[0];
   }
 };
 

--- a/jlm/llvm/ir/operators/MemoryStateOperations.hpp
+++ b/jlm/llvm/ir/operators/MemoryStateOperations.hpp
@@ -125,7 +125,7 @@ public:
 class LambdaEntryMemoryStateSplitOperation final : public MemoryStateOperation
 {
 public:
-  ~LambdaEntryMemoryStateSplitOperation() override;
+  ~LambdaEntryMemoryStateSplitOperation() noexcept override;
 
   explicit LambdaEntryMemoryStateSplitOperation(size_t numResults)
       : MemoryStateOperation(1, numResults)
@@ -162,7 +162,7 @@ public:
 class LambdaExitMemoryStateMergeOperation final : public MemoryStateOperation
 {
 public:
-  ~LambdaExitMemoryStateMergeOperation() override;
+  ~LambdaExitMemoryStateMergeOperation() noexcept override;
 
   explicit LambdaExitMemoryStateMergeOperation(size_t numOperands)
       : MemoryStateOperation(numOperands, 1)
@@ -193,12 +193,12 @@ public:
  *
  * The operation has no equivalent LLVM instruction.
  *
- * @see CallExitMemStateOperator
+ * @see CallExitMemoryStateSplitOperation
  */
 class CallEntryMemoryStateMergeOperation final : public MemoryStateOperation
 {
 public:
-  ~CallEntryMemoryStateMergeOperation() override;
+  ~CallEntryMemoryStateMergeOperation() noexcept override;
 
   explicit CallEntryMemoryStateMergeOperation(size_t numOperands)
       : MemoryStateOperation(numOperands, 1)
@@ -221,33 +221,40 @@ public:
   }
 };
 
-/** \brief CallExitMemStateOperator class
+/**
+ * A call exit memory state split operation takes a single input state and splits it into
+ * multiple output states. In contrast to the MemoryStateSplitOperation, this operation is allowed
+ * to have zero output states. The operation's input is required to be connected to the memory state
+ * result of a call.
+ *
+ * The operation has no equivalent LLVM instruction.
+ *
+ * @see CallEntryMemoryStateMergeOperation
  */
-class CallExitMemStateOperator final : public MemoryStateOperation
+class CallExitMemoryStateSplitOperation final : public MemoryStateOperation
 {
 public:
-  ~CallExitMemStateOperator() override;
+  ~CallExitMemoryStateSplitOperation() noexcept override;
 
-public:
-  explicit CallExitMemStateOperator(size_t nresults)
-      : MemoryStateOperation(1, nresults)
+  explicit CallExitMemoryStateSplitOperation(size_t numResults)
+      : MemoryStateOperation(1, numResults)
   {}
 
   bool
   operator==(const operation & other) const noexcept override;
 
-  std::string
+  [[nodiscard]] std::string
   debug_string() const override;
 
-  std::unique_ptr<jlm::rvsdg::operation>
+  [[nodiscard]] std::unique_ptr<rvsdg::operation>
   copy() const override;
 
-  static std::vector<jlm::rvsdg::output *>
-  Create(jlm::rvsdg::output * output, size_t nresults)
+  static std::vector<rvsdg::output *>
+  Create(rvsdg::output & output, size_t numResults)
   {
-    auto region = output->region();
-    CallExitMemStateOperator op(nresults);
-    return jlm::rvsdg::simple_node::create_normalized(region, op, { output });
+    auto region = output.region();
+    CallExitMemoryStateSplitOperation operation(numResults);
+    return rvsdg::simple_node::create_normalized(region, operation, { &output });
   }
 };
 

--- a/jlm/llvm/ir/operators/MemoryStateOperations.hpp
+++ b/jlm/llvm/ir/operators/MemoryStateOperations.hpp
@@ -32,7 +32,7 @@ private:
 };
 
 /**
- * A memory state merge operation takes multiple states as input and merges them together into a
+ * A memory state merge operation takes multiple states as input and merges them together to a
  * single output state.
  *
  * The operation has no equivalent LLVM instruction.
@@ -77,34 +77,38 @@ public:
   }
 };
 
-/** \brief MemStateSplit operator
+/**
+ * A memory state split operation takes a single input state and splits it into multiple output
+ * states.
+ *
+ * The operation has no equivalent LLVM instruction.
  */
-class MemStateSplitOperator final : public MemoryStateOperation
+class MemoryStateSplitOperation final : public MemoryStateOperation
 {
 public:
-  ~MemStateSplitOperator() override;
+  ~MemoryStateSplitOperation() noexcept override;
 
-  MemStateSplitOperator(size_t nresults)
-      : MemoryStateOperation(1, nresults)
+  explicit MemoryStateSplitOperation(size_t numResults)
+      : MemoryStateOperation(1, numResults)
   {}
 
-  virtual bool
+  bool
   operator==(const operation & other) const noexcept override;
 
-  virtual std::string
+  [[nodiscard]] std::string
   debug_string() const override;
 
-  virtual std::unique_ptr<jlm::rvsdg::operation>
+  [[nodiscard]] std::unique_ptr<jlm::rvsdg::operation>
   copy() const override;
 
-  static std::vector<jlm::rvsdg::output *>
-  Create(jlm::rvsdg::output * operand, size_t nresults)
+  static std::vector<rvsdg::output *>
+  Create(rvsdg::output & operand, size_t numResults)
   {
-    if (nresults == 0)
-      throw jlm::util::error("Insufficient number of results.");
+    if (numResults == 0)
+      throw util::error("Insufficient number of results.");
 
-    MemStateSplitOperator op(nresults);
-    return jlm::rvsdg::simple_node::create_normalized(operand->region(), op, { operand });
+    MemoryStateSplitOperation operation(numResults);
+    return rvsdg::simple_node::create_normalized(operand.region(), operation, { &operand });
   }
 };
 

--- a/jlm/llvm/ir/operators/MemoryStateOperations.hpp
+++ b/jlm/llvm/ir/operators/MemoryStateOperations.hpp
@@ -18,7 +18,7 @@ namespace jlm::llvm
  */
 class MemoryStateOperation : public rvsdg::simple_op
 {
-public:
+protected:
   MemoryStateOperation(size_t numOperands, size_t numResults)
       : simple_op(CreatePorts(numOperands), CreatePorts(numResults))
   {}
@@ -31,45 +31,49 @@ private:
   }
 };
 
-/** \brief MemStateMerge operator
+/**
+ * A memory state merge operation takes multiple states as input and merges them together into a
+ * single output state.
+ *
+ * The operation has no equivalent LLVM instruction.
  */
-class MemStateMergeOperator final : public MemoryStateOperation
+class MemoryStateMergeOperation final : public MemoryStateOperation
 {
 public:
-  ~MemStateMergeOperator() override;
+  ~MemoryStateMergeOperation() noexcept override;
 
-  MemStateMergeOperator(size_t noperands)
-      : MemoryStateOperation(noperands, 1)
+  explicit MemoryStateMergeOperation(size_t numOperands)
+      : MemoryStateOperation(numOperands, 1)
   {}
 
-  virtual bool
+  bool
   operator==(const operation & other) const noexcept override;
 
-  virtual std::string
+  [[nodiscard]] std::string
   debug_string() const override;
 
-  virtual std::unique_ptr<jlm::rvsdg::operation>
+  [[nodiscard]] std::unique_ptr<rvsdg::operation>
   copy() const override;
 
-  static jlm::rvsdg::output *
-  Create(const std::vector<jlm::rvsdg::output *> & operands)
+  static rvsdg::output *
+  Create(const std::vector<rvsdg::output *> & operands)
   {
     if (operands.empty())
-      throw jlm::util::error("Insufficient number of operands.");
+      throw util::error("Insufficient number of operands.");
 
-    MemStateMergeOperator op(operands.size());
+    MemoryStateMergeOperation operation(operands.size());
     auto region = operands.front()->region();
-    return jlm::rvsdg::simple_node::create_normalized(region, op, operands)[0];
+    return rvsdg::simple_node::create_normalized(region, operation, operands)[0];
   }
 
   static std::unique_ptr<tac>
   Create(const std::vector<const variable *> & operands)
   {
     if (operands.empty())
-      throw jlm::util::error("Insufficient number of operands.");
+      throw util::error("Insufficient number of operands.");
 
-    MemStateMergeOperator op(operands.size());
-    return tac::create(op, operands);
+    MemoryStateMergeOperation operation(operands.size());
+    return tac::create(operation, operands);
   }
 };
 

--- a/jlm/llvm/ir/operators/MemoryStateOperations.hpp
+++ b/jlm/llvm/ir/operators/MemoryStateOperations.hpp
@@ -112,33 +112,40 @@ public:
   }
 };
 
-/** \brief LambdaEntryMemStateOperator class
+/**
+ * A lambda entry memory state split operation takes a single input state and splits it into
+ * multiple output states. In contrast to the MemoryStateSplitOperation, this operation is allowed
+ * to have zero output states. The operation's input is required to be connected to the memory state
+ * argument of a lambda.
+ *
+ * The operation has no equivalent LLVM instruction.
+ *
+ * @see LambdaExitMemStateOperator
  */
-class LambdaEntryMemStateOperator final : public MemoryStateOperation
+class LambdaEntryMemoryStateSplitOperation final : public MemoryStateOperation
 {
 public:
-  ~LambdaEntryMemStateOperator() override;
+  ~LambdaEntryMemoryStateSplitOperation() override;
 
-public:
-  explicit LambdaEntryMemStateOperator(size_t nresults)
-      : MemoryStateOperation(1, nresults)
+  explicit LambdaEntryMemoryStateSplitOperation(size_t numResults)
+      : MemoryStateOperation(1, numResults)
   {}
 
   bool
   operator==(const operation & other) const noexcept override;
 
-  std::string
+  [[nodiscard]] std::string
   debug_string() const override;
 
-  std::unique_ptr<jlm::rvsdg::operation>
+  [[nodiscard]] std::unique_ptr<jlm::rvsdg::operation>
   copy() const override;
 
   static std::vector<jlm::rvsdg::output *>
-  Create(jlm::rvsdg::output * output, size_t nresults)
+  Create(rvsdg::output & output, size_t numResults)
   {
-    auto region = output->region();
-    LambdaEntryMemStateOperator op(nresults);
-    return jlm::rvsdg::simple_node::create_normalized(region, op, { output });
+    auto region = output.region();
+    LambdaEntryMemoryStateSplitOperation operation(numResults);
+    return rvsdg::simple_node::create_normalized(region, operation, { &output });
   }
 };
 

--- a/jlm/llvm/ir/operators/MemoryStateOperations.hpp
+++ b/jlm/llvm/ir/operators/MemoryStateOperations.hpp
@@ -13,32 +13,33 @@
 namespace jlm::llvm
 {
 
-/* MemState operator */
-
-class MemStateOperator : public jlm::rvsdg::simple_op
+/**
+ * Abstract base class for all memory state operations.
+ */
+class MemoryStateOperation : public rvsdg::simple_op
 {
 public:
-  MemStateOperator(size_t noperands, size_t nresults)
-      : simple_op(create_portvector(noperands), create_portvector(nresults))
+  MemoryStateOperation(size_t numOperands, size_t numResults)
+      : simple_op(CreatePorts(numOperands), CreatePorts(numResults))
   {}
 
 private:
-  static std::vector<jlm::rvsdg::port>
-  create_portvector(size_t size)
+  static std::vector<rvsdg::port>
+  CreatePorts(size_t size)
   {
-    return { size, jlm::rvsdg::port(MemoryStateType::Create()) };
+    return { size, rvsdg::port(MemoryStateType()) };
   }
 };
 
 /** \brief MemStateMerge operator
  */
-class MemStateMergeOperator final : public MemStateOperator
+class MemStateMergeOperator final : public MemoryStateOperation
 {
 public:
   ~MemStateMergeOperator() override;
 
   MemStateMergeOperator(size_t noperands)
-      : MemStateOperator(noperands, 1)
+      : MemoryStateOperation(noperands, 1)
   {}
 
   virtual bool
@@ -74,13 +75,13 @@ public:
 
 /** \brief MemStateSplit operator
  */
-class MemStateSplitOperator final : public MemStateOperator
+class MemStateSplitOperator final : public MemoryStateOperation
 {
 public:
   ~MemStateSplitOperator() override;
 
   MemStateSplitOperator(size_t nresults)
-      : MemStateOperator(1, nresults)
+      : MemoryStateOperation(1, nresults)
   {}
 
   virtual bool
@@ -105,14 +106,14 @@ public:
 
 /** \brief LambdaEntryMemStateOperator class
  */
-class LambdaEntryMemStateOperator final : public MemStateOperator
+class LambdaEntryMemStateOperator final : public MemoryStateOperation
 {
 public:
   ~LambdaEntryMemStateOperator() override;
 
 public:
   explicit LambdaEntryMemStateOperator(size_t nresults)
-      : MemStateOperator(1, nresults)
+      : MemoryStateOperation(1, nresults)
   {}
 
   bool
@@ -135,14 +136,14 @@ public:
 
 /** \brief LambdaExitMemStateOperator class
  */
-class LambdaExitMemStateOperator final : public MemStateOperator
+class LambdaExitMemStateOperator final : public MemoryStateOperation
 {
 public:
   ~LambdaExitMemStateOperator() override;
 
 public:
   explicit LambdaExitMemStateOperator(size_t noperands)
-      : MemStateOperator(noperands, 1)
+      : MemoryStateOperation(noperands, 1)
   {}
 
   bool
@@ -164,14 +165,14 @@ public:
 
 /** \brief CallEntryMemStateOperator class
  */
-class CallEntryMemStateOperator final : public MemStateOperator
+class CallEntryMemStateOperator final : public MemoryStateOperation
 {
 public:
   ~CallEntryMemStateOperator() override;
 
 public:
   explicit CallEntryMemStateOperator(size_t noperands)
-      : MemStateOperator(noperands, 1)
+      : MemoryStateOperation(noperands, 1)
   {}
 
   bool
@@ -193,14 +194,14 @@ public:
 
 /** \brief CallExitMemStateOperator class
  */
-class CallExitMemStateOperator final : public MemStateOperator
+class CallExitMemStateOperator final : public MemoryStateOperation
 {
 public:
   ~CallExitMemStateOperator() override;
 
 public:
   explicit CallExitMemStateOperator(size_t nresults)
-      : MemStateOperator(1, nresults)
+      : MemoryStateOperation(1, nresults)
   {}
 
   bool

--- a/jlm/llvm/ir/operators/Store.cpp
+++ b/jlm/llvm/ir/operators/Store.cpp
@@ -168,7 +168,7 @@ is_store_mux_reducible(const std::vector<jlm::rvsdg::output *> & operands)
   JLM_ASSERT(operands.size() > 2);
 
   auto memStateMergeNode = jlm::rvsdg::node_output::node(operands[2]);
-  if (!is<MemStateMergeOperator>(memStateMergeNode))
+  if (!is<MemoryStateMergeOperation>(memStateMergeNode))
     return false;
 
   for (size_t n = 2; n < operands.size(); n++)
@@ -254,7 +254,7 @@ perform_store_mux_reduction(
       operands[1],
       memStateMergeOperands,
       op.GetAlignment());
-  return { MemStateMergeOperator::Create(states) };
+  return { MemoryStateMergeOperation::Create(states) };
 }
 
 static std::vector<jlm::rvsdg::output *>

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
@@ -806,7 +806,8 @@ MemoryStateEncoder::EncodeLambdaEntry(const lambda::node & lambdaNode)
 
   stateMap.PushRegion(*lambdaNode.subregion());
 
-  auto states = LambdaEntryMemStateOperator::Create(memoryStateArgument, memoryNodes.Size());
+  auto states =
+      LambdaEntryMemoryStateSplitOperation::Create(*memoryStateArgument, memoryNodes.Size());
 
   size_t n = 0;
   for (auto & memoryNode : memoryNodes.Items())
@@ -816,17 +817,18 @@ MemoryStateEncoder::EncodeLambdaEntry(const lambda::node & lambdaNode)
   {
     // This additional MemoryStateMergeOperation node makes all other nodes in the function that
     // consume the memory state dependent on this node and therefore transitively on the
-    // LambdaEntryMemStateOperator. This ensures that the LambdaEntryMemStateOperator is always
-    // visited before all other memory state consuming nodes:
+    // LambdaEntryMemoryStateSplitOperation. This ensures that the
+    // LambdaEntryMemoryStateSplitOperation is always visited before all other memory state
+    // consuming nodes:
     //
     // ... := LAMBDA[f]
     //   [..., a1, ...]
-    //     o1, ..., ox := LambdaEntryMemStateOperator a1
-    //     oy = MemoryStateMergeOperation o1, ..., ox
+    //     o1, ..., ox := LambdaEntryMemoryStateSplit a1
+    //     oy = MemoryStateMerge o1, ..., ox
     //     ....
     //
-    // No other memory state consuming node aside from the LambdaEntryMemStateOperator should now
-    // consume a1.
+    // No other memory state consuming node aside from the LambdaEntryMemoryStateSplitOperation
+    // should now consume a1.
     auto state = MemoryStateMergeOperation::Create(states);
     memoryStateArgumentUser->divert_to(state);
   }

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
@@ -844,8 +844,8 @@ MemoryStateEncoder::EncodeLambdaExit(const lambda::node & lambdaNode)
 
   auto memoryNodeStatePairs = stateMap.GetStates(*subregion, memoryNodes);
   auto states = StateMap::MemoryNodeStatePair::States(memoryNodeStatePairs);
-  auto mergedState = LambdaExitMemStateOperator::Create(subregion, states);
-  memoryStateResult->divert_to(mergedState);
+  auto & mergedState = LambdaExitMemoryStateMergeOperation::Create(*subregion, states);
+  memoryStateResult->divert_to(&mergedState);
 
   stateMap.PopRegion(*lambdaNode.subregion());
 }

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
@@ -739,8 +739,8 @@ MemoryStateEncoder::EncodeCallEntry(const CallNode & callNode)
   }
 
   auto states = StateMap::MemoryNodeStatePair::States(memoryNodeStatePairs);
-  auto state = CallEntryMemStateOperator::Create(region, states);
-  callNode.GetMemoryStateInput()->divert_to(state);
+  auto & state = CallEntryMemoryStateMergeOperation::Create(*region, states);
+  callNode.GetMemoryStateInput()->divert_to(&state);
 }
 
 void

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
@@ -749,8 +749,9 @@ MemoryStateEncoder::EncodeCallExit(const CallNode & callNode)
   auto & stateMap = Context_->GetRegionalizedStateMap();
   auto & memoryNodes = Context_->GetMemoryNodeProvisioning().GetCallExitNodes(callNode);
 
-  auto states =
-      CallExitMemStateOperator::Create(callNode.GetMemoryStateOutput(), memoryNodes.Size());
+  auto states = CallExitMemoryStateSplitOperation::Create(
+      *callNode.GetMemoryStateOutput(),
+      memoryNodes.Size());
   auto memoryNodeStatePairs = stateMap.GetStates(*callNode.region(), memoryNodes);
   StateMap::MemoryNodeStatePair::ReplaceStates(memoryNodeStatePairs, states);
 }

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
@@ -648,7 +648,8 @@ MemoryStateEncoder::EncodeMalloc(const rvsdg::simple_node & mallocNode)
   // is not just simply replaced and therefore "lost".
   auto memoryNodeStatePair = stateMap.GetState(*mallocNode.region(), mallocMemoryNode);
   auto mallocState = mallocNode.output(1);
-  auto mergedState = MemStateMergeOperator::Create({ mallocState, &memoryNodeStatePair->State() });
+  auto mergedState =
+      MemoryStateMergeOperation::Create({ mallocState, &memoryNodeStatePair->State() });
   memoryNodeStatePair->ReplaceState(*mergedState);
 }
 
@@ -813,7 +814,7 @@ MemoryStateEncoder::EncodeLambdaEntry(const lambda::node & lambdaNode)
 
   if (!states.empty())
   {
-    // This additional MemStateMergeOperator node makes all other nodes in the function that
+    // This additional MemoryStateMergeOperation node makes all other nodes in the function that
     // consume the memory state dependent on this node and therefore transitively on the
     // LambdaEntryMemStateOperator. This ensures that the LambdaEntryMemStateOperator is always
     // visited before all other memory state consuming nodes:
@@ -821,12 +822,12 @@ MemoryStateEncoder::EncodeLambdaEntry(const lambda::node & lambdaNode)
     // ... := LAMBDA[f]
     //   [..., a1, ...]
     //     o1, ..., ox := LambdaEntryMemStateOperator a1
-    //     oy = MemStateMergeOperator o1, ..., ox
+    //     oy = MemoryStateMergeOperation o1, ..., ox
     //     ....
     //
     // No other memory state consuming node aside from the LambdaEntryMemStateOperator should now
     // consume a1.
-    auto state = MemStateMergeOperator::Create(states);
+    auto state = MemoryStateMergeOperation::Create(states);
     memoryStateArgumentUser->divert_to(state);
   }
 }

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
@@ -599,7 +599,7 @@ MemoryStateEncoder::EncodeSimpleNode(const rvsdg::simple_node & simpleNode)
   {
     EncodeMemcpy(simpleNode);
   }
-  else if (is<MemStateOperator>(&simpleNode))
+  else if (is<MemoryStateOperation>(&simpleNode))
   {
     // Nothing needs to be done
   }

--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -32,13 +32,13 @@ StoreTest1::SetupRvsdg()
   auto b = alloca_op::create(pointerType, csize, 4);
   auto a = alloca_op::create(pointerType, csize, 4);
 
-  auto merge_d = MemStateMergeOperator::Create({ d[1], fct->fctargument(0) });
+  auto merge_d = MemoryStateMergeOperation::Create({ d[1], fct->fctargument(0) });
   auto merge_c =
-      MemStateMergeOperator::Create(std::vector<jlm::rvsdg::output *>({ c[1], merge_d }));
+      MemoryStateMergeOperation::Create(std::vector<jlm::rvsdg::output *>({ c[1], merge_d }));
   auto merge_b =
-      MemStateMergeOperator::Create(std::vector<jlm::rvsdg::output *>({ b[1], merge_c }));
+      MemoryStateMergeOperation::Create(std::vector<jlm::rvsdg::output *>({ b[1], merge_c }));
   auto merge_a =
-      MemStateMergeOperator::Create(std::vector<jlm::rvsdg::output *>({ a[1], merge_b }));
+      MemoryStateMergeOperation::Create(std::vector<jlm::rvsdg::output *>({ a[1], merge_b }));
 
   auto a_amp_b = StoreNonVolatileNode::Create(a[0], b[0], { merge_a }, 4);
   auto b_amp_c = StoreNonVolatileNode::Create(b[0], c[0], { a_amp_b[0] }, 4);
@@ -87,15 +87,15 @@ StoreTest2::SetupRvsdg()
   auto y = alloca_op::create(pointerType, csize, 4);
   auto p = alloca_op::create(pointerType, csize, 4);
 
-  auto merge_a = MemStateMergeOperator::Create({ a[1], fct->fctargument(0) });
+  auto merge_a = MemoryStateMergeOperation::Create({ a[1], fct->fctargument(0) });
   auto merge_b =
-      MemStateMergeOperator::Create(std::vector<jlm::rvsdg::output *>({ b[1], merge_a }));
+      MemoryStateMergeOperation::Create(std::vector<jlm::rvsdg::output *>({ b[1], merge_a }));
   auto merge_x =
-      MemStateMergeOperator::Create(std::vector<jlm::rvsdg::output *>({ x[1], merge_b }));
+      MemoryStateMergeOperation::Create(std::vector<jlm::rvsdg::output *>({ x[1], merge_b }));
   auto merge_y =
-      MemStateMergeOperator::Create(std::vector<jlm::rvsdg::output *>({ y[1], merge_x }));
+      MemoryStateMergeOperation::Create(std::vector<jlm::rvsdg::output *>({ y[1], merge_x }));
   auto merge_p =
-      MemStateMergeOperator::Create(std::vector<jlm::rvsdg::output *>({ p[1], merge_y }));
+      MemoryStateMergeOperation::Create(std::vector<jlm::rvsdg::output *>({ p[1], merge_y }));
 
   auto x_amp_a = StoreNonVolatileNode::Create(x[0], a[0], { merge_p }, 4);
   auto y_amp_b = StoreNonVolatileNode::Create(y[0], b[0], { x_amp_a[0] }, 4);
@@ -181,15 +181,15 @@ LoadTest2::SetupRvsdg()
   auto y = alloca_op::create(pointerType, csize, 4);
   auto p = alloca_op::create(pointerType, csize, 4);
 
-  auto merge_a = MemStateMergeOperator::Create({ a[1], fct->fctargument(0) });
+  auto merge_a = MemoryStateMergeOperation::Create({ a[1], fct->fctargument(0) });
   auto merge_b =
-      MemStateMergeOperator::Create(std::vector<jlm::rvsdg::output *>({ b[1], merge_a }));
+      MemoryStateMergeOperation::Create(std::vector<jlm::rvsdg::output *>({ b[1], merge_a }));
   auto merge_x =
-      MemStateMergeOperator::Create(std::vector<jlm::rvsdg::output *>({ x[1], merge_b }));
+      MemoryStateMergeOperation::Create(std::vector<jlm::rvsdg::output *>({ x[1], merge_b }));
   auto merge_y =
-      MemStateMergeOperator::Create(std::vector<jlm::rvsdg::output *>({ y[1], merge_x }));
+      MemoryStateMergeOperation::Create(std::vector<jlm::rvsdg::output *>({ y[1], merge_x }));
   auto merge_p =
-      MemStateMergeOperator::Create(std::vector<jlm::rvsdg::output *>({ p[1], merge_y }));
+      MemoryStateMergeOperation::Create(std::vector<jlm::rvsdg::output *>({ p[1], merge_y }));
 
   auto x_amp_a = StoreNonVolatileNode::Create(x[0], a[0], { merge_p }, 4);
   auto y_amp_b = StoreNonVolatileNode::Create(y[0], b[0], x_amp_a, 4);
@@ -535,10 +535,10 @@ CallTest1::SetupRvsdg()
     auto y = alloca_op::create(jlm::rvsdg::bit32, size, 4);
     auto z = alloca_op::create(jlm::rvsdg::bit32, size, 4);
 
-    auto mx = MemStateMergeOperator::Create(
+    auto mx = MemoryStateMergeOperation::Create(
         std::vector<jlm::rvsdg::output *>({ x[1], memoryStateArgument }));
-    auto my = MemStateMergeOperator::Create(std::vector<jlm::rvsdg::output *>({ y[1], mx }));
-    auto mz = MemStateMergeOperator::Create(std::vector<jlm::rvsdg::output *>({ z[1], my }));
+    auto my = MemoryStateMergeOperation::Create(std::vector<jlm::rvsdg::output *>({ y[1], mx }));
+    auto mz = MemoryStateMergeOperation::Create(std::vector<jlm::rvsdg::output *>({ z[1], my }));
 
     auto five = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 5);
     auto six = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 6);
@@ -618,7 +618,7 @@ CallTest2::SetupRvsdg()
 
     auto alloc = malloc_op::create(prod);
     auto cast = bitcast_op::create(alloc[0], pt32);
-    auto mx = MemStateMergeOperator::Create(
+    auto mx = MemoryStateMergeOperation::Create(
         std::vector<jlm::rvsdg::output *>({ alloc[1], memoryStateArgument }));
 
     lambda->finalize({ cast, iOStateArgument, mx });
@@ -968,9 +968,9 @@ IndirectCallTest2::SetupRvsdg()
     auto pxAlloca = alloca_op::create(jlm::rvsdg::bit32, constantSize, 4);
     auto pyAlloca = alloca_op::create(jlm::rvsdg::bit32, constantSize, 4);
 
-    auto pxMerge = MemStateMergeOperator::Create({ pxAlloca[1], memoryStateArgument });
-    auto pyMerge =
-        MemStateMergeOperator::Create(std::vector<jlm::rvsdg::output *>({ pyAlloca[1], pxMerge }));
+    auto pxMerge = MemoryStateMergeOperation::Create({ pxAlloca[1], memoryStateArgument });
+    auto pyMerge = MemoryStateMergeOperation::Create(
+        std::vector<jlm::rvsdg::output *>({ pyAlloca[1], pxMerge }));
 
     auto & callX = CallNode::CreateNode(
         functionXCv,
@@ -1021,7 +1021,7 @@ IndirectCallTest2::SetupRvsdg()
     auto constantSize = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
 
     auto pzAlloca = alloca_op::create(jlm::rvsdg::bit32, constantSize, 4);
-    auto pzMerge = MemStateMergeOperator::Create({ pzAlloca[1], memoryStateArgument });
+    auto pzMerge = MemoryStateMergeOperation::Create({ pzAlloca[1], memoryStateArgument });
 
     auto functionXCv = lambda->add_ctxvar(&functionX);
 
@@ -1123,8 +1123,8 @@ ExternalCallTest1::SetupRvsdg()
     auto allocaPath = alloca_op::create(pointerType, size, 4);
     auto allocaMode = alloca_op::create(pointerType, size, 4);
 
-    auto mergePath = MemStateMergeOperator::Create({ allocaPath[1], memoryStateArgument });
-    auto mergeMode = MemStateMergeOperator::Create(
+    auto mergePath = MemoryStateMergeOperation::Create({ allocaPath[1], memoryStateArgument });
+    auto mergeMode = MemoryStateMergeOperation::Create(
         std::vector<jlm::rvsdg::output *>({ allocaMode[1], mergePath }));
 
     auto storePath = StoreNonVolatileNode::Create(allocaPath[0], pathArgument, { mergeMode }, 4);
@@ -1204,7 +1204,7 @@ ExternalCallTest2::SetupRvsdg()
   auto twentyFour = jlm::rvsdg::create_bitconstant(LambdaG_->subregion(), 64, 24);
 
   auto allocaResults = alloca_op::create(*structType, twentyFour, 16);
-  auto memoryState = MemStateMergeOperator::Create({ allocaResults[1], memoryStateArgument });
+  auto memoryState = MemoryStateMergeOperation::Create({ allocaResults[1], memoryStateArgument });
 
   auto & callLLvmLifetimeStart = CallNode::CreateNode(
       llvmLifetimeStartArgument,
@@ -1375,7 +1375,8 @@ GammaTest2::SetupRvsdg()
 
     auto allocaZResults = alloca_op::create(pointerType, size, 4);
 
-    auto memoryState = MemStateMergeOperator::Create({ allocaZResults[1], memoryStateArgument });
+    auto memoryState =
+        MemoryStateMergeOperation::Create({ allocaZResults[1], memoryStateArgument });
 
     auto nullPointer = ConstantPointerNullOperation::Create(lambda->subregion(), pointerType);
     auto storeZResults =
@@ -1428,8 +1429,9 @@ GammaTest2::SetupRvsdg()
     auto allocaXResults = alloca_op::create(rvsdg::bit32, size, 4);
     auto allocaYResults = alloca_op::create(pointerType, size, 4);
 
-    auto memoryState = MemStateMergeOperator::Create({ allocaXResults[1], memoryStateArgument });
-    memoryState = MemStateMergeOperator::Create(
+    auto memoryState =
+        MemoryStateMergeOperation::Create({ allocaXResults[1], memoryStateArgument });
+    memoryState = MemoryStateMergeOperation::Create(
         std::vector<jlm::rvsdg::output *>({ allocaYResults[1], memoryState }));
 
     auto predicate = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, cValue);
@@ -2036,7 +2038,7 @@ PhiTest1::SetupRvsdg()
 
     auto ten = jlm::rvsdg::create_bitconstant(lambda->subregion(), 64, 10);
     auto allocaResults = alloca_op::create(at, ten, 16);
-    auto state = MemStateMergeOperator::Create({ allocaResults[1], memoryStateArgument });
+    auto state = MemoryStateMergeOperation::Create({ allocaResults[1], memoryStateArgument });
 
     auto zero = jlm::rvsdg::create_bitconstant(lambda->subregion(), 64, 0);
     auto gep = GetElementPtrOperation::Create(allocaResults[0], { zero, zero }, at, pbit64);
@@ -2151,7 +2153,7 @@ PhiTest2::SetupRvsdg()
 
     auto four = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
     auto paAlloca = alloca_op::create(jlm::rvsdg::bit32, four, 4);
-    auto paMerge = MemStateMergeOperator::Create(
+    auto paMerge = MemoryStateMergeOperation::Create(
         std::vector<jlm::rvsdg::output *>({ paAlloca[1], storeNode[0] }));
 
     auto & callB = CallNode::CreateNode(
@@ -2196,7 +2198,7 @@ PhiTest2::SetupRvsdg()
 
     auto four = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
     auto pbAlloca = alloca_op::create(jlm::rvsdg::bit32, four, 4);
-    auto pbMerge = MemStateMergeOperator::Create(
+    auto pbMerge = MemoryStateMergeOperation::Create(
         std::vector<jlm::rvsdg::output *>({ pbAlloca[1], storeNode[0] }));
 
     auto & callI = CallNode::CreateNode(
@@ -2236,7 +2238,7 @@ PhiTest2::SetupRvsdg()
 
     auto four = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
     auto pcAlloca = alloca_op::create(jlm::rvsdg::bit32, four, 4);
-    auto pcMerge = MemStateMergeOperator::Create(
+    auto pcMerge = MemoryStateMergeOperation::Create(
         std::vector<jlm::rvsdg::output *>({ pcAlloca[1], storeNode[0] }));
 
     auto & callA = CallNode::CreateNode(
@@ -2274,7 +2276,7 @@ PhiTest2::SetupRvsdg()
     auto storeNode = StoreNonVolatileNode::Create(xArgument, four, { memoryStateArgument }, 4);
 
     auto pdAlloca = alloca_op::create(jlm::rvsdg::bit32, four, 4);
-    auto pdMerge = MemStateMergeOperator::Create(
+    auto pdMerge = MemoryStateMergeOperation::Create(
         std::vector<jlm::rvsdg::output *>({ pdAlloca[1], storeNode[0] }));
 
     auto & callA = CallNode::CreateNode(
@@ -2355,7 +2357,7 @@ PhiTest2::SetupRvsdg()
 
     auto four = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
     auto pTestAlloca = alloca_op::create(jlm::rvsdg::bit32, four, 4);
-    auto pTestMerge = MemStateMergeOperator::Create(
+    auto pTestMerge = MemoryStateMergeOperation::Create(
         std::vector<jlm::rvsdg::output *>({ pTestAlloca[1], memoryStateArgument }));
 
     auto & callA = CallNode::CreateNode(
@@ -2687,7 +2689,7 @@ EscapedMemoryTest2::SetupRvsdg()
     auto eight = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 8);
 
     auto mallocResults = malloc_op::create(eight);
-    auto mergeResults = MemStateMergeOperator::Create(
+    auto mergeResults = MemoryStateMergeOperation::Create(
         std::vector<jlm::rvsdg::output *>({ memoryStateArgument, mallocResults[1] }));
 
     auto lambdaOutput = lambda->finalize({ mallocResults[0], iOStateArgument, mergeResults });
@@ -2718,7 +2720,7 @@ EscapedMemoryTest2::SetupRvsdg()
     auto eight = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 8);
 
     auto mallocResults = malloc_op::create(eight);
-    auto mergeResult = MemStateMergeOperator::Create(
+    auto mergeResult = MemoryStateMergeOperation::Create(
         std::vector<jlm::rvsdg::output *>({ memoryStateArgument, mallocResults[1] }));
 
     auto & call = CallNode::CreateNode(
@@ -3177,7 +3179,7 @@ MemcpyTest3::SetupRvsdg()
   auto three = jlm::rvsdg::create_bitconstant(Lambda_->subregion(), 64, 3);
 
   auto allocaResults = alloca_op::create(*structType, eight, 8);
-  auto memoryState = MemStateMergeOperator::Create({ allocaResults[1], memoryStateArgument });
+  auto memoryState = MemoryStateMergeOperation::Create({ allocaResults[1], memoryStateArgument });
 
   auto memcpyResults =
       MemCpyNonVolatileOperation::create(allocaResults[0], pArgument, eight, { memoryState });
@@ -3255,7 +3257,7 @@ LinkedListTest::SetupRvsdg()
     auto size = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
 
     auto alloca = alloca_op::create(pointerType, size, 4);
-    auto mergedMemoryState = MemStateMergeOperator::Create({ alloca[1], memoryStateArgument });
+    auto mergedMemoryState = MemoryStateMergeOperation::Create({ alloca[1], memoryStateArgument });
 
     auto load1 = LoadNonVolatileNode::Create(myListArgument, { mergedMemoryState }, pointerType, 4);
     auto store1 = StoreNonVolatileNode::Create(alloca[0], load1[0], { load1[1] }, 4);
@@ -3328,7 +3330,7 @@ AllMemoryNodesTest::SetupRvsdg()
   auto allocaOutputs = alloca_op::create(pointerType, allocaSize, 8);
   Alloca_ = jlm::rvsdg::node_output::node(allocaOutputs[0]);
 
-  auto afterAllocaMemoryState = MemStateMergeOperator::Create(
+  auto afterAllocaMemoryState = MemoryStateMergeOperation::Create(
       std::vector<jlm::rvsdg::output *>{ entryMemoryState, allocaOutputs[1] });
 
   // Create malloc node
@@ -3336,7 +3338,7 @@ AllMemoryNodesTest::SetupRvsdg()
   auto mallocOutputs = malloc_op::create(mallocSize);
   Malloc_ = jlm::rvsdg::node_output::node(mallocOutputs[0]);
 
-  auto afterMallocMemoryState = MemStateMergeOperator::Create(
+  auto afterMallocMemoryState = MemoryStateMergeOperation::Create(
       std::vector<jlm::rvsdg::output *>{ afterAllocaMemoryState, mallocOutputs[1] });
 
   // Store the result of malloc into the alloca'd memory
@@ -3407,7 +3409,7 @@ NAllocaNodesTest::SetupRvsdg()
 
     // Update latestMemoryState to include the alloca memory state output
     latestMemoryState =
-        MemStateMergeOperator::Create(std::vector{ latestMemoryState, allocaOutputs[1] });
+        MemoryStateMergeOperation::Create(std::vector{ latestMemoryState, allocaOutputs[1] });
   }
 
   Function_->finalize({ latestMemoryState });
@@ -3455,7 +3457,7 @@ EscapingLocalFunctionTest::SetupRvsdg()
   LocalFuncParamAllocaNode_ = rvsdg::node_output::node(allocaOutputs[0]);
 
   // Merge function's input Memory State and alloca node's memory state
-  rvsdg::output * mergedMemoryState = MemStateMergeOperator::Create(
+  rvsdg::output * mergedMemoryState = MemoryStateMergeOperation::Create(
       std::vector<rvsdg::output *>{ LocalFunc_->fctargument(1), allocaOutputs[1] });
 
   // Store the function parameter into the alloca node
@@ -3571,7 +3573,7 @@ LambdaCallArgumentMismatch::SetupRvsdg()
 
     auto allocaResults = alloca_op::create(rvsdg::bit32, one, 4);
 
-    auto memoryState = MemStateMergeOperator::Create(
+    auto memoryState = MemoryStateMergeOperation::Create(
         std::vector<rvsdg::output *>{ memoryStateArgument, allocaResults[1] });
 
     auto storeResults = StoreNonVolatileNode::Create(allocaResults[0], six, { memoryState }, 4);
@@ -3660,7 +3662,7 @@ VariadicFunctionTest1::SetupRvsdg()
     auto five = jlm::rvsdg::create_bitconstant(LambdaG_->subregion(), 32, 5);
 
     auto allocaResults = alloca_op::create(rvsdg::bit32, one, 4);
-    auto merge = MemStateMergeOperator::Create({ allocaResults[1], memoryStateArgument });
+    auto merge = MemoryStateMergeOperation::Create({ allocaResults[1], memoryStateArgument });
     AllocaNode_ = rvsdg::node_output::node(allocaResults[0]);
 
     auto storeResults = StoreNonVolatileNode::Create(allocaResults[0], five, { merge }, 4);
@@ -3738,7 +3740,7 @@ VariadicFunctionTest2::SetupRvsdg()
     auto fortyOne = jlm::rvsdg::create_bitconstant(LambdaFst_->subregion(), 32, 41);
 
     auto allocaResults = alloca_op::create(arrayType, one, 16);
-    auto memoryState = MemStateMergeOperator::Create({ allocaResults[1], memoryStateArgument });
+    auto memoryState = MemoryStateMergeOperation::Create({ allocaResults[1], memoryStateArgument });
     AllocaNode_ = rvsdg::node_output::node(allocaResults[0]);
 
     auto & callLLvmLifetimeStart = CallNode::CreateNode(

--- a/tests/jlm/llvm/frontend/llvm/test-function-call.cpp
+++ b/tests/jlm/llvm/frontend/llvm/test-function-call.cpp
@@ -114,7 +114,7 @@ test_malloc_call()
     }
 
     auto bb = dynamic_cast<const basic_block *>(cfg->entry()->outedge(0)->sink());
-    assert(is<MemStateMergeOperator>(*std::next(bb->rbegin())));
+    assert(is<MemoryStateMergeOperation>(*std::next(bb->rbegin())));
     assert(is<malloc_op>((*std::next(bb->rbegin(), 2))));
   };
 

--- a/tests/jlm/llvm/ir/operators/LoadTests.cpp
+++ b/tests/jlm/llvm/ir/operators/LoadTests.cpp
@@ -289,12 +289,12 @@ TestLoadLoadReduction()
   assert(is<LoadNonVolatileOperation>(ld));
 
   auto mx1 = jlm::rvsdg::node_output::node(x2->origin());
-  assert(is<MemStateMergeOperator>(mx1) && mx1->ninputs() == 2);
+  assert(is<MemoryStateMergeOperation>(mx1) && mx1->ninputs() == 2);
   assert(mx1->input(0)->origin() == ld1[1] || mx1->input(0)->origin() == ld->output(2));
   assert(mx1->input(1)->origin() == ld1[1] || mx1->input(1)->origin() == ld->output(2));
 
   auto mx2 = jlm::rvsdg::node_output::node(x3->origin());
-  assert(is<MemStateMergeOperator>(mx2) && mx2->ninputs() == 2);
+  assert(is<MemoryStateMergeOperation>(mx2) && mx2->ninputs() == 2);
   assert(mx2->input(0)->origin() == ld2[1] || mx2->input(0)->origin() == ld->output(3));
   assert(mx2->input(1)->origin() == ld2[1] || mx2->input(1)->origin() == ld->output(3));
 }

--- a/tests/jlm/llvm/ir/operators/MemoryStateOperationTests.cpp
+++ b/tests/jlm/llvm/ir/operators/MemoryStateOperationTests.cpp
@@ -84,8 +84,8 @@ LambdaExitMemStateOperatorEquality()
 
   // Arrange
   jlm::llvm::MemoryStateType memoryStateType;
-  LambdaExitMemStateOperator operation1(2);
-  LambdaExitMemStateOperator operation2(4);
+  LambdaExitMemoryStateMergeOperation operation1(2);
+  LambdaExitMemoryStateMergeOperation operation2(4);
   jlm::tests::test_op operation3({ &memoryStateType, &memoryStateType }, { &memoryStateType });
 
   // Act & Assert

--- a/tests/jlm/llvm/ir/operators/MemoryStateOperationTests.cpp
+++ b/tests/jlm/llvm/ir/operators/MemoryStateOperationTests.cpp
@@ -38,8 +38,8 @@ MemoryStateMergeEquality()
 
   // Arrange
   MemoryStateType memoryStateType;
-  MemStateMergeOperator operation1(2);
-  MemStateMergeOperator operation2(4);
+  MemoryStateMergeOperation operation1(2);
+  MemoryStateMergeOperation operation2(4);
   jlm::tests::test_op operation3({ &memoryStateType, &memoryStateType }, { &memoryStateType });
 
   // Act & Assert

--- a/tests/jlm/llvm/ir/operators/MemoryStateOperationTests.cpp
+++ b/tests/jlm/llvm/ir/operators/MemoryStateOperationTests.cpp
@@ -107,8 +107,8 @@ CallEntryMemStateOperatorEquality()
 
   // Arrange
   jlm::llvm::MemoryStateType memoryStateType;
-  CallEntryMemStateOperator operation1(2);
-  CallEntryMemStateOperator operation2(4);
+  CallEntryMemoryStateMergeOperation operation1(2);
+  CallEntryMemoryStateMergeOperation operation2(4);
   jlm::tests::test_op operation3({ &memoryStateType, &memoryStateType }, { &memoryStateType });
 
   // Act & Assert

--- a/tests/jlm/llvm/ir/operators/MemoryStateOperationTests.cpp
+++ b/tests/jlm/llvm/ir/operators/MemoryStateOperationTests.cpp
@@ -61,8 +61,8 @@ LambdaEntryMemStateOperatorEquality()
 
   // Arrange
   jlm::llvm::MemoryStateType memoryStateType;
-  LambdaEntryMemStateOperator operation1(2);
-  LambdaEntryMemStateOperator operation2(4);
+  LambdaEntryMemoryStateSplitOperation operation1(2);
+  LambdaEntryMemoryStateSplitOperation operation2(4);
   jlm::tests::test_op operation3({ &memoryStateType }, { &memoryStateType, &memoryStateType });
 
   // Act & Assert

--- a/tests/jlm/llvm/ir/operators/MemoryStateOperationTests.cpp
+++ b/tests/jlm/llvm/ir/operators/MemoryStateOperationTests.cpp
@@ -15,8 +15,8 @@ MemoryStateSplitEquality()
 
   // Arrange
   MemoryStateType memoryStateType;
-  MemStateSplitOperator operation1(2);
-  MemStateSplitOperator operation2(4);
+  MemoryStateSplitOperation operation1(2);
+  MemoryStateSplitOperation operation2(4);
   jlm::tests::test_op operation3({ &memoryStateType }, { &memoryStateType, &memoryStateType });
 
   // Act & Assert

--- a/tests/jlm/llvm/ir/operators/MemoryStateOperationTests.cpp
+++ b/tests/jlm/llvm/ir/operators/MemoryStateOperationTests.cpp
@@ -130,8 +130,8 @@ CallExitMemStateOperatorEquality()
 
   // Arrange
   jlm::llvm::MemoryStateType memoryStateType;
-  CallExitMemStateOperator operation1(2);
-  CallExitMemStateOperator operation2(4);
+  CallExitMemoryStateSplitOperation operation1(2);
+  CallExitMemoryStateSplitOperation operation2(4);
   jlm::tests::test_op operation3({ &memoryStateType }, { &memoryStateType, &memoryStateType });
 
   // Act & Assert

--- a/tests/jlm/llvm/ir/operators/StoreTests.cpp
+++ b/tests/jlm/llvm/ir/operators/StoreTests.cpp
@@ -225,7 +225,7 @@ TestStoreMuxReduction()
   auto s2 = graph.add_import({ mt, "s2" });
   auto s3 = graph.add_import({ mt, "s3" });
 
-  auto mux = MemStateMergeOperator::Create({ s1, s2, s3 });
+  auto mux = MemoryStateMergeOperation::Create({ s1, s2, s3 });
   auto state = StoreNonVolatileNode::Create(a, v, { mux }, 4);
 
   auto ex = graph.add_export(state[0], { state[0]->type(), "s" });
@@ -242,7 +242,7 @@ TestStoreMuxReduction()
 
   // Assert
   auto muxnode = jlm::rvsdg::node_output::node(ex->origin());
-  assert(is<MemStateMergeOperator>(muxnode));
+  assert(is<MemoryStateMergeOperation>(muxnode));
   assert(muxnode->ninputs() == 3);
   auto n0 = jlm::rvsdg::node_output::node(muxnode->input(0)->origin());
   auto n1 = jlm::rvsdg::node_output::node(muxnode->input(1)->origin());

--- a/tests/jlm/llvm/opt/TestLoadMuxReduction.cpp
+++ b/tests/jlm/llvm/opt/TestLoadMuxReduction.cpp
@@ -31,7 +31,7 @@ TestSuccess()
   auto s2 = graph.add_import({ mt, "s2" });
   auto s3 = graph.add_import({ mt, "s3" });
 
-  auto mux = MemStateMergeOperator::Create({ s1, s2, s3 });
+  auto mux = MemoryStateMergeOperation::Create({ s1, s2, s3 });
   auto ld = LoadNonVolatileNode::Create(a, { mux }, vt, 4);
 
   auto ex1 = graph.add_export(ld[0], { ld[0]->type(), "v" });
@@ -56,7 +56,7 @@ TestSuccess()
   assert(load->input(3)->origin() == s3);
 
   auto merge = jlm::rvsdg::node_output::node(ex2->origin());
-  assert(is<MemStateMergeOperator>(merge));
+  assert(is<MemoryStateMergeOperation>(merge));
   assert(merge->ninputs() == 3);
   for (size_t n = 0; n < merge->ninputs(); n++)
   {
@@ -84,7 +84,7 @@ TestWrongNumberOfOperands()
   auto s1 = graph.add_import({ mt, "s1" });
   auto s2 = graph.add_import({ mt, "s2" });
 
-  auto merge = MemStateMergeOperator::Create(std::vector<jlm::rvsdg::output *>{ s1, s2 });
+  auto merge = MemoryStateMergeOperation::Create(std::vector<jlm::rvsdg::output *>{ s1, s2 });
   auto ld = LoadNonVolatileNode::Create(a, { merge, merge }, vt, 4);
 
   auto ex1 = graph.add_export(ld[0], { ld[0]->type(), "v" });

--- a/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
@@ -80,7 +80,7 @@ ValidateStoreTest1SteensgaardAgnostic(const jlm::tests::StoreTest1 & test)
   assert(test.lambda->subregion()->nnodes() == 10);
 
   auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
-  assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 6, 1));
+  assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 6, 1));
 
   assert(test.alloca_d->output(1)->nusers() == 1);
   assert(test.alloca_c->output(1)->nusers() == 1);
@@ -113,7 +113,7 @@ ValidateStoreTest1SteensgaardRegionAware(const jlm::tests::StoreTest1 & test)
   assert(test.lambda->subregion()->nnodes() == 9);
 
   auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
-  assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 4, 1));
+  assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 4, 1));
 
   assert(test.alloca_d->output(1)->nusers() == 1);
   assert(test.alloca_c->output(1)->nusers() == 1);
@@ -146,7 +146,7 @@ ValidateStoreTest1SteensgaardAgnosticTopDown(const jlm::tests::StoreTest1 & test
   assert(test.lambda->subregion()->nnodes() == 2);
 
   auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
-  assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
+  assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
   auto lambdaEntrySplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
@@ -161,7 +161,7 @@ ValidateStoreTest2SteensgaardAgnostic(const jlm::tests::StoreTest2 & test)
   assert(test.lambda->subregion()->nnodes() == 12);
 
   auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
-  assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 7, 1));
+  assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 7, 1));
 
   assert(test.alloca_a->output(1)->nusers() == 1);
   assert(test.alloca_b->output(1)->nusers() == 1);
@@ -201,7 +201,7 @@ ValidateStoreTest2SteensgaardRegionAware(const jlm::tests::StoreTest2 & test)
   assert(test.lambda->subregion()->nnodes() == 11);
 
   auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
-  assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 5, 1));
+  assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
 
   assert(test.alloca_a->output(1)->nusers() == 1);
   assert(test.alloca_b->output(1)->nusers() == 1);
@@ -241,7 +241,7 @@ ValidateStoreTest2SteensgaardAgnosticTopDown(const jlm::tests::StoreTest2 & test
   assert(test.lambda->subregion()->nnodes() == 2);
 
   auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
-  assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
+  assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
   auto lambdaEntrySplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
@@ -256,7 +256,7 @@ ValidateLoadTest1SteensgaardAgnostic(const jlm::tests::LoadTest1 & test)
   assert(test.lambda->subregion()->nnodes() == 4);
 
   auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(1)->origin());
-  assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
+  assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
   auto lambdaEntrySplit = input_node(*test.lambda->fctargument(1)->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
@@ -280,7 +280,7 @@ ValidateLoadTest1SteensgaardRegionAware(const jlm::tests::LoadTest1 & test)
   assert(test.lambda->subregion()->nnodes() == 4);
 
   auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(1)->origin());
-  assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
+  assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
   auto lambdaEntrySplit = input_node(*test.lambda->fctargument(1)->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
@@ -304,7 +304,7 @@ ValidateLoadTest1SteensgaardAgnosticTopDown(const jlm::tests::LoadTest1 & test)
   assert(test.lambda->subregion()->nnodes() == 4);
 
   auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(1)->origin());
-  assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
+  assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
   auto lambdaEntrySplit = input_node(*test.lambda->fctargument(1)->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
@@ -328,7 +328,7 @@ ValidateLoadTest2SteensgaardAgnostic(const jlm::tests::LoadTest2 & test)
   assert(test.lambda->subregion()->nnodes() == 14);
 
   auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
-  assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 7, 1));
+  assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 7, 1));
 
   assert(test.alloca_a->output(1)->nusers() == 1);
   assert(test.alloca_b->output(1)->nusers() == 1);
@@ -378,7 +378,7 @@ ValidateLoadTest2SteensgaardRegionAware(const jlm::tests::LoadTest2 & test)
   assert(test.lambda->subregion()->nnodes() == 13);
 
   auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
-  assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 5, 1));
+  assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
 
   assert(test.alloca_a->output(1)->nusers() == 1);
   assert(test.alloca_b->output(1)->nusers() == 1);
@@ -425,7 +425,7 @@ ValidateLoadTest2SteensgaardAgnosticTopDown(const jlm::tests::LoadTest2 & test)
   assert(test.lambda->subregion()->nnodes() == 2);
 
   auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
-  assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
+  assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
   auto lambdaEntrySplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
@@ -440,7 +440,7 @@ ValidateLoadFromUndefSteensgaardAgnostic(const jlm::tests::LoadFromUndefTest & t
   assert(test.Lambda().subregion()->nnodes() == 4);
 
   auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.Lambda().fctresult(1)->origin());
-  assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
+  assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
   auto load = jlm::rvsdg::node_output::node(test.Lambda().fctresult(0)->origin());
   assert(is<LoadNonVolatileOperation>(*load, 1, 1));
@@ -457,7 +457,7 @@ ValidateLoadFromUndefSteensgaardRegionAware(const jlm::tests::LoadFromUndefTest 
   assert(test.Lambda().subregion()->nnodes() == 3);
 
   auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.Lambda().fctresult(1)->origin());
-  assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 0, 1));
+  assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 0, 1));
 
   auto load = jlm::rvsdg::node_output::node(test.Lambda().fctresult(0)->origin());
   assert(is<LoadNonVolatileOperation>(*load, 1, 1));
@@ -471,7 +471,7 @@ ValidateLoadFromUndefSteensgaardAgnosticTopDown(const jlm::tests::LoadFromUndefT
   assert(test.Lambda().subregion()->nnodes() == 4);
 
   auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.Lambda().fctresult(1)->origin());
-  assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
+  assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
   auto load = jlm::rvsdg::node_output::node(test.Lambda().fctresult(0)->origin());
   assert(is<LoadNonVolatileOperation>(*load, 1, 1));
@@ -492,7 +492,7 @@ ValidateCallTest1SteensgaardAgnostic(const jlm::tests::CallTest1 & test)
     auto loadX = input_node(*test.lambda_f->fctargument(0)->begin());
     auto loadY = input_node(*test.lambda_f->fctargument(1)->begin());
 
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 7, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 7, 1));
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 7));
 
     assert(is<LoadNonVolatileOperation>(*loadX, 2, 2));
@@ -509,7 +509,7 @@ ValidateCallTest1SteensgaardAgnostic(const jlm::tests::CallTest1 & test)
     auto loadX = input_node(*test.lambda_g->fctargument(0)->begin());
     auto loadY = input_node(*test.lambda_g->fctargument(1)->begin());
 
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 7, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 7, 1));
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 7));
 
     assert(is<LoadNonVolatileOperation>(*loadX, 2, 2));
@@ -547,7 +547,7 @@ ValidateCallTest1SteensgaardRegionAware(const jlm::tests::CallTest1 & test)
     auto loadX = input_node(*test.lambda_f->fctargument(0)->begin());
     auto loadY = input_node(*test.lambda_f->fctargument(1)->begin());
 
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 
     assert(is<LoadNonVolatileOperation>(*loadX, 2, 2));
@@ -564,7 +564,7 @@ ValidateCallTest1SteensgaardRegionAware(const jlm::tests::CallTest1 & test)
     auto loadX = input_node(*test.lambda_g->fctargument(0)->begin());
     auto loadY = input_node(*test.lambda_g->fctargument(1)->begin());
 
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 1, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 1, 1));
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 1));
 
     assert(is<LoadNonVolatileOperation>(*loadX, 2, 2));
@@ -602,7 +602,7 @@ ValidateCallTest1SteensgaardAgnosticTopDown(const jlm::tests::CallTest1 & test)
     auto loadX = input_node(*test.lambda_f->fctargument(0)->begin());
     auto loadY = input_node(*test.lambda_f->fctargument(1)->begin());
 
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 7, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 7, 1));
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 7));
 
     assert(is<LoadNonVolatileOperation>(*loadX, 2, 2));
@@ -619,7 +619,7 @@ ValidateCallTest1SteensgaardAgnosticTopDown(const jlm::tests::CallTest1 & test)
     auto loadX = input_node(*test.lambda_g->fctargument(0)->begin());
     auto loadY = input_node(*test.lambda_g->fctargument(1)->begin());
 
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 7, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 7, 1));
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 7));
 
     assert(is<LoadNonVolatileOperation>(*loadX, 2, 2));
@@ -661,7 +661,7 @@ ValidateCallTest2SteensgaardAgnostic(const jlm::tests::CallTest2 & test)
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
 
     auto lambdaExitMerge = input_node(*stateMerge->output(0)->begin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 5, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
 
     auto mallocStateLambdaEntryIndex = stateMerge->input(1)->origin()->index();
     auto mallocStateLambdaExitIndex = (*stateMerge->output(0)->begin())->index();
@@ -695,7 +695,7 @@ ValidateCallTest2SteensgaardRegionAware(const jlm::tests::CallTest2 & test)
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 1));
 
     auto lambdaExitMerge = input_node(*stateMerge->output(0)->begin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 1, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 1, 1));
 
     auto mallocStateLambdaEntryIndex = stateMerge->input(1)->origin()->index();
     auto mallocStateLambdaExitIndex = (*stateMerge->output(0)->begin())->index();
@@ -729,7 +729,7 @@ ValidateCallTest2SteensgaardAgnosticTopDown(const jlm::tests::CallTest2 & test)
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
 
     auto lambdaExitMerge = input_node(*stateMerge->output(0)->begin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 5, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
   }
 
   // validate destroy function
@@ -754,7 +754,7 @@ ValidateIndirectCallTest1SteensgaardAgnostic(const jlm::tests::IndirectCallTest1
 
     auto lambda_exit_mux =
         jlm::rvsdg::node_output::node(test.GetLambdaIndcall().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambda_exit_mux, 5, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambda_exit_mux, 5, 1));
 
     auto call_exit_mux = jlm::rvsdg::node_output::node(lambda_exit_mux->input(0)->origin());
     assert(is<CallExitMemStateOperator>(*call_exit_mux, 1, 5));
@@ -775,7 +775,7 @@ ValidateIndirectCallTest1SteensgaardAgnostic(const jlm::tests::IndirectCallTest1
 
     auto lambda_exit_mux =
         jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambda_exit_mux, 5, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambda_exit_mux, 5, 1));
 
     auto call_exit_mux = jlm::rvsdg::node_output::node(lambda_exit_mux->input(0)->origin());
     assert(is<CallExitMemStateOperator>(*call_exit_mux, 1, 5));
@@ -811,7 +811,7 @@ ValidateIndirectCallTest1SteensgaardRegionAware(const jlm::tests::IndirectCallTe
 
     auto lambdaExitMerge =
         jlm::rvsdg::node_output::node(test.GetLambdaIndcall().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 1, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 1, 1));
 
     auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
     assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 1));
@@ -832,7 +832,7 @@ ValidateIndirectCallTest1SteensgaardRegionAware(const jlm::tests::IndirectCallTe
 
     auto lambdaExitMerge =
         jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 1, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 1, 1));
 
     auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
     assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 1));
@@ -868,7 +868,7 @@ ValidateIndirectCallTest1SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
 
     auto lambda_exit_mux =
         jlm::rvsdg::node_output::node(test.GetLambdaIndcall().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambda_exit_mux, 5, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambda_exit_mux, 5, 1));
 
     auto call_exit_mux = jlm::rvsdg::node_output::node(lambda_exit_mux->input(0)->origin());
     assert(is<CallExitMemStateOperator>(*call_exit_mux, 1, 5));
@@ -889,7 +889,7 @@ ValidateIndirectCallTest1SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
 
     auto lambda_exit_mux =
         jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambda_exit_mux, 5, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambda_exit_mux, 5, 1));
 
     auto call_exit_mux = jlm::rvsdg::node_output::node(lambda_exit_mux->input(0)->origin());
     assert(is<CallExitMemStateOperator>(*call_exit_mux, 1, 5));
@@ -925,7 +925,7 @@ ValidateIndirectCallTest2SteensgaardAgnostic(const jlm::tests::IndirectCallTest2
 
     auto lambdaExitMerge =
         jlm::rvsdg::node_output::node(test.GetLambdaThree().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 13, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 13, 1));
 
     auto lambdaEntrySplit = input_node(*test.GetLambdaThree().fctargument(1)->begin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 13));
@@ -937,7 +937,7 @@ ValidateIndirectCallTest2SteensgaardAgnostic(const jlm::tests::IndirectCallTest2
 
     auto lambdaExitMerge =
         jlm::rvsdg::node_output::node(test.GetLambdaFour().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 13, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 13, 1));
 
     auto lambdaEntrySplit = input_node(*test.GetLambdaFour().fctargument(1)->begin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 13));
@@ -948,7 +948,7 @@ ValidateIndirectCallTest2SteensgaardAgnostic(const jlm::tests::IndirectCallTest2
     assert(test.GetLambdaI().subregion()->nnodes() == 5);
 
     auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaI().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 13, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 13, 1));
 
     auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
     assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 13));
@@ -972,7 +972,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
 
     auto lambdaExitMerge =
         jlm::rvsdg::node_output::node(test.GetLambdaThree().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 0, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 0, 1));
   }
 
   // validate function four()
@@ -981,7 +981,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
 
     auto lambdaExitMerge =
         jlm::rvsdg::node_output::node(test.GetLambdaFour().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 0, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 0, 1));
   }
 
   // validate function i()
@@ -989,7 +989,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(test.GetLambdaI().subregion()->nnodes() == 5);
 
     auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaI().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 6, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 6, 1));
 
     auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
     assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 6));
@@ -1006,7 +1006,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(test.GetLambdaX().subregion()->nnodes() == 7);
 
     auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaX().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 6, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 6, 1));
 
     auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
     assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 6));
@@ -1043,7 +1043,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(test.GetLambdaY().subregion()->nnodes() == 7);
 
     auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaY().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 6, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 6, 1));
 
     auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
     assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 6));
@@ -1080,7 +1080,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
 
     auto lambdaExitMerge =
         jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 6, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 6, 1));
 
     auto loadG1 = input_node(*test.GetLambdaTest().cvargument(2)->begin());
     assert(is<LoadNonVolatileOperation>(*loadG1, 2, 2));
@@ -1098,7 +1098,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
 
     auto lambdaExitMerge =
         jlm::rvsdg::node_output::node(test.GetLambdaTest2().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 6, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 6, 1));
 
     auto lambdaEntrySplit = input_node(*test.GetLambdaTest().fctargument(1)->begin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 6));
@@ -1116,7 +1116,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
 
     auto lambdaExitMerge =
         jlm::rvsdg::node_output::node(test.GetLambdaThree().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 13, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 13, 1));
 
     auto lambdaEntrySplit = input_node(*test.GetLambdaThree().fctargument(1)->begin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 13));
@@ -1128,7 +1128,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
 
     auto lambdaExitMerge =
         jlm::rvsdg::node_output::node(test.GetLambdaFour().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 13, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 13, 1));
 
     auto lambdaEntrySplit = input_node(*test.GetLambdaFour().fctargument(1)->begin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 13));
@@ -1139,7 +1139,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(test.GetLambdaI().subregion()->nnodes() == 5);
 
     auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaI().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 13, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 13, 1));
 
     auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
     assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 13));
@@ -1156,7 +1156,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(test.GetLambdaX().subregion()->nnodes() == 7);
 
     auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaX().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 13, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 13, 1));
 
     auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
     assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 13));
@@ -1193,7 +1193,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(test.GetLambdaY().subregion()->nnodes() == 8);
 
     auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaY().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 12, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 12, 1));
 
     auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
     assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 13));
@@ -1237,7 +1237,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
 
     auto lambdaExitMerge =
         jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 10, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 10, 1));
 
     auto loadG1 = input_node(*test.GetLambdaTest().cvargument(2)->begin());
     assert(is<LoadNonVolatileOperation>(*loadG1, 2, 2));
@@ -1274,7 +1274,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
 
     auto lambdaExitMerge =
         jlm::rvsdg::node_output::node(test.GetLambdaTest2().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 10, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 10, 1));
 
     auto callXEntryMerge = jlm::rvsdg::node_output::node(test.GetTest2CallX().input(3)->origin());
     assert(is<CallEntryMemStateOperator>(*callXEntryMerge, 13, 1));
@@ -1309,7 +1309,7 @@ ValidateGammaTestSteensgaardAgnostic(const jlm::tests::GammaTest & test)
   using namespace jlm::llvm;
 
   auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(1)->origin());
-  assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
+  assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
   auto loadTmp2 = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
   assert(is<LoadNonVolatileOperation>(*loadTmp2, 3, 3));
@@ -1327,7 +1327,7 @@ ValidateGammaTestSteensgaardRegionAware(const jlm::tests::GammaTest & test)
   using namespace jlm::llvm;
 
   auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(1)->origin());
-  assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
+  assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
   auto loadTmp2 = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
   assert(is<LoadNonVolatileOperation>(*loadTmp2, 3, 3));
@@ -1345,7 +1345,7 @@ ValidateGammaTestSteensgaardAgnosticTopDown(const jlm::tests::GammaTest & test)
   using namespace jlm::llvm;
 
   auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(1)->origin());
-  assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
+  assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
   auto loadTmp2 = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
   assert(is<LoadNonVolatileOperation>(*loadTmp2, 3, 3));
@@ -1365,7 +1365,7 @@ ValidateThetaTestSteensgaardAgnostic(const jlm::tests::ThetaTest & test)
   assert(test.lambda->subregion()->nnodes() == 4);
 
   auto lambda_exit_mux = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
-  assert(is<LambdaExitMemStateOperator>(*lambda_exit_mux, 2, 1));
+  assert(is<LambdaExitMemoryStateMergeOperation>(*lambda_exit_mux, 2, 1));
 
   auto thetaOutput =
       jlm::util::AssertedCast<jlm::rvsdg::theta_output>(lambda_exit_mux->input(0)->origin());
@@ -1389,7 +1389,7 @@ ValidateThetaTestSteensgaardRegionAware(const jlm::tests::ThetaTest & test)
   assert(test.lambda->subregion()->nnodes() == 4);
 
   auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
-  assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
+  assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
   auto thetaOutput =
       jlm::util::AssertedCast<jlm::rvsdg::theta_output>(lambdaExitMerge->input(0)->origin());
@@ -1413,7 +1413,7 @@ ValidateThetaTestSteensgaardAgnosticTopDown(const jlm::tests::ThetaTest & test)
   assert(test.lambda->subregion()->nnodes() == 4);
 
   auto lambda_exit_mux = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
-  assert(is<LambdaExitMemStateOperator>(*lambda_exit_mux, 2, 1));
+  assert(is<LambdaExitMemoryStateMergeOperation>(*lambda_exit_mux, 2, 1));
 
   auto thetaOutput =
       jlm::util::AssertedCast<jlm::rvsdg::theta_output>(lambda_exit_mux->input(0)->origin());
@@ -1526,7 +1526,7 @@ ValidateDeltaTest2SteensgaardRegionAware(const jlm::tests::DeltaTest2 & test)
     assert(test.lambda_f1->subregion()->nnodes() == 4);
 
     auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda_f1->fctresult(1)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 1, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 1, 1));
 
     auto storeNode = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
     assert(is<StoreNonVolatileOperation>(*storeNode, 3, 1));
@@ -1560,7 +1560,7 @@ ValidateDeltaTest2SteensgaardRegionAware(const jlm::tests::DeltaTest2 & test)
     assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 1));
 
     auto lambdaExitMerge = input_node(*callExitSplit->output(0)->begin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
   }
 }
 
@@ -1599,7 +1599,7 @@ ValidateDeltaTest3SteensgaardAgnostic(const jlm::tests::DeltaTest3 & test)
     assert(test.LambdaF().subregion()->nnodes() == 6);
 
     auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.LambdaF().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 5, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
 
     auto truncNode = jlm::rvsdg::node_output::node(test.LambdaF().fctresult(0)->origin());
     assert(is<trunc_op>(*truncNode, 1, 1));
@@ -1641,7 +1641,7 @@ ValidateDeltaTest3SteensgaardRegionAware(const jlm::tests::DeltaTest3 & test)
     assert(test.LambdaF().subregion()->nnodes() == 6);
 
     auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.LambdaF().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
     auto truncNode = jlm::rvsdg::node_output::node(test.LambdaF().fctresult(0)->origin());
     assert(is<trunc_op>(*truncNode, 1, 1));
@@ -1683,7 +1683,7 @@ ValidateDeltaTest3SteensgaardAgnosticTopDown(const jlm::tests::DeltaTest3 & test
     assert(test.LambdaF().subregion()->nnodes() == 6);
 
     auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.LambdaF().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 5, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
 
     auto truncNode = jlm::rvsdg::node_output::node(test.LambdaF().fctresult(0)->origin());
     assert(is<trunc_op>(*truncNode, 1, 1));
@@ -1752,7 +1752,7 @@ ValidateImportTestSteensgaardRegionAware(const jlm::tests::ImportTest & test)
     assert(test.lambda_f1->subregion()->nnodes() == 4);
 
     auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda_f1->fctresult(1)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 1, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 1, 1));
 
     auto storeNode = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
     assert(is<StoreNonVolatileOperation>(*storeNode, 3, 1));
@@ -1786,7 +1786,7 @@ ValidateImportTestSteensgaardRegionAware(const jlm::tests::ImportTest & test)
     assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 1));
 
     auto lambdaExitMerge = input_node(*callExitSplit->output(0)->begin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
   }
 }
 
@@ -1827,7 +1827,7 @@ ValidatePhiTestSteensgaardAgnostic(const jlm::tests::PhiTest1 & test)
   auto arrayStateIndex = (*test.alloca->output(1)->begin())->index();
 
   auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda_fib->fctresult(1)->origin());
-  assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 4, 1));
+  assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 4, 1));
 
   auto store = jlm::rvsdg::node_output::node(lambdaExitMerge->input(arrayStateIndex)->origin());
   assert(is<StoreNonVolatileOperation>(*store, 3, 1));
@@ -1855,7 +1855,7 @@ ValidatePhiTestSteensgaardRegionAware(const jlm::tests::PhiTest1 & test)
   auto arrayStateIndex = (*test.alloca->output(1)->begin())->index();
 
   auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda_fib->fctresult(1)->origin());
-  assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 1, 1));
+  assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 1, 1));
 
   auto store = jlm::rvsdg::node_output::node(lambdaExitMerge->input(arrayStateIndex)->origin());
   assert(is<StoreNonVolatileOperation>(*store, 3, 1));
@@ -1881,7 +1881,7 @@ ValidatePhiTestSteensgaardAgnosticTopDown(const jlm::tests::PhiTest1 & test)
   using namespace jlm::llvm;
 
   auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda_fib->fctresult(1)->origin());
-  assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 4, 1));
+  assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 4, 1));
 
   const StoreNonVolatileNode * storeNode = nullptr;
   const jlm::rvsdg::gamma_node * gammaNode = nullptr;
@@ -1925,7 +1925,7 @@ ValidateMemcpySteensgaardAgnostic(const jlm::tests::MemcpyTest & test)
    */
   {
     auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.LambdaF().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 5, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
 
     auto load = jlm::rvsdg::node_output::node(test.LambdaF().fctresult(0)->origin());
     assert(is<LoadNonVolatileOperation>(*load, 3, 3));
@@ -1942,7 +1942,7 @@ ValidateMemcpySteensgaardAgnostic(const jlm::tests::MemcpyTest & test)
    */
   {
     auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.LambdaG().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 5, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
 
     auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
     assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 5));
@@ -1978,7 +1978,7 @@ ValidateMemcpySteensgaardRegionAware(const jlm::tests::MemcpyTest & test)
    */
   {
     auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.LambdaF().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
     auto load = jlm::rvsdg::node_output::node(test.LambdaF().fctresult(0)->origin());
     assert(is<LoadNonVolatileOperation>(*load, 3, 3));
@@ -2011,7 +2011,7 @@ ValidateMemcpySteensgaardRegionAware(const jlm::tests::MemcpyTest & test)
     assert(jlm::rvsdg::node_output::node(memcpyNode->input(5)->origin()) == lambdaEntrySplit);
 
     auto lambdaExitMerge = input_node(*callExitSplit->output(0)->begin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
   }
 }
 
@@ -2023,7 +2023,7 @@ ValidateMemcpyTestSteensgaardAgnosticTopDown(const jlm::tests::MemcpyTest & test
   // Validate function f
   {
     auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.LambdaF().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 5, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
 
     auto load = jlm::rvsdg::node_output::node(test.LambdaF().fctresult(0)->origin());
     assert(is<LoadNonVolatileOperation>(*load, 3, 3));
@@ -2038,7 +2038,7 @@ ValidateMemcpyTestSteensgaardAgnosticTopDown(const jlm::tests::MemcpyTest & test
   // Validate function g
   {
     auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.LambdaG().fctresult(2)->origin());
-    assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 5, 1));
+    assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
 
     auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
     assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 5));
@@ -2070,7 +2070,7 @@ ValidateFreeNullTestSteensgaardAgnostic(const jlm::tests::FreeNullTest & test)
   using namespace jlm::llvm;
 
   auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.LambdaMain().fctresult(0)->origin());
-  assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
+  assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
   auto free = jlm::rvsdg::node_output::node(test.LambdaMain().fctresult(1)->origin());
   assert(is<FreeOperation>(*free, 2, 1));

--- a/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
@@ -149,7 +149,7 @@ ValidateStoreTest1SteensgaardAgnosticTopDown(const jlm::tests::StoreTest1 & test
   assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
 
   auto lambdaEntrySplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
-  assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 2));
+  assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
   assert(lambdaEntrySplit == jlm::rvsdg::node_output::node(lambdaExitMerge->input(1)->origin()));
 }
 
@@ -244,7 +244,7 @@ ValidateStoreTest2SteensgaardAgnosticTopDown(const jlm::tests::StoreTest2 & test
   assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
 
   auto lambdaEntrySplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
-  assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 2));
+  assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
   assert(lambdaEntrySplit == jlm::rvsdg::node_output::node(lambdaExitMerge->input(1)->origin()));
 }
 
@@ -259,7 +259,7 @@ ValidateLoadTest1SteensgaardAgnostic(const jlm::tests::LoadTest1 & test)
   assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
 
   auto lambdaEntrySplit = input_node(*test.lambda->fctargument(1)->begin());
-  assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 2));
+  assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 
   auto loadA = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
   auto loadX = jlm::rvsdg::node_output::node(loadA->input(0)->origin());
@@ -283,7 +283,7 @@ ValidateLoadTest1SteensgaardRegionAware(const jlm::tests::LoadTest1 & test)
   assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
 
   auto lambdaEntrySplit = input_node(*test.lambda->fctargument(1)->begin());
-  assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 2));
+  assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 
   auto loadA = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
   auto loadX = jlm::rvsdg::node_output::node(loadA->input(0)->origin());
@@ -307,7 +307,7 @@ ValidateLoadTest1SteensgaardAgnosticTopDown(const jlm::tests::LoadTest1 & test)
   assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
 
   auto lambdaEntrySplit = input_node(*test.lambda->fctargument(1)->begin());
-  assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 2));
+  assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 
   auto loadA = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
   auto loadX = jlm::rvsdg::node_output::node(loadA->input(0)->origin());
@@ -428,7 +428,7 @@ ValidateLoadTest2SteensgaardAgnosticTopDown(const jlm::tests::LoadTest2 & test)
   assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
 
   auto lambdaEntrySplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
-  assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 2));
+  assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
   assert(lambdaEntrySplit == jlm::rvsdg::node_output::node(lambdaExitMerge->input(1)->origin()));
 }
 
@@ -446,7 +446,7 @@ ValidateLoadFromUndefSteensgaardAgnostic(const jlm::tests::LoadFromUndefTest & t
   assert(is<LoadNonVolatileOperation>(*load, 1, 1));
 
   auto lambdaEntrySplit = input_node(*test.Lambda().fctargument(0)->begin());
-  assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 2));
+  assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 }
 
 static void
@@ -477,7 +477,7 @@ ValidateLoadFromUndefSteensgaardAgnosticTopDown(const jlm::tests::LoadFromUndefT
   assert(is<LoadNonVolatileOperation>(*load, 1, 1));
 
   auto lambdaEntrySplit = input_node(*test.Lambda().fctargument(0)->begin());
-  assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 2));
+  assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 }
 
 static void
@@ -493,7 +493,7 @@ ValidateCallTest1SteensgaardAgnostic(const jlm::tests::CallTest1 & test)
     auto loadY = input_node(*test.lambda_f->fctargument(1)->begin());
 
     assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 7, 1));
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 7));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 7));
 
     assert(is<LoadNonVolatileOperation>(*loadX, 2, 2));
     assert(jlm::rvsdg::node_output::node(loadX->input(1)->origin()) == lambdaEntrySplit);
@@ -510,7 +510,7 @@ ValidateCallTest1SteensgaardAgnostic(const jlm::tests::CallTest1 & test)
     auto loadY = input_node(*test.lambda_g->fctargument(1)->begin());
 
     assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 7, 1));
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 7));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 7));
 
     assert(is<LoadNonVolatileOperation>(*loadX, 2, 2));
     assert(jlm::rvsdg::node_output::node(loadX->input(1)->origin()) == lambdaEntrySplit);
@@ -548,7 +548,7 @@ ValidateCallTest1SteensgaardRegionAware(const jlm::tests::CallTest1 & test)
     auto loadY = input_node(*test.lambda_f->fctargument(1)->begin());
 
     assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 2, 1));
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 2));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 
     assert(is<LoadNonVolatileOperation>(*loadX, 2, 2));
     assert(jlm::rvsdg::node_output::node(loadX->input(1)->origin()) == lambdaEntrySplit);
@@ -565,7 +565,7 @@ ValidateCallTest1SteensgaardRegionAware(const jlm::tests::CallTest1 & test)
     auto loadY = input_node(*test.lambda_g->fctargument(1)->begin());
 
     assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 1, 1));
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 1));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 1));
 
     assert(is<LoadNonVolatileOperation>(*loadX, 2, 2));
     assert(jlm::rvsdg::node_output::node(loadX->input(1)->origin()) == lambdaEntrySplit);
@@ -603,7 +603,7 @@ ValidateCallTest1SteensgaardAgnosticTopDown(const jlm::tests::CallTest1 & test)
     auto loadY = input_node(*test.lambda_f->fctargument(1)->begin());
 
     assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 7, 1));
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 7));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 7));
 
     assert(is<LoadNonVolatileOperation>(*loadX, 2, 2));
     assert(jlm::rvsdg::node_output::node(loadX->input(1)->origin()) == lambdaEntrySplit);
@@ -620,7 +620,7 @@ ValidateCallTest1SteensgaardAgnosticTopDown(const jlm::tests::CallTest1 & test)
     auto loadY = input_node(*test.lambda_g->fctargument(1)->begin());
 
     assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 7, 1));
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 7));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 7));
 
     assert(is<LoadNonVolatileOperation>(*loadX, 2, 2));
     assert(jlm::rvsdg::node_output::node(loadX->input(1)->origin()) == lambdaEntrySplit);
@@ -658,7 +658,7 @@ ValidateCallTest2SteensgaardAgnostic(const jlm::tests::CallTest2 & test)
     assert(is<MemoryStateMergeOperation>(*stateMerge, 2, 1));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(stateMerge->input(1)->origin());
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 5));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
 
     auto lambdaExitMerge = input_node(*stateMerge->output(0)->begin());
     assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 5, 1));
@@ -692,7 +692,7 @@ ValidateCallTest2SteensgaardRegionAware(const jlm::tests::CallTest2 & test)
     assert(is<MemoryStateMergeOperation>(*stateMerge, 2, 1));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(stateMerge->input(1)->origin());
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 1));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 1));
 
     auto lambdaExitMerge = input_node(*stateMerge->output(0)->begin());
     assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 1, 1));
@@ -726,7 +726,7 @@ ValidateCallTest2SteensgaardAgnosticTopDown(const jlm::tests::CallTest2 & test)
     assert(is<MemoryStateMergeOperation>(*stateMerge, 2, 1));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(stateMerge->input(1)->origin());
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 5));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
 
     auto lambdaExitMerge = input_node(*stateMerge->output(0)->begin());
     assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 5, 1));
@@ -766,7 +766,7 @@ ValidateIndirectCallTest1SteensgaardAgnostic(const jlm::tests::IndirectCallTest1
     assert(is<CallEntryMemStateOperator>(*call_entry_mux, 5, 1));
 
     auto lambda_entry_mux = jlm::rvsdg::node_output::node(call_entry_mux->input(2)->origin());
-    assert(is<LambdaEntryMemStateOperator>(*lambda_entry_mux, 1, 5));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambda_entry_mux, 1, 5));
   }
 
   /* validate test function */
@@ -796,7 +796,7 @@ ValidateIndirectCallTest1SteensgaardAgnostic(const jlm::tests::IndirectCallTest1
     assert(is<CallEntryMemStateOperator>(*call_entry_mux, 5, 1));
 
     auto lambda_entry_mux = jlm::rvsdg::node_output::node(call_entry_mux->input(2)->origin());
-    assert(is<LambdaEntryMemStateOperator>(*lambda_entry_mux, 1, 5));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambda_entry_mux, 1, 5));
   }
 }
 
@@ -823,7 +823,7 @@ ValidateIndirectCallTest1SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(is<CallEntryMemStateOperator>(*callEntryMerge, 1, 1));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(callEntryMerge->input(0)->origin());
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 1));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 1));
   }
 
   /* validate test function */
@@ -853,7 +853,7 @@ ValidateIndirectCallTest1SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(is<CallEntryMemStateOperator>(*callEntryMerge, 1, 1));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(callEntryMerge->input(0)->origin());
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 1));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 1));
   }
 }
 
@@ -880,7 +880,7 @@ ValidateIndirectCallTest1SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(is<CallEntryMemStateOperator>(*call_entry_mux, 5, 1));
 
     auto lambda_entry_mux = jlm::rvsdg::node_output::node(call_entry_mux->input(2)->origin());
-    assert(is<LambdaEntryMemStateOperator>(*lambda_entry_mux, 1, 5));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambda_entry_mux, 1, 5));
   }
 
   // validate test function
@@ -910,7 +910,7 @@ ValidateIndirectCallTest1SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(is<CallEntryMemStateOperator>(*call_entry_mux, 5, 1));
 
     auto lambda_entry_mux = jlm::rvsdg::node_output::node(call_entry_mux->input(2)->origin());
-    assert(is<LambdaEntryMemStateOperator>(*lambda_entry_mux, 1, 5));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambda_entry_mux, 1, 5));
   }
 }
 
@@ -928,7 +928,7 @@ ValidateIndirectCallTest2SteensgaardAgnostic(const jlm::tests::IndirectCallTest2
     assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 13, 1));
 
     auto lambdaEntrySplit = input_node(*test.GetLambdaThree().fctargument(1)->begin());
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 13));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 13));
   }
 
   // validate function four()
@@ -940,7 +940,7 @@ ValidateIndirectCallTest2SteensgaardAgnostic(const jlm::tests::IndirectCallTest2
     assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 13, 1));
 
     auto lambdaEntrySplit = input_node(*test.GetLambdaFour().fctargument(1)->begin());
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 13));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 13));
   }
 
   // validate function i()
@@ -957,7 +957,7 @@ ValidateIndirectCallTest2SteensgaardAgnostic(const jlm::tests::IndirectCallTest2
     assert(is<CallEntryMemStateOperator>(*callEntryMerge, 13, 1));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(callEntryMerge->input(0)->origin());
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 13));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 13));
   }
 }
 
@@ -998,7 +998,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(is<CallEntryMemStateOperator>(*callEntryMerge, 6, 1));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(callEntryMerge->input(0)->origin());
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 6));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 6));
   }
 
   // validate function x()
@@ -1024,7 +1024,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
       {
         storeNode = node;
       }
-      else if (is<LambdaEntryMemStateOperator>(node))
+      else if (is<LambdaEntryMemoryStateSplitOperation>(node))
       {
         lambdaEntrySplit = node;
       }
@@ -1035,7 +1035,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     }
     assert(storeNode && lambdaEntrySplit);
     assert(is<StoreNonVolatileOperation>(*storeNode, 4, 2));
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 6));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 6));
   }
 
   // validate function y()
@@ -1060,7 +1060,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
       {
         storeNode = node;
       }
-      else if (is<LambdaEntryMemStateOperator>(node))
+      else if (is<LambdaEntryMemoryStateSplitOperation>(node))
       {
         lambdaEntrySplit = node;
       }
@@ -1071,7 +1071,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     }
     assert(storeNode && lambdaEntrySplit);
     assert(is<StoreNonVolatileOperation>(*storeNode, 3, 1));
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 6));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 6));
   }
 
   // validate function test()
@@ -1089,7 +1089,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(is<LoadNonVolatileOperation>(*loadG2, 2, 2));
 
     auto lambdaEntrySplit = input_node(*test.GetLambdaTest().fctargument(1)->begin());
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 6));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 6));
   }
 
   // validate function test2()
@@ -1101,7 +1101,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 6, 1));
 
     auto lambdaEntrySplit = input_node(*test.GetLambdaTest().fctargument(1)->begin());
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 6));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 6));
   }
 }
 
@@ -1119,7 +1119,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 13, 1));
 
     auto lambdaEntrySplit = input_node(*test.GetLambdaThree().fctargument(1)->begin());
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 13));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 13));
   }
 
   // validate function four()
@@ -1131,7 +1131,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(is<LambdaExitMemStateOperator>(*lambdaExitMerge, 13, 1));
 
     auto lambdaEntrySplit = input_node(*test.GetLambdaFour().fctargument(1)->begin());
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 13));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 13));
   }
 
   // validate function i()
@@ -1148,7 +1148,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(is<CallEntryMemStateOperator>(*callEntryMerge, 13, 1));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(callEntryMerge->input(0)->origin());
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 13));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 13));
   }
 
   // validate function x()
@@ -1174,7 +1174,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
       {
         storeNode = node;
       }
-      else if (is<LambdaEntryMemStateOperator>(node))
+      else if (is<LambdaEntryMemoryStateSplitOperation>(node))
       {
         lambdaEntrySplit = node;
       }
@@ -1185,7 +1185,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     }
     assert(storeNode && lambdaEntrySplit);
     assert(is<StoreNonVolatileOperation>(*storeNode, 4, 2));
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 13));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 13));
   }
 
   // validate function y()
@@ -1212,7 +1212,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
         assert(storeNode == nullptr);
         storeNode = node;
       }
-      else if (is<LambdaEntryMemStateOperator>(node))
+      else if (is<LambdaEntryMemoryStateSplitOperation>(node))
       {
         lambdaEntrySplit = node;
       }
@@ -1228,7 +1228,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     }
     assert(storeNode && lambdaEntrySplit && undefNode);
     assert(is<StoreNonVolatileOperation>(*storeNode, 3, 1));
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 12));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 12));
   }
 
   // validate function test()
@@ -1265,7 +1265,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(is<LoadNonVolatileOperation>(*loadG2, 2, 2));
 
     auto lambdaEntrySplit = input_node(*test.GetLambdaTest().fctargument(1)->begin());
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 10));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 10));
   }
 
   // validate function test2()
@@ -1299,7 +1299,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     }
 
     auto lambdaEntrySplit = input_node(*test.GetLambdaTest2().fctargument(1)->begin());
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 10));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 10));
   }
 }
 
@@ -1336,7 +1336,7 @@ ValidateGammaTestSteensgaardRegionAware(const jlm::tests::GammaTest & test)
   assert(is<LoadNonVolatileOperation>(*loadTmp1, 3, 3));
 
   auto lambdaEntrySplit = jlm::rvsdg::node_output::node(loadTmp1->input(1)->origin());
-  assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 2));
+  assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 }
 
 static void
@@ -1378,7 +1378,7 @@ ValidateThetaTestSteensgaardAgnostic(const jlm::tests::ThetaTest & test)
   assert(store->input(storeStateOutput->index() + 2)->origin() == thetaOutput->argument());
 
   auto lambda_entry_mux = jlm::rvsdg::node_output::node(thetaOutput->input()->origin());
-  assert(is<LambdaEntryMemStateOperator>(*lambda_entry_mux, 1, 2));
+  assert(is<LambdaEntryMemoryStateSplitOperation>(*lambda_entry_mux, 1, 2));
 }
 
 static void
@@ -1402,7 +1402,7 @@ ValidateThetaTestSteensgaardRegionAware(const jlm::tests::ThetaTest & test)
   assert(store->input(storeStateOutput->index() + 2)->origin() == thetaOutput->argument());
 
   auto lambdaEntrySplit = jlm::rvsdg::node_output::node(thetaOutput->input()->origin());
-  assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 2));
+  assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 }
 
 static void
@@ -1426,7 +1426,7 @@ ValidateThetaTestSteensgaardAgnosticTopDown(const jlm::tests::ThetaTest & test)
   assert(store->input(storeStateOutput->index() + 2)->origin() == thetaOutput->argument());
 
   auto lambda_entry_mux = jlm::rvsdg::node_output::node(thetaOutput->input()->origin());
-  assert(is<LambdaEntryMemStateOperator>(*lambda_entry_mux, 1, 2));
+  assert(is<LambdaEntryMemoryStateSplitOperation>(*lambda_entry_mux, 1, 2));
 }
 
 static void
@@ -1437,7 +1437,7 @@ ValidateDeltaTest1SteensgaardAgnostic(const jlm::tests::DeltaTest1 & test)
   assert(test.lambda_h->subregion()->nnodes() == 7);
 
   auto lambdaEntrySplit = input_node(*test.lambda_h->fctargument(1)->begin());
-  assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 4));
+  assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 4));
 
   auto storeF = input_node(*test.constantFive->output(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeF, 3, 1));
@@ -1458,7 +1458,7 @@ ValidateDeltaTest1SteensgaardRegionAware(const jlm::tests::DeltaTest1 & test)
   assert(test.lambda_h->subregion()->nnodes() == 7);
 
   auto lambdaEntrySplit = input_node(*test.lambda_h->fctargument(1)->begin());
-  assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 1));
+  assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 1));
 
   auto storeF = input_node(*test.constantFive->output(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeF, 3, 1));
@@ -1479,7 +1479,7 @@ ValidateDeltaTest1SteensgaardAgnosticTopDown(const jlm::tests::DeltaTest1 & test
   assert(test.lambda_h->subregion()->nnodes() == 7);
 
   auto lambdaEntrySplit = input_node(*test.lambda_h->fctargument(1)->begin());
-  assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 4));
+  assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 4));
 
   auto storeF = input_node(*test.constantFive->output(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeF, 3, 1));
@@ -1497,7 +1497,7 @@ ValidateDeltaTest2SteensgaardAgnostic(const jlm::tests::DeltaTest2 & test)
   assert(test.lambda_f2->subregion()->nnodes() == 9);
 
   auto lambdaEntrySplit = input_node(*test.lambda_f2->fctargument(1)->begin());
-  assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 5));
+  assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
 
   auto storeD1InF2 = input_node(*test.lambda_f2->cvargument(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
@@ -1532,7 +1532,7 @@ ValidateDeltaTest2SteensgaardRegionAware(const jlm::tests::DeltaTest2 & test)
     assert(is<StoreNonVolatileOperation>(*storeNode, 3, 1));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(storeNode->input(2)->origin());
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 1));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 1));
   }
 
   /* Validate f2() */
@@ -1540,7 +1540,7 @@ ValidateDeltaTest2SteensgaardRegionAware(const jlm::tests::DeltaTest2 & test)
     assert(test.lambda_f2->subregion()->nnodes() == 9);
 
     auto lambdaEntrySplit = input_node(*test.lambda_f2->fctargument(1)->begin());
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 2));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 
     auto storeD1 = input_node(*test.lambda_f2->cvargument(0)->begin());
     assert(is<StoreNonVolatileOperation>(*storeD1, 3, 1));
@@ -1572,7 +1572,7 @@ ValidateDeltaTest2SteensgaardAgnosticTopDown(const jlm::tests::DeltaTest2 & test
   assert(test.lambda_f2->subregion()->nnodes() == 9);
 
   auto lambdaEntrySplit = input_node(*test.lambda_f2->fctargument(1)->begin());
-  assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 5));
+  assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
 
   auto storeD1InF2 = input_node(*test.lambda_f2->cvargument(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
@@ -1608,7 +1608,7 @@ ValidateDeltaTest3SteensgaardAgnostic(const jlm::tests::DeltaTest3 & test)
     assert(is<LoadNonVolatileOperation>(*loadG1Node, 2, 2));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(loadG1Node->input(1)->origin());
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 5));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
 
     jlm::rvsdg::node * storeG2Node = nullptr;
     for (size_t n = 0; n < lambdaExitMerge->ninputs(); n++)
@@ -1650,7 +1650,7 @@ ValidateDeltaTest3SteensgaardRegionAware(const jlm::tests::DeltaTest3 & test)
     assert(is<LoadNonVolatileOperation>(*loadG1Node, 2, 2));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(loadG1Node->input(1)->origin());
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 2));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 
     jlm::rvsdg::node * storeG2Node = nullptr;
     for (size_t n = 0; n < lambdaExitMerge->ninputs(); n++)
@@ -1692,7 +1692,7 @@ ValidateDeltaTest3SteensgaardAgnosticTopDown(const jlm::tests::DeltaTest3 & test
     assert(is<LoadNonVolatileOperation>(*loadG1Node, 2, 2));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(loadG1Node->input(1)->origin());
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 5));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
 
     jlm::rvsdg::node * storeG2Node = nullptr;
     for (size_t n = 0; n < lambdaExitMerge->ninputs(); n++)
@@ -1723,7 +1723,7 @@ ValidateImportTestSteensgaardAgnostic(const jlm::tests::ImportTest & test)
   assert(test.lambda_f2->subregion()->nnodes() == 9);
 
   auto lambdaEntrySplit = input_node(*test.lambda_f2->fctargument(1)->begin());
-  assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 5));
+  assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
 
   auto storeD1InF2 = input_node(*test.lambda_f2->cvargument(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
@@ -1758,7 +1758,7 @@ ValidateImportTestSteensgaardRegionAware(const jlm::tests::ImportTest & test)
     assert(is<StoreNonVolatileOperation>(*storeNode, 3, 1));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(storeNode->input(2)->origin());
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 1));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 1));
   }
 
   /* Validate f2() */
@@ -1766,7 +1766,7 @@ ValidateImportTestSteensgaardRegionAware(const jlm::tests::ImportTest & test)
     assert(test.lambda_f2->subregion()->nnodes() == 9);
 
     auto lambdaEntrySplit = input_node(*test.lambda_f2->fctargument(1)->begin());
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 2));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 
     auto storeD1 = input_node(*test.lambda_f2->cvargument(0)->begin());
     assert(is<StoreNonVolatileOperation>(*storeD1, 3, 1));
@@ -1798,7 +1798,7 @@ ValidateImportTestSteensgaardAgnosticTopDown(const jlm::tests::ImportTest & test
   assert(test.lambda_f2->subregion()->nnodes() == 9);
 
   auto lambdaEntrySplit = input_node(*test.lambda_f2->fctargument(1)->begin());
-  assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 5));
+  assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
 
   auto storeD1InF2 = input_node(*test.lambda_f2->cvargument(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
@@ -1934,7 +1934,7 @@ ValidateMemcpySteensgaardAgnostic(const jlm::tests::MemcpyTest & test)
     assert(is<StoreNonVolatileOperation>(*store, 4, 2));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(store->input(2)->origin());
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 5));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
   }
 
   /*
@@ -1964,7 +1964,7 @@ ValidateMemcpySteensgaardAgnostic(const jlm::tests::MemcpyTest & test)
     assert(is<MemCpyNonVolatileOperation>(*memcpy, 7, 4));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(memcpy->input(5)->origin());
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 5));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
   }
 }
 
@@ -1987,7 +1987,7 @@ ValidateMemcpySteensgaardRegionAware(const jlm::tests::MemcpyTest & test)
     assert(is<StoreNonVolatileOperation>(*store, 4, 2));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(store->input(2)->origin());
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 2));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
   }
 
   /*
@@ -2007,7 +2007,7 @@ ValidateMemcpySteensgaardRegionAware(const jlm::tests::MemcpyTest & test)
     assert(is<MemCpyNonVolatileOperation>(*memcpyNode, 7, 4));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(memcpyNode->input(4)->origin());
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 2));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
     assert(jlm::rvsdg::node_output::node(memcpyNode->input(5)->origin()) == lambdaEntrySplit);
 
     auto lambdaExitMerge = input_node(*callExitSplit->output(0)->begin());
@@ -2032,7 +2032,7 @@ ValidateMemcpyTestSteensgaardAgnosticTopDown(const jlm::tests::MemcpyTest & test
     assert(is<StoreNonVolatileOperation>(*store, 4, 2));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(store->input(2)->origin());
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 5));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
   }
 
   // Validate function g
@@ -2060,7 +2060,7 @@ ValidateMemcpyTestSteensgaardAgnosticTopDown(const jlm::tests::MemcpyTest & test
     assert(is<MemCpyNonVolatileOperation>(*memcpy, 7, 4));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(memcpy->input(5)->origin());
-    assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 5));
+    assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
   }
 }
 
@@ -2076,7 +2076,7 @@ ValidateFreeNullTestSteensgaardAgnostic(const jlm::tests::FreeNullTest & test)
   assert(is<FreeOperation>(*free, 2, 1));
 
   auto lambdaEntrySplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
-  assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 2));
+  assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 }
 
 static int

--- a/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
@@ -524,13 +524,13 @@ ValidateCallTest1SteensgaardAgnostic(const jlm::tests::CallTest1 & test)
     auto callEntryMerge = jlm::rvsdg::node_output::node(test.CallF().input(4)->origin());
     auto callExitSplit = input_node(*test.CallF().output(2)->begin());
 
-    assert(is<CallEntryMemStateOperator>(*callEntryMerge, 7, 1));
+    assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 7, 1));
     assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 7));
 
     callEntryMerge = jlm::rvsdg::node_output::node(test.CallG().input(4)->origin());
     callExitSplit = input_node(*test.CallG().output(2)->begin());
 
-    assert(is<CallEntryMemStateOperator>(*callEntryMerge, 7, 1));
+    assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 7, 1));
     assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 7));
   }
 }
@@ -579,13 +579,13 @@ ValidateCallTest1SteensgaardRegionAware(const jlm::tests::CallTest1 & test)
     auto callEntryMerge = jlm::rvsdg::node_output::node(test.CallF().input(4)->origin());
     auto callExitSplit = input_node(*test.CallF().output(2)->begin());
 
-    assert(is<CallEntryMemStateOperator>(*callEntryMerge, 2, 1));
+    assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 2, 1));
     assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 2));
 
     callEntryMerge = jlm::rvsdg::node_output::node(test.CallG().input(4)->origin());
     callExitSplit = input_node(*test.CallG().output(2)->begin());
 
-    assert(is<CallEntryMemStateOperator>(*callEntryMerge, 1, 1));
+    assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 1, 1));
     assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 1));
   }
 }
@@ -634,13 +634,13 @@ ValidateCallTest1SteensgaardAgnosticTopDown(const jlm::tests::CallTest1 & test)
     auto callEntryMerge = jlm::rvsdg::node_output::node(test.CallF().input(4)->origin());
     auto callExitSplit = input_node(*test.CallF().output(2)->begin());
 
-    assert(is<CallEntryMemStateOperator>(*callEntryMerge, 7, 1));
+    assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 7, 1));
     assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 7));
 
     callEntryMerge = jlm::rvsdg::node_output::node(test.CallG().input(4)->origin());
     callExitSplit = input_node(*test.CallG().output(2)->begin());
 
-    assert(is<CallEntryMemStateOperator>(*callEntryMerge, 7, 1));
+    assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 7, 1));
     assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 7));
   }
 }
@@ -763,7 +763,7 @@ ValidateIndirectCallTest1SteensgaardAgnostic(const jlm::tests::IndirectCallTest1
     assert(is<CallOperation>(*call, 3, 3));
 
     auto call_entry_mux = jlm::rvsdg::node_output::node(call->input(2)->origin());
-    assert(is<CallEntryMemStateOperator>(*call_entry_mux, 5, 1));
+    assert(is<CallEntryMemoryStateMergeOperation>(*call_entry_mux, 5, 1));
 
     auto lambda_entry_mux = jlm::rvsdg::node_output::node(call_entry_mux->input(2)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambda_entry_mux, 1, 5));
@@ -784,7 +784,7 @@ ValidateIndirectCallTest1SteensgaardAgnostic(const jlm::tests::IndirectCallTest1
     assert(is<CallOperation>(*call, 4, 3));
 
     auto call_entry_mux = jlm::rvsdg::node_output::node(call->input(3)->origin());
-    assert(is<CallEntryMemStateOperator>(*call_entry_mux, 5, 1));
+    assert(is<CallEntryMemoryStateMergeOperation>(*call_entry_mux, 5, 1));
 
     call_exit_mux = jlm::rvsdg::node_output::node(call_entry_mux->input(0)->origin());
     assert(is<CallExitMemStateOperator>(*call_exit_mux, 1, 5));
@@ -793,7 +793,7 @@ ValidateIndirectCallTest1SteensgaardAgnostic(const jlm::tests::IndirectCallTest1
     assert(is<CallOperation>(*call, 4, 3));
 
     call_entry_mux = jlm::rvsdg::node_output::node(call->input(3)->origin());
-    assert(is<CallEntryMemStateOperator>(*call_entry_mux, 5, 1));
+    assert(is<CallEntryMemoryStateMergeOperation>(*call_entry_mux, 5, 1));
 
     auto lambda_entry_mux = jlm::rvsdg::node_output::node(call_entry_mux->input(2)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambda_entry_mux, 1, 5));
@@ -820,7 +820,7 @@ ValidateIndirectCallTest1SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(is<CallOperation>(*call, 3, 3));
 
     auto callEntryMerge = jlm::rvsdg::node_output::node(call->input(2)->origin());
-    assert(is<CallEntryMemStateOperator>(*callEntryMerge, 1, 1));
+    assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 1, 1));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(callEntryMerge->input(0)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 1));
@@ -841,7 +841,7 @@ ValidateIndirectCallTest1SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(is<CallOperation>(*call, 4, 3));
 
     auto callEntryMerge = jlm::rvsdg::node_output::node(call->input(3)->origin());
-    assert(is<CallEntryMemStateOperator>(*callEntryMerge, 1, 1));
+    assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 1, 1));
 
     callExitSplit = jlm::rvsdg::node_output::node(callEntryMerge->input(0)->origin());
     assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 1));
@@ -850,7 +850,7 @@ ValidateIndirectCallTest1SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(is<CallOperation>(*call, 4, 3));
 
     callEntryMerge = jlm::rvsdg::node_output::node(call->input(3)->origin());
-    assert(is<CallEntryMemStateOperator>(*callEntryMerge, 1, 1));
+    assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 1, 1));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(callEntryMerge->input(0)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 1));
@@ -877,7 +877,7 @@ ValidateIndirectCallTest1SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(is<CallOperation>(*call, 3, 3));
 
     auto call_entry_mux = jlm::rvsdg::node_output::node(call->input(2)->origin());
-    assert(is<CallEntryMemStateOperator>(*call_entry_mux, 5, 1));
+    assert(is<CallEntryMemoryStateMergeOperation>(*call_entry_mux, 5, 1));
 
     auto lambda_entry_mux = jlm::rvsdg::node_output::node(call_entry_mux->input(2)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambda_entry_mux, 1, 5));
@@ -898,7 +898,7 @@ ValidateIndirectCallTest1SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(is<CallOperation>(*call, 4, 3));
 
     auto call_entry_mux = jlm::rvsdg::node_output::node(call->input(3)->origin());
-    assert(is<CallEntryMemStateOperator>(*call_entry_mux, 5, 1));
+    assert(is<CallEntryMemoryStateMergeOperation>(*call_entry_mux, 5, 1));
 
     call_exit_mux = jlm::rvsdg::node_output::node(call_entry_mux->input(0)->origin());
     assert(is<CallExitMemStateOperator>(*call_exit_mux, 1, 5));
@@ -907,7 +907,7 @@ ValidateIndirectCallTest1SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(is<CallOperation>(*call, 4, 3));
 
     call_entry_mux = jlm::rvsdg::node_output::node(call->input(3)->origin());
-    assert(is<CallEntryMemStateOperator>(*call_entry_mux, 5, 1));
+    assert(is<CallEntryMemoryStateMergeOperation>(*call_entry_mux, 5, 1));
 
     auto lambda_entry_mux = jlm::rvsdg::node_output::node(call_entry_mux->input(2)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambda_entry_mux, 1, 5));
@@ -954,7 +954,7 @@ ValidateIndirectCallTest2SteensgaardAgnostic(const jlm::tests::IndirectCallTest2
     assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 13));
 
     auto callEntryMerge = jlm::rvsdg::node_output::node(test.GetIndirectCall().input(2)->origin());
-    assert(is<CallEntryMemStateOperator>(*callEntryMerge, 13, 1));
+    assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 13, 1));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(callEntryMerge->input(0)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 13));
@@ -995,7 +995,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 6));
 
     auto callEntryMerge = jlm::rvsdg::node_output::node(test.GetIndirectCall().input(2)->origin());
-    assert(is<CallEntryMemStateOperator>(*callEntryMerge, 6, 1));
+    assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 6, 1));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(callEntryMerge->input(0)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 6));
@@ -1013,7 +1013,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
 
     auto callEntryMerge =
         jlm::rvsdg::node_output::node(test.GetCallIWithThree().input(3)->origin());
-    assert(is<CallEntryMemStateOperator>(*callEntryMerge, 6, 1));
+    assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 6, 1));
 
     const jlm::rvsdg::node * storeNode = nullptr;
     const jlm::rvsdg::node * lambdaEntrySplit = nullptr;
@@ -1049,7 +1049,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 6));
 
     auto callEntryMerge = jlm::rvsdg::node_output::node(test.GetCallIWithFour().input(3)->origin());
-    assert(is<CallEntryMemStateOperator>(*callEntryMerge, 6, 1));
+    assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 6, 1));
 
     const jlm::rvsdg::node * storeNode = nullptr;
     const jlm::rvsdg::node * lambdaEntrySplit = nullptr;
@@ -1145,7 +1145,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 13));
 
     auto callEntryMerge = jlm::rvsdg::node_output::node(test.GetIndirectCall().input(2)->origin());
-    assert(is<CallEntryMemStateOperator>(*callEntryMerge, 13, 1));
+    assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 13, 1));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(callEntryMerge->input(0)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 13));
@@ -1163,7 +1163,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
 
     auto callEntryMerge =
         jlm::rvsdg::node_output::node(test.GetCallIWithThree().input(3)->origin());
-    assert(is<CallEntryMemStateOperator>(*callEntryMerge, 13, 1));
+    assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 13, 1));
 
     const jlm::rvsdg::node * storeNode = nullptr;
     const jlm::rvsdg::node * lambdaEntrySplit = nullptr;
@@ -1199,7 +1199,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 13));
 
     auto callEntryMerge = jlm::rvsdg::node_output::node(test.GetCallIWithFour().input(3)->origin());
-    assert(is<CallEntryMemStateOperator>(*callEntryMerge, 13, 1));
+    assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 13, 1));
 
     jlm::rvsdg::node * undefNode = nullptr;
     const jlm::rvsdg::node * storeNode = nullptr;
@@ -1243,7 +1243,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(is<LoadNonVolatileOperation>(*loadG1, 2, 2));
 
     auto callXEntryMerge = jlm::rvsdg::node_output::node(test.GetTestCallX().input(3)->origin());
-    assert(is<CallEntryMemStateOperator>(*callXEntryMerge, 13, 1));
+    assert(is<CallEntryMemoryStateMergeOperation>(*callXEntryMerge, 13, 1));
 
     auto callXExitSplit = input_node(*test.GetTestCallX().output(2)->begin());
     assert(is<CallExitMemStateOperator>(*callXExitSplit, 1, 13));
@@ -1277,7 +1277,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 10, 1));
 
     auto callXEntryMerge = jlm::rvsdg::node_output::node(test.GetTest2CallX().input(3)->origin());
-    assert(is<CallEntryMemStateOperator>(*callXEntryMerge, 13, 1));
+    assert(is<CallEntryMemoryStateMergeOperation>(*callXEntryMerge, 13, 1));
 
     auto callXExitSplit = input_node(*test.GetTest2CallX().output(2)->begin());
     assert(is<CallExitMemStateOperator>(*callXExitSplit, 1, 13));
@@ -1551,7 +1551,7 @@ ValidateDeltaTest2SteensgaardRegionAware(const jlm::tests::DeltaTest2 & test)
     assert(jlm::rvsdg::node_output::node(storeD2->input(2)->origin()) == lambdaEntrySplit);
 
     auto callEntryMerge = input_node(*storeD1->output(0)->begin());
-    assert(is<CallEntryMemStateOperator>(*callEntryMerge, 1, 1));
+    assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 1, 1));
 
     auto callF1 = input_node(*callEntryMerge->output(0)->begin());
     assert(is<CallOperation>(*callF1, 3, 2));
@@ -1777,7 +1777,7 @@ ValidateImportTestSteensgaardRegionAware(const jlm::tests::ImportTest & test)
     assert(jlm::rvsdg::node_output::node(storeD2->input(2)->origin()) == lambdaEntrySplit);
 
     auto callEntryMerge = input_node(*storeD1->output(0)->begin());
-    assert(is<CallEntryMemStateOperator>(*callEntryMerge, 1, 1));
+    assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 1, 1));
 
     auto callF1 = input_node(*callEntryMerge->output(0)->begin());
     assert(is<CallOperation>(*callF1, 3, 2));
@@ -1951,7 +1951,7 @@ ValidateMemcpySteensgaardAgnostic(const jlm::tests::MemcpyTest & test)
     assert(is<CallOperation>(*call, 3, 3));
 
     auto callEntryMerge = jlm::rvsdg::node_output::node(call->input(2)->origin());
-    assert(is<CallEntryMemStateOperator>(*callEntryMerge, 5, 1));
+    assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 5, 1));
 
     jlm::rvsdg::node * memcpy = nullptr;
     for (size_t n = 0; n < callEntryMerge->ninputs(); n++)
@@ -1998,7 +1998,7 @@ ValidateMemcpySteensgaardRegionAware(const jlm::tests::MemcpyTest & test)
     assert(is<CallOperation>(*callNode, 3, 3));
 
     auto callEntryMerge = jlm::rvsdg::node_output::node(callNode->input(2)->origin());
-    assert(is<CallEntryMemStateOperator>(*callEntryMerge, 2, 1));
+    assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 2, 1));
 
     auto callExitSplit = input_node(*callNode->output(2)->begin());
     assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 2));
@@ -2047,7 +2047,7 @@ ValidateMemcpyTestSteensgaardAgnosticTopDown(const jlm::tests::MemcpyTest & test
     assert(is<CallOperation>(*call, 3, 3));
 
     auto callEntryMerge = jlm::rvsdg::node_output::node(call->input(2)->origin());
-    assert(is<CallEntryMemStateOperator>(*callEntryMerge, 5, 1));
+    assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 5, 1));
 
     jlm::rvsdg::node * memcpy = nullptr;
     for (size_t n = 0; n < callEntryMerge->ninputs(); n++)

--- a/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
@@ -655,7 +655,7 @@ ValidateCallTest2SteensgaardAgnostic(const jlm::tests::CallTest2 & test)
     assert(test.lambda_create->subregion()->nnodes() == 7);
 
     auto stateMerge = input_node(*test.malloc->output(1)->begin());
-    assert(is<MemStateMergeOperator>(*stateMerge, 2, 1));
+    assert(is<MemoryStateMergeOperation>(*stateMerge, 2, 1));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(stateMerge->input(1)->origin());
     assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 5));
@@ -689,7 +689,7 @@ ValidateCallTest2SteensgaardRegionAware(const jlm::tests::CallTest2 & test)
     assert(test.lambda_create->subregion()->nnodes() == 7);
 
     auto stateMerge = input_node(*test.malloc->output(1)->begin());
-    assert(is<MemStateMergeOperator>(*stateMerge, 2, 1));
+    assert(is<MemoryStateMergeOperation>(*stateMerge, 2, 1));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(stateMerge->input(1)->origin());
     assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 1));
@@ -723,7 +723,7 @@ ValidateCallTest2SteensgaardAgnosticTopDown(const jlm::tests::CallTest2 & test)
     assert(test.lambda_create->subregion()->nnodes() == 7);
 
     auto stateMerge = input_node(*test.malloc->output(1)->begin());
-    assert(is<MemStateMergeOperator>(*stateMerge, 2, 1));
+    assert(is<MemoryStateMergeOperation>(*stateMerge, 2, 1));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(stateMerge->input(1)->origin());
     assert(is<LambdaEntryMemStateOperator>(*lambdaEntrySplit, 1, 5));

--- a/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
@@ -525,13 +525,13 @@ ValidateCallTest1SteensgaardAgnostic(const jlm::tests::CallTest1 & test)
     auto callExitSplit = input_node(*test.CallF().output(2)->begin());
 
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 7, 1));
-    assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 7));
+    assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 7));
 
     callEntryMerge = jlm::rvsdg::node_output::node(test.CallG().input(4)->origin());
     callExitSplit = input_node(*test.CallG().output(2)->begin());
 
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 7, 1));
-    assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 7));
+    assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 7));
   }
 }
 
@@ -580,13 +580,13 @@ ValidateCallTest1SteensgaardRegionAware(const jlm::tests::CallTest1 & test)
     auto callExitSplit = input_node(*test.CallF().output(2)->begin());
 
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 2, 1));
-    assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 2));
+    assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 2));
 
     callEntryMerge = jlm::rvsdg::node_output::node(test.CallG().input(4)->origin());
     callExitSplit = input_node(*test.CallG().output(2)->begin());
 
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 1, 1));
-    assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 1));
+    assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 1));
   }
 }
 
@@ -635,13 +635,13 @@ ValidateCallTest1SteensgaardAgnosticTopDown(const jlm::tests::CallTest1 & test)
     auto callExitSplit = input_node(*test.CallF().output(2)->begin());
 
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 7, 1));
-    assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 7));
+    assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 7));
 
     callEntryMerge = jlm::rvsdg::node_output::node(test.CallG().input(4)->origin());
     callExitSplit = input_node(*test.CallG().output(2)->begin());
 
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 7, 1));
-    assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 7));
+    assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 7));
   }
 }
 
@@ -757,7 +757,7 @@ ValidateIndirectCallTest1SteensgaardAgnostic(const jlm::tests::IndirectCallTest1
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambda_exit_mux, 5, 1));
 
     auto call_exit_mux = jlm::rvsdg::node_output::node(lambda_exit_mux->input(0)->origin());
-    assert(is<CallExitMemStateOperator>(*call_exit_mux, 1, 5));
+    assert(is<CallExitMemoryStateSplitOperation>(*call_exit_mux, 1, 5));
 
     auto call = jlm::rvsdg::node_output::node(call_exit_mux->input(0)->origin());
     assert(is<CallOperation>(*call, 3, 3));
@@ -778,7 +778,7 @@ ValidateIndirectCallTest1SteensgaardAgnostic(const jlm::tests::IndirectCallTest1
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambda_exit_mux, 5, 1));
 
     auto call_exit_mux = jlm::rvsdg::node_output::node(lambda_exit_mux->input(0)->origin());
-    assert(is<CallExitMemStateOperator>(*call_exit_mux, 1, 5));
+    assert(is<CallExitMemoryStateSplitOperation>(*call_exit_mux, 1, 5));
 
     auto call = jlm::rvsdg::node_output::node(call_exit_mux->input(0)->origin());
     assert(is<CallOperation>(*call, 4, 3));
@@ -787,7 +787,7 @@ ValidateIndirectCallTest1SteensgaardAgnostic(const jlm::tests::IndirectCallTest1
     assert(is<CallEntryMemoryStateMergeOperation>(*call_entry_mux, 5, 1));
 
     call_exit_mux = jlm::rvsdg::node_output::node(call_entry_mux->input(0)->origin());
-    assert(is<CallExitMemStateOperator>(*call_exit_mux, 1, 5));
+    assert(is<CallExitMemoryStateSplitOperation>(*call_exit_mux, 1, 5));
 
     call = jlm::rvsdg::node_output::node(call_exit_mux->input(0)->origin());
     assert(is<CallOperation>(*call, 4, 3));
@@ -814,7 +814,7 @@ ValidateIndirectCallTest1SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 1, 1));
 
     auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
-    assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 1));
+    assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 1));
 
     auto call = jlm::rvsdg::node_output::node(callExitSplit->input(0)->origin());
     assert(is<CallOperation>(*call, 3, 3));
@@ -835,7 +835,7 @@ ValidateIndirectCallTest1SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 1, 1));
 
     auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
-    assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 1));
+    assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 1));
 
     auto call = jlm::rvsdg::node_output::node(callExitSplit->input(0)->origin());
     assert(is<CallOperation>(*call, 4, 3));
@@ -844,7 +844,7 @@ ValidateIndirectCallTest1SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 1, 1));
 
     callExitSplit = jlm::rvsdg::node_output::node(callEntryMerge->input(0)->origin());
-    assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 1));
+    assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 1));
 
     call = jlm::rvsdg::node_output::node(callExitSplit->input(0)->origin());
     assert(is<CallOperation>(*call, 4, 3));
@@ -871,7 +871,7 @@ ValidateIndirectCallTest1SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambda_exit_mux, 5, 1));
 
     auto call_exit_mux = jlm::rvsdg::node_output::node(lambda_exit_mux->input(0)->origin());
-    assert(is<CallExitMemStateOperator>(*call_exit_mux, 1, 5));
+    assert(is<CallExitMemoryStateSplitOperation>(*call_exit_mux, 1, 5));
 
     auto call = jlm::rvsdg::node_output::node(call_exit_mux->input(0)->origin());
     assert(is<CallOperation>(*call, 3, 3));
@@ -892,7 +892,7 @@ ValidateIndirectCallTest1SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambda_exit_mux, 5, 1));
 
     auto call_exit_mux = jlm::rvsdg::node_output::node(lambda_exit_mux->input(0)->origin());
-    assert(is<CallExitMemStateOperator>(*call_exit_mux, 1, 5));
+    assert(is<CallExitMemoryStateSplitOperation>(*call_exit_mux, 1, 5));
 
     auto call = jlm::rvsdg::node_output::node(call_exit_mux->input(0)->origin());
     assert(is<CallOperation>(*call, 4, 3));
@@ -901,7 +901,7 @@ ValidateIndirectCallTest1SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(is<CallEntryMemoryStateMergeOperation>(*call_entry_mux, 5, 1));
 
     call_exit_mux = jlm::rvsdg::node_output::node(call_entry_mux->input(0)->origin());
-    assert(is<CallExitMemStateOperator>(*call_exit_mux, 1, 5));
+    assert(is<CallExitMemoryStateSplitOperation>(*call_exit_mux, 1, 5));
 
     call = jlm::rvsdg::node_output::node(call_exit_mux->input(0)->origin());
     assert(is<CallOperation>(*call, 4, 3));
@@ -951,7 +951,7 @@ ValidateIndirectCallTest2SteensgaardAgnostic(const jlm::tests::IndirectCallTest2
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 13, 1));
 
     auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
-    assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 13));
+    assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 13));
 
     auto callEntryMerge = jlm::rvsdg::node_output::node(test.GetIndirectCall().input(2)->origin());
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 13, 1));
@@ -992,7 +992,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 6, 1));
 
     auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
-    assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 6));
+    assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 6));
 
     auto callEntryMerge = jlm::rvsdg::node_output::node(test.GetIndirectCall().input(2)->origin());
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 6, 1));
@@ -1009,7 +1009,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 6, 1));
 
     auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
-    assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 6));
+    assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 6));
 
     auto callEntryMerge =
         jlm::rvsdg::node_output::node(test.GetCallIWithThree().input(3)->origin());
@@ -1046,7 +1046,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 6, 1));
 
     auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
-    assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 6));
+    assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 6));
 
     auto callEntryMerge = jlm::rvsdg::node_output::node(test.GetCallIWithFour().input(3)->origin());
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 6, 1));
@@ -1142,7 +1142,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 13, 1));
 
     auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
-    assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 13));
+    assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 13));
 
     auto callEntryMerge = jlm::rvsdg::node_output::node(test.GetIndirectCall().input(2)->origin());
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 13, 1));
@@ -1159,7 +1159,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 13, 1));
 
     auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
-    assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 13));
+    assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 13));
 
     auto callEntryMerge =
         jlm::rvsdg::node_output::node(test.GetCallIWithThree().input(3)->origin());
@@ -1196,7 +1196,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 12, 1));
 
     auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
-    assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 13));
+    assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 13));
 
     auto callEntryMerge = jlm::rvsdg::node_output::node(test.GetCallIWithFour().input(3)->origin());
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 13, 1));
@@ -1246,7 +1246,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(is<CallEntryMemoryStateMergeOperation>(*callXEntryMerge, 13, 1));
 
     auto callXExitSplit = input_node(*test.GetTestCallX().output(2)->begin());
-    assert(is<CallExitMemStateOperator>(*callXExitSplit, 1, 13));
+    assert(is<CallExitMemoryStateSplitOperation>(*callXExitSplit, 1, 13));
 
     jlm::rvsdg::node * undefNode = nullptr;
     for (auto & node : test.GetLambdaTest().subregion()->nodes)
@@ -1280,7 +1280,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(is<CallEntryMemoryStateMergeOperation>(*callXEntryMerge, 13, 1));
 
     auto callXExitSplit = input_node(*test.GetTest2CallX().output(2)->begin());
-    assert(is<CallExitMemStateOperator>(*callXExitSplit, 1, 13));
+    assert(is<CallExitMemoryStateSplitOperation>(*callXExitSplit, 1, 13));
 
     jlm::rvsdg::node * undefNode = nullptr;
     for (auto & node : test.GetLambdaTest2().subregion()->nodes)
@@ -1557,7 +1557,7 @@ ValidateDeltaTest2SteensgaardRegionAware(const jlm::tests::DeltaTest2 & test)
     assert(is<CallOperation>(*callF1, 3, 2));
 
     auto callExitSplit = input_node(*callF1->output(1)->begin());
-    assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 1));
+    assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 1));
 
     auto lambdaExitMerge = input_node(*callExitSplit->output(0)->begin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
@@ -1783,7 +1783,7 @@ ValidateImportTestSteensgaardRegionAware(const jlm::tests::ImportTest & test)
     assert(is<CallOperation>(*callF1, 3, 2));
 
     auto callExitSplit = input_node(*callF1->output(1)->begin());
-    assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 1));
+    assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 1));
 
     auto lambdaExitMerge = input_node(*callExitSplit->output(0)->begin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
@@ -1945,7 +1945,7 @@ ValidateMemcpySteensgaardAgnostic(const jlm::tests::MemcpyTest & test)
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
 
     auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
-    assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 5));
+    assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 5));
 
     auto call = jlm::rvsdg::node_output::node(callExitSplit->input(0)->origin());
     assert(is<CallOperation>(*call, 3, 3));
@@ -2001,7 +2001,7 @@ ValidateMemcpySteensgaardRegionAware(const jlm::tests::MemcpyTest & test)
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 2, 1));
 
     auto callExitSplit = input_node(*callNode->output(2)->begin());
-    assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 2));
+    assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 2));
 
     auto memcpyNode = jlm::rvsdg::node_output::node(callEntryMerge->input(0)->origin());
     assert(is<MemCpyNonVolatileOperation>(*memcpyNode, 7, 4));
@@ -2041,7 +2041,7 @@ ValidateMemcpyTestSteensgaardAgnosticTopDown(const jlm::tests::MemcpyTest & test
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
 
     auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
-    assert(is<CallExitMemStateOperator>(*callExitSplit, 1, 5));
+    assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 5));
 
     auto call = jlm::rvsdg::node_output::node(callExitSplit->input(0)->origin());
     assert(is<CallOperation>(*call, 3, 3));


### PR DESCRIPTION
The PR does the following:
1. Rename the operations to consistent names
2. Adds some documentation
3. Cleans up some minor code smells