### PR TITLE
Convert various llvm IR ops to shared_ptr of type

### DIFF
--- a/jlm/llvm/backend/jlm2llvm/instruction.cpp
+++ b/jlm/llvm/backend/jlm2llvm/instruction.cpp
@@ -840,7 +840,7 @@ convert_cast(
     context & ctx)
 {
   JLM_ASSERT(::llvm::Instruction::isCast(OPCODE));
-  auto & dsttype = *static_cast<const rvsdg::valuetype *>(&op.result(0).type());
+  auto dsttype = std::dynamic_pointer_cast<const rvsdg::valuetype>(op.result(0).Type());
   auto operand = operands[0];
 
   if (auto vt = dynamic_cast<const fixedvectortype *>(&operand->type()))
@@ -855,7 +855,7 @@ convert_cast(
     return builder.CreateCast(OPCODE, ctx.value(operand), type);
   }
 
-  auto type = convert_type(dsttype, ctx);
+  auto type = convert_type(*dsttype, ctx);
   return builder.CreateCast(OPCODE, ctx.value(operand), type);
 }
 

--- a/jlm/llvm/frontend/LlvmInstructionConversion.cpp
+++ b/jlm/llvm/frontend/LlvmInstructionConversion.cpp
@@ -1116,7 +1116,7 @@ convert(::llvm::UnaryOperator * unaryOperator, tacsvector_t & threeAddressCodeVe
 
 template<class OP>
 static std::unique_ptr<rvsdg::operation>
-create_unop(std::unique_ptr<rvsdg::type> st, std::unique_ptr<rvsdg::type> dt)
+create_unop(std::shared_ptr<const rvsdg::type> st, std::shared_ptr<const rvsdg::type> dt)
 {
   return std::unique_ptr<rvsdg::operation>(new OP(std::move(st), std::move(dt)));
 }
@@ -1131,8 +1131,8 @@ convert_cast_instruction(::llvm::Instruction * i, tacsvector_t & tacs, context &
   static std::unordered_map<
       unsigned,
       std::unique_ptr<rvsdg::operation> (*)(
-          std::unique_ptr<rvsdg::type>,
-          std::unique_ptr<rvsdg::type>)>
+          std::shared_ptr<const rvsdg::type>,
+          std::shared_ptr<const rvsdg::type>)>
       map({ { ::llvm::Instruction::Trunc, create_unop<trunc_op> },
             { ::llvm::Instruction::ZExt, create_unop<zext_op> },
             { ::llvm::Instruction::UIToFP, create_unop<uitofp_op> },

--- a/jlm/llvm/frontend/LlvmTypeConversion.cpp
+++ b/jlm/llvm/frontend/LlvmTypeConversion.cpp
@@ -25,27 +25,28 @@ ExtractFloatingPointSize(const ::llvm::Type * type)
         { ::llvm::Type::DoubleTyID, fpsize::dbl },
         { ::llvm::Type::X86_FP80TyID, fpsize::x86fp80 } });
 
-  JLM_ASSERT(map.find(type->getTypeID()) != map.end());
-  return map[type->getTypeID()];
+  auto i = map.find(type->getTypeID());
+  JLM_ASSERT(i != map.end());
+  return i->second;
 }
 
-static std::unique_ptr<rvsdg::valuetype>
+static std::shared_ptr<const rvsdg::valuetype>
 convert_integer_type(const ::llvm::Type * t, context & ctx)
 {
   JLM_ASSERT(t->getTypeID() == ::llvm::Type::IntegerTyID);
   auto * type = static_cast<const ::llvm::IntegerType *>(t);
 
-  return std::unique_ptr<rvsdg::valuetype>(new rvsdg::bittype(type->getBitWidth()));
+  return rvsdg::bittype::Create(type->getBitWidth());
 }
 
-static std::unique_ptr<rvsdg::valuetype>
+static std::shared_ptr<const rvsdg::valuetype>
 convert_pointer_type(const ::llvm::Type * t, context &)
 {
   JLM_ASSERT(t->getTypeID() == ::llvm::Type::PointerTyID);
-  return std::make_unique<PointerType>();
+  return PointerType::Create();
 }
 
-static std::unique_ptr<rvsdg::valuetype>
+static std::shared_ptr<const rvsdg::valuetype>
 convert_function_type(const ::llvm::Type * t, context & ctx)
 {
   JLM_ASSERT(t->getTypeID() == ::llvm::Type::FunctionTyID);
@@ -67,24 +68,24 @@ convert_function_type(const ::llvm::Type * t, context & ctx)
   resultTypes.push_back(iostatetype::Create());
   resultTypes.push_back(MemoryStateType::Create());
 
-  return std::unique_ptr<rvsdg::valuetype>(
-      new FunctionType(std::move(argumentTypes), std::move(resultTypes)));
+  return FunctionType::Create(std::move(argumentTypes), std::move(resultTypes));
 }
 
