### PR TITLE
Remove duplicate input_node() methods

### DIFF
--- a/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.cpp
+++ b/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.cpp
@@ -1068,10 +1068,10 @@ RhlsToFirrtlConverter::MlirGenHlsLocalMem(const jlm::rvsdg::simple_node * node)
 {
   auto lmem_op = dynamic_cast<const local_mem_op *>(&(node->operation()));
   JLM_ASSERT(lmem_op);
-  auto res_node = llvm::input_node(*node->output(0)->begin());
+  auto res_node = rvsdg::input::GetNode(**node->output(0)->begin());
   auto res_op = dynamic_cast<const local_mem_resp_op *>(&res_node->operation());
   JLM_ASSERT(res_op);
-  auto req_node = llvm::input_node(*node->output(1)->begin());
+  auto req_node = rvsdg::input::GetNode(**node->output(1)->begin());
   auto req_op = dynamic_cast<const local_mem_req_op *>(&req_node->operation());
   JLM_ASSERT(req_op);
   // Create the module and its input/output ports - we use a non-standard way here
@@ -1115,7 +1115,7 @@ RhlsToFirrtlConverter::MlirGenHlsLocalMem(const jlm::rvsdg::simple_node * node)
 
   auto body = module.getBodyBlock();
 
-  size_t loads = llvm::input_node(*node->output(0)->begin())->noutputs();
+  size_t loads = rvsdg::input::GetNode(**node->output(0)->begin())->noutputs();
 
   // Input signals
   ::llvm::SmallVector<circt::firrtl::SubfieldOp> loadAddrReadys;
@@ -2584,7 +2584,7 @@ RhlsToFirrtlConverter::MlirGen(jlm::rvsdg::region * subRegion, mlir::Block * cir
     if (dynamic_cast<const hls::local_mem_op *>(&(rvsdgNode->operation())))
     {
       // hook up request port
-      auto requestNode = llvm::input_node(*rvsdgNode->output(1)->begin());
+      auto requestNode = rvsdg::input::GetNode(**rvsdgNode->output(1)->begin());
       // skip connection to mem
       for (size_t i = 1; i < requestNode->ninputs(); i++)
       {
@@ -3950,10 +3950,10 @@ RhlsToFirrtlConverter::GetModuleName(const jlm::rvsdg::node * node)
     append.append(
         std::to_string(dynamic_cast<const llvm::arraytype *>(&op->result(0).type())->nelements()));
     append.append("_L");
-    size_t loads = llvm::input_node(*node->output(0)->begin())->noutputs();
+    size_t loads = rvsdg::input::GetNode(**node->output(0)->begin())->noutputs();
     append.append(std::to_string(loads));
     append.append("_S");
-    size_t stores = (llvm::input_node(*node->output(1)->begin())->ninputs() - 1 - loads) / 2;
+    size_t stores = (rvsdg::input::GetNode(**node->output(1)->begin())->ninputs() - 1 - loads) / 2;
     append.append(std::to_string(stores));
   }
   auto name = jlm::util::strfmt("op_", node->operation().debug_string() + append);

--- a/jlm/hls/backend/rvsdg2rhls/alloca-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/alloca-conv.cpp
@@ -199,7 +199,7 @@ alloca_conv(jlm::rvsdg::region * region)
       // TODO: handle general case of other nodes getting state edge without a merge
       JLM_ASSERT(node->output(1)->nusers() == 1);
       auto merge_in = *node->output(1)->begin();
-      auto merge_node = llvm::input_node(merge_in);
+      auto merge_node = rvsdg::input::GetNode(*merge_in);
       if (dynamic_cast<const llvm::MemoryStateMergeOperation *>(&merge_node->operation()))
       {
         // merge after alloca -> remove merge

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -222,7 +222,7 @@ convert_alloca(jlm::rvsdg::region * region)
       // TODO: handle general case of other nodes getting state edge without a merge
       JLM_ASSERT(node->output(1)->nusers() == 1);
       auto mux_in = *node->output(1)->begin();
-      auto mux_node = llvm::input_node(mux_in);
+      auto mux_node = rvsdg::input::GetNode(*mux_in);
       if (dynamic_cast<const llvm::MemoryStateMergeOperation *>(&mux_node->operation()))
       {
         // merge after alloca -> remove merge

--- a/jlm/llvm/backend/rvsdg2jlm/rvsdg2jlm.cpp
+++ b/jlm/llvm/backend/rvsdg2jlm/rvsdg2jlm.cpp
@@ -333,7 +333,7 @@ convert_gamma_node(const rvsdg::node & node, context & ctx)
 static inline bool
 phi_needed(const rvsdg::input * i, const llvm::variable * v)
 {
-  auto node = input_node(i);
+  auto node = rvsdg::input::GetNode(*i);
   JLM_ASSERT(is<rvsdg::theta_op>(node));
   auto theta = static_cast<const rvsdg::structural_node *>(node);
   auto input = static_cast<const rvsdg::structural_input *>(i);

--- a/jlm/llvm/ir/operators/operators.hpp
+++ b/jlm/llvm/ir/operators/operators.hpp
@@ -2634,16 +2634,6 @@ private:
   }
 };
 
-/*
-  FIXME: This function should be in librvsdg and not in libllvm.
-*/
-static inline jlm::rvsdg::node *
-input_node(const jlm::rvsdg::input * input)
-{
-  auto ni = dynamic_cast<const jlm::rvsdg::node_input *>(input);
-  return ni != nullptr ? ni->node() : nullptr;
-}
-
 }
 
 #endif

--- a/jlm/llvm/opt/inversion.cpp
+++ b/jlm/llvm/opt/inversion.cpp
@@ -62,10 +62,10 @@ is_applicable(const jlm::rvsdg::theta_node * theta)
     if (user == theta->predicate())
       continue;
 
-    if (!jlm::rvsdg::is<jlm::rvsdg::gamma_op>(input_node(user)))
+    if (!rvsdg::is<rvsdg::gamma_op>(rvsdg::input::GetNode(*user)))
       return nullptr;
 
-    gnode = dynamic_cast<jlm::rvsdg::gamma_node *>(input_node(user));
+    gnode = dynamic_cast<rvsdg::gamma_node *>(rvsdg::input::GetNode(*user));
   }
 
   return gnode;

--- a/jlm/llvm/opt/pull.cpp
+++ b/jlm/llvm/opt/pull.cpp
@@ -62,7 +62,7 @@ single_successor(const jlm::rvsdg::node * node)
   for (size_t n = 0; n < node->noutputs(); n++)
   {
     for (const auto & user : *node->output(n))
-      successors.insert(input_node(user));
+      successors.insert(rvsdg::input::GetNode(*user));
   }
 
   return successors.size() == 1;
@@ -157,7 +157,7 @@ pullin_bottom(jlm::rvsdg::gamma_node * gamma)
     auto output = gamma->output(n);
     for (const auto & user : *output)
     {
-      auto node = input_node(user);
+      auto node = rvsdg::input::GetNode(*user);
       if (node && node->depth() == gamma->depth() + 1)
         workset.insert(node);
     }
@@ -200,7 +200,7 @@ pullin_bottom(jlm::rvsdg::gamma_node * gamma)
       auto output = node->output(n);
       for (const auto & user : *output)
       {
-        auto tmp = input_node(user);
+        auto tmp = rvsdg::input::GetNode(*user);
         if (tmp && tmp->depth() == node->depth() + 1)
           workset.insert(tmp);
       }

--- a/jlm/llvm/opt/push.cpp
+++ b/jlm/llvm/opt/push.cpp
@@ -185,7 +185,7 @@ push(jlm::rvsdg::gamma_node * gamma)
       auto argument = region->argument(n);
       for (const auto & user : *argument)
       {
-        auto tmp = input_node(user);
+        auto tmp = jlm::rvsdg::input::GetNode(*user);
         if (tmp && tmp->depth() == 0)
           wl.push_back(tmp);
       }
@@ -206,7 +206,7 @@ push(jlm::rvsdg::gamma_node * gamma)
       {
         for (const auto & user : *argument)
         {
-          auto tmp = input_node(user);
+          auto tmp = jlm::rvsdg::input::GetNode(*user);
           if (tmp && tmp->depth() == 0)
             wl.push_back(tmp);
         }
@@ -261,7 +261,7 @@ push_top(jlm::rvsdg::theta_node * theta)
     auto argument = lv->argument();
     for (const auto & user : *argument)
     {
-      auto tmp = input_node(user);
+      auto tmp = jlm::rvsdg::input::GetNode(*user);
       if (tmp && tmp->depth() == 0 && is_theta_invariant(tmp, invariants))
         wl.push_back(tmp);
     }
@@ -284,7 +284,7 @@ push_top(jlm::rvsdg::theta_node * theta)
     {
       for (const auto & user : *argument)
       {
-        auto tmp = input_node(user);
+        auto tmp = jlm::rvsdg::input::GetNode(*user);
         if (tmp && tmp->depth() == 0 && is_theta_invariant(tmp, invariants))
           wl.push_back(tmp);
       }
@@ -361,7 +361,7 @@ pushout_store(jlm::rvsdg::node * storenode)
     std::unordered_set<jlm::rvsdg::input *> users;
     for (const auto & user : *states[n])
     {
-      if (input_node(user) != jlm::rvsdg::node_output::node(nstates[0]))
+      if (jlm::rvsdg::input::GetNode(*user) != jlm::rvsdg::node_output::node(nstates[0]))
         users.insert(user);
     }
 

--- a/jlm/llvm/opt/unroll.cpp
+++ b/jlm/llvm/opt/unroll.cpp
@@ -95,7 +95,7 @@ is_idv(jlm::rvsdg::input * input)
 {
   using namespace jlm::rvsdg;
 
-  auto node = input_node(input);
+  auto node = rvsdg::input::GetNode(*input);
   JLM_ASSERT(is<bitadd_op>(node) || is<bitsub_op>(node));
 
   auto a = dynamic_cast<jlm::rvsdg::argument *>(input->origin());

--- a/jlm/rvsdg/graph.cpp
+++ b/jlm/rvsdg/graph.cpp
@@ -104,7 +104,7 @@ graph::ExtractTailNodes(const graph & rvsdg)
         return false;
       }
 
-      if (rvsdg::node_input::node(*input))
+      if (rvsdg::input::GetNode(*input))
       {
         return false;
       }

--- a/jlm/rvsdg/node.cpp
+++ b/jlm/rvsdg/node.cpp
@@ -87,10 +87,10 @@ input::divert_to(jlm::rvsdg::output * new_origin)
   on_input_change(this, old_origin, new_origin);
 }
 
-jlm::rvsdg::node *
-input::GetNode(const jlm::rvsdg::input & input) noexcept
+rvsdg::node *
+input::GetNode(const rvsdg::input & input) noexcept
 {
-  auto nodeInput = dynamic_cast<const jlm::rvsdg::node_input *>(&input);
+  auto nodeInput = dynamic_cast<const rvsdg::node_input *>(&input);
   return nodeInput ? nodeInput->node() : nullptr;
 }
 

--- a/jlm/rvsdg/node.hpp
+++ b/jlm/rvsdg/node.hpp
@@ -115,8 +115,8 @@ public:
    * @return The node associated with \p input if input is derived from jlm::rvsdg::node_input,
    * otherwise nullptr.
    */
-  [[nodiscard]] static jlm::rvsdg::node *
-  GetNode(const jlm::rvsdg::input & input) noexcept;
+  [[nodiscard]] static rvsdg::node *
+  GetNode(const rvsdg::input & input) noexcept;
 
   template<class T>
   class iterator
@@ -606,21 +606,6 @@ public:
   node() const noexcept
   {
     return node_;
-  }
-
-  /**
-   * Returns the associated node if \p input is a jlm::rvsdg::node_input, otherwise null.
-   *
-   * @param input A jlm::rvsdg::input
-   * @return Returns a jlm::rvsdg::node or null.
-   *
-   * @see jlm::rvsdg::node_input::node()
-   */
-  [[nodiscard]] static jlm::rvsdg::node *
-  node(const jlm::rvsdg::input & input)
-  {
-    auto nodeInput = dynamic_cast<const node_input *>(&input);
-    return nodeInput != nullptr ? nodeInput->node() : nullptr;
   }
 
 private:

--- a/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
@@ -87,19 +87,19 @@ ValidateStoreTest1SteensgaardAgnostic(const jlm::tests::StoreTest1 & test)
   assert(test.alloca_b->output(1)->nusers() == 1);
   assert(test.alloca_a->output(1)->nusers() == 1);
 
-  assert(input_node((*test.alloca_d->output(1)->begin())) == lambdaExitMerge);
+  assert(jlm::rvsdg::input::GetNode((**test.alloca_d->output(1)->begin())) == lambdaExitMerge);
 
-  auto storeD = input_node(*test.alloca_c->output(1)->begin());
+  auto storeD = jlm::rvsdg::input::GetNode(**test.alloca_c->output(1)->begin());
   assert(is<StoreNonVolatileOperation>(*storeD, 3, 1));
   assert(storeD->input(0)->origin() == test.alloca_c->output(0));
   assert(storeD->input(1)->origin() == test.alloca_d->output(0));
 
-  auto storeC = input_node(*test.alloca_b->output(1)->begin());
+  auto storeC = jlm::rvsdg::input::GetNode(**test.alloca_b->output(1)->begin());
   assert(is<StoreNonVolatileOperation>(*storeC, 3, 1));
   assert(storeC->input(0)->origin() == test.alloca_b->output(0));
   assert(storeC->input(1)->origin() == test.alloca_c->output(0));
 
-  auto storeB = input_node(*test.alloca_a->output(1)->begin());
+  auto storeB = jlm::rvsdg::input::GetNode(**test.alloca_a->output(1)->begin());
   assert(is<StoreNonVolatileOperation>(*storeB, 3, 1));
   assert(storeB->input(0)->origin() == test.alloca_a->output(0));
   assert(storeB->input(1)->origin() == test.alloca_b->output(0));
@@ -120,19 +120,19 @@ ValidateStoreTest1SteensgaardRegionAware(const jlm::tests::StoreTest1 & test)
   assert(test.alloca_b->output(1)->nusers() == 1);
   assert(test.alloca_a->output(1)->nusers() == 1);
 
-  assert(input_node((*test.alloca_d->output(1)->begin())) == lambdaExitMerge);
+  assert(jlm::rvsdg::input::GetNode((**test.alloca_d->output(1)->begin())) == lambdaExitMerge);
 
-  auto storeD = input_node(*test.alloca_c->output(1)->begin());
+  auto storeD = jlm::rvsdg::input::GetNode(**test.alloca_c->output(1)->begin());
   assert(is<StoreNonVolatileOperation>(*storeD, 3, 1));
   assert(storeD->input(0)->origin() == test.alloca_c->output(0));
   assert(storeD->input(1)->origin() == test.alloca_d->output(0));
 
-  auto storeC = input_node(*test.alloca_b->output(1)->begin());
+  auto storeC = jlm::rvsdg::input::GetNode(**test.alloca_b->output(1)->begin());
   assert(is<StoreNonVolatileOperation>(*storeC, 3, 1));
   assert(storeC->input(0)->origin() == test.alloca_b->output(0));
   assert(storeC->input(1)->origin() == test.alloca_c->output(0));
 
-  auto storeB = input_node(*test.alloca_a->output(1)->begin());
+  auto storeB = jlm::rvsdg::input::GetNode(**test.alloca_a->output(1)->begin());
   assert(is<StoreNonVolatileOperation>(*storeB, 3, 1));
   assert(storeB->input(0)->origin() == test.alloca_a->output(0));
   assert(storeB->input(1)->origin() == test.alloca_b->output(0));
@@ -169,25 +169,25 @@ ValidateStoreTest2SteensgaardAgnostic(const jlm::tests::StoreTest2 & test)
   assert(test.alloca_y->output(1)->nusers() == 1);
   assert(test.alloca_p->output(1)->nusers() == 1);
 
-  assert(input_node((*test.alloca_a->output(1)->begin())) == lambdaExitMerge);
-  assert(input_node((*test.alloca_b->output(1)->begin())) == lambdaExitMerge);
+  assert(jlm::rvsdg::input::GetNode((**test.alloca_a->output(1)->begin())) == lambdaExitMerge);
+  assert(jlm::rvsdg::input::GetNode((**test.alloca_b->output(1)->begin())) == lambdaExitMerge);
 
-  auto storeA = input_node(*test.alloca_a->output(0)->begin());
+  auto storeA = jlm::rvsdg::input::GetNode(**test.alloca_a->output(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeA, 4, 2));
   assert(storeA->input(0)->origin() == test.alloca_x->output(0));
 
-  auto storeB = input_node(*test.alloca_b->output(0)->begin());
+  auto storeB = jlm::rvsdg::input::GetNode(**test.alloca_b->output(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeB, 4, 2));
   assert(storeB->input(0)->origin() == test.alloca_y->output(0));
   assert(jlm::rvsdg::node_output::node(storeB->input(2)->origin()) == storeA);
   assert(jlm::rvsdg::node_output::node(storeB->input(3)->origin()) == storeA);
 
-  auto storeX = input_node(*test.alloca_p->output(1)->begin());
+  auto storeX = jlm::rvsdg::input::GetNode(**test.alloca_p->output(1)->begin());
   assert(is<StoreNonVolatileOperation>(*storeX, 3, 1));
   assert(storeX->input(0)->origin() == test.alloca_p->output(0));
   assert(storeX->input(1)->origin() == test.alloca_x->output(0));
 
-  auto storeY = input_node(*storeX->output(0)->begin());
+  auto storeY = jlm::rvsdg::input::GetNode(**storeX->output(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeY, 3, 1));
   assert(storeY->input(0)->origin() == test.alloca_p->output(0));
   assert(storeY->input(1)->origin() == test.alloca_y->output(0));
@@ -209,25 +209,25 @@ ValidateStoreTest2SteensgaardRegionAware(const jlm::tests::StoreTest2 & test)
   assert(test.alloca_y->output(1)->nusers() == 1);
   assert(test.alloca_p->output(1)->nusers() == 1);
 
-  assert(input_node((*test.alloca_a->output(1)->begin())) == lambdaExitMerge);
-  assert(input_node((*test.alloca_b->output(1)->begin())) == lambdaExitMerge);
+  assert(jlm::rvsdg::input::GetNode((**test.alloca_a->output(1)->begin())) == lambdaExitMerge);
+  assert(jlm::rvsdg::input::GetNode((**test.alloca_b->output(1)->begin())) == lambdaExitMerge);
 
-  auto storeA = input_node(*test.alloca_a->output(0)->begin());
+  auto storeA = jlm::rvsdg::input::GetNode(**test.alloca_a->output(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeA, 4, 2));
   assert(storeA->input(0)->origin() == test.alloca_x->output(0));
 
-  auto storeB = input_node(*test.alloca_b->output(0)->begin());
+  auto storeB = jlm::rvsdg::input::GetNode(**test.alloca_b->output(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeB, 4, 2));
   assert(storeB->input(0)->origin() == test.alloca_y->output(0));
   assert(jlm::rvsdg::node_output::node(storeB->input(2)->origin()) == storeA);
   assert(jlm::rvsdg::node_output::node(storeB->input(3)->origin()) == storeA);
 
-  auto storeX = input_node(*test.alloca_p->output(1)->begin());
+  auto storeX = jlm::rvsdg::input::GetNode(**test.alloca_p->output(1)->begin());
   assert(is<StoreNonVolatileOperation>(*storeX, 3, 1));
   assert(storeX->input(0)->origin() == test.alloca_p->output(0));
   assert(storeX->input(1)->origin() == test.alloca_x->output(0));
 
-  auto storeY = input_node(*storeX->output(0)->begin());
+  auto storeY = jlm::rvsdg::input::GetNode(**storeX->output(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeY, 3, 1));
   assert(storeY->input(0)->origin() == test.alloca_p->output(0));
   assert(storeY->input(1)->origin() == test.alloca_y->output(0));
@@ -258,7 +258,7 @@ ValidateLoadTest1SteensgaardAgnostic(const jlm::tests::LoadTest1 & test)
   auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(1)->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
-  auto lambdaEntrySplit = input_node(*test.lambda->fctargument(1)->begin());
+  auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda->fctargument(1)->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 
   auto loadA = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
@@ -282,7 +282,7 @@ ValidateLoadTest1SteensgaardRegionAware(const jlm::tests::LoadTest1 & test)
   auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(1)->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
-  auto lambdaEntrySplit = input_node(*test.lambda->fctargument(1)->begin());
+  auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda->fctargument(1)->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 
   auto loadA = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
@@ -306,7 +306,7 @@ ValidateLoadTest1SteensgaardAgnosticTopDown(const jlm::tests::LoadTest1 & test)
   auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(1)->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
-  auto lambdaEntrySplit = input_node(*test.lambda->fctargument(1)->begin());
+  auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda->fctargument(1)->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 
   auto loadA = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
@@ -336,34 +336,34 @@ ValidateLoadTest2SteensgaardAgnostic(const jlm::tests::LoadTest2 & test)
   assert(test.alloca_y->output(1)->nusers() == 1);
   assert(test.alloca_p->output(1)->nusers() == 1);
 
-  assert(input_node((*test.alloca_a->output(1)->begin())) == lambdaExitMerge);
-  assert(input_node((*test.alloca_b->output(1)->begin())) == lambdaExitMerge);
+  assert(jlm::rvsdg::input::GetNode((**test.alloca_a->output(1)->begin())) == lambdaExitMerge);
+  assert(jlm::rvsdg::input::GetNode((**test.alloca_b->output(1)->begin())) == lambdaExitMerge);
 
-  auto storeA = input_node(*test.alloca_a->output(0)->begin());
+  auto storeA = jlm::rvsdg::input::GetNode(**test.alloca_a->output(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeA, 4, 2));
   assert(storeA->input(0)->origin() == test.alloca_x->output(0));
 
-  auto storeB = input_node(*test.alloca_b->output(0)->begin());
+  auto storeB = jlm::rvsdg::input::GetNode(**test.alloca_b->output(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeB, 4, 2));
   assert(storeB->input(0)->origin() == test.alloca_y->output(0));
   assert(jlm::rvsdg::node_output::node(storeB->input(2)->origin()) == storeA);
   assert(jlm::rvsdg::node_output::node(storeB->input(3)->origin()) == storeA);
 
-  auto storeX = input_node(*test.alloca_p->output(1)->begin());
+  auto storeX = jlm::rvsdg::input::GetNode(**test.alloca_p->output(1)->begin());
   assert(is<StoreNonVolatileOperation>(*storeX, 3, 1));
   assert(storeX->input(0)->origin() == test.alloca_p->output(0));
   assert(storeX->input(1)->origin() == test.alloca_x->output(0));
 
-  auto loadP = input_node(*storeX->output(0)->begin());
+  auto loadP = jlm::rvsdg::input::GetNode(**storeX->output(0)->begin());
   assert(is<LoadNonVolatileOperation>(*loadP, 2, 2));
   assert(loadP->input(0)->origin() == test.alloca_p->output(0));
 
-  auto loadXY = input_node(*loadP->output(0)->begin());
+  auto loadXY = jlm::rvsdg::input::GetNode(**loadP->output(0)->begin());
   assert(is<LoadNonVolatileOperation>(*loadXY, 3, 3));
   assert(jlm::rvsdg::node_output::node(loadXY->input(1)->origin()) == storeB);
   assert(jlm::rvsdg::node_output::node(loadXY->input(2)->origin()) == storeB);
 
-  auto storeY = input_node(*loadXY->output(0)->begin());
+  auto storeY = jlm::rvsdg::input::GetNode(**loadXY->output(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeY, 4, 2));
   assert(storeY->input(0)->origin() == test.alloca_y->output(0));
   assert(jlm::rvsdg::node_output::node(storeY->input(2)->origin()) == loadXY);
@@ -386,31 +386,31 @@ ValidateLoadTest2SteensgaardRegionAware(const jlm::tests::LoadTest2 & test)
   assert(test.alloca_y->output(1)->nusers() == 1);
   assert(test.alloca_p->output(1)->nusers() == 1);
 
-  auto storeA = input_node(*test.alloca_a->output(0)->begin());
+  auto storeA = jlm::rvsdg::input::GetNode(**test.alloca_a->output(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeA, 4, 2));
   assert(storeA->input(0)->origin() == test.alloca_x->output(0));
 
-  auto storeB = input_node(*test.alloca_b->output(0)->begin());
+  auto storeB = jlm::rvsdg::input::GetNode(**test.alloca_b->output(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeB, 4, 2));
   assert(storeB->input(0)->origin() == test.alloca_y->output(0));
   assert(jlm::rvsdg::node_output::node(storeB->input(2)->origin()) == storeA);
   assert(jlm::rvsdg::node_output::node(storeB->input(3)->origin()) == storeA);
 
-  auto storeX = input_node(*test.alloca_p->output(1)->begin());
+  auto storeX = jlm::rvsdg::input::GetNode(**test.alloca_p->output(1)->begin());
   assert(is<StoreNonVolatileOperation>(*storeX, 3, 1));
   assert(storeX->input(0)->origin() == test.alloca_p->output(0));
   assert(storeX->input(1)->origin() == test.alloca_x->output(0));
 
-  auto loadP = input_node(*storeX->output(0)->begin());
+  auto loadP = jlm::rvsdg::input::GetNode(**storeX->output(0)->begin());
   assert(is<LoadNonVolatileOperation>(*loadP, 2, 2));
   assert(loadP->input(0)->origin() == test.alloca_p->output(0));
 
-  auto loadXY = input_node(*loadP->output(0)->begin());
+  auto loadXY = jlm::rvsdg::input::GetNode(**loadP->output(0)->begin());
   assert(is<LoadNonVolatileOperation>(*loadXY, 3, 3));
   assert(jlm::rvsdg::node_output::node(loadXY->input(1)->origin()) == storeB);
   assert(jlm::rvsdg::node_output::node(loadXY->input(2)->origin()) == storeB);
 
-  auto storeY = input_node(*loadXY->output(0)->begin());
+  auto storeY = jlm::rvsdg::input::GetNode(**loadXY->output(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeY, 4, 2));
   assert(storeY->input(0)->origin() == test.alloca_y->output(0));
   assert(jlm::rvsdg::node_output::node(storeY->input(2)->origin()) == loadXY);
@@ -445,7 +445,7 @@ ValidateLoadFromUndefSteensgaardAgnostic(const jlm::tests::LoadFromUndefTest & t
   auto load = jlm::rvsdg::node_output::node(test.Lambda().fctresult(0)->origin());
   assert(is<LoadNonVolatileOperation>(*load, 1, 1));
 
-  auto lambdaEntrySplit = input_node(*test.Lambda().fctargument(0)->begin());
+  auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.Lambda().fctargument(0)->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 }
 
@@ -476,7 +476,7 @@ ValidateLoadFromUndefSteensgaardAgnosticTopDown(const jlm::tests::LoadFromUndefT
   auto load = jlm::rvsdg::node_output::node(test.Lambda().fctresult(0)->origin());
   assert(is<LoadNonVolatileOperation>(*load, 1, 1));
 
-  auto lambdaEntrySplit = input_node(*test.Lambda().fctargument(0)->begin());
+  auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.Lambda().fctargument(0)->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 }
 
@@ -487,10 +487,10 @@ ValidateCallTest1SteensgaardAgnostic(const jlm::tests::CallTest1 & test)
 
   /* validate f */
   {
-    auto lambdaEntrySplit = input_node(*test.lambda_f->fctargument(3)->begin());
+    auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_f->fctargument(3)->begin());
     auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda_f->fctresult(2)->origin());
-    auto loadX = input_node(*test.lambda_f->fctargument(0)->begin());
-    auto loadY = input_node(*test.lambda_f->fctargument(1)->begin());
+    auto loadX = jlm::rvsdg::input::GetNode(**test.lambda_f->fctargument(0)->begin());
+    auto loadY = jlm::rvsdg::input::GetNode(**test.lambda_f->fctargument(1)->begin());
 
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 7, 1));
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 7));
@@ -504,10 +504,10 @@ ValidateCallTest1SteensgaardAgnostic(const jlm::tests::CallTest1 & test)
 
   /* validate g */
   {
-    auto lambdaEntrySplit = input_node(*test.lambda_g->fctargument(3)->begin());
+    auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(3)->begin());
     auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda_g->fctresult(2)->origin());
