### PR TITLE
Mostly get rid of "ports" in constructors.

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/UnusedStateRemoval.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/UnusedStateRemoval.cpp
@@ -114,7 +114,7 @@ RemoveUnusedStatesFromLambda(llvm::lambda::node & lambdaNode)
       newLambda->region(),
       newLambdaOutput,
       nullptr,
-      newLambdaOutput->type());
+      newLambdaOutput->Type());
 }
 
 static void

--- a/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
@@ -78,7 +78,7 @@ add_lambda_argument(llvm::lambda::node * ln, const jlm::rvsdg::type * type)
   //            ln->output()->divert_users(new_out);
   ln->region()->RemoveResult((*ln->output()->begin())->index());
   remove(ln);
-  jlm::rvsdg::result::create(new_lambda->region(), new_out, nullptr, new_out->type());
+  jlm::rvsdg::result::create(new_lambda->region(), new_out, nullptr, new_out->Type());
   return new_lambda;
 }
 

--- a/jlm/hls/backend/rvsdg2rhls/dae-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/dae-conv.cpp
@@ -246,9 +246,9 @@ decouple_load(
           else
           {
             auto new_in =
-                jlm::rvsdg::structural_input::create(new_loop, arg->input()->origin(), arg->type());
+                jlm::rvsdg::structural_input::create(new_loop, arg->input()->origin(), arg->Type());
             smap.insert(arg->input(), new_in);
-            new_arg = jlm::rvsdg::argument::create(new_loop->subregion(), new_in, arg->type());
+            new_arg = jlm::rvsdg::argument::create(new_loop->subregion(), new_in, arg->Type());
           }
           smap.insert(arg, new_arg);
           continue;
@@ -296,12 +296,12 @@ decouple_load(
       }
       auto new_res_origin = smap.lookup(res->origin());
       auto new_state_output =
-          jlm::rvsdg::structural_output::create(new_loop, new_res_origin->port());
+          jlm::rvsdg::structural_output::create(new_loop, new_res_origin->Type());
       jlm::rvsdg::result::create(
           new_loop->subregion(),
           new_res_origin,
           new_state_output,
-          new_res_origin->type());
+          new_res_origin->Type());
       res->output()->divert_users(new_state_output);
     }
   }
@@ -332,8 +332,8 @@ decouple_load(
 
   // create output for address
   auto load_addr = gate_out[0];
-  auto addr_output = jlm::rvsdg::structural_output::create(new_loop, load_addr->port());
-  jlm::rvsdg::result::create(new_loop->subregion(), load_addr, addr_output, load_addr->type());
+  auto addr_output = jlm::rvsdg::structural_output::create(new_loop, load_addr->Type());
+  jlm::rvsdg::result::create(new_loop->subregion(), load_addr, addr_output, load_addr->Type());
   // trace and remove loop input for mem data reponse
   auto mem_data_loop_out = new_load->input(new_load->ninputs() - 1)->origin();
   auto mem_data_loop_arg = dynamic_cast<jlm::rvsdg::argument *>(mem_data_loop_out);
@@ -363,9 +363,9 @@ decouple_load(
   // use a buffer here to make ready logic for response easy and consistent
   auto buf = buffer_op::create(*dload_out[0], 2, true)[0];
   // replace data output of loadNode
-  auto old_data_in = jlm::rvsdg::structural_input::create(loopNode, buf, dload_out[0]->type());
+  auto old_data_in = jlm::rvsdg::structural_input::create(loopNode, buf, dload_out[0]->Type());
   auto old_data_arg =
-      jlm::rvsdg::argument::create(loopNode->subregion(), old_data_in, dload_out[0]->type());
+      jlm::rvsdg::argument::create(loopNode->subregion(), old_data_in, dload_out[0]->Type());
   loadNode->output(0)->divert_users(old_data_arg);
   remove(loadNode);
 }

--- a/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
@@ -30,8 +30,8 @@ jlm::hls::route_response(jlm::rvsdg::region * target, jlm::rvsdg::output * respo
     auto parent_response = route_response(target->node()->region(), response);
     auto ln = dynamic_cast<jlm::hls::loop_node *>(target->node());
     JLM_ASSERT(ln);
-    auto input = jlm::rvsdg::structural_input::create(ln, parent_response, parent_response->port());
-    auto argument = jlm::rvsdg::argument::create(target, input, response->type());
+    auto input = jlm::rvsdg::structural_input::create(ln, parent_response, parent_response->Type());
+    auto argument = jlm::rvsdg::argument::create(target, input, response->Type());
     return argument;
   }
 }
@@ -47,8 +47,8 @@ jlm::hls::route_request(jlm::rvsdg::region * target, jlm::rvsdg::output * reques
   {
     auto ln = dynamic_cast<jlm::hls::loop_node *>(request->region()->node());
     JLM_ASSERT(ln);
-    auto output = jlm::rvsdg::structural_output::create(ln, request->port());
-    jlm::rvsdg::result::create(request->region(), request, output, request->type());
+    auto output = jlm::rvsdg::structural_output::create(ln, request->Type());
+    jlm::rvsdg::result::create(request->region(), request, output, request->Type());
     return route_request(target, output);
   }
 }
@@ -696,7 +696,7 @@ jlm::hls::MemoryConverter(jlm::llvm::RvsdgModule & rm)
   }
   originalResults.insert(originalResults.end(), newResults.begin(), newResults.end());
   auto newOut = newLambda->finalize(originalResults);
