### PR TITLE
Introduce shared ptr for types

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/add-prints.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-prints.cpp
@@ -58,7 +58,9 @@ convert_prints(llvm::RvsdgModule & rm)
   auto & graph = rm.Rvsdg();
   auto root = graph.root();
   // TODO: make this less hacky by using the correct state types
-  llvm::FunctionType fct({ &rvsdg::bit64, &rvsdg::bit64 }, std::vector<const rvsdg::type *>());
+  llvm::FunctionType fct(
+      { &*rvsdg::bittype::Create(64), &*rvsdg::bittype::Create(64) },
+      std::vector<const rvsdg::type *>());
   llvm::impport imp(fct, "printnode", llvm::linkage::external_linkage);
   auto printf = graph.add_import(imp);
   convert_prints(root, printf, fct);
@@ -115,7 +117,7 @@ convert_prints(
       auto printf_local = route_to_region(printf, region); // TODO: prevent repetition?
       auto bc = jlm::rvsdg::create_bitconstant(region, 64, po->id());
       jlm::rvsdg::output * val = node->input(0)->origin();
-      if (val->type() != jlm::rvsdg::bit64)
+      if (val->type() != *jlm::rvsdg::bittype::Create(64))
       {
         auto bt = dynamic_cast<const jlm::rvsdg::bittype *>(&val->type());
         JLM_ASSERT(bt);

--- a/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
@@ -90,7 +90,7 @@ instrument_ref(llvm::RvsdgModule & rm)
   //  addr, width, memstate
   jlm::llvm::FunctionType loadFunctionType(
       { jlm::llvm::PointerType::Create().get(),
-        &jlm::rvsdg::bit64,
+        &*jlm::rvsdg::bittype::Create(64),
         llvm::iostatetype::create().get(),
         llvm::MemoryStateType::Create().get() },
       { llvm::iostatetype::create().get(), llvm::MemoryStateType::Create().get() });
@@ -102,8 +102,8 @@ instrument_ref(llvm::RvsdgModule & rm)
   // addr, data, width, memstate
   jlm::llvm::FunctionType storeFunctionType(
       { jlm::llvm::PointerType::Create().get(),
-        &jlm::rvsdg::bit64,
-        &jlm::rvsdg::bit64,
+        &*jlm::rvsdg::bittype::Create(64),
+        &*jlm::rvsdg::bittype::Create(64),
         llvm::iostatetype::create().get(),
         jlm::llvm::MemoryStateType::Create().get() },
       { llvm::iostatetype::create().get(), jlm::llvm::MemoryStateType::Create().get() });
@@ -115,7 +115,7 @@ instrument_ref(llvm::RvsdgModule & rm)
   // addr, size, memstate
   jlm::llvm::FunctionType allocaFunctionType(
       { jlm::llvm::PointerType::Create().get(),
-        &jlm::rvsdg::bit64,
+        &*jlm::rvsdg::bittype::Create(64),
         llvm::iostatetype::create().get(),
         jlm::llvm::MemoryStateType::Create().get() },
       { llvm::iostatetype::create().get(), jlm::llvm::MemoryStateType::Create().get() });
@@ -246,7 +246,7 @@ instrument_ref(
       }
       auto data = node->input(1)->origin();
       auto dbt = dynamic_cast<const jlm::rvsdg::bittype *>(&data->type());
-      if (*dbt != jlm::rvsdg::bit64)
+      if (*dbt != *jlm::rvsdg::bittype::Create(64))
       {
         jlm::llvm::zext_op op(dbt->nbits(), 64);
         data = jlm::rvsdg::simple_node::create_normalized(data->region(), op, { data })[0];

--- a/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
@@ -91,9 +91,9 @@ instrument_ref(llvm::RvsdgModule & rm)
   jlm::llvm::FunctionType loadFunctionType(
       { jlm::llvm::PointerType::Create().get(),
         &*jlm::rvsdg::bittype::Create(64),
-        llvm::iostatetype::create().get(),
+        llvm::iostatetype::Create().get(),
         llvm::MemoryStateType::Create().get() },
-      { llvm::iostatetype::create().get(), llvm::MemoryStateType::Create().get() });
+      { llvm::iostatetype::Create().get(), llvm::MemoryStateType::Create().get() });
   jlm::llvm::impport load_imp(
       loadFunctionType,
       "reference_load",
@@ -104,9 +104,9 @@ instrument_ref(llvm::RvsdgModule & rm)
       { jlm::llvm::PointerType::Create().get(),
         &*jlm::rvsdg::bittype::Create(64),
         &*jlm::rvsdg::bittype::Create(64),
-        llvm::iostatetype::create().get(),
+        llvm::iostatetype::Create().get(),
         jlm::llvm::MemoryStateType::Create().get() },
-      { llvm::iostatetype::create().get(), jlm::llvm::MemoryStateType::Create().get() });
+      { llvm::iostatetype::Create().get(), jlm::llvm::MemoryStateType::Create().get() });
   jlm::llvm::impport store_imp(
       storeFunctionType,
       "reference_store",
@@ -116,9 +116,9 @@ instrument_ref(llvm::RvsdgModule & rm)
   jlm::llvm::FunctionType allocaFunctionType(
       { jlm::llvm::PointerType::Create().get(),
         &*jlm::rvsdg::bittype::Create(64),
-        llvm::iostatetype::create().get(),
+        llvm::iostatetype::Create().get(),
         jlm::llvm::MemoryStateType::Create().get() },
-      { llvm::iostatetype::create().get(), jlm::llvm::MemoryStateType::Create().get() });
+      { llvm::iostatetype::Create().get(), jlm::llvm::MemoryStateType::Create().get() });
   jlm::llvm::impport alloca_imp(
       allocaFunctionType,
       "reference_alloca",

--- a/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
@@ -587,9 +587,9 @@ jlm::hls::MemoryConverter(jlm::llvm::RvsdgModule & rm)
   port_load_store_decouple portNodes;
   trace_pointer_arguments(lambda, portNodes);
 
-  auto responseTypePtr = get_mem_res_type(jlm::rvsdg::bit64);
-  auto requestTypePtr = get_mem_req_type(jlm::rvsdg::bit64, false);
-  auto requestTypePtrWrite = get_mem_req_type(jlm::rvsdg::bit64, true);
+  auto responseTypePtr = get_mem_res_type(*jlm::rvsdg::bittype::Create(64));
+  auto requestTypePtr = get_mem_req_type(*jlm::rvsdg::bittype::Create(64), false);
+  auto requestTypePtrWrite = get_mem_req_type(*jlm::rvsdg::bittype::Create(64), true);
 
   std::unordered_set<jlm::rvsdg::simple_node *> accountedNodes;
   for (auto & portNode : portNodes)
@@ -781,7 +781,7 @@ jlm::hls::ConnectRequestResponseMemPorts(
     auto decoupledOutput =
         dynamic_cast<jlm::rvsdg::simple_output *>(smap.lookup(decoupledNode->output(0)));
     decoupledNodes.push_back(decoupledOutput->node());
-    loadTypes.push_back(&jlm::rvsdg::bit32);
+    loadTypes.push_back(&*jlm::rvsdg::bittype::Create(32));
   }
 
   auto lambdaRegion = lambda->subregion();

--- a/jlm/hls/ir/hls.cpp
+++ b/jlm/hls/ir/hls.cpp
@@ -137,7 +137,8 @@ loop_node::set_predicate(jlm::rvsdg::output * p)
 std::unique_ptr<bundletype>
 get_mem_req_type(const rvsdg::valuetype & elementType, bool write)
 {
-  auto elements = new std::vector<std::pair<std::string, std::unique_ptr<jlm::rvsdg::type>>>();
+  auto elements =
+      new std::vector<std::pair<std::string, std::shared_ptr<const jlm::rvsdg::type>>>();
   elements->emplace_back("addr", llvm::PointerType::Create());
   elements->emplace_back("size", std::make_unique<jlm::rvsdg::bittype>(4));
   elements->emplace_back("id", std::make_unique<jlm::rvsdg::bittype>(8));
@@ -152,7 +153,8 @@ get_mem_req_type(const rvsdg::valuetype & elementType, bool write)
 std::unique_ptr<bundletype>
 get_mem_res_type(const jlm::rvsdg::valuetype & dataType)
 {
-  auto elements = new std::vector<std::pair<std::string, std::unique_ptr<jlm::rvsdg::type>>>();
+  auto elements =
+      new std::vector<std::pair<std::string, std::shared_ptr<const jlm::rvsdg::type>>>();
   elements->emplace_back("data", dataType.copy());
   elements->emplace_back("id", std::make_unique<jlm::rvsdg::bittype>(8));
   return std::make_unique<bundletype>(elements);

--- a/jlm/hls/ir/hls.hpp
+++ b/jlm/hls/ir/hls.hpp
@@ -409,10 +409,10 @@ public:
     return type;
   };
 
-  virtual std::unique_ptr<jlm::rvsdg::type>
+  std::shared_ptr<const jlm::rvsdg::type>
   copy() const override
   {
-    return std::unique_ptr<jlm::rvsdg::type>(new triggertype(*this));
+    return std::make_shared<triggertype>(*this);
   }
 
 private:
@@ -663,7 +663,7 @@ public:
   {}
 
   bundletype(
-      const std::vector<std::pair<std::string, std::unique_ptr<jlm::rvsdg::type>>> * elements)
+      const std::vector<std::pair<std::string, std::shared_ptr<const jlm::rvsdg::type>>> * elements)
       : jlm::rvsdg::valuetype(),
         elements_(std::move(elements))
   {}
@@ -698,7 +698,7 @@ public:
     return true;
   };
 
-  jlm::rvsdg::type *
+  const jlm::rvsdg::type *
   get_element_type(std::string element) const
   {
     for (size_t i = 0; i < elements_->size(); ++i)
@@ -712,10 +712,10 @@ public:
     return nullptr;
   }
 
-  virtual std::unique_ptr<jlm::rvsdg::type>
+  std::shared_ptr<const jlm::rvsdg::type>
   copy() const override
   {
-    return std::unique_ptr<jlm::rvsdg::type>(new bundletype(*this));
+    return std::make_shared<bundletype>(*this);
   }
 
   virtual std::string
@@ -726,7 +726,7 @@ public:
 
   //        private:
   // TODO: fix memory leak
-  const std::vector<std::pair<std::string, std::unique_ptr<jlm::rvsdg::type>>> * elements_;
+  const std::vector<std::pair<std::string, std::shared_ptr<const jlm::rvsdg::type>>> * elements_;
 };
 
 std::unique_ptr<bundletype>