-    auto loadX = input_node(*test.lambda_g->fctargument(0)->begin());
-    auto loadY = input_node(*test.lambda_g->fctargument(1)->begin());
+    auto loadX = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(0)->begin());
+    auto loadY = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(1)->begin());
 
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 7, 1));
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 7));
@@ -522,13 +522,13 @@ ValidateCallTest1SteensgaardAgnostic(const jlm::tests::CallTest1 & test)
   /* validate h */
   {
     auto callEntryMerge = jlm::rvsdg::node_output::node(test.CallF().input(4)->origin());
-    auto callExitSplit = input_node(*test.CallF().output(2)->begin());
+    auto callExitSplit = jlm::rvsdg::input::GetNode(**test.CallF().output(2)->begin());
 
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 7, 1));
     assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 7));
 
     callEntryMerge = jlm::rvsdg::node_output::node(test.CallG().input(4)->origin());
-    callExitSplit = input_node(*test.CallG().output(2)->begin());
+    callExitSplit = jlm::rvsdg::input::GetNode(**test.CallG().output(2)->begin());
 
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 7, 1));
     assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 7));
@@ -542,10 +542,10 @@ ValidateCallTest1SteensgaardRegionAware(const jlm::tests::CallTest1 & test)
 
   /* validate f */
   {
-    auto lambdaEntrySplit = input_node(*test.lambda_f->fctargument(3)->begin());
+    auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_f->fctargument(3)->begin());
     auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda_f->fctresult(2)->origin());
