### PR TITLE
Rework bitstring comparison ops using templates instead of macros

### DIFF
--- a/jlm/rvsdg/Makefile.sub
+++ b/jlm/rvsdg/Makefile.sub
@@ -42,6 +42,7 @@ librvsdg_HEADERS = \
 	jlm/rvsdg/bitstring/value-representation.hpp \
 	jlm/rvsdg/bitstring/concat.hpp \
 	jlm/rvsdg/bitstring/bitoperation-classes.hpp \
+	jlm/rvsdg/bitstring/comparison-impl.hpp \
 	jlm/rvsdg/bitstring/comparison.hpp \
 	jlm/rvsdg/view.hpp \
 	jlm/rvsdg/traverser.hpp \

--- a/jlm/rvsdg/bitstring/comparison-impl.hpp
+++ b/jlm/rvsdg/bitstring/comparison-impl.hpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024 Helge Bahmann <hcb@chaoticmind.net>
+ * See COPYING for terms of redistribution.
+ */
+
+#ifndef JLM_RVSDG_BITSTRING_COMPARISON_IMPL_HPP
+#define JLM_RVSDG_BITSTRING_COMPARISON_IMPL_HPP
+
+#include <jlm/rvsdg/bitstring/comparison.hpp>
+
+namespace jlm::rvsdg
+{
+
+template<typename reduction, const char * name, enum binary_op::flags opflags>
+MakeBitComparisonOperation<reduction, name, opflags>::~MakeBitComparisonOperation() noexcept
+{}
+
+template<typename reduction, const char * name, enum binary_op::flags opflags>
+bool
+MakeBitComparisonOperation<reduction, name, opflags>::operator==(
+    const operation & other) const noexcept
+{
+  auto op = dynamic_cast<const MakeBitComparisonOperation<reduction, name, opflags> *>(&other);
+  return op && op->type() == type();
+}
+
+template<typename reduction, const char * name, enum binary_op::flags opflags>
+compare_result
+MakeBitComparisonOperation<reduction, name, opflags>::reduce_constants(
+    const bitvalue_repr & arg1,
+    const bitvalue_repr & arg2) const
+{
+  switch (reduction()(arg1, arg2))
+  {
+  case '0':
+    return compare_result::static_false;
+  case '1':
+    return compare_result::static_true;
+  default:
+    return compare_result::undecidable;
+  }
+}
+
+template<typename reduction, const char * name, enum binary_op::flags opflags>
+enum binary_op::flags
+MakeBitComparisonOperation<reduction, name, opflags>::flags() const noexcept
+{
+  return opflags;
+}
+
+template<typename reduction, const char * name, enum binary_op::flags opflags>
+std::string
+MakeBitComparisonOperation<reduction, name, opflags>::debug_string() const
+{
+  return jlm::util::strfmt(name, type().nbits());
+}
+
+template<typename reduction, const char * name, enum binary_op::flags opflags>
+std::unique_ptr<jlm::rvsdg::operation>
+MakeBitComparisonOperation<reduction, name, opflags>::copy() const
+{
+  return std::make_unique<MakeBitComparisonOperation>(*this);
+}
+
+template<typename reduction, const char * name, enum binary_op::flags opflags>
+std::unique_ptr<bitcompare_op>
+MakeBitComparisonOperation<reduction, name, opflags>::create(size_t nbits) const
+{
+  return std::make_unique<MakeBitComparisonOperation>(nbits);
+}
+
+}
+
+#endif

--- a/jlm/rvsdg/bitstring/comparison.cpp
+++ b/jlm/rvsdg/bitstring/comparison.cpp
@@ -1,68 +1,133 @@
 /*
- * Copyright 2014 Helge Bahmann <hcb@chaoticmind.net>
+ * Copyright 2014 2024 Helge Bahmann <hcb@chaoticmind.net>
  * Copyright 2011 2012 2013 2014 Nico Reißmann <nico.reissmann@gmail.com>
  * See COPYING for terms of redistribution.
  */
 