-  jlm::rvsdg::result::create(newLambda->region(), newOut, nullptr, newOut->type());
+  jlm::rvsdg::result::create(newLambda->region(), newOut, nullptr, newOut->Type());
 
   JLM_ASSERT(lambda->output()->nusers() == 1);
   lambda->region()->RemoveResult((*lambda->output()->begin())->index());

--- a/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
@@ -242,7 +242,7 @@ remove_lambda_passthrough(llvm::lambda::node * ln)
   JLM_ASSERT(ln->output()->nusers() == 1);
   ln->region()->RemoveResult((*ln->output()->begin())->index());
   remove(ln);
-  jlm::rvsdg::result::create(new_lambda->region(), new_out, nullptr, new_out->type());
+  jlm::rvsdg::result::create(new_lambda->region(), new_out, nullptr, new_out->Type());
   return new_lambda;
 }
 

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -391,7 +391,7 @@ split_hls_function(llvm::RvsdgModule & rm, const std::string & function_name)
           rhls->Rvsdg().root(),
           new_ln->output(),
           nullptr,
-          new_ln->output()->type());
+          new_ln->output()->Type());
       // add function as input to rm and remove it
       llvm::impport im(
           ln->type(),

--- a/jlm/hls/ir/hls.cpp
+++ b/jlm/hls/ir/hls.cpp
@@ -11,10 +11,10 @@ namespace jlm::hls
 jlm::rvsdg::structural_output *
 loop_node::add_loopvar(jlm::rvsdg::output * origin, jlm::rvsdg::output ** buffer)
 {
-  auto input = jlm::rvsdg::structural_input::create(this, origin, origin->type());
-  auto output = jlm::rvsdg::structural_output::create(this, origin->type());
+  auto input = jlm::rvsdg::structural_input::create(this, origin, origin->Type());
+  auto output = jlm::rvsdg::structural_output::create(this, origin->Type());
 
-  auto argument_in = jlm::rvsdg::argument::create(subregion(), input, origin->type());
+  auto argument_in = jlm::rvsdg::argument::create(subregion(), input, origin->Type());
   auto argument_loop = add_backedge(origin->type());
 
   auto mux =
@@ -24,7 +24,7 @@ loop_node::add_loopvar(jlm::rvsdg::output * origin, jlm::rvsdg::output ** buffer
   {
     *buffer = mux;
   }
-  jlm::rvsdg::result::create(subregion(), branch[0], output, origin->type());
+  jlm::rvsdg::result::create(subregion(), branch[0], output, origin->Type());
   auto result_loop = argument_loop->result();
   auto buf = hls::buffer_op::create(*branch[1], 2)[0];
   result_loop->divert_to(buf);
@@ -34,9 +34,9 @@ loop_node::add_loopvar(jlm::rvsdg::output * origin, jlm::rvsdg::output ** buffer
 jlm::rvsdg::output *
 loop_node::add_loopconst(jlm::rvsdg::output * origin)
 {
-  auto input = jlm::rvsdg::structural_input::create(this, origin, origin->type());
+  auto input = jlm::rvsdg::structural_input::create(this, origin, origin->Type());
 
-  auto argument_in = jlm::rvsdg::argument::create(subregion(), input, origin->type());
+  auto argument_in = jlm::rvsdg::argument::create(subregion(), input, origin->Type());
   auto buffer = hls::loop_constant_buffer_op::create(*predicate_buffer(), *argument_in)[0];
   return buffer;
 }
@@ -52,7 +52,7 @@ loop_node::copy(jlm::rvsdg::region * region, jlm::rvsdg::substitution_map & smap
   for (size_t i = 0; i < ninputs(); ++i)
   {
     auto in_origin = smap.lookup(input(i)->origin());
-    auto inp = jlm::rvsdg::structural_input::create(loop, in_origin, in_origin->type());
+    auto inp = jlm::rvsdg::structural_input::create(loop, in_origin, in_origin->Type());
     smap.insert(input(i), loop->input(i));
     auto oarg = input(i)->arguments.begin().ptr();
     auto narg = jlm::rvsdg::argument::create(loop->subregion(), inp, oarg->port());
@@ -60,7 +60,7 @@ loop_node::copy(jlm::rvsdg::region * region, jlm::rvsdg::substitution_map & smap
   }
   for (size_t i = 0; i < noutputs(); ++i)
   {
-    auto out = jlm::rvsdg::structural_output::create(loop, output(i)->type());
+    auto out = jlm::rvsdg::structural_output::create(loop, output(i)->Type());
     smap.insert(output(i), out);
     smap.insert(output(i), out);
   }

--- a/jlm/hls/ir/hls.hpp
+++ b/jlm/hls/ir/hls.hpp
@@ -558,7 +558,7 @@ public:
 
 private:
   backedge_argument(jlm::rvsdg::region * region, const jlm::rvsdg::type & type)
-      : jlm::rvsdg::argument(region, nullptr, type),
+      : jlm::rvsdg::argument(region, nullptr, type.copy()),
         result_(nullptr)
   {}
 

--- a/jlm/llvm/ir/operators/Phi.cpp
+++ b/jlm/llvm/ir/operators/Phi.cpp
@@ -50,8 +50,8 @@ node::output(size_t n) const noexcept
 cvargument *
 node::add_ctxvar(jlm::rvsdg::output * origin)
 {
-  auto input = cvinput::create(this, origin, origin->type());
-  return cvargument::create(subregion(), input, origin->type());
+  auto input = cvinput::create(this, origin, origin->Type());
+  return cvargument::create(subregion(), input, origin->Type());
 }
 
 phi::node *
@@ -127,9 +127,9 @@ builder::add_recvar(const jlm::rvsdg::type & type)
   if (!node_)
     return nullptr;
 
-  auto argument = rvargument::create(subregion(), type);
-  auto output = rvoutput::create(node_, argument, type);
-  rvresult::create(subregion(), argument, output, type);
+  auto argument = rvargument::create(subregion(), type.copy());
+  auto output = rvoutput::create(node_, argument, type.copy());
+  rvresult::create(subregion(), argument, output, type.copy());
   argument->output_ = output;
 
   return output;

--- a/jlm/llvm/ir/operators/Phi.hpp
+++ b/jlm/llvm/ir/operators/Phi.hpp
@@ -557,11 +557,14 @@ class cvinput final : public jlm::rvsdg::structural_input
 public:
   ~cvinput() override;
 
-private:
-  cvinput(phi::node * node, jlm::rvsdg::output * origin, const jlm::rvsdg::port & port)
-      : structural_input(node, origin, port)
+  cvinput(
+      phi::node * node,
+      jlm::rvsdg::output * origin,
+      std::shared_ptr<const jlm::rvsdg::type> type)
+      : structural_input(node, origin, std::move(type))
   {}
 
+private:
   cvinput(const cvinput &) = delete;
 
   cvinput(cvinput &&) = delete;
@@ -573,9 +576,12 @@ private:
   operator=(cvinput &&) = delete;
 
   static cvinput *
-  create(phi::node * node, jlm::rvsdg::output * origin, const jlm::rvsdg::port & port)
+  create(
+      phi::node * node,
+      jlm::rvsdg::output * origin,
+      std::shared_ptr<const jlm::rvsdg::type> type)
   {
-    auto input = std::unique_ptr<cvinput>(new cvinput(node, origin, port));
+    auto input = std::make_unique<cvinput>(node, origin, std::move(type));
     return static_cast<cvinput *>(node->append_input(std::move(input)));
   }
 
@@ -603,8 +609,8 @@ public:
   ~rvoutput() override;
 
 private:
-  rvoutput(phi::node * node, rvargument * argument, const jlm::rvsdg::port & port)
-      : structural_output(node, port),
+  rvoutput(phi::node * node, rvargument * argument, std::shared_ptr<const rvsdg::type> type)
+      : structural_output(node, std::move(type)),
         argument_(argument)
   {}
 
@@ -619,7 +625,7 @@ private:
   operator=(rvoutput &&) = delete;
 
   static rvoutput *
-  create(phi::node * node, rvargument * argument, const jlm::rvsdg::port & port);
+  create(phi::node * node, rvargument * argument, std::shared_ptr<const rvsdg::type> type);
 
 public:
   rvargument *
@@ -662,6 +668,11 @@ private:
         output_(nullptr)
   {}
 
+  rvargument(jlm::rvsdg::region * region, const std::shared_ptr<const jlm::rvsdg::type> type)
+      : argument(region, nullptr, std::move(type)),
+        output_(nullptr)
+  {}
+
   rvargument(const rvargument &) = delete;
 
   rvargument(rvargument &&) = delete;
@@ -676,6 +687,14 @@ private:
   create(jlm::rvsdg::region * region, const jlm::rvsdg::port & port)
   {
     auto argument = new rvargument(region, port);
+    region->append_argument(argument);
+    return argument;
+  }
+
+  static rvargument *
+  create(jlm::rvsdg::region * region, std::shared_ptr<const jlm::rvsdg::type> type)
+  {
+    auto argument = new rvargument(region, std::move(type));
     region->append_argument(argument);
     return argument;
   }
@@ -710,11 +729,18 @@ class cvargument final : public jlm::rvsdg::argument
 public:
   ~cvargument() override;
 
-private:
   cvargument(jlm::rvsdg::region * region, phi::cvinput * input, const jlm::rvsdg::port & port)
       : jlm::rvsdg::argument(region, input, port)
   {}
 
+  cvargument(
+      jlm::rvsdg::region * region,
+      phi::cvinput * input,
+      std::shared_ptr<const rvsdg::type> type)
+      : jlm::rvsdg::argument(region, input, std::move(type))
+  {}
+
+private:
   cvargument(const cvargument &) = delete;
 
   cvargument(cvargument &&) = delete;
@@ -729,6 +755,14 @@ private:
   create(jlm::rvsdg::region * region, phi::cvinput * input, const jlm::rvsdg::port & port)
   {
     auto argument = new cvargument(region, input, port);
+    region->append_argument(argument);
+    return argument;
+  }
+
+  static cvargument *
+  create(jlm::rvsdg::region * region, phi::cvinput * input, std::shared_ptr<const rvsdg::type> type)
+  {
+    auto argument = new cvargument(region, input, std::move(type));
     region->append_argument(argument);
     return argument;
   }
@@ -759,6 +793,14 @@ private:
       : jlm::rvsdg::result(region, origin, output, port)
   {}
 
+  rvresult(
+      jlm::rvsdg::region * region,
+      jlm::rvsdg::output * origin,
+      rvoutput * output,
+      std::shared_ptr<const rvsdg::type> type)
+      : jlm::rvsdg::result(region, origin, output, std::move(type))
+  {}
+
   rvresult(const rvresult &) = delete;
 
   rvresult(rvresult &&) = delete;
@@ -777,6 +819,18 @@ private:
       const jlm::rvsdg::port & port)
   {
     auto result = new rvresult(region, origin, output, port);
+    region->append_result(result);
+    return result;
+  }
+
+  static rvresult *
+  create(
+      jlm::rvsdg::region * region,
+      jlm::rvsdg::output * origin,
+      rvoutput * output,
+      std::shared_ptr<const rvsdg::type> type)
+  {
+    auto result = new rvresult(region, origin, output, type);
     region->append_result(result);
     return result;
   }
@@ -861,10 +915,10 @@ cvinput::argument() const noexcept
 }
 
 inline rvoutput *
-rvoutput::create(phi::node * node, rvargument * argument, const jlm::rvsdg::port & port)
+rvoutput::create(phi::node * node, rvargument * argument, std::shared_ptr<const rvsdg::type> type)
 {
-  JLM_ASSERT(argument->type() == port.type());
-  auto output = std::unique_ptr<rvoutput>(new rvoutput(node, argument, port));
+  JLM_ASSERT(argument->type() == *type);
+  auto output = std::unique_ptr<rvoutput>(new rvoutput(node, argument, std::move(type)));
   return static_cast<rvoutput *>(node->append_output(std::move(output)));
 }
 

--- a/jlm/llvm/ir/operators/delta.cpp
+++ b/jlm/llvm/ir/operators/delta.cpp
@@ -148,7 +148,7 @@ node::finalize(jlm::rvsdg::output * origin)
 
   delta::result::create(origin);
 
-  return output::create(this, PointerType());
+  return output::create(this, PointerType::Create());
 }
 
 /* delta context variable input class */

--- a/jlm/llvm/ir/operators/delta.hpp
+++ b/jlm/llvm/ir/operators/delta.hpp
@@ -335,7 +335,7 @@ public:
 
 private:
   cvinput(delta::node * node, rvsdg::output * origin)
-      : structural_input(node, origin, origin->port())
+      : structural_input(node, origin, origin->Type())
   {}
 
   static cvinput *
@@ -405,15 +405,26 @@ class output final : public rvsdg::structural_output
 public:
   ~output() override;
 
-private:
   output(delta::node * node, const rvsdg::port & port)
-      : structural_output(node, port)
+      : structural_output(node, port.Type())
   {}
 
+  output(delta::node * node, std::shared_ptr<const rvsdg::type> type)
+      : structural_output(node, std::move(type))
+  {}
+
+private:
   static output *
   create(delta::node * node, const rvsdg::port & port)
   {
-    auto output = std::unique_ptr<delta::output>(new delta::output(node, port));
+    auto output = std::make_unique<delta::output>(node, port);
+    return static_cast<delta::output *>(node->append_output(std::move(output)));
+  }
+
+  static output *
+  create(delta::node * node, std::shared_ptr<const rvsdg::type> type)
+  {
+    auto output = std::make_unique<delta::output>(node, std::move(type));
     return static_cast<delta::output *>(node->append_output(std::move(output)));
   }
 

--- a/jlm/llvm/ir/operators/lambda.cpp
+++ b/jlm/llvm/ir/operators/lambda.cpp
@@ -219,7 +219,7 @@ node::finalize(const std::vector<jlm::rvsdg::output *> & results)
   for (const auto & origin : results)
     lambda::result::create(origin);
 
-  return output::create(this, PointerType());
+  return output::create(this, PointerType::Create());
 }
 
 lambda::node *

--- a/jlm/llvm/ir/operators/lambda.hpp
+++ b/jlm/llvm/ir/operators/lambda.hpp
@@ -402,7 +402,7 @@ public:
 
 private:
   cvinput(lambda::node * node, jlm::rvsdg::output * origin)
-      : structural_input(node, origin, origin->port())
+      : structural_input(node, origin, origin->Type())
   {}
 
   static cvinput *
@@ -472,15 +472,15 @@ class output final : public jlm::rvsdg::structural_output
 public:
   ~output() override;
 
-private:
-  output(lambda::node * node, const jlm::rvsdg::port & port)
-      : structural_output(node, port)
+  output(lambda::node * node, std::shared_ptr<const rvsdg::type> type)
+      : structural_output(node, std::move(type))
   {}
 
+private:
   static output *
-  create(lambda::node * node, const jlm::rvsdg::port & port)
+  create(lambda::node * node, std::shared_ptr<const rvsdg::type> type)
   {
-    auto output = std::unique_ptr<lambda::output>(new lambda::output(node, port));
+    auto output = std::make_unique<lambda::output>(node, std::move(type));
     return jlm::util::AssertedCast<lambda::output>(node->append_output(std::move(output)));
   }
 
@@ -521,7 +521,7 @@ public:
 
 private:
   fctargument(jlm::rvsdg::region * region, const jlm::rvsdg::type & type)
-      : jlm::rvsdg::argument(region, nullptr, type)
+      : jlm::rvsdg::argument(region, nullptr, type.copy())
   {}
 
   static fctargument *

--- a/jlm/rvsdg/node.cpp
+++ b/jlm/rvsdg/node.cpp
@@ -39,6 +39,24 @@ input::input(
   origin->add_user(this);
 }
 
+input::input(
+    jlm::rvsdg::output * origin,
+    jlm::rvsdg::region * region,
+    std::shared_ptr<const rvsdg::type> type)
+    : index_(0),
+      origin_(origin),
+      region_(region),
+      port_(std::make_unique<rvsdg::port>(std::move(type)))
+{
+  if (region != origin->region())
+    throw jlm::util::error("Invalid operand region.");
+
+  if (port_->type() != origin->type())
+    throw jlm::util::type_error(port_->type().debug_string(), origin->type().debug_string());
+
+  origin->add_user(this);
+}
+
 std::string
 input::debug_string() const
 {
@@ -87,6 +105,12 @@ output::output(jlm::rvsdg::region * region, const jlm::rvsdg::port & port)
     : index_(0),
       region_(region),
       port_(port.copy())
+{}
+
+output::output(jlm::rvsdg::region * region, std::shared_ptr<const rvsdg::type> type)
+    : index_(0),
+      region_(region),
+      port_(std::make_unique<rvsdg::port>(std::move(type)))
 {}
 
 std::string
@@ -148,15 +172,15 @@ namespace jlm::rvsdg
 node_input::node_input(
     jlm::rvsdg::output * origin,
     jlm::rvsdg::node * node,
-    const jlm::rvsdg::port & port)
-    : jlm::rvsdg::input(origin, node->region(), port),
+    std::shared_ptr<const rvsdg::type> type)
+    : jlm::rvsdg::input(origin, node->region(), std::move(type)),
       node_(node)
 {}
 
 /* node_output class */
 
-node_output::node_output(jlm::rvsdg::node * node, const jlm::rvsdg::port & port)
-    : jlm::rvsdg::output(node->region(), port),
+node_output::node_output(jlm::rvsdg::node * node, std::shared_ptr<const rvsdg::type> type)
+    : jlm::rvsdg::output(node->region(), std::move(type)),
       node_(node)
 {}
 

--- a/jlm/rvsdg/node.hpp
+++ b/jlm/rvsdg/node.hpp
@@ -42,6 +42,11 @@ public:
 
   input(jlm::rvsdg::output * origin, jlm::rvsdg::region * region, const jlm::rvsdg::port & port);
 
+  input(
+      jlm::rvsdg::output * origin,
+      jlm::rvsdg::region * region,
+      std::shared_ptr<const rvsdg::type> type);
+
   input(const input &) = delete;
 
   input(input &&) = delete;
@@ -305,6 +310,8 @@ public:
   virtual ~output() noexcept;
 
   output(jlm::rvsdg::region * region, const jlm::rvsdg::port & port);
+
+  output(jlm::rvsdg::region * region, std::shared_ptr<const rvsdg::type> type);
 
   output(const output &) = delete;
 
@@ -590,7 +597,10 @@ is(const jlm::rvsdg::output * output) noexcept
 class node_input : public jlm::rvsdg::input
 {
 public:
-  node_input(jlm::rvsdg::output * origin, jlm::rvsdg::node * node, const jlm::rvsdg::port & port);
+  node_input(
+      jlm::rvsdg::output * origin,
+      jlm::rvsdg::node * node,
+      std::shared_ptr<const rvsdg::type> type);
 
   jlm::rvsdg::node *
   node() const noexcept
@@ -622,7 +632,7 @@ private:
 class node_output : public jlm::rvsdg::output
 {
 public:
-  node_output(jlm::rvsdg::node * node, const jlm::rvsdg::port & port);
+  node_output(jlm::rvsdg::node * node, std::shared_ptr<const rvsdg::type> type);
 
   jlm::rvsdg::node *
   node() const noexcept

--- a/jlm/rvsdg/operation.cpp
+++ b/jlm/rvsdg/operation.cpp
@@ -16,10 +16,6 @@ namespace jlm::rvsdg
 port::~port()
 {}
 
-port::port(const jlm::rvsdg::type & type)
-    : port(type.copy())
-{}
-
 port::port(std::shared_ptr<const jlm::rvsdg::type> type)
     : type_(std::move(type))
 {}

--- a/jlm/rvsdg/operation.hpp
+++ b/jlm/rvsdg/operation.hpp
@@ -31,9 +31,7 @@ class port
 public:
   virtual ~port();
 
-  port(const jlm::rvsdg::type & type);
-
-  port(std::shared_ptr<const jlm::rvsdg::type> type);
+  explicit port(std::shared_ptr<const jlm::rvsdg::type> type);
 
   port(const port & other) = default;
 

--- a/jlm/rvsdg/region.cpp
+++ b/jlm/rvsdg/region.cpp
@@ -39,6 +39,22 @@ argument::argument(
   }
 }
 
+argument::argument(
+    jlm::rvsdg::region * region,
+    jlm::rvsdg::structural_input * input,
+    std::shared_ptr<const rvsdg::type> type)
+    : output(region, std::move(type)),
+      input_(input)
+{
+  if (input)
+  {
+    if (input->node() != region->node())
+      throw jlm::util::error("Argument cannot be added to input.");
+
+    input->arguments.push_back(this);
+  }
+}
+
 jlm::rvsdg::argument *
 argument::create(
     jlm::rvsdg::region * region,
@@ -56,7 +72,7 @@ argument::create(
     structural_input * input,
     std::shared_ptr<const jlm::rvsdg::type> type)
 {
-  auto argument = new jlm::rvsdg::argument(region, input, jlm::rvsdg::port(std::move(type)));
+  auto argument = new jlm::rvsdg::argument(region, input, std::move(type));
   region->append_argument(argument);
   return argument;
 }
@@ -77,6 +93,23 @@ result::result(
     jlm::rvsdg::structural_output * output,
     const jlm::rvsdg::port & port)
     : input(origin, region, port),
+      output_(output)
+{
+  if (output)
+  {
+    if (output->node() != region->node())
+      throw jlm::util::error("Result cannot be added to output.");
+
+    output->results.push_back(this);
+  }
+}
+
+result::result(
+    jlm::rvsdg::region * region,
+    jlm::rvsdg::output * origin,
+    jlm::rvsdg::structural_output * output,
+    std::shared_ptr<const rvsdg::type> type)
+    : input(origin, region, std::move(type)),
       output_(output)
 {
   if (output)

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -42,6 +42,11 @@ protected:
       jlm::rvsdg::structural_input * input,
       const jlm::rvsdg::port & port);
 
+  argument(
+      jlm::rvsdg::region * region,
+      jlm::rvsdg::structural_input * input,
+      std::shared_ptr<const rvsdg::type> type);
+
   argument(const argument &) = delete;
 
   argument(argument &&) = delete;
@@ -89,6 +94,12 @@ protected:
       jlm::rvsdg::output * origin,
       jlm::rvsdg::structural_output * output,
       const jlm::rvsdg::port & port);
+
+  result(
+      jlm::rvsdg::region * region,
+      jlm::rvsdg::output * origin,
+      jlm::rvsdg::structural_output * output,
+      std::shared_ptr<const rvsdg::type> type);
 
   result(const result &) = delete;
 

--- a/jlm/rvsdg/simple-node.cpp
+++ b/jlm/rvsdg/simple-node.cpp
@@ -21,14 +21,16 @@ simple_input::~simple_input() noexcept
 simple_input::simple_input(
     jlm::rvsdg::simple_node * node,
     jlm::rvsdg::output * origin,
-    const jlm::rvsdg::port & port)
-    : node_input(origin, node, port)
+    std::shared_ptr<const rvsdg::type> type)
+    : node_input(origin, node, std::move(type))
 {}
 
 /* outputs */
 
-simple_output::simple_output(jlm::rvsdg::simple_node * node, const jlm::rvsdg::port & port)
-    : node_output(node, port)
+simple_output::simple_output(
+    jlm::rvsdg::simple_node * node,
+    std::shared_ptr<const rvsdg::type> type)
+    : node_output(node, std::move(type))
 {}
 
 simple_output::~simple_output() noexcept
@@ -60,11 +62,11 @@ simple_node::simple_node(
   for (size_t n = 0; n < operation().narguments(); n++)
   {
     node::add_input(
-        std::unique_ptr<node_input>(new simple_input(this, operands[n], operation().argument(n))));
+        std::make_unique<simple_input>(this, operands[n], operation().argument(n).Type()));
   }
 
   for (size_t n = 0; n < operation().nresults(); n++)
-    node::add_output(std::unique_ptr<node_output>(new simple_output(this, operation().result(n))));
+    node::add_output(std::make_unique<simple_output>(this, operation().result(n).Type()));
 
   on_node_create(this);
 }

--- a/jlm/rvsdg/simple-node.hpp
+++ b/jlm/rvsdg/simple-node.hpp
@@ -77,7 +77,10 @@ class simple_input final : public node_input
 public:
   virtual ~simple_input() noexcept;
 
-  simple_input(simple_node * node, jlm::rvsdg::output * origin, const jlm::rvsdg::port & port);
+  simple_input(
+      simple_node * node,
+      jlm::rvsdg::output * origin,
+      std::shared_ptr<const rvsdg::type> type);
 
 public:
   simple_node *
@@ -96,7 +99,7 @@ class simple_output final : public node_output
 public:
   virtual ~simple_output() noexcept;
 
-  simple_output(jlm::rvsdg::simple_node * node, const jlm::rvsdg::port & port);
+  simple_output(jlm::rvsdg::simple_node * node, std::shared_ptr<const rvsdg::type> type);
 
 public:
   simple_node *

--- a/jlm/rvsdg/structural-node.cpp
+++ b/jlm/rvsdg/structural-node.cpp
@@ -23,8 +23,8 @@ structural_input::~structural_input() noexcept
 structural_input::structural_input(
     jlm::rvsdg::structural_node * node,
     jlm::rvsdg::output * origin,
-    const jlm::rvsdg::port & port)
-    : node_input(origin, node, port)
+    std::shared_ptr<const rvsdg::type> type)
+    : node_input(origin, node, std::move(type))
 {
   on_input_create(this);
 }