-    auto loadX = input_node(*test.lambda_f->fctargument(0)->begin());
-    auto loadY = input_node(*test.lambda_f->fctargument(1)->begin());
+    auto loadX = jlm::rvsdg::input::GetNode(**test.lambda_f->fctargument(0)->begin());
+    auto loadY = jlm::rvsdg::input::GetNode(**test.lambda_f->fctargument(1)->begin());
 
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
@@ -559,10 +559,10 @@ ValidateCallTest1SteensgaardRegionAware(const jlm::tests::CallTest1 & test)
 
   /* validate g */
   {
-    auto lambdaEntrySplit = input_node(*test.lambda_g->fctargument(3)->begin());
+    auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(3)->begin());
     auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda_g->fctresult(2)->origin());
-    auto loadX = input_node(*test.lambda_g->fctargument(0)->begin());
-    auto loadY = input_node(*test.lambda_g->fctargument(1)->begin());
+    auto loadX = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(0)->begin());
+    auto loadY = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(1)->begin());
 
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 1, 1));
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 1));
@@ -577,13 +577,13 @@ ValidateCallTest1SteensgaardRegionAware(const jlm::tests::CallTest1 & test)
   /* validate h */
   {
     auto callEntryMerge = jlm::rvsdg::node_output::node(test.CallF().input(4)->origin());
-    auto callExitSplit = input_node(*test.CallF().output(2)->begin());
+    auto callExitSplit = jlm::rvsdg::input::GetNode(**test.CallF().output(2)->begin());
 
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 2, 1));
     assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 2));
 
     callEntryMerge = jlm::rvsdg::node_output::node(test.CallG().input(4)->origin());
