### PR TITLE
Convert base + most of llvm ops  to shared_ptr of type

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
@@ -150,7 +150,7 @@ instrument_ref(
   load_func = route_to_region(load_func, region);
   store_func = route_to_region(store_func, region);
   alloca_func = route_to_region(alloca_func, region);
-  jlm::llvm::PointerType void_ptr;
+  auto void_ptr = jlm::llvm::PointerType::Create();
   for (auto & node : jlm::rvsdg::topdown_traverser(region))
   {
     if (auto structnode = dynamic_cast<jlm::rvsdg::structural_node *>(node))
@@ -181,7 +181,7 @@ instrument_ref(
       auto width = jlm::rvsdg::create_bitconstant(region, 64, log2Bytes);
 
       // Does this IF make sense now when the void_ptr doesn't have a type?
-      if (addr->type() != void_ptr)
+      if (addr->type() != *void_ptr)
       {
         addr = jlm::llvm::bitcast_op::create(addr, void_ptr);
       }
@@ -212,7 +212,7 @@ instrument_ref(
       auto size = jlm::rvsdg::create_bitconstant(region, 64, BaseHLS::JlmSize(at) / 8);
 
       // Does this IF make sense now when the void_ptr doesn't have a type?
-      if (addr->type() != void_ptr)
+      if (addr->type() != *void_ptr)
       {
         addr = jlm::llvm::bitcast_op::create(addr, void_ptr);
       }
@@ -240,7 +240,7 @@ instrument_ref(
       auto width = jlm::rvsdg::create_bitconstant(region, 64, log2Bytes);
 
       // Does this IF make sense now when the void_ptr doesn't have a type?
-      if (addr->type() != void_ptr)
+      if (addr->type() != *void_ptr)
       {
         addr = jlm::llvm::bitcast_op::create(addr, void_ptr);
       }

--- a/jlm/llvm/backend/rvsdg2jlm/rvsdg2jlm.cpp
+++ b/jlm/llvm/backend/rvsdg2jlm/rvsdg2jlm.cpp
@@ -134,7 +134,7 @@ create_cfg(const lambda::node & lambda, context & ctx)
   /* add arguments */
   for (auto & fctarg : lambda.fctarguments())
   {
-    auto argument = llvm::argument::create("", fctarg.type(), fctarg.attributes());
+    auto argument = llvm::argument::create("", fctarg.Type(), fctarg.attributes());
     auto v = cfg->entry()->append_argument(std::move(argument));
     ctx.insert(&fctarg, v);
   }
@@ -221,7 +221,7 @@ convert_empty_gamma_node(const rvsdg::gamma_node * gamma, context & ctx)
     {
       auto vo0 = ctx.variable(o0);
       auto vo1 = ctx.variable(o1);
-      bb->append_last(ctl2bits_op::create(ctx.variable(predicate), rvsdg::bittype(1)));
+      bb->append_last(ctl2bits_op::create(ctx.variable(predicate), rvsdg::bittype::Create(1)));
       bb->append_last(select_op::create(bb->last()->result(0), vo0, vo1));
     }
 
@@ -323,7 +323,7 @@ convert_gamma_node(const rvsdg::node & node, context & ctx)
     }
 
     /* create phi instruction */
-    exit->append_last(phi_op::create(arguments, output->type()));
+    exit->append_last(phi_op::create(arguments, output->Type()));
     ctx.insert(output, exit->last()->result(0));
   }
 
@@ -372,7 +372,7 @@ convert_theta_node(const rvsdg::node & node, context & ctx)
     auto v = ctx.variable(argument->input()->origin());
     if (phi_needed(argument->input(), v))
     {
-      auto phi = entry->append_last(phi_op::create({}, argument->type()));
+      auto phi = entry->append_last(phi_op::create({}, argument->Type()));
       phis.push_back(phi);
       v = phi->result(0);
     }
@@ -395,7 +395,7 @@ convert_theta_node(const rvsdg::node & node, context & ctx)
     auto vr = ctx.variable(result->origin());
     auto phi = phis.front();
     phis.pop_front();
-    phi->replace(phi_op({ pre_entry, ctx.lpbb() }, vr->type()), { ve, vr });
+    phi->replace(phi_op({ pre_entry, ctx.lpbb() }, vr->Type()), { ve, vr });
     ctx.insert(result->output(), vr);
   }
   JLM_ASSERT(phis.empty());

--- a/jlm/llvm/frontend/ControlFlowRestructuring.cpp
+++ b/jlm/llvm/frontend/ControlFlowRestructuring.cpp
@@ -71,7 +71,7 @@ create_pvariable(basic_block & bb, const rvsdg::ctltype & type)
 {
   static size_t c = 0;
   auto name = util::strfmt("#p", c++, "#");
-  return bb.insert_before_branch(UndefValueOperation::Create(type, name))->result(0);
+  return bb.insert_before_branch(UndefValueOperation::Create(type.copy(), name))->result(0);
 }
 
 static const tacvariable *
@@ -79,7 +79,7 @@ create_qvariable(basic_block & bb, const rvsdg::ctltype & type)
 {
   static size_t c = 0;
   auto name = util::strfmt("#q", c++, "#");
-  return bb.append_last(UndefValueOperation::Create(type, name))->result(0);
+  return bb.append_last(UndefValueOperation::Create(type.copy(), name))->result(0);
 }
 
 static const tacvariable *
@@ -87,7 +87,7 @@ create_tvariable(basic_block & bb, const rvsdg::ctltype & type)
 {
   static size_t c = 0;
   auto name = util::strfmt("#q", c++, "#");
-  return bb.insert_before_branch(UndefValueOperation::Create(type, name))->result(0);
+  return bb.insert_before_branch(UndefValueOperation::Create(type.copy(), name))->result(0);
 }
 
 static const tacvariable *
@@ -96,8 +96,7 @@ create_rvariable(basic_block & bb)
   static size_t c = 0;
   auto name = util::strfmt("#r", c++, "#");
 
-  rvsdg::ctltype type(2);
-  return bb.append_last(UndefValueOperation::Create(type, name))->result(0);
+  return bb.append_last(UndefValueOperation::Create(rvsdg::ctltype::Create(2), name))->result(0);
 }
 
 static inline void

--- a/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
+++ b/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
@@ -632,7 +632,7 @@ Convert(
     }
     else
     {
-      auto value = UndefValueOperation::Create(*lambdaNode.subregion(), v.type());
+      auto value = UndefValueOperation::Create(*lambdaNode.subregion(), v.Type());
       topVariableMap.insert(&v, value);
     }
   }