@@ -40,8 +40,8 @@ structural_output::~structural_output() noexcept
 
 structural_output::structural_output(
     jlm::rvsdg::structural_node * node,
-    const jlm::rvsdg::port & port)
-    : node_output(node, port)
+    std::shared_ptr<const rvsdg::type> type)
+    : node_output(node, std::move(type))
 {
   on_output_create(this);
 }

--- a/jlm/rvsdg/structural-node.hpp
+++ b/jlm/rvsdg/structural-node.hpp
@@ -80,14 +80,7 @@ public:
   structural_input(
       jlm::rvsdg::structural_node * node,
       jlm::rvsdg::output * origin,
-      const jlm::rvsdg::port & port);
-
-  static structural_input *
-  create(structural_node * node, jlm::rvsdg::output * origin, const jlm::rvsdg::port & port)
-  {
-    auto input = std::unique_ptr<structural_input>(new structural_input(node, origin, port));
-    return node->append_input(std::move(input));
-  }
+      std::shared_ptr<const rvsdg::type> type);
 
   static structural_input *
   create(
@@ -95,8 +88,7 @@ public:
       jlm::rvsdg::output * origin,
       std::shared_ptr<const jlm::rvsdg::type> type)
   {
-    auto input =
-        std::make_unique<structural_input>(node, origin, jlm::rvsdg::port(std::move(type)));
+    auto input = std::make_unique<structural_input>(node, origin, std::move(type));
     return node->append_input(std::move(input));
   }
 
