### PR TITLE
Add overloads to shared_ptr of type for various ops

### DIFF
--- a/jlm/llvm/ir/RvsdgModule.hpp
+++ b/jlm/llvm/ir/RvsdgModule.hpp
@@ -27,6 +27,15 @@ public:
         ValueType_(valueType.copy())
   {}
 
+  impport(
+      std::shared_ptr<const jlm::rvsdg::valuetype> valueType,
+      const std::string & name,
+      const linkage & lnk)
+      : jlm::rvsdg::impport(PointerType(), name),
+        linkage_(lnk),
+        ValueType_(std::move(valueType))
+  {}
+
   impport(const impport & other)
       : jlm::rvsdg::impport(other),
         linkage_(other.linkage_),

--- a/jlm/llvm/ir/cfg.hpp
+++ b/jlm/llvm/ir/cfg.hpp
@@ -28,13 +28,16 @@ class argument final : public variable
 public:
   ~argument() override;
 
-  argument(const std::string & name, const jlm::rvsdg::type & type, const attributeset & attributes)
-      : variable(*type.copy(), name),
+  argument(
+      const std::string & name,
+      std::shared_ptr<const jlm::rvsdg::type> type,
+      const attributeset & attributes)
+      : variable(std::move(type), name),
         attributes_(attributes)
   {}
 
-  argument(const std::string & name, const jlm::rvsdg::type & type)
-      : variable(*type.copy(), name)
+  argument(const std::string & name, std::shared_ptr<const jlm::rvsdg::type> type)
+      : variable(std::move(type), name)
   {}
 
   argument(
@@ -66,13 +69,13 @@ public:
   static std::unique_ptr<argument>
   create(const std::string & name, const jlm::rvsdg::type & type, const attributeset & attributes)
   {
-    return std::make_unique<argument>(name, type, attributes);
+    return std::make_unique<argument>(name, type.copy(), attributes);
   }
 
   static std::unique_ptr<argument>
   create(
       const std::string & name,
-      std::unique_ptr<jlm::rvsdg::type> type,
+      std::shared_ptr<const jlm::rvsdg::type> type,
       const attributeset & attributes)
   {
     return std::make_unique<argument>(name, std::move(type), attributes);
@@ -81,7 +84,13 @@ public:
   static std::unique_ptr<argument>
   create(const std::string & name, const jlm::rvsdg::type & type)
   {
-    return create(name, type, {});
+    return create(name, type.copy(), {});
+  }
+
+  static std::unique_ptr<argument>
+  create(const std::string & name, std::shared_ptr<const jlm::rvsdg::type> type)
+  {
+    return create(name, std::move(type), {});
   }
 
 private:
@@ -376,11 +385,11 @@ public:
   {
     std::vector<std::shared_ptr<const jlm::rvsdg::type>> arguments;
     for (size_t n = 0; n < entry()->narguments(); n++)
-      arguments.push_back(entry()->argument(n)->type().copy());
+      arguments.push_back(entry()->argument(n)->Type());
 
     std::vector<std::shared_ptr<const jlm::rvsdg::type>> results;
     for (size_t n = 0; n < exit()->nresults(); n++)
-      results.push_back(exit()->result(n)->type().copy());
+      results.push_back(exit()->result(n)->Type());
 
     return FunctionType(arguments, results);
   }

--- a/jlm/llvm/ir/ipgraph-module.hpp
+++ b/jlm/llvm/ir/ipgraph-module.hpp
@@ -136,6 +136,25 @@ public:
   }
 
   inline llvm::variable *
+  create_variable(std::shared_ptr<const jlm::rvsdg::type> type, const std::string & name)
+  {
+    auto v = std::make_unique<llvm::variable>(std::move(type), name);
+    auto pv = v.get();
+    variables_.insert(std::move(v));
+    return pv;
+  }
+
+  inline llvm::variable *
+  create_variable(std::shared_ptr<const jlm::rvsdg::type> type)
+  {
+    static uint64_t c = 0;
+    auto v = std::make_unique<llvm::variable>(std::move(type), jlm::util::strfmt("v", c++));
+    auto pv = v.get();
+    variables_.insert(std::move(v));
+    return pv;
+  }
+
+  inline llvm::variable *
   create_variable(function_node * node)
   {
     JLM_ASSERT(!variable(node));

--- a/jlm/llvm/ir/operators/Store.hpp
+++ b/jlm/llvm/ir/operators/Store.hpp
@@ -148,7 +148,19 @@ public:
       size_t numMemoryStates,
       size_t alignment)
       : StoreOperation(
-          CreateOperandPorts(storedType, numMemoryStates),
+          CreateOperandPorts(
+              std::static_pointer_cast<const rvsdg::valuetype>(storedType.copy()),
+              numMemoryStates),
+          std::vector<jlm::rvsdg::port>(numMemoryStates, { MemoryStateType() }),
+          alignment)
+  {}
+
+  StoreNonVolatileOperation(
+      std::shared_ptr<const rvsdg::valuetype> storedType,
+      size_t numMemoryStates,
+      size_t alignment)
+      : StoreOperation(
+          CreateOperandPorts(std::move(storedType), numMemoryStates),
           std::vector<jlm::rvsdg::port>(numMemoryStates, { MemoryStateType() }),
           alignment)
   {}
@@ -194,9 +206,10 @@ private:
   }
 
   static std::vector<rvsdg::port>