+#include <jlm/rvsdg/bitstring/comparison-impl.hpp>
 #include <jlm/rvsdg/bitstring/comparison.hpp>
 
 namespace jlm::rvsdg
 {
 
-#define DEFINE_BITCOMPARISON_OPERATION(NAME, FLAGS, DEBUG_STRING)             \
-  bit##NAME##_op::~bit##NAME##_op() noexcept                                  \
-  {}                                                                          \
-                                                                              \
-  bool bit##NAME##_op::operator==(const operation & other) const noexcept     \
-  {                                                                           \
-    auto op = dynamic_cast<const bit##NAME##_op *>(&other);                   \
-    return op && op->type() == type();                                        \
-  }                                                                           \
-                                                                              \
-  compare_result bit##NAME##_op::reduce_constants(                            \
-      const bitvalue_repr & arg1,                                             \
-      const bitvalue_repr & arg2) const                                       \
-  {                                                                           \
-    switch (arg1.NAME(arg2))                                                  \
-    {                                                                         \
-    case '0':                                                                 \
-      return compare_result::static_false;                                    \
-    case '1':                                                                 \
-      return compare_result::static_true;                                     \
-    default:                                                                  \
-      return compare_result::undecidable;                                     \
-    }                                                                         \
-  }                                                                           \
-                                                                              \
-  enum binary_op::flags bit##NAME##_op::flags() const noexcept                \
-  {                                                                           \
-    return FLAGS;                                                             \
-  }                                                                           \
-                                                                              \
-  std::string bit##NAME##_op::debug_string() const                            \
-  {                                                                           \
-    return jlm::util::strfmt(#DEBUG_STRING, type().nbits());                  \
-  }                                                                           \
-                                                                              \
-  std::unique_ptr<jlm::rvsdg::operation> bit##NAME##_op::copy() const         \
-  {                                                                           \
-    return std::unique_ptr<jlm::rvsdg::operation>(new bit##NAME##_op(*this)); \
-  }                                                                           \
-                                                                              \
-  std::unique_ptr<bitcompare_op> bit##NAME##_op::create(size_t nbits) const   \
-  {                                                                           \
-    return std::unique_ptr<bitcompare_op>(new bit##NAME##_op(nbits));         \
+struct reduce_eq
+{
+  char
+  operator()(const bitvalue_repr & arg1, const bitvalue_repr & arg2) const
+  {
+    return arg1.eq(arg2);
   }
+};
 
-DEFINE_BITCOMPARISON_OPERATION(eq, binary_op::flags::commutative, BITEQ)
-DEFINE_BITCOMPARISON_OPERATION(ne, binary_op::flags::commutative, BITNE)
-DEFINE_BITCOMPARISON_OPERATION(sge, binary_op::flags::none, BITSGE)
-DEFINE_BITCOMPARISON_OPERATION(sgt, binary_op::flags::none, BITSGT)
-DEFINE_BITCOMPARISON_OPERATION(sle, binary_op::flags::none, BITSLE)
-DEFINE_BITCOMPARISON_OPERATION(slt, binary_op::flags::none, BITSLT)
-DEFINE_BITCOMPARISON_OPERATION(uge, binary_op::flags::none, BITUGE)
-DEFINE_BITCOMPARISON_OPERATION(ugt, binary_op::flags::none, BITUGT)
-DEFINE_BITCOMPARISON_OPERATION(ule, binary_op::flags::none, BITULE)
-DEFINE_BITCOMPARISON_OPERATION(ult, binary_op::flags::none, BITULT)
+const char BitEqLabel[] = "BitEq";
+template class MakeBitComparisonOperation<reduce_eq, BitEqLabel, binary_op::flags::commutative>;
+
+struct reduce_ne
+{
+  char
+  operator()(const bitvalue_repr & arg1, const bitvalue_repr & arg2) const
+  {
+    return arg1.ne(arg2);
+  }
+};
+
+const char BitNeLabel[] = "BitNe";
+template class MakeBitComparisonOperation<reduce_ne, BitNeLabel, binary_op::flags::commutative>;
+
+struct reduce_sge
+{
+  char
+  operator()(const bitvalue_repr & arg1, const bitvalue_repr & arg2) const
+  {
+    return arg1.sge(arg2);
+  }
+};
+
+const char BitSgeLabel[] = "BitSge";
+template class MakeBitComparisonOperation<reduce_sge, BitSgeLabel, binary_op::flags::none>;
+
+struct reduce_sgt
+{
+  char
+  operator()(const bitvalue_repr & arg1, const bitvalue_repr & arg2) const
+  {
+    return arg1.sgt(arg2);
+  }
+};
+
+const char BitSgtLabel[] = "BitSgt";
+template class MakeBitComparisonOperation<reduce_sgt, BitSgtLabel, binary_op::flags::none>;
+
+struct reduce_sle
+{
+  char
+  operator()(const bitvalue_repr & arg1, const bitvalue_repr & arg2) const
+  {
+    return arg1.sle(arg2);
+  }
+};
+
+const char BitSleLabel[] = "BitSle";
+template class MakeBitComparisonOperation<reduce_sle, BitSleLabel, binary_op::flags::none>;
+
+struct reduce_slt
+{
+  char
+  operator()(const bitvalue_repr & arg1, const bitvalue_repr & arg2) const
+  {
+    return arg1.slt(arg2);
+  }
+};
+
+const char BitSltLabel[] = "BitSlt";
+template class MakeBitComparisonOperation<reduce_slt, BitSltLabel, binary_op::flags::none>;
+
+struct reduce_uge
+{
+  char
+  operator()(const bitvalue_repr & arg1, const bitvalue_repr & arg2) const
+  {
+    return arg1.uge(arg2);
+  }
+};
+
+const char BitUgeLabel[] = "BitUge";
+template class MakeBitComparisonOperation<reduce_uge, BitUgeLabel, binary_op::flags::none>;
+
+struct reduce_ugt
+{
+  char
+  operator()(const bitvalue_repr & arg1, const bitvalue_repr & arg2) const
+  {
+    return arg1.ugt(arg2);
+  }
+};
+
+const char BitUgtLabel[] = "BitUgt";
+template class MakeBitComparisonOperation<reduce_ugt, BitUgtLabel, binary_op::flags::none>;
+
+struct reduce_ule
+{
+  char
+  operator()(const bitvalue_repr & arg1, const bitvalue_repr & arg2) const
+  {
+    return arg1.ule(arg2);
+  }
+};
+
+const char BitUleLabel[] = "BitUle";
+template class MakeBitComparisonOperation<reduce_ule, BitUleLabel, binary_op::flags::none>;
+
+struct reduce_ult
+{
+  char
+  operator()(const bitvalue_repr & arg1, const bitvalue_repr & arg2) const
+  {
+    return arg1.ult(arg2);
+  }
+};
+
+const char BitUltLabel[] = "BitUlt";
+template class MakeBitComparisonOperation<reduce_ult, BitUltLabel, binary_op::flags::none>;
 
 }

--- a/jlm/rvsdg/bitstring/comparison.hpp
+++ b/jlm/rvsdg/bitstring/comparison.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2011 2012 2014 Nico Reißmann <nico.reissmann@gmail.com>
- * Copyright 2014 Helge Bahmann <hcb@chaoticmind.net>
+ * Copyright 2014 2024 Helge Bahmann <hcb@chaoticmind.net>
  * See COPYING for terms of redistribution.
  */
 
@@ -13,51 +13,99 @@
 namespace jlm::rvsdg
 {
 
-#define DECLARE_BITCOMPARISON_OPERATION(NAME)                                                  \
-  class NAME##_op final : public bitcompare_op                                                 \
-  {                                                                                            \
-  public:                                                                                      \
-    virtual ~NAME##_op() noexcept;                                                             \
-                                                                                               \
-    inline NAME##_op(const bittype & type) noexcept                                            \
-        : bitcompare_op(type)                                                                  \
-    {}                                                                                         \
-                                                                                               \
-    virtual bool                                                                               \
-    operator==(const operation & other) const noexcept override;                               \
-                                                                                               \
-    virtual enum jlm::rvsdg::binary_op::flags                                                  \
-    flags() const noexcept override;                                                           \
-                                                                                               \
-    virtual compare_result                                                                     \
-    reduce_constants(const bitvalue_repr & arg1, const bitvalue_repr & arg2) const override;   \
-                                                                                               \
-    virtual std::string                                                                        \
-    debug_string() const override;                                                             \
-                                                                                               \
-    virtual std::unique_ptr<jlm::rvsdg::operation>                                             \
-    copy() const override;                                                                     \
-                                                                                               \
-    virtual std::unique_ptr<bitcompare_op>                                                     \
-    create(size_t nbits) const override;                                                       \
-                                                                                               \
-    static inline jlm::rvsdg::output *                                                         \
-    create(size_t nbits, jlm::rvsdg::output * op1, jlm::rvsdg::output * op2)                   \
-    {                                                                                          \
-      return simple_node::create_normalized(op1->region(), NAME##_op(nbits), { op1, op2 })[0]; \
-    }                                                                                          \
-  };
+template<typename reduction, const char * name, enum binary_op::flags opflags>
+class MakeBitComparisonOperation final : public bitcompare_op
+{
+public:
+  ~MakeBitComparisonOperation() noexcept override;
 
-DECLARE_BITCOMPARISON_OPERATION(biteq)
-DECLARE_BITCOMPARISON_OPERATION(bitne)
-DECLARE_BITCOMPARISON_OPERATION(bitsge)
-DECLARE_BITCOMPARISON_OPERATION(bitsgt)
-DECLARE_BITCOMPARISON_OPERATION(bitsle)
-DECLARE_BITCOMPARISON_OPERATION(bitslt)
-DECLARE_BITCOMPARISON_OPERATION(bituge)
-DECLARE_BITCOMPARISON_OPERATION(bitugt)
-DECLARE_BITCOMPARISON_OPERATION(bitule)
-DECLARE_BITCOMPARISON_OPERATION(bitult)
+  explicit MakeBitComparisonOperation(const bittype & type) noexcept
+      : bitcompare_op(type)
+  {}
+
+  bool
+  operator==(const operation & other) const noexcept override;
+
+  enum binary_op::flags
+  flags() const noexcept override;
+
+  compare_result
+  reduce_constants(const bitvalue_repr & arg1, const bitvalue_repr & arg2) const override;
+
+  std::string
+  debug_string() const override;
+
+  std::unique_ptr<operation>
+  copy() const override;
+
+  std::unique_ptr<bitcompare_op>
+  create(size_t nbits) const override;
+
+  static output *
+  create(size_t nbits, output * op1, output * op2)
+  {
+    return simple_node::create_normalized(
+        op1->region(),
+        MakeBitComparisonOperation(nbits),
+        { op1, op2 })[0];
+  }
+};
+
+struct reduce_eq;
+extern const char BitEqLabel[];
+using biteq_op = MakeBitComparisonOperation<reduce_eq, BitEqLabel, binary_op::flags::commutative>;
+extern template class MakeBitComparisonOperation<
+    reduce_eq,
+    BitEqLabel,
+    binary_op::flags::commutative>;
+
+struct reduce_ne;
+extern const char BitNeLabel[];
+using bitne_op = MakeBitComparisonOperation<reduce_ne, BitNeLabel, binary_op::flags::commutative>;
+extern template class MakeBitComparisonOperation<
+    reduce_ne,
+    BitNeLabel,
+    binary_op::flags::commutative>;
+
+struct reduce_sge;
+extern const char BitSgeLabel[];
+using bitsge_op = MakeBitComparisonOperation<reduce_sge, BitSgeLabel, binary_op::flags::none>;
+extern template class MakeBitComparisonOperation<reduce_sge, BitSgeLabel, binary_op::flags::none>;
+
+struct reduce_sgt;
+extern const char BitSgtLabel[];
+using bitsgt_op = MakeBitComparisonOperation<reduce_sgt, BitSgtLabel, binary_op::flags::none>;
+extern template class MakeBitComparisonOperation<reduce_sgt, BitSgtLabel, binary_op::flags::none>;
+
+struct reduce_sle;
+extern const char BitSleLabel[];
+using bitsle_op = MakeBitComparisonOperation<reduce_sle, BitSleLabel, binary_op::flags::none>;
+extern template class MakeBitComparisonOperation<reduce_sle, BitSleLabel, binary_op::flags::none>;
+
+struct reduce_slt;
+extern const char BitSltLabel[];
+using bitslt_op = MakeBitComparisonOperation<reduce_slt, BitSltLabel, binary_op::flags::none>;
+extern template class MakeBitComparisonOperation<reduce_slt, BitSltLabel, binary_op::flags::none>;
+
+struct reduce_uge;
+extern const char BitUgeLabel[];
+using bituge_op = MakeBitComparisonOperation<reduce_uge, BitUgeLabel, binary_op::flags::none>;
+extern template class MakeBitComparisonOperation<reduce_uge, BitUgeLabel, binary_op::flags::none>;
+
+struct reduce_ugt;
+extern const char BitUgtLabel[];
+using bitugt_op = MakeBitComparisonOperation<reduce_ugt, BitUgtLabel, binary_op::flags::none>;
+extern template class MakeBitComparisonOperation<reduce_ugt, BitUgtLabel, binary_op::flags::none>;
+
+struct reduce_ule;
+extern const char BitUleLabel[];
+using bitule_op = MakeBitComparisonOperation<reduce_ule, BitUleLabel, binary_op::flags::none>;
+extern template class MakeBitComparisonOperation<reduce_ule, BitUleLabel, binary_op::flags::none>;
+
+struct reduce_ult;
+extern const char BitUltLabel[];
+using bitult_op = MakeBitComparisonOperation<reduce_ult, BitUltLabel, binary_op::flags::none>;
+extern template class MakeBitComparisonOperation<reduce_ult, BitUltLabel, binary_op::flags::none>;
 
 }
 


### PR DESCRIPTION
Remove all code generation macros for instantiating bitstring comparison operation classes. Replace this with normal C++ template classes.