@@ -1088,8 +1088,8 @@ public:
       const std::vector<const rvsdg::valuetype *> & store_types)
       : simple_op(CreateInPorts(load_types, store_types), CreateOutPorts(load_types, store_types))
   {
-    LoadTypes_ = new std::vector<std::unique_ptr<rvsdg::type>>();
-    StoreTypes_ = new std::vector<std::unique_ptr<rvsdg::type>>();
+    LoadTypes_ = new std::vector<std::shared_ptr<const rvsdg::type>>();
+    StoreTypes_ = new std::vector<std::shared_ptr<const rvsdg::type>>();
     for (auto loadType : load_types)
     {
       JLM_ASSERT(
@@ -1106,8 +1106,8 @@ public:
   mem_req_op(const mem_req_op & other)
       : simple_op(other)
   {
-    LoadTypes_ = new std::vector<std::unique_ptr<rvsdg::type>>();
-    StoreTypes_ = new std::vector<std::unique_ptr<rvsdg::type>>();
+    LoadTypes_ = new std::vector<std::shared_ptr<const rvsdg::type>>();
+    StoreTypes_ = new std::vector<std::shared_ptr<const rvsdg::type>>();
     for (auto & loadType : *other.LoadTypes_)
     {
       LoadTypes_->push_back(loadType->copy());
@@ -1207,21 +1207,21 @@ public:
     return LoadTypes_->size();
   }
 
-  std::vector<std::unique_ptr<rvsdg::type>> *
+  std::vector<std::shared_ptr<const rvsdg::type>> *
   GetLoadTypes() const
   {
     return LoadTypes_;
   }
 
-  std::vector<std::unique_ptr<rvsdg::type>> *
+  std::vector<std::shared_ptr<const rvsdg::type>> *
   GetStoreTypes() const
   {
     return StoreTypes_;
   }
 
 private:
-  std::vector<std::unique_ptr<rvsdg::type>> * LoadTypes_;
-  std::vector<std::unique_ptr<rvsdg::type>> * StoreTypes_;
+  std::vector<std::shared_ptr<const rvsdg::type>> * LoadTypes_;
+  std::vector<std::shared_ptr<const rvsdg::type>> * StoreTypes_;
 };
 
 class store_op final : public jlm::rvsdg::simple_op

--- a/jlm/hls/ir/hls.hpp
+++ b/jlm/hls/ir/hls.hpp
@@ -1416,7 +1416,7 @@ public:
   static std::vector<jlm::rvsdg::port>
   CreateInPorts(const jlm::rvsdg::valuetype & valuetype, size_t numStates)
   {
-    std::vector<jlm::rvsdg::port> ports(1, { jlm::rvsdg::bit64 });
+    std::vector<jlm::rvsdg::port> ports(1, { *jlm::rvsdg::bittype::Create(64) });
     std::vector<jlm::rvsdg::port> states(numStates, { llvm::MemoryStateType::Create() });
     ports.insert(ports.end(), states.begin(), states.end());
     ports.emplace_back(valuetype); // result
@@ -1429,7 +1429,7 @@ public:
     std::vector<jlm::rvsdg::port> ports(1, { valuetype });
     std::vector<jlm::rvsdg::port> states(numStates, { llvm::MemoryStateType::Create() });
     ports.insert(ports.end(), states.begin(), states.end());
-    ports.emplace_back(jlm::rvsdg::bit64); // addr
+    ports.emplace_back(*jlm::rvsdg::bittype::Create(64)); // addr
     return ports;
   }
 
@@ -1490,7 +1490,7 @@ public:
   static std::vector<jlm::rvsdg::port>
   CreateInPorts(const jlm::rvsdg::valuetype & valuetype, size_t numStates)
   {
-    std::vector<jlm::rvsdg::port> ports({ jlm::rvsdg::bit64, valuetype });
+    std::vector<jlm::rvsdg::port> ports({ *jlm::rvsdg::bittype::Create(64), valuetype });
     std::vector<jlm::rvsdg::port> states(numStates, { llvm::MemoryStateType::Create() });
     ports.insert(ports.end(), states.begin(), states.end());
     return ports;
@@ -1500,8 +1500,8 @@ public:
   CreateOutPorts(const jlm::rvsdg::valuetype & valuetype, size_t numStates)
   {
     std::vector<jlm::rvsdg::port> ports(numStates, { llvm::MemoryStateType::Create() });
-    ports.emplace_back(jlm::rvsdg::bit64); // addr
-    ports.emplace_back(valuetype);         // data
+    ports.emplace_back(*jlm::rvsdg::bittype::Create(64)); // addr
+    ports.emplace_back(valuetype);                        // data
     return ports;
   }
 
@@ -1567,12 +1567,12 @@ public:
     std::vector<jlm::rvsdg::port> ports(1, at);
     for (size_t i = 0; i < load_cnt; ++i)
     {
-      ports.emplace_back(jlm::rvsdg::bit64); // addr
+      ports.emplace_back(*jlm::rvsdg::bittype::Create(64)); // addr
     }
     for (size_t i = 0; i < store_cnt; ++i)
     {
-      ports.emplace_back(jlm::rvsdg::bit64); // addr
-      ports.emplace_back(at.element_type()); // data
+      ports.emplace_back(*jlm::rvsdg::bittype::Create(64)); // addr
+      ports.emplace_back(at.element_type());                // data
     }
     return ports;
   }

--- a/jlm/llvm/frontend/LlvmTypeConversion.cpp
+++ b/jlm/llvm/frontend/LlvmTypeConversion.cpp
@@ -42,7 +42,7 @@ static std::unique_ptr<rvsdg::valuetype>
 convert_pointer_type(const ::llvm::Type * t, context &)
 {
   JLM_ASSERT(t->getTypeID() == ::llvm::Type::PointerTyID);
-  return PointerType::Create();
+  return std::make_unique<PointerType>();
 }
 
 static std::unique_ptr<rvsdg::valuetype>
@@ -57,14 +57,14 @@ convert_function_type(const ::llvm::Type * t, context & ctx)
     argumentTypes.push_back(ConvertType(type->getParamType(n), ctx));
   if (type->isVarArg())
     argumentTypes.push_back(create_varargtype());
-  argumentTypes.push_back(iostatetype::create());
+  argumentTypes.push_back(iostatetype::Create());
   argumentTypes.push_back(MemoryStateType::Create());
 
   /* results */
   std::vector<std::shared_ptr<const rvsdg::type>> resultTypes;
   if (type->getReturnType()->getTypeID() != ::llvm::Type::VoidTyID)
     resultTypes.push_back(ConvertType(type->getReturnType(), ctx));
-  resultTypes.push_back(iostatetype::create());
+  resultTypes.push_back(iostatetype::Create());
   resultTypes.push_back(MemoryStateType::Create());
 
   return std::unique_ptr<rvsdg::valuetype>(

--- a/jlm/llvm/frontend/LlvmTypeConversion.cpp
+++ b/jlm/llvm/frontend/LlvmTypeConversion.cpp
@@ -52,7 +52,7 @@ convert_function_type(const ::llvm::Type * t, context & ctx)
   auto type = ::llvm::cast<const ::llvm::FunctionType>(t);
 
   /* arguments */
-  std::vector<std::unique_ptr<rvsdg::type>> argumentTypes;
+  std::vector<std::shared_ptr<const rvsdg::type>> argumentTypes;
   for (size_t n = 0; n < type->getNumParams(); n++)
     argumentTypes.push_back(ConvertType(type->getParamType(n), ctx));
   if (type->isVarArg())
@@ -61,7 +61,7 @@ convert_function_type(const ::llvm::Type * t, context & ctx)
   argumentTypes.push_back(MemoryStateType::Create());
 
   /* results */
-  std::vector<std::unique_ptr<rvsdg::type>> resultTypes;
+  std::vector<std::shared_ptr<const rvsdg::type>> resultTypes;
   if (type->getReturnType()->getTypeID() != ::llvm::Type::VoidTyID)
     resultTypes.push_back(ConvertType(type->getReturnType(), ctx));
   resultTypes.push_back(iostatetype::create());

--- a/jlm/llvm/ir/RvsdgModule.hpp
+++ b/jlm/llvm/ir/RvsdgModule.hpp
@@ -54,7 +54,7 @@ public:
   [[nodiscard]] const jlm::rvsdg::valuetype &
   GetValueType() const noexcept
   {
-    return *jlm::util::AssertedCast<jlm::rvsdg::valuetype>(ValueType_.get());
+    return *jlm::util::AssertedCast<const jlm::rvsdg::valuetype>(ValueType_.get());
   }
 
   virtual bool
@@ -65,7 +65,7 @@ public:
 
 private:
   jlm::llvm::linkage linkage_;
-  std::unique_ptr<jlm::rvsdg::type> ValueType_;
+  std::shared_ptr<const jlm::rvsdg::type> ValueType_;
 };
 
 static inline bool

--- a/jlm/llvm/ir/attribute.hpp
+++ b/jlm/llvm/ir/attribute.hpp
@@ -276,7 +276,7 @@ private:
 
   type_attribute(attribute::kind kind, const jlm::rvsdg::valuetype & type)
       : enum_attribute(kind),
-        type_(static_cast<jlm::rvsdg::valuetype *>(type.copy().release()))
+        type_(std::dynamic_pointer_cast<const jlm::rvsdg::valuetype>(type.copy()))
   {}
 
 public:
@@ -306,7 +306,7 @@ public:
   }
 
 private:
-  std::unique_ptr<jlm::rvsdg::valuetype> type_;
+  std::shared_ptr<const jlm::rvsdg::valuetype> type_;
 };
 
 /** \brief Attribute set

--- a/jlm/llvm/ir/ipgraph.hpp
+++ b/jlm/llvm/ir/ipgraph.hpp
@@ -383,7 +383,7 @@ public:
   [[nodiscard]] const jlm::rvsdg::valuetype &
   GetValueType() const noexcept
   {
-    return *jlm::util::AssertedCast<jlm::rvsdg::valuetype>(ValueType_.get());
+    return *jlm::util::AssertedCast<const jlm::rvsdg::valuetype>(ValueType_.get());
   }
 
   const std::string &
@@ -446,7 +446,7 @@ private:
   std::string name_;
   std::string Section_;
   llvm::linkage linkage_;
-  std::unique_ptr<jlm::rvsdg::type> ValueType_;
+  std::shared_ptr<const jlm::rvsdg::type> ValueType_;
   std::unique_ptr<data_node_init> init_;
 };
 

--- a/jlm/llvm/ir/operators/GetElementPtr.hpp
+++ b/jlm/llvm/ir/operators/GetElementPtr.hpp
@@ -161,7 +161,7 @@ private:
     return ports;
   }
 
-  std::unique_ptr<rvsdg::type> PointeeType_;
+  std::shared_ptr<const rvsdg::type> PointeeType_;
 };
 
 }

--- a/jlm/llvm/ir/operators/MemCpy.hpp
+++ b/jlm/llvm/ir/operators/MemCpy.hpp
@@ -37,7 +37,7 @@ protected:
     JLM_ASSERT(is<PointerType>(srcAddressType));
 
     auto & lengthType = operandPorts[2].type();
-    if (lengthType != rvsdg::bit32 && lengthType != rvsdg::bit64)
+    if (lengthType != *rvsdg::bittype::Create(32) && lengthType != *rvsdg::bittype::Create(64))
     {
       throw util::error("Expected 32 bit or 64 bit integer type.");
     }

--- a/jlm/llvm/ir/operators/alloca.hpp
+++ b/jlm/llvm/ir/operators/alloca.hpp
@@ -95,7 +95,7 @@ public:
 
 private:
   size_t alignment_;
-  std::unique_ptr<rvsdg::type> AllocatedType_;
+  std::shared_ptr<const rvsdg::type> AllocatedType_;
 };
 
 }

--- a/jlm/llvm/ir/operators/delta.hpp
+++ b/jlm/llvm/ir/operators/delta.hpp
@@ -96,7 +96,7 @@ public:
   [[nodiscard]] const rvsdg::valuetype &
   type() const noexcept
   {
-    return *jlm::util::AssertedCast<rvsdg::valuetype>(type_.get());
+    return *jlm::util::AssertedCast<const rvsdg::valuetype>(type_.get());
   }
 
 private:
@@ -104,7 +104,7 @@ private:
   std::string name_;
   std::string Section_;
   llvm::linkage linkage_;
-  std::unique_ptr<rvsdg::type> type_;
+  std::shared_ptr<const rvsdg::type> type_;
 };
 
 class cvargument;

--- a/jlm/llvm/ir/operators/operators.hpp
+++ b/jlm/llvm/ir/operators/operators.hpp
@@ -129,7 +129,7 @@ public:
   virtual ~select_op() noexcept;
 
   select_op(const jlm::rvsdg::type & type)
-      : jlm::rvsdg::simple_op({ jlm::rvsdg::bit1, type, type }, { type })
+      : jlm::rvsdg::simple_op({ *jlm::rvsdg::bittype::Create(1), type, type }, { type })
   {}
 
   virtual bool
@@ -207,7 +207,7 @@ private:
   createVectorSelectTac(const variable * p, const variable * t, const variable * f)
   {
     auto fvt = static_cast<const T *>(&t->type());
-    T pt(jlm::rvsdg::bit1, fvt->size());
+    T pt(*jlm::rvsdg::bittype::Create(1), fvt->size());
     T vt(fvt->type(), fvt->size());
     vectorselect_op op(pt, vt);
     return tac::create(op, { p, t, f });
@@ -684,7 +684,7 @@ public:
   virtual ~ptrcmp_op();
 
   inline ptrcmp_op(const PointerType & ptype, const llvm::cmp & cmp)
-      : binary_op({ ptype, ptype }, { jlm::rvsdg::bit1 }),
+      : binary_op({ ptype, ptype }, { *jlm::rvsdg::bittype::Create(1) }),
         cmp_(cmp)
   {}
 
@@ -898,7 +898,7 @@ public:
   virtual ~fpcmp_op();
 
   inline fpcmp_op(const fpcmp & cmp, const fpsize & size)
-      : binary_op({ fptype(size), fptype(size) }, { jlm::rvsdg::bit1 }),
+      : binary_op({ fptype(size), fptype(size) }, { *jlm::rvsdg::bittype::Create(1) }),
         cmp_(cmp)
   {}
 

--- a/jlm/llvm/ir/operators/operators.hpp
+++ b/jlm/llvm/ir/operators/operators.hpp
@@ -1366,7 +1366,7 @@ class valist_op final : public jlm::rvsdg::simple_op
 public:
   virtual ~valist_op();
 
-  inline valist_op(std::vector<std::unique_ptr<jlm::rvsdg::type>> types)
+  explicit valist_op(std::vector<std::shared_ptr<const jlm::rvsdg::type>> types)
       : simple_op(create_srcports(std::move(types)), { varargtype() })
   {}
 
@@ -1390,7 +1390,7 @@ public:
   static std::unique_ptr<llvm::tac>
   create(const std::vector<const variable *> & arguments)
   {
-    std::vector<std::unique_ptr<jlm::rvsdg::type>> operands;
+    std::vector<std::shared_ptr<const jlm::rvsdg::type>> operands;
     for (const auto & argument : arguments)
       operands.push_back(argument->type().copy());
 
@@ -1401,7 +1401,7 @@ public:
   static rvsdg::output *
   Create(rvsdg::region & region, const std::vector<rvsdg::output *> & operands)
   {
-    std::vector<std::unique_ptr<rvsdg::type>> operandTypes;
+    std::vector<std::shared_ptr<const rvsdg::type>> operandTypes;
     operandTypes.reserve(operands.size());
     for (auto & operand : operands)
       operandTypes.emplace_back(operand->type().copy());
@@ -1412,11 +1412,11 @@ public:
 
 private:
   static inline std::vector<jlm::rvsdg::port>
-  create_srcports(std::vector<std::unique_ptr<jlm::rvsdg::type>> types)
+  create_srcports(std::vector<std::shared_ptr<const jlm::rvsdg::type>> types)
   {
     std::vector<jlm::rvsdg::port> ports;
     for (const auto & type : types)
-      ports.push_back(jlm::rvsdg::port(*type));
+      ports.push_back(jlm::rvsdg::port(type));
 
     return ports;
   }

--- a/jlm/llvm/ir/operators/operators.hpp
+++ b/jlm/llvm/ir/operators/operators.hpp
@@ -2489,7 +2489,7 @@ private:
 
     std::vector<jlm::rvsdg::port> ports({ PointerType() });
     ports.insert(ports.end(), memoryStates.begin(), memoryStates.end());
-    ports.emplace_back(iostatetype::instance());
+    ports.emplace_back(rvsdg::port(iostatetype::Create()));
 
     return ports;
   }
@@ -2498,7 +2498,7 @@ private:
   CreateResultPorts(size_t numMemoryStates)
   {
     std::vector<jlm::rvsdg::port> ports(numMemoryStates, { MemoryStateType::Create() });
-    ports.emplace_back(iostatetype::instance());
+    ports.emplace_back(rvsdg::port(iostatetype::Create()));
 
     return ports;
   }

--- a/jlm/llvm/ir/types.cpp
+++ b/jlm/llvm/ir/types.cpp
@@ -147,6 +147,13 @@ PointerType::copy() const
   return std::make_shared<PointerType>(*this);
 }
 
+std::shared_ptr<const PointerType>
+PointerType::Create()
+{
+  static const PointerType instance;
+  return std::shared_ptr<const PointerType>(std::shared_ptr<void>(), &instance);
+}
+
 /* array type */
 
 arraytype::~arraytype()
@@ -324,6 +331,13 @@ iostatetype::copy() const
   return std::make_shared<iostatetype>(*this);
 }
 
+std::shared_ptr<const iostatetype>
+iostatetype::Create()
+{
+  static const iostatetype instance;
+  return std::shared_ptr<const iostatetype>(std::shared_ptr<void>(), &instance);
+}
+
 /**
  * MemoryStateType class
  */
@@ -345,6 +359,13 @@ std::shared_ptr<const jlm::rvsdg::type>
 MemoryStateType::copy() const
 {
   return std::make_shared<MemoryStateType>(*this);
+}
+
+std::shared_ptr<const MemoryStateType>
+MemoryStateType::Create()
+{
+  static const MemoryStateType instance;
+  return std::shared_ptr<const MemoryStateType>(std::shared_ptr<void>(), &instance);
 }
 
 }

--- a/jlm/llvm/ir/types.cpp
+++ b/jlm/llvm/ir/types.cpp
@@ -29,8 +29,8 @@ FunctionType::FunctionType(
 }
 
 FunctionType::FunctionType(
-    std::vector<std::unique_ptr<jlm::rvsdg::type>> argumentTypes,
-    std::vector<std::unique_ptr<jlm::rvsdg::type>> resultTypes)
+    std::vector<std::shared_ptr<const jlm::rvsdg::type>> argumentTypes,
+    std::vector<std::shared_ptr<const jlm::rvsdg::type>> resultTypes)
     : jlm::rvsdg::valuetype(),
       ResultTypes_(std::move(resultTypes)),
       ArgumentTypes_(std::move(argumentTypes))
@@ -98,10 +98,10 @@ FunctionType::operator==(const jlm::rvsdg::type & _other) const noexcept
   return true;
 }
 
-std::unique_ptr<jlm::rvsdg::type>
+std::shared_ptr<const jlm::rvsdg::type>
 FunctionType::copy() const
 {
-  return std::unique_ptr<jlm::rvsdg::type>(new FunctionType(*this));
+  return std::make_shared<FunctionType>(*this);
 }
 
 FunctionType &
@@ -141,10 +141,10 @@ PointerType::operator==(const jlm::rvsdg::type & other) const noexcept
   return jlm::rvsdg::is<PointerType>(other);
 }
 
-std::unique_ptr<jlm::rvsdg::type>
+std::shared_ptr<const jlm::rvsdg::type>
 PointerType::copy() const
 {
-  return std::unique_ptr<jlm::rvsdg::type>(new PointerType(*this));
+  return std::make_shared<PointerType>(*this);
 }
 
 /* array type */
@@ -165,10 +165,10 @@ arraytype::operator==(const jlm::rvsdg::type & other) const noexcept
   return type && type->element_type() == element_type() && type->nelements() == nelements();
 }
 
-std::unique_ptr<jlm::rvsdg::type>
+std::shared_ptr<const jlm::rvsdg::type>
 arraytype::copy() const
 {
-  return std::unique_ptr<jlm::rvsdg::type>(new arraytype(*this));
+  return std::make_shared<arraytype>(*this);
 }
 
 /* floating point type */
@@ -195,10 +195,10 @@ fptype::operator==(const jlm::rvsdg::type & other) const noexcept
   return type && type->size() == size();
 }
 
-std::unique_ptr<jlm::rvsdg::type>
+std::shared_ptr<const jlm::rvsdg::type>
 fptype::copy() const
 {
-  return std::unique_ptr<jlm::rvsdg::type>(new fptype(*this));
+  return std::make_shared<fptype>(*this);
 }
 
 /* vararg type */
@@ -218,10 +218,10 @@ varargtype::debug_string() const
   return "vararg";
 }
 
-std::unique_ptr<jlm::rvsdg::type>
+std::shared_ptr<const jlm::rvsdg::type>
 varargtype::copy() const
 {
-  return std::unique_ptr<jlm::rvsdg::type>(new varargtype(*this));
+  return std::make_shared<varargtype>(*this);
 }
 
 StructType::~StructType() = default;
@@ -240,10 +240,10 @@ StructType::debug_string() const
   return "struct";
 }
 
-std::unique_ptr<jlm::rvsdg::type>
+std::shared_ptr<const jlm::rvsdg::type>
 StructType::copy() const
 {
-  return std::unique_ptr<jlm::rvsdg::type>(new StructType(*this));
+  return std::make_shared<StructType>(*this);
 }
 
 /* vectortype */
@@ -272,10 +272,10 @@ fixedvectortype::debug_string() const
   return util::strfmt("fixedvector[", type().debug_string(), ":", size(), "]");
 }
 
-std::unique_ptr<jlm::rvsdg::type>
+std::shared_ptr<const jlm::rvsdg::type>
 fixedvectortype::copy() const
 {
-  return std::unique_ptr<jlm::rvsdg::type>(new fixedvectortype(*this));
+  return std::make_shared<fixedvectortype>(*this);
 }
 
 /* scalablevectortype */
@@ -295,10 +295,10 @@ scalablevectortype::debug_string() const
   return util::strfmt("scalablevector[", type().debug_string(), ":", size(), "]");
 }
 
-std::unique_ptr<jlm::rvsdg::type>
+std::shared_ptr<const jlm::rvsdg::type>
 scalablevectortype::copy() const
 {
-  return std::unique_ptr<jlm::rvsdg::type>(new scalablevectortype(*this));
+  return std::make_shared<scalablevectortype>(*this);
 }
 
 /* I/O state type */
@@ -318,10 +318,10 @@ iostatetype::debug_string() const
   return "iostate";
 }
 
