### PR TITLE
Add methods for retrieving memory states from lambda nodes [AndersenAgnostic][SteensgaardAgnostic]

### DIFF
--- a/jlm/llvm/ir/operators/lambda.cpp
+++ b/jlm/llvm/ir/operators/lambda.cpp
@@ -148,13 +148,28 @@ node::add_ctxvar(jlm::rvsdg::output * origin)
   return cvargument::create(subregion(), input);
 }
 
+rvsdg::argument &
+node::GetMemoryStateRegionArgument() const noexcept
+{
+  auto argument = fctargument(nfctarguments() - 1);
+  JLM_ASSERT(is<MemoryStateType>(argument->type()));
+  return *argument;
+}
+
+rvsdg::result &
+node::GetMemoryStateRegionResult() const noexcept
+{
+  auto result = fctresult(nfctresults() - 1);
+  JLM_ASSERT(is<MemoryStateType>(result->type()));
+  return *result;
+}
+
 rvsdg::simple_node *
 node::GetMemoryStateExitMerge(const lambda::node & lambdaNode) noexcept
 {
-  auto result = lambdaNode.fctresult(lambdaNode.nfctresults() - 1);
-  JLM_ASSERT(is<MemoryStateType>(result->type()));
+  auto & result = lambdaNode.GetMemoryStateRegionResult();
 
-  auto node = rvsdg::node_output::node(result->origin());
+  auto node = rvsdg::node_output::node(result.origin());
   return is<LambdaExitMemoryStateMergeOperation>(node) ? dynamic_cast<rvsdg::simple_node *>(node)
                                                        : nullptr;
 }
@@ -162,15 +177,14 @@ node::GetMemoryStateExitMerge(const lambda::node & lambdaNode) noexcept
 rvsdg::simple_node *
 node::GetMemoryStateEntrySplit(const lambda::node & lambdaNode) noexcept
 {
-  auto argument = lambdaNode.fctargument(lambdaNode.nfctarguments() - 1);
-  JLM_ASSERT(is<MemoryStateType>(argument->type()));
+  auto & argument = lambdaNode.GetMemoryStateRegionArgument();
 
   // If a memory state entry split node is present, then we would expect the node to be the only
   // user of the memory state argument.
-  if (argument->nusers() != 1)
+  if (argument.nusers() != 1)
     return nullptr;
 
-  auto node = rvsdg::node_input::GetNode(**argument->begin());
+  auto node = rvsdg::node_input::GetNode(**argument.begin());
   return is<LambdaEntryMemoryStateSplitOperation>(node) ? dynamic_cast<rvsdg::simple_node *>(node)
                                                         : nullptr;
 }

--- a/jlm/llvm/ir/operators/lambda.hpp
+++ b/jlm/llvm/ir/operators/lambda.hpp
@@ -303,6 +303,18 @@ public:
   copy(jlm::rvsdg::region * region, jlm::rvsdg::substitution_map & smap) const override;
 
   /**
+   * @return The memory state argument of the lambda subregion.
+   */
+  [[nodiscard]] rvsdg::argument &
+  GetMemoryStateRegionArgument() const noexcept;
+
+  /**
+   * @return The memory state result of the lambda subregion.
+   */
+  [[nodiscard]] rvsdg::result &
+  GetMemoryStateRegionResult() const noexcept;
+
+  /**
    *
    * @param lambdaNode The lambda node for which to retrieve the
    * LambdaEntryMemoryStateSplitOperation node.

--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -3588,8 +3588,8 @@ FreeNullTest::SetupRvsdg()
   using namespace jlm::llvm;
 
   auto functionType = FunctionType::Create(
-      { MemoryStateType::Create(), iostatetype::Create() },
-      { MemoryStateType::Create(), iostatetype::Create() });
+      { iostatetype::Create(), MemoryStateType::Create() },
+      { iostatetype::Create(), MemoryStateType::Create() });
 
   auto module = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto graph = &module->Rvsdg();
@@ -3599,8 +3599,8 @@ FreeNullTest::SetupRvsdg()
 
   LambdaMain_ =
       lambda::node::create(graph->root(), functionType, "main", linkage::external_linkage);
-  auto memoryStateArgument = LambdaMain_->fctargument(0);
-  auto iOStateArgument = LambdaMain_->fctargument(1);
+  auto iOStateArgument = LambdaMain_->fctargument(0);
+  auto memoryStateArgument = LambdaMain_->fctargument(1);
 
   auto constantPointerNullResult =
       ConstantPointerNullOperation::Create(LambdaMain_->subregion(), PointerType::Create());
@@ -3608,7 +3608,7 @@ FreeNullTest::SetupRvsdg()
   auto FreeResults =
       FreeOperation::Create(constantPointerNullResult, { memoryStateArgument }, iOStateArgument);
 
-  LambdaMain_->finalize(FreeResults);
+  LambdaMain_->finalize({ FreeResults[1], FreeResults[0] });
 
   graph->add_export(LambdaMain_->output(), { PointerType::Create(), "main" });
 

--- a/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
@@ -2068,14 +2068,15 @@ static void
 ValidateFreeNullTestSteensgaardAgnostic(const jlm::tests::FreeNullTest & test)
 {
   using namespace jlm::llvm;
+  using namespace jlm::rvsdg;
 
-  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.LambdaMain().fctresult(0)->origin());
+  auto lambdaExitMerge = node_output::node(test.LambdaMain().GetMemoryStateRegionResult().origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
-  auto free = jlm::rvsdg::node_output::node(test.LambdaMain().fctresult(1)->origin());
+  auto free = node_output::node(test.LambdaMain().fctresult(0)->origin());
   assert(is<FreeOperation>(*free, 2, 1));
 
-  auto lambdaEntrySplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+  auto lambdaEntrySplit = node_output::node(lambdaExitMerge->input(0)->origin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 }
 


### PR DESCRIPTION
This PR does the following:
1. Adds convenience methods to the lambda node for retrieving the memory state region argument or result.
2. Uses them to remove some FIXMEs in the memory state encoder.
3. Fixes an FreeNull RVSDG test where the memory state was not the last argument/result.

It is currently not enforced on lambda creation that the last argument/result of a lambda node needs to be a memory state. This is only enforced on the call nodes at the moment. The reason why we currently cannot enforce this is because the HLS dialect uses the same lambda, but without memory states. This tight coupling will hopefully be resolved in the near future and then we can start to enforce it on the lambda side as well.