@@ -767,7 +767,7 @@ Convert(
     rvsdg::output * value = nullptr;
     if (!outerVariableMap.contains(&v))
     {
-      value = UndefValueOperation::Create(parentRegion, v.type());
+      value = UndefValueOperation::Create(parentRegion, v.Type());
       outerVariableMap.insert(&v, value);
     }
     else
@@ -1127,7 +1127,7 @@ ConvertStronglyConnectedComponent(
   std::unordered_map<const variable *, phi::rvoutput *> recursionVariables;
   for (const auto & ipgNode : stronglyConnectedComponent)
   {
-    auto recursionVariable = pb.add_recvar(ipgNode->type());
+    auto recursionVariable = pb.add_recvar(ipgNode->type().copy());
     auto ipgNodeVariable = interProceduralGraphModule.variable(ipgNode);
     phiVariableMap.insert(ipgNodeVariable, recursionVariable->argument());
     JLM_ASSERT(recursionVariables.find(ipgNodeVariable) == recursionVariables.end());

--- a/jlm/llvm/frontend/LlvmConversionContext.hpp
+++ b/jlm/llvm/frontend/LlvmConversionContext.hpp
@@ -195,7 +195,7 @@ public:
     auto declaration = StructType::Declaration::Create();
     for (size_t n = 0; n < type->getNumElements(); n++)
     {
-      declaration->Append(*ConvertType(type->getElementType(n), *this));
+      declaration->Append(ConvertType(type->getElementType(n), *this));
     }
 
     declarations_[type] = declaration.get();

--- a/jlm/llvm/frontend/LlvmModuleConversion.cpp
+++ b/jlm/llvm/frontend/LlvmModuleConversion.cpp
@@ -63,7 +63,7 @@ patch_phi_operands(const std::vector<::llvm::PHINode *> & phis, context & ctx)
     }
 
     auto phi_tac = static_cast<const tacvariable *>(ctx.lookup_value(phi))->tac();
-    phi_tac->replace(phi_op(nodes, phi_tac->result(0)->type()), operands);
+    phi_tac->replace(phi_op(nodes, phi_tac->result(0)->Type()), operands);
   }
 }
 
@@ -260,7 +260,7 @@ convert_argument(const ::llvm::Argument & argument, context & ctx)
   auto attributes =
       convert_attributes(function->getAttributes().getParamAttrs(argument.getArgNo()), ctx);
 
-  return llvm::argument::create(name, *type, attributes);
+  return llvm::argument::create(name, type, attributes);
 }
 
 static void
@@ -346,15 +346,15 @@ create_cfg(::llvm::Function & f, context & ctx)
     if (f.isVarArg())
     {
       JLM_ASSERT(n < node->fcttype().NumArguments());
-      auto & type = node->fcttype().ArgumentType(n++);
+      auto & type = node->fcttype().Arguments()[n++];
       cfg.entry()->append_argument(argument::create("_varg_", type));
     }
     JLM_ASSERT(n < node->fcttype().NumArguments());
 