-    callExitSplit = input_node(*test.CallG().output(2)->begin());
+    callExitSplit = jlm::rvsdg::input::GetNode(**test.CallG().output(2)->begin());
 
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 1, 1));
     assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 1));
@@ -597,10 +597,10 @@ ValidateCallTest1SteensgaardAgnosticTopDown(const jlm::tests::CallTest1 & test)
 
   // validate function f
   {
-    auto lambdaEntrySplit = input_node(*test.lambda_f->fctargument(3)->begin());
+    auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_f->fctargument(3)->begin());
     auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda_f->fctresult(2)->origin());
-    auto loadX = input_node(*test.lambda_f->fctargument(0)->begin());
-    auto loadY = input_node(*test.lambda_f->fctargument(1)->begin());
+    auto loadX = jlm::rvsdg::input::GetNode(**test.lambda_f->fctargument(0)->begin());
+    auto loadY = jlm::rvsdg::input::GetNode(**test.lambda_f->fctargument(1)->begin());
 
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 7, 1));
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 7));
@@ -614,10 +614,10 @@ ValidateCallTest1SteensgaardAgnosticTopDown(const jlm::tests::CallTest1 & test)
 
   // validate function g
   {
-    auto lambdaEntrySplit = input_node(*test.lambda_g->fctargument(3)->begin());
+    auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(3)->begin());
     auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda_g->fctresult(2)->origin());