-static inline std::unique_ptr<rvsdg::valuetype>
+static std::shared_ptr<const rvsdg::valuetype>
 convert_fp_type(const ::llvm::Type * t, context & ctx)
 {
-  static std::unordered_map<::llvm::Type::TypeID, fpsize> map(
+  static const std::unordered_map<::llvm::Type::TypeID, fpsize> map(
       { { ::llvm::Type::HalfTyID, fpsize::half },
         { ::llvm::Type::FloatTyID, fpsize::flt },
         { ::llvm::Type::DoubleTyID, fpsize::dbl },
         { ::llvm::Type::X86_FP80TyID, fpsize::x86fp80 } });
 
-  JLM_ASSERT(map.find(t->getTypeID()) != map.end());
-  return std::unique_ptr<rvsdg::valuetype>(new fptype(map[t->getTypeID()]));
+  auto i = map.find(t->getTypeID());
+  JLM_ASSERT(i != map.end());
+  return fptype::Create(i->second);
 }
 
-static std::unique_ptr<rvsdg::valuetype>
+static std::shared_ptr<const rvsdg::valuetype>
 convert_struct_type(const ::llvm::Type * t, context & ctx)
 {
   JLM_ASSERT(t->isStructTy());
@@ -97,39 +98,40 @@ convert_struct_type(const ::llvm::Type * t, context & ctx)
                          : StructType::Create(isPacked, declaration);
 }
 
-static std::unique_ptr<rvsdg::valuetype>
+static std::shared_ptr<const rvsdg::valuetype>
 convert_array_type(const ::llvm::Type * t, context & ctx)
 {
   JLM_ASSERT(t->isArrayTy());
   auto etype = ConvertType(t->getArrayElementType(), ctx);
-  return std::unique_ptr<rvsdg::valuetype>(new arraytype(*etype, t->getArrayNumElements()));
+  return arraytype::Create(std::move(etype), t->getArrayNumElements());
 }
 
-static std::unique_ptr<rvsdg::valuetype>
+static std::shared_ptr<const rvsdg::valuetype>
 convert_fixed_vector_type(const ::llvm::Type * t, context & ctx)
 {
   JLM_ASSERT(t->getTypeID() == ::llvm::Type::FixedVectorTyID);
   auto type = ConvertType(t->getScalarType(), ctx);
-  return std::unique_ptr<rvsdg::valuetype>(
-      new fixedvectortype(*type, ::llvm::cast<::llvm::FixedVectorType>(t)->getNumElements()));
+  return fixedvectortype::Create(
+      std::move(type),
+      ::llvm::cast<::llvm::FixedVectorType>(t)->getNumElements());
 }
 
-static std::unique_ptr<rvsdg::valuetype>
+static std::shared_ptr<const rvsdg::valuetype>
 convert_scalable_vector_type(const ::llvm::Type * t, context & ctx)
 {
   JLM_ASSERT(t->getTypeID() == ::llvm::Type::ScalableVectorTyID);
   auto type = ConvertType(t->getScalarType(), ctx);
-  return std::unique_ptr<rvsdg::valuetype>(new scalablevectortype(
-      *type,
-      ::llvm::cast<::llvm::ScalableVectorType>(t)->getMinNumElements()));
+  return scalablevectortype::Create(
+      std::move(type),
+      ::llvm::cast<::llvm::ScalableVectorType>(t)->getMinNumElements());
 }
 
-std::unique_ptr<rvsdg::valuetype>
+std::shared_ptr<const rvsdg::valuetype>
 ConvertType(const ::llvm::Type * t, context & ctx)
 {
   static std::unordered_map<
       ::llvm::Type::TypeID,
-      std::function<std::unique_ptr<rvsdg::valuetype>(const ::llvm::Type *, context &)>>
+      std::function<std::shared_ptr<const rvsdg::valuetype>(const ::llvm::Type *, context &)>>
       map({ { ::llvm::Type::IntegerTyID, convert_integer_type },
             { ::llvm::Type::PointerTyID, convert_pointer_type },
             { ::llvm::Type::FunctionTyID, convert_function_type },

--- a/jlm/llvm/frontend/LlvmTypeConversion.hpp
+++ b/jlm/llvm/frontend/LlvmTypeConversion.hpp
@@ -27,23 +27,23 @@ class context;
 fpsize
 ExtractFloatingPointSize(const ::llvm::Type * type);
 
-std::unique_ptr<rvsdg::valuetype>
+std::shared_ptr<const rvsdg::valuetype>
 ConvertType(const ::llvm::Type * type, context & ctx);
 
-static inline std::unique_ptr<FunctionType>
+static inline std::shared_ptr<const FunctionType>
 ConvertFunctionType(const ::llvm::FunctionType * type, context & ctx)
 {
   auto t = ConvertType(::llvm::cast<::llvm::Type>(type), ctx);
   JLM_ASSERT(dynamic_cast<const FunctionType *>(t.get()));
-  return std::unique_ptr<FunctionType>(static_cast<FunctionType *>(t.release()));
+  return std::dynamic_pointer_cast<const FunctionType>(t);
 }
 
-static inline std::unique_ptr<PointerType>
+static inline std::shared_ptr<const PointerType>
 ConvertPointerType(const ::llvm::PointerType * type, context & ctx)
 {
   auto t = ConvertType(::llvm::cast<::llvm::Type>(type), ctx);
   JLM_ASSERT(dynamic_cast<const PointerType *>(t.get()));
-  return std::unique_ptr<PointerType>(static_cast<PointerType *>(t.release()));
+  return std::dynamic_pointer_cast<const PointerType>(t);
 }
 
 }

--- a/jlm/llvm/ir/attribute.cpp
+++ b/jlm/llvm/ir/attribute.cpp
@@ -82,7 +82,7 @@ type_attribute::operator==(const attribute & other) const
 std::unique_ptr<attribute>
 type_attribute::copy() const
 {
-  return std::unique_ptr<attribute>(new type_attribute(kind(), type()));
+  return std::make_unique<type_attribute>(kind(), type_);
 }
 
 /* attribute set class */

--- a/jlm/llvm/ir/attribute.hpp
+++ b/jlm/llvm/ir/attribute.hpp
@@ -268,18 +268,11 @@ class type_attribute final : public enum_attribute
 public:
   ~type_attribute() override;
 
-private:
-  type_attribute(attribute::kind kind, std::unique_ptr<jlm::rvsdg::valuetype> type)
+  type_attribute(attribute::kind kind, std::shared_ptr<const jlm::rvsdg::valuetype> type)
       : enum_attribute(kind),
         type_(std::move(type))
   {}
 
-  type_attribute(attribute::kind kind, const jlm::rvsdg::valuetype & type)
-      : enum_attribute(kind),
-        type_(std::dynamic_pointer_cast<const jlm::rvsdg::valuetype>(type.copy()))
-  {}
-
-public:
   const jlm::rvsdg::valuetype &
   type() const noexcept
   {
@@ -293,16 +286,15 @@ public:
   copy() const override;
 
   static std::unique_ptr<attribute>
-  create_byval(std::unique_ptr<jlm::rvsdg::valuetype> type)
+  create_byval(std::shared_ptr<const jlm::rvsdg::valuetype> type)
   {
-    std::unique_ptr<type_attribute> ta(new type_attribute(kind::ByVal, std::move(type)));
-    return ta;
+    return std::make_unique<type_attribute>(kind::ByVal, std::move(type));
   }
 
   static std::unique_ptr<attribute>
-  CreateStructRetAttribute(std::unique_ptr<jlm::rvsdg::valuetype> type)
+  CreateStructRetAttribute(std::shared_ptr<const jlm::rvsdg::valuetype> type)
   {
-    return std::unique_ptr<attribute>(new type_attribute(kind::StructRet, std::move(type)));
+    return std::make_unique<type_attribute>(kind::StructRet, std::move(type));
   }
 
 private:

--- a/jlm/llvm/ir/operators/operators.hpp
+++ b/jlm/llvm/ir/operators/operators.hpp
@@ -207,8 +207,8 @@ private:
   createVectorSelectTac(const variable * p, const variable * t, const variable * f)
   {
     auto fvt = static_cast<const T *>(&t->type());
-    T pt(*jlm::rvsdg::bittype::Create(1), fvt->size());
-    T vt(fvt->type(), fvt->size());
+    T pt(jlm::rvsdg::bittype::Create(1), fvt->size());
+    T vt(fvt->Type(), fvt->size());
     vectorselect_op op(pt, vt);
     return tac::create(op, { p, t, f });
   }
@@ -226,8 +226,8 @@ public:
   {}
 
   inline fp2ui_op(
-      std::unique_ptr<jlm::rvsdg::type> srctype,
-      std::unique_ptr<jlm::rvsdg::type> dsttype)
+      std::shared_ptr<const jlm::rvsdg::type> srctype,
+      std::shared_ptr<const jlm::rvsdg::type> dsttype)
       : unary_op(*srctype, *dsttype)
   {
     auto st = dynamic_cast<const fptype *>(srctype.get());
@@ -283,8 +283,8 @@ public:
   {}
 
   inline fp2si_op(
-      std::unique_ptr<jlm::rvsdg::type> srctype,
-      std::unique_ptr<jlm::rvsdg::type> dsttype)
+      std::shared_ptr<const jlm::rvsdg::type> srctype,
+      std::shared_ptr<const jlm::rvsdg::type> dsttype)
       : jlm::rvsdg::unary_op({ *srctype }, { *dsttype })
   {
     auto st = dynamic_cast<const fptype *>(srctype.get());
@@ -468,8 +468,8 @@ public:
   {}
 
   inline bits2ptr_op(
-      std::unique_ptr<jlm::rvsdg::type> srctype,
-      std::unique_ptr<jlm::rvsdg::type> dsttype)
+      std::shared_ptr<const jlm::rvsdg::type> srctype,
+      std::shared_ptr<const jlm::rvsdg::type> dsttype)
       : unary_op(*srctype, *dsttype)
   {
     auto at = dynamic_cast<const jlm::rvsdg::bittype *>(srctype.get());
@@ -546,8 +546,8 @@ public:
   {}
 
   inline ptr2bits_op(
-      std::unique_ptr<jlm::rvsdg::type> srctype,
-      std::unique_ptr<jlm::rvsdg::type> dsttype)
+      std::shared_ptr<const jlm::rvsdg::type> srctype,
+      std::shared_ptr<const jlm::rvsdg::type> dsttype)
       : unary_op(*srctype, *dsttype)
   {
     auto pt = dynamic_cast<const PointerType *>(srctype.get());
@@ -605,7 +605,9 @@ public:
   virtual ~ConstantDataArray();
 
   ConstantDataArray(const jlm::rvsdg::valuetype & type, size_t size)
-      : simple_op(std::vector<jlm::rvsdg::port>(size, type), { arraytype(type, size) })
+      : simple_op(
+          std::vector<jlm::rvsdg::port>(size, type),
+          { arraytype(std::static_pointer_cast<const rvsdg::valuetype>(type.copy()), size) })
   {
     if (size == 0)
       throw jlm::util::error("size equals zero.");
@@ -743,8 +745,8 @@ public:
   }
 
   inline zext_op(
-      std::unique_ptr<jlm::rvsdg::type> srctype,
-      std::unique_ptr<jlm::rvsdg::type> dsttype)
+      std::shared_ptr<const jlm::rvsdg::type> srctype,
+      std::shared_ptr<const jlm::rvsdg::type> dsttype)
       : unary_op(*srctype, *dsttype)
   {
     auto st = dynamic_cast<const jlm::rvsdg::bittype *>(srctype.get());
@@ -1169,8 +1171,8 @@ public:
   }
 
   inline fpext_op(
-      std::unique_ptr<jlm::rvsdg::type> srctype,
-      std::unique_ptr<jlm::rvsdg::type> dsttype)
+      std::shared_ptr<const jlm::rvsdg::type> srctype,
+      std::shared_ptr<const jlm::rvsdg::type> dsttype)
       : unary_op(*srctype, *dsttype)
   {
     auto st = dynamic_cast<const fptype *>(srctype.get());
@@ -1298,8 +1300,8 @@ public:
   }
 
   inline fptrunc_op(
-      std::unique_ptr<jlm::rvsdg::type> srctype,
-      std::unique_ptr<jlm::rvsdg::type> dsttype)
+      std::shared_ptr<const jlm::rvsdg::type> srctype,
+      std::shared_ptr<const jlm::rvsdg::type> dsttype)
       : unary_op(*srctype, *dsttype)
   {
     auto st = dynamic_cast<const fptype *>(srctype.get());
@@ -1434,8 +1436,8 @@ public:
   {}
 
   inline bitcast_op(
-      std::unique_ptr<jlm::rvsdg::type> srctype,
-      std::unique_ptr<jlm::rvsdg::type> dsttype)
+      std::shared_ptr<const jlm::rvsdg::type> srctype,
+      std::shared_ptr<const jlm::rvsdg::type> dsttype)
       : unary_op(*srctype, *dsttype)
   {
     check_types(*srctype, *dsttype);
@@ -1586,8 +1588,8 @@ public:
   }
 
   inline trunc_op(
-      std::unique_ptr<jlm::rvsdg::type> optype,
-      std::unique_ptr<jlm::rvsdg::type> restype)
+      std::shared_ptr<const jlm::rvsdg::type> optype,
+      std::shared_ptr<const jlm::rvsdg::type> restype)
       : unary_op(*optype, *restype)
   {
     auto ot = dynamic_cast<const jlm::rvsdg::bittype *>(optype.get());
@@ -1669,8 +1671,8 @@ public:
   {}
 
   inline uitofp_op(
-      std::unique_ptr<jlm::rvsdg::type> optype,
-      std::unique_ptr<jlm::rvsdg::type> restype)
+      std::shared_ptr<const jlm::rvsdg::type> optype,
+      std::shared_ptr<const jlm::rvsdg::type> restype)
       : unary_op(*optype, *restype)
   {
     auto st = dynamic_cast<const jlm::rvsdg::bittype *>(optype.get());
@@ -1726,8 +1728,8 @@ public:
   {}
 
   inline sitofp_op(
-      std::unique_ptr<jlm::rvsdg::type> srctype,
-      std::unique_ptr<jlm::rvsdg::type> dsttype)
+      std::shared_ptr<const jlm::rvsdg::type> srctype,
+      std::shared_ptr<const jlm::rvsdg::type> dsttype)
       : unary_op(*srctype, *dsttype)
   {
     auto st = dynamic_cast<const jlm::rvsdg::bittype *>(srctype.get());
@@ -1779,7 +1781,9 @@ public:
   virtual ~ConstantArray();
 
   ConstantArray(const jlm::rvsdg::valuetype & type, size_t size)
-      : jlm::rvsdg::simple_op(std::vector<jlm::rvsdg::port>(size, type), { arraytype(type, size) })
+      : jlm::rvsdg::simple_op(
+          std::vector<jlm::rvsdg::port>(size, type),
+          { arraytype(std::static_pointer_cast<const rvsdg::valuetype>(type.copy()), size) })
   {
     if (size == 0)
       throw jlm::util::error("size equals zero.\n");
@@ -2281,11 +2285,11 @@ public:
     if (elements.empty())
       throw jlm::util::error("Expected at least one element.");
 
-    auto vt = dynamic_cast<const jlm::rvsdg::valuetype *>(&elements[0]->type());
+    auto vt = std::dynamic_pointer_cast<const jlm::rvsdg::valuetype>(elements[0]->type().copy());
     if (!vt)
       throw jlm::util::error("Expected value type.");
 
-    constant_data_vector_op op(fixedvectortype(*vt, elements.size()));
+    constant_data_vector_op op(fixedvectortype(vt, elements.size()));
     return tac::create(op, elements);
   }
 };