-    auto & iotype = node->fcttype().ArgumentType(n++);
+    auto & iotype = node->fcttype().Arguments()[n++];
     auto iostate = cfg.entry()->append_argument(argument::create("_io_", iotype));
 
-    auto & memtype = node->fcttype().ArgumentType(n++);
+    auto & memtype = node->fcttype().Arguments()[n++];
     auto memstate = cfg.entry()->append_argument(argument::create("_s_", memtype));
 
     JLM_ASSERT(n == node->fcttype().NumArguments());
@@ -377,7 +377,7 @@ create_cfg(::llvm::Function & f, context & ctx)
   if (!f.getReturnType()->isVoidTy())
   {
     auto type = ConvertType(f.getReturnType(), ctx);
-    entry_block->append_last(UndefValueOperation::Create(*type, "_r_"));
+    entry_block->append_last(UndefValueOperation::Create(type, "_r_"));
     result = entry_block->last()->result(0);
 
     JLM_ASSERT(node->fcttype().NumResults() == 3);

--- a/jlm/llvm/ir/cfg-structure.cpp
+++ b/jlm/llvm/ir/cfg-structure.cpp
@@ -773,7 +773,7 @@ update_phi_operands(llvm::tac & phitac, const std::unordered_set<cfg_node *> & d
     }
   }
 
-  phitac.replace(phi_op(nodes, phi->type()), operands);
+  phitac.replace(phi_op(nodes, phi->Type()), operands);
 }
 
 static void

--- a/jlm/llvm/ir/cfg.hpp
+++ b/jlm/llvm/ir/cfg.hpp
@@ -67,24 +67,12 @@ public:
   }
 
   static std::unique_ptr<argument>
-  create(const std::string & name, const jlm::rvsdg::type & type, const attributeset & attributes)
-  {
-    return std::make_unique<argument>(name, type.copy(), attributes);
-  }
-
-  static std::unique_ptr<argument>
   create(
       const std::string & name,
       std::shared_ptr<const jlm::rvsdg::type> type,
       const attributeset & attributes)
   {
     return std::make_unique<argument>(name, std::move(type), attributes);
-  }
-
-  static std::unique_ptr<argument>
-  create(const std::string & name, const jlm::rvsdg::type & type)
-  {
-    return create(name, type.copy(), {});
   }
 
   static std::unique_ptr<argument>

--- a/jlm/llvm/ir/ipgraph-module.hpp
+++ b/jlm/llvm/ir/ipgraph-module.hpp
@@ -117,25 +117,6 @@ public:
   }
 
   inline llvm::variable *
-  create_variable(const jlm::rvsdg::type & type, const std::string & name)
-  {
-    auto v = std::make_unique<llvm::variable>(type, name);
-    auto pv = v.get();
-    variables_.insert(std::move(v));
-    return pv;
-  }
-
-  inline llvm::variable *
-  create_variable(const jlm::rvsdg::type & type)
-  {
-    static uint64_t c = 0;
-    auto v = std::make_unique<llvm::variable>(type, jlm::util::strfmt("v", c++));
-    auto pv = v.get();
-    variables_.insert(std::move(v));
-    return pv;
-  }
-
-  inline llvm::variable *
   create_variable(std::shared_ptr<const jlm::rvsdg::type> type, const std::string & name)
   {
     auto v = std::make_unique<llvm::variable>(std::move(type), name);

--- a/jlm/llvm/ir/operators/Phi.cpp
+++ b/jlm/llvm/ir/operators/Phi.cpp
@@ -76,7 +76,7 @@ node::copy(jlm::rvsdg::region * region, jlm::rvsdg::substitution_map & smap) con
   std::vector<rvoutput *> newrvs;
   for (auto it = begin_rv(); it != end_rv(); it++)
   {
-    auto newrv = pb.add_recvar(it->type());
+    auto newrv = pb.add_recvar(it->Type());
     subregionmap.insert(it->argument(), newrv->argument());
     newrvs.push_back(newrv);
   }
@@ -120,20 +120,6 @@ node::ExtractLambdaNodes(const phi::node & phiNode)
 }
 
 /* phi builder class */
-
-rvoutput *
-builder::add_recvar(const jlm::rvsdg::type & type)
-{
-  if (!node_)
-    return nullptr;
-
-  auto argument = rvargument::create(subregion(), type.copy());
-  auto output = rvoutput::create(node_, argument, type.copy());
-  rvresult::create(subregion(), argument, output, type.copy());
-  argument->output_ = output;
-
-  return output;
-}
 
 rvoutput *
 builder::add_recvar(std::shared_ptr<const jlm::rvsdg::type> type)