-    auto loadX = input_node(*test.lambda_g->fctargument(0)->begin());
-    auto loadY = input_node(*test.lambda_g->fctargument(1)->begin());
+    auto loadX = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(0)->begin());
+    auto loadY = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(1)->begin());
 
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 7, 1));
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 7));
@@ -632,13 +632,13 @@ ValidateCallTest1SteensgaardAgnosticTopDown(const jlm::tests::CallTest1 & test)
   // validate function h
   {
     auto callEntryMerge = jlm::rvsdg::node_output::node(test.CallF().input(4)->origin());
-    auto callExitSplit = input_node(*test.CallF().output(2)->begin());
+    auto callExitSplit = jlm::rvsdg::input::GetNode(**test.CallF().output(2)->begin());
 
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 7, 1));
     assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 7));
 
     callEntryMerge = jlm::rvsdg::node_output::node(test.CallG().input(4)->origin());
-    callExitSplit = input_node(*test.CallG().output(2)->begin());
+    callExitSplit = jlm::rvsdg::input::GetNode(**test.CallG().output(2)->begin());
 
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 7, 1));
     assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 7));
@@ -654,13 +654,13 @@ ValidateCallTest2SteensgaardAgnostic(const jlm::tests::CallTest2 & test)
   {
     assert(test.lambda_create->subregion()->nnodes() == 7);
 
-    auto stateMerge = input_node(*test.malloc->output(1)->begin());
+    auto stateMerge = jlm::rvsdg::input::GetNode(**test.malloc->output(1)->begin());
     assert(is<MemoryStateMergeOperation>(*stateMerge, 2, 1));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(stateMerge->input(1)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
 
-    auto lambdaExitMerge = input_node(*stateMerge->output(0)->begin());
+    auto lambdaExitMerge = jlm::rvsdg::input::GetNode(**stateMerge->output(0)->begin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
 
     auto mallocStateLambdaEntryIndex = stateMerge->input(1)->origin()->index();
@@ -688,13 +688,13 @@ ValidateCallTest2SteensgaardRegionAware(const jlm::tests::CallTest2 & test)
   {
     assert(test.lambda_create->subregion()->nnodes() == 7);
 
-    auto stateMerge = input_node(*test.malloc->output(1)->begin());
+    auto stateMerge = jlm::rvsdg::input::GetNode(**test.malloc->output(1)->begin());
     assert(is<MemoryStateMergeOperation>(*stateMerge, 2, 1));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(stateMerge->input(1)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 1));
 
-    auto lambdaExitMerge = input_node(*stateMerge->output(0)->begin());
+    auto lambdaExitMerge = jlm::rvsdg::input::GetNode(**stateMerge->output(0)->begin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 1, 1));
 
     auto mallocStateLambdaEntryIndex = stateMerge->input(1)->origin()->index();
@@ -722,13 +722,13 @@ ValidateCallTest2SteensgaardAgnosticTopDown(const jlm::tests::CallTest2 & test)
   {
     assert(test.lambda_create->subregion()->nnodes() == 7);
 
-    auto stateMerge = input_node(*test.malloc->output(1)->begin());
+    auto stateMerge = jlm::rvsdg::input::GetNode(**test.malloc->output(1)->begin());
     assert(is<MemoryStateMergeOperation>(*stateMerge, 2, 1));
 
     auto lambdaEntrySplit = jlm::rvsdg::node_output::node(stateMerge->input(1)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
 
-    auto lambdaExitMerge = input_node(*stateMerge->output(0)->begin());
+    auto lambdaExitMerge = jlm::rvsdg::input::GetNode(**stateMerge->output(0)->begin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
   }
 
@@ -927,7 +927,8 @@ ValidateIndirectCallTest2SteensgaardAgnostic(const jlm::tests::IndirectCallTest2
         jlm::rvsdg::node_output::node(test.GetLambdaThree().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 13, 1));
 
-    auto lambdaEntrySplit = input_node(*test.GetLambdaThree().fctargument(1)->begin());
+    auto lambdaEntrySplit =
+        jlm::rvsdg::input::GetNode(**test.GetLambdaThree().fctargument(1)->begin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 13));
   }
 
@@ -939,7 +940,8 @@ ValidateIndirectCallTest2SteensgaardAgnostic(const jlm::tests::IndirectCallTest2
         jlm::rvsdg::node_output::node(test.GetLambdaFour().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 13, 1));
 
-    auto lambdaEntrySplit = input_node(*test.GetLambdaFour().fctargument(1)->begin());
+    auto lambdaEntrySplit =
+        jlm::rvsdg::input::GetNode(**test.GetLambdaFour().fctargument(1)->begin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 13));
   }
 