-  CreateOperandPorts(const rvsdg::valuetype & storedType, size_t numMemoryStates)
+  CreateOperandPorts(std::shared_ptr<const rvsdg::valuetype> storedType, size_t numMemoryStates)
   {
-    std::vector<rvsdg::port> ports({ PointerType(), storedType });
+    std::vector<rvsdg::port> ports(
+        { rvsdg::port(PointerType::Create()), rvsdg::port(std::move(storedType)) });
     std::vector<rvsdg::port> states(numMemoryStates, { MemoryStateType() });
     ports.insert(ports.end(), states.begin(), states.end());
     return ports;
@@ -411,7 +424,19 @@ public:
       size_t numMemoryStates,
       size_t alignment)
       : StoreOperation(
-          CreateOperandPorts(storedType, numMemoryStates),
+          CreateOperandPorts(
+              std::static_pointer_cast<const rvsdg::valuetype>(storedType.copy()),
+              numMemoryStates),
+          CreateResultPorts(numMemoryStates),
+          alignment)
+  {}
+
+  StoreVolatileOperation(
+      std::shared_ptr<const rvsdg::valuetype> storedType,
+      size_t numMemoryStates,
+      size_t alignment)
+      : StoreOperation(
+          CreateOperandPorts(std::move(storedType), numMemoryStates),
           CreateResultPorts(numMemoryStates),
           alignment)
   {}
@@ -453,10 +478,12 @@ private:
   }
 
   static std::vector<rvsdg::port>
-  CreateOperandPorts(const rvsdg::valuetype & storedType, size_t numMemoryStates)
+  CreateOperandPorts(std::shared_ptr<const rvsdg::valuetype> storedType, size_t numMemoryStates)
   {
-    std::vector<rvsdg::port> ports({ PointerType(), storedType, iostatetype() });
-    std::vector<rvsdg::port> states(numMemoryStates, { MemoryStateType() });
+    std::vector<rvsdg::port> ports({ rvsdg::port(PointerType::Create()),
+                                     rvsdg::port(std::move(storedType)),
+                                     rvsdg::port(iostatetype::Create()) });
+    std::vector<rvsdg::port> states(numMemoryStates, { MemoryStateType::Create() });
     ports.insert(ports.end(), states.begin(), states.end());
     return ports;
   }

--- a/jlm/llvm/ir/operators/alloca.hpp
+++ b/jlm/llvm/ir/operators/alloca.hpp
@@ -24,25 +24,17 @@ public:
   virtual ~alloca_op() noexcept;
 
   inline alloca_op(
-      const rvsdg::valuetype & allocatedType,
-      const rvsdg::bittype & btype,
+      std::shared_ptr<const rvsdg::valuetype> allocatedType,
+      std::shared_ptr<const rvsdg::bittype> btype,
       size_t alignment)
-      : simple_op({ btype }, { PointerType(), { MemoryStateType::Create() } }),
+      : simple_op({ btype }, { { PointerType::Create() }, { MemoryStateType::Create() } }),
         alignment_(alignment),
-        AllocatedType_(allocatedType.copy())
+        AllocatedType_(std::move(allocatedType))
   {}
 