--- a/jlm/llvm/ir/operators/sext.hpp
+++ b/jlm/llvm/ir/operators/sext.hpp
@@ -27,7 +27,9 @@ public:
       throw jlm::util::error("expected operand's #bits to be smaller than results's #bits.");
   }
 
-  inline sext_op(std::unique_ptr<rvsdg::type> srctype, std::unique_ptr<rvsdg::type> dsttype)
+  inline sext_op(
+      std::shared_ptr<const rvsdg::type> srctype,
+      std::shared_ptr<const rvsdg::type> dsttype)
       : unary_op(*srctype, *dsttype)
   {
     auto ot = dynamic_cast<const rvsdg::bittype *>(srctype.get());

--- a/jlm/llvm/ir/types.cpp
+++ b/jlm/llvm/ir/types.cpp
@@ -115,6 +115,14 @@ FunctionType::operator=(FunctionType && rhs) noexcept
   return *this;
 }
 
+std::shared_ptr<const FunctionType>
+FunctionType::Create(
+    std::vector<std::shared_ptr<const jlm::rvsdg::type>> argumentTypes,
+    std::vector<std::shared_ptr<const jlm::rvsdg::type>> resultTypes)
+{
+  return std::make_shared<FunctionType>(std::move(argumentTypes), std::move(resultTypes));
+}
+
 PointerType::~PointerType() noexcept = default;
 
 std::string