@@ -1082,13 +1084,14 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
         jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 6, 1));
 
-    auto loadG1 = input_node(*test.GetLambdaTest().cvargument(2)->begin());
+    auto loadG1 = jlm::rvsdg::input::GetNode(**test.GetLambdaTest().cvargument(2)->begin());
     assert(is<LoadNonVolatileOperation>(*loadG1, 2, 2));
 
-    auto loadG2 = input_node(*test.GetLambdaTest().cvargument(3)->begin());
+    auto loadG2 = jlm::rvsdg::input::GetNode(**test.GetLambdaTest().cvargument(3)->begin());
     assert(is<LoadNonVolatileOperation>(*loadG2, 2, 2));
 
-    auto lambdaEntrySplit = input_node(*test.GetLambdaTest().fctargument(1)->begin());
+    auto lambdaEntrySplit =
+        jlm::rvsdg::input::GetNode(**test.GetLambdaTest().fctargument(1)->begin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 6));
   }
 
@@ -1100,7 +1103,8 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
         jlm::rvsdg::node_output::node(test.GetLambdaTest2().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 6, 1));
 
-    auto lambdaEntrySplit = input_node(*test.GetLambdaTest().fctargument(1)->begin());
+    auto lambdaEntrySplit =
+        jlm::rvsdg::input::GetNode(**test.GetLambdaTest().fctargument(1)->begin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 6));
   }
 }
@@ -1118,7 +1122,8 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
         jlm::rvsdg::node_output::node(test.GetLambdaThree().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 13, 1));
 
-    auto lambdaEntrySplit = input_node(*test.GetLambdaThree().fctargument(1)->begin());
+    auto lambdaEntrySplit =
+        jlm::rvsdg::input::GetNode(**test.GetLambdaThree().fctargument(1)->begin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 13));
   }
 
@@ -1130,7 +1135,8 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
         jlm::rvsdg::node_output::node(test.GetLambdaFour().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 13, 1));
 
-    auto lambdaEntrySplit = input_node(*test.GetLambdaFour().fctargument(1)->begin());
+    auto lambdaEntrySplit =
+        jlm::rvsdg::input::GetNode(**test.GetLambdaFour().fctargument(1)->begin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 13));
   }
 
@@ -1239,13 +1245,13 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
         jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 10, 1));
 
-    auto loadG1 = input_node(*test.GetLambdaTest().cvargument(2)->begin());
+    auto loadG1 = jlm::rvsdg::input::GetNode(**test.GetLambdaTest().cvargument(2)->begin());
     assert(is<LoadNonVolatileOperation>(*loadG1, 2, 2));
 
     auto callXEntryMerge = jlm::rvsdg::node_output::node(test.GetTestCallX().input(3)->origin());
     assert(is<CallEntryMemoryStateMergeOperation>(*callXEntryMerge, 13, 1));
 
-    auto callXExitSplit = input_node(*test.GetTestCallX().output(2)->begin());
+    auto callXExitSplit = jlm::rvsdg::input::GetNode(**test.GetTestCallX().output(2)->begin());
     assert(is<CallExitMemoryStateSplitOperation>(*callXExitSplit, 1, 13));
 
     jlm::rvsdg::node * undefNode = nullptr;
@@ -1259,12 +1265,13 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     }
     assert(undefNode != nullptr);
     assert(undefNode->output(0)->nusers() == 1);
-    assert(input_node(*undefNode->output(0)->begin()) == callXEntryMerge);
+    assert(jlm::rvsdg::input::GetNode(**undefNode->output(0)->begin()) == callXEntryMerge);
 
-    auto loadG2 = input_node(*test.GetLambdaTest().cvargument(3)->begin());
+    auto loadG2 = jlm::rvsdg::input::GetNode(**test.GetLambdaTest().cvargument(3)->begin());
     assert(is<LoadNonVolatileOperation>(*loadG2, 2, 2));
 
-    auto lambdaEntrySplit = input_node(*test.GetLambdaTest().fctargument(1)->begin());
+    auto lambdaEntrySplit =
+        jlm::rvsdg::input::GetNode(**test.GetLambdaTest().fctargument(1)->begin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 10));
   }
 
@@ -1279,7 +1286,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     auto callXEntryMerge = jlm::rvsdg::node_output::node(test.GetTest2CallX().input(3)->origin());
     assert(is<CallEntryMemoryStateMergeOperation>(*callXEntryMerge, 13, 1));
 
-    auto callXExitSplit = input_node(*test.GetTest2CallX().output(2)->begin());
+    auto callXExitSplit = jlm::rvsdg::input::GetNode(**test.GetTest2CallX().output(2)->begin());
     assert(is<CallExitMemoryStateSplitOperation>(*callXExitSplit, 1, 13));
 
     jlm::rvsdg::node * undefNode = nullptr;