-  alloca_op(const alloca_op & other)
-      : simple_op(other),
-        alignment_(other.alignment_),
-        AllocatedType_(other.AllocatedType_->copy())
-  {}
+  alloca_op(const alloca_op & other) = default;
 
-  alloca_op(alloca_op && other) noexcept
-      : simple_op(other),
-        alignment_(other.alignment_),
-        AllocatedType_(std::move(other.AllocatedType_))
-  {}
+  alloca_op(alloca_op && other) noexcept = default;
 
   virtual bool
   operator==(const operation & other) const noexcept override;
@@ -74,22 +66,56 @@ public:
   static std::unique_ptr<llvm::tac>
   create(const rvsdg::valuetype & allocatedType, const variable * size, size_t alignment)
   {
-    auto bt = dynamic_cast<const rvsdg::bittype *>(&size->type());
+    auto bt = std::dynamic_pointer_cast<const rvsdg::bittype>(size->Type());
     if (!bt)
       throw jlm::util::error("expected bits type.");
 
-    alloca_op op(allocatedType, *bt, alignment);
+    alloca_op op(
+        std::static_pointer_cast<const rvsdg::valuetype>(allocatedType.copy()),
+        std::move(bt),
+        alignment);
+    return tac::create(op, { size });
+  }
+
+  static std::unique_ptr<llvm::tac>
+  create(
+      std::shared_ptr<const rvsdg::valuetype> allocatedType,
+      const variable * size,
+      size_t alignment)
+  {
+    auto bt = std::dynamic_pointer_cast<const rvsdg::bittype>(size->Type());
+    if (!bt)
+      throw jlm::util::error("expected bits type.");
+
+    alloca_op op(std::move(allocatedType), std::move(bt), alignment);
     return tac::create(op, { size });
   }
 
   static std::vector<rvsdg::output *>
   create(const rvsdg::valuetype & allocatedType, rvsdg::output * size, size_t alignment)
   {
-    auto bt = dynamic_cast<const rvsdg::bittype *>(&size->type());
+    auto bt = std::dynamic_pointer_cast<const rvsdg::bittype>(size->Type());
     if (!bt)
       throw jlm::util::error("expected bits type.");
 
-    alloca_op op(allocatedType, *bt, alignment);
+    alloca_op op(
+        std::static_pointer_cast<const rvsdg::valuetype>(allocatedType.copy()),
+        std::move(bt),
+        alignment);
+    return rvsdg::simple_node::create_normalized(size->region(), op, { size });
+  }
+
+  static std::vector<rvsdg::output *>
+  create(
+      std::shared_ptr<const rvsdg::valuetype> allocatedType,
+      rvsdg::output * size,
+      size_t alignment)
+  {
+    auto bt = std::dynamic_pointer_cast<const rvsdg::bittype>(size->Type());
+    if (!bt)
+      throw jlm::util::error("expected bits type.");
+
+    alloca_op op(std::move(allocatedType), std::move(bt), alignment);
     return rvsdg::simple_node::create_normalized(size->region(), op, { size });
   }
 

--- a/jlm/llvm/ir/operators/sext.hpp
+++ b/jlm/llvm/ir/operators/sext.hpp
@@ -21,7 +21,7 @@ public:
   virtual ~sext_op();
 
   inline sext_op(const rvsdg::bittype & otype, const rvsdg::bittype & rtype)