@@ -122,19 +114,12 @@ class structural_output : public node_output
 public:
   virtual ~structural_output() noexcept;
 
-  structural_output(jlm::rvsdg::structural_node * node, const jlm::rvsdg::port & port);
-
-  static structural_output *
-  create(structural_node * node, const jlm::rvsdg::port & port)
-  {
-    auto output = std::make_unique<structural_output>(node, port);
-    return node->append_output(std::move(output));
-  }
+  structural_output(jlm::rvsdg::structural_node * node, std::shared_ptr<const rvsdg::type> type);
 
   static structural_output *
   create(structural_node * node, std::shared_ptr<const jlm::rvsdg::type> type)
   {
-    auto output = std::make_unique<structural_output>(node, jlm::rvsdg::port(std::move(type)));
+    auto output = std::make_unique<structural_output>(node, std::move(type));
     return node->append_output(std::move(output));
   }
 

--- a/jlm/rvsdg/theta.cpp
+++ b/jlm/rvsdg/theta.cpp
@@ -70,16 +70,16 @@ theta_node::loopvar_iterator::operator++() noexcept
 jlm::rvsdg::theta_output *
 theta_node::add_loopvar(jlm::rvsdg::output * origin)
 {
-  node::add_input(std::unique_ptr<node_input>(new theta_input(this, origin, origin->type())));
-  node::add_output(std::unique_ptr<node_output>(new theta_output(this, origin->type())));
+  node::add_input(std::make_unique<theta_input>(this, origin, origin->Type()));
+  node::add_output(std::make_unique<theta_output>(this, origin->Type()));
 
   auto input = theta_node::input(ninputs() - 1);
   auto output = theta_node::output(noutputs() - 1);
   input->output_ = output;
   output->input_ = input;
 
-  auto argument = argument::create(subregion(), input, origin->type());
-  result::create(subregion(), argument, output, origin->type());
+  auto argument = argument::create(subregion(), input, origin->Type());
+  result::create(subregion(), argument, output, origin->Type());
   return output;
 }
 

