### PR TITLE
Configuration of tracing format moved to verilator command

### DIFF
--- a/jlm/hls/backend/rhls2firrtl/verilator-harness-hls.cpp
+++ b/jlm/hls/backend/rhls2firrtl/verilator-harness-hls.cpp
@@ -21,9 +21,6 @@ VerilatorHarnessHLS::get_text(llvm::RvsdgModule & rm)
   auto mem_resps = get_mem_resps(ln);
   JLM_ASSERT(mem_reqs.size() == mem_resps.size());
   cpp << "#define TRACE_CHUNK_SIZE 100000\n"
-#ifndef HLS_USE_VCD
-         "#define FST 1\n"
-#endif
          //		"#define HLS_MEM_DEBUG 1\n"
          "\n"
          "#include <verilated.h>\n"


### PR DESCRIPTION
Instead of controlling which tracing format to be used at compile time of jlm it is now given as a -D flag when compiling the generated file with verilator.