-std::unique_ptr<jlm::rvsdg::type>
+std::shared_ptr<const jlm::rvsdg::type>
 iostatetype::copy() const
 {
-  return std::unique_ptr<jlm::rvsdg::type>(new iostatetype(*this));
+  return std::make_shared<iostatetype>(*this);
 }
 
 /**
@@ -341,10 +341,10 @@ MemoryStateType::operator==(const jlm::rvsdg::type & other) const noexcept
   return jlm::rvsdg::is<MemoryStateType>(other);
 }
 
-std::unique_ptr<jlm::rvsdg::type>
+std::shared_ptr<const jlm::rvsdg::type>
 MemoryStateType::copy() const
 {
-  return std::unique_ptr<jlm::rvsdg::type>(new MemoryStateType(*this));
+  return std::make_shared<MemoryStateType>(*this);
 }
 
 }

--- a/jlm/llvm/ir/types.hpp
+++ b/jlm/llvm/ir/types.hpp
@@ -32,25 +32,25 @@ class FunctionType final : public jlm::rvsdg::valuetype
     using reference = jlm::rvsdg::type *&;
 
     explicit TypeConstIterator(
-        const std::vector<std::unique_ptr<jlm::rvsdg::type>>::const_iterator & it)
+        const std::vector<std::shared_ptr<const jlm::rvsdg::type>>::const_iterator & it)
         : It_(it)
     {}
 
   public:
-    jlm::rvsdg::type *
+    const jlm::rvsdg::type *
     type() const noexcept
     {
       return It_->get();
     }
 
-    jlm::rvsdg::type &
+    const jlm::rvsdg::type &
     operator*() const
     {
       JLM_ASSERT(type() != nullptr);
       return *type();
     }
 
-    jlm::rvsdg::type *
+    const jlm::rvsdg::type *
     operator->() const
     {
       return type();
@@ -84,7 +84,7 @@ class FunctionType final : public jlm::rvsdg::valuetype
     }
 
   private:
-    std::vector<std::unique_ptr<jlm::rvsdg::type>>::const_iterator It_;
+    std::vector<std::shared_ptr<const jlm::rvsdg::type>>::const_iterator It_;
   };
 
   using ArgumentConstRange = jlm::util::iterator_range<TypeConstIterator>;
@@ -98,8 +98,8 @@ public:
       const std::vector<const jlm::rvsdg::type *> & resultTypes);
 
   FunctionType(
-      std::vector<std::unique_ptr<jlm::rvsdg::type>> argumentTypes,
-      std::vector<std::unique_ptr<jlm::rvsdg::type>> resultTypes);
+      std::vector<std::shared_ptr<const jlm::rvsdg::type>> argumentTypes,
+      std::vector<std::shared_ptr<const jlm::rvsdg::type>> resultTypes);
 
   FunctionType(const FunctionType & other);
 
@@ -149,12 +149,12 @@ public:
   bool
   operator==(const jlm::rvsdg::type & other) const noexcept override;
 
-  std::unique_ptr<jlm::rvsdg::type>
+  std::shared_ptr<const jlm::rvsdg::type>
   copy() const override;
 
 private:
-  std::vector<std::unique_ptr<jlm::rvsdg::type>> ResultTypes_;
-  std::vector<std::unique_ptr<jlm::rvsdg::type>> ArgumentTypes_;
+  std::vector<std::shared_ptr<const jlm::rvsdg::type>> ResultTypes_;
+  std::vector<std::shared_ptr<const jlm::rvsdg::type>> ArgumentTypes_;
 };
 
 /** \brief PointerType class
@@ -174,7 +174,7 @@ public:
   bool
   operator==(const jlm::rvsdg::type & other) const noexcept override;
 
-  [[nodiscard]] std::unique_ptr<jlm::rvsdg::type>
+  [[nodiscard]] std::shared_ptr<const jlm::rvsdg::type>
   copy() const override;
 
   static std::unique_ptr<PointerType>
@@ -221,7 +221,7 @@ public:
   virtual bool
   operator==(const jlm::rvsdg::type & other) const noexcept override;
 
-  virtual std::unique_ptr<jlm::rvsdg::type>
+  std::shared_ptr<const jlm::rvsdg::type>
   copy() const override;
 
   inline size_t
@@ -238,7 +238,7 @@ public:
 
 private:
   size_t nelements_;
-  std::unique_ptr<jlm::rvsdg::type> type_;
+  std::shared_ptr<const jlm::rvsdg::type> type_;
 };
 
 static inline std::unique_ptr<jlm::rvsdg::type>
@@ -277,7 +277,7 @@ public:
   virtual bool
   operator==(const jlm::rvsdg::type & other) const noexcept override;
 
-  virtual std::unique_ptr<jlm::rvsdg::type>
+  std::shared_ptr<const jlm::rvsdg::type>
   copy() const override;
 
   inline const fpsize &
@@ -304,7 +304,7 @@ public:
   virtual bool
   operator==(const jlm::rvsdg::type & other) const noexcept override;
 
-  virtual std::unique_ptr<jlm::rvsdg::type>
+  std::shared_ptr<const jlm::rvsdg::type>
   copy() const override;
 
   virtual std::string
@@ -384,7 +384,7 @@ public:
   bool
   operator==(const jlm::rvsdg::type & other) const noexcept override;
 
-  [[nodiscard]] std::unique_ptr<jlm::rvsdg::type>
+  [[nodiscard]] std::shared_ptr<const jlm::rvsdg::type>
   copy() const override;
 
   [[nodiscard]] std::string
@@ -458,7 +458,7 @@ public:
   }
 
 private:
-  std::vector<std::unique_ptr<rvsdg::type>> Types_;
+  std::vector<std::shared_ptr<const rvsdg::type>> Types_;
 };
 
 /* vector type */
@@ -522,7 +522,7 @@ public:
 
 private:
   size_t size_;
-  std::unique_ptr<jlm::rvsdg::type> type_;
+  std::shared_ptr<const jlm::rvsdg::type> type_;
 };
 
 class fixedvectortype final : public vectortype
@@ -537,7 +537,7 @@ public:
   virtual bool
   operator==(const jlm::rvsdg::type & other) const noexcept override;
 
-  virtual std::unique_ptr<jlm::rvsdg::type>
+  std::shared_ptr<const jlm::rvsdg::type>
   copy() const override;
 
   virtual std::string
@@ -556,7 +556,7 @@ public:
   virtual bool
   operator==(const jlm::rvsdg::type & other) const noexcept override;
 
-  virtual std::unique_ptr<jlm::rvsdg::type>
+  std::shared_ptr<const jlm::rvsdg::type>
   copy() const override;
 
   virtual std::string
@@ -578,7 +578,7 @@ public:
   virtual bool
   operator==(const jlm::rvsdg::type & other) const noexcept override;
 
-  virtual std::unique_ptr<jlm::rvsdg::type>
+  std::shared_ptr<const jlm::rvsdg::type>
   copy() const override;
 
   virtual std::string
@@ -618,7 +618,7 @@ public:
   bool
   operator==(const jlm::rvsdg::type & other) const noexcept override;
 
-  std::unique_ptr<jlm::rvsdg::type>
+  std::shared_ptr<const jlm::rvsdg::type>
   copy() const override;
 
   static std::unique_ptr<MemoryStateType>

--- a/jlm/llvm/ir/types.hpp
+++ b/jlm/llvm/ir/types.hpp
@@ -177,11 +177,8 @@ public:
   [[nodiscard]] std::shared_ptr<const jlm::rvsdg::type>
   copy() const override;
 
-  static std::unique_ptr<PointerType>
-  Create()
-  {
-    return std::make_unique<PointerType>();
-  }
+  static std::shared_ptr<const PointerType>
+  Create();
 };
 
 /* array type */
@@ -584,18 +581,8 @@ public:
   virtual std::string
   debug_string() const override;
 
-  static std::unique_ptr<jlm::rvsdg::type>
-  create()
-  {
-    return std::make_unique<iostatetype>();
-  }
-
-  static const iostatetype &
-  instance() noexcept
-  {
-    static iostatetype iotype;
-    return iotype;
-  }
+  static std::shared_ptr<const iostatetype>
+  Create();
 };
 
 /** \brief Memory state type class
@@ -621,11 +608,8 @@ public:
   std::shared_ptr<const jlm::rvsdg::type>
   copy() const override;
 
-  static std::unique_ptr<MemoryStateType>
-  Create()
-  {
-    return std::make_unique<MemoryStateType>();
-  }
+  static std::shared_ptr<const MemoryStateType>
+  Create();
 };
 
 template<class ELEMENTYPE>

--- a/jlm/llvm/ir/variable.hpp
+++ b/jlm/llvm/ir/variable.hpp
@@ -67,7 +67,7 @@ public:
 
 private:
   std::string name_;
-  std::unique_ptr<jlm::rvsdg::type> type_;
+  std::shared_ptr<const jlm::rvsdg::type> type_;
 };
 
 template<class T>

--- a/jlm/mlir/frontend/MlirToJlmConverter.cpp
+++ b/jlm/mlir/frontend/MlirToJlmConverter.cpp
@@ -359,15 +359,15 @@ MlirToJlmConverter::ConvertLambda(::mlir::Operation & mlirLambda, rvsdg::region 
 
   // Create the RVSDG function signature
   auto lambdaRefType = ::mlir::cast<::mlir::rvsdg::LambdaRefType>(result);
-  std::vector<std::unique_ptr<rvsdg::type>> argumentTypes;
+  std::vector<std::shared_ptr<const rvsdg::type>> argumentTypes;
   for (auto argumentType : lambdaRefType.getParameterTypes())
   {
-    argumentTypes.push_back(ConvertType(argumentType));
+    argumentTypes.push_back(ConvertType(argumentType)->copy());
   }
-  std::vector<std::unique_ptr<rvsdg::type>> resultTypes;
+  std::vector<std::shared_ptr<const rvsdg::type>> resultTypes;
   for (auto returnType : lambdaRefType.getReturnTypes())
   {
-    resultTypes.push_back(ConvertType(returnType));
+    resultTypes.push_back(ConvertType(returnType)->copy());
   }
   llvm::FunctionType functionType(std::move(argumentTypes), std::move(resultTypes));
 

--- a/jlm/rvsdg/bitstring/bitoperation-classes.hpp
+++ b/jlm/rvsdg/bitstring/bitoperation-classes.hpp
@@ -95,7 +95,7 @@ public:
   virtual ~bitcompare_op() noexcept;
 
   inline bitcompare_op(const bittype & type) noexcept
-      : binary_op({ type, type }, bit1)
+      : binary_op({ type, type }, *bittype::Create(1))
   {}
 
   virtual binop_reduction_path_t

--- a/jlm/rvsdg/bitstring/type.cpp
+++ b/jlm/rvsdg/bitstring/type.cpp
@@ -28,10 +28,10 @@ bittype::operator==(const jlm::rvsdg::type & other) const noexcept
   return type != nullptr && this->nbits() == type->nbits();
 }
 
-std::unique_ptr<jlm::rvsdg::type>
+std::shared_ptr<const jlm::rvsdg::type>
 bittype::copy() const
 {
-  return std::unique_ptr<jlm::rvsdg::type>(new bittype(*this));
+  return std::make_shared<bittype>(nbits_);
 }
 
 const bittype bit1(1);

--- a/jlm/rvsdg/bitstring/type.cpp
+++ b/jlm/rvsdg/bitstring/type.cpp
@@ -34,10 +34,35 @@ bittype::copy() const
   return std::make_shared<bittype>(nbits_);
 }
 
-const bittype bit1(1);
-const bittype bit8(8);
-const bittype bit16(16);
-const bittype bit32(32);
-const bittype bit64(64);
+std::shared_ptr<const bittype>
+bittype::Create(std::size_t nbits)
+{
+  static const bittype static_instances[65] = {
+    bittype(0),  bittype(1),  bittype(2),  bittype(3),  bittype(4),  bittype(5),  bittype(6),
+    bittype(7),  bittype(8),  bittype(9),  bittype(10), bittype(11), bittype(12), bittype(13),
+    bittype(14), bittype(15), bittype(16), bittype(17), bittype(18), bittype(19), bittype(20),
+    bittype(21), bittype(22), bittype(23), bittype(24), bittype(25), bittype(26), bittype(27),
+    bittype(28), bittype(29), bittype(30), bittype(31), bittype(32), bittype(33), bittype(34),
+    bittype(35), bittype(36), bittype(37), bittype(38), bittype(39), bittype(40), bittype(41),
+    bittype(42), bittype(43), bittype(44), bittype(45), bittype(46), bittype(47), bittype(48),
+    bittype(49), bittype(50), bittype(51), bittype(52), bittype(53), bittype(54), bittype(55),
+    bittype(56), bittype(57), bittype(58), bittype(59), bittype(60), bittype(61), bittype(62),
+    bittype(63), bittype(64)
+  };
+
+  if (nbits <= 64)
+  {
+    if (nbits == 0)
+    {
+      throw jlm::util::error("Number of bits must be greater than zero.");
+    }
+
+    return std::shared_ptr<const bittype>(std::shared_ptr<void>(), &static_instances[nbits]);
+  }
+  else
+  {
+    return std::make_shared<bittype>(nbits);
+  }
+}
 
 }

--- a/jlm/rvsdg/bitstring/type.hpp
+++ b/jlm/rvsdg/bitstring/type.hpp
@@ -22,10 +22,7 @@ public:
 
   inline constexpr bittype(size_t nbits)
       : nbits_(nbits)
-  {
-    if (nbits == 0)
-      throw jlm::util::error("Number of bits must be greater than zero.");
-  }
+  {}
 
   inline size_t
   nbits() const noexcept
@@ -42,15 +39,25 @@ public:
   std::shared_ptr<const jlm::rvsdg::type>
   copy() const override;
 
+  /**
+   * \brief Creates bit type of specified width
+   *
+   * \param nbits
+   *    Width of type
+   *
+   * \returns
+   *    Type representing bitstring of specified width.
+   *
+   * Returns an instance of a bitstring type with specified
+   * width. Usually this returns a singleton object instance
+   * for the type
+   */
+  static std::shared_ptr<const bittype>
+  Create(std::size_t nbits);
+
 private:
   size_t nbits_;
 };
-
-extern const bittype bit1;
-extern const bittype bit8;
-extern const bittype bit16;
-extern const bittype bit32;
-extern const bittype bit64;
 
 }
 

--- a/jlm/rvsdg/bitstring/type.hpp
+++ b/jlm/rvsdg/bitstring/type.hpp
@@ -39,7 +39,7 @@ public:
   virtual bool
   operator==(const jlm::rvsdg::type & other) const noexcept override;
 
-  virtual std::unique_ptr<jlm::rvsdg::type>
+  std::shared_ptr<const jlm::rvsdg::type>
   copy() const override;
 
 private:

--- a/jlm/rvsdg/control.cpp
+++ b/jlm/rvsdg/control.cpp
@@ -41,10 +41,10 @@ ctltype::operator==(const jlm::rvsdg::type & other) const noexcept
   return type && type->nalternatives_ == nalternatives_;
 }
 
-std::unique_ptr<jlm::rvsdg::type>
+std::shared_ptr<const jlm::rvsdg::type>
 ctltype::copy() const
 {
-  return std::unique_ptr<jlm::rvsdg::type>(new ctltype(*this));
+  return std::make_shared<ctltype>(*this);
 }
 
 const ctltype ctl2(2);

--- a/jlm/rvsdg/control.cpp
+++ b/jlm/rvsdg/control.cpp
@@ -23,10 +23,7 @@ ctltype::~ctltype() noexcept
 ctltype::ctltype(size_t nalternatives)
     : jlm::rvsdg::statetype(),
       nalternatives_(nalternatives)
-{
-  if (nalternatives == 0)
-    throw jlm::util::error("Alternatives of a control type must be non-zero.");
-}
+{}
 
 std::string
 ctltype::debug_string() const
@@ -47,7 +44,32 @@ ctltype::copy() const
   return std::make_shared<ctltype>(*this);
 }
 
-const ctltype ctl2(2);
+std::shared_ptr<const ctltype>
+ctltype::Create(std::size_t nalternatives)
+{
+  static const ctltype static_instances[4] = { // ctltype(0) is not valid, but put it in here so
+                                               // the static array indexing works correctly
+                                               ctltype(0),
+                                               ctltype(1),
+                                               ctltype(2),
+                                               ctltype(3)
+  };
+
+  if (nalternatives < 4)
+  {
+    if (nalternatives == 0)
+    {
+      throw jlm::util::error("Alternatives of a control type must be non-zero.");
+    }
+    return std::shared_ptr<const jlm::rvsdg::ctltype>(
+        std::shared_ptr<void>(),
+        &static_instances[nalternatives]);
+  }
+  else
+  {
+    return std::make_shared<ctltype>(nalternatives);
+  }
+}
 
 /* control value representation */
 

--- a/jlm/rvsdg/control.hpp
+++ b/jlm/rvsdg/control.hpp
@@ -44,6 +44,20 @@ public:
     return nalternatives_;
   }
 
+  /**
+   * \brief Instantiates control type
+   *
+   * \param nalternatives Number of alternatives
+   *
+   * \returns Control type instance
+   *
+   * Creates an instance of a control type capable of representing
+   * the specified number of alternatives. The returned instance
+   * will usually be a static singleton for the type.
+   */
+  static std::shared_ptr<const ctltype>
+  Create(std::size_t nalternatives);
+
 private:
   size_t nalternatives_;
 };
@@ -231,8 +245,6 @@ match(
     uint64_t default_alternative,
     size_t nalternatives,
     jlm::rvsdg::output * operand);
-
-extern const ctltype ctl2;
 
 // declare explicit instantiation
 extern template class domain_const_op<ctltype, ctlvalue_repr, ctlformat_value, ctltype_of_value>;