-      : unary_op({ otype }, { rtype })
+      : unary_op(otype.copy(), rtype.copy())
   {
     if (otype.nbits() >= rtype.nbits())
       throw jlm::util::error("expected operand's #bits to be smaller than results's #bits.");
@@ -30,7 +30,7 @@ public:
   inline sext_op(
       std::shared_ptr<const rvsdg::type> srctype,
       std::shared_ptr<const rvsdg::type> dsttype)
-      : unary_op(*srctype, *dsttype)
+      : unary_op(srctype, dsttype)
   {
     auto ot = dynamic_cast<const rvsdg::bittype *>(srctype.get());
     if (!ot)

--- a/jlm/llvm/ir/variable.hpp
+++ b/jlm/llvm/ir/variable.hpp
@@ -28,7 +28,7 @@ public:
         type_(type.copy())
   {}
 
-  variable(std::unique_ptr<jlm::rvsdg::type> type, const std::string & name)
+  variable(std::shared_ptr<const jlm::rvsdg::type> type, const std::string & name)
       : name_(name),
         type_(std::move(type))
   {}
@@ -63,6 +63,12 @@ public:
   type() const noexcept
   {
     return *type_;
+  }
+
+  inline const std::shared_ptr<const jlm::rvsdg::type>
+  Type() const noexcept
+  {
+    return type_;
   }
 
 private:

--- a/jlm/rvsdg/binary.hpp
+++ b/jlm/rvsdg/binary.hpp
@@ -134,8 +134,10 @@ public:
 
   virtual ~binary_op() noexcept;
 
-  inline binary_op(const std::vector<jlm::rvsdg::port> & operands, const jlm::rvsdg::port & result)
-      : simple_op(operands, { result })
+  inline binary_op(
+      const std::vector<std::shared_ptr<const jlm::rvsdg::type>> operands,
+      std::shared_ptr<const jlm::rvsdg::type> result)
+      : simple_op(std::move(operands), { std::move(result) })
   {}
 
   virtual binop_reduction_path_t

--- a/jlm/rvsdg/bitstring/arithmetic-impl.hpp
+++ b/jlm/rvsdg/bitstring/arithmetic-impl.hpp
@@ -42,14 +42,14 @@ template<typename reduction, const char * name>
 std::unique_ptr<operation>
 MakeBitUnaryOperation<reduction, name>::copy() const
 {
-  return std::unique_ptr<operation>(new MakeBitUnaryOperation(*this));
+  return std::make_unique<MakeBitUnaryOperation>(*this);
 }
 
 template<typename reduction, const char * name>
 std::unique_ptr<bitunary_op>
 MakeBitUnaryOperation<reduction, name>::create(size_t nbits) const
 {
-  return std::unique_ptr<bitunary_op>(new MakeBitUnaryOperation(nbits));
+  return std::make_unique<MakeBitUnaryOperation>(nbits);
 }
 
 template<typename reduction, const char * name, enum binary_op::flags opflags>

--- a/jlm/rvsdg/bitstring/arithmetic.hpp
+++ b/jlm/rvsdg/bitstring/arithmetic.hpp
@@ -50,8 +50,8 @@ class MakeBitBinaryOperation final : public bitbinary_op
 public:
   ~MakeBitBinaryOperation() noexcept override;
 
-  explicit MakeBitBinaryOperation(const bittype & type) noexcept
-      : bitbinary_op(type)
+  explicit MakeBitBinaryOperation(std::size_t nbits) noexcept
+      : bitbinary_op(bittype::Create(nbits))
   {}
 
   bool

--- a/jlm/rvsdg/bitstring/bitoperation-classes.hpp
+++ b/jlm/rvsdg/bitstring/bitoperation-classes.hpp
@@ -23,7 +23,7 @@ public:
   virtual ~bitunary_op() noexcept;
 
   inline bitunary_op(const bittype & type) noexcept
-      : unary_op(type, type)
+      : unary_op(type.copy(), type.copy())
   {}
 
   inline const bittype &
@@ -54,8 +54,8 @@ class bitbinary_op : public jlm::rvsdg::binary_op
 public:
   virtual ~bitbinary_op() noexcept;
 
-  inline bitbinary_op(const bittype & type, size_t arity = 2) noexcept
-      : binary_op(std::vector<jlm::rvsdg::port>(arity, { type }), type)
+  inline bitbinary_op(const std::shared_ptr<const bittype> type, size_t arity = 2) noexcept
+      : binary_op({ arity, type }, type)
   {}
 
   /* reduction methods */
@@ -94,8 +94,8 @@ class bitcompare_op : public jlm::rvsdg::binary_op
 public:
   virtual ~bitcompare_op() noexcept;
 
-  inline bitcompare_op(const bittype & type) noexcept
-      : binary_op({ type, type }, *bittype::Create(1))
+  inline bitcompare_op(std::shared_ptr<const bittype> type) noexcept
+      : binary_op({ type, type }, bittype::Create(1))
   {}
 
   virtual binop_reduction_path_t

--- a/jlm/rvsdg/bitstring/comparison.hpp
+++ b/jlm/rvsdg/bitstring/comparison.hpp
@@ -19,8 +19,8 @@ class MakeBitComparisonOperation final : public bitcompare_op
 public:
   ~MakeBitComparisonOperation() noexcept override;
 
-  explicit MakeBitComparisonOperation(const bittype & type) noexcept
-      : bitcompare_op(type)
+  explicit MakeBitComparisonOperation(std::size_t nbits) noexcept
+      : bitcompare_op(bittype::Create(nbits))
   {}
 
   bool

--- a/jlm/rvsdg/bitstring/concat.cpp
+++ b/jlm/rvsdg/bitstring/concat.cpp
@@ -17,9 +17,9 @@ namespace jlm::rvsdg
 jlm::rvsdg::output *
 bitconcat(const std::vector<jlm::rvsdg::output *> & operands)
 {
-  std::vector<jlm::rvsdg::bittype> types;
+  std::vector<std::shared_ptr<const jlm::rvsdg::bittype>> types;
   for (const auto operand : operands)
-    types.push_back(dynamic_cast<const jlm::rvsdg::bittype &>(operand->type()));
+    types.push_back(std::dynamic_pointer_cast<const jlm::rvsdg::bittype>(operand->Type()));
 
   auto region = operands[0]->region();
   jlm::rvsdg::bitconcat_op op(std::move(types));
@@ -68,13 +68,13 @@ concat_reduce_arg_pair(jlm::rvsdg::output * arg1, jlm::rvsdg::output * arg2)
   return nullptr;
 }
 
-std::vector<bittype>
+std::vector<std::shared_ptr<const bittype>>
 types_from_arguments(const std::vector<jlm::rvsdg::output *> & args)
 {
-  std::vector<bittype> types;
+  std::vector<std::shared_ptr<const bittype>> types;
   for (const auto arg : args)
   {
-    types.push_back(static_cast<const bittype &>(arg->type()));
+    types.push_back(std::dynamic_pointer_cast<const bittype>(arg->Type()));
   }
   return types;
 }
@@ -245,25 +245,16 @@ static void __attribute__((constructor)) register_node_normal_form(void)
       get_default_normal_form);
 }
 