@@ -194,6 +202,38 @@ std::shared_ptr<const jlm::rvsdg::type>
 fptype::copy() const
 {
   return std::make_shared<fptype>(*this);
+}
+
+std::shared_ptr<const fptype>
+fptype::Create(fpsize size)
+{
+  switch (size)
+  {
+  case fpsize::half:
+  {
+    static const fptype instance(fpsize::half);
+    return std::shared_ptr<const fptype>(std::shared_ptr<void>(), &instance);
+  }
+  case fpsize::flt:
+  {
+    static const fptype instance(fpsize::flt);
+    return std::shared_ptr<const fptype>(std::shared_ptr<void>(), &instance);
+  }
+  case fpsize::dbl:
+  {
+    static const fptype instance(fpsize::dbl);
+    return std::shared_ptr<const fptype>(std::shared_ptr<void>(), &instance);
+  }
+  case fpsize::x86fp80:
+  {
+    static const fptype instance(fpsize::x86fp80);
+    return std::shared_ptr<const fptype>(std::shared_ptr<void>(), &instance);
+  }
+  default:
+  {
+    JLM_UNREACHABLE("unknown fpsize");
+  }
+  }
 }
 
 /* vararg type */

--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -270,7 +270,7 @@ GetElementPtrTest::SetupRvsdg()
   nf->set_mutable(false);
 
   auto & declaration = module->AddStructTypeDeclaration(StructType::Declaration::Create(
-      { &*jlm::rvsdg::bittype::Create(32), &*jlm::rvsdg::bittype::Create(32) }));
+      { jlm::rvsdg::bittype::Create(32), jlm::rvsdg::bittype::Create(32) }));
   StructType structType(false, declaration);
 
   MemoryStateType mt;