--- a/jlm/rvsdg/control.hpp
+++ b/jlm/rvsdg/control.hpp
@@ -35,7 +35,7 @@ public:
   virtual bool
   operator==(const jlm::rvsdg::type & other) const noexcept override;
 
-  virtual std::unique_ptr<jlm::rvsdg::type>
+  std::shared_ptr<const jlm::rvsdg::type>
   copy() const override;
 
   inline size_t

--- a/jlm/rvsdg/operation.cpp
+++ b/jlm/rvsdg/operation.cpp
@@ -20,14 +20,16 @@ port::port(const jlm::rvsdg::type & type)
     : port(type.copy())
 {}
 
-port::port(std::unique_ptr<jlm::rvsdg::type> type)
+port::port(std::shared_ptr<const jlm::rvsdg::type> type)
     : type_(std::move(type))
 {}
 
 bool
 port::operator==(const port & other) const noexcept
 {
-  return *type_ == *other.type_;
+  // If both types are identical (same pointer), no need
+  // to semantically check for equality.
+  return type_ == other.type_ || *type_ == *other.type_;
 }
 
 std::unique_ptr<port>

--- a/jlm/rvsdg/operation.hpp
+++ b/jlm/rvsdg/operation.hpp
@@ -33,37 +33,17 @@ public:
 
   port(const jlm::rvsdg::type & type);
 
-  port(std::unique_ptr<jlm::rvsdg::type> type);
+  port(std::shared_ptr<const jlm::rvsdg::type> type);
 
-  inline port(const port & other)
-      : type_(other.type_->copy())
-  {}
+  port(const port & other) = default;
 
-  inline port(port && other)
-      : type_(std::move(other.type_))
-  {}
+  port(port && other) = default;
 
-  inline port &
-  operator=(const port & other)
-  {
-    if (&other == this)
-      return *this;
+  port &
+  operator=(const port & other) = default;
 
-    type_ = other.type_->copy();
-
-    return *this;
-  }
-
-  inline port &
-  operator=(port && other)
-  {
-    if (&other == this)
-      return *this;
-
-    type_ = std::move(other.type_);
-
-    return *this;
-  }
+  port &
+  operator=(port && other) = default;
 
   virtual bool
   operator==(const port &) const noexcept;
@@ -84,7 +64,7 @@ public:
   copy() const;
 
 private:
-  std::unique_ptr<jlm::rvsdg::type> type_;
+  std::shared_ptr<const jlm::rvsdg::type> type_;
 };
 
 /* operation */

--- a/jlm/rvsdg/type.hpp
+++ b/jlm/rvsdg/type.hpp
@@ -32,7 +32,7 @@ public:
     return !(*this == other);
   }
 
-  virtual std::unique_ptr<type>
+  virtual std::shared_ptr<const type>
   copy() const = 0;
 
   virtual std::string

--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -27,7 +27,7 @@ StoreTest1::SetupRvsdg()
 
   auto csize = jlm::rvsdg::create_bitconstant(fct->subregion(), 32, 4);
 
-  auto d = alloca_op::create(jlm::rvsdg::bit32, csize, 4);
+  auto d = alloca_op::create(*jlm::rvsdg::bittype::Create(32), csize, 4);
   auto c = alloca_op::create(pointerType, csize, 4);
   auto b = alloca_op::create(pointerType, csize, 4);
   auto a = alloca_op::create(pointerType, csize, 4);
@@ -81,8 +81,8 @@ StoreTest2::SetupRvsdg()
 
   auto csize = jlm::rvsdg::create_bitconstant(fct->subregion(), 32, 4);
 
-  auto a = alloca_op::create(jlm::rvsdg::bit32, csize, 4);
-  auto b = alloca_op::create(jlm::rvsdg::bit32, csize, 4);
+  auto a = alloca_op::create(*jlm::rvsdg::bittype::Create(32), csize, 4);
+  auto b = alloca_op::create(*jlm::rvsdg::bittype::Create(32), csize, 4);
   auto x = alloca_op::create(pointerType, csize, 4);
   auto y = alloca_op::create(pointerType, csize, 4);
   auto p = alloca_op::create(pointerType, csize, 4);
@@ -128,7 +128,7 @@ LoadTest1::SetupRvsdg()
 
   MemoryStateType mt;
   PointerType pointerType;
-  FunctionType fcttype({ &pointerType, &mt }, { &jlm::rvsdg::bit32, &mt });
+  FunctionType fcttype({ &pointerType, &mt }, { &*jlm::rvsdg::bittype::Create(32), &mt });
 
   auto module = RvsdgModule::Create(jlm::util::filepath("LoadTest1.c"), "", "");
   auto graph = &module->Rvsdg();
@@ -140,7 +140,7 @@ LoadTest1::SetupRvsdg()
 
   auto ld1 =
       LoadNonVolatileNode::Create(fct->fctargument(0), { fct->fctargument(1) }, pointerType, 4);
-  auto ld2 = LoadNonVolatileNode::Create(ld1[0], { ld1[1] }, jlm::rvsdg::bit32, 4);
+  auto ld2 = LoadNonVolatileNode::Create(ld1[0], { ld1[1] }, *jlm::rvsdg::bittype::Create(32), 4);
 
   fct->finalize(ld2);
 
@@ -175,8 +175,8 @@ LoadTest2::SetupRvsdg()
 
   auto csize = jlm::rvsdg::create_bitconstant(fct->subregion(), 32, 4);
 
-  auto a = alloca_op::create(jlm::rvsdg::bit32, csize, 4);
-  auto b = alloca_op::create(jlm::rvsdg::bit32, csize, 4);
+  auto a = alloca_op::create(*jlm::rvsdg::bittype::Create(32), csize, 4);
+  auto b = alloca_op::create(*jlm::rvsdg::bittype::Create(32), csize, 4);
   auto x = alloca_op::create(pointerType, csize, 4);
   auto y = alloca_op::create(pointerType, csize, 4);
   auto p = alloca_op::create(pointerType, csize, 4);
@@ -227,7 +227,9 @@ LoadFromUndefTest::SetupRvsdg()
   using namespace jlm::llvm;
 
   MemoryStateType memoryStateType;
-  FunctionType functionType({ &memoryStateType }, { &jlm::rvsdg::bit32, &memoryStateType });
+  FunctionType functionType(
+      { &memoryStateType },
+      { &*jlm::rvsdg::bittype::Create(32), &memoryStateType });
   PointerType pointerType;
 
   auto rvsdgModule = RvsdgModule::Create(jlm::util::filepath(""), "", "");
@@ -239,8 +241,11 @@ LoadFromUndefTest::SetupRvsdg()
   Lambda_ = lambda::node::create(rvsdg.root(), functionType, "f", linkage::external_linkage);
 
   auto undefValue = UndefValueOperation::Create(*Lambda_->subregion(), pointerType);
-  auto loadResults =
-      LoadNonVolatileNode::Create(undefValue, { Lambda_->fctargument(0) }, jlm::rvsdg::bit32, 4);
+  auto loadResults = LoadNonVolatileNode::Create(
+      undefValue,
+      { Lambda_->fctargument(0) },
+      *jlm::rvsdg::bittype::Create(32),
+      4);
 
   Lambda_->finalize(loadResults);
   rvsdg.add_export(Lambda_->output(), { pointerType, "f" });
@@ -264,13 +269,13 @@ GetElementPtrTest::SetupRvsdg()
   auto nf = graph->node_normal_form(typeid(jlm::rvsdg::operation));
   nf->set_mutable(false);
 
-  auto & declaration = module->AddStructTypeDeclaration(
-      StructType::Declaration::Create({ &jlm::rvsdg::bit32, &jlm::rvsdg::bit32 }));
+  auto & declaration = module->AddStructTypeDeclaration(StructType::Declaration::Create(
+      { &*jlm::rvsdg::bittype::Create(32), &*jlm::rvsdg::bittype::Create(32) }));
   StructType structType(false, declaration);
 
   MemoryStateType mt;
   PointerType pointerType;
-  FunctionType fcttype({ &pointerType, &mt }, { &jlm::rvsdg::bit32, &mt });
+  FunctionType fcttype({ &pointerType, &mt }, { &*jlm::rvsdg::bittype::Create(32), &mt });
 
   auto fct = lambda::node::create(graph->root(), fcttype, "f", linkage::external_linkage);
 
@@ -279,11 +284,15 @@ GetElementPtrTest::SetupRvsdg()
 
   auto gepx =
       GetElementPtrOperation::Create(fct->fctargument(0), { zero, zero }, structType, pointerType);
-  auto ldx = LoadNonVolatileNode::Create(gepx, { fct->fctargument(1) }, jlm::rvsdg::bit32, 4);
+  auto ldx = LoadNonVolatileNode::Create(
+      gepx,
+      { fct->fctargument(1) },
+      *jlm::rvsdg::bittype::Create(32),
+      4);
 
   auto gepy =
       GetElementPtrOperation::Create(fct->fctargument(0), { zero, one }, structType, pointerType);
-  auto ldy = LoadNonVolatileNode::Create(gepy, { ldx[1] }, jlm::rvsdg::bit32, 4);
+  auto ldy = LoadNonVolatileNode::Create(gepy, { ldx[1] }, *jlm::rvsdg::bittype::Create(32), 4);
 
   auto sum = jlm::rvsdg::bitadd_op::create(32, ldx[0], ldy[0]);
 
@@ -350,7 +359,7 @@ Bits2PtrTest::SetupRvsdg()
     iostatetype iOStateType;
     MemoryStateType memoryStateType;
     FunctionType functionType(
-        { &jlm::rvsdg::bit64, &iOStateType, &memoryStateType },
+        { &*jlm::rvsdg::bittype::Create(64), &iOStateType, &memoryStateType },
         { &pt, &iOStateType, &memoryStateType });
 
     auto lambda =
@@ -371,7 +380,7 @@ Bits2PtrTest::SetupRvsdg()
     iostatetype iOStateType;
     MemoryStateType memoryStateType;
     FunctionType functionType(
-        { &jlm::rvsdg::bit64, &iOStateType, &memoryStateType },
+        { &*jlm::rvsdg::bittype::Create(64), &iOStateType, &memoryStateType },
         { &iOStateType, &memoryStateType });
 
     auto lambda =