-bittype
-bitconcat_op::aggregate_arguments(const std::vector<bittype> & types) noexcept
+std::shared_ptr<const bittype>
+bitconcat_op::aggregate_arguments(
+    const std::vector<std::shared_ptr<const bittype>> & types) noexcept
 {
   size_t total = 0;
   for (const auto & t : types)
   {
-    total += t.nbits();
+    total += t->nbits();
   }
-  return bittype(total);
-}
-
-std::vector<jlm::rvsdg::port>
-bitconcat_op::to_ports(const std::vector<bittype> & types)
-{
-  std::vector<jlm::rvsdg::port> ports;
-  for (const auto & type : types)
-    ports.push_back({ type });
-
-  return ports;
+  return bittype::Create(total);
 }
 
 bitconcat_op::~bitconcat_op() noexcept

--- a/jlm/rvsdg/bitstring/concat.hpp
+++ b/jlm/rvsdg/bitstring/concat.hpp
@@ -21,8 +21,8 @@ class bitconcat_op final : public jlm::rvsdg::binary_op
 public:
   virtual ~bitconcat_op() noexcept;
 
-  explicit inline bitconcat_op(const std::vector<bittype> & types)
-      : binary_op(to_ports(types), { aggregate_arguments(types) })
+  explicit inline bitconcat_op(const std::vector<std::shared_ptr<const bittype>> types)
+      : binary_op({ types.begin(), types.end() }, aggregate_arguments(types))
   {}
 
   virtual bool
@@ -48,11 +48,8 @@ public:
   copy() const override;
 
 private:
-  static bittype
-  aggregate_arguments(const std::vector<bittype> & types) noexcept;
-
-  static std::vector<jlm::rvsdg::port>
-  to_ports(const std::vector<bittype> & types);
+  static std::shared_ptr<const bittype>
+  aggregate_arguments(const std::vector<std::shared_ptr<const bittype>> & types) noexcept;
 };
 
 jlm::rvsdg::output *

--- a/jlm/rvsdg/bitstring/slice.hpp
+++ b/jlm/rvsdg/bitstring/slice.hpp
@@ -20,7 +20,7 @@ public:
   virtual ~bitslice_op() noexcept;
 
   inline bitslice_op(const bittype & argument, size_t low, size_t high) noexcept
-      : unary_op(argument, bittype(high - low)),
+      : unary_op(argument.copy(), bittype::Create(high - low)),
         low_(low)
   {}
 

