### PR TITLE
Fix make target for Andersen with agnostic encoding [AndersenAgnostic]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,7 +66,7 @@ jobs:
         run: cd jlm-eval-suite/llvm-test-suite && make llvm-run-opt
 
   llvm-test-suite-andersen-agnostic:
-    if: contains(github.event.pull_request.title, '[AndersenAgnostic]')
+    if: contains(github.event.pull_request.title, '[AndersenAnostic]')
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,7 +66,7 @@ jobs:
         run: cd jlm-eval-suite/llvm-test-suite && make llvm-run-opt
 
   llvm-test-suite-andersen-agnostic:
-    if: contains(github.event.pull_request.title, '[AndersenAnostic]')
+    if: contains(github.event.pull_request.title, '[AndersenAgnostic]')
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,8 +65,8 @@ jobs:
       - name: Run llvm-test-suite
         run: cd jlm-eval-suite/llvm-test-suite && make llvm-run-opt
 
-  llvm-test-suite-andersen:
-    if: contains(github.event.pull_request.title, '[Andersen]')
+  llvm-test-suite-andersen-agnostic:
+    if: contains(github.event.pull_request.title, '[AndersenAgnostic]')
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
       - name: Apply patch
         run: cd jlm-eval-suite && make apply-llvm-git-patch
       - name: Run llvm-test-suite-andersen
-        run: cd jlm-eval-suite/llvm-test-suite && make llvm-run-andersen
+        run: cd jlm-eval-suite/llvm-test-suite && make llvm-run-andersen-agnostic
 
   llvm-test-suite-steensgaard-agnostic:
     if: contains(github.event.pull_request.title, '[SteensgaardAgnostic]')


### PR DESCRIPTION
We changed the make target for Andersen alias analysis with agnostic encoding in this [PR](https://github.com/phate/jlm-eval-suite/pull/31). Fix the CI to reflect this change.