### PR TITLE
Convert FunctionType to shared_ptr of type

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/UnusedStateRemoval.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/UnusedStateRemoval.cpp
@@ -62,7 +62,7 @@ RemoveUnusedStatesFromLambda(llvm::lambda::node & lambdaNode)
     }
   }
 
-  llvm::FunctionType newFunctionType(newArgumentTypes, newResultTypes);
+  auto newFunctionType = llvm::FunctionType::Create(newArgumentTypes, newResultTypes);
   auto newLambda = llvm::lambda::node::create(
       lambdaNode.region(),
       newFunctionType,

--- a/jlm/hls/backend/rvsdg2rhls/add-prints.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-prints.cpp
@@ -58,7 +58,8 @@ convert_prints(llvm::RvsdgModule & rm)
   auto & graph = rm.Rvsdg();
   auto root = graph.root();
   // TODO: make this less hacky by using the correct state types
-  llvm::FunctionType fct({ rvsdg::bittype::Create(64), rvsdg::bittype::Create(64) }, {});
+  auto fct =
+      llvm::FunctionType::Create({ rvsdg::bittype::Create(64), rvsdg::bittype::Create(64) }, {});
   llvm::impport imp(fct, "printnode", llvm::linkage::external_linkage);
   auto printf = graph.add_import(imp);
   convert_prints(root, printf, fct);
@@ -99,7 +100,7 @@ void
 convert_prints(
     jlm::rvsdg::region * region,
     jlm::rvsdg::output * printf,
-    const llvm::FunctionType & functionType)
+    const std::shared_ptr<const llvm::FunctionType> & functionType)
 {
   for (auto & node : jlm::rvsdg::topdown_traverser(region))
   {

--- a/jlm/hls/backend/rvsdg2rhls/add-prints.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-prints.hpp
@@ -25,7 +25,7 @@ void
 convert_prints(
     rvsdg::region * region,
     rvsdg::output * printf,
-    const llvm::FunctionType & functionType);
+    const std::shared_ptr<const llvm::FunctionType> & functionType);
 
 rvsdg::output *
 route_to_region(rvsdg::output * output, rvsdg::region * region);

--- a/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
@@ -42,7 +42,7 @@ add_lambda_argument(llvm::lambda::node * ln, const jlm::rvsdg::type * type)
   {
     new_result_types.push_back(old_fcttype.ResultType(i).copy());
   }
-  llvm::FunctionType new_fcttype(new_argument_types, new_result_types);
+  auto new_fcttype = llvm::FunctionType::Create(new_argument_types, new_result_types);
   auto new_lambda = llvm::lambda::node::create(
       ln->region(),
       new_fcttype,

--- a/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
@@ -24,7 +24,7 @@ llvm::lambda::node *
 change_function_name(llvm::lambda::node * ln, const std::string & name)
 {
   auto lambda =
-      llvm::lambda::node::create(ln->region(), ln->type(), name, ln->linkage(), ln->attributes());
+      llvm::lambda::node::create(ln->region(), ln->Type(), name, ln->linkage(), ln->attributes());
 
   /* add context variables */
   jlm::rvsdg::substitution_map subregionmap;
@@ -188,7 +188,7 @@ instrument_ref(
       auto memstate = node->input(1)->origin();
       auto callOp = jlm::llvm::CallNode::Create(
           load_func,
-          loadFunctionType,
+          std::static_pointer_cast<const llvm::FunctionType>(loadFunctionType.copy()),
           { addr, width, ioState, memstate });
       // Divert the memory state of the load to the new memstate from the call operation
       node->input(1)->divert_to(callOp[1]);
@@ -220,7 +220,7 @@ instrument_ref(
       auto memstate = node->output(1);
       auto callOp = jlm::llvm::CallNode::Create(
           alloca_func,
-          allocaFunctionType,
+          std::static_pointer_cast<const llvm::FunctionType>(allocaFunctionType.copy()),
           { addr, size, ioState, memstate });
       for (auto ou : old_users)
       {
@@ -254,7 +254,7 @@ instrument_ref(
       auto memstate = node->input(2)->origin();
       auto callOp = jlm::llvm::CallNode::Create(
           store_func,
-          storeFunctionType,
+          std::static_pointer_cast<const llvm::FunctionType>(storeFunctionType.copy()),
           { addr, data, width, ioState, memstate });
       // Divert the memory state of the load to the new memstate from the call operation
       node->input(2)->divert_to(callOp[1]);

--- a/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
@@ -633,7 +633,7 @@ jlm::hls::MemoryConverter(jlm::llvm::RvsdgModule & rm)
   //
   // Create new lambda and copy the region from the old lambda
   //
-  jlm::llvm::FunctionType newFunctionType(newArgumentTypes, newResultTypes);
+  auto newFunctionType = jlm::llvm::FunctionType::Create(newArgumentTypes, newResultTypes);
   auto newLambda = jlm::llvm::lambda::node::create(
       lambda->region(),
       newFunctionType,

--- a/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
@@ -196,7 +196,7 @@ remove_lambda_passthrough(llvm::lambda::node * ln)
       new_result_types.push_back(old_fcttype.ResultType(i).copy());
     }
   }
-  llvm::FunctionType new_fcttype(new_argument_types, new_result_types);
+  auto new_fcttype = llvm::FunctionType::Create(new_argument_types, new_result_types);
   auto new_lambda = llvm::lambda::node::create(
       ln->region(),
       new_fcttype,

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -286,7 +286,7 @@ llvm::lambda::node *
 change_linkage(llvm::lambda::node * ln, llvm::linkage link)
 {
   auto lambda =
-      llvm::lambda::node::create(ln->region(), ln->type(), ln->name(), link, ln->attributes());
+      llvm::lambda::node::create(ln->region(), ln->Type(), ln->name(), link, ln->attributes());
 
   /* add context variables */
   jlm::rvsdg::substitution_map subregionmap;

--- a/jlm/llvm/backend/jlm2llvm/instruction.cpp
+++ b/jlm/llvm/backend/jlm2llvm/instruction.cpp
@@ -206,7 +206,7 @@ convert(
     operands.push_back(ctx.value(argument));
   }
 
-  auto ftype = convert_type(op.GetFunctionType(), ctx);
+  auto ftype = convert_type(*op.GetFunctionType(), ctx);
   return builder.CreateCall(ftype, function, operands);
 }
 

--- a/jlm/llvm/backend/rvsdg2jlm/rvsdg2jlm.cpp
+++ b/jlm/llvm/backend/rvsdg2jlm/rvsdg2jlm.cpp
@@ -418,7 +418,7 @@ convert_lambda_node(const rvsdg::node & node, context & ctx)
   auto f = function_node::create(
       clg,
       lambda->name(),
-      lambda->type(),
+      lambda->Type(),
       lambda->linkage(),
       lambda->attributes());
   auto v = module.create_variable(f);
@@ -454,7 +454,7 @@ convert_phi_node(const rvsdg::node & node, context & ctx)
       auto f = function_node::create(
           ipg,
           lambda->name(),
-          lambda->type(),
+          lambda->Type(),
           lambda->linkage(),
           lambda->attributes());
       ctx.insert(subregion->argument(n), module.create_variable(f));
@@ -558,7 +558,11 @@ convert_imports(const rvsdg::graph & graph, ipgraph_module & im, context & ctx)
     auto import = static_cast<const llvm::impport *>(&argument->port());
     if (auto ftype = is_function_import(argument))
     {
-      auto f = function_node::create(ipg, import->name(), *ftype, import->linkage());
+      auto f = function_node::create(
+          ipg,
+          import->name(),
+          std::static_pointer_cast<const FunctionType>(ftype->copy()),
+          import->linkage());
       auto v = im.create_variable(f);
       ctx.insert(argument, v);
     }

--- a/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
+++ b/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
@@ -915,14 +915,14 @@ ConvertAggregationTreeToLambda(
     const AnnotationMap & demandMap,
     RegionalizedVariableMap & scopedVariableMap,
     const std::string & functionName,
-    const FunctionType & functionType,
+    std::shared_ptr<const FunctionType> functionType,
     const linkage & functionLinkage,
     const attributeset & functionAttributes,
     InterProceduralGraphToRvsdgStatisticsCollector & statisticsCollector)
 {
   auto lambdaNode = lambda::node::create(
       &scopedVariableMap.GetTopRegion(),
-      functionType,
+      std::move(functionType),
       functionName,
       functionLinkage,
       functionAttributes);
@@ -964,7 +964,7 @@ ConvertControlFlowGraph(
       *demandMap,
       regionalizedVariableMap,
       functionName,
-      functionNode.fcttype(),
+      functionNode.GetFunctionType(),
       functionNode.linkage(),
       functionNode.attributes(),
       statisticsCollector);

--- a/jlm/llvm/frontend/LlvmInstructionConversion.cpp
+++ b/jlm/llvm/frontend/LlvmInstructionConversion.cpp
@@ -851,7 +851,7 @@ convert_call_instruction(::llvm::Instruction * instruction, tacsvector_t & tacs,
   arguments.push_back(ctx.memory_state());
 
   auto fctvar = ConvertValue(i->getCalledOperand(), tacs, ctx);
-  auto call = CallOperation::create(fctvar, *ConvertFunctionType(ftype, ctx), arguments);
+  auto call = CallOperation::create(fctvar, ConvertFunctionType(ftype, ctx), arguments);
 
   auto result = call->result(0);
   auto iostate = call->result(call->nresults() - 2);

--- a/jlm/llvm/frontend/LlvmModuleConversion.cpp
+++ b/jlm/llvm/frontend/LlvmModuleConversion.cpp
@@ -461,7 +461,7 @@ declare_globals(::llvm::Module & lm, context & ctx)
     auto type = ConvertFunctionType(f.getFunctionType(), ctx);
     auto attributes = convert_attributes(f.getAttributes().getFnAttrs(), ctx);
 
-    return function_node::create(ctx.module().ipgraph(), name, *type, linkage, attributes);
+    return function_node::create(ctx.module().ipgraph(), name, type, linkage, attributes);
   };
 
   for (auto & gv : lm.getGlobalList())

--- a/jlm/llvm/ir/ipgraph.hpp
+++ b/jlm/llvm/ir/ipgraph.hpp
@@ -203,7 +203,7 @@ private:
   inline function_node(
       llvm::ipgraph & clg,
       const std::string & name,
-      const FunctionType & type,
+      std::shared_ptr<const FunctionType> type,
       const llvm::linkage & linkage,
       const attributeset & attributes)
       : ipgraph_node(clg),
@@ -225,6 +225,12 @@ public:
 
   const FunctionType &
   fcttype() const noexcept
+  {
+    return *FunctionType_;
+  }
+
+  const std::shared_ptr<const FunctionType> &
+  GetFunctionType() const noexcept
   {
     return FunctionType_;
   }
@@ -255,11 +261,12 @@ public:
   create(
       llvm::ipgraph & ipg,
       const std::string & name,
-      const FunctionType & type,
+      std::shared_ptr<const FunctionType> type,
       const llvm::linkage & linkage,
       const attributeset & attributes)
   {
-    std::unique_ptr<function_node> node(new function_node(ipg, name, type, linkage, attributes));
+    std::unique_ptr<function_node> node(
+        new function_node(ipg, name, std::move(type), linkage, attributes));
     auto tmp = node.get();
     ipg.add_node(std::move(node));
     return tmp;
@@ -269,14 +276,14 @@ public:
   create(
       llvm::ipgraph & ipg,
       const std::string & name,
-      const FunctionType & type,
+      std::shared_ptr<const FunctionType> type,
       const llvm::linkage & linkage)
   {
-    return create(ipg, name, type, linkage, {});
+    return create(ipg, name, std::move(type), linkage, {});
   }
 
 private:
-  FunctionType FunctionType_;
+  std::shared_ptr<const FunctionType> FunctionType_;
   std::string name_;
   llvm::linkage linkage_;
   attributeset attributes_;

--- a/jlm/llvm/ir/operators/lambda.cpp
+++ b/jlm/llvm/ir/operators/lambda.cpp
@@ -178,7 +178,7 @@ node::GetMemoryStateEntrySplit(const lambda::node & lambdaNode) noexcept
 lambda::node *
 node::create(
     jlm::rvsdg::region * parent,
-    const FunctionType & type,
+    std::shared_ptr<const jlm::llvm::FunctionType> type,
     const std::string & name,
     const llvm::linkage & linkage,
     const attributeset & attributes)
@@ -186,7 +186,7 @@ node::create(
   lambda::operation op(type, name, linkage, attributes);
   auto node = new lambda::node(parent, std::move(op));
 
-  for (auto & argumentType : type.Arguments())
+  for (auto & argumentType : type->Arguments())
     lambda::fctargument::create(node->subregion(), *argumentType);
 
   return node;
@@ -231,7 +231,7 @@ node::copy(jlm::rvsdg::region * region, const std::vector<jlm::rvsdg::output *> 
 lambda::node *
 node::copy(jlm::rvsdg::region * region, jlm::rvsdg::substitution_map & smap) const
 {
-  auto lambda = create(region, type(), name(), linkage(), attributes());
+  auto lambda = create(region, Type(), name(), linkage(), attributes());
 
   /* add context variables */
   jlm::rvsdg::substitution_map subregionmap;

--- a/jlm/llvm/ir/operators/lambda.hpp
+++ b/jlm/llvm/ir/operators/lambda.hpp
@@ -34,7 +34,7 @@ public:
   ~operation() override;
 
   operation(
-      jlm::llvm::FunctionType type,
+      std::shared_ptr<const jlm::llvm::FunctionType> type,
       std::string name,
       const jlm::llvm::linkage & linkage,
       jlm::llvm::attributeset attributes)
@@ -44,49 +44,24 @@ public:
         attributes_(std::move(attributes))
   {}
 
-  operation(const operation & other)
-      : type_(other.type_),
-        name_(other.name_),
-        linkage_(other.linkage_),
-        attributes_(other.attributes_)
-  {}
+  operation(const operation & other) = default;
 
-  operation(operation && other) noexcept
-      : type_(std::move(other.type_)),
-        name_(std::move(other.name_)),
-        linkage_(other.linkage_)
-  {}
+  operation(operation && other) noexcept = default;
 
   operation &
-  operator=(const operation & other)
-  {
-    if (this == &other)
-      return *this;
-
-    type_ = other.type_;
-    name_ = other.name_;
-    linkage_ = other.linkage_;
-    attributes_ = other.attributes_;
-
-    return *this;
-  }
+  operator=(const operation & other) = default;
 
   operation &
-  operator=(operation && other) noexcept
-  {
-    if (this == &other)
-      return *this;
-
-    type_ = std::move(other.type_);
-    name_ = std::move(other.name_);
-    linkage_ = other.linkage_;
-    attributes_ = std::move(other.attributes_);
-
-    return *this;
-  }
+  operator=(operation && other) noexcept = default;
 
   [[nodiscard]] const jlm::llvm::FunctionType &
   type() const noexcept
+  {
+    return *type_;
+  }
+
+  [[nodiscard]] const std::shared_ptr<const jlm::llvm::FunctionType> &
+  Type() const noexcept
   {
     return type_;
   }
@@ -119,7 +94,7 @@ public:
   copy() const override;
 
 private:
-  jlm::llvm::FunctionType type_;
+  std::shared_ptr<const jlm::llvm::FunctionType> type_;
   std::string name_;
   jlm::llvm::linkage linkage_;
   jlm::llvm::attributeset attributes_;
@@ -219,6 +194,12 @@ public:
   type() const noexcept
   {
     return operation().type();
+  }
+
+  [[nodiscard]] const std::shared_ptr<const jlm::llvm::FunctionType> &
+  Type() const noexcept
+  {
+    return operation().Type();
   }
 
   [[nodiscard]] const std::string &
@@ -362,7 +343,7 @@ public:
   static node *
   create(
       jlm::rvsdg::region * parent,
-      const jlm::llvm::FunctionType & type,
+      std::shared_ptr<const jlm::llvm::FunctionType> type,
       const std::string & name,
       const jlm::llvm::linkage & linkage,
       const jlm::llvm::attributeset & attributes);
@@ -373,7 +354,7 @@ public:
   static node *
   create(
       jlm::rvsdg::region * parent,
-      const jlm::llvm::FunctionType & type,
+      std::shared_ptr<const jlm::llvm::FunctionType> type,
       const std::string & name,
       const jlm::llvm::linkage & linkage)
   {

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -1160,7 +1160,7 @@ void
 Steensgaard::AnalyzeDirectCall(const CallNode & callNode, const lambda::node & lambdaNode)
 {
   auto & lambdaFunctionType = lambdaNode.operation().type();
-  auto & callFunctionType = callNode.GetOperation().GetFunctionType();
+  auto & callFunctionType = *callNode.GetOperation().GetFunctionType();
   if (callFunctionType != lambdaFunctionType)
   {
     // LLVM permits code where it can happen that the number and type of the arguments handed in to

--- a/jlm/mlir/frontend/MlirToJlmConverter.cpp
+++ b/jlm/mlir/frontend/MlirToJlmConverter.cpp
@@ -369,7 +369,7 @@ MlirToJlmConverter::ConvertLambda(::mlir::Operation & mlirLambda, rvsdg::region 
   {
     resultTypes.push_back(ConvertType(returnType)->copy());
   }
-  llvm::FunctionType functionType(std::move(argumentTypes), std::move(resultTypes));
+  auto functionType = llvm::FunctionType::Create(std::move(argumentTypes), std::move(resultTypes));
 
   // FIXME
   // The linkage should be part of the MLIR attributes so it can be extracted here

--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -14,7 +14,7 @@ StoreTest1::SetupRvsdg()
   using namespace jlm::llvm;
 
   auto pointerType = PointerType::Create();
-  FunctionType fcttype({ MemoryStateType::Create() }, { MemoryStateType::Create() });
+  auto fcttype = FunctionType::Create({ MemoryStateType::Create() }, { MemoryStateType::Create() });
 
   auto module = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto graph = &module->Rvsdg();
@@ -67,7 +67,7 @@ StoreTest2::SetupRvsdg()
   using namespace jlm::llvm;
 
   auto pointerType = PointerType::Create();
-  FunctionType fcttype({ MemoryStateType::Create() }, { MemoryStateType::Create() });
+  auto fcttype = FunctionType::Create({ MemoryStateType::Create() }, { MemoryStateType::Create() });
 
   auto module = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto graph = &module->Rvsdg();
@@ -126,7 +126,7 @@ LoadTest1::SetupRvsdg()
 
   auto mt = MemoryStateType::Create();
   auto pointerType = PointerType::Create();
-  FunctionType fcttype(
+  auto fcttype = FunctionType::Create(
       { PointerType::Create(), MemoryStateType::Create() },
       { jlm::rvsdg::bittype::Create(32), MemoryStateType::Create() });
 
@@ -163,7 +163,7 @@ LoadTest2::SetupRvsdg()
 
   auto mt = MemoryStateType::Create();
   auto pointerType = PointerType::Create();
-  FunctionType fcttype({ MemoryStateType::Create() }, { MemoryStateType::Create() });
+  auto fcttype = FunctionType::Create({ MemoryStateType::Create() }, { MemoryStateType::Create() });
 
   auto module = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto graph = &module->Rvsdg();
@@ -227,7 +227,7 @@ LoadFromUndefTest::SetupRvsdg()
   using namespace jlm::llvm;
 
   auto memoryStateType = MemoryStateType::Create();
-  FunctionType functionType(
+  auto functionType = FunctionType::Create(
       { MemoryStateType::Create() },
       { jlm::rvsdg::bittype::Create(32), MemoryStateType::Create() });
   auto pointerType = PointerType::Create();
@@ -275,7 +275,7 @@ GetElementPtrTest::SetupRvsdg()
 
   auto mt = MemoryStateType::Create();
   auto pointerType = PointerType::Create();
-  FunctionType fcttype(
+  auto fcttype = FunctionType::Create(
       { PointerType::Create(), MemoryStateType::Create() },
       { jlm::rvsdg::bittype::Create(32), MemoryStateType::Create() });
 
@@ -319,7 +319,7 @@ BitCastTest::SetupRvsdg()
   using namespace jlm::llvm;
 
   auto pointerType = PointerType::Create();
-  FunctionType fcttype({ PointerType::Create() }, { PointerType::Create() });
+  auto fcttype = FunctionType::Create({ PointerType::Create() }, { PointerType::Create() });
 
   auto module = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto graph = &module->Rvsdg();
@@ -360,7 +360,7 @@ Bits2PtrTest::SetupRvsdg()
     auto pt = PointerType::Create();
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { jlm::rvsdg::bittype::Create(64), iostatetype::Create(), MemoryStateType::Create() },
         { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() });
 
@@ -381,7 +381,7 @@ Bits2PtrTest::SetupRvsdg()
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { jlm::rvsdg::bittype::Create(64), iostatetype::Create(), MemoryStateType::Create() },
         { iostatetype::Create(), MemoryStateType::Create() });
 
@@ -395,7 +395,7 @@ Bits2PtrTest::SetupRvsdg()
 
     auto & call = CallNode::CreateNode(
         cvbits2ptr,
-        b2p->node()->type(),
+        b2p->node()->Type(),
         { valueArgument, iOStateArgument, memoryStateArgument });
 
     lambda->finalize({ call.GetIoStateOutput(), call.GetMemoryStateOutput() });
@@ -425,7 +425,7 @@ ConstantPointerNullTest::SetupRvsdg()
 
   auto mt = MemoryStateType::Create();
   auto pointerType = PointerType::Create();
-  FunctionType fcttype(
+  auto fcttype = FunctionType::Create(
       { PointerType::Create(), MemoryStateType::Create() },
       { MemoryStateType::Create() });
 
@@ -474,7 +474,7 @@ CallTest1::SetupRvsdg()
     auto pt = PointerType::Create();
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { PointerType::Create(),
           PointerType::Create(),
           iostatetype::Create(),
@@ -510,7 +510,7 @@ CallTest1::SetupRvsdg()
     auto pt = PointerType::Create();
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { PointerType::Create(),
           PointerType::Create(),
           iostatetype::Create(),
@@ -545,7 +545,7 @@ CallTest1::SetupRvsdg()
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
@@ -575,10 +575,10 @@ CallTest1::SetupRvsdg()
     auto sty = StoreNonVolatileNode::Create(y[0], six, { stx[0] }, 4);
     auto stz = StoreNonVolatileNode::Create(z[0], seven, { sty[0] }, 4);
 
-    auto & callF = CallNode::CreateNode(cvf, f->type(), { x[0], y[0], iOStateArgument, stz[0] });
+    auto & callF = CallNode::CreateNode(cvf, f->Type(), { x[0], y[0], iOStateArgument, stz[0] });
     auto & callG = CallNode::CreateNode(
         cvg,
-        g->type(),
+        g->Type(),
         { z[0], z[0], callF.GetIoStateOutput(), callF.GetMemoryStateOutput() });
 
     auto sum = jlm::rvsdg::bitadd_op::create(32, callF.Result(0), callG.Result(0));
@@ -630,7 +630,7 @@ CallTest2::SetupRvsdg()
     PointerType pt32;
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() },
         { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() });
 
@@ -659,7 +659,7 @@ CallTest2::SetupRvsdg()
     auto pointerType = PointerType::Create();
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() },
         { iostatetype::Create(), MemoryStateType::Create() });
 
@@ -682,7 +682,7 @@ CallTest2::SetupRvsdg()
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { iostatetype::Create(), MemoryStateType::Create() });
 
@@ -699,20 +699,20 @@ CallTest2::SetupRvsdg()
 
     auto & create1 = CallNode::CreateNode(
         create_cv,
-        lambdaCreate->type(),
+        lambdaCreate->Type(),
         { six, iOStateArgument, memoryStateArgument });
     auto & create2 = CallNode::CreateNode(
         create_cv,
-        lambdaCreate->type(),
+        lambdaCreate->Type(),
         { seven, create1.GetIoStateOutput(), create1.GetMemoryStateOutput() });
 
     auto & destroy1 = CallNode::CreateNode(
         destroy_cv,
-        lambdaDestroy->type(),
+        lambdaDestroy->Type(),
         { create1.Result(0), create2.GetIoStateOutput(), create2.GetMemoryStateOutput() });
     auto & destroy2 = CallNode::CreateNode(
         destroy_cv,
-        lambdaDestroy->type(),
+        lambdaDestroy->Type(),
         { create2.Result(0), destroy1.GetIoStateOutput(), destroy1.GetMemoryStateOutput() });
 
     lambda->finalize({ destroy2.GetIoStateOutput(), destroy2.GetMemoryStateOutput() });
@@ -752,7 +752,7 @@ IndirectCallTest1::SetupRvsdg()
 
   auto iOStateType = iostatetype::Create();
   auto memoryStateType = MemoryStateType::Create();
-  FunctionType constantFunctionType(
+  auto constantFunctionType = FunctionType::Create(
       { iostatetype::Create(), MemoryStateType::Create() },
       { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
   auto pointerType = PointerType::Create();
@@ -779,7 +779,7 @@ IndirectCallTest1::SetupRvsdg()
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
@@ -802,7 +802,7 @@ IndirectCallTest1::SetupRvsdg()
   auto SetupTestFunction =
       [&](lambda::output * fctindcall, lambda::output * fctthree, lambda::output * fctfour)
   {
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
@@ -817,11 +817,11 @@ IndirectCallTest1::SetupRvsdg()
 
     auto & call_four = CallNode::CreateNode(
         fctindcall_cv,
-        fctindcall->node()->type(),
+        fctindcall->node()->Type(),
         { fctfour_cv, iOStateArgument, memoryStateArgument });
     auto & call_three = CallNode::CreateNode(
         fctindcall_cv,
-        fctindcall->node()->type(),
+        fctindcall->node()->Type(),
         { fctthree_cv, call_four.GetIoStateOutput(), call_four.GetMemoryStateOutput() });
 
     auto add = jlm::rvsdg::bitadd_op::create(32, call_four.Result(0), call_three.Result(0));
@@ -861,7 +861,7 @@ IndirectCallTest2::SetupRvsdg()
 
   auto iOStateType = iostatetype::Create();
   auto memoryStateType = MemoryStateType::Create();
-  FunctionType constantFunctionType(
+  auto constantFunctionType = FunctionType::Create(
       { iostatetype::Create(), MemoryStateType::Create() },
       { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
   auto pointerType = PointerType::Create();
@@ -918,7 +918,7 @@ IndirectCallTest2::SetupRvsdg()
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
@@ -944,7 +944,7 @@ IndirectCallTest2::SetupRvsdg()
   {
     auto pointerType = PointerType::Create();
 
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
@@ -963,7 +963,7 @@ IndirectCallTest2::SetupRvsdg()
 
     auto & call = CallNode::CreateNode(
         functionICv,
-        functionI.node()->type(),
+        functionI.node()->Type(),
         { argumentFunctionCv, iOStateArgument, storeNode[0] });
 
     auto lambdaOutput = lambda->finalize(call.Results());
@@ -976,7 +976,7 @@ IndirectCallTest2::SetupRvsdg()
                                delta::output & globalG1,
                                delta::output & globalG2)
   {
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
@@ -1001,12 +1001,12 @@ IndirectCallTest2::SetupRvsdg()
 
     auto & callX = CallNode::CreateNode(
         functionXCv,
-        functionX.node()->type(),
+        functionX.node()->Type(),
         { pxAlloca[0], iOStateArgument, pyMerge });
 
     auto & callY = CallNode::CreateNode(
         functionYCv,
-        functionY.node()->type(),
+        functionY.node()->Type(),
         { pyAlloca[0], callX.GetIoStateOutput(), callX.GetMemoryStateOutput() });
 
     auto loadG1 = LoadNonVolatileNode::Create(
@@ -1037,7 +1037,7 @@ IndirectCallTest2::SetupRvsdg()
 
   auto SetupTest2Function = [&](lambda::output & functionX)
   {
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
@@ -1055,7 +1055,7 @@ IndirectCallTest2::SetupRvsdg()
 
     auto & callX = CallNode::CreateNode(
         functionXCv,
-        functionX.node()->type(),
+        functionX.node()->Type(),
         { pzAlloca[0], iOStateArgument, pzMerge });
 
     auto lambdaOutput = lambda->finalize(callX.Results());
@@ -1120,7 +1120,7 @@ ExternalCallTest1::SetupRvsdg()
   auto pointerType = PointerType::Create();
   auto iOStateType = iostatetype::Create();
   auto memoryStateType = MemoryStateType::Create();
-  FunctionType functionGType(
+  auto functionGType = FunctionType::Create(
       { PointerType::Create(),
         PointerType::Create(),
         iostatetype::Create(),
@@ -1137,7 +1137,7 @@ ExternalCallTest1::SetupRvsdg()
     auto pointerType = PointerType::Create();
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { PointerType::Create(),
           PointerType::Create(),
           iostatetype::Create(),
@@ -1205,22 +1205,22 @@ ExternalCallTest2::SetupRvsdg()
   auto iOStateType = iostatetype::Create();
   auto memoryStateType = MemoryStateType::Create();
   varargtype varArgType;
-  FunctionType lambdaLlvmLifetimeStartType(
+  auto lambdaLlvmLifetimeStartType = FunctionType::Create(
       { rvsdg::bittype::Create(64),
         PointerType::Create(),
         iostatetype::Create(),
         MemoryStateType::Create() },
       { iostatetype::Create(), MemoryStateType::Create() });
-  FunctionType lambdaLlvmLifetimeEndType(
+  auto lambdaLlvmLifetimeEndType = FunctionType::Create(
       { rvsdg::bittype::Create(64),
         PointerType::Create(),
         iostatetype::Create(),
         MemoryStateType::Create() },
       { iostatetype::Create(), MemoryStateType::Create() });
-  FunctionType lambdaFType(
+  auto lambdaFType = FunctionType::Create(
       { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() },
       { iostatetype::Create(), MemoryStateType::Create() });
-  FunctionType lambdaGType(
+  auto lambdaGType = FunctionType::Create(
       { iostatetype::Create(), MemoryStateType::Create() },
       {
           iostatetype::Create(),
@@ -1299,7 +1299,7 @@ GammaTest::SetupRvsdg()
 
   auto mt = MemoryStateType::Create();
   auto pt = PointerType::Create();
-  FunctionType fcttype(
+  auto fcttype = FunctionType::Create(
       { jlm::rvsdg::bittype::Create(32),
         PointerType::Create(),
         PointerType::Create(),
@@ -1409,7 +1409,7 @@ GammaTest2::SetupRvsdg()
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
     auto pointerType = PointerType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { rvsdg::bittype::Create(32),
           PointerType::Create(),
           PointerType::Create(),
@@ -1467,7 +1467,7 @@ GammaTest2::SetupRvsdg()
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
     auto pointerType = PointerType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
@@ -1499,7 +1499,7 @@ GammaTest2::SetupRvsdg()
 
     auto & call = CallNode::CreateNode(
         lambdaFArgument,
-        lambdaF.node()->type(),
+        lambdaF.node()->Type(),
         { predicate, allocaXResults[0], allocaYResults[0], iOStateArgument, storeYResults[0] });
 
     lambda->finalize(call.Results());
@@ -1542,7 +1542,7 @@ ThetaTest::SetupRvsdg()
 
   auto mt = MemoryStateType::Create();
   auto pointerType = PointerType::Create();
-  FunctionType fcttype(
+  auto fcttype = FunctionType::Create(
       { jlm::rvsdg::bittype::Create(32),
         PointerType::Create(),
         jlm::rvsdg::bittype::Create(32),
@@ -1627,7 +1627,7 @@ DeltaTest1::SetupRvsdg()
     auto pt = PointerType::Create();
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
@@ -1649,7 +1649,7 @@ DeltaTest1::SetupRvsdg()
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
@@ -1662,7 +1662,7 @@ DeltaTest1::SetupRvsdg()
 
     auto five = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 5);
     auto st = StoreNonVolatileNode::Create(cvf, five, { memoryStateArgument }, 4);
-    auto & callG = CallNode::CreateNode(cvg, g->node()->type(), { cvf, iOStateArgument, st[0] });
+    auto & callG = CallNode::CreateNode(cvg, g->node()->Type(), { cvf, iOStateArgument, st[0] });
 
     auto lambdaOutput = lambda->finalize(callG.Results());
     graph->add_export(lambda->output(), { PointerType::Create(), "h" });
@@ -1733,7 +1733,7 @@ DeltaTest2::SetupRvsdg()
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { iostatetype::Create(), MemoryStateType::Create() });
 
@@ -1753,7 +1753,7 @@ DeltaTest2::SetupRvsdg()
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { iostatetype::Create(), MemoryStateType::Create() });
 
@@ -1769,7 +1769,7 @@ DeltaTest2::SetupRvsdg()
     auto b5 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 5);
     auto b42 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 42);
     auto st = StoreNonVolatileNode::Create(cvd1, b5, { memoryStateArgument }, 4);
-    auto & call = CallNode::CreateNode(cvf1, f1->node()->type(), { iOStateArgument, st[0] });
+    auto & call = CallNode::CreateNode(cvf1, f1->node()->Type(), { iOStateArgument, st[0] });
     st = StoreNonVolatileNode::Create(cvd2, b42, { call.GetMemoryStateOutput() }, 4);
 
     auto lambdaOutput = lambda->finalize(call.Results());
@@ -1837,7 +1837,7 @@ DeltaTest3::SetupRvsdg()
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(16), iostatetype::Create(), MemoryStateType::Create() });
 
@@ -1863,7 +1863,7 @@ DeltaTest3::SetupRvsdg()
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { iostatetype::Create(), MemoryStateType::Create() });
 
@@ -1876,7 +1876,7 @@ DeltaTest3::SetupRvsdg()
 
     auto & call = CallNode::CreateNode(
         lambdaFArgument,
-        lambdaF.node()->type(),
+        lambdaF.node()->Type(),
         { iOStateArgument, memoryStateArgument });
 
     auto lambdaOutput = lambda->finalize({ call.GetIoStateOutput(), call.GetMemoryStateOutput() });
@@ -1919,7 +1919,7 @@ ImportTest::SetupRvsdg()
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { iostatetype::Create(), MemoryStateType::Create() });
 
@@ -1940,7 +1940,7 @@ ImportTest::SetupRvsdg()
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { iostatetype::Create(), MemoryStateType::Create() });
 
@@ -1955,7 +1955,7 @@ ImportTest::SetupRvsdg()
     auto b2 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 2);
     auto b21 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 21);
     auto st = StoreNonVolatileNode::Create(cvd1, b2, { memoryStateArgument }, 4);
-    auto & call = CallNode::CreateNode(cvf1, f1->node()->type(), { iOStateArgument, st[0] });
+    auto & call = CallNode::CreateNode(cvf1, f1->node()->Type(), { iOStateArgument, st[0] });
     st = StoreNonVolatileNode::Create(cvd2, b21, { call.GetMemoryStateOutput() }, 4);
 
     auto lambdaOutput = lambda->finalize(call.Results());
@@ -1998,7 +1998,7 @@ PhiTest1::SetupRvsdg()
   PointerType pbit64;
   auto iOStateType = iostatetype::Create();
   auto memoryStateType = MemoryStateType::Create();
-  FunctionType fibFunctionType(
+  auto fibFunctionType = FunctionType::Create(
       { jlm::rvsdg::bittype::Create(64),
         PointerType::Create(),
         iostatetype::Create(),
@@ -2100,7 +2100,7 @@ PhiTest1::SetupRvsdg()
     PointerType pbit64;
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { iostatetype::Create(), MemoryStateType::Create() });
 
@@ -2156,19 +2156,19 @@ PhiTest2::SetupRvsdg()
 
   auto pointerType = PointerType::Create();
 
-  FunctionType constantFunctionType(
+  auto constantFunctionType = FunctionType::Create(
       { iostatetype::Create(), MemoryStateType::Create() },
       { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
-  FunctionType recursiveFunctionType(
+  auto recursiveFunctionType = FunctionType::Create(
       { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() },
       { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
-  FunctionType functionIType(
+  auto functionIType = FunctionType::Create(
       { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() },
       { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
-  FunctionType recFunctionType(
+  auto recFunctionType = FunctionType::Create(
       { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() },
       { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
@@ -2418,7 +2418,7 @@ PhiTest2::SetupRvsdg()
   {
     auto pointerType = PointerType::Create();
 
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
@@ -2555,7 +2555,7 @@ ExternalMemoryTest::SetupRvsdg()
 
   auto mt = MemoryStateType::Create();
   auto pointerType = PointerType::Create();
-  FunctionType ft(
+  auto ft = FunctionType::Create(
       { PointerType::Create(), PointerType::Create(), MemoryStateType::Create() },
       { MemoryStateType::Create() });
 
@@ -2658,7 +2658,7 @@ EscapedMemoryTest1::SetupRvsdg()
     auto pointerType = PointerType::Create();
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
@@ -2728,11 +2728,11 @@ EscapedMemoryTest2::SetupRvsdg()
   auto iOStateType = iostatetype::Create();
   auto memoryStateType = MemoryStateType::Create();
 
-  FunctionType externalFunction1Type(
+  auto externalFunction1Type = FunctionType::Create(
       { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() },
       { iostatetype::Create(), MemoryStateType::Create() });
 
-  FunctionType externalFunction2Type(
+  auto externalFunction2Type = FunctionType::Create(
       { iostatetype::Create(), MemoryStateType::Create() },
       { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() });
 
@@ -2753,7 +2753,7 @@ EscapedMemoryTest2::SetupRvsdg()
     PointerType p8;
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() });
 
@@ -2782,7 +2782,7 @@ EscapedMemoryTest2::SetupRvsdg()
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { iostatetype::Create(), MemoryStateType::Create() });
 
@@ -2818,7 +2818,7 @@ EscapedMemoryTest2::SetupRvsdg()
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
@@ -2898,7 +2898,7 @@ EscapedMemoryTest3::SetupRvsdg()
   auto pointerType = PointerType::Create();
   auto iOStateType = iostatetype::Create();
   auto memoryStateType = MemoryStateType::Create();
-  FunctionType externalFunctionType(
+  auto externalFunctionType = FunctionType::Create(
       { iostatetype::Create(), MemoryStateType::Create() },
       { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() });
 
@@ -2931,7 +2931,7 @@ EscapedMemoryTest3::SetupRvsdg()
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
@@ -3040,7 +3040,7 @@ MemcpyTest::SetupRvsdg()
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
@@ -3077,7 +3077,7 @@ MemcpyTest::SetupRvsdg()
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
@@ -3102,7 +3102,7 @@ MemcpyTest::SetupRvsdg()
 
     auto & call = CallNode::CreateNode(
         functionFArgument,
-        lambdaF.node()->type(),
+        lambdaF.node()->Type(),
         { iOStateArgument, memcpyResults[0] });
 
     auto lambdaOutput = lambda->finalize(call.Results());
@@ -3151,7 +3151,7 @@ MemcpyTest2::SetupRvsdg()
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { PointerType::Create(),
           PointerType::Create(),
           iostatetype::Create(),
@@ -3186,7 +3186,7 @@ MemcpyTest2::SetupRvsdg()
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { PointerType::Create(),
           PointerType::Create(),
           iostatetype::Create(),
@@ -3211,7 +3211,7 @@ MemcpyTest2::SetupRvsdg()
 
     auto & call = CallNode::CreateNode(
         functionFArgument,
-        functionF.node()->type(),
+        functionF.node()->Type(),
         { ldS1[0], ldS2[0], iOStateArgument, ldS2[1] });
 
     auto lambdaOutput = lambda->finalize(call.Results());
@@ -3250,7 +3250,7 @@ MemcpyTest3::SetupRvsdg()
 
   auto iOStateType = iostatetype::Create();
   auto memoryStateType = MemoryStateType::Create();
-  FunctionType functionType(
+  auto functionType = FunctionType::Create(
       { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() },
       { iostatetype::Create(), MemoryStateType::Create() });
 
@@ -3328,7 +3328,7 @@ LinkedListTest::SetupRvsdg()
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() });
 
@@ -3382,7 +3382,7 @@ AllMemoryNodesTest::SetupRvsdg()
 
   auto mt = MemoryStateType::Create();
   auto pointerType = PointerType::Create();
-  FunctionType fcttype({ MemoryStateType::Create() }, { MemoryStateType::Create() });
+  auto fcttype = FunctionType::Create({ MemoryStateType::Create() }, { MemoryStateType::Create() });
 
   auto module = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto graph = &module->Rvsdg();
@@ -3476,7 +3476,7 @@ NAllocaNodesTest::SetupRvsdg()
 
   auto mt = MemoryStateType::Create();
   auto pointerType = PointerType::Create();
-  FunctionType fcttype({ MemoryStateType::Create() }, { MemoryStateType::Create() });
+  auto fcttype = FunctionType::Create({ MemoryStateType::Create() }, { MemoryStateType::Create() });
 
   auto module = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto graph = &module->Rvsdg();
@@ -3517,10 +3517,10 @@ EscapingLocalFunctionTest::SetupRvsdg()
   rvsdg::bittype uint32Type = *rvsdg::bittype::Create(32);
   auto mt = MemoryStateType::Create();
   auto pointerType = PointerType::Create();
-  FunctionType localFuncType(
+  auto localFuncType = FunctionType::Create(
       { PointerType::Create(), MemoryStateType::Create() },
       { PointerType::Create(), MemoryStateType::Create() });
-  FunctionType exportedFuncType(
+  auto exportedFuncType = FunctionType::Create(
       { MemoryStateType::Create() },
       { PointerType::Create(), MemoryStateType::Create() });
 
@@ -3587,7 +3587,7 @@ FreeNullTest::SetupRvsdg()
 {
   using namespace jlm::llvm;
 
-  FunctionType functionType(
+  auto functionType = FunctionType::Create(
       { MemoryStateType::Create(), iostatetype::Create() },
       { MemoryStateType::Create(), iostatetype::Create() });
 
@@ -3628,7 +3628,7 @@ LambdaCallArgumentMismatch::SetupRvsdg()
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
@@ -3647,10 +3647,10 @@ LambdaCallArgumentMismatch::SetupRvsdg()
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
     auto variableArgumentType = varargtype::Create();
-    FunctionType functionTypeMain(
+    auto functionTypeMain = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
-    FunctionType functionTypeCall(
+    auto functionTypeCall = FunctionType::Create(
         { rvsdg::bittype::Create(32),
           variableArgumentType,
           iostatetype::Create(),
@@ -3711,16 +3711,16 @@ VariadicFunctionTest1::SetupRvsdg()
   auto iOStateType = iostatetype::Create();
   auto memoryStateType = MemoryStateType::Create();
   auto varArgType = varargtype::Create();
-  FunctionType lambdaHType(
+  auto lambdaHType = FunctionType::Create(
       { jlm::rvsdg::bittype::Create(32),
         varArgType,
         iostatetype::Create(),
         MemoryStateType::Create() },
       { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() });
-  FunctionType lambdaFType(
+  auto lambdaFType = FunctionType::Create(
       { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() },
       { iostatetype::Create(), MemoryStateType::Create() });
-  FunctionType lambdaGType(
+  auto lambdaGType = FunctionType::Create(
       { iostatetype::Create(), MemoryStateType::Create() },
       { iostatetype::Create(), MemoryStateType::Create() });
 
@@ -3803,28 +3803,28 @@ VariadicFunctionTest2::SetupRvsdg()
   auto iOStateType = iostatetype::Create();
   auto memoryStateType = MemoryStateType::Create();
   auto varArgType = varargtype::Create();
-  FunctionType lambdaLlvmLifetimeStartType(
+  auto lambdaLlvmLifetimeStartType = FunctionType::Create(
       { rvsdg::bittype::Create(64),
         PointerType::Create(),
         iostatetype::Create(),
         MemoryStateType::Create() },
       { iostatetype::Create(), MemoryStateType::Create() });
-  FunctionType lambdaLlvmLifetimeEndType(
+  auto lambdaLlvmLifetimeEndType = FunctionType::Create(
       { rvsdg::bittype::Create(64),
         PointerType::Create(),
         iostatetype::Create(),
         MemoryStateType::Create() },
       { iostatetype::Create(), MemoryStateType::Create() });
-  FunctionType lambdaVaStartType(
+  auto lambdaVaStartType = FunctionType::Create(
       { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() },
       { iostatetype::Create(), MemoryStateType::Create() });
-  FunctionType lambdaVaEndType(
+  auto lambdaVaEndType = FunctionType::Create(
       { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() },
       { iostatetype::Create(), MemoryStateType::Create() });
-  FunctionType lambdaFstType(
+  auto lambdaFstType = FunctionType::Create(
       { rvsdg::bittype::Create(32), varArgType, iostatetype::Create(), MemoryStateType::Create() },
       { rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
-  FunctionType lambdaGType(
+  auto lambdaGType = FunctionType::Create(
       { iostatetype::Create(), MemoryStateType::Create() },
       { rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 

--- a/tests/jlm/hls/backend/rvsdg2rhls/DeadNodeEliminationTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/DeadNodeEliminationTests.cpp
@@ -16,9 +16,8 @@ TestDeadLoopNode()
 
   // Arrange
   auto valueType = jlm::tests::valuetype::Create();
-  jlm::llvm::FunctionType functionType(
-      { jlm::rvsdg::ctltype::Create(2), valueType },
-      { valueType });
+  auto functionType =
+      jlm::llvm::FunctionType::Create({ jlm::rvsdg::ctltype::Create(2), valueType }, { valueType });
 
   jlm::llvm::RvsdgModule rvsdgModule(jlm::util::filepath(""), "", "");
   auto & rvsdg = rvsdgModule.Rvsdg();
@@ -47,7 +46,7 @@ TestDeadLoopNodeOutput()
 
   // Arrange
   auto valueType = jlm::tests::valuetype::Create();
-  jlm::llvm::FunctionType functionType(
+  auto functionType = jlm::llvm::FunctionType::Create(
       { jlm::rvsdg::ctltype::Create(2), valueType },
       { jlm::rvsdg::ctltype::Create(2) });
 

--- a/tests/jlm/hls/backend/rvsdg2rhls/TestGamma.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/TestGamma.cpp
@@ -18,7 +18,7 @@ TestWithMatch()
   using namespace jlm::llvm;
 
   auto vt = jlm::tests::valuetype::Create();
-  FunctionType ft({ jlm::rvsdg::bittype::Create(1), vt, vt }, { vt });
+  auto ft = FunctionType::Create({ jlm::rvsdg::bittype::Create(1), vt, vt }, { vt });
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto nf = rm.Rvsdg().node_normal_form(typeid(jlm::rvsdg::operation));
@@ -55,7 +55,7 @@ TestWithoutMatch()
   using namespace jlm::llvm;
 
   auto vt = jlm::tests::valuetype::Create();
-  FunctionType ft({ jlm::rvsdg::ctltype::Create(2), vt, vt }, { vt });
+  auto ft = FunctionType::Create({ jlm::rvsdg::ctltype::Create(2), vt, vt }, { vt });
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto nf = rm.Rvsdg().node_normal_form(typeid(jlm::rvsdg::operation));

--- a/tests/jlm/hls/backend/rvsdg2rhls/TestTheta.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/TestTheta.cpp
@@ -17,7 +17,7 @@ TestUnknownBoundaries()
 
   // Arrange
   auto b32 = jlm::rvsdg::bittype::Create(32);
-  FunctionType ft({ b32, b32, b32 }, { b32, b32, b32 });
+  auto ft = FunctionType::Create({ b32, b32, b32 }, { b32, b32, b32 });
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto nf = rm.Rvsdg().node_normal_form(typeid(jlm::rvsdg::operation));

--- a/tests/jlm/hls/backend/rvsdg2rhls/UnusedStateRemovalTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/UnusedStateRemovalTests.cpp
@@ -78,7 +78,7 @@ TestTheta()
 
   // Arrange
   auto valueType = jlm::tests::valuetype::Create();
-  FunctionType functionType(
+  auto functionType = FunctionType::Create(
       { jlm::rvsdg::ctltype::Create(2), valueType, valueType, valueType },
       { valueType });
 
@@ -127,7 +127,7 @@ TestLambda()
 
   // Arrange
   auto valueType = jlm::tests::valuetype::Create();
-  FunctionType functionType(
+  auto functionType = FunctionType::Create(
       { valueType, valueType },
       { valueType, valueType, valueType, valueType });
 

--- a/tests/jlm/hls/backend/rvsdg2rhls/test-loop-passthrough.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/test-loop-passthrough.cpp
@@ -34,7 +34,7 @@ test()
 {
   using namespace jlm;
 
-  jlm::llvm::FunctionType ft(
+  auto ft = jlm::llvm::FunctionType::Create(
       { rvsdg::bittype::Create(1), rvsdg::bittype::Create(8), rvsdg::bittype::Create(8) },
       { rvsdg::bittype::Create(8) });
 

--- a/tests/jlm/llvm/backend/llvm/jlm-llvm/LoadTests.cpp
+++ b/tests/jlm/llvm/backend/llvm/jlm-llvm/LoadTests.cpp
@@ -18,7 +18,7 @@ LoadConversion()
   using namespace jlm::llvm;
 
   // Arrange
-  FunctionType functionType(
+  auto functionType = FunctionType::Create(
       { PointerType::Create(), MemoryStateType::Create() },
       { jlm::rvsdg::bittype::Create(64), MemoryStateType::Create() });
 
@@ -80,7 +80,7 @@ LoadVolatileConversion()
   iostatetype ioStateType;
   auto memoryStateType = MemoryStateType::Create();
   jlm::rvsdg::bittype bit64Type(64);
-  FunctionType functionType(
+  auto functionType = FunctionType::Create(
       { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() },
       { jlm::rvsdg::bittype::Create(64), iostatetype::Create(), MemoryStateType::Create() });
 

--- a/tests/jlm/llvm/backend/llvm/jlm-llvm/MemCpyTests.cpp
+++ b/tests/jlm/llvm/backend/llvm/jlm-llvm/MemCpyTests.cpp
@@ -22,7 +22,7 @@ MemCpyConversion()
   PointerType pointerType;
   auto memoryStateType = MemoryStateType::Create();
   jlm::rvsdg::bittype bit64Type(64);
-  FunctionType functionType(
+  auto functionType = FunctionType::Create(
       { PointerType::Create(),
         PointerType::Create(),
         jlm::rvsdg::bittype::Create(64),
@@ -89,7 +89,7 @@ MemCpyVolatileConversion()
   iostatetype ioStateType;
   auto memoryStateType = MemoryStateType::Create();
   jlm::rvsdg::bittype bit64Type(64);
-  FunctionType functionType(
+  auto functionType = FunctionType::Create(
       { PointerType::Create(),
         PointerType::Create(),
         jlm::rvsdg::bittype::Create(64),

--- a/tests/jlm/llvm/backend/llvm/jlm-llvm/StoreTests.cpp
+++ b/tests/jlm/llvm/backend/llvm/jlm-llvm/StoreTests.cpp
@@ -22,7 +22,7 @@ StoreConversion()
   PointerType pointerType;
   auto memoryStateType = MemoryStateType::Create();
   jlm::rvsdg::bittype bit64Type(64);
-  FunctionType functionType(
+  auto functionType = FunctionType::Create(
       { PointerType::Create(), jlm::rvsdg::bittype::Create(64), MemoryStateType::Create() },
       { MemoryStateType::Create() });
 
@@ -83,7 +83,7 @@ StoreVolatileConversion()
   iostatetype ioStateType;
   auto memoryStateType = MemoryStateType::Create();
   jlm::rvsdg::bittype bit64Type(64);
-  FunctionType functionType(
+  auto functionType = FunctionType::Create(
       { PointerType::Create(),
         jlm::rvsdg::bittype::Create(64),
         iostatetype::Create(),

--- a/tests/jlm/llvm/backend/llvm/jlm-llvm/test-bitconstant.cpp
+++ b/tests/jlm/llvm/backend/llvm/jlm-llvm/test-bitconstant.cpp
@@ -26,7 +26,7 @@ test()
 
   using namespace jlm::llvm;
 
-  FunctionType ft({}, { jlm::rvsdg::bittype::Create(65) });
+  auto ft = FunctionType::Create({}, { jlm::rvsdg::bittype::Create(65) });
 
   jlm::rvsdg::bitvalue_repr vr(bs);
 

--- a/tests/jlm/llvm/backend/llvm/jlm-llvm/test-function-calls.cpp
+++ b/tests/jlm/llvm/backend/llvm/jlm-llvm/test-function-calls.cpp
@@ -38,7 +38,7 @@ test_malloc()
     cfg->exit()->append_result(bb->last()->result(0));
     cfg->exit()->append_result(bb->last()->result(1));
 
-    FunctionType ft(
+    auto ft = FunctionType::Create(
         { jlm::rvsdg::bittype::Create(64) },
         { PointerType::Create(), MemoryStateType::Create() });
     auto f = function_node::create(im->ipgraph(), "f", ft, linkage::external_linkage);
@@ -82,7 +82,7 @@ test_free()
 
     auto ipgmod = ipgraph_module::create(jlm::util::filepath(""), "", "");
 
-    FunctionType ft(
+    auto ft = FunctionType::Create(
         { PointerType::Create(), MemoryStateType::Create(), iostatetype::Create() },
         { MemoryStateType::Create(), iostatetype::Create() });
     auto f = function_node::create(ipgmod->ipgraph(), "f", ft, linkage::external_linkage);

--- a/tests/jlm/llvm/backend/llvm/jlm-llvm/test-select-with-state.cpp
+++ b/tests/jlm/llvm/backend/llvm/jlm-llvm/test-select-with-state.cpp
@@ -40,7 +40,7 @@ test()
   cfg->exit()->append_result(s3);
   cfg->exit()->append_result(s3);
 
-  FunctionType ft(
+  auto ft = FunctionType::Create(
       { jlm::rvsdg::bittype::Create(1), MemoryStateType::Create(), MemoryStateType::Create() },
       { MemoryStateType::Create(), MemoryStateType::Create() });
   auto f = function_node::create(m.ipgraph(), "f", ft, linkage::external_linkage);

--- a/tests/jlm/llvm/backend/llvm/r2j/test-empty-gamma.cpp
+++ b/tests/jlm/llvm/backend/llvm/r2j/test-empty-gamma.cpp
@@ -24,7 +24,7 @@ test_with_match()
   using namespace jlm::llvm;
 
   auto vt = jlm::tests::valuetype::Create();
-  FunctionType ft({ jlm::rvsdg::bittype::Create(1), vt, vt }, { vt });
+  auto ft = FunctionType::Create({ jlm::rvsdg::bittype::Create(1), vt, vt }, { vt });
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto nf = rm.Rvsdg().node_normal_form(typeid(jlm::rvsdg::operation));
@@ -67,7 +67,7 @@ test_without_match()
   using namespace jlm::llvm;
 
   auto vt = jlm::tests::valuetype::Create();
-  FunctionType ft({ jlm::rvsdg::ctltype::Create(2), vt, vt }, { vt });
+  auto ft = FunctionType::Create({ jlm::rvsdg::ctltype::Create(2), vt, vt }, { vt });
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto nf = rm.Rvsdg().node_normal_form(typeid(jlm::rvsdg::operation));
@@ -110,7 +110,7 @@ test_gamma3()
   using namespace jlm::llvm;
 
   auto vt = jlm::tests::valuetype::Create();
-  FunctionType ft({ jlm::rvsdg::bittype::Create(32), vt, vt }, { vt });
+  auto ft = FunctionType::Create({ jlm::rvsdg::bittype::Create(32), vt, vt }, { vt });
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto nf = rm.Rvsdg().node_normal_form(typeid(jlm::rvsdg::operation));

--- a/tests/jlm/llvm/backend/llvm/r2j/test-partial-gamma.cpp
+++ b/tests/jlm/llvm/backend/llvm/r2j/test-partial-gamma.cpp
@@ -25,7 +25,7 @@ test()
   using namespace jlm::llvm;
 
   auto vt = jlm::tests::valuetype::Create();
-  FunctionType ft({ jlm::rvsdg::bittype::Create(1), vt }, { vt });
+  auto ft = FunctionType::Create({ jlm::rvsdg::bittype::Create(1), vt }, { vt });
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
 

--- a/tests/jlm/llvm/frontend/llvm/ThreeAddressCodeConversionTests.cpp
+++ b/tests/jlm/llvm/frontend/llvm/ThreeAddressCodeConversionTests.cpp
@@ -69,7 +69,7 @@ SetupFunctionWithThreeAddressCode(const jlm::rvsdg::simple_op & operation)
     resultTypes.emplace_back(operation.result(n).Type());
   }
 
-  FunctionType functionType(operandTypes, resultTypes);
+  auto functionType = FunctionType::Create(operandTypes, resultTypes);
 
   auto functionNode =
       function_node::create(ipgraph, "test", functionType, linkage::external_linkage);

--- a/tests/jlm/llvm/frontend/llvm/test-export.cpp
+++ b/tests/jlm/llvm/frontend/llvm/test-export.cpp
@@ -19,7 +19,7 @@ test()
   using namespace jlm::llvm;
 
   auto vt = jlm::tests::valuetype::Create();
-  FunctionType ft({ vt }, { vt });
+  auto ft = FunctionType::Create({ vt }, { vt });
 
   ipgraph_module im(jlm::util::filepath(""), "", "");
 

--- a/tests/jlm/llvm/ir/TestTypes.cpp
+++ b/tests/jlm/llvm/ir/TestTypes.cpp
@@ -36,13 +36,13 @@ TestIsOrContains()
   assert(IsOrContains<jlm::rvsdg::statetype>(*ioStateType));
 
   // Function types are not aggregate types
-  FunctionType functionType(
+  auto functionType = FunctionType::Create(
       { PointerType::Create(), MemoryStateType::Create(), iostatetype::Create() },
       { PointerType::Create(), MemoryStateType::Create(), iostatetype::Create() });
-  assert(!IsAggregateType(functionType));
-  assert(IsOrContains<FunctionType>(functionType));
-  assert(!IsOrContains<PointerType>(functionType));
-  assert(!IsOrContains<jlm::rvsdg::statetype>(functionType));
+  assert(!IsAggregateType(*functionType));
+  assert(IsOrContains<FunctionType>(*functionType));
+  assert(!IsOrContains<PointerType>(*functionType));
+  assert(!IsOrContains<jlm::rvsdg::statetype>(*functionType));
 
   // Struct types are aggregates that can contain other types
   auto declaration = StructType::Declaration::Create({ valueType, pointerType });

--- a/tests/jlm/llvm/ir/operators/TestCall.cpp
+++ b/tests/jlm/llvm/ir/operators/TestCall.cpp
@@ -21,7 +21,7 @@ TestCopy()
   auto valueType = jlm::tests::valuetype::Create();
   auto iOStateType = iostatetype::Create();
   auto memoryStateType = MemoryStateType::Create();
-  FunctionType functionType(
+  auto functionType = FunctionType::Create(
       { valueType, iostatetype::Create(), MemoryStateType::Create() },
       { valueType, iostatetype::Create(), MemoryStateType::Create() });
 
@@ -58,7 +58,7 @@ TestCallNodeAccessors()
   auto valueType = jlm::tests::valuetype::Create();
   auto iOStateType = iostatetype::Create();
   auto memoryStateType = MemoryStateType::Create();
-  FunctionType functionType(
+  auto functionType = FunctionType::Create(
       { valueType, iostatetype::Create(), MemoryStateType::Create() },
       { valueType, iostatetype::Create(), MemoryStateType::Create() });
 
@@ -101,10 +101,10 @@ TestCallTypeClassifierIndirectCall()
   auto vt = jlm::tests::valuetype::Create();
   auto iOStateType = iostatetype::Create();
   auto memoryStateType = MemoryStateType::Create();
-  FunctionType fcttype1(
+  auto fcttype1 = FunctionType::Create(
       { iostatetype::Create(), MemoryStateType::Create() },
       { vt, iostatetype::Create(), MemoryStateType::Create() });
-  FunctionType fcttype2(
+  auto fcttype2 = FunctionType::Create(
       { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() },
       { vt, iostatetype::Create(), MemoryStateType::Create() });
 
@@ -166,7 +166,7 @@ TestCallTypeClassifierNonRecursiveDirectCall()
   auto iOStateType = iostatetype::Create();
   auto memoryStateType = MemoryStateType::Create();
 
-  FunctionType functionTypeG(
+  auto functionTypeG = FunctionType::Create(
       { iostatetype::Create(), MemoryStateType::Create() },
       { vt, iostatetype::Create(), MemoryStateType::Create() });
 
@@ -210,7 +210,7 @@ TestCallTypeClassifierNonRecursiveDirectCall()
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
 
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { vt, iostatetype::Create(), MemoryStateType::Create() });
 
@@ -262,7 +262,7 @@ TestCallTypeClassifierNonRecursiveDirectCallTheta()
   auto iOStateType = iostatetype::Create();
   auto memoryStateType = MemoryStateType::Create();
 
-  FunctionType functionTypeG(
+  auto functionTypeG = FunctionType::Create(
       { iostatetype::Create(), MemoryStateType::Create() },
       { vt, iostatetype::Create(), MemoryStateType::Create() });
 
@@ -323,7 +323,7 @@ TestCallTypeClassifierNonRecursiveDirectCallTheta()
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
 
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { vt, iostatetype::Create(), MemoryStateType::Create() });
 
@@ -377,7 +377,7 @@ TestCallTypeClassifierRecursiveDirectCall()
     PointerType pbit64;
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { jlm::rvsdg::bittype::Create(64),
           PointerType::Create(),
           iostatetype::Create(),

--- a/tests/jlm/llvm/ir/operators/TestLambda.cpp
+++ b/tests/jlm/llvm/ir/operators/TestLambda.cpp
@@ -20,7 +20,7 @@ TestArgumentIterators()
   RvsdgModule rvsdgModule(jlm::util::filepath(""), "", "");
 
   {
-    FunctionType functionType({ vt }, { vt });
+    auto functionType = FunctionType::Create({ vt }, { vt });
 
     auto lambda = lambda::node::create(
         rvsdgModule.Rvsdg().root(),
@@ -37,7 +37,7 @@ TestArgumentIterators()
   }
 
   {
-    FunctionType functionType({}, { vt });
+    auto functionType = FunctionType::Create({}, { vt });
 
     auto lambda = lambda::node::create(
         rvsdgModule.Rvsdg().root(),
@@ -55,7 +55,7 @@ TestArgumentIterators()
   {
     auto rvsdgImport = rvsdgModule.Rvsdg().add_import({ vt, "" });
 
-    FunctionType functionType({ vt, vt, vt }, { vt, vt });
+    auto functionType = FunctionType::Create({ vt, vt, vt }, { vt, vt });
 
     auto lambda = lambda::node::create(
         rvsdgModule.Rvsdg().root(),
@@ -84,7 +84,7 @@ TestInvalidOperandRegion()
   using namespace jlm::llvm;
 
   auto vt = jlm::tests::valuetype::Create();
-  FunctionType functionType({}, { vt });
+  auto functionType = FunctionType::Create({}, { vt });
 
   auto rvsdgModule = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto rvsdg = &rvsdgModule->Rvsdg();
@@ -116,7 +116,7 @@ TestRemoveLambdaInputsWhere()
 
   // Arrange
   auto valueType = jlm::tests::valuetype::Create();
-  FunctionType functionType({}, { valueType });
+  auto functionType = FunctionType::Create({}, { valueType });
 
   auto rvsdgModule = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto & rvsdg = rvsdgModule->Rvsdg();
@@ -185,7 +185,7 @@ TestPruneLambdaInputs()
 
   // Arrange
   auto valueType = jlm::tests::valuetype::Create();
-  FunctionType functionType({}, { valueType });
+  auto functionType = FunctionType::Create({}, { valueType });
 
   auto rvsdgModule = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto & rvsdg = rvsdgModule->Rvsdg();
@@ -227,7 +227,7 @@ TestCallSummaryComputationDead()
 
   // Arrange
   auto vt = tests::valuetype::Create();
-  jlm::llvm::FunctionType functionType({}, { vt });
+  auto functionType = jlm::llvm::FunctionType::Create({}, { vt });
 
   auto rvsdgModule = jlm::llvm::RvsdgModule::Create(util::filepath(""), "", "");
   auto & rvsdg = rvsdgModule->Rvsdg();
@@ -261,7 +261,7 @@ TestCallSummaryComputationExport()
 
   // Arrange
   auto vt = tests::valuetype::Create();
-  jlm::llvm::FunctionType functionType({}, { vt });
+  auto functionType = jlm::llvm::FunctionType::Create({}, { vt });
 
   auto rvsdgModule = jlm::llvm::RvsdgModule::Create(util::filepath(""), "", "");
   auto & rvsdg = rvsdgModule->Rvsdg();
@@ -296,7 +296,7 @@ TestCallSummaryComputationDirectCalls()
 
   // Arrange
   auto vt = tests::valuetype::Create();
-  jlm::llvm::FunctionType functionType(
+  auto functionType = jlm::llvm::FunctionType::Create(
       { jlm::llvm::iostatetype::Create(), jlm::llvm::MemoryStateType::Create() },
       { vt, jlm::llvm::iostatetype::Create(), jlm::llvm::MemoryStateType::Create() });
 
@@ -455,7 +455,7 @@ TestCallSummaryComputationFunctionPointerInDelta()
   nf->set_mutable(false);
 
   auto valueType = jlm::tests::valuetype::Create();
-  FunctionType functionType({ valueType }, { valueType });
+  auto functionType = FunctionType::Create({ valueType }, { valueType });
 
   auto lambdaNode =
       lambda::node::create(rvsdg->root(), functionType, "f", linkage::external_linkage);
@@ -494,8 +494,8 @@ TestCallSummaryComputationLambdaResult()
 
   auto pointerType = PointerType::Create();
   auto valueType = jlm::tests::valuetype::Create();
-  FunctionType functionTypeG({ valueType }, { valueType });
-  FunctionType functionTypeF({ valueType }, { PointerType::Create() });
+  auto functionTypeG = FunctionType::Create({ valueType }, { valueType });
+  auto functionTypeF = FunctionType::Create({ valueType }, { PointerType::Create() });
 
   auto lambdaNodeG =
       lambda::node::create(rvsdg.root(), functionTypeG, "g", linkage::external_linkage);

--- a/tests/jlm/llvm/ir/operators/TestPhi.cpp
+++ b/tests/jlm/llvm/ir/operators/TestPhi.cpp
@@ -22,10 +22,10 @@ TestPhiCreation()
   auto vtype = jlm::tests::valuetype::Create();
   auto iOStateType = iostatetype::Create();
   auto memoryStateType = MemoryStateType::Create();
-  FunctionType f0type(
+  auto f0type = FunctionType::Create(
       { vtype, iostatetype::Create(), MemoryStateType::Create() },
       { iostatetype::Create(), MemoryStateType::Create() });
-  FunctionType f1type(
+  auto f1type = FunctionType::Create(
       { vtype, iostatetype::Create(), MemoryStateType::Create() },
       { vtype, iostatetype::Create(), MemoryStateType::Create() });
 

--- a/tests/jlm/llvm/opt/InvariantValueRedirectionTests.cpp
+++ b/tests/jlm/llvm/opt/InvariantValueRedirectionTests.cpp
@@ -37,7 +37,8 @@ TestGamma()
   // Arrange
   auto valueType = jlm::tests::valuetype::Create();
   auto controlType = jlm::rvsdg::ctltype::Create(2);
-  FunctionType functionType({ controlType, valueType, valueType }, { valueType, valueType });
+  auto functionType =
+      FunctionType::Create({ controlType, valueType, valueType }, { valueType, valueType });
 
   auto rvsdgModule = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto & rvsdg = rvsdgModule->Rvsdg();
@@ -88,7 +89,7 @@ TestTheta()
   auto ioStateType = iostatetype::Create();
   auto valueType = jlm::tests::valuetype::Create();
   auto controlType = jlm::rvsdg::ctltype::Create(2);
-  FunctionType functionType(
+  auto functionType = FunctionType::Create(
       { controlType, valueType, ioStateType },
       { controlType, valueType, ioStateType });
 
@@ -143,7 +144,7 @@ TestCall()
   auto memoryStateType = MemoryStateType::Create();
   auto valueType = jlm::tests::valuetype::Create();
   auto controlType = jlm::rvsdg::ctltype::Create(2);
-  FunctionType functionTypeTest1(
+  auto functionTypeTest1 = FunctionType::Create(
       { controlType, valueType, valueType, ioStateType, memoryStateType },
       { valueType, valueType, ioStateType, memoryStateType });
 
@@ -181,7 +182,7 @@ TestCall()
 
   lambda::output * lambdaOutputTest2;
   {
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { valueType, valueType, ioStateType, memoryStateType },
         { valueType, valueType, ioStateType, memoryStateType });
 
@@ -230,7 +231,7 @@ TestCallWithMemoryStateNodes()
   auto memoryStateType = MemoryStateType::Create();
   auto valueType = jlm::tests::valuetype::Create();
   auto controlType = jlm::rvsdg::ctltype::Create(2);
-  FunctionType functionTypeTest1(
+  auto functionTypeTest1 = FunctionType::Create(
       { controlType, valueType, ioStateType, memoryStateType },
       { valueType, ioStateType, memoryStateType });
 
@@ -273,7 +274,7 @@ TestCallWithMemoryStateNodes()
 
   lambda::output * lambdaOutputTest2;
   {
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { valueType, ioStateType, memoryStateType },
         { valueType, ioStateType, memoryStateType });
 

--- a/tests/jlm/llvm/opt/TestDeadNodeElimination.cpp
+++ b/tests/jlm/llvm/opt/TestDeadNodeElimination.cpp
@@ -251,8 +251,11 @@ TestLambda()
   auto x = graph.add_import({ vt, "x" });
   auto y = graph.add_import({ vt, "y" });
 
-  auto lambda =
-      lambda::node::create(graph.root(), { { vt }, { vt, vt } }, "f", linkage::external_linkage);
+  auto lambda = lambda::node::create(
+      graph.root(),
+      FunctionType::Create({ vt }, { vt, vt }),
+      "f",
+      linkage::external_linkage);
 
   auto cv1 = lambda->add_ctxvar(x);
   auto cv2 = lambda->add_ctxvar(y);
@@ -277,7 +280,7 @@ TestPhi()
 
   // Arrange
   auto valueType = jlm::tests::valuetype::Create();
-  FunctionType functionType({ valueType }, { valueType });
+  auto functionType = FunctionType::Create({ valueType }, { valueType });
 
   RvsdgModule rvsdgModule(jlm::util::filepath(""), "", "");
   auto & rvsdg = rvsdgModule.Rvsdg();

--- a/tests/jlm/llvm/opt/test-cne.cpp
+++ b/tests/jlm/llvm/opt/test-cne.cpp
@@ -389,7 +389,7 @@ test_lambda()
   using namespace jlm::llvm;
 
   auto vt = jlm::tests::valuetype::Create();
-  FunctionType ft({ vt, vt }, { vt });
+  auto ft = FunctionType::Create({ vt, vt }, { vt });
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto & graph = rm.Rvsdg();
@@ -424,7 +424,7 @@ test_phi()
   using namespace jlm::llvm;
 
   auto vt = jlm::tests::valuetype::Create();
-  FunctionType ft({ vt, vt }, { vt });
+  auto ft = FunctionType::Create({ vt, vt }, { vt });
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto & graph = rm.Rvsdg();

--- a/tests/jlm/llvm/opt/test-inlining.cpp
+++ b/tests/jlm/llvm/opt/test-inlining.cpp
@@ -33,7 +33,7 @@ test1()
     auto vt = jlm::tests::valuetype::Create();
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { vt, iostatetype::Create(), MemoryStateType::Create() },
         { vt, iostatetype::Create(), MemoryStateType::Create() });
 
@@ -51,7 +51,7 @@ test1()
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
     auto ct = jlm::rvsdg::ctltype::Create(2);
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { jlm::rvsdg::ctltype::Create(2), vt, iostatetype::Create(), MemoryStateType::Create() },
         { vt, iostatetype::Create(), MemoryStateType::Create() });
 
@@ -70,7 +70,7 @@ test1()
 
     auto callResults = CallNode::Create(
         gammaInputF1->argument(0),
-        f1->node()->type(),
+        f1->node()->Type(),
         { gammaInputValue->argument(0),
           gammaInputIoState->argument(0),
           gammaInputMemoryState->argument(0) });
@@ -110,12 +110,12 @@ test2()
   auto iOStateType = iostatetype::Create();
   auto memoryStateType = MemoryStateType::Create();
 
-  FunctionType functionType1(
+  auto functionType1 = FunctionType::Create(
       { vt, iostatetype::Create(), MemoryStateType::Create() },
       { iostatetype::Create(), MemoryStateType::Create() });
   auto pt = PointerType::Create();
 
-  FunctionType functionType2(
+  auto functionType2 = FunctionType::Create(
       { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() },
       { iostatetype::Create(), MemoryStateType::Create() });
 
@@ -123,7 +123,7 @@ test2()
   auto & graph = rm.Rvsdg();
   auto i = graph.add_import({ pt, "i" });
 
-  auto SetupF1 = [&](const FunctionType & functionType)
+  auto SetupF1 = [&](const std::shared_ptr<const FunctionType> & functionType)
   {
     auto lambda = lambda::node::create(graph.root(), functionType, "f1", linkage::external_linkage);
     return lambda->finalize({ lambda->fctargument(1), lambda->fctargument(2) });
@@ -133,7 +133,7 @@ test2()
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { iostatetype::Create(), MemoryStateType::Create() });
 

--- a/tests/jlm/mlir/backend/TestJlmToMlirConverter.cpp
+++ b/tests/jlm/mlir/backend/TestJlmToMlirConverter.cpp
@@ -28,7 +28,7 @@ TestLambda()
     std::cout << "Function Setup" << std::endl;
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
@@ -149,7 +149,7 @@ TestAddOperation()
     std::cout << "Function Setup" << std::endl;
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
@@ -250,7 +250,7 @@ TestComZeroExt()
     std::cout << "Function Setup" << std::endl;
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
-    FunctionType functionType(
+    auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(1), iostatetype::Create(), MemoryStateType::Create() });
 


### PR DESCRIPTION
Convert lambda, call nodes and others to use "std::shared_ptr<FunctionType>" instead of "const FunctionType &" to avoid copying instances.