--- a/jlm/rvsdg/control.cpp
+++ b/jlm/rvsdg/control.cpp
@@ -91,7 +91,7 @@ match_op::match_op(
     const std::unordered_map<uint64_t, uint64_t> & mapping,
     uint64_t default_alternative,
     size_t nalternatives)
-    : jlm::rvsdg::unary_op(bittype(nbits), ctltype(nalternatives)),
+    : jlm::rvsdg::unary_op(bittype::Create(nbits), ctltype::Create(nalternatives)),
       default_alternative_(default_alternative),
       mapping_(mapping)
 {}

--- a/jlm/rvsdg/graph.hpp
+++ b/jlm/rvsdg/graph.hpp
@@ -34,6 +34,11 @@ public:
         name_(name)
   {}
 
+  impport(std::shared_ptr<const jlm::rvsdg::type> type, const std::string & name)
+      : port(std::move(type)),
+        name_(name)
+  {}
+
   impport(const impport & other)
       : port(other),
         name_(other.name_)
@@ -75,6 +80,11 @@ public:
 
   expport(const jlm::rvsdg::type & type, const std::string & name)
       : port(type),
+        name_(name)
+  {}
+
+  expport(std::shared_ptr<const jlm::rvsdg::type> type, const std::string & name)
+      : port(std::move(type)),
         name_(name)
   {}
 

--- a/jlm/rvsdg/operation.hpp
+++ b/jlm/rvsdg/operation.hpp
@@ -124,6 +124,20 @@ public:
         operands_(operands)
   {}
 
+  inline simple_op(
+      std::vector<std::shared_ptr<const jlm::rvsdg::type>> operands,
+      std::vector<std::shared_ptr<const jlm::rvsdg::type>> results)
+  {
+    for (auto & op : operands)
+    {
+      operands_.push_back(port(std::move(op)));
+    }
+    for (auto & res : results)
+    {
+      results_.push_back(port(std::move(res)));
+    }
+  }
+
   size_t
   narguments() const noexcept;
 

--- a/jlm/rvsdg/region.cpp
+++ b/jlm/rvsdg/region.cpp
@@ -50,6 +50,17 @@ argument::create(
   return argument;
 }
 
+jlm::rvsdg::argument *
+argument::create(
+    jlm::rvsdg::region * region,
+    structural_input * input,
+    std::shared_ptr<const jlm::rvsdg::type> type)
+{
+  auto argument = new jlm::rvsdg::argument(region, input, jlm::rvsdg::port(std::move(type)));
+  region->append_argument(argument);
+  return argument;
+}
+
 /* result */
 
 result::~result() noexcept
@@ -85,6 +96,18 @@ result::create(
     const jlm::rvsdg::port & port)
 {
   auto result = new jlm::rvsdg::result(region, origin, output, port);
+  region->append_result(result);
+  return result;
+}
+
+jlm::rvsdg::result *
+result::create(
+    jlm::rvsdg::region * region,
+    jlm::rvsdg::output * origin,
+    jlm::rvsdg::structural_output * output,
+    std::shared_ptr<const jlm::rvsdg::type> type)
+{
+  auto result = new jlm::rvsdg::result(region, origin, output, jlm::rvsdg::port(std::move(type)));
   region->append_result(result);
   return result;
 }

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -62,6 +62,12 @@ public:
   static jlm::rvsdg::argument *
   create(jlm::rvsdg::region * region, structural_input * input, const jlm::rvsdg::port & port);
 
+  static jlm::rvsdg::argument *
+  create(
+      jlm::rvsdg::region * region,
+      structural_input * input,
+      std::shared_ptr<const jlm::rvsdg::type> type);
+
 private:
   jlm::rvsdg::structural_input * input_;
 };
@@ -107,6 +113,13 @@ public:
       jlm::rvsdg::output * origin,
       jlm::rvsdg::structural_output * output,
       const jlm::rvsdg::port & port);
+
+  static jlm::rvsdg::result *
+  create(
+      jlm::rvsdg::region * region,
+      jlm::rvsdg::output * origin,
+      jlm::rvsdg::structural_output * output,
+      std::shared_ptr<const jlm::rvsdg::type> type);
 
 private:
   jlm::rvsdg::structural_output * output_;

