### PR TITLE
Adds support for custom make targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 Makefile.config
+Makefile.custom
 .idea
 docs/html
 build

--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,8 @@ include jlm/mlir/Makefile.sub
 endif
 
 include Makefile.rules
+
+# Provide support for custom make targets
+ifneq ("$(wildcard Makefile.custom)","")
+include Makefile.custom
+endif


### PR DESCRIPTION
The user can write their own make targets in Makefile.custom, which is not tracked by git.