--- a/jlm/rvsdg/theta.hpp
+++ b/jlm/rvsdg/theta.hpp
@@ -95,7 +95,7 @@ private:
       : structural_node(jlm::rvsdg::theta_op(), parent, 1)
   {
     auto predicate = jlm::rvsdg::control_false(subregion());
-    result::create(subregion(), predicate, nullptr, ctltype(2));
+    result::create(subregion(), predicate, nullptr, ctltype::Create(2));
   }
 
 public:
@@ -265,13 +265,14 @@ class theta_input final : public structural_input
 public:
   virtual ~theta_input() noexcept;
 
-private:
-  inline theta_input(theta_node * node, jlm::rvsdg::output * origin, const jlm::rvsdg::port & port)
-      : structural_input(node, origin, port),
+  inline theta_input(
+      theta_node * node,
+      jlm::rvsdg::output * origin,
+      std::shared_ptr<const rvsdg::type> type)
+      : structural_input(node, origin, std::move(type)),
         output_(nullptr)
   {}
 
-public:
   theta_node *
   node() const noexcept
   {
@@ -320,13 +321,11 @@ class theta_output final : public structural_output
 public:
   virtual ~theta_output() noexcept;
 
-private:
-  inline theta_output(theta_node * node, const jlm::rvsdg::port & port)
-      : structural_output(node, port),
+  inline theta_output(theta_node * node, const std::shared_ptr<const rvsdg::type> type)
+      : structural_output(node, std::move(type)),
         input_(nullptr)
   {}
 
-public:
   theta_node *
   node() const noexcept
   {

--- a/tests/Makefile.sub
+++ b/tests/Makefile.sub
@@ -5,6 +5,9 @@ libjlmtest_SOURCES = \
 	tests/test-types.cpp \
 	tests/TestRvsdgs.cpp \
 
+libjlmtest_HEADERS = \
+	tests/test-operation.hpp \
+
 $(eval $(call common_library,libjlmtest))
 
 ################################################################################

--- a/tests/jlm/rvsdg/TestRegion.cpp
+++ b/tests/jlm/rvsdg/TestRegion.cpp
@@ -91,13 +91,13 @@ TestContainsMethod()
   auto structuralInput1 = jlm::rvsdg::structural_input::create(structuralNode1, import, vt);
   auto regionArgument1 =
       jlm::rvsdg::argument::create(structuralNode1->subregion(0), structuralInput1, vt);
-  unary_op::create(structuralNode1->subregion(0), { vt }, regionArgument1, { vt });
+  unary_op::create(structuralNode1->subregion(0), vt, regionArgument1, vt);
 
   auto structuralNode2 = structural_node::create(graph.root(), 1);
   auto structuralInput2 = jlm::rvsdg::structural_input::create(structuralNode2, import, vt);
   auto regionArgument2 =
       jlm::rvsdg::argument::create(structuralNode2->subregion(0), structuralInput2, vt);
-  binary_op::create({ vt }, { vt }, regionArgument2, regionArgument2);
+  binary_op::create(vt, vt, regionArgument2, regionArgument2);
 
   assert(jlm::rvsdg::region::Contains<structural_op>(*graph.root(), false));
   assert(jlm::rvsdg::region::Contains<unary_op>(*graph.root(), true));

--- a/tests/jlm/rvsdg/TestStructuralNode.cpp
+++ b/tests/jlm/rvsdg/TestStructuralNode.cpp
@@ -16,14 +16,14 @@ TestOutputRemoval()
 
   // Arrange
   rvsdg::graph rvsdg;
-  tests::valuetype valueType;
+  auto valueType = tests::valuetype::Create();
 
   auto structuralNode = tests::structural_node::create(rvsdg.root(), 1);
-  auto output0 = rvsdg::structural_output::create(structuralNode, { valueType });
-  auto output1 = rvsdg::structural_output::create(structuralNode, { valueType });
-  auto output2 = rvsdg::structural_output::create(structuralNode, { valueType });
-  auto output3 = rvsdg::structural_output::create(structuralNode, { valueType });
-  auto output4 = rvsdg::structural_output::create(structuralNode, { valueType });
+  auto output0 = rvsdg::structural_output::create(structuralNode, valueType);
+  auto output1 = rvsdg::structural_output::create(structuralNode, valueType);
+  auto output2 = rvsdg::structural_output::create(structuralNode, valueType);
+  auto output3 = rvsdg::structural_output::create(structuralNode, valueType);
+  auto output4 = rvsdg::structural_output::create(structuralNode, valueType);
 
   // Act & Assert
   assert(structuralNode->noutputs() == 5);

--- a/tests/jlm/rvsdg/test-binary.cpp
+++ b/tests/jlm/rvsdg/test-binary.cpp
@@ -15,7 +15,7 @@ test_flattened_binary_reduction()
   using namespace jlm::rvsdg;
 
   auto vt = jlm::tests::valuetype::Create();
-  jlm::tests::binary_op op(*vt, *vt, binary_op::flags::associative);
+  jlm::tests::binary_op op(vt, vt, binary_op::flags::associative);
 
   /* test paralell reduction */
   {

--- a/tests/test-operation.cpp
+++ b/tests/test-operation.cpp
@@ -163,14 +163,14 @@ structural_node::copy(rvsdg::region * parent, rvsdg::substitution_map & smap) co
   {
     auto origin = smap.lookup(input(n)->origin());
     auto neworigin = origin ? origin : input(n)->origin();
-    auto new_input = rvsdg::structural_input::create(node, neworigin, input(n)->port());
+    auto new_input = rvsdg::structural_input::create(node, neworigin, input(n)->Type());
     smap.insert(input(n), new_input);
   }
 
   /* copy outputs */
   for (size_t n = 0; n < noutputs(); n++)
   {
-    auto new_output = rvsdg::structural_output::create(node, output(n)->port());
+    auto new_output = rvsdg::structural_output::create(node, output(n)->Type());
     smap.insert(output(n), new_output);
   }
 

--- a/tests/test-operation.hpp
+++ b/tests/test-operation.hpp
@@ -31,7 +31,9 @@ public:
       : rvsdg::unary_op(srcport.Type(), dstport.Type())
   {}
 
-  inline unary_op(std::shared_ptr<const rvsdg::type> srctype, std::shared_ptr<const rvsdg::type> dsttype) noexcept
+  inline unary_op(
+      std::shared_ptr<const rvsdg::type> srctype,
+      std::shared_ptr<const rvsdg::type> dsttype) noexcept
       : rvsdg::unary_op(std::move(srctype), std::move(dsttype))
   {}
 
@@ -77,7 +79,10 @@ public:
       rvsdg::output * operand,
       std::shared_ptr<const rvsdg::type> dsttype)
   {
-    return rvsdg::simple_node::create(region, unary_op(std::move(srctype), std::move(dsttype)), { operand });
+    return rvsdg::simple_node::create(
+        region,
+        unary_op(std::move(srctype), std::move(dsttype)),
+        { operand });
   }
 
   static inline rvsdg::output *


### PR DESCRIPTION
Remove implicit conversion of "const type &" to port, and mark the construction from "std::shared_ptr<type>" explicit. Remove constructability through "const port&" from all node_input/node_output (as well as structural input and all decendants). It still exists for region args & results where it plays a role in carrying additional information besides a type.

After this change, there is no type copying in and around graph nodes anymore, although a few node factory functions need to be cleaned up still.