--- a/jlm/rvsdg/statemux.hpp
+++ b/jlm/rvsdg/statemux.hpp
@@ -71,6 +71,12 @@ public:
           std::vector<jlm::rvsdg::port>(nresults, { type }))
   {}
 
+  inline mux_op(std::shared_ptr<const statetype> type, size_t narguments, size_t nresults)
+      : simple_op(
+          std::vector<jlm::rvsdg::port>(narguments, { type }),
+          std::vector<jlm::rvsdg::port>(nresults, { type }))
+  {}
+
   virtual bool
   operator==(const operation & other) const noexcept override;
 
@@ -111,6 +117,24 @@ create_state_mux(
   return simple_node::create_normalized(region, op, operands);
 }
 
+static inline std::vector<jlm::rvsdg::output *>
+create_state_mux(
+    std::shared_ptr<const jlm::rvsdg::type> type,
+    const std::vector<jlm::rvsdg::output *> & operands,
+    size_t nresults)
+{
+  if (operands.empty())
+    throw jlm::util::error("Insufficient number of operands.");
+
+  auto st = std::dynamic_pointer_cast<const jlm::rvsdg::statetype>(type);
+  if (!st)
+    throw jlm::util::error("Expected state type.");
+
+  auto region = operands.front()->region();
+  jlm::rvsdg::mux_op op(std::move(st), operands.size(), nresults);
+  return simple_node::create_normalized(region, op, operands);
+}
+
 static inline jlm::rvsdg::output *
 create_state_merge(
     const jlm::rvsdg::type & type,
@@ -119,10 +143,27 @@ create_state_merge(
   return create_state_mux(type, operands, 1)[0];
 }
 
+static inline jlm::rvsdg::output *
+create_state_merge(
+    std::shared_ptr<const jlm::rvsdg::type> type,
+    const std::vector<jlm::rvsdg::output *> & operands)
+{
+  return create_state_mux(std::move(type), operands, 1)[0];
+}
+
 static inline std::vector<jlm::rvsdg::output *>
 create_state_split(const jlm::rvsdg::type & type, jlm::rvsdg::output * operand, size_t nresults)
 {
   return create_state_mux(type, { operand }, nresults);
+}
+
+static inline std::vector<jlm::rvsdg::output *>
+create_state_split(
+    std::shared_ptr<const jlm::rvsdg::type> type,
+    jlm::rvsdg::output * operand,
+    size_t nresults)
+{
+  return create_state_mux(std::move(type), { operand }, nresults);
 }
 
 }

--- a/jlm/rvsdg/structural-node.hpp
+++ b/jlm/rvsdg/structural-node.hpp
@@ -77,17 +77,26 @@ class structural_input : public node_input
 public:
   virtual ~structural_input() noexcept;
 
-protected:
   structural_input(
       jlm::rvsdg::structural_node * node,
       jlm::rvsdg::output * origin,
       const jlm::rvsdg::port & port);
 
-public:
   static structural_input *
   create(structural_node * node, jlm::rvsdg::output * origin, const jlm::rvsdg::port & port)
   {
     auto input = std::unique_ptr<structural_input>(new structural_input(node, origin, port));
+    return node->append_input(std::move(input));
+  }
+
+  static structural_input *
+  create(
+      structural_node * node,
+      jlm::rvsdg::output * origin,
+      std::shared_ptr<const jlm::rvsdg::type> type)
+  {
+    auto input =
+        std::make_unique<structural_input>(node, origin, jlm::rvsdg::port(std::move(type)));
     return node->append_input(std::move(input));
   }
 
@@ -113,14 +122,19 @@ class structural_output : public node_output
 public:
   virtual ~structural_output() noexcept;
 
-protected:
   structural_output(jlm::rvsdg::structural_node * node, const jlm::rvsdg::port & port);
 
-public:
   static structural_output *
   create(structural_node * node, const jlm::rvsdg::port & port)
   {
-    auto output = std::unique_ptr<structural_output>(new structural_output(node, port));
+    auto output = std::make_unique<structural_output>(node, port);
+    return node->append_output(std::move(output));
+  }
+
+  static structural_output *
+  create(structural_node * node, std::shared_ptr<const jlm::rvsdg::type> type)
+  {
+    auto output = std::make_unique<structural_output>(node, jlm::rvsdg::port(std::move(type)));
     return node->append_output(std::move(output));
   }
 

