### PR TITLE
Change testnode to expect shared_ptr of type

### DIFF
--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -226,7 +226,7 @@ LoadFromUndefTest::SetupRvsdg()
 {
   using namespace jlm::llvm;
 
-  MemoryStateType memoryStateType;
+  auto memoryStateType = MemoryStateType::Create();
   FunctionType functionType(
       { MemoryStateType::Create() },
       { jlm::rvsdg::bittype::Create(32), MemoryStateType::Create() });
@@ -358,8 +358,8 @@ Bits2PtrTest::SetupRvsdg()
   auto setupBit2PtrFunction = [&]()
   {
     PointerType pt;
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { jlm::rvsdg::bittype::Create(64), iostatetype::Create(), MemoryStateType::Create() },
         { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() });
@@ -379,8 +379,8 @@ Bits2PtrTest::SetupRvsdg()
 
   auto setupTestFunction = [&](lambda::output * b2p)
   {
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { jlm::rvsdg::bittype::Create(64), iostatetype::Create(), MemoryStateType::Create() },
         { iostatetype::Create(), MemoryStateType::Create() });
@@ -472,8 +472,8 @@ CallTest1::SetupRvsdg()
   auto SetupF = [&]()
   {
     PointerType pt;
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { PointerType::Create(),
           PointerType::Create(),
@@ -508,8 +508,8 @@ CallTest1::SetupRvsdg()
   auto SetupG = [&]()
   {
     PointerType pt;
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { PointerType::Create(),
           PointerType::Create(),
@@ -543,8 +543,8 @@ CallTest1::SetupRvsdg()
 
   auto SetupH = [&](lambda::node * f, lambda::node * g)
   {
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
@@ -628,8 +628,8 @@ CallTest2::SetupRvsdg()
   auto SetupCreate = [&]()
   {
     PointerType pt32;
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() },
         { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() });
@@ -657,8 +657,8 @@ CallTest2::SetupRvsdg()
   auto SetupDestroy = [&]()
   {
     PointerType pointerType;
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() },
         { iostatetype::Create(), MemoryStateType::Create() });
@@ -680,8 +680,8 @@ CallTest2::SetupRvsdg()
 
   auto SetupTest = [&](lambda::node * lambdaCreate, lambda::node * lambdaDestroy)
   {
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { iostatetype::Create(), MemoryStateType::Create() },
         { iostatetype::Create(), MemoryStateType::Create() });
@@ -750,8 +750,8 @@ IndirectCallTest1::SetupRvsdg()
 {
   using namespace jlm::llvm;
 
-  iostatetype iOStateType;
-  MemoryStateType memoryStateType;
+  auto iOStateType = iostatetype::Create();
+  auto memoryStateType = MemoryStateType::Create();
   FunctionType constantFunctionType(
       { iostatetype::Create(), MemoryStateType::Create() },
       { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
@@ -777,8 +777,8 @@ IndirectCallTest1::SetupRvsdg()
 
   auto SetupIndirectCallFunction = [&]()
   {
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
@@ -859,8 +859,8 @@ IndirectCallTest2::SetupRvsdg()
 {
   using namespace jlm::llvm;
 
-  iostatetype iOStateType;
-  MemoryStateType memoryStateType;
+  auto iOStateType = iostatetype::Create();
+  auto memoryStateType = MemoryStateType::Create();
   FunctionType constantFunctionType(
       { iostatetype::Create(), MemoryStateType::Create() },
       { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
@@ -916,8 +916,8 @@ IndirectCallTest2::SetupRvsdg()
 
   auto SetupI = [&]()
   {
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
@@ -1118,8 +1118,8 @@ ExternalCallTest1::SetupRvsdg()
   nf->set_mutable(false);
 
   PointerType pointerType;
-  iostatetype iOStateType;
-  MemoryStateType memoryStateType;
+  auto iOStateType = iostatetype::Create();
+  auto memoryStateType = MemoryStateType::Create();
   FunctionType functionGType(
       { PointerType::Create(),
         PointerType::Create(),
@@ -1135,8 +1135,8 @@ ExternalCallTest1::SetupRvsdg()
   auto SetupFunctionF = [&](jlm::rvsdg::argument * functionG)
   {
     PointerType pointerType;
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { PointerType::Create(),
           PointerType::Create(),
@@ -1202,8 +1202,8 @@ ExternalCallTest2::SetupRvsdg()
   auto & structDeclaration = rvsdgModule->AddStructTypeDeclaration(StructType::Declaration::Create(
       { rvsdg::bittype::Create(32), PointerType::Create(), PointerType::Create() }));
   auto structType = StructType::Create("myStruct", false, structDeclaration);
-  iostatetype iOStateType;
-  MemoryStateType memoryStateType;
+  auto iOStateType = iostatetype::Create();
+  auto memoryStateType = MemoryStateType::Create();
   varargtype varArgType;
   FunctionType lambdaLlvmLifetimeStartType(
       { rvsdg::bittype::Create(64),
@@ -1406,8 +1406,8 @@ GammaTest2::SetupRvsdg()
       return std::make_tuple(gammaOutputA, gammaOutputMemoryState);
     };
 
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     PointerType pointerType;
     FunctionType functionType(
         { rvsdg::bittype::Create(32),
@@ -1464,8 +1464,8 @@ GammaTest2::SetupRvsdg()
                            int64_t yValue,
                            const char * functionName)
   {
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     PointerType pointerType;
     FunctionType functionType(
         { iostatetype::Create(), MemoryStateType::Create() },
@@ -1625,8 +1625,8 @@ DeltaTest1::SetupRvsdg()
   auto SetupFunctionG = [&]()
   {
     PointerType pt;
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
@@ -1647,8 +1647,8 @@ DeltaTest1::SetupRvsdg()
 
   auto SetupFunctionH = [&](delta::output * f, lambda::output * g)
   {
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
@@ -1731,8 +1731,8 @@ DeltaTest2::SetupRvsdg()
 
   auto SetupF1 = [&](delta::output * d1)
   {
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { iostatetype::Create(), MemoryStateType::Create() },
         { iostatetype::Create(), MemoryStateType::Create() });
@@ -1751,8 +1751,8 @@ DeltaTest2::SetupRvsdg()
 
   auto SetupF2 = [&](lambda::output * f1, delta::output * d1, delta::output * d2)
   {
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { iostatetype::Create(), MemoryStateType::Create() },
         { iostatetype::Create(), MemoryStateType::Create() });
@@ -1835,8 +1835,8 @@ DeltaTest3::SetupRvsdg()
 
   auto SetupF = [&](delta::output & g1, delta::output & g2)
   {
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(16), iostatetype::Create(), MemoryStateType::Create() });
@@ -1861,8 +1861,8 @@ DeltaTest3::SetupRvsdg()
 
   auto SetupTest = [&](lambda::output & lambdaF)
   {
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { iostatetype::Create(), MemoryStateType::Create() },
         { iostatetype::Create(), MemoryStateType::Create() });
@@ -1917,8 +1917,8 @@ ImportTest::SetupRvsdg()
 
   auto SetupF1 = [&](jlm::rvsdg::output * d1)
   {
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { iostatetype::Create(), MemoryStateType::Create() },
         { iostatetype::Create(), MemoryStateType::Create() });
@@ -1938,8 +1938,8 @@ ImportTest::SetupRvsdg()
 
   auto SetupF2 = [&](lambda::output * f1, jlm::rvsdg::output * d1, jlm::rvsdg::output * d2)
   {
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { iostatetype::Create(), MemoryStateType::Create() },
         { iostatetype::Create(), MemoryStateType::Create() });
@@ -1996,8 +1996,8 @@ PhiTest1::SetupRvsdg()
   nf->set_mutable(false);
 
   PointerType pbit64;
-  iostatetype iOStateType;
-  MemoryStateType memoryStateType;
+  auto iOStateType = iostatetype::Create();
+  auto memoryStateType = MemoryStateType::Create();
   FunctionType fibFunctionType(
       { jlm::rvsdg::bittype::Create(64),
         PointerType::Create(),
@@ -2098,8 +2098,8 @@ PhiTest1::SetupRvsdg()
   {
     arraytype at(jlm::rvsdg::bittype::Create(64), 10);
     PointerType pbit64;
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { iostatetype::Create(), MemoryStateType::Create() },
         { iostatetype::Create(), MemoryStateType::Create() });
@@ -2151,8 +2151,8 @@ PhiTest2::SetupRvsdg()
 {
   using namespace jlm::llvm;
 
-  iostatetype iOStateType;
-  MemoryStateType memoryStateType;
+  auto iOStateType = iostatetype::Create();
+  auto memoryStateType = MemoryStateType::Create();
 
   PointerType pointerType;
 
@@ -2656,8 +2656,8 @@ EscapedMemoryTest1::SetupRvsdg()
   auto SetupLambdaTest = [&](delta::output & deltaB)
   {
     PointerType pointerType;
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
@@ -2725,8 +2725,8 @@ EscapedMemoryTest2::SetupRvsdg()
   nf->set_mutable(false);
 
   PointerType pointerType;
-  iostatetype iOStateType;
-  MemoryStateType memoryStateType;
+  auto iOStateType = iostatetype::Create();
+  auto memoryStateType = MemoryStateType::Create();
 
   FunctionType externalFunction1Type(
       { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() },
@@ -2751,8 +2751,8 @@ EscapedMemoryTest2::SetupRvsdg()
   auto SetupReturnAddressFunction = [&]()
   {
     PointerType p8;
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { iostatetype::Create(), MemoryStateType::Create() },
         { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() });
@@ -2780,8 +2780,8 @@ EscapedMemoryTest2::SetupRvsdg()
 
   auto SetupCallExternalFunction1 = [&](jlm::rvsdg::argument * externalFunction1Argument)
   {
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { iostatetype::Create(), MemoryStateType::Create() },
         { iostatetype::Create(), MemoryStateType::Create() });
@@ -2816,8 +2816,8 @@ EscapedMemoryTest2::SetupRvsdg()
 
   auto SetupCallExternalFunction2 = [&](jlm::rvsdg::argument * externalFunction2Argument)
   {
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
@@ -2896,8 +2896,8 @@ EscapedMemoryTest3::SetupRvsdg()
   nf->set_mutable(false);
 
   PointerType pointerType;
-  iostatetype iOStateType;
-  MemoryStateType memoryStateType;
+  auto iOStateType = iostatetype::Create();
+  auto memoryStateType = MemoryStateType::Create();
   FunctionType externalFunctionType(
       { iostatetype::Create(), MemoryStateType::Create() },
       { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() });
@@ -2929,8 +2929,8 @@ EscapedMemoryTest3::SetupRvsdg()
 
   auto SetupTestFunction = [&](jlm::rvsdg::argument * externalFunctionArgument)
   {
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
@@ -3038,8 +3038,8 @@ MemcpyTest::SetupRvsdg()
 
   auto SetupFunctionF = [&](delta::output & globalArray)
   {
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
@@ -3075,8 +3075,8 @@ MemcpyTest::SetupRvsdg()
   auto SetupFunctionG =
       [&](delta::output & localArray, delta::output & globalArray, lambda::output & lambdaF)
   {
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
@@ -3149,8 +3149,8 @@ MemcpyTest2::SetupRvsdg()
 
   auto SetupFunctionG = [&]()
   {
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { PointerType::Create(),
           PointerType::Create(),
@@ -3184,8 +3184,8 @@ MemcpyTest2::SetupRvsdg()
 
   auto SetupFunctionF = [&](lambda::output & functionF)
   {
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { PointerType::Create(),
           PointerType::Create(),
@@ -3248,8 +3248,8 @@ MemcpyTest3::SetupRvsdg()
       StructType::Declaration::Create({ PointerType::Create() }));
   auto structType = StructType::Create("myStruct", false, declaration);
 
-  iostatetype iOStateType;
-  MemoryStateType memoryStateType;
+  auto iOStateType = iostatetype::Create();
+  auto memoryStateType = MemoryStateType::Create();
   FunctionType functionType(
       { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() },
       { iostatetype::Create(), MemoryStateType::Create() });
@@ -3326,8 +3326,8 @@ LinkedListTest::SetupRvsdg()
 
   auto SetupFunctionNext = [&](delta::output & myList)
   {
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { iostatetype::Create(), MemoryStateType::Create() },
         { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() });
@@ -3626,8 +3626,8 @@ LambdaCallArgumentMismatch::SetupRvsdg()
 
   auto setupLambdaG = [&]()
   {
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { iostatetype::Create(), MemoryStateType::Create() },
         { rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
@@ -3644,8 +3644,8 @@ LambdaCallArgumentMismatch::SetupRvsdg()
   auto setupLambdaMain = [&](lambda::output & lambdaG)
   {
     PointerType pointerType;
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     auto variableArgumentType = varargtype::Create();
     FunctionType functionTypeMain(
         { iostatetype::Create(), MemoryStateType::Create() },
@@ -3708,8 +3708,8 @@ VariadicFunctionTest1::SetupRvsdg()
   rvsdg.node_normal_form(typeid(rvsdg::operation))->set_mutable(false);
 
   PointerType pointerType;
-  iostatetype iOStateType;
-  MemoryStateType memoryStateType;
+  auto iOStateType = iostatetype::Create();
+  auto memoryStateType = MemoryStateType::Create();
   auto varArgType = varargtype::Create();
   FunctionType lambdaHType(
       { jlm::rvsdg::bittype::Create(32),
@@ -3800,8 +3800,8 @@ VariadicFunctionTest2::SetupRvsdg()
                                         PointerType::Create() }));
   auto structType = StructType::Create("struct.__va_list_tag", false, structDeclaration);
   arraytype arrayType(structType, 1);
-  iostatetype iOStateType;
-  MemoryStateType memoryStateType;
+  auto iOStateType = iostatetype::Create();
+  auto memoryStateType = MemoryStateType::Create();
   auto varArgType = varargtype::Create();
   FunctionType lambdaLlvmLifetimeStartType(
       { rvsdg::bittype::Create(64),

--- a/tests/jlm/hls/backend/rvsdg2rhls/UnusedStateRemovalTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/UnusedStateRemovalTests.cpp
@@ -20,7 +20,7 @@ TestGamma()
   using namespace jlm::llvm;
 
   // Arrange
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
 
   auto rvsdgModule = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto & rvsdg = rvsdgModule->Rvsdg();
@@ -103,7 +103,7 @@ TestTheta()
   auto result = jlm::tests::SimpleNode::Create(
                     *rvsdg.root(),
                     { thetaOutput0, thetaOutput1, thetaOutput2, thetaOutput3 },
-                    { &*valueType })
+                    { valueType })
                     .output(0);
 
   rvsdg.add_export(result, { *valueType, "f" });
@@ -144,10 +144,10 @@ TestLambda()
   auto argument3 = lambdaNode->add_ctxvar(x);
 
   auto result1 =
-      jlm::tests::SimpleNode::Create(*lambdaNode->subregion(), { argument1 }, { &*valueType })
+      jlm::tests::SimpleNode::Create(*lambdaNode->subregion(), { argument1 }, { valueType })
           .output(0);
   auto result3 =
-      jlm::tests::SimpleNode::Create(*lambdaNode->subregion(), { argument3 }, { &*valueType })
+      jlm::tests::SimpleNode::Create(*lambdaNode->subregion(), { argument3 }, { valueType })
           .output(0);
 
   auto lambdaOutput = lambdaNode->finalize({ argument0, result1, argument2, result3 });

--- a/tests/jlm/llvm/backend/llvm/jlm-llvm/LoadTests.cpp
+++ b/tests/jlm/llvm/backend/llvm/jlm-llvm/LoadTests.cpp
@@ -78,7 +78,7 @@ LoadVolatileConversion()
   // Arrange
   PointerType pointerType;
   iostatetype ioStateType;
-  MemoryStateType memoryStateType;
+  auto memoryStateType = MemoryStateType::Create();
   jlm::rvsdg::bittype bit64Type(64);
   FunctionType functionType(
       { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() },

--- a/tests/jlm/llvm/backend/llvm/jlm-llvm/MemCpyTests.cpp
+++ b/tests/jlm/llvm/backend/llvm/jlm-llvm/MemCpyTests.cpp
@@ -20,7 +20,7 @@ MemCpyConversion()
 
   // Arrange
   PointerType pointerType;
-  MemoryStateType memoryStateType;
+  auto memoryStateType = MemoryStateType::Create();
   jlm::rvsdg::bittype bit64Type(64);
   FunctionType functionType(
       { PointerType::Create(),
@@ -87,7 +87,7 @@ MemCpyVolatileConversion()
   // Arrange
   PointerType pointerType;
   iostatetype ioStateType;
-  MemoryStateType memoryStateType;
+  auto memoryStateType = MemoryStateType::Create();
   jlm::rvsdg::bittype bit64Type(64);
   FunctionType functionType(
       { PointerType::Create(),

--- a/tests/jlm/llvm/backend/llvm/jlm-llvm/StoreTests.cpp
+++ b/tests/jlm/llvm/backend/llvm/jlm-llvm/StoreTests.cpp
@@ -20,7 +20,7 @@ StoreConversion()
 
   // Arrange
   PointerType pointerType;
-  MemoryStateType memoryStateType;
+  auto memoryStateType = MemoryStateType::Create();
   jlm::rvsdg::bittype bit64Type(64);
   FunctionType functionType(
       { PointerType::Create(), jlm::rvsdg::bittype::Create(64), MemoryStateType::Create() },
@@ -81,7 +81,7 @@ StoreVolatileConversion()
   // Arrange
   PointerType pointerType;
   iostatetype ioStateType;
-  MemoryStateType memoryStateType;
+  auto memoryStateType = MemoryStateType::Create();
   jlm::rvsdg::bittype bit64Type(64);
   FunctionType functionType(
       { PointerType::Create(),

--- a/tests/jlm/llvm/backend/llvm/jlm-llvm/test-select-with-state.cpp
+++ b/tests/jlm/llvm/backend/llvm/jlm-llvm/test-select-with-state.cpp
@@ -20,7 +20,7 @@ test()
 {
   using namespace jlm::llvm;
 
-  jlm::tests::valuetype vt;
+  auto vt = jlm::tests::valuetype::Create();
   PointerType pt;
   MemoryStateType mt;
   ipgraph_module m(jlm::util::filepath(""), "", "");

--- a/tests/jlm/llvm/backend/llvm/r2j/test-partial-gamma.cpp
+++ b/tests/jlm/llvm/backend/llvm/r2j/test-partial-gamma.cpp
@@ -34,8 +34,7 @@ test()
   auto match = jlm::rvsdg::match(1, { { 0, 0 } }, 1, 2, lambda->fctargument(0));
   auto gamma = jlm::rvsdg::gamma_node::create(match, 2);
   auto ev = gamma->add_entryvar(lambda->fctargument(1));
-  auto output =
-      jlm::tests::create_testop(gamma->subregion(1), { ev->argument(1) }, { vt.get() })[0];
+  auto output = jlm::tests::create_testop(gamma->subregion(1), { ev->argument(1) }, { vt })[0];
   auto ex = gamma->add_exitvar({ ev->argument(0), output });
 
   auto f = lambda->finalize({ ex });

--- a/tests/jlm/llvm/backend/llvm/r2j/test-recursive-data.cpp
+++ b/tests/jlm/llvm/backend/llvm/r2j/test-recursive-data.cpp
@@ -21,7 +21,7 @@ test()
 {
   using namespace jlm::llvm;
 
-  jlm::tests::valuetype vt;
+  auto vt = jlm::tests::valuetype::Create();
   PointerType pt;
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
@@ -39,20 +39,20 @@ test()
   jlm::rvsdg::output *delta1, *delta2;
   {
     auto delta =
-        delta::node::Create(region, vt, "test-delta1", linkage::external_linkage, "", false);
+        delta::node::Create(region, *vt, "test-delta1", linkage::external_linkage, "", false);
     auto dep1 = delta->add_ctxvar(r2->argument());
     auto dep2 = delta->add_ctxvar(dep);
     delta1 =
-        delta->finalize(jlm::tests::create_testop(delta->subregion(), { dep1, dep2 }, { &vt })[0]);
+        delta->finalize(jlm::tests::create_testop(delta->subregion(), { dep1, dep2 }, { vt })[0]);
   }
 
   {
     auto delta =
-        delta::node::Create(region, vt, "test-delta2", linkage::external_linkage, "", false);
+        delta::node::Create(region, *vt, "test-delta2", linkage::external_linkage, "", false);
     auto dep1 = delta->add_ctxvar(r1->argument());
     auto dep2 = delta->add_ctxvar(dep);
     delta2 =
-        delta->finalize(jlm::tests::create_testop(delta->subregion(), { dep1, dep2 }, { &vt })[0]);
+        delta->finalize(jlm::tests::create_testop(delta->subregion(), { dep1, dep2 }, { vt })[0]);
   }
 
   r1->set_rvorigin(delta1);

--- a/tests/jlm/llvm/frontend/llvm/ThreeAddressCodeConversionTests.cpp
+++ b/tests/jlm/llvm/frontend/llvm/ThreeAddressCodeConversionTests.cpp
@@ -86,8 +86,8 @@ LoadVolatileConversion()
   using namespace jlm::llvm;
 
   // Arrange
-  jlm::tests::valuetype valueType;
-  LoadVolatileOperation operation(valueType, 3, 4);
+  auto valueType = jlm::tests::valuetype::Create();
+  LoadVolatileOperation operation(*valueType, 3, 4);
   auto ipgModule = SetupFunctionWithThreeAddressCode(operation);
 
   // Act
@@ -115,7 +115,7 @@ StoreVolatileConversion()
   using namespace jlm::llvm;
 
   // Arrange
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
   StoreVolatileOperation operation(valueType, 3, 4);
   auto ipgModule = SetupFunctionWithThreeAddressCode(operation);
 

--- a/tests/jlm/llvm/frontend/llvm/test-recursive-data.cpp
+++ b/tests/jlm/llvm/frontend/llvm/test-recursive-data.cpp
@@ -19,13 +19,13 @@ test()
 {
   using namespace jlm::llvm;
 
-  jlm::tests::valuetype vt;
+  auto vt = jlm::tests::valuetype::Create();
   ipgraph_module im(jlm::util::filepath(""), "", "");
 
-  auto d0 = data_node::Create(im.ipgraph(), "d0", vt, linkage::external_linkage, "", false);
+  auto d0 = data_node::Create(im.ipgraph(), "d0", *vt, linkage::external_linkage, "", false);
 
-  auto d1 = data_node::Create(im.ipgraph(), "d1", vt, linkage::external_linkage, "", false);
-  auto d2 = data_node::Create(im.ipgraph(), "d2", vt, linkage::external_linkage, "", false);
+  auto d1 = data_node::Create(im.ipgraph(), "d1", *vt, linkage::external_linkage, "", false);
+  auto d2 = data_node::Create(im.ipgraph(), "d2", *vt, linkage::external_linkage, "", false);
 
   auto v0 = im.create_global_value(d0);
   auto v1 = im.create_global_value(d1);
@@ -37,8 +37,8 @@ test()
   d2->add_dependency(d1);
 
   tacsvector_t tvec1, tvec2;
-  tvec1.push_back(jlm::tests::create_testop_tac({ v0, v2 }, { &vt }));
-  tvec2.push_back(jlm::tests::create_testop_tac({ v0, v1 }, { &vt }));
+  tvec1.push_back(jlm::tests::create_testop_tac({ v0, v2 }, { vt }));
+  tvec2.push_back(jlm::tests::create_testop_tac({ v0, v1 }, { vt }));
 
   d1->set_initialization(std::make_unique<data_node_init>(std::move(tvec1)));
   d2->set_initialization(std::make_unique<data_node_init>(std::move(tvec2)));

--- a/tests/jlm/llvm/ir/TestAnnotation.cpp
+++ b/tests/jlm/llvm/ir/TestAnnotation.cpp
@@ -24,8 +24,8 @@ TestBasicBlockAnnotation()
    */
   auto SetupAggregationTree = [](ipgraph_module & module)
   {
-    jlm::tests::valuetype vt;
-    jlm::tests::test_op op({ &vt }, { &vt });
+    auto vt = jlm::tests::valuetype::Create();
+    jlm::tests::test_op op({ vt }, { vt });
 
     auto v0 = module.create_variable(vt, "v0");
 
@@ -71,8 +71,8 @@ TestLinearSubgraphAnnotation()
     /*
      * Setup simple linear CFG: Entry -> B1 -> B2 -> Exit
      */
-    jlm::tests::valuetype vt;
-    jlm::tests::test_op op({ &vt }, { &vt });
+    auto vt = jlm::tests::valuetype::Create();
+    jlm::tests::test_op op({ vt }, { vt });
 
     taclist bb1, bb2;
     bb1.append_last(tac::create(op, { &argument }));
@@ -156,8 +156,8 @@ TestBranchAnnotation()
     /*
      * Setup conditional CFG with nodes bbs, b1, b2, and edges bbs -> b1 and bbs -> b2.
      */
-    jlm::tests::valuetype vt;
-    jlm::tests::test_op op({ &vt }, { &vt });
+    auto vt = jlm::tests::valuetype::Create();
+    jlm::tests::test_op op({ vt }, { vt });
 
     auto argument = module.create_variable(vt, "arg");
     auto v3 = module.create_variable(vt, "v3");
@@ -187,8 +187,8 @@ TestBranchAnnotation()
     return std::make_tuple(std::move(root), argument, v1, v2, v3, v4);
   };
 
-  jlm::tests::valuetype vt;
-  jlm::tests::test_op op({ &vt }, { &vt });
+  auto vt = jlm::tests::valuetype::Create();
+  jlm::tests::test_op op({ vt }, { vt });
 
   ipgraph_module module(jlm::util::filepath(""), "", "");
   auto [aggregationTreeRoot, argument, v1, v2, v3, v4] = SetupAggregationTree(module);
@@ -239,8 +239,8 @@ TestLoopAnnotation()
    */
   auto SetupAggregationTree = [](ipgraph_module & module)
   {
-    jlm::tests::valuetype vt;
-    jlm::tests::test_op op({ &vt }, { &vt });
+    auto vt = jlm::tests::valuetype::Create();
+    jlm::tests::test_op op({ vt }, { vt });
 
     auto v1 = module.create_variable(vt, "v1");
     auto v4 = module.create_variable(vt, "v4");
@@ -304,8 +304,8 @@ TestBranchInLoopAnnotation()
    */
   auto SetupAggregationTree = [](ipgraph_module & module)
   {
-    jlm::tests::valuetype vt;
-    jlm::tests::test_op op({ &vt }, { &vt });
+    auto vt = jlm::tests::valuetype::Create();
+    jlm::tests::test_op op({ vt }, { vt });
 
     auto v1 = module.create_variable(vt, "v1");
     auto v3 = module.create_variable(vt, "v3");
@@ -396,7 +396,7 @@ TestAssignmentAnnotation()
    */
   auto SetupAggregationTree = [](ipgraph_module & module)
   {
-    jlm::tests::valuetype vt;
+    auto vt = jlm::tests::valuetype::Create();
 
     auto v1 = module.create_variable(vt, "v1");
     auto v2 = module.create_variable(vt, "v2");
@@ -436,8 +436,8 @@ TestBranchPassByAnnotation()
    */
   auto SetupAggregationTree = [](ipgraph_module & module)
   {
-    jlm::tests::valuetype vt;
-    jlm::tests::test_op op({}, { &vt });
+    auto vt = jlm::tests::valuetype::Create();
+    jlm::tests::test_op op({}, { vt });
 
     auto v3 = module.create_variable(vt, "v3");
 

--- a/tests/jlm/llvm/ir/operators/LoadTests.cpp
+++ b/tests/jlm/llvm/ir/operators/LoadTests.cpp
@@ -29,7 +29,7 @@ OperationEquality()
   LoadNonVolatileOperation operation2(pointerType, 2, 4);
   LoadNonVolatileOperation operation3(valueType, 4, 4);
   LoadNonVolatileOperation operation4(valueType, 2, 8);
-  jlm::tests::test_op operation5({ &pointerType }, { &pointerType });
+  jlm::tests::test_op operation5({ PointerType::Create() }, { PointerType::Create() });
 
   // Assert
   assert(operation1 == operation1);
@@ -52,7 +52,7 @@ TestCopy()
 
   // Arrange
   MemoryStateType memoryType;
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
   PointerType pointerType;
 
   jlm::rvsdg::graph graph;
@@ -62,7 +62,7 @@ TestCopy()
   auto address2 = graph.add_import({ pointerType, "address2" });
   auto memoryState2 = graph.add_import({ memoryType, "memoryState2" });
 
-  auto loadResults = LoadNonVolatileNode::Create(address1, { memoryState1 }, valueType, 4);
+  auto loadResults = LoadNonVolatileNode::Create(address1, { memoryState1 }, *valueType, 4);
 
   // Act
   auto node = jlm::rvsdg::node_output::node(loadResults[0]);
@@ -124,7 +124,7 @@ TestMultipleOriginReduction()
 
   // Arrange
   MemoryStateType mt;
-  jlm::tests::valuetype vt;
+  auto vt = jlm::tests::valuetype::Create();
   PointerType pt;
 
   jlm::rvsdg::graph graph;
@@ -135,7 +135,7 @@ TestMultipleOriginReduction()
   auto a = graph.add_import({ pt, "a" });
   auto s = graph.add_import({ mt, "s" });
 
-  auto load = LoadNonVolatileNode::Create(a, { s, s, s, s }, vt, 4)[0];
+  auto load = LoadNonVolatileNode::Create(a, { s, s, s, s }, *vt, 4)[0];
 
   auto ex = graph.add_export(load, { load->type(), "l" });
 
@@ -206,7 +206,7 @@ TestLoadStoreReduction()
   using namespace jlm::llvm;
 
   // Arrange
-  jlm::tests::valuetype vt;
+  auto vt = jlm::tests::valuetype::Create();
   PointerType pt;
   MemoryStateType mt;
 
@@ -220,7 +220,7 @@ TestLoadStoreReduction()
   auto s = graph.add_import({ mt, "state" });
 
   auto s1 = StoreNonVolatileNode::Create(a, v, { s }, 4)[0];
-  auto load = LoadNonVolatileNode::Create(a, { s1 }, vt, 4);
+  auto load = LoadNonVolatileNode::Create(a, { s1 }, *vt, 4);
 
   auto x1 = graph.add_export(load[0], { load[0]->type(), "value" });
   auto x2 = graph.add_export(load[1], { load[1]->type(), "state" });
@@ -246,7 +246,7 @@ TestLoadLoadReduction()
   using namespace jlm::llvm;
 
   // Arrange
-  jlm::tests::valuetype vt;
+  auto vt = jlm::tests::valuetype::Create();
   PointerType pt;
   MemoryStateType mt;
 
@@ -322,14 +322,14 @@ LoadVolatileOperationEquality()
 
   // Arrange
   MemoryStateType memoryType;
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
   PointerType pointerType;
 
   LoadVolatileOperation operation1(valueType, 2, 4);
   LoadVolatileOperation operation2(pointerType, 2, 4);
   LoadVolatileOperation operation3(valueType, 4, 4);
   LoadVolatileOperation operation4(valueType, 2, 8);
-  jlm::tests::test_op operation5({ &pointerType }, { &pointerType });
+  jlm::tests::test_op operation5({ PointerType::Create() }, { PointerType::Create() });
 
   // Assert
   assert(operation1 == operation1);
@@ -352,7 +352,7 @@ OperationCopy()
 
   // Arrange
   MemoryStateType memoryType;
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
   PointerType pointerType;
 
   LoadVolatileOperation operation(valueType, 2, 4);
@@ -375,7 +375,7 @@ OperationAccessors()
 
   // Arrange
   MemoryStateType memoryType;
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
   PointerType pointerType;
 
   size_t alignment = 4;
@@ -383,7 +383,7 @@ OperationAccessors()
   LoadVolatileOperation operation(valueType, numMemoryStates, alignment);
 
   // Assert
-  assert(operation.GetLoadedType() == valueType);
+  assert(operation.GetLoadedType() == *valueType);
   assert(operation.NumMemoryStates() == numMemoryStates);
   assert(operation.GetAlignment() == alignment);
   assert(operation.narguments() == numMemoryStates + 2); // [address, ioState, memoryStates]
@@ -403,9 +403,9 @@ NodeCopy()
 
   // Arrange
   PointerType pointerType;
-  iostatetype iOStateType;
+  auto iOStateType = iostatetype::Create();
   MemoryStateType memoryType;
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
 
   jlm::rvsdg::graph graph;
   auto & address1 = *graph.add_import({ pointerType, "address1" });
@@ -427,7 +427,7 @@ NodeCopy()
   assert(loadNode.GetOperation() == copiedLoadNode->GetOperation());
   assert(copiedLoadNode->GetAddressInput().origin() == &address2);
   assert(copiedLoadNode->GetIoStateInput().origin() == &iOState2);
-  assert(copiedLoadNode->GetLoadedValueOutput().type() == valueType);
+  assert(copiedLoadNode->GetLoadedValueOutput().type() == *valueType);
 
   return 0;
 }

--- a/tests/jlm/llvm/ir/operators/MemCpyTests.cpp
+++ b/tests/jlm/llvm/ir/operators/MemCpyTests.cpp
@@ -15,13 +15,13 @@ OperationEquality()
   using namespace jlm::llvm;
 
   // Arrange
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
   jlm::rvsdg::bittype bit32Type(32);
   jlm::rvsdg::bittype bit64Type(64);
 
   MemCpyNonVolatileOperation operation1(bit32Type, 1);
   MemCpyNonVolatileOperation operation2(bit64Type, 4);
-  jlm::tests::test_op operation3({ &valueType }, { &valueType });
+  jlm::tests::test_op operation3({ valueType }, { valueType });
 
   // Act & Assert
   assert(operation1 == operation1);

--- a/tests/jlm/llvm/ir/operators/MemoryStateOperationTests.cpp
+++ b/tests/jlm/llvm/ir/operators/MemoryStateOperationTests.cpp
@@ -14,10 +14,10 @@ MemoryStateSplitEquality()
   using namespace jlm::llvm;
 
   // Arrange
-  MemoryStateType memoryStateType;
+  auto memoryStateType = MemoryStateType::Create();
   MemoryStateSplitOperation operation1(2);
   MemoryStateSplitOperation operation2(4);
-  jlm::tests::test_op operation3({ &memoryStateType }, { &memoryStateType, &memoryStateType });
+  jlm::tests::test_op operation3({ memoryStateType }, { memoryStateType, memoryStateType });
 
   // Act & Assert
   assert(operation1 == operation1);
@@ -37,10 +37,10 @@ MemoryStateMergeEquality()
   using namespace jlm::llvm;
 
   // Arrange
-  MemoryStateType memoryStateType;
+  auto memoryStateType = MemoryStateType::Create();
   MemoryStateMergeOperation operation1(2);
   MemoryStateMergeOperation operation2(4);
-  jlm::tests::test_op operation3({ &memoryStateType, &memoryStateType }, { &memoryStateType });
+  jlm::tests::test_op operation3({ memoryStateType, memoryStateType }, { memoryStateType });
 
   // Act & Assert
   assert(operation1 == operation1);
@@ -60,10 +60,10 @@ LambdaEntryMemStateOperatorEquality()
   using namespace jlm::llvm;
 
   // Arrange
-  jlm::llvm::MemoryStateType memoryStateType;
+  auto memoryStateType = MemoryStateType::Create();
   LambdaEntryMemoryStateSplitOperation operation1(2);
   LambdaEntryMemoryStateSplitOperation operation2(4);
-  jlm::tests::test_op operation3({ &memoryStateType }, { &memoryStateType, &memoryStateType });
+  jlm::tests::test_op operation3({ memoryStateType }, { memoryStateType, memoryStateType });
 
   // Act & Assert
   assert(operation1 == operation1);
@@ -83,10 +83,10 @@ LambdaExitMemStateOperatorEquality()
   using namespace jlm::llvm;
 
   // Arrange
-  jlm::llvm::MemoryStateType memoryStateType;
+  auto memoryStateType = MemoryStateType::Create();
   LambdaExitMemoryStateMergeOperation operation1(2);
   LambdaExitMemoryStateMergeOperation operation2(4);
-  jlm::tests::test_op operation3({ &memoryStateType, &memoryStateType }, { &memoryStateType });
+  jlm::tests::test_op operation3({ memoryStateType, memoryStateType }, { memoryStateType });
 
   // Act & Assert
   assert(operation1 == operation1);
@@ -106,10 +106,10 @@ CallEntryMemStateOperatorEquality()
   using namespace jlm::llvm;
 
   // Arrange
-  jlm::llvm::MemoryStateType memoryStateType;
+  auto memoryStateType = MemoryStateType::Create();
   CallEntryMemoryStateMergeOperation operation1(2);
   CallEntryMemoryStateMergeOperation operation2(4);
-  jlm::tests::test_op operation3({ &memoryStateType, &memoryStateType }, { &memoryStateType });
+  jlm::tests::test_op operation3({ memoryStateType, memoryStateType }, { memoryStateType });
 
   // Act & Assert
   assert(operation1 == operation1);
@@ -129,10 +129,10 @@ CallExitMemStateOperatorEquality()
   using namespace jlm::llvm;
 
   // Arrange
-  jlm::llvm::MemoryStateType memoryStateType;
+  auto memoryStateType = MemoryStateType::Create();
   CallExitMemoryStateSplitOperation operation1(2);
   CallExitMemoryStateSplitOperation operation2(4);
-  jlm::tests::test_op operation3({ &memoryStateType }, { &memoryStateType, &memoryStateType });
+  jlm::tests::test_op operation3({ memoryStateType }, { memoryStateType, memoryStateType });
 
   // Act & Assert
   assert(operation1 == operation1);

--- a/tests/jlm/llvm/ir/operators/StoreTests.cpp
+++ b/tests/jlm/llvm/ir/operators/StoreTests.cpp
@@ -21,14 +21,14 @@ StoreNonVolatileOperationEquality()
 
   // Arrange
   MemoryStateType memoryType;
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
   PointerType pointerType;
 
   StoreNonVolatileOperation operation1(valueType, 2, 4);
   StoreNonVolatileOperation operation2(pointerType, 2, 4);
   StoreNonVolatileOperation operation3(valueType, 4, 4);
   StoreNonVolatileOperation operation4(valueType, 2, 8);
-  jlm::tests::test_op operation5({ &pointerType }, { &pointerType });
+  jlm::tests::test_op operation5({ PointerType::Create() }, { PointerType::Create() });
 
   // Act & Assert
   assert(operation1 == operation1);
@@ -51,14 +51,14 @@ StoreVolatileOperationEquality()
 
   // Arrange
   MemoryStateType memoryType;
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
   PointerType pointerType;
 
   StoreVolatileOperation operation1(valueType, 2, 4);
   StoreVolatileOperation operation2(pointerType, 2, 4);
   StoreVolatileOperation operation3(valueType, 4, 4);
   StoreVolatileOperation operation4(valueType, 2, 8);
-  jlm::tests::test_op operation5({ &pointerType }, { &pointerType });
+  jlm::tests::test_op operation5({ PointerType::Create() }, { PointerType::Create() });
 
   // Assert
   assert(operation1 == operation1);
@@ -81,7 +81,7 @@ StoreVolatileOperationCopy()
 
   // Arrange
   MemoryStateType memoryType;
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
   PointerType pointerType;
 
   StoreVolatileOperation operation(valueType, 2, 4);
@@ -106,7 +106,7 @@ StoreVolatileOperationAccessors()
 
   // Arrange
   MemoryStateType memoryType;
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
   PointerType pointerType;
 
   size_t alignment = 4;
@@ -114,7 +114,7 @@ StoreVolatileOperationAccessors()
   StoreVolatileOperation operation(valueType, numMemoryStates, alignment);
 
   // Assert
-  assert(operation.GetStoredType() == valueType);
+  assert(operation.GetStoredType() == *valueType);
   assert(operation.NumMemoryStates() == numMemoryStates);
   assert(operation.GetAlignment() == alignment);
   assert(
@@ -138,7 +138,7 @@ StoreVolatileNodeCopy()
   PointerType pointerType;
   iostatetype ioStateType;
   MemoryStateType memoryType;
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
 
   jlm::rvsdg::graph graph;
   auto & address1 = *graph.add_import({ pointerType, "address1" });
@@ -177,9 +177,9 @@ TestCopy()
 {
   using namespace jlm::llvm;
 
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
   PointerType pointerType;
-  MemoryStateType memoryStateType;
+  auto memoryStateType = MemoryStateType::Create();
 
   jlm::rvsdg::graph graph;
   auto address1 = graph.add_import({ pointerType, "address1" });
@@ -209,7 +209,7 @@ TestStoreMuxReduction()
   using namespace jlm::llvm;
 
   // Arrange
-  jlm::tests::valuetype vt;
+  auto vt = jlm::tests::valuetype::Create();
   PointerType pt;
   MemoryStateType mt;
 
@@ -258,7 +258,7 @@ TestMultipleOriginReduction()
   using namespace jlm::llvm;
 
   // Arrange
-  jlm::tests::valuetype vt;
+  auto vt = jlm::tests::valuetype::Create();
   PointerType pt;
   MemoryStateType mt;
 
@@ -297,7 +297,7 @@ TestStoreAllocaReduction()
   using namespace jlm::llvm;
 
   // Arrange
-  jlm::tests::valuetype vt;
+  auto vt = jlm::tests::valuetype::Create();
   MemoryStateType mt;
   jlm::rvsdg::bittype bt(32);
 
@@ -346,7 +346,7 @@ TestStoreStoreReduction()
   using namespace jlm::llvm;
 
   // Arrange
-  jlm::tests::valuetype vt;
+  auto vt = jlm::tests::valuetype::Create();
   PointerType pt;
   MemoryStateType mt;
 

--- a/tests/jlm/llvm/ir/operators/TestCall.cpp
+++ b/tests/jlm/llvm/ir/operators/TestCall.cpp
@@ -19,8 +19,8 @@ TestCopy()
 
   // Arrange
   auto valueType = jlm::tests::valuetype::Create();
-  iostatetype iOStateType;
-  MemoryStateType memoryStateType;
+  auto iOStateType = iostatetype::Create();
+  auto memoryStateType = MemoryStateType::Create();
   FunctionType functionType(
       { valueType, iostatetype::Create(), MemoryStateType::Create() },
       { valueType, iostatetype::Create(), MemoryStateType::Create() });
@@ -56,8 +56,8 @@ TestCallNodeAccessors()
 
   // Arrange
   auto valueType = jlm::tests::valuetype::Create();
-  iostatetype iOStateType;
-  MemoryStateType memoryStateType;
+  auto iOStateType = iostatetype::Create();
+  auto memoryStateType = MemoryStateType::Create();
   FunctionType functionType(
       { valueType, iostatetype::Create(), MemoryStateType::Create() },
       { valueType, iostatetype::Create(), MemoryStateType::Create() });
@@ -81,15 +81,15 @@ TestCallNodeAccessors()
 
   assert(callNode.NumResults() == 3);
   assert(callNode.Result(0)->type() == *valueType);
-  assert(callNode.Result(1)->type() == iOStateType);
-  assert(callNode.Result(2)->type() == memoryStateType);
+  assert(callNode.Result(1)->type() == *iOStateType);
+  assert(callNode.Result(2)->type() == *memoryStateType);
 
   assert(callNode.GetFunctionInput()->origin() == f);
   assert(callNode.GetIoStateInput()->origin() == i);
   assert(callNode.GetMemoryStateInput()->origin() == m);
 
-  assert(callNode.GetIoStateOutput()->type() == iOStateType);
-  assert(callNode.GetMemoryStateOutput()->type() == memoryStateType);
+  assert(callNode.GetIoStateOutput()->type() == *iOStateType);
+  assert(callNode.GetMemoryStateOutput()->type() == *memoryStateType);
 }
 
 static void
@@ -99,8 +99,8 @@ TestCallTypeClassifierIndirectCall()
 
   // Arrange
   auto vt = jlm::tests::valuetype::Create();
-  iostatetype iOStateType;
-  MemoryStateType memoryStateType;
+  auto iOStateType = iostatetype::Create();
+  auto memoryStateType = MemoryStateType::Create();
   FunctionType fcttype1(
       { iostatetype::Create(), MemoryStateType::Create() },
       { vt, iostatetype::Create(), MemoryStateType::Create() });
@@ -163,8 +163,8 @@ TestCallTypeClassifierNonRecursiveDirectCall()
   nf->set_mutable(false);
 
   auto vt = jlm::tests::valuetype::Create();
-  iostatetype iOStateType;
-  MemoryStateType memoryStateType;
+  auto iOStateType = iostatetype::Create();
+  auto memoryStateType = MemoryStateType::Create();
 
   FunctionType functionTypeG(
       { iostatetype::Create(), MemoryStateType::Create() },
@@ -177,7 +177,7 @@ TestCallTypeClassifierNonRecursiveDirectCall()
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
 
-    auto constant = jlm::tests::test_op::create(lambda->subregion(), {}, { &*vt });
+    auto constant = jlm::tests::test_op::create(lambda->subregion(), {}, { vt });
 
     auto lambdaOutput =
         lambda->finalize({ constant->output(0), iOStateArgument, memoryStateArgument });
@@ -207,8 +207,8 @@ TestCallTypeClassifierNonRecursiveDirectCall()
     };
 
     auto vt = jlm::tests::valuetype::Create();
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
 
     FunctionType functionType(
         { iostatetype::Create(), MemoryStateType::Create() },
@@ -259,8 +259,8 @@ TestCallTypeClassifierNonRecursiveDirectCallTheta()
   nf->set_mutable(false);
 
   auto vt = jlm::tests::valuetype::Create();
-  iostatetype iOStateType;
-  MemoryStateType memoryStateType;
+  auto iOStateType = iostatetype::Create();
+  auto memoryStateType = MemoryStateType::Create();
 
   FunctionType functionTypeG(
       { iostatetype::Create(), MemoryStateType::Create() },
@@ -273,7 +273,7 @@ TestCallTypeClassifierNonRecursiveDirectCallTheta()
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
 
-    auto c1 = jlm::tests::test_op::create(lambda->subregion(), {}, { &*vt });
+    auto c1 = jlm::tests::test_op::create(lambda->subregion(), {}, { vt });
 
     return lambda->finalize({ c1->output(0), iOStateArgument, memoryStateArgument });
   };
@@ -320,8 +320,8 @@ TestCallTypeClassifierNonRecursiveDirectCallTheta()
     };
 
     auto vt = jlm::tests::valuetype::Create();
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
 
     FunctionType functionType(
         { iostatetype::Create(), MemoryStateType::Create() },
@@ -332,7 +332,7 @@ TestCallTypeClassifierNonRecursiveDirectCallTheta()
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
 
-    auto value = jlm::tests::test_op::create(lambda->subregion(), {}, { &*vt })->output(0);
+    auto value = jlm::tests::test_op::create(lambda->subregion(), {}, { vt })->output(0);
 
     auto [loopValue, iOState, memoryState, callNode] = SetupOuterTheta(
         lambda->subregion(),
@@ -375,8 +375,8 @@ TestCallTypeClassifierRecursiveDirectCall()
   auto SetupFib = [&]()
   {
     PointerType pbit64;
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { jlm::rvsdg::bittype::Create(64),
           PointerType::Create(),

--- a/tests/jlm/llvm/ir/operators/TestLambda.cpp
+++ b/tests/jlm/llvm/ir/operators/TestLambda.cpp
@@ -45,7 +45,7 @@ TestArgumentIterators()
         "f",
         linkage::external_linkage);
 
-    auto nullaryNode = jlm::tests::create_testop(lambda->subregion(), {}, { &*vt });
+    auto nullaryNode = jlm::tests::create_testop(lambda->subregion(), {}, { vt });
 
     lambda->finalize({ nullaryNode });
 
@@ -91,7 +91,7 @@ TestInvalidOperandRegion()
 
   auto lambdaNode =
       lambda::node::create(rvsdg->root(), functionType, "f", linkage::external_linkage);
-  auto result = jlm::tests::create_testop(rvsdg->root(), {}, { &*vt })[0];
+  auto result = jlm::tests::create_testop(rvsdg->root(), {}, { vt })[0];
 
   bool invalidRegionErrorCaught = false;
   try
@@ -133,7 +133,7 @@ TestRemoveLambdaInputsWhere()
   auto result = jlm::tests::SimpleNode::Create(
                     *lambdaNode->subregion(),
                     { lambdaInput1->argument() },
-                    { &*valueType })
+                    { valueType })
                     .output(0);
 
   lambdaNode->finalize({ result });
@@ -202,7 +202,7 @@ TestPruneLambdaInputs()
   auto result = jlm::tests::SimpleNode::Create(
                     *lambdaNode->subregion(),
                     { lambdaInput1->argument() },
-                    { &*valueType })
+                    { valueType })
                     .output(0);
 
   lambdaNode->finalize({ result });
@@ -238,7 +238,7 @@ TestCallSummaryComputationDead()
       "f",
       jlm::llvm::linkage::external_linkage);
 
-  auto result = tests::create_testop(lambdaNode->subregion(), {}, { &*vt })[0];
+  auto result = tests::create_testop(lambdaNode->subregion(), {}, { vt })[0];
 
   lambdaNode->finalize({ result });
 
@@ -272,7 +272,7 @@ TestCallSummaryComputationExport()
       "f",
       jlm::llvm::linkage::external_linkage);
 
-  auto result = tests::create_testop(lambdaNode->subregion(), {}, { &*vt })[0];
+  auto result = tests::create_testop(lambdaNode->subregion(), {}, { vt })[0];
 
   auto lambdaOutput = lambdaNode->finalize({ result });
   auto rvsdgExport = rvsdg.add_export(lambdaOutput, { jlm::llvm::PointerType(), "f" });
@@ -313,7 +313,7 @@ TestCallSummaryComputationDirectCalls()
     auto iOStateArgument = lambdaNode->fctargument(0);
     auto memoryStateArgument = lambdaNode->fctargument(1);
 
-    auto result = tests::create_testop(lambdaNode->subregion(), {}, { &*vt })[0];
+    auto result = tests::create_testop(lambdaNode->subregion(), {}, { vt })[0];
 
     return lambdaNode->finalize({ result, iOStateArgument, memoryStateArgument });
   };
@@ -362,7 +362,7 @@ TestCallSummaryComputationDirectCalls()
     auto result = tests::create_testop(
         lambdaNode->subregion(),
         { callXResults[0], callYResults[0] },
-        { &*vt })[0];
+        { vt })[0];
 
     auto lambdaOutput = lambdaNode->finalize({ result, callYResults[1], callYResults[2] });
     rvsdg.add_export(lambdaOutput, { jlm::llvm::PointerType(), "z" });

--- a/tests/jlm/llvm/ir/operators/TestPhi.cpp
+++ b/tests/jlm/llvm/ir/operators/TestPhi.cpp
@@ -20,8 +20,8 @@ TestPhiCreation()
   jlm::rvsdg::graph graph;
 
   auto vtype = jlm::tests::valuetype::Create();
-  iostatetype iOStateType;
-  MemoryStateType memoryStateType;
+  auto iOStateType = iostatetype::Create();
+  auto memoryStateType = MemoryStateType::Create();
   FunctionType f0type(
       { vtype, iostatetype::Create(), MemoryStateType::Create() },
       { iostatetype::Create(), MemoryStateType::Create() });
@@ -82,7 +82,7 @@ TestRemovePhiArgumentsWhere()
 
   // Arrange
   // The phi setup is nonsense, but it is sufficient for this test
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
   RvsdgModule rvsdgModule(jlm::util::filepath(""), "", "");
 
   auto x = rvsdgModule.Rvsdg().add_import({ valueType, "" });
@@ -90,16 +90,16 @@ TestRemovePhiArgumentsWhere()
   phi::builder phiBuilder;
   phiBuilder.begin(rvsdgModule.Rvsdg().root());
 
-  auto phiOutput0 = phiBuilder.add_recvar(valueType);
-  auto phiOutput1 = phiBuilder.add_recvar(valueType);
-  auto phiOutput2 = phiBuilder.add_recvar(valueType);
+  auto phiOutput0 = phiBuilder.add_recvar(*valueType);
+  auto phiOutput1 = phiBuilder.add_recvar(*valueType);
+  auto phiOutput2 = phiBuilder.add_recvar(*valueType);
   auto phiArgument3 = phiBuilder.add_ctxvar(x);
   auto phiArgument4 = phiBuilder.add_ctxvar(x);
 
   auto result = jlm::tests::SimpleNode::Create(
                     *phiBuilder.subregion(),
                     { phiOutput0->argument(), phiOutput2->argument(), phiArgument4 },
-                    { &valueType })
+                    { valueType })
                     .output(0);
 
   phiOutput0->set_rvorigin(result);
@@ -165,7 +165,7 @@ TestPrunePhiArguments()
 
   // Arrange
   // The phi setup is nonsense, but it is sufficient for this test
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
   RvsdgModule rvsdgModule(jlm::util::filepath(""), "", "");
 
   auto x = rvsdgModule.Rvsdg().add_import({ valueType, "" });
@@ -173,16 +173,16 @@ TestPrunePhiArguments()
   phi::builder phiBuilder;
   phiBuilder.begin(rvsdgModule.Rvsdg().root());
 
-  auto phiOutput0 = phiBuilder.add_recvar(valueType);
-  auto phiOutput1 = phiBuilder.add_recvar(valueType);
-  auto phiOutput2 = phiBuilder.add_recvar(valueType);
+  auto phiOutput0 = phiBuilder.add_recvar(*valueType);
+  auto phiOutput1 = phiBuilder.add_recvar(*valueType);
+  auto phiOutput2 = phiBuilder.add_recvar(*valueType);
   phiBuilder.add_ctxvar(x);
   auto phiArgument4 = phiBuilder.add_ctxvar(x);
 
   auto result = jlm::tests::SimpleNode::Create(
                     *phiBuilder.subregion(),
                     { phiOutput0->argument(), phiOutput2->argument(), phiArgument4 },
-                    { &valueType })
+                    { valueType })
                     .output(0);
 
   phiOutput0->set_rvorigin(result);
@@ -211,20 +211,20 @@ TestRemovePhiOutputsWhere()
 
   // Arrange
   // The phi setup is nonsense, but it is sufficient for this test
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
   RvsdgModule rvsdgModule(jlm::util::filepath(""), "", "");
 
   phi::builder phiBuilder;
   phiBuilder.begin(rvsdgModule.Rvsdg().root());
 
-  auto phiOutput0 = phiBuilder.add_recvar(valueType);
-  auto phiOutput1 = phiBuilder.add_recvar(valueType);
-  auto phiOutput2 = phiBuilder.add_recvar(valueType);
+  auto phiOutput0 = phiBuilder.add_recvar(*valueType);
+  auto phiOutput1 = phiBuilder.add_recvar(*valueType);
+  auto phiOutput2 = phiBuilder.add_recvar(*valueType);
 
   auto result = jlm::tests::SimpleNode::Create(
                     *phiBuilder.subregion(),
                     { phiOutput0->argument(), phiOutput2->argument() },
-                    { &valueType })
+                    { valueType })
                     .output(0);
 
   phiOutput0->set_rvorigin(result);
@@ -260,20 +260,20 @@ TestPrunePhiOutputs()
 
   // Arrange
   // The phi setup is nonsense, but it is sufficient for this test
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
   RvsdgModule rvsdgModule(jlm::util::filepath(""), "", "");
 
   phi::builder phiBuilder;
   phiBuilder.begin(rvsdgModule.Rvsdg().root());
 
-  auto phiOutput0 = phiBuilder.add_recvar(valueType);
-  auto phiOutput1 = phiBuilder.add_recvar(valueType);
-  auto phiOutput2 = phiBuilder.add_recvar(valueType);
+  auto phiOutput0 = phiBuilder.add_recvar(*valueType);
+  auto phiOutput1 = phiBuilder.add_recvar(*valueType);
+  auto phiOutput2 = phiBuilder.add_recvar(*valueType);
 
   auto result = jlm::tests::SimpleNode::Create(
                     *phiBuilder.subregion(),
                     { phiOutput0->argument(), phiOutput2->argument() },
-                    { &valueType })
+                    { valueType })
                     .output(0);
 
   phiOutput0->set_rvorigin(result);

--- a/tests/jlm/llvm/ir/operators/test-delta.cpp
+++ b/tests/jlm/llvm/ir/operators/test-delta.cpp
@@ -18,7 +18,7 @@ TestDeltaCreation()
   using namespace jlm::llvm;
 
   // Arrange & Act
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
   PointerType pointerType;
   RvsdgModule rvsdgModule(jlm::util::filepath(""), "", "");
 
@@ -26,23 +26,23 @@ TestDeltaCreation()
 
   auto delta1 = delta::node::Create(
       rvsdgModule.Rvsdg().root(),
-      valueType,
+      *valueType,
       "test-delta1",
       linkage::external_linkage,
       "",
       true);
   auto dep = delta1->add_ctxvar(imp);
   auto d1 =
-      delta1->finalize(jlm::tests::create_testop(delta1->subregion(), { dep }, { &valueType })[0]);
+      delta1->finalize(jlm::tests::create_testop(delta1->subregion(), { dep }, { valueType })[0]);
 
   auto delta2 = delta::node::Create(
       rvsdgModule.Rvsdg().root(),
-      valueType,
+      *valueType,
       "test-delta2",
       linkage::internal_linkage,
       "",
       false);
-  auto d2 = delta2->finalize(jlm::tests::create_testop(delta2->subregion(), {}, { &valueType })[0]);
+  auto d2 = delta2->finalize(jlm::tests::create_testop(delta2->subregion(), {}, { valueType })[0]);
 
   rvsdgModule.Rvsdg().add_export(d1, { d1->type(), "" });
   rvsdgModule.Rvsdg().add_export(d2, { d2->type(), "" });
@@ -54,11 +54,11 @@ TestDeltaCreation()
 
   assert(delta1->linkage() == linkage::external_linkage);
   assert(delta1->constant() == true);
-  assert(delta1->type() == valueType);
+  assert(delta1->type() == *valueType);
 
   assert(delta2->linkage() == linkage::internal_linkage);
   assert(delta2->constant() == false);
-  assert(delta2->type() == valueType);
+  assert(delta2->type() == *valueType);
 }
 
 static void
@@ -67,14 +67,14 @@ TestRemoveDeltaInputsWhere()
   using namespace jlm::llvm;
 
   // Arrange
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
   RvsdgModule rvsdgModule(jlm::util::filepath(""), "", "");
 
   auto x = rvsdgModule.Rvsdg().add_import({ valueType, "" });
 
   auto deltaNode = delta::node::Create(
       rvsdgModule.Rvsdg().root(),
-      valueType,
+      *valueType,
       "delta",
       linkage::external_linkage,
       "",
@@ -86,7 +86,7 @@ TestRemoveDeltaInputsWhere()
   auto result = jlm::tests::SimpleNode::Create(
                     *deltaNode->subregion(),
                     { deltaInput1->argument() },
-                    { &valueType })
+                    { valueType })
                     .output(0);
 
   deltaNode->finalize(result);
@@ -134,14 +134,14 @@ TestPruneDeltaInputs()
   using namespace jlm::llvm;
 
   // Arrange
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
   RvsdgModule rvsdgModule(jlm::util::filepath(""), "", "");
 
   auto x = rvsdgModule.Rvsdg().add_import({ valueType, "" });
 
   auto deltaNode = delta::node::Create(
       rvsdgModule.Rvsdg().root(),
-      valueType,
+      *valueType,
       "delta",
       linkage::external_linkage,
       "",
@@ -154,7 +154,7 @@ TestPruneDeltaInputs()
   auto result = jlm::tests::SimpleNode::Create(
                     *deltaNode->subregion(),
                     { deltaInput1->argument() },
-                    { &valueType })
+                    { valueType })
                     .output(0);
 
   deltaNode->finalize(result);

--- a/tests/jlm/llvm/ir/test-cfg-prune.cpp
+++ b/tests/jlm/llvm/ir/test-cfg-prune.cpp
@@ -18,8 +18,8 @@ test()
 {
   using namespace jlm::llvm;
 
-  jlm::tests::valuetype vt;
-  jlm::tests::test_op op({}, { &vt });
+  auto vt = jlm::tests::valuetype::Create();
+  jlm::tests::test_op op({}, { vt });
 
   /* setup cfg */
 

--- a/tests/jlm/llvm/ir/test-cfg-structure.cpp
+++ b/tests/jlm/llvm/ir/test-cfg-structure.cpp
@@ -19,7 +19,7 @@ test_straightening()
 {
   using namespace jlm::llvm;
 
-  jlm::tests::valuetype vt;
+  auto vt = jlm::tests::valuetype::Create();
   ipgraph_module module(jlm::util::filepath(""), "", "");
 
   jlm::llvm::cfg cfg(module);
@@ -33,9 +33,9 @@ test_straightening()
   bb3->add_outedge(cfg.exit());
 
   auto arg = cfg.entry()->append_argument(argument::create("arg", vt));
-  bb1->append_last(jlm::tests::create_testop_tac({ arg }, { &vt }));
-  bb2->append_last(jlm::tests::create_testop_tac({ arg }, { &vt }));
-  bb3->append_last(jlm::tests::create_testop_tac({ arg }, { &vt }));
+  bb1->append_last(jlm::tests::create_testop_tac({ arg }, { vt }));
+  bb2->append_last(jlm::tests::create_testop_tac({ arg }, { vt }));
+  bb3->append_last(jlm::tests::create_testop_tac({ arg }, { vt }));
 
   auto bb3_last = static_cast<const basic_block *>(bb3)->tacs().last();
   straighten(cfg);

--- a/tests/jlm/llvm/ir/test-cfg-validity.cpp
+++ b/tests/jlm/llvm/ir/test-cfg-validity.cpp
@@ -17,7 +17,7 @@ test_single_operand_phi()
 {
   using namespace jlm::llvm;
 
-  jlm::tests::valuetype vt;
+  auto vt = jlm::tests::valuetype::Create();
 
   ipgraph_module im(jlm::util::filepath(""), "", "");
 

--- a/tests/jlm/llvm/ir/test-ssa-destruction.cpp
+++ b/tests/jlm/llvm/ir/test-ssa-destruction.cpp
@@ -18,7 +18,7 @@ test_two_phis()
 {
   using namespace jlm::llvm;
 
-  jlm::tests::valuetype vt;
+  auto vt = jlm::tests::valuetype::Create();
   ipgraph_module module(jlm::util::filepath(""), "", "");
 
   jlm::llvm::cfg cfg(module);
@@ -34,16 +34,16 @@ test_two_phis()
   bb3->add_outedge(bb4);
   bb4->add_outedge(cfg.exit());
 
-  bb2->append_last(jlm::tests::create_testop_tac({}, { &vt }));
+  bb2->append_last(jlm::tests::create_testop_tac({}, { vt }));
   auto v1 = bb2->last()->result(0);
 
-  bb2->append_last(jlm::tests::create_testop_tac({}, { &vt }));
+  bb2->append_last(jlm::tests::create_testop_tac({}, { vt }));
   auto v3 = bb2->last()->result(0);
 
-  bb3->append_last(jlm::tests::create_testop_tac({}, { &vt }));
+  bb3->append_last(jlm::tests::create_testop_tac({}, { vt }));
   auto v2 = bb3->last()->result(0);
 
-  bb3->append_last(jlm::tests::create_testop_tac({}, { &vt }));
+  bb3->append_last(jlm::tests::create_testop_tac({}, { vt }));
   auto v4 = bb3->last()->result(0);
 
   bb4->append_last(phi_op::create({ { v1, bb2 }, { v2, bb3 } }, vt));

--- a/tests/jlm/llvm/opt/TestDeadNodeElimination.cpp
+++ b/tests/jlm/llvm/opt/TestDeadNodeElimination.cpp
@@ -49,8 +49,8 @@ TestGamma()
 {
   using namespace jlm::llvm;
 
-  jlm::tests::valuetype vt;
-  jlm::rvsdg::ctltype ct(2);
+  auto vt = jlm::tests::valuetype::Create();
+  auto ct = jlm::rvsdg::ctltype::Create(2);
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto & graph = rm.Rvsdg();
@@ -63,7 +63,7 @@ TestGamma()
   auto ev2 = gamma->add_entryvar(y);
   auto ev3 = gamma->add_entryvar(x);
 
-  auto t = jlm::tests::create_testop(gamma->subregion(1), { ev2->argument(1) }, { &vt })[0];
+  auto t = jlm::tests::create_testop(gamma->subregion(1), { ev2->argument(1) }, { vt })[0];
 
   gamma->add_exitvar({ ev1->argument(0), ev1->argument(1) });
   gamma->add_exitvar({ ev2->argument(0), t });
@@ -88,8 +88,8 @@ TestGamma2()
 {
   using namespace jlm::llvm;
 
-  jlm::tests::valuetype vt;
-  jlm::rvsdg::ctltype ct(2);
+  auto vt = jlm::tests::valuetype::Create();
+  auto ct = jlm::rvsdg::ctltype::Create(2);
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto & graph = rm.Rvsdg();
@@ -99,8 +99,8 @@ TestGamma2()
   auto gamma = jlm::rvsdg::gamma_node::create(c, 2);
   gamma->add_entryvar(x);
 
-  auto n1 = jlm::tests::create_testop(gamma->subregion(0), {}, { &vt })[0];
-  auto n2 = jlm::tests::create_testop(gamma->subregion(1), {}, { &vt })[0];
+  auto n1 = jlm::tests::create_testop(gamma->subregion(0), {}, { vt })[0];
+  auto n2 = jlm::tests::create_testop(gamma->subregion(1), {}, { vt })[0];
 
   gamma->add_exitvar({ n1, n2 });
 
@@ -118,8 +118,8 @@ TestTheta()
 {
   using namespace jlm::llvm;
 
-  jlm::tests::valuetype vt;
-  jlm::rvsdg::ctltype ct(2);
+  auto vt = jlm::tests::valuetype::Create();
+  auto ct = jlm::rvsdg::ctltype::Create(2);
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto & graph = rm.Rvsdg();
@@ -137,11 +137,11 @@ TestTheta()
   lv1->result()->divert_to(lv2->argument());
   lv2->result()->divert_to(lv1->argument());
 
-  auto t = jlm::tests::create_testop(theta->subregion(), { lv3->argument() }, { &vt })[0];
+  auto t = jlm::tests::create_testop(theta->subregion(), { lv3->argument() }, { vt })[0];
   lv3->result()->divert_to(t);
   lv4->result()->divert_to(lv2->argument());
 
-  auto c = jlm::tests::create_testop(theta->subregion(), {}, { &ct })[0];
+  auto c = jlm::tests::create_testop(theta->subregion(), {}, { ct })[0];
   theta->set_predicate(c);
 
   graph.add_export(theta->output(0), { theta->output(0)->type(), "a" });
@@ -161,8 +161,8 @@ TestNestedTheta()
 {
   using namespace jlm::llvm;
 
-  jlm::tests::valuetype vt;
-  jlm::rvsdg::ctltype ct(2);
+  auto vt = jlm::tests::valuetype::Create();
+  auto ct = jlm::rvsdg::ctltype::Create(2);
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto & graph = rm.Rvsdg();
@@ -205,8 +205,8 @@ TestEvolvingTheta()
 {
   using namespace jlm::llvm;
 
-  jlm::tests::valuetype vt;
-  jlm::rvsdg::ctltype ct(2);
+  auto vt = jlm::tests::valuetype::Create();
+  auto ct = jlm::rvsdg::ctltype::Create(2);
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto & graph = rm.Rvsdg();
@@ -256,7 +256,7 @@ TestLambda()
 
   auto cv1 = lambda->add_ctxvar(x);
   auto cv2 = lambda->add_ctxvar(y);
-  jlm::tests::create_testop(lambda->subregion(), { lambda->fctargument(0), cv1 }, { &*vt });
+  jlm::tests::create_testop(lambda->subregion(), { lambda->fctargument(0), cv1 }, { vt });
 
   auto output = lambda->finalize({ lambda->fctargument(0), cv2 });
 
@@ -294,7 +294,7 @@ TestPhi()
     auto result = jlm::tests::SimpleNode::Create(
                       *lambda1->subregion(),
                       { lambda1->fctargument(0), f2Argument, xArgument },
-                      { &*valueType })
+                      { valueType })
                       .output(0);
 
     return lambda1->finalize({ result });
@@ -309,7 +309,7 @@ TestPhi()
     auto result = jlm::tests::SimpleNode::Create(
                       *lambda2->subregion(),
                       { lambda2->fctargument(0), f1Argument },
-                      { &*valueType })
+                      { valueType })
                       .output(0);
 
     return lambda2->finalize({ result });
@@ -323,7 +323,7 @@ TestPhi()
     auto result = jlm::tests::SimpleNode::Create(
                       *lambda3->subregion(),
                       { lambda3->fctargument(0), zArgument },
-                      { &*valueType })
+                      { valueType })
                       .output(0);
 
     return lambda3->finalize({ result });
@@ -388,7 +388,7 @@ TestDelta()
   using namespace jlm::llvm;
 
   // Arrange
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
 
   RvsdgModule rvsdgModule(jlm::util::filepath(""), "", "");
   auto & rvsdg = rvsdgModule.Rvsdg();
@@ -398,14 +398,14 @@ TestDelta()
   auto z = rvsdg.add_import({ valueType, "z" });
 
   auto deltaNode =
-      delta::node::Create(rvsdg.root(), valueType, "delta", linkage::external_linkage, "", false);
+      delta::node::Create(rvsdg.root(), *valueType, "delta", linkage::external_linkage, "", false);
 
   auto xArgument = deltaNode->add_ctxvar(x);
   deltaNode->add_ctxvar(y);
   auto zArgument = deltaNode->add_ctxvar(z);
 
   auto result =
-      jlm::tests::SimpleNode::Create(*deltaNode->subregion(), { xArgument }, { &valueType })
+      jlm::tests::SimpleNode::Create(*deltaNode->subregion(), { xArgument }, { valueType })
           .output(0);
 
   jlm::tests::SimpleNode::Create(*deltaNode->subregion(), { zArgument }, {});

--- a/tests/jlm/llvm/opt/TestLoadMuxReduction.cpp
+++ b/tests/jlm/llvm/opt/TestLoadMuxReduction.cpp
@@ -17,7 +17,7 @@ TestSuccess()
   using namespace jlm::llvm;
 
   // Arrange
-  jlm::tests::valuetype vt;
+  auto vt = jlm::tests::valuetype::Create();
   PointerType pt;
   MemoryStateType mt;
 
@@ -71,7 +71,7 @@ TestWrongNumberOfOperands()
   // Arrange
   using namespace jlm::llvm;
 
-  jlm::tests::valuetype vt;
+  auto vt = jlm::tests::valuetype::Create();
   PointerType pt;
   MemoryStateType mt;
 
@@ -117,7 +117,7 @@ TestLoadWithoutStates()
   using namespace jlm::llvm;
 
   // Arrange
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
   PointerType pointerType;
 
   jlm::rvsdg::graph graph;

--- a/tests/jlm/llvm/opt/TestLoadStoreReduction.cpp
+++ b/tests/jlm/llvm/opt/TestLoadStoreReduction.cpp
@@ -21,7 +21,7 @@ TestLoadStoreReductionWithDifferentValueOperandType()
 
   // Arrange
   PointerType pointerType;
-  MemoryStateType memoryStateType;
+  auto memoryStateType = MemoryStateType::Create();
 
   jlm::rvsdg::graph graph;
   auto nf = LoadNonVolatileOperation::GetNormalForm(&graph);

--- a/tests/jlm/llvm/opt/test-cne.cpp
+++ b/tests/jlm/llvm/opt/test-cne.cpp
@@ -24,7 +24,7 @@ test_simple()
 {
   using namespace jlm::llvm;
 
-  jlm::tests::valuetype vt;
+  auto vt = jlm::tests::valuetype::Create();
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto & graph = rm.Rvsdg();
@@ -35,15 +35,15 @@ test_simple()
   auto y = graph.add_import({ vt, "y" });
   auto z = graph.add_import({ vt, "z" });
 
-  auto n1 = jlm::tests::create_testop(graph.root(), {}, { &vt })[0];
-  auto n2 = jlm::tests::create_testop(graph.root(), {}, { &vt })[0];
+  auto n1 = jlm::tests::create_testop(graph.root(), {}, { vt })[0];
+  auto n2 = jlm::tests::create_testop(graph.root(), {}, { vt })[0];
 
-  auto u1 = jlm::tests::create_testop(graph.root(), { z }, { &vt })[0];
+  auto u1 = jlm::tests::create_testop(graph.root(), { z }, { vt })[0];
 
-  auto b1 = jlm::tests::create_testop(graph.root(), { x, y }, { &vt })[0];
-  auto b2 = jlm::tests::create_testop(graph.root(), { x, y }, { &vt })[0];
-  auto b3 = jlm::tests::create_testop(graph.root(), { n1, z }, { &vt })[0];
-  auto b4 = jlm::tests::create_testop(graph.root(), { n2, z }, { &vt })[0];
+  auto b1 = jlm::tests::create_testop(graph.root(), { x, y }, { vt })[0];
+  auto b2 = jlm::tests::create_testop(graph.root(), { x, y }, { vt })[0];
+  auto b3 = jlm::tests::create_testop(graph.root(), { n1, z }, { vt })[0];
+  auto b4 = jlm::tests::create_testop(graph.root(), { n2, z }, { vt })[0];
 
   graph.add_export(n1, { n1->type(), "n1" });
   graph.add_export(n2, { n2->type(), "n2" });
@@ -68,8 +68,8 @@ test_gamma()
 {
   using namespace jlm::llvm;
 
-  jlm::tests::valuetype vt;
-  jlm::rvsdg::ctltype ct(2);
+  auto vt = jlm::tests::valuetype::Create();
+  auto ct = jlm::rvsdg::ctltype::Create(2);
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto & graph = rm.Rvsdg();
@@ -81,8 +81,8 @@ test_gamma()
   auto y = graph.add_import({ vt, "y" });
   auto z = graph.add_import({ vt, "z" });
 
-  auto u1 = jlm::tests::create_testop(graph.root(), { x }, { &vt })[0];
-  auto u2 = jlm::tests::create_testop(graph.root(), { x }, { &vt })[0];
+  auto u1 = jlm::tests::create_testop(graph.root(), { x }, { vt })[0];
+  auto u2 = jlm::tests::create_testop(graph.root(), { x }, { vt })[0];
 
   auto gamma = jlm::rvsdg::gamma_node::create(c, 2);
 
@@ -92,9 +92,9 @@ test_gamma()
   auto ev4 = gamma->add_entryvar(z);
   auto ev5 = gamma->add_entryvar(z);
 
-  auto n1 = jlm::tests::create_testop(gamma->subregion(0), {}, { &vt })[0];
-  auto n2 = jlm::tests::create_testop(gamma->subregion(0), {}, { &vt })[0];
-  auto n3 = jlm::tests::create_testop(gamma->subregion(0), {}, { &vt })[0];
+  auto n1 = jlm::tests::create_testop(gamma->subregion(0), {}, { vt })[0];
+  auto n2 = jlm::tests::create_testop(gamma->subregion(0), {}, { vt })[0];
+  auto n3 = jlm::tests::create_testop(gamma->subregion(0), {}, { vt })[0];
 
   gamma->add_exitvar({ ev1->argument(0), ev2->argument(1) });
   gamma->add_exitvar({ ev2->argument(0), ev2->argument(1) });
@@ -132,8 +132,8 @@ test_theta()
 {
   using namespace jlm::llvm;
 
-  jlm::tests::valuetype vt;
-  jlm::rvsdg::ctltype ct(2);
+  auto vt = jlm::tests::valuetype::Create();
+  auto ct = jlm::rvsdg::ctltype::Create(2);
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto & graph = rm.Rvsdg();
@@ -151,9 +151,9 @@ test_theta()
   auto lv3 = theta->add_loopvar(x);
   auto lv4 = theta->add_loopvar(x);
 
-  auto u1 = jlm::tests::create_testop(region, { lv2->argument() }, { &vt })[0];
-  auto u2 = jlm::tests::create_testop(region, { lv3->argument() }, { &vt })[0];
-  auto b1 = jlm::tests::create_testop(region, { lv3->argument(), lv4->argument() }, { &vt })[0];
+  auto u1 = jlm::tests::create_testop(region, { lv2->argument() }, { vt })[0];
+  auto u2 = jlm::tests::create_testop(region, { lv3->argument() }, { vt })[0];
+  auto b1 = jlm::tests::create_testop(region, { lv3->argument(), lv4->argument() }, { vt })[0];
 
   lv2->result()->divert_to(u1);
   lv3->result()->divert_to(u2);
@@ -185,8 +185,8 @@ test_theta2()
 {
   using namespace jlm::llvm;
 
-  jlm::tests::valuetype vt;
-  jlm::rvsdg::ctltype ct(2);
+  auto vt = jlm::tests::valuetype::Create();
+  auto ct = jlm::rvsdg::ctltype::Create(2);
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto & graph = rm.Rvsdg();
@@ -203,9 +203,9 @@ test_theta2()
   auto lv2 = theta->add_loopvar(x);
   auto lv3 = theta->add_loopvar(x);
 
-  auto u1 = jlm::tests::create_testop(region, { lv2->argument() }, { &vt })[0];
-  auto u2 = jlm::tests::create_testop(region, { lv3->argument() }, { &vt })[0];
-  auto b1 = jlm::tests::create_testop(region, { u2, u2 }, { &vt })[0];
+  auto u1 = jlm::tests::create_testop(region, { lv2->argument() }, { vt })[0];
+  auto u2 = jlm::tests::create_testop(region, { lv3->argument() }, { vt })[0];
+  auto b1 = jlm::tests::create_testop(region, { u2, u2 }, { vt })[0];
 
   lv2->result()->divert_to(u1);
   lv3->result()->divert_to(b1);
@@ -229,8 +229,8 @@ test_theta3()
 {
   using namespace jlm::llvm;
 
-  jlm::tests::valuetype vt;
-  jlm::rvsdg::ctltype ct(2);
+  auto vt = jlm::tests::valuetype::Create();
+  auto ct = jlm::rvsdg::ctltype::Create(2);
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto & graph = rm.Rvsdg();
@@ -256,9 +256,9 @@ test_theta3()
   theta2->add_loopvar(lv4->argument());
   theta2->set_predicate(p->argument());
 
-  auto u1 = jlm::tests::test_op::create(r1, { theta2->output(1) }, { &vt });
-  auto b1 = jlm::tests::test_op::create(r1, { theta2->output(2), theta2->output(2) }, { &vt });
-  auto u2 = jlm::tests::test_op::create(r1, { theta2->output(3) }, { &vt });
+  auto u1 = jlm::tests::test_op::create(r1, { theta2->output(1) }, { vt });
+  auto b1 = jlm::tests::test_op::create(r1, { theta2->output(2), theta2->output(2) }, { vt });
+  auto u2 = jlm::tests::test_op::create(r1, { theta2->output(3) }, { vt });
 
   lv2->result()->divert_to(u1->output(0));
   lv3->result()->divert_to(b1->output(0));
@@ -288,8 +288,8 @@ test_theta4()
 {
   using namespace jlm::llvm;
 
-  jlm::tests::valuetype vt;
-  jlm::rvsdg::ctltype ct(2);
+  auto vt = jlm::tests::valuetype::Create();
+  auto ct = jlm::rvsdg::ctltype::Create(2);
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto & graph = rm.Rvsdg();
@@ -311,8 +311,8 @@ test_theta4()
   auto lv6 = theta->add_loopvar(x);
   auto lv7 = theta->add_loopvar(x);
 
-  auto u1 = jlm::tests::test_op::create(region, { lv2->argument() }, { &vt });
-  auto b1 = jlm::tests::test_op::create(region, { lv3->argument(), lv3->argument() }, { &vt });
+  auto u1 = jlm::tests::test_op::create(region, { lv2->argument() }, { vt });
+  auto b1 = jlm::tests::test_op::create(region, { lv3->argument(), lv3->argument() }, { vt });
 
   lv2->result()->divert_to(lv4->argument());
   lv3->result()->divert_to(lv5->argument());
@@ -341,8 +341,8 @@ test_theta5()
 {
   using namespace jlm::llvm;
 
-  jlm::tests::valuetype vt;
-  jlm::rvsdg::ctltype ct(2);
+  auto vt = jlm::tests::valuetype::Create();
+  auto ct = jlm::rvsdg::ctltype::Create(2);
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto & graph = rm.Rvsdg();
@@ -403,7 +403,7 @@ test_lambda()
   auto d1 = lambda->add_ctxvar(x);
   auto d2 = lambda->add_ctxvar(x);
 
-  auto b1 = jlm::tests::create_testop(lambda->subregion(), { d1, d2 }, { &*vt })[0];
+  auto b1 = jlm::tests::create_testop(lambda->subregion(), { d1, d2 }, { vt })[0];
 
   auto output = lambda->finalize({ b1 });
 

--- a/tests/jlm/llvm/opt/test-inlining.cpp
+++ b/tests/jlm/llvm/opt/test-inlining.cpp
@@ -31,8 +31,8 @@ test1()
   auto SetupF1 = [&]()
   {
     auto vt = jlm::tests::valuetype::Create();
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { vt, iostatetype::Create(), MemoryStateType::Create() },
         { vt, iostatetype::Create(), MemoryStateType::Create() });
@@ -40,7 +40,7 @@ test1()
     auto lambda = lambda::node::create(graph.root(), functionType, "f1", linkage::external_linkage);
     lambda->add_ctxvar(i);
 
-    auto t = jlm::tests::test_op::create(lambda->subregion(), { lambda->fctargument(0) }, { &*vt });
+    auto t = jlm::tests::test_op::create(lambda->subregion(), { lambda->fctargument(0) }, { vt });
 
     return lambda->finalize({ t->output(0), lambda->fctargument(1), lambda->fctargument(2) });
   };
@@ -48,9 +48,9 @@ test1()
   auto SetupF2 = [&](lambda::output * f1)
   {
     auto vt = jlm::tests::valuetype::Create();
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
-    jlm::rvsdg::ctltype ct(2);
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
+    auto ct = jlm::rvsdg::ctltype::Create(2);
     FunctionType functionType(
         { jlm::rvsdg::ctltype::Create(2), vt, iostatetype::Create(), MemoryStateType::Create() },
         { vt, iostatetype::Create(), MemoryStateType::Create() });
@@ -107,8 +107,8 @@ test2()
 
   // Arrange
   auto vt = jlm::tests::valuetype::Create();
-  iostatetype iOStateType;
-  MemoryStateType memoryStateType;
+  auto iOStateType = iostatetype::Create();
+  auto memoryStateType = MemoryStateType::Create();
 
   FunctionType functionType1(
       { vt, iostatetype::Create(), MemoryStateType::Create() },
@@ -131,8 +131,8 @@ test2()
 
   auto SetupF2 = [&](lambda::output * f1)
   {
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { iostatetype::Create(), MemoryStateType::Create() },
         { iostatetype::Create(), MemoryStateType::Create() });

--- a/tests/jlm/llvm/opt/test-inversion.cpp
+++ b/tests/jlm/llvm/opt/test-inversion.cpp
@@ -14,7 +14,7 @@
 #include <jlm/llvm/opt/inversion.hpp>
 #include <jlm/util/Statistics.hpp>
 
-static const jlm::tests::valuetype vt;
+static const auto vt = jlm::tests::valuetype::Create();
 static jlm::util::StatisticsCollector statisticsCollector;
 
 static inline void
@@ -38,7 +38,7 @@ test1()
   auto a = jlm::tests::create_testop(
       theta->subregion(),
       { lvx->argument(), lvy->argument() },
-      { &*jlm::rvsdg::bittype::Create(1) })[0];
+      { jlm::rvsdg::bittype::Create(1) })[0];
   auto predicate = jlm::rvsdg::match(1, { { 1, 0 } }, 1, 2, a);
 
   auto gamma = jlm::rvsdg::gamma_node::create(predicate, 2);
@@ -49,11 +49,11 @@ test1()
   auto b = jlm::tests::create_testop(
       gamma->subregion(0),
       { evx->argument(0), evy->argument(0) },
-      { &vt })[0];
+      { vt })[0];
   auto c = jlm::tests::create_testop(
       gamma->subregion(1),
       { evx->argument(1), evy->argument(1) },
-      { &vt })[0];
+      { vt })[0];
 
   auto xvy = gamma->add_exitvar({ b, c });
 
@@ -92,8 +92,8 @@ test2()
   auto n1 = jlm::tests::create_testop(
       theta->subregion(),
       { lv1->argument() },
-      { &*jlm::rvsdg::bittype::Create(1) })[0];
-  auto n2 = jlm::tests::create_testop(theta->subregion(), { lv1->argument() }, { &vt })[0];
+      { jlm::rvsdg::bittype::Create(1) })[0];
+  auto n2 = jlm::tests::create_testop(theta->subregion(), { lv1->argument() }, { vt })[0];
   auto predicate = jlm::rvsdg::match(1, { { 1, 0 } }, 1, 2, n1);
 
   auto gamma = jlm::rvsdg::gamma_node::create(predicate, 2);

--- a/tests/jlm/llvm/opt/test-pull.cpp
+++ b/tests/jlm/llvm/opt/test-pull.cpp
@@ -14,7 +14,7 @@
 #include <jlm/llvm/opt/pull.hpp>
 #include <jlm/util/Statistics.hpp>
 
-static const jlm::tests::valuetype vt;
+static const auto vt = jlm::tests::valuetype::Create();
 static jlm::util::StatisticsCollector statisticsCollector;
 
 static inline void
@@ -22,10 +22,10 @@ test_pullin_top()
 {
   using namespace jlm::llvm;
 
-  jlm::rvsdg::ctltype ct(2);
-  jlm::tests::test_op uop({ &vt }, { &vt });
-  jlm::tests::test_op bop({ &vt, &vt }, { &vt });
-  jlm::tests::test_op cop({ &ct, &vt }, { &ct });
+  auto ct = jlm::rvsdg::ctltype::Create(2);
+  jlm::tests::test_op uop({ vt }, { vt });
+  jlm::tests::test_op bop({ vt, vt }, { vt });
+  jlm::tests::test_op cop({ ct, vt }, { ct });
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto & graph = rm.Rvsdg();
@@ -33,11 +33,11 @@ test_pullin_top()
   auto c = graph.add_import({ ct, "c" });
   auto x = graph.add_import({ vt, "x" });
 
-  auto n1 = jlm::tests::create_testop(graph.root(), { x }, { &vt })[0];
-  auto n2 = jlm::tests::create_testop(graph.root(), { x }, { &vt })[0];
-  auto n3 = jlm::tests::create_testop(graph.root(), { n2 }, { &vt })[0];
-  auto n4 = jlm::tests::create_testop(graph.root(), { c, n1 }, { &ct })[0];
-  auto n5 = jlm::tests::create_testop(graph.root(), { n1, n3 }, { &vt })[0];
+  auto n1 = jlm::tests::create_testop(graph.root(), { x }, { vt })[0];
+  auto n2 = jlm::tests::create_testop(graph.root(), { x }, { vt })[0];
+  auto n3 = jlm::tests::create_testop(graph.root(), { n2 }, { vt })[0];
+  auto n4 = jlm::tests::create_testop(graph.root(), { c, n1 }, { ct })[0];
+  auto n5 = jlm::tests::create_testop(graph.root(), { n1, n3 }, { vt })[0];
 
   auto gamma = jlm::rvsdg::gamma_node::create(n4, 2);
 
@@ -59,8 +59,8 @@ test_pullin_top()
 static inline void
 test_pullin_bottom()
 {
-  jlm::tests::valuetype vt;
-  jlm::rvsdg::ctltype ct(2);
+  auto vt = jlm::tests::valuetype::Create();
+  auto ct = jlm::rvsdg::ctltype::Create(2);
 
   jlm::rvsdg::graph graph;
   auto c = graph.add_import({ ct, "c" });
@@ -71,8 +71,8 @@ test_pullin_bottom()
   auto ev = gamma->add_entryvar(x);
   gamma->add_exitvar({ ev->argument(0), ev->argument(1) });
 
-  auto b1 = jlm::tests::create_testop(graph.root(), { gamma->output(0), x }, { &vt })[0];
-  auto b2 = jlm::tests::create_testop(graph.root(), { gamma->output(0), b1 }, { &vt })[0];
+  auto b1 = jlm::tests::create_testop(graph.root(), { gamma->output(0), x }, { vt })[0];
+  auto b2 = jlm::tests::create_testop(graph.root(), { gamma->output(0), b1 }, { vt })[0];
 
   auto xp = graph.add_export(b2, { b2->type(), "x" });
 
@@ -95,20 +95,20 @@ test_pull()
 
   auto p = graph.add_import({ *jlm::rvsdg::ctltype::Create(2), "" });
 
-  auto croot = jlm::tests::create_testop(graph.root(), {}, { &vt })[0];
+  auto croot = jlm::tests::create_testop(graph.root(), {}, { vt })[0];
 
   /* outer gamma */
   auto gamma1 = jlm::rvsdg::gamma_node::create(p, 2);
   auto ev1 = gamma1->add_entryvar(p);
   auto ev2 = gamma1->add_entryvar(croot);
 
-  auto cg1 = jlm::tests::create_testop(gamma1->subregion(0), {}, { &vt })[0];
+  auto cg1 = jlm::tests::create_testop(gamma1->subregion(0), {}, { vt })[0];
 
   /* inner gamma */
   auto gamma2 = jlm::rvsdg::gamma_node::create(ev1->argument(1), 2);
   auto ev3 = gamma2->add_entryvar(ev2->argument(1));
-  auto cg2 = jlm::tests::create_testop(gamma2->subregion(0), {}, { &vt })[0];
-  auto un = jlm::tests::create_testop(gamma2->subregion(1), { ev3->argument(1) }, { &vt })[0];
+  auto cg2 = jlm::tests::create_testop(gamma2->subregion(0), {}, { vt })[0];
+  auto un = jlm::tests::create_testop(gamma2->subregion(1), { ev3->argument(1) }, { vt })[0];
   auto g2xv = gamma2->add_exitvar({ cg2, un });
 
   auto g1xv = gamma1->add_exitvar({ cg1, g2xv });

--- a/tests/jlm/llvm/opt/test-push.cpp
+++ b/tests/jlm/llvm/opt/test-push.cpp
@@ -16,8 +16,8 @@
 #include <jlm/llvm/opt/push.hpp>
 #include <jlm/util/Statistics.hpp>
 
-static const jlm::tests::statetype st;
-static const jlm::tests::valuetype vt;
+static const auto st = jlm::tests::statetype::Create();
+static const auto vt = jlm::tests::valuetype::Create();
 static jlm::util::StatisticsCollector statisticsCollector;
 
 static inline void
@@ -25,7 +25,7 @@ test_gamma()
 {
   using namespace jlm::llvm;
 
-  jlm::rvsdg::ctltype ct(2);
+  auto ct = jlm::rvsdg::ctltype::Create(2);
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto & graph = rm.Rvsdg();
@@ -38,10 +38,9 @@ test_gamma()
   auto evx = gamma->add_entryvar(x);
   auto evs = gamma->add_entryvar(s);
 
-  auto null = jlm::tests::create_testop(gamma->subregion(0), {}, { &vt })[0];
-  auto bin = jlm::tests::create_testop(gamma->subregion(0), { null, evx->argument(0) }, { &vt })[0];
-  auto state =
-      jlm::tests::create_testop(gamma->subregion(0), { bin, evs->argument(0) }, { &st })[0];
+  auto null = jlm::tests::create_testop(gamma->subregion(0), {}, { vt })[0];
+  auto bin = jlm::tests::create_testop(gamma->subregion(0), { null, evx->argument(0) }, { vt })[0];
+  auto state = jlm::tests::create_testop(gamma->subregion(0), { bin, evs->argument(0) }, { st })[0];
 
   gamma->add_exitvar({ state, evs->argument(1) });
 
@@ -60,11 +59,11 @@ test_theta()
 {
   using namespace jlm::llvm;
 
-  jlm::rvsdg::ctltype ct(2);
+  auto ct = jlm::rvsdg::ctltype::Create(2);
 
-  jlm::tests::test_op nop({}, { &vt });
-  jlm::tests::test_op bop({ &vt, &vt }, { &vt });
-  jlm::tests::test_op sop({ &vt, &st }, { &st });
+  jlm::tests::test_op nop({}, { vt });
+  jlm::tests::test_op bop({ vt, vt }, { vt });
+  jlm::tests::test_op sop({ vt, st }, { st });
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto & graph = rm.Rvsdg();
@@ -80,13 +79,13 @@ test_theta()
   auto lv3 = theta->add_loopvar(x);
   auto lv4 = theta->add_loopvar(s);
 
-  auto o1 = jlm::tests::create_testop(theta->subregion(), {}, { &vt })[0];
-  auto o2 = jlm::tests::create_testop(theta->subregion(), { o1, lv3->argument() }, { &vt })[0];
-  auto o3 = jlm::tests::create_testop(theta->subregion(), { lv2->argument(), o2 }, { &vt })[0];
+  auto o1 = jlm::tests::create_testop(theta->subregion(), {}, { vt })[0];
+  auto o2 = jlm::tests::create_testop(theta->subregion(), { o1, lv3->argument() }, { vt })[0];
+  auto o3 = jlm::tests::create_testop(theta->subregion(), { lv2->argument(), o2 }, { vt })[0];
   auto o4 = jlm::tests::create_testop(
       theta->subregion(),
       { lv3->argument(), lv4->argument() },
-      { &st })[0];
+      { st })[0];
 
   lv2->result()->divert_to(o3);
   lv4->result()->divert_to(o4);
@@ -110,7 +109,7 @@ test_push_theta_bottom()
 
   MemoryStateType mt;
   PointerType pt;
-  jlm::rvsdg::ctltype ct(2);
+  auto ct = jlm::rvsdg::ctltype::Create(2);
 
   jlm::rvsdg::graph graph;
   auto c = graph.add_import({ ct, "c" });

--- a/tests/jlm/llvm/opt/test-unroll.cpp
+++ b/tests/jlm/llvm/opt/test-unroll.cpp
@@ -233,8 +233,8 @@ test_unknown_boundaries()
 {
   using namespace jlm::llvm;
 
-  jlm::rvsdg::bittype bt(32);
-  jlm::tests::test_op op({ &bt }, { &bt });
+  auto bt = jlm::rvsdg::bittype::Create(32);
+  jlm::tests::test_op op({ bt }, { bt });
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto & graph = rm.Rvsdg();

--- a/tests/jlm/mlir/backend/TestJlmToMlirConverter.cpp
+++ b/tests/jlm/mlir/backend/TestJlmToMlirConverter.cpp
@@ -26,8 +26,8 @@ TestLambda()
   {
     // Setup the function
     std::cout << "Function Setup" << std::endl;
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
@@ -147,8 +147,8 @@ TestAddOperation()
   {
     // Setup the function
     std::cout << "Function Setup" << std::endl;
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
@@ -248,8 +248,8 @@ TestComZeroExt()
   {
     // Setup the function
     std::cout << "Function Setup" << std::endl;
-    iostatetype iOStateType;
-    MemoryStateType memoryStateType;
+    auto iOStateType = iostatetype::Create();
+    auto memoryStateType = MemoryStateType::Create();
     FunctionType functionType(
         { iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(1), iostatetype::Create(), MemoryStateType::Create() });

--- a/tests/jlm/rvsdg/TestRegion.cpp
+++ b/tests/jlm/rvsdg/TestRegion.cpp
@@ -17,7 +17,7 @@ TestArgumentNodeMismatch()
 {
   using namespace jlm::rvsdg;
 
-  jlm::tests::valuetype vt;
+  auto vt = jlm::tests::valuetype::Create();
 
   jlm::rvsdg::graph graph;
   auto import = graph.add_import({ vt, "import" });
@@ -48,7 +48,7 @@ TestResultNodeMismatch()
 {
   using namespace jlm::rvsdg;
 
-  jlm::tests::valuetype vt;
+  auto vt = jlm::tests::valuetype::Create();
 
   jlm::rvsdg::graph graph;
   auto import = graph.add_import({ vt, "import" });
@@ -153,8 +153,8 @@ TestRemoveResultsWhere()
   jlm::rvsdg::graph rvsdg;
   jlm::rvsdg::region region(rvsdg.root(), &rvsdg);
 
-  jlm::tests::valuetype valueType;
-  auto node = jlm::tests::test_op::Create(&region, {}, {}, { &valueType });
+  auto valueType = jlm::tests::valuetype::Create();
+  auto node = jlm::tests::test_op::Create(&region, {}, {}, { valueType });
 
   auto result0 =
       jlm::rvsdg::result::create(&region, node->output(0), nullptr, jlm::rvsdg::port(valueType));
@@ -205,12 +205,12 @@ TestRemoveArgumentsWhere()
   jlm::rvsdg::graph rvsdg;
   jlm::rvsdg::region region(rvsdg.root(), &rvsdg);
 
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
   auto argument0 = jlm::rvsdg::argument::create(&region, nullptr, jlm::rvsdg::port(valueType));
   auto argument1 = jlm::rvsdg::argument::create(&region, nullptr, jlm::rvsdg::port(valueType));
   auto argument2 = jlm::rvsdg::argument::create(&region, nullptr, jlm::rvsdg::port(valueType));
 
-  auto node = jlm::tests::test_op::Create(&region, { &valueType }, { argument1 }, { &valueType });
+  auto node = jlm::tests::test_op::Create(&region, { valueType }, { argument1 }, { valueType });
 
   // Act & Arrange
   assert(region.narguments() == 3);
@@ -253,16 +253,16 @@ TestPruneArguments()
   jlm::rvsdg::graph rvsdg;
   jlm::rvsdg::region region(rvsdg.root(), &rvsdg);
 
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
   auto argument0 = jlm::rvsdg::argument::create(&region, nullptr, jlm::rvsdg::port(valueType));
   jlm::rvsdg::argument::create(&region, nullptr, jlm::rvsdg::port(valueType));
   auto argument2 = jlm::rvsdg::argument::create(&region, nullptr, jlm::rvsdg::port(valueType));
 
   auto node = jlm::tests::test_op::Create(
       &region,
-      { &valueType, &valueType },
+      { valueType, valueType },
       { argument0, argument2 },
-      { &valueType });
+      { valueType });
 
   // Act & Arrange
   assert(region.narguments() == 3);

--- a/tests/jlm/rvsdg/test-binary.cpp
+++ b/tests/jlm/rvsdg/test-binary.cpp
@@ -14,8 +14,8 @@ test_flattened_binary_reduction()
 {
   using namespace jlm::rvsdg;
 
-  jlm::tests::valuetype vt;
-  jlm::tests::binary_op op(vt, vt, binary_op::flags::associative);
+  auto vt = jlm::tests::valuetype::Create();
+  jlm::tests::binary_op op(*vt, *vt, binary_op::flags::associative);
 
   /* test paralell reduction */
   {

--- a/tests/jlm/rvsdg/test-bottomup.cpp
+++ b/tests/jlm/rvsdg/test-bottomup.cpp
@@ -13,9 +13,9 @@ static void
 test_initialization()
 {
   jlm::rvsdg::graph graph;
-  jlm::tests::valuetype vtype;
+  auto vtype = jlm::tests::valuetype::Create();
   auto n1 = jlm::tests::test_op::create(graph.root(), {}, {});
-  auto n2 = jlm::tests::test_op::create(graph.root(), {}, { &vtype });
+  auto n2 = jlm::tests::test_op::create(graph.root(), {}, { vtype });
 
   graph.add_export(n2->output(0), { n2->output(0)->type(), "dummy" });
 
@@ -37,9 +37,9 @@ static void
 test_basic_traversal()
 {
   jlm::rvsdg::graph graph;
-  jlm::tests::valuetype type;
-  auto n1 = jlm::tests::test_op::create(graph.root(), {}, { &type, &type });
-  auto n2 = jlm::tests::test_op::create(graph.root(), { n1->output(0), n1->output(1) }, { &type });
+  auto type = jlm::tests::valuetype::Create();
+  auto n1 = jlm::tests::test_op::create(graph.root(), {}, { type, type });
+  auto n2 = jlm::tests::test_op::create(graph.root(), { n1->output(0), n1->output(1) }, { type });
 
   graph.add_export(n2->output(0), { n2->output(0)->type(), "dummy" });
 
@@ -61,10 +61,10 @@ static void
 test_order_enforcement_traversal()
 {
   jlm::rvsdg::graph graph;
-  jlm::tests::valuetype type;
-  auto n1 = jlm::tests::test_op::create(graph.root(), {}, { &type, &type });
-  auto n2 = jlm::tests::test_op::create(graph.root(), { n1->output(0) }, { &type });
-  auto n3 = jlm::tests::test_op::create(graph.root(), { n2->output(0), n1->output(1) }, { &type });
+  auto type = jlm::tests::valuetype::Create();
+  auto n1 = jlm::tests::test_op::create(graph.root(), {}, { type, type });
+  auto n2 = jlm::tests::test_op::create(graph.root(), { n1->output(0) }, { type });
+  auto n3 = jlm::tests::test_op::create(graph.root(), { n2->output(0), n1->output(1) }, { type });
 
   jlm::rvsdg::node * tmp;
   {

--- a/tests/jlm/rvsdg/test-cse.cpp
+++ b/tests/jlm/rvsdg/test-cse.cpp
@@ -12,13 +12,13 @@ test_main()
 {
   using namespace jlm::rvsdg;
 
-  jlm::tests::valuetype t;
+  auto t = jlm::tests::valuetype::Create();
 
   jlm::rvsdg::graph graph;
   auto i = graph.add_import({ t, "i" });
 
-  auto o1 = jlm::tests::test_op::create(graph.root(), {}, { &t })->output(0);
-  auto o2 = jlm::tests::test_op::create(graph.root(), { i }, { &t })->output(0);
+  auto o1 = jlm::tests::test_op::create(graph.root(), {}, { t })->output(0);
+  auto o2 = jlm::tests::test_op::create(graph.root(), { i }, { t })->output(0);
 
   auto e1 = graph.add_export(o1, { o1->type(), "o1" });
   auto e2 = graph.add_export(o2, { o2->type(), "o2" });
@@ -27,8 +27,8 @@ test_main()
       graph.node_normal_form(typeid(jlm::tests::test_op)));
   nf->set_mutable(false);
 
-  auto o3 = jlm::tests::create_testop(graph.root(), {}, { &t })[0];
-  auto o4 = jlm::tests::create_testop(graph.root(), { i }, { &t })[0];
+  auto o3 = jlm::tests::create_testop(graph.root(), {}, { t })[0];
+  auto o4 = jlm::tests::create_testop(graph.root(), { i }, { t })[0];
 
   auto e3 = graph.add_export(o3, { o3->type(), "o3" });
   auto e4 = graph.add_export(o4, { o4->type(), "o4" });
@@ -38,15 +38,15 @@ test_main()
   assert(e1->origin() == e3->origin());
   assert(e2->origin() == e4->origin());
 
-  auto o5 = jlm::tests::create_testop(graph.root(), {}, { &t })[0];
+  auto o5 = jlm::tests::create_testop(graph.root(), {}, { t })[0];
   assert(o5 == e1->origin());
 
-  auto o6 = jlm::tests::create_testop(graph.root(), { i }, { &t })[0];
+  auto o6 = jlm::tests::create_testop(graph.root(), { i }, { t })[0];
   assert(o6 == e2->origin());
 
   nf->set_cse(false);
 
-  auto o7 = jlm::tests::create_testop(graph.root(), {}, { &t })[0];
+  auto o7 = jlm::tests::create_testop(graph.root(), {}, { t })[0];
   assert(o7 != e1->origin());
 
   graph.normalize();

--- a/tests/jlm/rvsdg/test-gamma.cpp
+++ b/tests/jlm/rvsdg/test-gamma.cpp
@@ -183,7 +183,7 @@ TestRemoveGammaOutputsWhere()
 
   // Arrange
   jlm::rvsdg::graph rvsdg;
-  jlm::tests::valuetype vt;
+  auto vt = jlm::tests::valuetype::Create();
   ctltype ct(2);
 
   auto predicate = rvsdg.add_import({ *ctltype::Create(2), "" });
@@ -245,7 +245,7 @@ TestPruneOutputs()
 
   // Arrange
   jlm::rvsdg::graph rvsdg;
-  jlm::tests::valuetype vt;
+  auto vt = jlm::tests::valuetype::Create();
   ctltype ct(2);
 
   auto predicate = rvsdg.add_import({ *ctltype::Create(2), "" });
@@ -294,7 +294,7 @@ TestIsInvariant()
 
   // Arrange
   jlm::rvsdg::graph rvsdg;
-  jlm::tests::valuetype vt;
+  auto vt = jlm::tests::valuetype::Create();
   ctltype ct(2);
 
   auto predicate = rvsdg.add_import({ *ctltype::Create(2), "" });

--- a/tests/jlm/rvsdg/test-graph.cpp
+++ b/tests/jlm/rvsdg/test-graph.cpp
@@ -30,19 +30,19 @@ test_recursive_prune()
 {
   using namespace jlm::rvsdg;
 
-  jlm::tests::valuetype t;
+  auto t = jlm::tests::valuetype::Create();
 
   jlm::rvsdg::graph graph;
   auto imp = graph.add_import({ t, "i" });
 
-  auto n1 = jlm::tests::test_op::create(graph.root(), { imp }, { &t });
-  auto n2 = jlm::tests::test_op::create(graph.root(), { imp }, { &t });
+  auto n1 = jlm::tests::test_op::create(graph.root(), { imp }, { t });
+  auto n2 = jlm::tests::test_op::create(graph.root(), { imp }, { t });
 
   auto n3 = jlm::tests::structural_node::create(graph.root(), 1);
   structural_input::create(n3, imp, t);
   auto a1 = argument::create(n3->subregion(0), nullptr, t);
-  auto n4 = jlm::tests::test_op::create(n3->subregion(0), { a1 }, { &t });
-  auto n5 = jlm::tests::test_op::create(n3->subregion(0), { a1 }, { &t });
+  auto n4 = jlm::tests::test_op::create(n3->subregion(0), { a1 }, { t });
+  auto n5 = jlm::tests::test_op::create(n3->subregion(0), { a1 }, { t });
   result::create(n3->subregion(0), n4->output(0), nullptr, t);
   auto o1 = structural_output::create(n3, t);
 
@@ -90,17 +90,17 @@ test_prune_replace(void)
 {
   using namespace jlm::rvsdg;
 
-  jlm::tests::valuetype type;
+  auto type = jlm::tests::valuetype::Create();
 
   jlm::rvsdg::graph graph;
-  auto n1 = jlm::tests::test_op::create(graph.root(), {}, { &type });
-  auto n2 = jlm::tests::test_op::create(graph.root(), { n1->output(0) }, { &type });
-  auto n3 = jlm::tests::test_op::create(graph.root(), { n2->output(0) }, { &type });
+  auto n1 = jlm::tests::test_op::create(graph.root(), {}, { type });
+  auto n2 = jlm::tests::test_op::create(graph.root(), { n1->output(0) }, { type });
+  auto n3 = jlm::tests::test_op::create(graph.root(), { n2->output(0) }, { type });
 
   graph.add_export(n2->output(0), { n2->output(0)->type(), "n2" });
   graph.add_export(n3->output(0), { n2->output(0)->type(), "n3" });
 
-  auto n4 = jlm::tests::test_op::create(graph.root(), { n1->output(0) }, { &type });
+  auto n4 = jlm::tests::test_op::create(graph.root(), { n1->output(0) }, { type });
 
   n2->output(0)->divert_users(n4->output(0));
   assert(n2->output(0)->nusers() == 0);
@@ -119,11 +119,11 @@ test_graph(void)
 {
   using namespace jlm::rvsdg;
 
-  jlm::tests::valuetype type;
+  auto type = jlm::tests::valuetype::Create();
 
   jlm::rvsdg::graph graph;
 
-  auto n1 = jlm::tests::test_op::create(graph.root(), {}, { &type });
+  auto n1 = jlm::tests::test_op::create(graph.root(), {}, { type });
   assert(n1);
   assert(n1->depth() == 0);
 

--- a/tests/jlm/rvsdg/test-nodes.cpp
+++ b/tests/jlm/rvsdg/test-nodes.cpp
@@ -14,12 +14,12 @@ test_node_copy(void)
 {
   using namespace jlm::rvsdg;
 
-  jlm::tests::statetype stype;
-  jlm::tests::valuetype vtype;
+  auto stype = jlm::tests::statetype::Create();
+  auto vtype = jlm::tests::valuetype::Create();
 
   jlm::rvsdg::graph graph;
-  auto s = graph.add_import({ stype, "" });
-  auto v = graph.add_import({ vtype, "" });
+  auto s = graph.add_import({ *stype, "" });
+  auto v = graph.add_import({ *vtype, "" });
 
   auto n1 = jlm::tests::structural_node::create(graph.root(), 3);
   auto i1 = structural_input::create(n1, s, stype);
@@ -30,8 +30,8 @@ test_node_copy(void)
   auto a1 = argument::create(n1->subregion(0), i1, stype);
   auto a2 = argument::create(n1->subregion(0), i2, vtype);
 
-  auto n2 = jlm::tests::test_op::create(n1->subregion(0), { a1 }, { &stype });
-  auto n3 = jlm::tests::test_op::create(n1->subregion(0), { a2 }, { &vtype });
+  auto n2 = jlm::tests::test_op::create(n1->subregion(0), { a1 }, { stype });
+  auto n3 = jlm::tests::test_op::create(n1->subregion(0), { a2 }, { vtype });
 
   result::create(n1->subregion(0), n2->output(0), o1, stype);
   result::create(n1->subregion(0), n3->output(0), o2, vtype);
@@ -93,14 +93,14 @@ test_node_copy(void)
 static inline void
 test_node_depth()
 {
-  jlm::tests::valuetype vt;
+  auto vt = jlm::tests::valuetype::Create();
 
   jlm::rvsdg::graph graph;
   auto x = graph.add_import({ vt, "x" });
 
-  auto null = jlm::tests::test_op::create(graph.root(), {}, { &vt });
-  auto bin = jlm::tests::test_op::create(graph.root(), { null->output(0), x }, { &vt });
-  auto un = jlm::tests::test_op::create(graph.root(), { bin->output(0) }, { &vt });
+  auto null = jlm::tests::test_op::create(graph.root(), {}, { vt });
+  auto bin = jlm::tests::test_op::create(graph.root(), { null->output(0), x }, { vt });
+  auto un = jlm::tests::test_op::create(graph.root(), { bin->output(0) }, { vt });
 
   graph.add_export(un->output(0), { un->output(0)->type(), "x" });
 
@@ -124,16 +124,14 @@ TestRemoveOutputsWhere()
   // Arrange
   jlm::rvsdg::graph rvsdg;
 
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
   auto & node1 =
-      jlm::tests::SimpleNode::Create(*rvsdg.root(), {}, { &valueType, &valueType, &valueType });
+      jlm::tests::SimpleNode::Create(*rvsdg.root(), {}, { valueType, valueType, valueType });
   auto output0 = node1.output(0);
   auto output2 = node1.output(2);
 
-  auto & node2 = jlm::tests::SimpleNode::Create(
-      *rvsdg.root(),
-      { output0, output2 },
-      { &valueType, &valueType });
+  auto & node2 =
+      jlm::tests::SimpleNode::Create(*rvsdg.root(), { output0, output2 }, { valueType, valueType });
 
   // Act & Assert
   node2.RemoveOutputsWhere(
@@ -188,7 +186,7 @@ TestRemoveInputsWhere()
 {
   // Arrange
   jlm::rvsdg::graph rvsdg;
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
   auto x = rvsdg.add_import({ valueType, "x" });
 
   auto & node = jlm::tests::SimpleNode::Create(*rvsdg.root(), { x, x, x }, {});

--- a/tests/jlm/rvsdg/test-statemux.cpp
+++ b/tests/jlm/rvsdg/test-statemux.cpp
@@ -18,7 +18,7 @@ test_mux_mux_reduction()
 {
   using namespace jlm::rvsdg;
 
-  jlm::tests::statetype st;
+  auto st = jlm::tests::statetype::Create();
 
   jlm::rvsdg::graph graph;
   auto nf = graph.node_normal_form(typeid(jlm::rvsdg::mux_op));
@@ -58,7 +58,7 @@ test_multiple_origin_reduction()
 {
   using namespace jlm::rvsdg;
 
-  jlm::tests::statetype st;
+  auto st = jlm::tests::statetype::Create();
 
   jlm::rvsdg::graph graph;
   auto nf = graph.node_normal_form(typeid(jlm::rvsdg::mux_op));

--- a/tests/jlm/rvsdg/test-theta.cpp
+++ b/tests/jlm/rvsdg/test-theta.cpp
@@ -55,7 +55,7 @@ TestRemoveThetaOutputsWhere()
 
   // Arrange
   graph rvsdg;
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
 
   auto ctl = rvsdg.add_import({ *ctltype::Create(2), "ctl" });
   auto x = rvsdg.add_import({ valueType, "x" });
@@ -105,7 +105,7 @@ TestPruneThetaOutputs()
 
   // Arrange
   graph rvsdg;
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
 
   auto ctl = rvsdg.add_import({ *ctltype::Create(2), "ctl" });
   auto x = rvsdg.add_import({ valueType, "x" });
@@ -140,7 +140,7 @@ TestRemoveThetaInputsWhere()
 
   // Arrange
   graph rvsdg;
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
 
   auto ctl = rvsdg.add_import({ *ctltype::Create(2), "ctl" });
   auto x = rvsdg.add_import({ valueType, "x" });
@@ -154,7 +154,7 @@ TestRemoveThetaInputsWhere()
   thetaNode->set_predicate(thetaOutput0->argument());
 
   auto result =
-      jlm::tests::SimpleNode::Create(*thetaNode->subregion(), {}, { &valueType }).output(0);
+      jlm::tests::SimpleNode::Create(*thetaNode->subregion(), {}, { valueType }).output(0);
 
   thetaOutput1->result()->divert_to(result);
   thetaOutput2->result()->divert_to(result);
@@ -196,7 +196,7 @@ TestPruneThetaInputs()
 
   // Arrange
   graph rvsdg;
-  jlm::tests::valuetype valueType;
+  auto valueType = jlm::tests::valuetype::Create();
 
   auto ctl = rvsdg.add_import({ *ctltype::Create(2), "ctl" });
   auto x = rvsdg.add_import({ valueType, "x" });
@@ -210,7 +210,7 @@ TestPruneThetaInputs()
   thetaNode->set_predicate(thetaOutput0->argument());
 
   auto result =
-      jlm::tests::SimpleNode::Create(*thetaNode->subregion(), {}, { &valueType }).output(0);
+      jlm::tests::SimpleNode::Create(*thetaNode->subregion(), {}, { valueType }).output(0);
 
   thetaOutput1->result()->divert_to(result);
   thetaOutput2->result()->divert_to(result);

--- a/tests/jlm/rvsdg/test-topdown.cpp
+++ b/tests/jlm/rvsdg/test-topdown.cpp
@@ -12,14 +12,14 @@
 static void
 test_initialization()
 {
-  jlm::tests::valuetype vtype;
+  auto vtype = jlm::tests::valuetype::Create();
 
   jlm::rvsdg::graph graph;
   auto i = graph.add_import({ vtype, "i" });
 
-  auto constant = jlm::tests::test_op::create(graph.root(), {}, { &vtype });
-  auto unary = jlm::tests::test_op::create(graph.root(), { i }, { &vtype });
-  auto binary = jlm::tests::test_op::create(graph.root(), { i, unary->output(0) }, { &vtype });
+  auto constant = jlm::tests::test_op::create(graph.root(), {}, { vtype });
+  auto unary = jlm::tests::test_op::create(graph.root(), { i }, { vtype });
+  auto binary = jlm::tests::test_op::create(graph.root(), { i, unary->output(0) }, { vtype });
 
   graph.add_export(constant->output(0), { constant->output(0)->type(), "c" });
   graph.add_export(unary->output(0), { unary->output(0)->type(), "u" });
@@ -47,10 +47,10 @@ static void
 test_basic_traversal()
 {
   jlm::rvsdg::graph graph;
-  jlm::tests::valuetype type;
+  auto type = jlm::tests::valuetype::Create();
 
-  auto n1 = jlm::tests::test_op::create(graph.root(), {}, { &type, &type });
-  auto n2 = jlm::tests::test_op::create(graph.root(), { n1->output(0), n1->output(1) }, { &type });
+  auto n1 = jlm::tests::test_op::create(graph.root(), {}, { type, type });
+  auto n2 = jlm::tests::test_op::create(graph.root(), { n1->output(0), n1->output(1) }, { type });
 
   graph.add_export(n2->output(0), { n2->output(0)->type(), "dummy" });
 
@@ -73,11 +73,11 @@ static void
 test_order_enforcement_traversal()
 {
   jlm::rvsdg::graph graph;
-  jlm::tests::valuetype type;
+  auto type = jlm::tests::valuetype::Create();
 
-  auto n1 = jlm::tests::test_op::create(graph.root(), {}, { &type, &type });
-  auto n2 = jlm::tests::test_op::create(graph.root(), { n1->output(0) }, { &type });
-  auto n3 = jlm::tests::test_op::create(graph.root(), { n2->output(0), n1->output(1) }, { &type });
+  auto n1 = jlm::tests::test_op::create(graph.root(), {}, { type, type });
+  auto n2 = jlm::tests::test_op::create(graph.root(), { n1->output(0) }, { type });
+  auto n3 = jlm::tests::test_op::create(graph.root(), { n2->output(0), n1->output(1) }, { type });
 
   {
     jlm::rvsdg::node * tmp;
@@ -100,10 +100,10 @@ static void
 test_traversal_insertion()
 {
   jlm::rvsdg::graph graph;
-  jlm::tests::valuetype type;
+  auto type = jlm::tests::valuetype::Create();
 
-  auto n1 = jlm::tests::test_op::create(graph.root(), {}, { &type, &type });
-  auto n2 = jlm::tests::test_op::create(graph.root(), { n1->output(0), n1->output(1) }, { &type });
+  auto n1 = jlm::tests::test_op::create(graph.root(), {}, { type, type });
+  auto n2 = jlm::tests::test_op::create(graph.root(), { n1->output(0), n1->output(1) }, { type });
 
   graph.add_export(n2->output(0), { n2->output(0)->type(), "dummy" });
 
@@ -116,7 +116,7 @@ test_traversal_insertion()
 
     /* At this point, n1 has been visited, now create some nodes */
 
-    auto n3 = jlm::tests::test_op::create(graph.root(), {}, { &type });
+    auto n3 = jlm::tests::test_op::create(graph.root(), {}, { type });
     auto n4 = jlm::tests::test_op::create(graph.root(), { n3->output(0) }, {});
     auto n5 = jlm::tests::test_op::create(graph.root(), { n2->output(0) }, {});
 
@@ -180,9 +180,9 @@ test_mutable_traverse()
   };
 
   jlm::rvsdg::graph graph;
-  jlm::tests::valuetype type;
-  auto n1 = jlm::tests::test_op::create(graph.root(), {}, { &type });
-  auto n2 = jlm::tests::test_op::create(graph.root(), {}, { &type });
+  auto type = jlm::tests::valuetype::Create();
+  auto n1 = jlm::tests::test_op::create(graph.root(), {}, { type });
+  auto n2 = jlm::tests::test_op::create(graph.root(), {}, { type });
   auto n3 = jlm::tests::test_op::create(graph.root(), { n1->output(0) }, {});
 
   test(&graph, n1, n2, n3);

--- a/tests/jlm/rvsdg/test-typemismatch.cpp
+++ b/tests/jlm/rvsdg/test-typemismatch.cpp
@@ -17,15 +17,15 @@ test_main(void)
 
   jlm::rvsdg::graph graph;
 
-  jlm::tests::statetype type;
-  jlm::tests::valuetype value_type;
+  auto type = jlm::tests::statetype::Create();
+  auto value_type = jlm::tests::valuetype::Create();
 
-  auto n1 = jlm::tests::test_op::create(graph.root(), {}, { &type });
+  auto n1 = jlm::tests::test_op::create(graph.root(), {}, { type });
 
   bool error_handler_called = false;
   try
   {
-    jlm::tests::test_op::Create(graph.root(), { &value_type }, { n1->output(0) }, {});
+    jlm::tests::test_op::Create(graph.root(), { value_type }, { n1->output(0) }, {});
   }
   catch (jlm::util::type_error & e)
   {

--- a/tests/test-operation.hpp
+++ b/tests/test-operation.hpp
@@ -181,9 +181,9 @@ public:
   virtual ~test_op();
 
   inline test_op(
-      const std::vector<const rvsdg::type *> & arguments,
-      const std::vector<const rvsdg::type *> & results)
-      : simple_op(create_ports(arguments), create_ports(results))
+      std::vector<std::shared_ptr<const rvsdg::type>> arguments,
+      std::vector<std::shared_ptr<const rvsdg::type>> results)
+      : simple_op(std::move(arguments), std::move(results))
   {}
 
   test_op(const test_op &) = default;
@@ -201,24 +201,24 @@ public:
   create(
       rvsdg::region * region,
       const std::vector<rvsdg::output *> & operands,
-      const std::vector<const rvsdg::type *> & result_types)
+      std::vector<std::shared_ptr<const rvsdg::type>> result_types)
   {
-    std::vector<const rvsdg::type *> operand_types;
+    std::vector<std::shared_ptr<const rvsdg::type>> operand_types;
     for (const auto & operand : operands)
-      operand_types.push_back(&operand->type());
+      operand_types.push_back(operand->Type());
 
-    test_op op(operand_types, result_types);
+    test_op op(std::move(operand_types), std::move(result_types));
     return rvsdg::simple_node::create(region, op, { operands });
   }
 
   static rvsdg::simple_node *
   Create(
       rvsdg::region * region,
-      const std::vector<const rvsdg::type *> & operandTypes,
+      std::vector<std::shared_ptr<const rvsdg::type>> operandTypes,
       const std::vector<rvsdg::output *> & operands,
-      const std::vector<const rvsdg::type *> & resultTypes)
+      std::vector<std::shared_ptr<const rvsdg::type>> resultTypes)
   {
-    test_op op(operandTypes, resultTypes);
+    test_op op(std::move(operandTypes), std::move(resultTypes));
     return rvsdg::simple_node::create(region, op, { operands });
   }
 
@@ -253,24 +253,24 @@ public:
   Create(
       rvsdg::region & region,
       const std::vector<rvsdg::output *> & operands,
-      const std::vector<const rvsdg::type *> & resultTypes)
+      std::vector<std::shared_ptr<const rvsdg::type>> resultTypes)
   {
     auto operandTypes = ExtractTypes(operands);
-    test_op operation(operandTypes, resultTypes);
+    test_op operation(std::move(operandTypes), std::move(resultTypes));
 
     auto node = new SimpleNode(region, operation, operands);
     return *node;
   }
 
 private:
-  static std::vector<const rvsdg::type *>
+  static std::vector<std::shared_ptr<const rvsdg::type>>
   ExtractTypes(const std::vector<rvsdg::output *> & outputs)
   {
-    std::vector<const rvsdg::type *> types;
+    std::vector<std::shared_ptr<const rvsdg::type>> types;
     types.reserve(outputs.size());
     for (auto output : outputs)
     {
-      types.emplace_back(&output->type());
+      types.emplace_back(output->Type());
     }
 
     return types;
@@ -280,13 +280,13 @@ private:
 static inline std::unique_ptr<llvm::tac>
 create_testop_tac(
     const std::vector<const llvm::variable *> & arguments,
-    const std::vector<const rvsdg::type *> & result_types)
+    std::vector<std::shared_ptr<const rvsdg::type>> result_types)
 {
-  std::vector<const rvsdg::type *> argument_types;
+  std::vector<std::shared_ptr<const rvsdg::type>> argument_types;
   for (const auto & arg : arguments)
-    argument_types.push_back(&arg->type());
+    argument_types.push_back(arg->Type());
 
-  test_op op(argument_types, result_types);
+  test_op op(std::move(argument_types), std::move(result_types));
   return llvm::tac::create(op, arguments);
 }
 
@@ -294,13 +294,13 @@ static inline std::vector<rvsdg::output *>
 create_testop(
     rvsdg::region * region,
     const std::vector<rvsdg::output *> & operands,
-    const std::vector<const rvsdg::type *> & result_types)
+    std::vector<std::shared_ptr<const rvsdg::type>> result_types)
 {
-  std::vector<const rvsdg::type *> operand_types;
+  std::vector<std::shared_ptr<const rvsdg::type>> operand_types;
   for (const auto & operand : operands)
-    operand_types.push_back(&operand->type());
+    operand_types.push_back(operand->Type());
 
-  test_op op(operand_types, result_types);
+  test_op op(std::move(operand_types), std::move(result_types));
   return rvsdg::simple_node::create_normalized(region, op, { operands });
 }
 


### PR DESCRIPTION
Change the constructor of testnode to required shared_ptr<type> for input and output parameters. This is a large and purely mechanical change, but affects numerous files. This is the majority of node conversions required.