@@ -1295,10 +1302,11 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(undefNode->output(0)->nusers() == 2);
     for (auto & user : *undefNode->output(0))
     {
-      assert(input_node(user) == callXEntryMerge);
+      assert(jlm::rvsdg::input::GetNode(*user) == callXEntryMerge);
     }
 
-    auto lambdaEntrySplit = input_node(*test.GetLambdaTest2().fctargument(1)->begin());
+    auto lambdaEntrySplit =
+        jlm::rvsdg::input::GetNode(**test.GetLambdaTest2().fctargument(1)->begin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 10));
   }
 }
@@ -1436,16 +1444,16 @@ ValidateDeltaTest1SteensgaardAgnostic(const jlm::tests::DeltaTest1 & test)
 
   assert(test.lambda_h->subregion()->nnodes() == 7);
 
-  auto lambdaEntrySplit = input_node(*test.lambda_h->fctargument(1)->begin());
+  auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_h->fctargument(1)->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 4));
 
-  auto storeF = input_node(*test.constantFive->output(0)->begin());
+  auto storeF = jlm::rvsdg::input::GetNode(**test.constantFive->output(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeF, 3, 1));
   assert(jlm::rvsdg::node_output::node(storeF->input(2)->origin()) == lambdaEntrySplit);
 
   auto deltaStateIndex = storeF->input(2)->origin()->index();
 
-  auto loadF = input_node(*test.lambda_g->fctargument(0)->begin());
+  auto loadF = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(0)->begin());
   assert(is<LoadNonVolatileOperation>(*loadF, 2, 2));
   assert(loadF->input(1)->origin()->index() == deltaStateIndex);
 }
@@ -1457,16 +1465,16 @@ ValidateDeltaTest1SteensgaardRegionAware(const jlm::tests::DeltaTest1 & test)
 
   assert(test.lambda_h->subregion()->nnodes() == 7);
 
-  auto lambdaEntrySplit = input_node(*test.lambda_h->fctargument(1)->begin());
+  auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_h->fctargument(1)->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 1));
 
-  auto storeF = input_node(*test.constantFive->output(0)->begin());
+  auto storeF = jlm::rvsdg::input::GetNode(**test.constantFive->output(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeF, 3, 1));
   assert(jlm::rvsdg::node_output::node(storeF->input(2)->origin()) == lambdaEntrySplit);
 
   auto deltaStateIndex = storeF->input(2)->origin()->index();
 
-  auto loadF = input_node(*test.lambda_g->fctargument(0)->begin());
+  auto loadF = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(0)->begin());
   assert(is<LoadNonVolatileOperation>(*loadF, 2, 2));
   assert(loadF->input(1)->origin()->index() == deltaStateIndex);
 }
@@ -1478,14 +1486,14 @@ ValidateDeltaTest1SteensgaardAgnosticTopDown(const jlm::tests::DeltaTest1 & test
 
   assert(test.lambda_h->subregion()->nnodes() == 7);
 
-  auto lambdaEntrySplit = input_node(*test.lambda_h->fctargument(1)->begin());
+  auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_h->fctargument(1)->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 4));
 
-  auto storeF = input_node(*test.constantFive->output(0)->begin());
+  auto storeF = jlm::rvsdg::input::GetNode(**test.constantFive->output(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeF, 3, 1));
   assert(jlm::rvsdg::node_output::node(storeF->input(2)->origin()) == lambdaEntrySplit);
 
-  auto loadF = input_node(*test.lambda_g->fctargument(0)->begin());
+  auto loadF = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(0)->begin());
   assert(is<LoadNonVolatileOperation>(*loadF, 2, 2));
 }
 
@@ -1496,21 +1504,21 @@ ValidateDeltaTest2SteensgaardAgnostic(const jlm::tests::DeltaTest2 & test)
 
   assert(test.lambda_f2->subregion()->nnodes() == 9);
 
-  auto lambdaEntrySplit = input_node(*test.lambda_f2->fctargument(1)->begin());
+  auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_f2->fctargument(1)->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
 
-  auto storeD1InF2 = input_node(*test.lambda_f2->cvargument(0)->begin());
+  auto storeD1InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
   assert(jlm::rvsdg::node_output::node(storeD1InF2->input(2)->origin()) == lambdaEntrySplit);
 
   auto d1StateIndex = storeD1InF2->input(2)->origin()->index();
 
-  auto storeD1InF1 = input_node(*test.lambda_f1->cvargument(0)->begin());
+  auto storeD1InF1 = jlm::rvsdg::input::GetNode(**test.lambda_f1->cvargument(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF1, 3, 1));
 
   assert(d1StateIndex == storeD1InF1->input(2)->origin()->index());
 
-  auto storeD2InF2 = input_node(*test.lambda_f2->cvargument(1)->begin());
+  auto storeD2InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(1)->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
 
   assert(d1StateIndex != storeD2InF2->input(2)->origin()->index());
@@ -1539,27 +1547,27 @@ ValidateDeltaTest2SteensgaardRegionAware(const jlm::tests::DeltaTest2 & test)
   {
     assert(test.lambda_f2->subregion()->nnodes() == 9);
 
-    auto lambdaEntrySplit = input_node(*test.lambda_f2->fctargument(1)->begin());
+    auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_f2->fctargument(1)->begin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 
-    auto storeD1 = input_node(*test.lambda_f2->cvargument(0)->begin());
+    auto storeD1 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(0)->begin());
     assert(is<StoreNonVolatileOperation>(*storeD1, 3, 1));
     assert(jlm::rvsdg::node_output::node(storeD1->input(2)->origin()) == lambdaEntrySplit);
 
-    auto storeD2 = input_node(*test.lambda_f2->cvargument(1)->begin());
+    auto storeD2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(1)->begin());
     assert(is<StoreNonVolatileOperation>(*storeD2, 3, 1));
     assert(jlm::rvsdg::node_output::node(storeD2->input(2)->origin()) == lambdaEntrySplit);
 
-    auto callEntryMerge = input_node(*storeD1->output(0)->begin());
+    auto callEntryMerge = jlm::rvsdg::input::GetNode(**storeD1->output(0)->begin());
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 1, 1));
 
-    auto callF1 = input_node(*callEntryMerge->output(0)->begin());
+    auto callF1 = jlm::rvsdg::input::GetNode(**callEntryMerge->output(0)->begin());
     assert(is<CallOperation>(*callF1, 3, 2));
 
-    auto callExitSplit = input_node(*callF1->output(1)->begin());
+    auto callExitSplit = jlm::rvsdg::input::GetNode(**callF1->output(1)->begin());
     assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 1));
 
-    auto lambdaExitMerge = input_node(*callExitSplit->output(0)->begin());
+    auto lambdaExitMerge = jlm::rvsdg::input::GetNode(**callExitSplit->output(0)->begin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
   }
 }