@@ -1200,7 +1200,7 @@ ExternalCallTest2::SetupRvsdg()
 
   PointerType pointerType;
   auto & structDeclaration = rvsdgModule->AddStructTypeDeclaration(StructType::Declaration::Create(
-      { &*rvsdg::bittype::Create(32), &*PointerType::Create(), &*PointerType::Create() }));
+      { rvsdg::bittype::Create(32), PointerType::Create(), PointerType::Create() }));
   auto structType = StructType::Create("myStruct", false, structDeclaration);
   iostatetype iOStateType;
   MemoryStateType memoryStateType;
@@ -2096,7 +2096,7 @@ PhiTest1::SetupRvsdg()
 
   auto SetupTestFunction = [&](phi::node * phiNode)
   {
-    arraytype at(*jlm::rvsdg::bittype::Create(64), 10);
+    arraytype at(jlm::rvsdg::bittype::Create(64), 10);
     PointerType pbit64;
     iostatetype iOStateType;
     MemoryStateType memoryStateType;
@@ -2516,9 +2516,9 @@ PhiWithDeltaTest::SetupRvsdg()
 
   PointerType pointerType;
   auto & structDeclaration = rvsdgModule->AddStructTypeDeclaration(
-      StructType::Declaration::Create({ &*PointerType::Create() }));
+      StructType::Declaration::Create({ PointerType::Create() }));
   auto structType = StructType::Create("myStruct", false, structDeclaration);