--- a/jlm/llvm/ir/operators/Phi.hpp
+++ b/jlm/llvm/ir/operators/Phi.hpp
@@ -536,9 +536,6 @@ public:
   }
 
   phi::rvoutput *
-  add_recvar(const jlm::rvsdg::type & type);
-
-  phi::rvoutput *
   add_recvar(std::shared_ptr<const jlm::rvsdg::type> type);
 
   phi::node *

--- a/jlm/llvm/ir/operators/lambda.cpp
+++ b/jlm/llvm/ir/operators/lambda.cpp
@@ -201,7 +201,7 @@ node::create(
   auto node = new lambda::node(parent, std::move(op));
 
   for (auto & argumentType : type->Arguments())
-    lambda::fctargument::create(node->subregion(), *argumentType);
+    lambda::fctargument::create(node->subregion(), argumentType);
 
   return node;
 }

--- a/jlm/llvm/ir/operators/lambda.hpp
+++ b/jlm/llvm/ir/operators/lambda.hpp
@@ -532,14 +532,14 @@ public:
   }
 
 private:
-  fctargument(jlm::rvsdg::region * region, const jlm::rvsdg::type & type)
-      : jlm::rvsdg::argument(region, nullptr, type.copy())
+  fctargument(jlm::rvsdg::region * region, std::shared_ptr<const jlm::rvsdg::type> type)
+      : jlm::rvsdg::argument(region, nullptr, std::move(type))
   {}
 
   static fctargument *
-  create(jlm::rvsdg::region * region, const jlm::rvsdg::type & type)
+  create(jlm::rvsdg::region * region, std::shared_ptr<const jlm::rvsdg::type> type)
   {
-    auto argument = new fctargument(region, type);
+    auto argument = new fctargument(region, std::move(type));
     region->append_argument(argument);
     return argument;
   }

--- a/jlm/llvm/ir/ssa.cpp
+++ b/jlm/llvm/ir/ssa.cpp
@@ -58,7 +58,7 @@ destruct_ssa(llvm::cfg & cfg)
           break;
 
         auto phi = static_cast<const phi_op *>(&phitac->operation());
-        auto v = cfg.module().create_variable(phi->type());
+        auto v = cfg.module().create_variable(phi->Type());
 
         const variable * value = nullptr;
         for (size_t n = 0; n < phitac->noperands(); n++)

--- a/jlm/llvm/ir/tac.hpp
+++ b/jlm/llvm/ir/tac.hpp
@@ -26,8 +26,11 @@ class tacvariable final : public variable
 public:
   virtual ~tacvariable();
 
-  tacvariable(llvm::tac * tac, const jlm::rvsdg::type & type, const std::string & name)
-      : variable(type, name),
+  tacvariable(
+      llvm::tac * tac,
+      std::shared_ptr<const jlm::rvsdg::type> type,
+      const std::string & name)
+      : variable(std::move(type), name),
         tac_(tac)
   {}
 
@@ -38,9 +41,9 @@ public:
   }
 
   static std::unique_ptr<tacvariable>
-  create(llvm::tac * tac, const jlm::rvsdg::type & type, const std::string & name)
+  create(llvm::tac * tac, std::shared_ptr<const jlm::rvsdg::type> type, const std::string & name)
   {
-    return std::make_unique<tacvariable>(tac, type, name);
+    return std::make_unique<tacvariable>(tac, std::move(type), name);
   }
 
 private:
@@ -155,7 +158,7 @@ private:
 
     for (size_t n = 0; n < operation.nresults(); n++)
     {
-      auto & type = operation.result(n).type();
+      auto & type = operation.result(n).Type();
       results_.push_back(tacvariable::create(this, type, names[n]));
     }
   }

--- a/jlm/llvm/ir/types.hpp
+++ b/jlm/llvm/ir/types.hpp
@@ -154,7 +154,13 @@ public:
   inline const jlm::rvsdg::valuetype &
   element_type() const noexcept
   {
-    return *static_cast<const jlm::rvsdg::valuetype *>(type_.get());
+    return *type_;
+  }
+
+  inline const std::shared_ptr<const jlm::rvsdg::valuetype> &
+  GetElementType() const noexcept
+  {
+    return type_;
   }
 
   static std::shared_ptr<const arraytype>
@@ -165,7 +171,7 @@ public:
 
 private:
   size_t nelements_;
-  std::shared_ptr<const jlm::rvsdg::type> type_;
+  std::shared_ptr<const jlm::rvsdg::valuetype> type_;
 };
 
 /* floating point type */
@@ -360,10 +366,19 @@ public:
     return *util::AssertedCast<const valuetype>(Types_[index].get());
   }
 