@@ -1571,19 +1579,19 @@ ValidateDeltaTest2SteensgaardAgnosticTopDown(const jlm::tests::DeltaTest2 & test
 
   assert(test.lambda_f2->subregion()->nnodes() == 9);
 
-  auto lambdaEntrySplit = input_node(*test.lambda_f2->fctargument(1)->begin());
+  auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_f2->fctargument(1)->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
 
-  auto storeD1InF2 = input_node(*test.lambda_f2->cvargument(0)->begin());
+  auto storeD1InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
   assert(jlm::rvsdg::node_output::node(storeD1InF2->input(2)->origin()) == lambdaEntrySplit);
 
   auto d1StateIndex = storeD1InF2->input(2)->origin()->index();
 
-  auto storeD1InF1 = input_node(*test.lambda_f1->cvargument(0)->begin());
+  auto storeD1InF1 = jlm::rvsdg::input::GetNode(**test.lambda_f1->cvargument(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF1, 3, 1));
 
-  auto storeD2InF2 = input_node(*test.lambda_f2->cvargument(1)->begin());
+  auto storeD2InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(1)->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
 
   assert(d1StateIndex != storeD2InF2->input(2)->origin()->index());
@@ -1722,21 +1730,21 @@ ValidateImportTestSteensgaardAgnostic(const jlm::tests::ImportTest & test)
 
   assert(test.lambda_f2->subregion()->nnodes() == 9);
 
-  auto lambdaEntrySplit = input_node(*test.lambda_f2->fctargument(1)->begin());
+  auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_f2->fctargument(1)->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
 
-  auto storeD1InF2 = input_node(*test.lambda_f2->cvargument(0)->begin());
+  auto storeD1InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
   assert(jlm::rvsdg::node_output::node(storeD1InF2->input(2)->origin()) == lambdaEntrySplit);
 
   auto d1StateIndex = storeD1InF2->input(2)->origin()->index();
 
-  auto storeD1InF1 = input_node(*test.lambda_f1->cvargument(0)->begin());
+  auto storeD1InF1 = jlm::rvsdg::input::GetNode(**test.lambda_f1->cvargument(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF1, 3, 1));
 
   assert(d1StateIndex == storeD1InF1->input(2)->origin()->index());
 
-  auto storeD2InF2 = input_node(*test.lambda_f2->cvargument(1)->begin());
+  auto storeD2InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(1)->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
 
   assert(d1StateIndex != storeD2InF2->input(2)->origin()->index());
@@ -1765,27 +1773,27 @@ ValidateImportTestSteensgaardRegionAware(const jlm::tests::ImportTest & test)
   {
     assert(test.lambda_f2->subregion()->nnodes() == 9);
 
-    auto lambdaEntrySplit = input_node(*test.lambda_f2->fctargument(1)->begin());
+    auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_f2->fctargument(1)->begin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 
-    auto storeD1 = input_node(*test.lambda_f2->cvargument(0)->begin());
+    auto storeD1 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(0)->begin());
     assert(is<StoreNonVolatileOperation>(*storeD1, 3, 1));
     assert(jlm::rvsdg::node_output::node(storeD1->input(2)->origin()) == lambdaEntrySplit);
 
-    auto storeD2 = input_node(*test.lambda_f2->cvargument(1)->begin());
+    auto storeD2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(1)->begin());
     assert(is<StoreNonVolatileOperation>(*storeD2, 3, 1));
     assert(jlm::rvsdg::node_output::node(storeD2->input(2)->origin()) == lambdaEntrySplit);
 
-    auto callEntryMerge = input_node(*storeD1->output(0)->begin());
+    auto callEntryMerge = jlm::rvsdg::input::GetNode(**storeD1->output(0)->begin());
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 1, 1));
 
-    auto callF1 = input_node(*callEntryMerge->output(0)->begin());
+    auto callF1 = jlm::rvsdg::input::GetNode(**callEntryMerge->output(0)->begin());
     assert(is<CallOperation>(*callF1, 3, 2));
 
-    auto callExitSplit = input_node(*callF1->output(1)->begin());
+    auto callExitSplit = jlm::rvsdg::input::GetNode(**callF1->output(1)->begin());
     assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 1));
 
-    auto lambdaExitMerge = input_node(*callExitSplit->output(0)->begin());
+    auto lambdaExitMerge = jlm::rvsdg::input::GetNode(**callExitSplit->output(0)->begin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
   }
 }
@@ -1797,23 +1805,23 @@ ValidateImportTestSteensgaardAgnosticTopDown(const jlm::tests::ImportTest & test
 
   assert(test.lambda_f2->subregion()->nnodes() == 9);
 
-  auto lambdaEntrySplit = input_node(*test.lambda_f2->fctargument(1)->begin());
+  auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_f2->fctargument(1)->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
 
-  auto storeD1InF2 = input_node(*test.lambda_f2->cvargument(0)->begin());
+  auto storeD1InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
   assert(jlm::rvsdg::node_output::node(storeD1InF2->input(2)->origin()) == lambdaEntrySplit);
 
   assert(storeD1InF2->output(0)->nusers() == 1);
   auto d1StateIndexEntry = (*storeD1InF2->output(0)->begin())->index();
 
-  auto storeD1InF1 = input_node(*test.lambda_f1->cvargument(0)->begin());
+  auto storeD1InF1 = jlm::rvsdg::input::GetNode(**test.lambda_f1->cvargument(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF1, 3, 1));
   assert(d1StateIndexEntry == storeD1InF1->input(2)->origin()->index());
   assert(storeD1InF1->output(0)->nusers() == 1);
   auto d1StateIndexExit = (*storeD1InF1->output(0)->begin())->index();
 
-  auto storeD2InF2 = input_node(*test.lambda_f2->cvargument(1)->begin());
+  auto storeD2InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(1)->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
 
   assert(d1StateIndexExit != storeD2InF2->input(2)->origin()->index());
@@ -1994,13 +2002,13 @@ ValidateMemcpySteensgaardRegionAware(const jlm::tests::MemcpyTest & test)
    * Validate function g
    */
   {
-    auto callNode = input_node(*test.LambdaG().cvargument(2)->begin());
+    auto callNode = jlm::rvsdg::input::GetNode(**test.LambdaG().cvargument(2)->begin());
     assert(is<CallOperation>(*callNode, 3, 3));
 
     auto callEntryMerge = jlm::rvsdg::node_output::node(callNode->input(2)->origin());
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 2, 1));
 
-    auto callExitSplit = input_node(*callNode->output(2)->begin());
+    auto callExitSplit = jlm::rvsdg::input::GetNode(**callNode->output(2)->begin());
     assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 2));
 
     auto memcpyNode = jlm::rvsdg::node_output::node(callEntryMerge->input(0)->origin());
@@ -2010,7 +2018,7 @@ ValidateMemcpySteensgaardRegionAware(const jlm::tests::MemcpyTest & test)
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
     assert(jlm::rvsdg::node_output::node(memcpyNode->input(5)->origin()) == lambdaEntrySplit);
 
-    auto lambdaExitMerge = input_node(*callExitSplit->output(0)->begin());
+    auto lambdaExitMerge = jlm::rvsdg::input::GetNode(**callExitSplit->output(0)->begin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
   }
 }


### PR DESCRIPTION
We had three incarnations of the same method for retrieving the node connected to an input. Remove two, keep one.