--- a/jlm/rvsdg/unary.hpp
+++ b/jlm/rvsdg/unary.hpp
@@ -59,8 +59,10 @@ class unary_op : public simple_op
 public:
   virtual ~unary_op() noexcept;
 
-  inline unary_op(const jlm::rvsdg::port & operand, const jlm::rvsdg::port & result)
-      : simple_op({ operand }, { result })
+  inline unary_op(
+      std::shared_ptr<const jlm::rvsdg::type> operand,
+      std::shared_ptr<const jlm::rvsdg::type> result)
+      : simple_op({ port(std::move(operand)) }, { port(std::move(result)) })
   {}
 
   virtual unop_reduction_path_t

--- a/tests/jlm/llvm/ir/TestAnnotation.cpp
+++ b/tests/jlm/llvm/ir/TestAnnotation.cpp
@@ -95,7 +95,7 @@ TestLinearSubgraphAnnotation()
   };
 
   ipgraph_module module(jlm::util::filepath(""), "", "");
-  jlm::llvm::argument argument("argument", jlm::tests::valuetype());
+  jlm::llvm::argument argument("argument", jlm::tests::valuetype::Create());
   auto [aggregationTreeRoot, v1, v2] = SetupAggregationTree(module, argument);
 
   /*

--- a/tests/jlm/llvm/opt/test-unroll.cpp
+++ b/tests/jlm/llvm/opt/test-unroll.cpp
@@ -66,12 +66,12 @@ static inline void
 test_unrollinfo()
 {
   jlm::rvsdg::bittype bt32(32);
-  jlm::rvsdg::bitslt_op slt(bt32);
-  jlm::rvsdg::bitult_op ult(bt32);
-  jlm::rvsdg::bitule_op ule(bt32);
-  jlm::rvsdg::bitugt_op ugt(bt32);
-  jlm::rvsdg::bitsge_op sge(bt32);
-  jlm::rvsdg::biteq_op eq(bt32);
+  jlm::rvsdg::bitslt_op slt(32);
+  jlm::rvsdg::bitult_op ult(32);
+  jlm::rvsdg::bitule_op ule(32);
+  jlm::rvsdg::bitugt_op ugt(32);
+  jlm::rvsdg::bitsge_op sge(32);
+  jlm::rvsdg::biteq_op eq(32);
 
   jlm::rvsdg::bitadd_op add(32);
   jlm::rvsdg::bitsub_op sub(32);

--- a/tests/test-operation.hpp
+++ b/tests/test-operation.hpp
@@ -28,7 +28,7 @@ public:
   virtual ~unary_op() noexcept;
 
   inline unary_op(const rvsdg::port & srcport, const rvsdg::port & dstport) noexcept
-      : rvsdg::unary_op(srcport, dstport)
+      : rvsdg::unary_op(srcport.Type(), dstport.Type())
   {}
 
   virtual bool
@@ -90,7 +90,7 @@ public:
       const rvsdg::port & srcport,
       const rvsdg::port & dstport,
       const enum rvsdg::binary_op::flags & flags) noexcept
-      : rvsdg::binary_op({ srcport, srcport }, { dstport }),
+      : rvsdg::binary_op({ srcport.Type(), srcport.Type() }, dstport.Type()),
         flags_(flags)
   {}
 

--- a/tests/test-types.cpp
+++ b/tests/test-types.cpp
@@ -61,4 +61,11 @@ statetype::copy() const
   return std::make_shared<statetype>(*this);
 }
 
+std::shared_ptr<const statetype>
+statetype::Create()
+{
+  static const statetype instance;
+  return std::shared_ptr<const statetype>(std::shared_ptr<void>(), &instance);
+}
+
 }

--- a/tests/test-types.hpp
+++ b/tests/test-types.hpp
@@ -50,6 +50,9 @@ public:
 
   std::shared_ptr<const jlm::rvsdg::type>
   copy() const override;
+
+  static std::shared_ptr<const statetype>
+  Create();
 };
 
 }


### PR DESCRIPTION
Add overloaded constructors and/or creator functions that take "shared_ptr<const type>" instead of "const type &" arguments (and hence can take over reference from caller, instead of requiring a copy operation).

In some cases, the "type copy" methods can be removed as they have no callers anymore. For others, the superseded methods will be removed once all callers are converted.

This sets the groundwork for gradually converting all call sites to use shared type references.