@@ -463,7 +472,7 @@ CallTest1::SetupRvsdg()
     MemoryStateType memoryStateType;
     FunctionType functionType(
         { &pt, &pt, &iOStateType, &memoryStateType },
-        { &jlm::rvsdg::bit32, &iOStateType, &memoryStateType });
+        { &*jlm::rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
 
     auto lambda = lambda::node::create(graph->root(), functionType, "f", linkage::external_linkage);
     auto pointerArgument1 = lambda->fctargument(0);
@@ -474,9 +483,13 @@ CallTest1::SetupRvsdg()
     auto ld1 = LoadNonVolatileNode::Create(
         pointerArgument1,
         { memoryStateArgument },
-        jlm::rvsdg::bit32,
+        *jlm::rvsdg::bittype::Create(32),
         4);
-    auto ld2 = LoadNonVolatileNode::Create(pointerArgument2, { ld1[1] }, jlm::rvsdg::bit32, 4);
+    auto ld2 = LoadNonVolatileNode::Create(
+        pointerArgument2,
+        { ld1[1] },
+        *jlm::rvsdg::bittype::Create(32),
+        4);
 
     auto sum = jlm::rvsdg::bitadd_op::create(32, ld1[0], ld2[0]);
 
@@ -492,7 +505,7 @@ CallTest1::SetupRvsdg()
     MemoryStateType memoryStateType;
     FunctionType functionType(
         { &pt, &pt, &iOStateType, &memoryStateType },
-        { &jlm::rvsdg::bit32, &iOStateType, &memoryStateType });
+        { &*jlm::rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
 
     auto lambda = lambda::node::create(graph->root(), functionType, "g", linkage::external_linkage);
     auto pointerArgument1 = lambda->fctargument(0);
@@ -503,9 +516,13 @@ CallTest1::SetupRvsdg()
     auto ld1 = LoadNonVolatileNode::Create(
         pointerArgument1,
         { memoryStateArgument },
-        jlm::rvsdg::bit32,
+        *jlm::rvsdg::bittype::Create(32),
         4);
-    auto ld2 = LoadNonVolatileNode::Create(pointerArgument2, { ld1[1] }, jlm::rvsdg::bit32, 4);
+    auto ld2 = LoadNonVolatileNode::Create(
+        pointerArgument2,
+        { ld1[1] },
+        *jlm::rvsdg::bittype::Create(32),
+        4);
 
     auto diff = jlm::rvsdg::bitsub_op::create(32, ld1[0], ld2[0]);
 
@@ -520,7 +537,7 @@ CallTest1::SetupRvsdg()
     MemoryStateType memoryStateType;
     FunctionType functionType(
         { &iOStateType, &memoryStateType },
-        { &jlm::rvsdg::bit32, &iOStateType, &memoryStateType });
+        { &*jlm::rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
 
     auto lambda = lambda::node::create(graph->root(), functionType, "h", linkage::external_linkage);
     auto iOStateArgument = lambda->fctargument(0);
@@ -531,9 +548,9 @@ CallTest1::SetupRvsdg()
 
     auto size = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
 
-    auto x = alloca_op::create(jlm::rvsdg::bit32, size, 4);
-    auto y = alloca_op::create(jlm::rvsdg::bit32, size, 4);
-    auto z = alloca_op::create(jlm::rvsdg::bit32, size, 4);
+    auto x = alloca_op::create(*jlm::rvsdg::bittype::Create(32), size, 4);
+    auto y = alloca_op::create(*jlm::rvsdg::bittype::Create(32), size, 4);
+    auto z = alloca_op::create(*jlm::rvsdg::bittype::Create(32), size, 4);
 
     auto mx = MemoryStateMergeOperation::Create(
         std::vector<jlm::rvsdg::output *>({ x[1], memoryStateArgument }));
@@ -604,7 +621,7 @@ CallTest2::SetupRvsdg()
     iostatetype iOStateType;
     MemoryStateType memoryStateType;
     FunctionType functionType(
-        { &jlm::rvsdg::bit32, &iOStateType, &memoryStateType },
+        { &*jlm::rvsdg::bittype::Create(32), &iOStateType, &memoryStateType },
         { &pt32, &iOStateType, &memoryStateType });
 
     auto lambda =
@@ -727,7 +744,7 @@ IndirectCallTest1::SetupRvsdg()
   MemoryStateType memoryStateType;
   FunctionType constantFunctionType(
       { &iOStateType, &memoryStateType },
-      { &jlm::rvsdg::bit32, &iOStateType, &memoryStateType });
+      { &*jlm::rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
   PointerType pointerType;
 
   auto module = RvsdgModule::Create(jlm::util::filepath(""), "", "");
@@ -754,7 +771,7 @@ IndirectCallTest1::SetupRvsdg()
     MemoryStateType memoryStateType;
     FunctionType functionType(
         { &pointerType, &iOStateType, &memoryStateType },
-        { &jlm::rvsdg::bit32, &iOStateType, &memoryStateType });
+        { &*jlm::rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, "indcall", linkage::external_linkage);
@@ -777,7 +794,7 @@ IndirectCallTest1::SetupRvsdg()
   {
     FunctionType functionType(
         { &iOStateType, &memoryStateType },
-        { &jlm::rvsdg::bit32, &iOStateType, &memoryStateType });
+        { &*jlm::rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, "test", linkage::external_linkage);
@@ -836,7 +853,7 @@ IndirectCallTest2::SetupRvsdg()
   MemoryStateType memoryStateType;
   FunctionType constantFunctionType(
       { &iOStateType, &memoryStateType },
-      { &jlm::rvsdg::bit32, &iOStateType, &memoryStateType });
+      { &*jlm::rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
   PointerType pointerType;
 
   auto module = RvsdgModule::Create(jlm::util::filepath(""), "", "");
@@ -849,7 +866,7 @@ IndirectCallTest2::SetupRvsdg()
   {
     auto delta = delta::node::Create(
         graph->root(),
-        jlm::rvsdg::bit32,
+        *jlm::rvsdg::bittype::Create(32),
         "g1",
         linkage::external_linkage,
         "",
@@ -864,7 +881,7 @@ IndirectCallTest2::SetupRvsdg()
   {
     auto delta = delta::node::Create(
         graph->root(),
-        jlm::rvsdg::bit32,
+        *jlm::rvsdg::bittype::Create(32),
         "g2",
         linkage::external_linkage,
         "",
@@ -893,7 +910,7 @@ IndirectCallTest2::SetupRvsdg()
     MemoryStateType memoryStateType;
     FunctionType functionType(
         { &pointerType, &iOStateType, &memoryStateType },
-        { &jlm::rvsdg::bit32, &iOStateType, &memoryStateType });
+        { &*jlm::rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
 
     auto lambda = lambda::node::create(graph->root(), functionType, "i", linkage::external_linkage);
     auto pointerArgument = lambda->fctargument(0);
@@ -919,7 +936,7 @@ IndirectCallTest2::SetupRvsdg()
 
     FunctionType functionType(
         { &pointerType, &iOStateType, &memoryStateType },
-        { &jlm::rvsdg::bit32, &iOStateType, &memoryStateType });
+        { &*jlm::rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, name, linkage::external_linkage);
@@ -951,7 +968,7 @@ IndirectCallTest2::SetupRvsdg()
   {
     FunctionType functionType(
         { &iOStateType, &memoryStateType },
-        { &jlm::rvsdg::bit32, &iOStateType, &memoryStateType });
+        { &*jlm::rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, "test", linkage::external_linkage);
@@ -965,8 +982,8 @@ IndirectCallTest2::SetupRvsdg()
 
     auto constantSize = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
 
-    auto pxAlloca = alloca_op::create(jlm::rvsdg::bit32, constantSize, 4);
-    auto pyAlloca = alloca_op::create(jlm::rvsdg::bit32, constantSize, 4);
+    auto pxAlloca = alloca_op::create(*jlm::rvsdg::bittype::Create(32), constantSize, 4);
+    auto pyAlloca = alloca_op::create(*jlm::rvsdg::bittype::Create(32), constantSize, 4);
 
     auto pxMerge = MemoryStateMergeOperation::Create({ pxAlloca[1], memoryStateArgument });
     auto pyMerge = MemoryStateMergeOperation::Create(
@@ -985,9 +1002,10 @@ IndirectCallTest2::SetupRvsdg()
     auto loadG1 = LoadNonVolatileNode::Create(
         globalG1Cv,
         { callY.GetMemoryStateOutput() },
-        jlm::rvsdg::bit32,
+        *jlm::rvsdg::bittype::Create(32),
         4);
-    auto loadG2 = LoadNonVolatileNode::Create(globalG2Cv, { loadG1[1] }, jlm::rvsdg::bit32, 4);
+    auto loadG2 =
+        LoadNonVolatileNode::Create(globalG2Cv, { loadG1[1] }, *jlm::rvsdg::bittype::Create(32), 4);
 
     auto sum = jlm::rvsdg::bitadd_op::create(32, callX.Result(0), callY.Result(0));
     sum = jlm::rvsdg::bitadd_op::create(32, sum, loadG1[0]);
@@ -1011,7 +1029,7 @@ IndirectCallTest2::SetupRvsdg()
   {
     FunctionType functionType(
         { &iOStateType, &memoryStateType },
-        { &jlm::rvsdg::bit32, &iOStateType, &memoryStateType });
+        { &*jlm::rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, "test2", linkage::external_linkage);
@@ -1020,7 +1038,7 @@ IndirectCallTest2::SetupRvsdg()
 
     auto constantSize = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
 
-    auto pzAlloca = alloca_op::create(jlm::rvsdg::bit32, constantSize, 4);
+    auto pzAlloca = alloca_op::create(*jlm::rvsdg::bittype::Create(32), constantSize, 4);
     auto pzMerge = MemoryStateMergeOperation::Create({ pzAlloca[1], memoryStateArgument });
 
     auto functionXCv = lambda->add_ctxvar(&functionX);
@@ -1165,17 +1183,17 @@ ExternalCallTest2::SetupRvsdg()
   nf->set_mutable(false);
 
   PointerType pointerType;
-  auto & structDeclaration = rvsdgModule->AddStructTypeDeclaration(
-      StructType::Declaration::Create({ &rvsdg::bit32, &pointerType, &pointerType }));
+  auto & structDeclaration = rvsdgModule->AddStructTypeDeclaration(StructType::Declaration::Create(
+      { &*rvsdg::bittype::Create(32), &pointerType, &pointerType }));
   auto structType = StructType::Create("myStruct", false, structDeclaration);
   iostatetype iOStateType;
   MemoryStateType memoryStateType;
   varargtype varArgType;
   FunctionType lambdaLlvmLifetimeStartType(
-      { &rvsdg::bit64, &pointerType, &iOStateType, &memoryStateType },
+      { &*rvsdg::bittype::Create(64), &pointerType, &iOStateType, &memoryStateType },
       { &iOStateType, &memoryStateType });
   FunctionType lambdaLlvmLifetimeEndType(
-      { &rvsdg::bit64, &pointerType, &iOStateType, &memoryStateType },
+      { &*rvsdg::bittype::Create(64), &pointerType, &iOStateType, &memoryStateType },
       { &iOStateType, &memoryStateType });
   FunctionType lambdaFType(
       { &pointerType, &iOStateType, &memoryStateType },
@@ -1260,8 +1278,8 @@ GammaTest::SetupRvsdg()
   MemoryStateType mt;
   PointerType pt;
   FunctionType fcttype(
-      { &jlm::rvsdg::bit32, &pt, &pt, &pt, &pt, &mt },
-      { &jlm::rvsdg::bit32, &mt });
+      { &*jlm::rvsdg::bittype::Create(32), &pt, &pt, &pt, &pt, &mt },
+      { &*jlm::rvsdg::bittype::Create(32), &mt });
 
   auto module = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto graph = &module->Rvsdg();
@@ -1284,8 +1302,12 @@ GammaTest::SetupRvsdg()
   auto tmp1 = gammanode->add_exitvar({ p1ev->argument(0), p3ev->argument(1) });
   auto tmp2 = gammanode->add_exitvar({ p2ev->argument(0), p4ev->argument(1) });
 
-  auto ld1 = LoadNonVolatileNode::Create(tmp1, { fct->fctargument(5) }, jlm::rvsdg::bit32, 4);
-  auto ld2 = LoadNonVolatileNode::Create(tmp2, { ld1[1] }, jlm::rvsdg::bit32, 4);
+  auto ld1 = LoadNonVolatileNode::Create(
+      tmp1,
+      { fct->fctargument(5) },
+      *jlm::rvsdg::bittype::Create(32),
+      4);
+  auto ld2 = LoadNonVolatileNode::Create(tmp2, { ld1[1] }, *jlm::rvsdg::bittype::Create(32), 4);
   auto sum = jlm::rvsdg::bitadd_op::create(32, ld1[0], ld2[0]);
 
   fct->finalize({ sum, ld2[1] });
@@ -1331,7 +1353,7 @@ GammaTest2::SetupRvsdg()
       auto loadXResults = LoadNonVolatileNode::Create(
           gammaInputX->argument(0),
           { gammaInputMemoryState->argument(0) },
-          jlm::rvsdg::bit32,
+          *jlm::rvsdg::bittype::Create(32),
           4);
 
       auto one = rvsdg::create_bitconstant(gammaNode->subregion(0), 32, 1);
@@ -1342,7 +1364,7 @@ GammaTest2::SetupRvsdg()
       auto loadYResults = LoadNonVolatileNode::Create(
           gammaInputY->argument(1),
           { gammaInputMemoryState->argument(1) },
-          jlm::rvsdg::bit32,
+          *jlm::rvsdg::bittype::Create(32),
           4);
 
       auto two = rvsdg::create_bitconstant(gammaNode->subregion(1), 32, 2);
@@ -1361,8 +1383,12 @@ GammaTest2::SetupRvsdg()
     MemoryStateType memoryStateType;
     PointerType pointerType;
     FunctionType functionType(
-        { &rvsdg::bit32, &pointerType, &pointerType, &iOStateType, &memoryStateType },
-        { &rvsdg::bit32, &iOStateType, &memoryStateType });
+        { &*rvsdg::bittype::Create(32),
+          &pointerType,
+          &pointerType,
+          &iOStateType,
+          &memoryStateType },
+        { &*rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
 
     auto lambda = lambda::node::create(rvsdg->root(), functionType, "f", linkage::external_linkage);
     auto cArgument = lambda->fctargument(0);
@@ -1392,7 +1418,7 @@ GammaTest2::SetupRvsdg()
     auto loadZResults = LoadNonVolatileNode::Create(
         allocaZResults[0],
         { gammaOutputMemoryState },
-        jlm::rvsdg::bit32,
+        *jlm::rvsdg::bittype::Create(32),
         4);
 
     auto sum = jlm::rvsdg::bitadd_op::create(32, gammaOutputA, loadZResults[0]);
@@ -1416,7 +1442,7 @@ GammaTest2::SetupRvsdg()
     PointerType pointerType;
     FunctionType functionType(
         { &iOStateType, &memoryStateType },
-        { &rvsdg::bit32, &iOStateType, &memoryStateType });
+        { &*rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
 
     auto lambda =
         lambda::node::create(rvsdg->root(), functionType, functionName, linkage::external_linkage);
@@ -1426,7 +1452,7 @@ GammaTest2::SetupRvsdg()
 
     auto size = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
 
-    auto allocaXResults = alloca_op::create(rvsdg::bit32, size, 4);
+    auto allocaXResults = alloca_op::create(*rvsdg::bittype::Create(32), size, 4);
     auto allocaYResults = alloca_op::create(pointerType, size, 4);
 
     auto memoryState =
@@ -1489,7 +1515,9 @@ ThetaTest::SetupRvsdg()
 
   MemoryStateType mt;
   PointerType pointerType;
-  FunctionType fcttype({ &jlm::rvsdg::bit32, &pointerType, &jlm::rvsdg::bit32, &mt }, { &mt });
+  FunctionType fcttype(
+      { &*jlm::rvsdg::bittype::Create(32), &pointerType, &*jlm::rvsdg::bittype::Create(32), &mt },
+      { &mt });
 
   auto module = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto graph = &module->Rvsdg();
@@ -1512,7 +1540,7 @@ ThetaTest::SetupRvsdg()
   auto gepnode = GetElementPtrOperation::Create(
       a->argument(),
       { n->argument() },
-      jlm::rvsdg::bit32,
+      *jlm::rvsdg::bittype::Create(32),
       pointerType);
   auto store = StoreNonVolatileNode::Create(gepnode, c->argument(), { s->argument() }, 4);
 
@@ -1553,7 +1581,7 @@ DeltaTest1::SetupRvsdg()
   {
     auto dfNode = delta::node::Create(
         graph->root(),
-        jlm::rvsdg::bit32,
+        *jlm::rvsdg::bittype::Create(32),
         "f",
         linkage::external_linkage,
         "",
@@ -1571,15 +1599,18 @@ DeltaTest1::SetupRvsdg()
     MemoryStateType memoryStateType;
     FunctionType functionType(
         { &pt, &iOStateType, &memoryStateType },
-        { &jlm::rvsdg::bit32, &iOStateType, &memoryStateType });
+        { &*jlm::rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
 
     auto lambda = lambda::node::create(graph->root(), functionType, "g", linkage::external_linkage);
     auto pointerArgument = lambda->fctargument(0);
     auto iOStateArgument = lambda->fctargument(1);
     auto memoryStateArgument = lambda->fctargument(2);
 
-    auto ld =
-        LoadNonVolatileNode::Create(pointerArgument, { memoryStateArgument }, jlm::rvsdg::bit32, 4);
+    auto ld = LoadNonVolatileNode::Create(
+        pointerArgument,
+        { memoryStateArgument },
+        *jlm::rvsdg::bittype::Create(32),
+        4);
 
     return lambda->finalize({ ld[0], iOStateArgument, ld[1] });
   };
@@ -1590,7 +1621,7 @@ DeltaTest1::SetupRvsdg()
     MemoryStateType memoryStateType;
     FunctionType functionType(
         { &iOStateType, &memoryStateType },
-        { &jlm::rvsdg::bit32, &iOStateType, &memoryStateType });
+        { &*jlm::rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
 
     auto lambda = lambda::node::create(graph->root(), functionType, "h", linkage::external_linkage);
     auto iOStateArgument = lambda->fctargument(0);
@@ -1642,7 +1673,7 @@ DeltaTest2::SetupRvsdg()
   {
     auto delta = delta::node::Create(
         graph->root(),
-        jlm::rvsdg::bit32,
+        *jlm::rvsdg::bittype::Create(32),
         "d1",
         linkage::external_linkage,
         "",
@@ -1657,7 +1688,7 @@ DeltaTest2::SetupRvsdg()
   {
     auto delta = delta::node::Create(
         graph->root(),
-        jlm::rvsdg::bit32,
+        *jlm::rvsdg::bittype::Create(32),
         "d2",
         linkage::external_linkage,
         "",
@@ -1749,7 +1780,7 @@ DeltaTest3::SetupRvsdg()
   {
     auto delta = delta::node::Create(
         graph->root(),
-        jlm::rvsdg::bit32,
+        *jlm::rvsdg::bittype::Create(32),
         "g1",
         linkage::external_linkage,
         "",
@@ -1778,7 +1809,7 @@ DeltaTest3::SetupRvsdg()
     MemoryStateType memoryStateType;
     FunctionType functionType(
         { &iOStateType, &memoryStateType },
-        { &jlm::rvsdg::bit16, &iOStateType, &memoryStateType });
+        { &*jlm::rvsdg::bittype::Create(16), &iOStateType, &memoryStateType });
 
     auto lambda = lambda::node::create(graph->root(), functionType, "f", linkage::external_linkage);
     auto iOStateArgument = lambda->fctargument(0);
@@ -1791,7 +1822,8 @@ DeltaTest3::SetupRvsdg()
     auto storeResults =
         StoreNonVolatileNode::Create(g2CtxVar, loadResults[0], { loadResults[1] }, 8);
 
-    loadResults = LoadNonVolatileNode::Create(g1CtxVar, storeResults, jlm::rvsdg::bit32, 8);
+    loadResults =
+        LoadNonVolatileNode::Create(g1CtxVar, storeResults, *jlm::rvsdg::bittype::Create(32), 8);
     auto truncResult = trunc_op::create(16, loadResults[0]);
 
     return lambda->finalize({ truncResult, iOStateArgument, loadResults[1] });
@@ -1902,8 +1934,10 @@ ImportTest::SetupRvsdg()
     return std::make_tuple(lambdaOutput, &call);
   };
 
-  auto d1 = graph->add_import(impport(jlm::rvsdg::bit32, "d1", linkage::external_linkage));
-  auto d2 = graph->add_import(impport(jlm::rvsdg::bit32, "d2", linkage::external_linkage));
+  auto d1 =
+      graph->add_import(impport(*jlm::rvsdg::bittype::Create(32), "d1", linkage::external_linkage));
+  auto d2 =
+      graph->add_import(impport(*jlm::rvsdg::bittype::Create(32), "d2", linkage::external_linkage));
 
   auto f1 = SetupF1(d1);
   auto [f2, callF1] = SetupF2(f1, d1, d2);
@@ -1935,7 +1969,7 @@ PhiTest1::SetupRvsdg()
   iostatetype iOStateType;
   MemoryStateType memoryStateType;
   FunctionType fibFunctionType(
-      { &jlm::rvsdg::bit64, &pbit64, &iOStateType, &memoryStateType },
+      { &*jlm::rvsdg::bittype::Create(64), &pbit64, &iOStateType, &memoryStateType },
       { &iOStateType, &memoryStateType });
 
   auto SetupFib = [&]()
@@ -1983,17 +2017,24 @@ PhiTest1::SetupRvsdg()
           callFibm1.GetIoStateOutput(),
           callFibm1.GetMemoryStateOutput() });
 
-    auto gepnm1 =
-        GetElementPtrOperation::Create(resultev->argument(0), { nm1 }, jlm::rvsdg::bit64, pbit64);
+    auto gepnm1 = GetElementPtrOperation::Create(
+        resultev->argument(0),
+        { nm1 },
+        *jlm::rvsdg::bittype::Create(64),
+        pbit64);
     auto ldnm1 = LoadNonVolatileNode::Create(
         gepnm1,
         { callFibm2.GetMemoryStateOutput() },
-        jlm::rvsdg::bit64,
+        *jlm::rvsdg::bittype::Create(64),
         8);
 
-    auto gepnm2 =
-        GetElementPtrOperation::Create(resultev->argument(0), { nm2 }, jlm::rvsdg::bit64, pbit64);
-    auto ldnm2 = LoadNonVolatileNode::Create(gepnm2, { ldnm1[1] }, jlm::rvsdg::bit64, 8);
+    auto gepnm2 = GetElementPtrOperation::Create(
+        resultev->argument(0),
+        { nm2 },
+        *jlm::rvsdg::bittype::Create(64),
+        pbit64);
+    auto ldnm2 =
+        LoadNonVolatileNode::Create(gepnm2, { ldnm1[1] }, *jlm::rvsdg::bittype::Create(64), 8);
 
     auto sum = jlm::rvsdg::bitadd_op::create(64, ldnm1[0], ldnm2[0]);
 
@@ -2008,7 +2049,7 @@ PhiTest1::SetupRvsdg()
     auto gepn = GetElementPtrOperation::Create(
         pointerArgument,
         { valueArgument },
-        jlm::rvsdg::bit64,
+        *jlm::rvsdg::bittype::Create(64),
         pbit64);
     auto store = StoreNonVolatileNode::Create(gepn, sumex, { gOMemoryState }, 8);
 
@@ -2022,7 +2063,7 @@ PhiTest1::SetupRvsdg()
 
   auto SetupTestFunction = [&](phi::node * phiNode)
   {
-    arraytype at(jlm::rvsdg::bit64, 10);
+    arraytype at(*jlm::rvsdg::bittype::Create(64), 10);
     PointerType pbit64;
     iostatetype iOStateType;
     MemoryStateType memoryStateType;
@@ -2084,19 +2125,19 @@ PhiTest2::SetupRvsdg()
 
   FunctionType constantFunctionType(
       { &iOStateType, &memoryStateType },
-      { &jlm::rvsdg::bit32, &iOStateType, &memoryStateType });
+      { &*jlm::rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
 
   FunctionType recursiveFunctionType(
       { &pointerType, &iOStateType, &memoryStateType },
-      { &jlm::rvsdg::bit32, &iOStateType, &memoryStateType });
+      { &*jlm::rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
 
   FunctionType functionIType(
       { &pointerType, &iOStateType, &memoryStateType },
-      { &jlm::rvsdg::bit32, &iOStateType, &memoryStateType });
+      { &*jlm::rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
 
   FunctionType recFunctionType(
       { &pointerType, &iOStateType, &memoryStateType },
-      { &jlm::rvsdg::bit32, &iOStateType, &memoryStateType });
+      { &*jlm::rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
 
   auto module = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto graph = &module->Rvsdg();
@@ -2152,7 +2193,7 @@ PhiTest2::SetupRvsdg()
     auto storeNode = StoreNonVolatileNode::Create(pointerArgument, one, { memoryStateArgument }, 4);
 
     auto four = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
-    auto paAlloca = alloca_op::create(jlm::rvsdg::bit32, four, 4);
+    auto paAlloca = alloca_op::create(*jlm::rvsdg::bittype::Create(32), four, 4);
     auto paMerge = MemoryStateMergeOperation::Create(
         std::vector<jlm::rvsdg::output *>({ paAlloca[1], storeNode[0] }));
 
@@ -2197,7 +2238,7 @@ PhiTest2::SetupRvsdg()
     auto storeNode = StoreNonVolatileNode::Create(pointerArgument, two, { memoryStateArgument }, 4);
 
     auto four = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
-    auto pbAlloca = alloca_op::create(jlm::rvsdg::bit32, four, 4);
+    auto pbAlloca = alloca_op::create(*jlm::rvsdg::bittype::Create(32), four, 4);
     auto pbMerge = MemoryStateMergeOperation::Create(
         std::vector<jlm::rvsdg::output *>({ pbAlloca[1], storeNode[0] }));
 
@@ -2237,7 +2278,7 @@ PhiTest2::SetupRvsdg()
     auto storeNode = StoreNonVolatileNode::Create(xArgument, three, { memoryStateArgument }, 4);
 
     auto four = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
-    auto pcAlloca = alloca_op::create(jlm::rvsdg::bit32, four, 4);
+    auto pcAlloca = alloca_op::create(*jlm::rvsdg::bittype::Create(32), four, 4);
     auto pcMerge = MemoryStateMergeOperation::Create(
         std::vector<jlm::rvsdg::output *>({ pcAlloca[1], storeNode[0] }));
 
@@ -2249,7 +2290,7 @@ PhiTest2::SetupRvsdg()
     auto loadX = LoadNonVolatileNode::Create(
         xArgument,
         { callA.GetMemoryStateOutput() },
-        jlm::rvsdg::bit32,
+        *jlm::rvsdg::bittype::Create(32),
         4);
 
     auto sum = jlm::rvsdg::bitadd_op::create(32, callA.Result(0), loadX[0]);
@@ -2275,7 +2316,7 @@ PhiTest2::SetupRvsdg()
     auto four = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
     auto storeNode = StoreNonVolatileNode::Create(xArgument, four, { memoryStateArgument }, 4);
 
-    auto pdAlloca = alloca_op::create(jlm::rvsdg::bit32, four, 4);
+    auto pdAlloca = alloca_op::create(*jlm::rvsdg::bittype::Create(32), four, 4);
     auto pdMerge = MemoryStateMergeOperation::Create(
         std::vector<jlm::rvsdg::output *>({ pdAlloca[1], storeNode[0] }));
 
@@ -2346,7 +2387,7 @@ PhiTest2::SetupRvsdg()
 
     FunctionType functionType(
         { &iOStateType, &memoryStateType },
-        { &jlm::rvsdg::bit32, &iOStateType, &memoryStateType });
+        { &*jlm::rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, "test", linkage::external_linkage);
@@ -2356,7 +2397,7 @@ PhiTest2::SetupRvsdg()
     auto functionACv = lambda->add_ctxvar(&functionA);
 
     auto four = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
-    auto pTestAlloca = alloca_op::create(jlm::rvsdg::bit32, four, 4);
+    auto pTestAlloca = alloca_op::create(*jlm::rvsdg::bittype::Create(32), four, 4);
     auto pTestMerge = MemoryStateMergeOperation::Create(
         std::vector<jlm::rvsdg::output *>({ pTestAlloca[1], memoryStateArgument }));
 
@@ -2524,7 +2565,7 @@ EscapedMemoryTest1::SetupRvsdg()
   {
     auto deltaNode = delta::node::Create(
         rvsdg->root(),
-        jlm::rvsdg::bit32,
+        *jlm::rvsdg::bittype::Create(32),
         "a",
         linkage::external_linkage,
         "",
@@ -2539,7 +2580,7 @@ EscapedMemoryTest1::SetupRvsdg()
   {
     auto deltaNode = delta::node::Create(
         rvsdg->root(),
-        jlm::rvsdg::bit32,
+        *jlm::rvsdg::bittype::Create(32),
         "b",
         linkage::external_linkage,
         "",
@@ -2584,7 +2625,7 @@ EscapedMemoryTest1::SetupRvsdg()
     MemoryStateType memoryStateType;
     FunctionType functionType(
         { &pointerType, &iOStateType, &memoryStateType },
-        { &jlm::rvsdg::bit32, &iOStateType, &memoryStateType });
+        { &*jlm::rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
 
     auto lambda =
         lambda::node::create(rvsdg->root(), functionType, "test", linkage::external_linkage);
@@ -2596,8 +2637,11 @@ EscapedMemoryTest1::SetupRvsdg()
 
     auto loadResults1 =
         LoadNonVolatileNode::Create(pointerArgument, { memoryStateArgument }, pointerType, 4);
-    auto loadResults2 =
-        LoadNonVolatileNode::Create(loadResults1[0], { loadResults1[1] }, jlm::rvsdg::bit32, 4);
+    auto loadResults2 = LoadNonVolatileNode::Create(
+        loadResults1[0],
+        { loadResults1[1] },
+        *jlm::rvsdg::bittype::Create(32),
+        4);
 
     auto five = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 5);
     auto storeResults =
@@ -2741,7 +2785,7 @@ EscapedMemoryTest2::SetupRvsdg()
     MemoryStateType memoryStateType;
     FunctionType functionType(
         { &iOStateType, &memoryStateType },
-        { &jlm::rvsdg::bit32, &iOStateType, &memoryStateType });
+        { &*jlm::rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
 
     auto lambda = lambda::node::create(
         rvsdg->root(),
@@ -2761,7 +2805,7 @@ EscapedMemoryTest2::SetupRvsdg()
     auto loadResults = LoadNonVolatileNode::Create(
         call.Result(0),
         { call.GetMemoryStateOutput() },
-        jlm::rvsdg::bit32,
+        *jlm::rvsdg::bittype::Create(32),
         4);
 
     auto lambdaOutput =
@@ -2833,7 +2877,7 @@ EscapedMemoryTest3::SetupRvsdg()
   {
     auto delta = delta::node::Create(
         rvsdg->root(),
-        jlm::rvsdg::bit32,
+        *jlm::rvsdg::bittype::Create(32),
         "global",
         linkage::external_linkage,
         "",
@@ -2854,7 +2898,7 @@ EscapedMemoryTest3::SetupRvsdg()
     MemoryStateType memoryStateType;
     FunctionType functionType(
         { &iOStateType, &memoryStateType },
-        { &jlm::rvsdg::bit32, &iOStateType, &memoryStateType });
+        { &*jlm::rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
 
     auto lambda =
         lambda::node::create(rvsdg->root(), functionType, "test", linkage::external_linkage);
@@ -2871,7 +2915,7 @@ EscapedMemoryTest3::SetupRvsdg()
     auto loadResults = LoadNonVolatileNode::Create(
         call.Result(0),
         { call.GetMemoryStateOutput() },
-        jlm::rvsdg::bit32,
+        *jlm::rvsdg::bittype::Create(32),
         4);
 
     auto lambdaOutput =
@@ -2911,7 +2955,7 @@ MemcpyTest::SetupRvsdg()
   auto nf = rvsdg->node_normal_form(typeid(jlm::rvsdg::operation));
   nf->set_mutable(false);
 
-  arraytype arrayType(jlm::rvsdg::bit32, 5);
+  arraytype arrayType(*jlm::rvsdg::bittype::Create(32), 5);
 
   auto SetupLocalArray = [&]()
   {
@@ -2963,7 +3007,7 @@ MemcpyTest::SetupRvsdg()
     MemoryStateType memoryStateType;
     FunctionType functionType(
         { &iOStateType, &memoryStateType },
-        { &jlm::rvsdg::bit32, &iOStateType, &memoryStateType });
+        { &*jlm::rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
 
     auto lambda = lambda::node::create(rvsdg->root(), functionType, "f", linkage::external_linkage);
     auto iOStateArgument = lambda->fctargument(0);
@@ -2983,7 +3027,8 @@ MemcpyTest::SetupRvsdg()
 
     auto storeResults = StoreNonVolatileNode::Create(gep, six, { memoryStateArgument }, 8);
 
-    auto loadResults = LoadNonVolatileNode::Create(gep, { storeResults[0] }, jlm::rvsdg::bit32, 8);
+    auto loadResults =
+        LoadNonVolatileNode::Create(gep, { storeResults[0] }, *jlm::rvsdg::bittype::Create(32), 8);
 
     auto lambdaOutput = lambda->finalize({ loadResults[0], iOStateArgument, loadResults[1] });
 
@@ -2999,7 +3044,7 @@ MemcpyTest::SetupRvsdg()
     MemoryStateType memoryStateType;
     FunctionType functionType(
         { &iOStateType, &memoryStateType },
-        { &jlm::rvsdg::bit32, &iOStateType, &memoryStateType });
+        { &*jlm::rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
 
     auto lambda = lambda::node::create(rvsdg->root(), functionType, "g", linkage::external_linkage);
     auto iOStateArgument = lambda->fctargument(0);
@@ -3305,7 +3350,8 @@ AllMemoryNodesTest::SetupRvsdg()
   nf->set_mutable(false);
 
   // Create imported symbol "imported"
-  Import_ = graph->add_import(impport(jlm::rvsdg::bit32, "imported", linkage::external_linkage));
+  Import_ = graph->add_import(
+      impport(*jlm::rvsdg::bittype::Create(32), "imported", linkage::external_linkage));
 
   // Create global variable "global"
   Delta_ = delta::node::Create(
@@ -3353,8 +3399,11 @@ AllMemoryNodesTest::SetupRvsdg()
       LoadNonVolatileNode::Create(allocaOutputs[0], { storeAllocaOutputs[0] }, pointerType, 8);
 
   // Load the value of the imported symbol "imported"
-  auto loadImportedOutputs =
-      LoadNonVolatileNode::Create(importContextVar, { loadAllocaOutputs[1] }, jlm::rvsdg::bit32, 4);
+  auto loadImportedOutputs = LoadNonVolatileNode::Create(
+      importContextVar,
+      { loadAllocaOutputs[1] },
+      *jlm::rvsdg::bittype::Create(32),
+      4);
 
   // Store the loaded value from imported, into the address loaded from the alloca (aka. the malloc
   // result)
@@ -3402,7 +3451,7 @@ NAllocaNodesTest::SetupRvsdg()
 
   for (size_t i = 0; i < NumAllocaNodes_; i++)
   {
-    auto allocaOutputs = alloca_op::create(jlm::rvsdg::bit32, allocaSize, 4);
+    auto allocaOutputs = alloca_op::create(*jlm::rvsdg::bittype::Create(32), allocaSize, 4);
     auto allocaNode = jlm::rvsdg::node_output::node(allocaOutputs[0]);
 
     AllocaNodes_.push_back(allocaNode);
@@ -3424,7 +3473,7 @@ EscapingLocalFunctionTest::SetupRvsdg()
 {
   using namespace jlm::llvm;
 
-  rvsdg::bittype uint32Type = rvsdg::bit32;
+  rvsdg::bittype uint32Type = *rvsdg::bittype::Create(32);
   MemoryStateType mt;
   PointerType pointerType;
   FunctionType localFuncType({ &pointerType, &mt }, { &pointerType, &mt });
@@ -3536,7 +3585,7 @@ LambdaCallArgumentMismatch::SetupRvsdg()
     MemoryStateType memoryStateType;
     FunctionType functionType(
         { &iOStateType, &memoryStateType },
-        { &rvsdg::bit32, &iOStateType, &memoryStateType });
+        { &*rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
 
     auto lambda = lambda::node::create(rvsdg.root(), functionType, "g", linkage::internal_linkage);
     auto iOStateArgument = lambda->fctargument(0);
@@ -3555,10 +3604,10 @@ LambdaCallArgumentMismatch::SetupRvsdg()
     varargtype variableArgumentType;
     FunctionType functionTypeMain(
         { &iOStateType, &memoryStateType },
-        { &rvsdg::bit32, &iOStateType, &memoryStateType });
+        { &*rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
     FunctionType functionTypeCall(
-        { &rvsdg::bit32, &variableArgumentType, &iOStateType, &memoryStateType },
-        { &rvsdg::bit32, &iOStateType, &memoryStateType });
+        { &*rvsdg::bittype::Create(32), &variableArgumentType, &iOStateType, &memoryStateType },
+        { &*rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
 
     auto lambda =
         lambda::node::create(rvsdg.root(), functionTypeMain, "main", linkage::external_linkage);
@@ -3571,14 +3620,15 @@ LambdaCallArgumentMismatch::SetupRvsdg()
 
     auto vaList = valist_op::Create(*lambda->subregion(), {});
 
-    auto allocaResults = alloca_op::create(rvsdg::bit32, one, 4);
+    auto allocaResults = alloca_op::create(*rvsdg::bittype::Create(32), one, 4);
 
     auto memoryState = MemoryStateMergeOperation::Create(
         std::vector<rvsdg::output *>{ memoryStateArgument, allocaResults[1] });
 
     auto storeResults = StoreNonVolatileNode::Create(allocaResults[0], six, { memoryState }, 4);
 
-    auto loadResults = LoadNonVolatileNode::Create(allocaResults[0], storeResults, rvsdg::bit32, 4);
+    auto loadResults =
+        LoadNonVolatileNode::Create(allocaResults[0], storeResults, *rvsdg::bittype::Create(32), 4);
 
     auto & call = CallNode::CreateNode(
         lambdaGArgument,
@@ -3614,7 +3664,7 @@ VariadicFunctionTest1::SetupRvsdg()
   MemoryStateType memoryStateType;
   varargtype varArgType;
   FunctionType lambdaHType(
-      { &jlm::rvsdg::bit32, &varArgType, &iOStateType, &memoryStateType },
+      { &*jlm::rvsdg::bittype::Create(32), &varArgType, &iOStateType, &memoryStateType },
       { &pointerType, &iOStateType, &memoryStateType });
   FunctionType lambdaFType(
       { &pointerType, &iOStateType, &memoryStateType },
@@ -3661,7 +3711,7 @@ VariadicFunctionTest1::SetupRvsdg()
     auto one = jlm::rvsdg::create_bitconstant(LambdaG_->subregion(), 32, 1);
     auto five = jlm::rvsdg::create_bitconstant(LambdaG_->subregion(), 32, 5);
 
-    auto allocaResults = alloca_op::create(rvsdg::bit32, one, 4);
+    auto allocaResults = alloca_op::create(*jlm::rvsdg::bittype::Create(32), one, 4);
     auto merge = MemoryStateMergeOperation::Create({ allocaResults[1], memoryStateArgument });
     AllocaNode_ = rvsdg::node_output::node(allocaResults[0]);
 
@@ -3691,17 +3741,17 @@ VariadicFunctionTest2::SetupRvsdg()
 
   PointerType pointerType;
   auto & structDeclaration = rvsdgModule->AddStructTypeDeclaration(StructType::Declaration::Create(
-      { &rvsdg::bit32, &rvsdg::bit32, &pointerType, &pointerType }));
+      { &*rvsdg::bittype::Create(32), &*rvsdg::bittype::Create(32), &pointerType, &pointerType }));
   auto structType = StructType::Create("struct.__va_list_tag", false, structDeclaration);
   arraytype arrayType(*structType, 1);
   iostatetype iOStateType;
   MemoryStateType memoryStateType;
   varargtype varArgType;
   FunctionType lambdaLlvmLifetimeStartType(
-      { &rvsdg::bit64, &pointerType, &iOStateType, &memoryStateType },
+      { &*rvsdg::bittype::Create(64), &pointerType, &iOStateType, &memoryStateType },
       { &iOStateType, &memoryStateType });
   FunctionType lambdaLlvmLifetimeEndType(
-      { &rvsdg::bit64, &pointerType, &iOStateType, &memoryStateType },
+      { &*rvsdg::bittype::Create(64), &pointerType, &iOStateType, &memoryStateType },
       { &iOStateType, &memoryStateType });
   FunctionType lambdaVaStartType(
       { &pointerType, &iOStateType, &memoryStateType },
@@ -3710,11 +3760,11 @@ VariadicFunctionTest2::SetupRvsdg()
       { &pointerType, &iOStateType, &memoryStateType },
       { &iOStateType, &memoryStateType });
   FunctionType lambdaFstType(
-      { &rvsdg::bit32, &varArgType, &iOStateType, &memoryStateType },
-      { &rvsdg::bit32, &iOStateType, &memoryStateType });
+      { &*rvsdg::bittype::Create(32), &varArgType, &iOStateType, &memoryStateType },
+      { &*rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
   FunctionType lambdaGType(
       { &iOStateType, &memoryStateType },
-      { &rvsdg::bit32, &iOStateType, &memoryStateType });
+      { &*rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
 
   auto llvmLifetimeStart =
       rvsdg.add_import(impport(pointerType, "llvm.lifetime.start.p0", linkage::external_linkage));
@@ -3757,7 +3807,7 @@ VariadicFunctionTest2::SetupRvsdg()
     auto loadResults = LoadNonVolatileNode::Create(
         allocaResults[0],
         { callVaStart.GetMemoryStateOutput() },
-        rvsdg::bit32,
+        *rvsdg::bittype::Create(32),
         16);
     auto icmpResult = rvsdg::bitult_op::create(32, loadResults[0], fortyOne);
     auto matchResult = rvsdg::match_op::Create(*icmpResult, { { 1, 1 } }, 0, 2);
@@ -3778,8 +3828,11 @@ VariadicFunctionTest2::SetupRvsdg()
         pointerType);
     auto loadResultsGamma0 =
         LoadNonVolatileNode::Create(gepResult1, { gammaMemoryState->argument(0) }, pointerType, 8);
-    auto gepResult2 =
-        GetElementPtrOperation::Create(loadResultsGamma0[0], { eight }, rvsdg::bit8, pointerType);
+    auto gepResult2 = GetElementPtrOperation::Create(
+        loadResultsGamma0[0],
+        { eight },
+        *rvsdg::bittype::Create(8),
+        pointerType);
     auto storeResultsGamma0 =
         StoreNonVolatileNode::Create(gepResult1, gepResult2, { loadResultsGamma0[1] }, 8);
 
@@ -3794,11 +3847,11 @@ VariadicFunctionTest2::SetupRvsdg()
         pointerType);
     auto loadResultsGamma1 =
         LoadNonVolatileNode::Create(gepResult1, { gammaMemoryState->argument(1) }, pointerType, 16);
-    auto & zextResult = zext_op::Create(*gammaLoadResult->argument(1), rvsdg::bit64);
+    auto & zextResult = zext_op::Create(*gammaLoadResult->argument(1), *rvsdg::bittype::Create(64));
     gepResult2 = GetElementPtrOperation::Create(
         loadResultsGamma1[0],
         { &zextResult },
-        rvsdg::bit8,
+        *rvsdg::bittype::Create(8),
         pointerType);
     auto addResult = rvsdg::bitadd_op::create(32, gammaLoadResult->argument(1), eightBit32);
     auto storeResultsGamma1 = StoreNonVolatileNode::Create(
@@ -3811,8 +3864,11 @@ VariadicFunctionTest2::SetupRvsdg()
     auto gammaOutputMemoryState =
         gammaNode->add_exitvar({ storeResultsGamma0[0], storeResultsGamma1[0] });
 
-    loadResults =
-        LoadNonVolatileNode::Create(gammaAddress, { gammaOutputMemoryState }, rvsdg::bit32, 4);
+    loadResults = LoadNonVolatileNode::Create(
+        gammaAddress,
+        { gammaOutputMemoryState },
+        *rvsdg::bittype::Create(32),
+        4);
     auto & callVaEnd = CallNode::CreateNode(
         llvmVaEndArgument,
         lambdaVaEndType,

--- a/tests/jlm/hls/backend/rvsdg2rhls/DeadNodeEliminationTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/DeadNodeEliminationTests.cpp
@@ -16,7 +16,9 @@ TestDeadLoopNode()
 
   // Arrange
   jlm::tests::valuetype valueType;
-  jlm::llvm::FunctionType functionType({ &jlm::rvsdg::ctl2, &valueType }, { &valueType });
+  jlm::llvm::FunctionType functionType(
+      { &*jlm::rvsdg::ctltype::Create(2), &valueType },
+      { &valueType });
 
   jlm::llvm::RvsdgModule rvsdgModule(jlm::util::filepath(""), "", "");
   auto & rvsdg = rvsdgModule.Rvsdg();
@@ -45,7 +47,9 @@ TestDeadLoopNodeOutput()
 
   // Arrange
   jlm::tests::valuetype valueType;
-  jlm::llvm::FunctionType functionType({ &jlm::rvsdg::ctl2, &valueType }, { &jlm::rvsdg::ctl2 });
+  jlm::llvm::FunctionType functionType(
+      { &*jlm::rvsdg::ctltype::Create(2), &valueType },
+      { &*jlm::rvsdg::ctltype::Create(2) });
 
   jlm::llvm::RvsdgModule rvsdgModule(jlm::util::filepath(""), "", "");
   auto & rvsdg = rvsdgModule.Rvsdg();

--- a/tests/jlm/hls/backend/rvsdg2rhls/TestGamma.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/TestGamma.cpp
@@ -18,8 +18,7 @@ TestWithMatch()
   using namespace jlm::llvm;
 
   jlm::tests::valuetype vt;
-  jlm::rvsdg::bittype bt1(1);
-  FunctionType ft({ &bt1, &vt, &vt }, { &vt });
+  FunctionType ft({ &*jlm::rvsdg::bittype::Create(1), &vt, &vt }, { &vt });
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto nf = rm.Rvsdg().node_normal_form(typeid(jlm::rvsdg::operation));

--- a/tests/jlm/hls/backend/rvsdg2rhls/TestGamma.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/TestGamma.cpp
@@ -56,9 +56,7 @@ TestWithoutMatch()
   using namespace jlm::llvm;
 
   jlm::tests::valuetype vt;
-  jlm::rvsdg::ctltype ctl2(2);
-  jlm::rvsdg::bittype bt1(1);
-  FunctionType ft({ &ctl2, &vt, &vt }, { &vt });
+  FunctionType ft({ &*jlm::rvsdg::ctltype::Create(2), &vt, &vt }, { &vt });
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto nf = rm.Rvsdg().node_normal_form(typeid(jlm::rvsdg::operation));

--- a/tests/jlm/hls/backend/rvsdg2rhls/TestTheta.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/TestTheta.cpp
@@ -16,7 +16,7 @@ TestUnknownBoundaries()
   using namespace jlm::llvm;
 
   // Arrange
-  auto b32 = jlm::rvsdg::bit32;
+  auto b32 = *jlm::rvsdg::bittype::Create(32);
   FunctionType ft({ &b32, &b32, &b32 }, { &b32, &b32, &b32 });
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");

--- a/tests/jlm/hls/backend/rvsdg2rhls/UnusedStateRemovalTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/UnusedStateRemovalTests.cpp
@@ -25,7 +25,7 @@ TestGamma()
   auto rvsdgModule = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto & rvsdg = rvsdgModule->Rvsdg();
 
-  auto p = rvsdg.add_import({ jlm::rvsdg::ctl2, "p" });
+  auto p = rvsdg.add_import({ *jlm::rvsdg::ctltype::Create(2), "p" });
   auto x = rvsdg.add_import({ valueType, "x" });
   auto y = rvsdg.add_import({ valueType, "y" });
   auto z = rvsdg.add_import({ valueType, "z" });
@@ -79,12 +79,12 @@ TestTheta()
   // Arrange
   jlm::tests::valuetype valueType;
   FunctionType functionType(
-      { &jlm::rvsdg::ctl2, &valueType, &valueType, &valueType },
+      { &*jlm::rvsdg::ctltype::Create(2), &valueType, &valueType, &valueType },
       { &valueType });
 
   auto rvsdgModule = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto & rvsdg = rvsdgModule->Rvsdg();
-  auto p = rvsdg.add_import({ jlm::rvsdg::ctl2, "p" });
+  auto p = rvsdg.add_import({ *jlm::rvsdg::ctltype::Create(2), "p" });
   auto x = rvsdg.add_import({ valueType, "x" });
   auto y = rvsdg.add_import({ valueType, "y" });
   auto z = rvsdg.add_import({ valueType, "z" });

--- a/tests/jlm/hls/backend/rvsdg2rhls/test-loop-passthrough.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/test-loop-passthrough.cpp
@@ -34,8 +34,9 @@ test()
 {
   using namespace jlm;
 
-  rvsdg::bittype bt1(1);
-  jlm::llvm::FunctionType ft({ &bt1, &rvsdg::bit8, &rvsdg::bit8 }, { &rvsdg::bit8 });
+  jlm::llvm::FunctionType ft(
+      { &*rvsdg::bittype::Create(1), &*rvsdg::bittype::Create(8), &*rvsdg::bittype::Create(8) },
+      { &*rvsdg::bittype::Create(8) });
 
   jlm::llvm::RvsdgModule rm(util::filepath(""), "", "");
   auto nf = rm.Rvsdg().node_normal_form(typeid(rvsdg::operation));

--- a/tests/jlm/llvm/backend/llvm/jlm-llvm/test-function-calls.cpp
+++ b/tests/jlm/llvm/backend/llvm/jlm-llvm/test-function-calls.cpp
@@ -30,14 +30,15 @@ test_malloc()
     cfg->exit()->divert_inedges(bb);
     bb->add_outedge(cfg->exit());
 
-    auto size = cfg->entry()->append_argument(argument::create("size", jlm::rvsdg::bit64));
+    auto size =
+        cfg->entry()->append_argument(argument::create("size", *jlm::rvsdg::bittype::Create(64)));
 
     bb->append_last(malloc_op::create(size));
 
     cfg->exit()->append_result(bb->last()->result(0));
     cfg->exit()->append_result(bb->last()->result(1));
 
-    FunctionType ft({ &jlm::rvsdg::bit64 }, { &pt, &mt });
+    FunctionType ft({ &*jlm::rvsdg::bittype::Create(64) }, { &pt, &mt });
     auto f = function_node::create(im->ipgraph(), "f", ft, linkage::external_linkage);
     f->add_cfg(std::move(cfg));
 

--- a/tests/jlm/llvm/backend/llvm/jlm-llvm/test-select-with-state.cpp
+++ b/tests/jlm/llvm/backend/llvm/jlm-llvm/test-select-with-state.cpp
@@ -30,7 +30,7 @@ test()
   cfg->exit()->divert_inedges(bb);
   bb->add_outedge(cfg->exit());
 
-  auto p = cfg->entry()->append_argument(argument::create("p", jlm::rvsdg::bit1));
+  auto p = cfg->entry()->append_argument(argument::create("p", *jlm::rvsdg::bittype::Create(1)));
   auto s1 = cfg->entry()->append_argument(argument::create("s1", mt));
   auto s2 = cfg->entry()->append_argument(argument::create("s2", mt));
 
@@ -40,7 +40,7 @@ test()
   cfg->exit()->append_result(s3);
   cfg->exit()->append_result(s3);
 
-  FunctionType ft({ &jlm::rvsdg::bit1, &mt, &mt }, { &mt, &mt });
+  FunctionType ft({ &*jlm::rvsdg::bittype::Create(1), &mt, &mt }, { &mt, &mt });
   auto f = function_node::create(m.ipgraph(), "f", ft, linkage::external_linkage);
   f->add_cfg(std::move(cfg));
 

--- a/tests/jlm/llvm/backend/llvm/jlm-llvm/test-type-conversion.cpp
+++ b/tests/jlm/llvm/backend/llvm/jlm-llvm/test-type-conversion.cpp
@@ -15,7 +15,8 @@ test_structtype(jlm::llvm::jlm2llvm::context & ctx)
 {
   using namespace jlm::llvm;
 
-  auto decl1 = StructType::Declaration::Create({ &jlm::rvsdg::bit8, &jlm::rvsdg::bit32 });
+  auto decl1 = StructType::Declaration::Create(
+      { &*jlm::rvsdg::bittype::Create(8), &*jlm::rvsdg::bittype::Create(32) });
   StructType st1("mystruct", false, *decl1);
   auto ct = jlm2llvm::convert_type(st1, ctx);
 
@@ -25,8 +26,9 @@ test_structtype(jlm::llvm::jlm2llvm::context & ctx)
   assert(ct->getElementType(0)->isIntegerTy(8));
   assert(ct->getElementType(1)->isIntegerTy(32));
 
-  auto decl2 = StructType::Declaration::Create(
-      { &jlm::rvsdg::bit32, &jlm::rvsdg::bit8, &jlm::rvsdg::bit32 });
+  auto decl2 = StructType::Declaration::Create({ &*jlm::rvsdg::bittype::Create(32),
+                                                 &*jlm::rvsdg::bittype::Create(8),
+                                                 &*jlm::rvsdg::bittype::Create(32) });
   StructType st2(true, *decl2);
   ct = jlm2llvm::convert_type(st2, ctx);
 

--- a/tests/jlm/llvm/backend/llvm/r2j/test-empty-gamma.cpp
+++ b/tests/jlm/llvm/backend/llvm/r2j/test-empty-gamma.cpp
@@ -68,9 +68,7 @@ test_without_match()
   using namespace jlm::llvm;
 
   jlm::tests::valuetype vt;
-  jlm::rvsdg::ctltype ctl2(2);
-  jlm::rvsdg::bittype bt1(1);
-  FunctionType ft({ &ctl2, &vt, &vt }, { &vt });
+  FunctionType ft({ &*jlm::rvsdg::ctltype::Create(2), &vt, &vt }, { &vt });
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto nf = rm.Rvsdg().node_normal_form(typeid(jlm::rvsdg::operation));

--- a/tests/jlm/llvm/backend/llvm/r2j/test-empty-gamma.cpp
+++ b/tests/jlm/llvm/backend/llvm/r2j/test-empty-gamma.cpp
@@ -111,7 +111,7 @@ test_gamma3()
   using namespace jlm::llvm;
 
   jlm::tests::valuetype vt;
-  FunctionType ft({ &jlm::rvsdg::bit32, &vt, &vt }, { &vt });
+  FunctionType ft({ &*jlm::rvsdg::bittype::Create(32), &vt, &vt }, { &vt });
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto nf = rm.Rvsdg().node_normal_form(typeid(jlm::rvsdg::operation));

--- a/tests/jlm/llvm/ir/operators/TestCall.cpp
+++ b/tests/jlm/llvm/ir/operators/TestCall.cpp
@@ -379,7 +379,7 @@ TestCallTypeClassifierRecursiveDirectCall()
     iostatetype iOStateType;
     MemoryStateType memoryStateType;
     FunctionType functionType(
-        { &jlm::rvsdg::bit64, &pbit64, &iOStateType, &memoryStateType },
+        { &*jlm::rvsdg::bittype::Create(64), &pbit64, &iOStateType, &memoryStateType },
         { &iOStateType, &memoryStateType });
     PointerType pt;
 
@@ -421,13 +421,24 @@ TestCallTypeClassifierRecursiveDirectCall()
         functionType,
         { nm2, resultev->argument(0), callfibm1Results[0], callfibm1Results[1] });
 
-    auto gepnm1 =
-        GetElementPtrOperation::Create(resultev->argument(0), { nm1 }, jlm::rvsdg::bit64, pbit64);
-    auto ldnm1 = LoadNonVolatileNode::Create(gepnm1, { callfibm2Results[1] }, jlm::rvsdg::bit64, 8);
+    auto gepnm1 = GetElementPtrOperation::Create(
+        resultev->argument(0),
+        { nm1 },
+        *jlm::rvsdg::bittype::Create(64),
+        pbit64);
+    auto ldnm1 = LoadNonVolatileNode::Create(
+        gepnm1,
+        { callfibm2Results[1] },
+        *jlm::rvsdg::bittype::Create(64),
+        8);
 
-    auto gepnm2 =
-        GetElementPtrOperation::Create(resultev->argument(0), { nm2 }, jlm::rvsdg::bit64, pbit64);
-    auto ldnm2 = LoadNonVolatileNode::Create(gepnm2, { ldnm1[1] }, jlm::rvsdg::bit64, 8);
+    auto gepnm2 = GetElementPtrOperation::Create(
+        resultev->argument(0),
+        { nm2 },
+        *jlm::rvsdg::bittype::Create(64),
+        pbit64);
+    auto ldnm2 =
+        LoadNonVolatileNode::Create(gepnm2, { ldnm1[1] }, *jlm::rvsdg::bittype::Create(64), 8);
 
     auto sum = jlm::rvsdg::bitadd_op::create(64, ldnm1[0], ldnm2[0]);
 
@@ -441,7 +452,7 @@ TestCallTypeClassifierRecursiveDirectCall()
     auto gepn = GetElementPtrOperation::Create(
         pointerArgument,
         { valueArgument },
-        jlm::rvsdg::bit64,
+        *jlm::rvsdg::bittype::Create(64),
         pbit64);
     auto store = StoreNonVolatileNode::Create(gepn, sumex, { gOMemoryState }, 8);
 

--- a/tests/jlm/llvm/ir/operators/TestGetElementPtr.cpp
+++ b/tests/jlm/llvm/ir/operators/TestGetElementPtr.cpp
@@ -12,16 +12,22 @@ TestOperationEquality()
 {
   using namespace jlm::llvm;
 
-  arraytype arrayType(jlm::rvsdg::bit8, 11);
+  arraytype arrayType(*jlm::rvsdg::bittype::Create(8), 11);
 
-  auto declaration1 = StructType::Declaration::Create({ &jlm::rvsdg::bit64, &jlm::rvsdg::bit64 });
-  auto declaration2 = StructType::Declaration::Create({ &arrayType, &jlm::rvsdg::bit32 });
+  auto declaration1 = StructType::Declaration::Create(
+      { &*jlm::rvsdg::bittype::Create(64), &*jlm::rvsdg::bittype::Create(64) });
+  auto declaration2 =
+      StructType::Declaration::Create({ &arrayType, &*jlm::rvsdg::bittype::Create(32) });
 
   StructType structType1(false, *declaration1);
   StructType structType2("myStructType", false, *declaration2);
 
-  GetElementPtrOperation operation1({ jlm::rvsdg::bit32, jlm::rvsdg::bit32 }, structType1);
-  GetElementPtrOperation operation2({ jlm::rvsdg::bit32, jlm::rvsdg::bit32 }, structType2);
+  GetElementPtrOperation operation1(
+      { *jlm::rvsdg::bittype::Create(32), *jlm::rvsdg::bittype::Create(32) },
+      structType1);
+  GetElementPtrOperation operation2(
+      { *jlm::rvsdg::bittype::Create(32), *jlm::rvsdg::bittype::Create(32) },
+      structType2);
 
   assert(operation1 != operation2);
 }

--- a/tests/jlm/llvm/opt/TestLoadStoreReduction.cpp
+++ b/tests/jlm/llvm/opt/TestLoadStoreReduction.cpp
@@ -29,13 +29,14 @@ TestLoadStoreReductionWithDifferentValueOperandType()
   nf->set_load_store_reducible(false);
 
   auto address = graph.add_import({ pointerType, "address" });
-  auto value = graph.add_import({ jlm::rvsdg::bit32, "value" });
+  auto value = graph.add_import({ *jlm::rvsdg::bittype::Create(32), "value" });
   auto memoryState = graph.add_import({ memoryStateType, "memoryState" });
 
   auto storeResults = StoreNonVolatileNode::Create(address, value, { memoryState }, 4);
-  auto loadResults = LoadNonVolatileNode::Create(address, storeResults, jlm::rvsdg::bit8, 4);
+  auto loadResults =
+      LoadNonVolatileNode::Create(address, storeResults, *jlm::rvsdg::bittype::Create(8), 4);
 
-  auto exportedValue = graph.add_export(loadResults[0], { jlm::rvsdg::bit8, "v" });
+  auto exportedValue = graph.add_export(loadResults[0], { *jlm::rvsdg::bittype::Create(8), "v" });
   graph.add_export(loadResults[1], { memoryStateType, "s" });
 
   jlm::rvsdg::view(graph.root(), stdout);

--- a/tests/jlm/llvm/opt/test-inversion.cpp
+++ b/tests/jlm/llvm/opt/test-inversion.cpp
@@ -38,7 +38,7 @@ test1()
   auto a = jlm::tests::create_testop(
       theta->subregion(),
       { lvx->argument(), lvy->argument() },
-      { &jlm::rvsdg::bit1 })[0];
+      { &*jlm::rvsdg::bittype::Create(1) })[0];
   auto predicate = jlm::rvsdg::match(1, { { 1, 0 } }, 1, 2, a);
 
   auto gamma = jlm::rvsdg::gamma_node::create(predicate, 2);
@@ -89,8 +89,10 @@ test2()
 
   auto lv1 = theta->add_loopvar(x);
 
-  auto n1 =
-      jlm::tests::create_testop(theta->subregion(), { lv1->argument() }, { &jlm::rvsdg::bit1 })[0];
+  auto n1 = jlm::tests::create_testop(
+      theta->subregion(),
+      { lv1->argument() },
+      { &*jlm::rvsdg::bittype::Create(1) })[0];
   auto n2 = jlm::tests::create_testop(theta->subregion(), { lv1->argument() }, { &vt })[0];
   auto predicate = jlm::rvsdg::match(1, { { 1, 0 } }, 1, 2, n1);
 

--- a/tests/jlm/llvm/opt/test-pull.cpp
+++ b/tests/jlm/llvm/opt/test-pull.cpp
@@ -93,7 +93,7 @@ test_pull()
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto & graph = rm.Rvsdg();
 
-  auto p = graph.add_import({ jlm::rvsdg::ctl2, "" });
+  auto p = graph.add_import({ *jlm::rvsdg::ctltype::Create(2), "" });
 
   auto croot = jlm::tests::create_testop(graph.root(), {}, { &vt })[0];
 

--- a/tests/jlm/mlir/backend/TestJlmToMlirConverter.cpp
+++ b/tests/jlm/mlir/backend/TestJlmToMlirConverter.cpp
@@ -30,7 +30,7 @@ TestLambda()
     MemoryStateType memoryStateType;
     FunctionType functionType(
         { &iOStateType, &memoryStateType },
-        { &jlm::rvsdg::bit32, &iOStateType, &memoryStateType });
+        { &*jlm::rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, "test", linkage::external_linkage);
@@ -151,7 +151,7 @@ TestAddOperation()
     MemoryStateType memoryStateType;
     FunctionType functionType(
         { &iOStateType, &memoryStateType },
-        { &jlm::rvsdg::bit32, &iOStateType, &memoryStateType });
+        { &*jlm::rvsdg::bittype::Create(32), &iOStateType, &memoryStateType });
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, "test", linkage::external_linkage);
@@ -252,7 +252,7 @@ TestComZeroExt()
     MemoryStateType memoryStateType;
     FunctionType functionType(
         { &iOStateType, &memoryStateType },
-        { &jlm::rvsdg::bit1, &iOStateType, &memoryStateType });
+        { &*jlm::rvsdg::bittype::Create(1), &iOStateType, &memoryStateType });
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, "test", linkage::external_linkage);

--- a/tests/jlm/rvsdg/test-gamma.cpp
+++ b/tests/jlm/rvsdg/test-gamma.cpp
@@ -16,13 +16,11 @@ test_gamma(void)
 {
   using namespace jlm::rvsdg;
 
-  bittype bit2(2);
-
   jlm::rvsdg::graph graph;
-  auto cmp = graph.add_import({ bit2, "" });
-  auto v0 = graph.add_import({ bit32, "" });
-  auto v1 = graph.add_import({ bit32, "" });
-  auto v2 = graph.add_import({ bit32, "" });
+  auto cmp = graph.add_import({ *bittype::Create(2), "" });
+  auto v0 = graph.add_import({ *bittype::Create(32), "" });
+  auto v1 = graph.add_import({ *bittype::Create(32), "" });
+  auto v2 = graph.add_import({ *bittype::Create(32), "" });
   auto v3 = graph.add_import({ *ctltype::Create(2), "" });
 
   auto pred = match(2, { { 0, 0 }, { 1, 1 } }, 2, 3, cmp);
@@ -60,9 +58,9 @@ test_predicate_reduction(void)
 
   bittype bits2(2);
 
-  auto v0 = graph.add_import({ bit32, "" });
-  auto v1 = graph.add_import({ bit32, "" });
-  auto v2 = graph.add_import({ bit32, "" });
+  auto v0 = graph.add_import({ *bittype::Create(32), "" });
+  auto v1 = graph.add_import({ *bittype::Create(32), "" });
+  auto v2 = graph.add_import({ *bittype::Create(32), "" });
 
   auto pred = jlm::rvsdg::control_constant(graph.root(), 3, 1);
 
@@ -117,7 +115,7 @@ test_control_constant_reduction()
   jlm::rvsdg::graph graph;
   gamma_op::normal_form(&graph)->set_control_constant_reduction(true);
 
-  auto x = graph.add_import({ bit1, "x" });
+  auto x = graph.add_import({ *bittype::Create(1), "x" });
 
   auto c = match(1, { { 0, 0 } }, 1, 2, x);
 

--- a/tests/jlm/rvsdg/test-gamma.cpp
+++ b/tests/jlm/rvsdg/test-gamma.cpp
@@ -23,7 +23,7 @@ test_gamma(void)
   auto v0 = graph.add_import({ bit32, "" });
   auto v1 = graph.add_import({ bit32, "" });
   auto v2 = graph.add_import({ bit32, "" });
-  auto v3 = graph.add_import({ ctl2, "" });
+  auto v3 = graph.add_import({ *ctltype::Create(2), "" });
 
   auto pred = match(2, { { 0, 0 }, { 1, 1 } }, 2, 3, cmp);
 
@@ -92,7 +92,7 @@ test_invariant_reduction(void)
   jlm::rvsdg::graph graph;
   gamma_op::normal_form(&graph)->set_invariant_reduction(true);
 
-  auto pred = graph.add_import({ ctl2, "" });
+  auto pred = graph.add_import({ *ctltype::Create(2), "" });
   auto v = graph.add_import({ vtype, "" });
 
   auto gamma = jlm::rvsdg::gamma_node::create(pred, 2);
@@ -188,7 +188,7 @@ TestRemoveGammaOutputsWhere()
   jlm::tests::valuetype vt;
   ctltype ct(2);
 
-  auto predicate = rvsdg.add_import({ ctl2, "" });
+  auto predicate = rvsdg.add_import({ *ctltype::Create(2), "" });
   auto v0 = rvsdg.add_import({ vt, "" });
   auto v1 = rvsdg.add_import({ vt, "" });
   auto v2 = rvsdg.add_import({ vt, "" });
@@ -250,7 +250,7 @@ TestPruneOutputs()
   jlm::tests::valuetype vt;
   ctltype ct(2);
 
-  auto predicate = rvsdg.add_import({ ctl2, "" });
+  auto predicate = rvsdg.add_import({ *ctltype::Create(2), "" });
   auto v0 = rvsdg.add_import({ vt, "" });
   auto v1 = rvsdg.add_import({ vt, "" });
   auto v2 = rvsdg.add_import({ vt, "" });
@@ -299,7 +299,7 @@ TestIsInvariant()
   jlm::tests::valuetype vt;
   ctltype ct(2);
 
-  auto predicate = rvsdg.add_import({ ctl2, "" });
+  auto predicate = rvsdg.add_import({ *ctltype::Create(2), "" });
   auto v0 = rvsdg.add_import({ vt, "" });
   auto v1 = rvsdg.add_import({ vt, "" });
 

--- a/tests/jlm/rvsdg/test-theta.cpp
+++ b/tests/jlm/rvsdg/test-theta.cpp
@@ -18,7 +18,7 @@ TestThetaCreation()
   jlm::rvsdg::graph graph;
   jlm::tests::valuetype t;
 
-  auto imp1 = graph.add_import({ ctl2, "imp1" });
+  auto imp1 = graph.add_import({ *ctltype::Create(2), "imp1" });
   auto imp2 = graph.add_import({ t, "imp2" });
   auto imp3 = graph.add_import({ t, "imp3" });
 
@@ -57,7 +57,7 @@ TestRemoveThetaOutputsWhere()
   graph rvsdg;
   jlm::tests::valuetype valueType;
 
-  auto ctl = rvsdg.add_import({ ctl2, "ctl" });
+  auto ctl = rvsdg.add_import({ *ctltype::Create(2), "ctl" });
   auto x = rvsdg.add_import({ valueType, "x" });
   auto y = rvsdg.add_import({ valueType, "y" });
 
@@ -68,7 +68,7 @@ TestRemoveThetaOutputsWhere()
   auto thetaOutput2 = thetaNode->add_loopvar(y);
   thetaNode->set_predicate(thetaOutput0->argument());
 
-  rvsdg.add_export(thetaOutput0, { ctl2, "" });
+  rvsdg.add_export(thetaOutput0, { *ctltype::Create(2), "" });
 
   // Act & Assert
   auto deadInputs = thetaNode->RemoveThetaOutputsWhere(
@@ -107,7 +107,7 @@ TestPruneThetaOutputs()
   graph rvsdg;
   jlm::tests::valuetype valueType;
 
-  auto ctl = rvsdg.add_import({ ctl2, "ctl" });
+  auto ctl = rvsdg.add_import({ *ctltype::Create(2), "ctl" });
   auto x = rvsdg.add_import({ valueType, "x" });
   auto y = rvsdg.add_import({ valueType, "y" });
 
@@ -118,7 +118,7 @@ TestPruneThetaOutputs()
   thetaNode->add_loopvar(y);
   thetaNode->set_predicate(thetaOutput0->argument());
 
-  rvsdg.add_export(thetaOutput0, { ctl2, "" });
+  rvsdg.add_export(thetaOutput0, { *ctltype::Create(2), "" });
 
   // Act
   auto deadInputs = thetaNode->PruneThetaOutputs();
@@ -142,7 +142,7 @@ TestRemoveThetaInputsWhere()
   graph rvsdg;
   jlm::tests::valuetype valueType;
 
-  auto ctl = rvsdg.add_import({ ctl2, "ctl" });
+  auto ctl = rvsdg.add_import({ *ctltype::Create(2), "ctl" });
   auto x = rvsdg.add_import({ valueType, "x" });
   auto y = rvsdg.add_import({ valueType, "y" });
 
@@ -159,7 +159,7 @@ TestRemoveThetaInputsWhere()
   thetaOutput1->result()->divert_to(result);
   thetaOutput2->result()->divert_to(result);
 
-  rvsdg.add_export(thetaOutput0, { ctl2, "" });
+  rvsdg.add_export(thetaOutput0, { *ctltype::Create(2), "" });
 
   // Act & Assert
   auto deadOutputs = thetaNode->RemoveThetaInputsWhere(
@@ -198,7 +198,7 @@ TestPruneThetaInputs()
   graph rvsdg;
   jlm::tests::valuetype valueType;
 
-  auto ctl = rvsdg.add_import({ ctl2, "ctl" });
+  auto ctl = rvsdg.add_import({ *ctltype::Create(2), "ctl" });
   auto x = rvsdg.add_import({ valueType, "x" });
   auto y = rvsdg.add_import({ valueType, "y" });
 
@@ -215,7 +215,7 @@ TestPruneThetaInputs()
   thetaOutput1->result()->divert_to(result);
   thetaOutput2->result()->divert_to(result);
 
-  rvsdg.add_export(thetaOutput0, { ctl2, "" });
+  rvsdg.add_export(thetaOutput0, { *ctltype::Create(2), "" });
 
   // Act
   auto deadOutputs = thetaNode->PruneThetaInputs();

--- a/tests/test-types.cpp
+++ b/tests/test-types.cpp
@@ -25,10 +25,10 @@ valuetype::operator==(const rvsdg::type & other) const noexcept
   return dynamic_cast<const valuetype *>(&other) != nullptr;
 }
 
-std::unique_ptr<rvsdg::type>
+std::shared_ptr<const jlm::rvsdg::type>
 valuetype::copy() const
 {
-  return std::unique_ptr<rvsdg::type>(new valuetype(*this));
+  return std::make_shared<valuetype>(*this);
 }
 
 /* statetype */
@@ -48,10 +48,10 @@ statetype::operator==(const rvsdg::type & other) const noexcept
   return dynamic_cast<const statetype *>(&other) != nullptr;
 }
 
-std::unique_ptr<rvsdg::type>
+std::shared_ptr<const jlm::rvsdg::type>
 statetype::copy() const
 {
-  return std::unique_ptr<rvsdg::type>(new statetype(*this));
+  return std::make_shared<statetype>(*this);
 }
 
 }

--- a/tests/test-types.hpp
+++ b/tests/test-types.hpp
@@ -26,7 +26,7 @@ public:
   virtual bool
   operator==(const rvsdg::type & other) const noexcept override;
 
-  virtual std::unique_ptr<rvsdg::type>
+  std::shared_ptr<const jlm::rvsdg::type>
   copy() const override;
 };
 
@@ -45,7 +45,7 @@ public:
   virtual bool
   operator==(const rvsdg::type & other) const noexcept override;
 
-  virtual std::unique_ptr<rvsdg::type>
+  std::shared_ptr<const jlm::rvsdg::type>
   copy() const override;
 };
 


### PR DESCRIPTION
This change introduces shared_ptr for types, uses them in most places
for storage, and starts putting in singleton objects for several primitive
types.

The singletons use the "untracked feature" for std::shared_ptr -- the
"object used for lifetime tracking" can be separate from the "pointer
that the shared_ptr logically points to". It is possible to make the
former a "null" object in which case we actually have a non-reference
counted "shared" object that is supposed to have eternal lifetime.

This small trick allows to skip the cost of refcount inc/dec for these
eternal primitive objects. According to measurements, "create + destroy"
of e.g. bittype(32) is at ~6 CPU clock cycles (including function call
overhead), so this is already cheaper than before.