-  auto arrayType = arraytype(*structType, 2);
+  auto arrayType = arraytype(structType, 2);
 
   jlm::llvm::phi::builder pb;
   pb.begin(rvsdg.root());
@@ -2990,7 +2990,7 @@ MemcpyTest::SetupRvsdg()
   auto nf = rvsdg->node_normal_form(typeid(jlm::rvsdg::operation));
   nf->set_mutable(false);
 
-  arraytype arrayType(*jlm::rvsdg::bittype::Create(32), 5);
+  arraytype arrayType(jlm::rvsdg::bittype::Create(32), 5);
 
   auto SetupLocalArray = [&]()
   {
@@ -3142,9 +3142,9 @@ MemcpyTest2::SetupRvsdg()
   nf->set_mutable(false);
 
   PointerType pointerType;
-  arraytype arrayType(pointerType, 32);
+  auto arrayType = arraytype::Create(PointerType::Create(), 32);
   auto & structBDeclaration =
-      rvsdgModule->AddStructTypeDeclaration(StructType::Declaration::Create({ &arrayType }));
+      rvsdgModule->AddStructTypeDeclaration(StructType::Declaration::Create({ arrayType }));
   auto structTypeB = StructType::Create("structTypeB", false, structBDeclaration);
 
   auto SetupFunctionG = [&]()
@@ -3168,11 +3168,11 @@ MemcpyTest2::SetupRvsdg()
     auto c128 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 64, 128);
 
     auto gepS21 = GetElementPtrOperation::Create(s2Argument, { c0, c0 }, *structTypeB, pointerType);
-    auto gepS22 = GetElementPtrOperation::Create(gepS21, { c0, c0 }, arrayType, pointerType);
+    auto gepS22 = GetElementPtrOperation::Create(gepS21, { c0, c0 }, *arrayType, pointerType);
     auto ldS2 = LoadNonVolatileNode::Create(gepS22, { memoryStateArgument }, pointerType, 8);
 
     auto gepS11 = GetElementPtrOperation::Create(s1Argument, { c0, c0 }, *structTypeB, pointerType);
-    auto gepS12 = GetElementPtrOperation::Create(gepS11, { c0, c0 }, arrayType, pointerType);
+    auto gepS12 = GetElementPtrOperation::Create(gepS11, { c0, c0 }, *arrayType, pointerType);
     auto ldS1 = LoadNonVolatileNode::Create(gepS12, { ldS2[1] }, pointerType, 8);
 
     auto memcpyResults = MemCpyNonVolatileOperation::create(ldS2[0], ldS1[0], c128, { ldS1[1] });