-  void
-  Append(const jlm::rvsdg::valuetype & type)
+  [[nodiscard]] std::shared_ptr<const valuetype>
+  GetElementType(size_t index) const noexcept
   {
-    Types_.push_back(type.copy());
+    JLM_ASSERT(index < NumElements());
+    auto type = std::dynamic_pointer_cast<const valuetype>(Types_[index]);
+    JLM_ASSERT(type);
+    return type;
+  }
+
+  void
+  Append(std::shared_ptr<const jlm::rvsdg::valuetype> type)
+  {
+    Types_.push_back(std::move(type));
   }
 
   static std::unique_ptr<Declaration>

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
@@ -388,7 +388,7 @@ private:
   rvsdg::output &
   InsertUndefinedMemoryState(rvsdg::region & region) noexcept
   {
-    auto undefinedMemoryState = UndefValueOperation::Create(region, MemoryStateType());
+    auto undefinedMemoryState = UndefValueOperation::Create(region, MemoryStateType::Create());
     UndefinedMemoryStates_[&region] = undefinedMemoryState;
     return *undefinedMemoryState;
   }

--- a/jlm/llvm/opt/push.cpp
+++ b/jlm/llvm/opt/push.cpp
@@ -340,7 +340,7 @@ pushout_store(jlm::rvsdg::node * storenode)
   auto ovalue = storenode->input(1)->origin();
 
   /* insert new value for store */
-  auto nvalue = theta->add_loopvar(UndefValueOperation::Create(*theta->region(), ovalue->type()));
+  auto nvalue = theta->add_loopvar(UndefValueOperation::Create(*theta->region(), ovalue->Type()));
   nvalue->result()->divert_to(ovalue);
 
   /* collect store operands */

--- a/jlm/mlir/frontend/MlirToJlmConverter.cpp
+++ b/jlm/mlir/frontend/MlirToJlmConverter.cpp
@@ -275,7 +275,7 @@ MlirToJlmConverter::ConvertOperation(
     if (!st)
       JLM_ASSERT("frontend : expected bitstring type for ExtUIOp operation.");
     ::mlir::Type type = castedOp.getType();
-    return rvsdg::node_output::node(&llvm::zext_op::Create(*(inputs[0]), *ConvertType(type)));
+    return rvsdg::node_output::node(&llvm::zext_op::Create(*(inputs[0]), ConvertType(type)));
   }
 
   else if (::mlir::isa<::mlir::rvsdg::OmegaNode>(&mlirOperation))

--- a/jlm/rvsdg/statemux.cpp
+++ b/jlm/rvsdg/statemux.cpp
@@ -75,7 +75,7 @@ perform_multiple_origin_reduction(
     const std::vector<jlm::rvsdg::output *> & operands)
 {
   std::unordered_set<jlm::rvsdg::output *> set(operands.begin(), operands.end());
-  return create_state_mux(op.result(0).type(), { set.begin(), set.end() }, op.nresults());
+  return create_state_mux(op.result(0).Type(), { set.begin(), set.end() }, op.nresults());
 }
 
 static std::vector<jlm::rvsdg::output *>
@@ -102,7 +102,7 @@ perform_mux_mux_reduction(
       new_operands.push_back(operand);
   }
 
-  return create_state_mux(op.result(0).type(), new_operands, op.nresults());
+  return create_state_mux(op.result(0).Type(), new_operands, op.nresults());
 }
 
 mux_normal_form::~mux_normal_form() noexcept

--- a/jlm/rvsdg/statemux.hpp
+++ b/jlm/rvsdg/statemux.hpp
@@ -93,24 +93,6 @@ is_mux_op(const jlm::rvsdg::operation & op)
 
 static inline std::vector<jlm::rvsdg::output *>
 create_state_mux(
-    const jlm::rvsdg::type & type,
-    const std::vector<jlm::rvsdg::output *> & operands,
-    size_t nresults)
-{
-  if (operands.empty())
-    throw jlm::util::error("Insufficient number of operands.");
-
-  auto st = std::dynamic_pointer_cast<const jlm::rvsdg::statetype>(type.copy());
-  if (!st)
-    throw jlm::util::error("Expected state type.");
-
-  auto region = operands.front()->region();
-  jlm::rvsdg::mux_op op(st, operands.size(), nresults);
-  return simple_node::create_normalized(region, op, operands);
-}
-
-static inline std::vector<jlm::rvsdg::output *>
-create_state_mux(
     std::shared_ptr<const jlm::rvsdg::type> type,
     const std::vector<jlm::rvsdg::output *> & operands,
     size_t nresults)