@@ -3245,7 +3245,7 @@ MemcpyTest3::SetupRvsdg()
 
   PointerType pointerType;
   auto & declaration = rvsdgModule->AddStructTypeDeclaration(
-      StructType::Declaration::Create({ &*PointerType::Create() }));
+      StructType::Declaration::Create({ PointerType::Create() }));
   auto structType = StructType::Create("myStruct", false, declaration);
 
   iostatetype iOStateType;
@@ -3302,7 +3302,7 @@ LinkedListTest::SetupRvsdg()
 
   PointerType pointerType;
   auto & declaration = rvsdgModule->AddStructTypeDeclaration(
-      StructType::Declaration::Create({ &*PointerType::Create() }));
+      StructType::Declaration::Create({ PointerType::Create() }));
   auto structType = StructType::Create("list", false, declaration);
 
   auto SetupDeltaMyList = [&]()
@@ -3794,12 +3794,12 @@ VariadicFunctionTest2::SetupRvsdg()
 
   PointerType pointerType;
   auto & structDeclaration = rvsdgModule->AddStructTypeDeclaration(
-      StructType::Declaration::Create({ &*rvsdg::bittype::Create(32),
-                                        &*rvsdg::bittype::Create(32),
-                                        &*PointerType::Create(),
-                                        &*PointerType::Create() }));
+      StructType::Declaration::Create({ rvsdg::bittype::Create(32),
+                                        rvsdg::bittype::Create(32),
+                                        PointerType::Create(),
+                                        PointerType::Create() }));
   auto structType = StructType::Create("struct.__va_list_tag", false, structDeclaration);
-  arraytype arrayType(*structType, 1);
+  arraytype arrayType(structType, 1);
   iostatetype iOStateType;
   MemoryStateType memoryStateType;
   auto varArgType = varargtype::Create();

--- a/tests/jlm/llvm/backend/llvm/jlm-llvm/test-type-conversion.cpp
+++ b/tests/jlm/llvm/backend/llvm/jlm-llvm/test-type-conversion.cpp
@@ -16,7 +16,7 @@ test_structtype(jlm::llvm::jlm2llvm::context & ctx)
   using namespace jlm::llvm;
 
   auto decl1 = StructType::Declaration::Create(
-      { &*jlm::rvsdg::bittype::Create(8), &*jlm::rvsdg::bittype::Create(32) });
+      { jlm::rvsdg::bittype::Create(8), jlm::rvsdg::bittype::Create(32) });
   StructType st1("mystruct", false, *decl1);
   auto ct = jlm2llvm::convert_type(st1, ctx);
 
@@ -26,9 +26,9 @@ test_structtype(jlm::llvm::jlm2llvm::context & ctx)
   assert(ct->getElementType(0)->isIntegerTy(8));
   assert(ct->getElementType(1)->isIntegerTy(32));
 
-  auto decl2 = StructType::Declaration::Create({ &*jlm::rvsdg::bittype::Create(32),
-                                                 &*jlm::rvsdg::bittype::Create(8),
-                                                 &*jlm::rvsdg::bittype::Create(32) });
+  auto decl2 = StructType::Declaration::Create({ jlm::rvsdg::bittype::Create(32),
+                                                 jlm::rvsdg::bittype::Create(8),
+                                                 jlm::rvsdg::bittype::Create(32) });
   StructType st2(true, *decl2);
   ct = jlm2llvm::convert_type(st2, ctx);
 