@@ -129,24 +111,10 @@ create_state_mux(
 
 static inline jlm::rvsdg::output *
 create_state_merge(
-    const jlm::rvsdg::type & type,
-    const std::vector<jlm::rvsdg::output *> & operands)
-{
-  return create_state_mux(type, operands, 1)[0];
-}
-
-static inline jlm::rvsdg::output *
-create_state_merge(
     std::shared_ptr<const jlm::rvsdg::type> type,
     const std::vector<jlm::rvsdg::output *> & operands)
 {
   return create_state_mux(std::move(type), operands, 1)[0];
-}
-
-static inline std::vector<jlm::rvsdg::output *>
-create_state_split(const jlm::rvsdg::type & type, jlm::rvsdg::output * operand, size_t nresults)
-{
-  return create_state_mux(type, { operand }, nresults);
 }
 
 static inline std::vector<jlm::rvsdg::output *>

--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -240,7 +240,7 @@ LoadFromUndefTest::SetupRvsdg()
 
   Lambda_ = lambda::node::create(rvsdg.root(), functionType, "f", linkage::external_linkage);
 
-  auto undefValue = UndefValueOperation::Create(*Lambda_->subregion(), *pointerType);
+  auto undefValue = UndefValueOperation::Create(*Lambda_->subregion(), pointerType);
   auto loadResults = LoadNonVolatileNode::Create(
       undefValue,
       { Lambda_->fctargument(0) },
@@ -329,7 +329,7 @@ BitCastTest::SetupRvsdg()
 
   auto fct = lambda::node::create(graph->root(), fcttype, "f", linkage::external_linkage);
 
-  auto cast = bitcast_op::create(fct->fctargument(0), *pointerType);
+  auto cast = bitcast_op::create(fct->fctargument(0), pointerType);
 
   fct->finalize({ cast });
 
@@ -627,7 +627,7 @@ CallTest2::SetupRvsdg()
 
   auto SetupCreate = [&]()
   {
-    PointerType pt32;
+    auto pt32 = PointerType::Create();
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
     auto functionType = FunctionType::Create(
@@ -2518,7 +2518,7 @@ PhiWithDeltaTest::SetupRvsdg()
   auto & structDeclaration = rvsdgModule->AddStructTypeDeclaration(
       StructType::Declaration::Create({ PointerType::Create() }));
   auto structType = StructType::Create("myStruct", false, structDeclaration);
-  auto arrayType = arraytype(structType, 2);
+  auto arrayType = arraytype::Create(structType, 2);
 
   jlm::llvm::phi::builder pb;
   pb.begin(rvsdg.root());
@@ -2533,7 +2533,7 @@ PhiWithDeltaTest::SetupRvsdg()
       false);
   auto myArrayArgument = delta->add_ctxvar(myArrayRecVar->argument());
 
-  auto aggregateZero = ConstantAggregateZero::Create(*delta->subregion(), *structType);
+  auto aggregateZero = ConstantAggregateZero::Create(*delta->subregion(), structType);
   auto & constantStruct =
       ConstantStruct::Create(*delta->subregion(), { myArrayArgument }, structType);
   auto constantArray = ConstantArray::Create({ aggregateZero, &constantStruct });
@@ -3909,7 +3909,7 @@ VariadicFunctionTest2::SetupRvsdg()
         pointerType);
     auto loadResultsGamma1 =
         LoadNonVolatileNode::Create(gepResult1, { gammaMemoryState->argument(1) }, pointerType, 16);
-    auto & zextResult = zext_op::Create(*gammaLoadResult->argument(1), *rvsdg::bittype::Create(64));
+    auto & zextResult = zext_op::Create(*gammaLoadResult->argument(1), rvsdg::bittype::Create(64));
     gepResult2 = GetElementPtrOperation::Create(
         loadResultsGamma1[0],
         { &zextResult },

--- a/tests/jlm/llvm/backend/llvm/jlm-llvm/LoadTests.cpp
+++ b/tests/jlm/llvm/backend/llvm/jlm-llvm/LoadTests.cpp
@@ -26,9 +26,9 @@ LoadConversion()
 
   auto cfg = cfg::create(ipgModule);
   auto addressArgument =
-      cfg->entry()->append_argument(argument::create("address", *PointerType::Create()));
+      cfg->entry()->append_argument(argument::create("address", PointerType::Create()));
   auto memoryStateArgument =
-      cfg->entry()->append_argument(argument::create("memoryState", *MemoryStateType::Create()));
+      cfg->entry()->append_argument(argument::create("memoryState", MemoryStateType::Create()));
 
   auto basicBlock = basic_block::create(*cfg);
   size_t alignment = 4;
@@ -76,8 +76,8 @@ LoadVolatileConversion()
   using namespace jlm::llvm;
 
   // Arrange
-  PointerType pointerType;
-  iostatetype ioStateType;
+  auto pointerType = PointerType::Create();
+  auto ioStateType = iostatetype::Create();
   auto memoryStateType = MemoryStateType::Create();
   jlm::rvsdg::bittype bit64Type(64);
   auto functionType = FunctionType::Create(

--- a/tests/jlm/llvm/backend/llvm/jlm-llvm/MemCpyTests.cpp
+++ b/tests/jlm/llvm/backend/llvm/jlm-llvm/MemCpyTests.cpp
@@ -19,9 +19,9 @@ MemCpyConversion()
   using namespace jlm::llvm;
 
   // Arrange
-  PointerType pointerType;
+  auto pointerType = PointerType::Create();
   auto memoryStateType = MemoryStateType::Create();
-  jlm::rvsdg::bittype bit64Type(64);
+  auto bit64Type = jlm::rvsdg::bittype::Create(64);
   auto functionType = FunctionType::Create(
       { PointerType::Create(),
         PointerType::Create(),
@@ -85,10 +85,10 @@ MemCpyVolatileConversion()
   using namespace jlm::llvm;
 
   // Arrange
-  PointerType pointerType;
-  iostatetype ioStateType;
+  auto pointerType = PointerType::Create();
+  auto ioStateType = iostatetype::Create();
   auto memoryStateType = MemoryStateType::Create();
-  jlm::rvsdg::bittype bit64Type(64);
+  auto bit64Type = jlm::rvsdg::bittype::Create(64);
   auto functionType = FunctionType::Create(
       { PointerType::Create(),
         PointerType::Create(),

--- a/tests/jlm/llvm/backend/llvm/jlm-llvm/StoreTests.cpp
+++ b/tests/jlm/llvm/backend/llvm/jlm-llvm/StoreTests.cpp
@@ -19,9 +19,9 @@ StoreConversion()
   using namespace jlm::llvm;
 
   // Arrange
-  PointerType pointerType;
+  auto pointerType = PointerType::Create();
   auto memoryStateType = MemoryStateType::Create();
-  jlm::rvsdg::bittype bit64Type(64);
+  auto bit64Type = jlm::rvsdg::bittype::Create(64);
   auto functionType = FunctionType::Create(
       { PointerType::Create(), jlm::rvsdg::bittype::Create(64), MemoryStateType::Create() },
       { MemoryStateType::Create() });
@@ -79,10 +79,10 @@ StoreVolatileConversion()
   using namespace jlm::llvm;
 
   // Arrange
-  PointerType pointerType;
-  iostatetype ioStateType;
+  auto pointerType = PointerType::Create();
+  auto ioStateType = iostatetype::Create();
   auto memoryStateType = MemoryStateType::Create();
-  jlm::rvsdg::bittype bit64Type(64);
+  auto bit64Type = jlm::rvsdg::bittype::Create(64);
   auto functionType = FunctionType::Create(
       { PointerType::Create(),
         jlm::rvsdg::bittype::Create(64),

--- a/tests/jlm/llvm/backend/llvm/jlm-llvm/test-function-calls.cpp
+++ b/tests/jlm/llvm/backend/llvm/jlm-llvm/test-function-calls.cpp
@@ -31,7 +31,7 @@ test_malloc()
     bb->add_outedge(cfg->exit());
 
     auto size =
-        cfg->entry()->append_argument(argument::create("size", *jlm::rvsdg::bittype::Create(64)));
+        cfg->entry()->append_argument(argument::create("size", jlm::rvsdg::bittype::Create(64)));
 
     bb->append_last(malloc_op::create(size));
 
@@ -76,7 +76,7 @@ test_free()
   {
     using namespace jlm::llvm;
 
-    iostatetype iot;
+    auto iot = iostatetype::Create();
     auto mt = MemoryStateType::Create();
     auto pt = PointerType::Create();
 

--- a/tests/jlm/llvm/backend/llvm/jlm-llvm/test-select-with-state.cpp
+++ b/tests/jlm/llvm/backend/llvm/jlm-llvm/test-select-with-state.cpp
@@ -30,7 +30,7 @@ test()
   cfg->exit()->divert_inedges(bb);
   bb->add_outedge(cfg->exit());
 
-  auto p = cfg->entry()->append_argument(argument::create("p", *jlm::rvsdg::bittype::Create(1)));
+  auto p = cfg->entry()->append_argument(argument::create("p", jlm::rvsdg::bittype::Create(1)));
   auto s1 = cfg->entry()->append_argument(argument::create("s1", mt));
   auto s2 = cfg->entry()->append_argument(argument::create("s2", mt));
 

--- a/tests/jlm/llvm/frontend/llvm/ThreeAddressCodeConversionTests.cpp
+++ b/tests/jlm/llvm/frontend/llvm/ThreeAddressCodeConversionTests.cpp
@@ -29,7 +29,7 @@ SetupControlFlowGraph(
   std::vector<const variable *> operands;
   for (size_t n = 0; n < operation.narguments(); n++)
   {
-    auto & operandType = operation.argument(n).type();
+    auto & operandType = operation.argument(n).Type();
     auto operand = cfg->entry()->append_argument(argument::create("", operandType));
     operands.emplace_back(operand);
   }

--- a/tests/jlm/llvm/ir/operators/TestFree.cpp
+++ b/tests/jlm/llvm/ir/operators/TestFree.cpp
@@ -48,9 +48,9 @@ TestThreeAddressCodeCreator()
   // Arrange
   ipgraph_module ipgModule(jlm::util::filepath(""), "", "");
 
-  auto address = ipgModule.create_variable(PointerType(), "p");
-  auto memoryState = ipgModule.create_variable(MemoryStateType(), "m");
-  auto iOState = ipgModule.create_variable(iostatetype(), "io");
+  auto address = ipgModule.create_variable(PointerType::Create(), "p");
+  auto memoryState = ipgModule.create_variable(MemoryStateType::Create(), "m");
+  auto iOState = ipgModule.create_variable(iostatetype::Create(), "io");
 
   // Act
   auto free0 = FreeOperation::Create(address, {}, iOState);

--- a/tests/jlm/llvm/ir/operators/TestPhi.cpp
+++ b/tests/jlm/llvm/ir/operators/TestPhi.cpp
@@ -90,9 +90,9 @@ TestRemovePhiArgumentsWhere()
   phi::builder phiBuilder;
   phiBuilder.begin(rvsdgModule.Rvsdg().root());
 
-  auto phiOutput0 = phiBuilder.add_recvar(*valueType);
-  auto phiOutput1 = phiBuilder.add_recvar(*valueType);
-  auto phiOutput2 = phiBuilder.add_recvar(*valueType);
+  auto phiOutput0 = phiBuilder.add_recvar(valueType);
+  auto phiOutput1 = phiBuilder.add_recvar(valueType);
+  auto phiOutput2 = phiBuilder.add_recvar(valueType);
   auto phiArgument3 = phiBuilder.add_ctxvar(x);
   auto phiArgument4 = phiBuilder.add_ctxvar(x);
 
@@ -173,9 +173,9 @@ TestPrunePhiArguments()
   phi::builder phiBuilder;
   phiBuilder.begin(rvsdgModule.Rvsdg().root());
 
-  auto phiOutput0 = phiBuilder.add_recvar(*valueType);
-  auto phiOutput1 = phiBuilder.add_recvar(*valueType);
-  auto phiOutput2 = phiBuilder.add_recvar(*valueType);
+  auto phiOutput0 = phiBuilder.add_recvar(valueType);
+  auto phiOutput1 = phiBuilder.add_recvar(valueType);
+  auto phiOutput2 = phiBuilder.add_recvar(valueType);
   phiBuilder.add_ctxvar(x);
   auto phiArgument4 = phiBuilder.add_ctxvar(x);
 
@@ -217,9 +217,9 @@ TestRemovePhiOutputsWhere()
   phi::builder phiBuilder;
   phiBuilder.begin(rvsdgModule.Rvsdg().root());
 
-  auto phiOutput0 = phiBuilder.add_recvar(*valueType);
-  auto phiOutput1 = phiBuilder.add_recvar(*valueType);
-  auto phiOutput2 = phiBuilder.add_recvar(*valueType);
+  auto phiOutput0 = phiBuilder.add_recvar(valueType);
+  auto phiOutput1 = phiBuilder.add_recvar(valueType);
+  auto phiOutput2 = phiBuilder.add_recvar(valueType);
 
   auto result = jlm::tests::SimpleNode::Create(
                     *phiBuilder.subregion(),
@@ -266,9 +266,9 @@ TestPrunePhiOutputs()
   phi::builder phiBuilder;
   phiBuilder.begin(rvsdgModule.Rvsdg().root());
 
-  auto phiOutput0 = phiBuilder.add_recvar(*valueType);
-  auto phiOutput1 = phiBuilder.add_recvar(*valueType);
-  auto phiOutput2 = phiBuilder.add_recvar(*valueType);
+  auto phiOutput0 = phiBuilder.add_recvar(valueType);
+  auto phiOutput1 = phiBuilder.add_recvar(valueType);
+  auto phiOutput2 = phiBuilder.add_recvar(valueType);
 
   auto result = jlm::tests::SimpleNode::Create(
                     *phiBuilder.subregion(),


### PR DESCRIPTION
Convert constructors and creator functions to require "shared_ptr<const type>" instead of "const type &" arguments. This removes all type copying from affected instances.