--- a/tests/jlm/llvm/ir/TestTypes.cpp
+++ b/tests/jlm/llvm/ir/TestTypes.cpp
@@ -17,23 +17,23 @@ TestIsOrContains()
 {
   using namespace jlm::llvm;
 
-  jlm::tests::valuetype valueType;
-  PointerType pointerType;
-  MemoryStateType memoryStateType;
-  iostatetype ioStateType;
+  auto valueType = jlm::tests::valuetype::Create();
+  auto pointerType = PointerType::Create();
+  auto memoryStateType = MemoryStateType::Create();
+  auto ioStateType = iostatetype::Create();
 
   // Direct checks
-  assert(IsOrContains<PointerType>(pointerType));
-  assert(!IsOrContains<PointerType>(memoryStateType));
-  assert(!IsOrContains<PointerType>(ioStateType));
+  assert(IsOrContains<PointerType>(*pointerType));
+  assert(!IsOrContains<PointerType>(*memoryStateType));
+  assert(!IsOrContains<PointerType>(*ioStateType));
 
   // Checking supertypes should work
-  assert(IsOrContains<jlm::rvsdg::valuetype>(pointerType));
-  assert(!IsOrContains<jlm::rvsdg::valuetype>(memoryStateType));
-  assert(!IsOrContains<jlm::rvsdg::valuetype>(ioStateType));
-  assert(!IsOrContains<jlm::rvsdg::statetype>(pointerType));
-  assert(IsOrContains<jlm::rvsdg::statetype>(memoryStateType));
-  assert(IsOrContains<jlm::rvsdg::statetype>(ioStateType));
+  assert(IsOrContains<jlm::rvsdg::valuetype>(*pointerType));
+  assert(!IsOrContains<jlm::rvsdg::valuetype>(*memoryStateType));
+  assert(!IsOrContains<jlm::rvsdg::valuetype>(*ioStateType));
+  assert(!IsOrContains<jlm::rvsdg::statetype>(*pointerType));
+  assert(IsOrContains<jlm::rvsdg::statetype>(*memoryStateType));
+  assert(IsOrContains<jlm::rvsdg::statetype>(*ioStateType));
 
   // Function types are not aggregate types
   FunctionType functionType(
@@ -45,29 +45,29 @@ TestIsOrContains()
   assert(!IsOrContains<jlm::rvsdg::statetype>(functionType));
 
   // Struct types are aggregates that can contain other types
-  auto declaration = StructType::Declaration::Create({ &valueType, &pointerType });
-  StructType structType(false, *declaration);
-  assert(IsAggregateType(structType));
-  assert(IsOrContains<StructType>(structType));
-  assert(IsOrContains<PointerType>(structType));
-  assert(!IsOrContains<jlm::rvsdg::statetype>(structType));
+  auto declaration = StructType::Declaration::Create({ valueType, pointerType });
+  auto structType = StructType::Create(false, *declaration);
+  assert(IsAggregateType(*structType));
+  assert(IsOrContains<StructType>(*structType));
+  assert(IsOrContains<PointerType>(*structType));
+  assert(!IsOrContains<jlm::rvsdg::statetype>(*structType));
 
   // Create an array containing the atruct type
-  arraytype arrayType(structType, 20);
-  assert(IsAggregateType(arrayType));
-  assert(IsOrContains<arraytype>(arrayType));
-  assert(IsOrContains<StructType>(arrayType));
-  assert(IsOrContains<PointerType>(arrayType));
-  assert(!IsOrContains<jlm::rvsdg::statetype>(arrayType));
+  auto arrayType = arraytype::Create(structType, 20);
+  assert(IsAggregateType(*arrayType));
+  assert(IsOrContains<arraytype>(*arrayType));
+  assert(IsOrContains<StructType>(*arrayType));
+  assert(IsOrContains<PointerType>(*arrayType));
+  assert(!IsOrContains<jlm::rvsdg::statetype>(*arrayType));
 
   // Vector types are weird, as LLVM does not consider them to be aggregate types,
   // but they still contain other types
-  fixedvectortype vectorType(structType, 20);
-  assert(!IsAggregateType(vectorType));
-  assert(IsOrContains<vectortype>(vectorType));
-  assert(IsOrContains<StructType>(vectorType));
-  assert(IsOrContains<PointerType>(vectorType));
-  assert(!IsOrContains<jlm::rvsdg::statetype>(vectorType));
+  auto vectorType = fixedvectortype::Create(structType, 20);
+  assert(!IsAggregateType(*vectorType));
+  assert(IsOrContains<vectortype>(*vectorType));
+  assert(IsOrContains<StructType>(*vectorType));
+  assert(IsOrContains<PointerType>(*vectorType));
+  assert(!IsOrContains<jlm::rvsdg::statetype>(*vectorType));
 
   return 0;
 }

--- a/tests/jlm/llvm/ir/operators/TestGetElementPtr.cpp
+++ b/tests/jlm/llvm/ir/operators/TestGetElementPtr.cpp
@@ -12,12 +12,12 @@ TestOperationEquality()
 {
   using namespace jlm::llvm;
 
-  arraytype arrayType(*jlm::rvsdg::bittype::Create(8), 11);
+  auto arrayType = arraytype::Create(jlm::rvsdg::bittype::Create(8), 11);
 
   auto declaration1 = StructType::Declaration::Create(
-      { &*jlm::rvsdg::bittype::Create(64), &*jlm::rvsdg::bittype::Create(64) });
+      { jlm::rvsdg::bittype::Create(64), jlm::rvsdg::bittype::Create(64) });
   auto declaration2 =
-      StructType::Declaration::Create({ &arrayType, &*jlm::rvsdg::bittype::Create(32) });
+      StructType::Declaration::Create({ arrayType, jlm::rvsdg::bittype::Create(32) });
 
   StructType structType1(false, *declaration1);
   StructType structType2("myStructType", false, *declaration2);


### PR DESCRIPTION
Convert llvm type attribute, base types as well as the type conversion routines to use shared_ptr<type>.
