### PR TITLE
Convert remaining llvm operators

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
@@ -88,7 +88,7 @@ instrument_ref(llvm::RvsdgModule & rm)
 
   // TODO: make this less hacky by using the correct state types
   //  addr, width, memstate
-  jlm::llvm::FunctionType loadFunctionType(
+  auto loadFunctionType = jlm::llvm::FunctionType::Create(
       { jlm::llvm::PointerType::Create(),
         jlm::rvsdg::bittype::Create(64),
         llvm::iostatetype::Create(),
@@ -100,7 +100,7 @@ instrument_ref(llvm::RvsdgModule & rm)
       jlm::llvm::linkage::external_linkage);
   auto reference_load = graph.add_import(load_imp);
   // addr, data, width, memstate
-  jlm::llvm::FunctionType storeFunctionType(
+  auto storeFunctionType = jlm::llvm::FunctionType::Create(
       { jlm::llvm::PointerType::Create(),
         jlm::rvsdg::bittype::Create(64),
         jlm::rvsdg::bittype::Create(64),
@@ -113,7 +113,7 @@ instrument_ref(llvm::RvsdgModule & rm)
       jlm::llvm::linkage::external_linkage);
   auto reference_store = graph.add_import(store_imp);
   // addr, size, memstate
-  jlm::llvm::FunctionType allocaFunctionType(
+  auto allocaFunctionType = jlm::llvm::FunctionType::Create(
       { jlm::llvm::PointerType::Create(),
         jlm::rvsdg::bittype::Create(64),
         llvm::iostatetype::Create(),
@@ -129,11 +129,11 @@ instrument_ref(llvm::RvsdgModule & rm)
       root,
       newLambda->subregion()->argument(ioStateArgumentIndex),
       reference_load,
-      loadFunctionType,
+      *loadFunctionType,
       reference_store,
-      storeFunctionType,
+      *storeFunctionType,
       reference_alloca,
-      allocaFunctionType);
+      *allocaFunctionType);
 }
 
 void
@@ -141,11 +141,11 @@ instrument_ref(
     jlm::rvsdg::region * region,
     jlm::rvsdg::output * ioState,
     jlm::rvsdg::output * load_func,
-    jlm::llvm::FunctionType & loadFunctionType,
+    const jlm::llvm::FunctionType & loadFunctionType,
     jlm::rvsdg::output * store_func,
-    jlm::llvm::FunctionType & storeFunctionType,
+    const jlm::llvm::FunctionType & storeFunctionType,
     jlm::rvsdg::output * alloca_func,
-    jlm::llvm::FunctionType & allocaFunctionType)
+    const jlm::llvm::FunctionType & allocaFunctionType)
 {
   load_func = route_to_region(load_func, region);
   store_func = route_to_region(store_func, region);
@@ -176,7 +176,7 @@ instrument_ref(
     {
       auto addr = node->input(0)->origin();
       JLM_ASSERT(dynamic_cast<const jlm::llvm::PointerType *>(&addr->type()));
-      size_t bitWidth = BaseHLS::JlmSize(&loadOp->GetLoadedType());
+      size_t bitWidth = BaseHLS::JlmSize(&*loadOp->GetLoadedType());
       int log2Bytes = log2(bitWidth / 8);
       auto width = jlm::rvsdg::create_bitconstant(region, 64, log2Bytes);
 

--- a/jlm/hls/backend/rvsdg2rhls/instrument-ref.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/instrument-ref.hpp
@@ -20,11 +20,11 @@ instrument_ref(
     jlm::rvsdg::region * region,
     jlm::rvsdg::output * ioState,
     jlm::rvsdg::output * load_func,
-    llvm::FunctionType & loadFunctionType,
+    const llvm::FunctionType & loadFunctionType,
     jlm::rvsdg::output * store_func,
-    llvm::FunctionType & storeFunctionType,
+    const llvm::FunctionType & storeFunctionType,
     jlm::rvsdg::output * alloca_func,
-    llvm::FunctionType & allocaFunctionType);
+    const llvm::FunctionType & allocaFunctionType);
 
 } // namespace jlm::hls
 

--- a/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
@@ -765,7 +765,7 @@ jlm::hls::ConnectRequestResponseMemPorts(
     loadNodes.push_back(loadOutput->node());
     auto loadOp = jlm::util::AssertedCast<const jlm::llvm::LoadNonVolatileOperation>(
         &loadOutput->node()->operation());
-    loadTypes.push_back(&loadOp->GetLoadedType());
+    loadTypes.push_back(&*loadOp->GetLoadedType());
   }
   std::vector<jlm::rvsdg::simple_node *> storeNodes;
   for (auto storeNode : originalStoreNodes)

--- a/jlm/hls/ir/hls.hpp
+++ b/jlm/hls/ir/hls.hpp
@@ -1382,9 +1382,7 @@ public:
   static std::vector<std::shared_ptr<const jlm::rvsdg::type>>
   CreateOutTypes(const jlm::llvm::arraytype & at, size_t resp_count)
   {
-    std::vector<std::shared_ptr<const jlm::rvsdg::type>> types(
-        resp_count,
-        at.element_type().copy());
+    std::vector<std::shared_ptr<const jlm::rvsdg::type>> types(resp_count, at.GetElementType());
     return types;
   }
 
@@ -1597,7 +1595,7 @@ public:
     for (size_t i = 0; i < store_cnt; ++i)
     {
       types.emplace_back(jlm::rvsdg::bittype::Create(64)); // addr
-      types.emplace_back(at.element_type().copy());        // data
+      types.emplace_back(at.GetElementType());             // data
     }
     return types;
   }

--- a/jlm/llvm/backend/jlm2llvm/instruction.cpp
+++ b/jlm/llvm/backend/jlm2llvm/instruction.cpp
@@ -300,7 +300,7 @@ convert(
     context & ctx)
 {
   return CreateLoadInstruction(
-      operation.GetLoadedType(),
+      *operation.GetLoadedType(),
       operands[0],
       false,
       operation.GetAlignment(),
@@ -316,7 +316,7 @@ convert(
     context & ctx)
 {
   return CreateLoadInstruction(
-      operation.GetLoadedType(),
+      *operation.GetLoadedType(),
       operands[0],
       true,
       operation.GetAlignment(),

--- a/jlm/llvm/backend/jlm2llvm/jlm2llvm.cpp
+++ b/jlm/llvm/backend/jlm2llvm/jlm2llvm.cpp
@@ -478,7 +478,7 @@ convert_ipgraph(const llvm::ipgraph & clg, context & ctx)
 
     if (auto dataNode = dynamic_cast<const data_node *>(&node))
     {
-      auto type = convert_type(dataNode->GetValueType(), ctx);
+      auto type = convert_type(*dataNode->GetValueType(), ctx);
       auto linkage = convert_linkage(dataNode->linkage());
 
       auto gv = new ::llvm::GlobalVariable(

--- a/jlm/llvm/backend/rvsdg2jlm/rvsdg2jlm.cpp
+++ b/jlm/llvm/backend/rvsdg2jlm/rvsdg2jlm.cpp
@@ -464,7 +464,7 @@ convert_phi_node(const rvsdg::node & node, context & ctx)
       JLM_ASSERT(is<delta::operation>(node));
       auto d = static_cast<const delta::node *>(node);
       auto data =
-          data_node::Create(ipg, d->name(), d->type(), d->linkage(), d->Section(), d->constant());
+          data_node::Create(ipg, d->name(), d->Type(), d->linkage(), d->Section(), d->constant());
       ctx.insert(subregion->argument(n), module.create_global_value(data));
     }
   }
@@ -509,7 +509,7 @@ convert_delta_node(const rvsdg::node & node, context & ctx)
   auto dnode = data_node::Create(
       m.ipgraph(),
       delta->name(),
-      delta->type(),
+      delta->Type(),
       delta->linkage(),
       delta->Section(),
       delta->constant());
@@ -568,13 +568,8 @@ convert_imports(const rvsdg::graph & graph, ipgraph_module & im, context & ctx)
     }
     else
     {
-      auto dnode = data_node::Create(
-          ipg,
-          import->name(),
-          import->GetValueType(),
-          import->linkage(),
-          "",
-          false);
+      auto dnode =
+          data_node::Create(ipg, import->name(), import->Type(), import->linkage(), "", false);
       auto v = im.create_global_value(dnode);
       ctx.insert(argument, v);
     }

--- a/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
+++ b/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
@@ -986,7 +986,7 @@ ConvertFunctionNode(
    */
   if (functionNode.cfg() == nullptr)
   {
-    impport port(functionNode.fcttype(), functionNode.name(), functionNode.linkage());
+    impport port(functionNode.GetFunctionType(), functionNode.name(), functionNode.linkage());
     return region.graph()->add_import(port);
   }
 
@@ -1127,7 +1127,7 @@ ConvertStronglyConnectedComponent(
   std::unordered_map<const variable *, phi::rvoutput *> recursionVariables;
   for (const auto & ipgNode : stronglyConnectedComponent)
   {
-    auto recursionVariable = pb.add_recvar(ipgNode->type().copy());
+    auto recursionVariable = pb.add_recvar(ipgNode->Type());
     auto ipgNodeVariable = interProceduralGraphModule.variable(ipgNode);
     phiVariableMap.insert(ipgNodeVariable, recursionVariable->argument());
     JLM_ASSERT(recursionVariables.find(ipgNodeVariable) == recursionVariables.end());

--- a/jlm/llvm/frontend/LlvmInstructionConversion.cpp
+++ b/jlm/llvm/frontend/LlvmInstructionConversion.cpp
@@ -609,7 +609,7 @@ convert_load_instruction(::llvm::Instruction * i, tacsvector_t & tacs, context &
         address,
         ctx.iostate(),
         ctx.memory_state(),
-        *loadedType,
+        loadedType,
         alignment);
     tacs.push_back(std::move(loadVolatileTac));
 
@@ -620,7 +620,7 @@ convert_load_instruction(::llvm::Instruction * i, tacsvector_t & tacs, context &
   else
   {
     auto loadTac =
-        LoadNonVolatileOperation::Create(address, ctx.memory_state(), *loadedType, alignment);
+        LoadNonVolatileOperation::Create(address, ctx.memory_state(), loadedType, alignment);
     tacs.push_back(std::move(loadTac));
     loadedValue = tacs.back()->result(0);
     memoryState = tacs.back()->result(1);
@@ -700,7 +700,7 @@ convert_getelementptr_instruction(::llvm::Instruction * inst, tacsvector_t & tac
   auto pointeeType = ConvertType(i->getSourceElementType(), ctx);
   auto resultType = ConvertType(i->getType(), ctx);
 
-  tacs.push_back(GetElementPtrOperation::Create(base, indices, *pointeeType, *resultType));
+  tacs.push_back(GetElementPtrOperation::Create(base, indices, pointeeType, resultType));
 
   return tacs.back()->result(0);
 }
@@ -1029,7 +1029,7 @@ convert_alloca_instruction(::llvm::Instruction * instruction, tacsvector_t & tac
   auto vtype = ConvertType(i->getAllocatedType(), ctx);
   auto alignment = i->getAlign().value();
 
-  tacs.push_back(alloca_op::create(*vtype, size, alignment));
+  tacs.push_back(alloca_op::create(vtype, size, alignment));
   auto result = tacs.back()->result(0);
   auto astate = tacs.back()->result(1);
 

--- a/jlm/llvm/frontend/LlvmModuleConversion.cpp
+++ b/jlm/llvm/frontend/LlvmModuleConversion.cpp
@@ -448,7 +448,7 @@ declare_globals(::llvm::Module & lm, context & ctx)
     return data_node::Create(
         ctx.module().ipgraph(),
         name,
-        *type,
+        type,
         linkage,
         std::move(section),
         constant);

--- a/jlm/llvm/ir/RvsdgModule.hpp
+++ b/jlm/llvm/ir/RvsdgModule.hpp
@@ -21,12 +21,6 @@ class impport final : public jlm::rvsdg::impport
 public:
   virtual ~impport();
 
-  impport(const jlm::rvsdg::valuetype & valueType, const std::string & name, const linkage & lnk)
-      : jlm::rvsdg::impport(PointerType::Create(), name),
-        linkage_(lnk),
-        ValueType_(valueType.copy())
-  {}
-
   impport(
       std::shared_ptr<const jlm::rvsdg::valuetype> valueType,
       const std::string & name,
@@ -36,17 +30,9 @@ public:
         ValueType_(std::move(valueType))
   {}
 
-  impport(const impport & other)
-      : jlm::rvsdg::impport(other),
-        linkage_(other.linkage_),
-        ValueType_(other.ValueType_->copy())
-  {}
+  impport(const impport & other) = default;
 
-  impport(impport && other)
-      : jlm::rvsdg::impport(other),
-        linkage_(std::move(other.linkage_)),
-        ValueType_(std::move(other.ValueType_))
-  {}
+  impport(impport && other) = default;
 
   impport &
   operator=(const impport &) = delete;
@@ -60,10 +46,16 @@ public:
     return linkage_;
   }
 
+  [[nodiscard]] const std::shared_ptr<const jlm::rvsdg::valuetype> &
+  Type() const noexcept
+  {
+    return ValueType_;
+  }
+
   [[nodiscard]] const jlm::rvsdg::valuetype &
   GetValueType() const noexcept
   {
-    return *jlm::util::AssertedCast<const jlm::rvsdg::valuetype>(ValueType_.get());
+    return *ValueType_;
   }
 
   virtual bool
@@ -74,7 +66,7 @@ public:
 
 private:
   jlm::llvm::linkage linkage_;
-  std::shared_ptr<const jlm::rvsdg::type> ValueType_;
+  std::shared_ptr<const jlm::rvsdg::valuetype> ValueType_;
 };
 
 static inline bool

--- a/jlm/llvm/ir/ipgraph-module.hpp
+++ b/jlm/llvm/ir/ipgraph-module.hpp
@@ -23,7 +23,7 @@ public:
   virtual ~gblvalue();
 
   inline gblvalue(data_node * node)
-      : gblvariable(node->type(), node->name()),
+      : gblvariable(node->Type(), node->name()),
         node_(node)
   {}
 

--- a/jlm/llvm/ir/ipgraph.cpp
+++ b/jlm/llvm/ir/ipgraph.cpp
@@ -115,6 +115,12 @@ function_node::type() const noexcept
   return pointerType;
 }
 
+std::shared_ptr<const jlm::rvsdg::type>
+function_node::Type() const
+{
+  return PointerType::Create();
+}
+
 const llvm::linkage &
 function_node::linkage() const noexcept
 {
@@ -157,6 +163,12 @@ data_node::type() const noexcept
 {
   static PointerType pointerType;
   return pointerType;
+}
+
+std::shared_ptr<const rvsdg::type>
+data_node::Type() const
+{
+  return PointerType::Create();
 }
 
 const llvm::linkage &

--- a/jlm/llvm/ir/operators/GetElementPtr.hpp
+++ b/jlm/llvm/ir/operators/GetElementPtr.hpp
@@ -69,39 +69,6 @@ public:
   Create(
       const variable * baseAddress,
       const std::vector<const variable *> & offsets,
-      const rvsdg::valuetype & pointeeType,
-      const rvsdg::type & resultType)
-  {
-    CheckPointerType(baseAddress->type());
-    auto offsetTypes = CheckAndExtractOffsetTypes<const variable>(offsets);
-    CheckPointerType(resultType);
-
-    GetElementPtrOperation operation(
-        offsetTypes,
-        std::static_pointer_cast<const rvsdg::valuetype>(pointeeType.copy()));
-    std::vector<const variable *> operands(1, baseAddress);
-    operands.insert(operands.end(), offsets.begin(), offsets.end());
-
-    return tac::create(operation, operands);
-  }
-
-  /**
-   * Creates a GetElementPtr three address code.
-   *
-   * FIXME: We should not explicitly hand in the resultType parameter, but rather compute it from
-   * the pointeeType and the offsets. See LLVM's GetElementPtr instruction for reference.
-   *
-   * @param baseAddress The base address for the pointer calculation.
-   * @param offsets The offsets from the base address.
-   * @param pointeeType The type the base address points to.
-   * @param resultType The result type of the operation.
-   *
-   * @return A getElementPtr three address code.
-   */
-  static std::unique_ptr<llvm::tac>
-  Create(
-      const variable * baseAddress,
-      const std::vector<const variable *> & offsets,
       std::shared_ptr<const rvsdg::valuetype> pointeeType,
       std::shared_ptr<const rvsdg::type> resultType)
   {
@@ -114,39 +81,6 @@ public:
     operands.insert(operands.end(), offsets.begin(), offsets.end());
 
     return tac::create(operation, operands);
-  }
-
-  /**
-   * Creates a GetElementPtr RVSDG node.
-   *
-   * FIXME: We should not explicitly hand in the resultType parameter, but rather compute it from
-   * the pointeeType and the offsets. See LLVM's GetElementPtr instruction for reference.
-   *
-   * @param baseAddress The base address for the pointer calculation.
-   * @param offsets The offsets from the base address.
-   * @param pointeeType The type the base address points to.
-   * @param resultType The result type of the operation.
-   *
-   * @return The output of the created GetElementPtr RVSDG node.
-   */
-  static rvsdg::output *
-  Create(
-      rvsdg::output * baseAddress,
-      const std::vector<rvsdg::output *> & offsets,
-      const rvsdg::valuetype & pointeeType,
-      const rvsdg::type & resultType)
-  {
-    CheckPointerType(baseAddress->type());
-    auto offsetTypes = CheckAndExtractOffsetTypes<rvsdg::output>(offsets);
-    CheckPointerType(resultType);
-
-    GetElementPtrOperation operation(
-        offsetTypes,
-        std::static_pointer_cast<const rvsdg::valuetype>(pointeeType.copy()));
-    std::vector<rvsdg::output *> operands(1, baseAddress);
-    operands.insert(operands.end(), offsets.begin(), offsets.end());
-
-    return rvsdg::simple_node::create_normalized(baseAddress->region(), operation, operands)[0];
   }
 
   /**

--- a/jlm/llvm/ir/operators/Load.cpp
+++ b/jlm/llvm/ir/operators/Load.cpp
@@ -337,9 +337,9 @@ is_load_store_reducible(
   // FIXME: This is too restrictive and can be improved upon by inserting truncation or narrowing
   // operations instead. For example, a store of a 32 bit integer followed by a load of a 8 bit
   // integer can be converted to a trunc operation.
-  auto & loadedValueType = loadOperation.GetLoadedType();
+  auto loadedValueType = loadOperation.GetLoadedType();
   auto & storedValueType = storeNode->GetStoredValueInput().type();
-  if (loadedValueType != storedValueType)
+  if (*loadedValueType != storedValueType)
   {
     return false;
   }

--- a/jlm/llvm/ir/operators/MemCpy.hpp
+++ b/jlm/llvm/ir/operators/MemCpy.hpp
@@ -72,9 +72,9 @@ class MemCpyNonVolatileOperation final : public MemCpyOperation
 public:
   ~MemCpyNonVolatileOperation() override;
 
-  MemCpyNonVolatileOperation(const rvsdg::type & lengthType, size_t numMemoryStates)
+  MemCpyNonVolatileOperation(std::shared_ptr<const rvsdg::type> lengthType, size_t numMemoryStates)
       : MemCpyOperation(
-          CreateOperandTypes(lengthType, numMemoryStates),
+          CreateOperandTypes(std::move(lengthType), numMemoryStates),
           CreateResultTypes(numMemoryStates))
   {}
 
@@ -100,7 +100,7 @@ public:
     std::vector<const variable *> operands = { destination, source, length };
     operands.insert(operands.end(), memoryStates.begin(), memoryStates.end());
 
-    MemCpyNonVolatileOperation operation(length->type(), memoryStates.size());
+    MemCpyNonVolatileOperation operation(length->Type(), memoryStates.size());
     return tac::create(operation, operands);
   }
 
@@ -114,18 +114,16 @@ public:
     std::vector<rvsdg::output *> operands = { destination, source, length };
     operands.insert(operands.end(), memoryStates.begin(), memoryStates.end());
 
-    MemCpyNonVolatileOperation operation(length->type(), memoryStates.size());
+    MemCpyNonVolatileOperation operation(length->Type(), memoryStates.size());
     return rvsdg::simple_node::create_normalized(destination->region(), operation, operands);
   }
 
 private:
   static std::vector<std::shared_ptr<const rvsdg::type>>
-  CreateOperandTypes(const rvsdg::type & length, size_t numMemoryStates)
+  CreateOperandTypes(std::shared_ptr<const rvsdg::type> length, size_t numMemoryStates)
   {
     auto pointerType = PointerType::Create();
-    std::vector<std::shared_ptr<const rvsdg::type>> types = { pointerType,
-                                                              pointerType,
-                                                              length.copy() };
+    std::vector<std::shared_ptr<const rvsdg::type>> types = { pointerType, pointerType, length };
     types.insert(types.end(), numMemoryStates, MemoryStateType::Create());
     return types;
   }
@@ -153,9 +151,9 @@ class MemCpyVolatileOperation final : public MemCpyOperation
 public:
   ~MemCpyVolatileOperation() noexcept override;
 
-  MemCpyVolatileOperation(const rvsdg::type & lengthType, size_t numMemoryStates)
+  MemCpyVolatileOperation(std::shared_ptr<const rvsdg::type> lengthType, size_t numMemoryStates)
       : MemCpyOperation(
-          CreateOperandTypes(lengthType, numMemoryStates),
+          CreateOperandTypes(std::move(lengthType), numMemoryStates),
           CreateResultTypes(numMemoryStates))
   {}
 
@@ -182,7 +180,7 @@ public:
     std::vector<const variable *> operands = { &destination, &source, &length, &ioState };
     operands.insert(operands.end(), memoryStates.begin(), memoryStates.end());
 
-    MemCpyVolatileOperation operation(length.type(), memoryStates.size());
+    MemCpyVolatileOperation operation(length.Type(), memoryStates.size());
     return tac::create(operation, operands);
   }
 
@@ -197,18 +195,18 @@ public:
     std::vector<rvsdg::output *> operands = { &destination, &source, &length, &ioState };
     operands.insert(operands.end(), memoryStates.begin(), memoryStates.end());
 
-    MemCpyVolatileOperation operation(length.type(), memoryStates.size());
+    MemCpyVolatileOperation operation(length.Type(), memoryStates.size());
     return *rvsdg::simple_node::create(destination.region(), operation, operands);
   }
 
 private:
   static std::vector<std::shared_ptr<const rvsdg::type>>
-  CreateOperandTypes(const rvsdg::type & lengthType, size_t numMemoryStates)
+  CreateOperandTypes(std::shared_ptr<const rvsdg::type> lengthType, size_t numMemoryStates)
   {
     auto pointerType = PointerType::Create();
     std::vector<std::shared_ptr<const rvsdg::type>> types = { pointerType,
                                                               pointerType,
-                                                              lengthType.copy(),
+                                                              std::move(lengthType),
                                                               iostatetype::Create() };
     types.insert(types.end(), numMemoryStates, MemoryStateType::Create());
     return types;

--- a/jlm/llvm/ir/operators/Store.hpp
+++ b/jlm/llvm/ir/operators/Store.hpp
@@ -144,18 +144,6 @@ public:
   ~StoreNonVolatileOperation() noexcept override;
 
   StoreNonVolatileOperation(
-      const rvsdg::valuetype & storedType,
-      size_t numMemoryStates,
-      size_t alignment)
-      : StoreOperation(
-          CreateOperandTypes(
-              std::static_pointer_cast<const rvsdg::valuetype>(storedType.copy()),
-              numMemoryStates),
-          { numMemoryStates, MemoryStateType::Create() },
-          alignment)
-  {}
-
-  StoreNonVolatileOperation(
       std::shared_ptr<const rvsdg::valuetype> storedType,
       size_t numMemoryStates,
       size_t alignment)
@@ -187,19 +175,19 @@ public:
   static std::unique_ptr<llvm::tac>
   Create(const variable * address, const variable * value, const variable * state, size_t alignment)
   {
-    auto & storedType = CheckAndExtractStoredType(value->type());
+    auto storedType = CheckAndExtractStoredType(value->Type());
 
     StoreNonVolatileOperation op(storedType, 1, alignment);
     return tac::create(op, { address, value, state });
   }
 
 private:
-  static const jlm::rvsdg::valuetype &
-  CheckAndExtractStoredType(const rvsdg::type & type)
+  static const std::shared_ptr<const jlm::rvsdg::valuetype>
+  CheckAndExtractStoredType(const std::shared_ptr<const rvsdg::type> & type)
   {
-    if (auto storedType = dynamic_cast<const rvsdg::valuetype *>(&type))
+    if (auto storedType = std::dynamic_pointer_cast<const rvsdg::valuetype>(type))
     {
-      return *storedType;
+      return storedType;
     }
 
     throw util::error("Expected value type");
@@ -365,12 +353,12 @@ public:
       const std::vector<rvsdg::output *> & memoryStates,
       size_t alignment)
   {
-    auto & storedType = CheckAndExtractStoredType(value.type());
+    auto storedType = CheckAndExtractStoredType(value.Type());
 
     std::vector<rvsdg::output *> operands({ &address, &value });
     operands.insert(operands.end(), memoryStates.begin(), memoryStates.end());
 
-    StoreNonVolatileOperation storeOperation(storedType, memoryStates.size(), alignment);
+    StoreNonVolatileOperation storeOperation(std::move(storedType), memoryStates.size(), alignment);
     return CreateNode(*address.region(), storeOperation, operands);
   }
 
@@ -393,12 +381,12 @@ public:
   }
 
 private:
-  static const rvsdg::valuetype &
-  CheckAndExtractStoredType(const rvsdg::type & type)
+  static std::shared_ptr<const rvsdg::valuetype>
+  CheckAndExtractStoredType(const std::shared_ptr<const rvsdg::type> & type)
   {
-    if (auto storedType = dynamic_cast<const rvsdg::valuetype *>(&type))
+    if (auto storedType = std::dynamic_pointer_cast<const rvsdg::valuetype>(type))
     {
-      return *storedType;
+      return storedType;
     }
 
     throw util::error("Expected value type.");
@@ -420,18 +408,6 @@ class StoreVolatileOperation final : public StoreOperation
 {
 public:
   ~StoreVolatileOperation() noexcept override;
-
-  StoreVolatileOperation(
-      const rvsdg::valuetype & storedType,
-      size_t numMemoryStates,
-      size_t alignment)
-      : StoreOperation(
-          CreateOperandTypes(
-              std::static_pointer_cast<const rvsdg::valuetype>(storedType.copy()),
-              numMemoryStates),
-          CreateResultTypes(numMemoryStates),
-          alignment)
-  {}
 
   StoreVolatileOperation(
       std::shared_ptr<const rvsdg::valuetype> storedType,
@@ -463,18 +439,18 @@ public:
       const variable * memoryState,
       size_t alignment)
   {
-    auto & storedType = CheckAndExtractStoredType(value->type());
+    auto storedType = CheckAndExtractStoredType(value->Type());
 
     StoreVolatileOperation op(storedType, 1, alignment);
     return tac::create(op, { address, value, ioState, memoryState });
   }
 
 private:
-  static const rvsdg::valuetype &
-  CheckAndExtractStoredType(const rvsdg::type & type)
+  static std::shared_ptr<const rvsdg::valuetype>
+  CheckAndExtractStoredType(const std::shared_ptr<const rvsdg::type> & type)
   {
-    if (auto storedType = dynamic_cast<const rvsdg::valuetype *>(&type))
-      return *storedType;
+    if (auto storedType = std::dynamic_pointer_cast<const rvsdg::valuetype>(type))
+      return storedType;
 
     throw jlm::util::error("Expected value type");
   }
@@ -564,7 +540,7 @@ public:
       const std::vector<rvsdg::output *> & memoryStates,
       size_t alignment)
   {
-    auto & storedType = CheckAndExtractStoredType(value.type());
+    auto storedType = CheckAndExtractStoredType(value.Type());
 
     std::vector<rvsdg::output *> operands({ &address, &value, &ioState });
     operands.insert(operands.end(), memoryStates.begin(), memoryStates.end());
@@ -583,11 +559,11 @@ public:
   }
 
 private:
-  static const rvsdg::valuetype &
-  CheckAndExtractStoredType(const rvsdg::type & type)
+  static std::shared_ptr<const rvsdg::valuetype>
+  CheckAndExtractStoredType(const std::shared_ptr<const rvsdg::type> & type)
   {
-    if (auto storedType = dynamic_cast<const rvsdg::valuetype *>(&type))
-      return *storedType;
+    if (auto storedType = std::dynamic_pointer_cast<const rvsdg::valuetype>(type))
+      return storedType;
 
     throw jlm::util::error("Expected value type.");
   }

--- a/jlm/llvm/ir/operators/alloca.hpp
+++ b/jlm/llvm/ir/operators/alloca.hpp
@@ -54,27 +54,19 @@ public:
   inline const rvsdg::valuetype &
   value_type() const noexcept
   {
-    return *::jlm::util::AssertedCast<const rvsdg::valuetype>(AllocatedType_.get());
+    return *AllocatedType_;
+  }
+
+  inline const std::shared_ptr<const rvsdg::valuetype> &
+  ValueType() const noexcept
+  {
+    return AllocatedType_;
   }
 
   inline size_t
   alignment() const noexcept
   {
     return alignment_;
-  }
-
-  static std::unique_ptr<llvm::tac>
-  create(const rvsdg::valuetype & allocatedType, const variable * size, size_t alignment)
-  {
-    auto bt = std::dynamic_pointer_cast<const rvsdg::bittype>(size->Type());
-    if (!bt)
-      throw jlm::util::error("expected bits type.");
-
-    alloca_op op(
-        std::static_pointer_cast<const rvsdg::valuetype>(allocatedType.copy()),
-        std::move(bt),
-        alignment);
-    return tac::create(op, { size });
   }
 
   static std::unique_ptr<llvm::tac>
@@ -89,20 +81,6 @@ public:
 
     alloca_op op(std::move(allocatedType), std::move(bt), alignment);
     return tac::create(op, { size });
-  }
-
-  static std::vector<rvsdg::output *>
-  create(const rvsdg::valuetype & allocatedType, rvsdg::output * size, size_t alignment)
-  {
-    auto bt = std::dynamic_pointer_cast<const rvsdg::bittype>(size->Type());
-    if (!bt)
-      throw jlm::util::error("expected bits type.");
-
-    alloca_op op(
-        std::static_pointer_cast<const rvsdg::valuetype>(allocatedType.copy()),
-        std::move(bt),
-        alignment);
-    return rvsdg::simple_node::create_normalized(size->region(), op, { size });
   }
 
   static std::vector<rvsdg::output *>
@@ -121,7 +99,7 @@ public:
 
 private:
   size_t alignment_;
-  std::shared_ptr<const rvsdg::type> AllocatedType_;
+  std::shared_ptr<const rvsdg::valuetype> AllocatedType_;
 };
 
 }

--- a/jlm/llvm/ir/operators/delta.cpp
+++ b/jlm/llvm/ir/operators/delta.cpp
@@ -51,7 +51,7 @@ node::copy(jlm::rvsdg::region * region, const std::vector<jlm::rvsdg::output *> 
 delta::node *
 node::copy(jlm::rvsdg::region * region, jlm::rvsdg::substitution_map & smap) const
 {
-  auto delta = Create(region, type(), name(), linkage(), Section(), constant());
+  auto delta = Create(region, Type(), name(), linkage(), Section(), constant());
 
   /* add context variables */
   jlm::rvsdg::substitution_map subregionmap;

--- a/jlm/llvm/ir/operators/delta.hpp
+++ b/jlm/llvm/ir/operators/delta.hpp
@@ -84,7 +84,13 @@ public:
   [[nodiscard]] const rvsdg::valuetype &
   type() const noexcept
   {
-    return *jlm::util::AssertedCast<const rvsdg::valuetype>(type_.get());
+    return *type_;
+  }
+
+  [[nodiscard]] const std::shared_ptr<const rvsdg::valuetype> &
+  Type() const noexcept
+  {
+    return type_;
   }
 
 private:
@@ -92,7 +98,7 @@ private:
   std::string name_;
   std::string Section_;
   llvm::linkage linkage_;
-  std::shared_ptr<const rvsdg::type> type_;
+  std::shared_ptr<const rvsdg::valuetype> type_;
 };
 
 class cvargument;
@@ -160,6 +166,12 @@ public:
   type() const noexcept
   {
     return operation().type();
+  }
+
+  [[nodiscard]] const std::shared_ptr<const rvsdg::valuetype> &
+  Type() const noexcept
+  {
+    return operation().Type();
   }
 
   const std::string &
@@ -251,39 +263,6 @@ public:
 
   virtual delta::node *
   copy(rvsdg::region * region, rvsdg::substitution_map & smap) const override;
-
-  /**
-   * Creates a delta node in the region \p parent with the pointer type \p type and name \p name.
-   * After the invocation of \ref Create(), the delta node has no inputs or outputs.
-   * Free variables can be added to the delta node using \ref add_ctxvar(). The generation of the
-   * node can be finished using the \ref finalize() method.
-   *
-   * \param parent The region where the delta node is created.
-   * \param type The delta node's type.
-   * \param name The delta node's name.
-   * \param linkage The delta node's linkage.
-   * \param section The delta node's section.
-   * \param constant True, if the delta node is constant, otherwise false.
-   *
-   * \return A delta node without inputs or outputs.
-   */
-  static node *
-  Create(
-      rvsdg::region * parent,
-      const rvsdg::valuetype & type,
-      const std::string & name,
-      const llvm::linkage & linkage,
-      std::string section,
-      bool constant)
-  {
-    delta::operation op(
-        std::static_pointer_cast<const rvsdg::valuetype>(type.copy()),
-        name,
-        linkage,
-        std::move(section),
-        constant);
-    return new delta::node(parent, std::move(op));
-  }
 
   /**
    * Creates a delta node in the region \p parent with the pointer type \p type and name \p name.

--- a/jlm/llvm/ir/operators/operators.hpp
+++ b/jlm/llvm/ir/operators/operators.hpp
@@ -1624,7 +1624,7 @@ private:
   {
     std::vector<std::shared_ptr<const rvsdg::type>> types;
     for (size_t n = 0; n < type.GetDeclaration().NumElements(); n++)
-      types.push_back(type.GetDeclaration().GetElement(n).copy());
+      types.push_back(type.GetDeclaration().GetElementType(n));
 
     return types;
   }

--- a/jlm/llvm/ir/operators/sext.hpp
+++ b/jlm/llvm/ir/operators/sext.hpp
@@ -20,10 +20,12 @@ class sext_op final : public rvsdg::unary_op
 public:
   virtual ~sext_op();
 
-  inline sext_op(const rvsdg::bittype & otype, const rvsdg::bittype & rtype)
-      : unary_op(otype.copy(), rtype.copy())
+  inline sext_op(
+      std::shared_ptr<const rvsdg::bittype> otype,
+      std::shared_ptr<const rvsdg::bittype> rtype)
+      : unary_op(otype, rtype)
   {
-    if (otype.nbits() >= rtype.nbits())
+    if (otype->nbits() >= rtype->nbits())
       throw jlm::util::error("expected operand's #bits to be smaller than results's #bits.");
   }
 
@@ -32,11 +34,11 @@ public:
       std::shared_ptr<const rvsdg::type> dsttype)
       : unary_op(srctype, dsttype)
   {
-    auto ot = dynamic_cast<const rvsdg::bittype *>(srctype.get());
+    auto ot = std::dynamic_pointer_cast<const rvsdg::bittype>(srctype);
     if (!ot)
       throw jlm::util::error("expected bits type.");
 
-    auto rt = dynamic_cast<const rvsdg::bittype *>(dsttype.get());
+    auto rt = std::dynamic_pointer_cast<const rvsdg::bittype>(dsttype);
     if (!rt)
       throw jlm::util::error("expected bits type.");
 
@@ -72,28 +74,28 @@ public:
   }
 
   static std::unique_ptr<llvm::tac>
-  create(const variable * operand, const rvsdg::type & type)
+  create(const variable * operand, const std::shared_ptr<const rvsdg::type> & type)
   {
-    auto ot = dynamic_cast<const rvsdg::bittype *>(&operand->type());
+    auto ot = std::dynamic_pointer_cast<const rvsdg::bittype>(operand->Type());
     if (!ot)
       throw jlm::util::error("expected bits type.");
 
-    auto rt = dynamic_cast<const rvsdg::bittype *>(&type);
+    auto rt = std::dynamic_pointer_cast<const rvsdg::bittype>(type);
     if (!rt)
       throw jlm::util::error("expected bits type.");
 
-    sext_op op(*ot, *rt);
+    sext_op op(std::move(ot), std::move(rt));
     return tac::create(op, { operand });
   }
 
   static rvsdg::output *
   create(size_t ndstbits, rvsdg::output * operand)
   {
-    auto ot = dynamic_cast<const rvsdg::bittype *>(&operand->type());
+    auto ot = std::dynamic_pointer_cast<const rvsdg::bittype>(operand->Type());
     if (!ot)
       throw jlm::util::error("expected bits type.");
 
-    sext_op op(*ot, rvsdg::bittype(ndstbits));
+    sext_op op(std::move(ot), rvsdg::bittype::Create(ndstbits));
     return rvsdg::simple_node::create_normalized(operand->region(), op, { operand })[0];
   }
 };

--- a/jlm/llvm/ir/types.cpp
+++ b/jlm/llvm/ir/types.cpp
@@ -24,15 +24,7 @@ FunctionType::FunctionType(
       ArgumentTypes_(std::move(argumentTypes))
 {}
 
-FunctionType::FunctionType(const FunctionType & rhs)
-    : jlm::rvsdg::valuetype(rhs)
-{
-  for (auto & type : rhs.ArgumentTypes_)
-    ArgumentTypes_.push_back(type->copy());
-
-  for (auto & type : rhs.ResultTypes_)
-    ResultTypes_.push_back(type->copy());
-}
+FunctionType::FunctionType(const FunctionType & rhs) = default;
 
 FunctionType::FunctionType(FunctionType && other) noexcept
     : jlm::rvsdg::valuetype(other),
@@ -93,19 +85,7 @@ FunctionType::copy() const
 }
 
 FunctionType &
-FunctionType::operator=(const FunctionType & rhs)
-{
-  ResultTypes_.clear();
-  ArgumentTypes_.clear();
-
-  for (auto & type : rhs.ArgumentTypes_)
-    ArgumentTypes_.push_back(type->copy());
-
-  for (auto & type : rhs.ResultTypes_)
-    ResultTypes_.push_back(type->copy());
-
-  return *this;
-}
+FunctionType::operator=(const FunctionType & rhs) = default;
 
 FunctionType &
 FunctionType::operator=(FunctionType && rhs) noexcept

--- a/jlm/llvm/ir/variable.hpp
+++ b/jlm/llvm/ir/variable.hpp
@@ -23,11 +23,6 @@ class variable
 public:
   virtual ~variable() noexcept;
 
-  inline variable(const jlm::rvsdg::type & type, const std::string & name)
-      : name_(name),
-        type_(type.copy())
-  {}
-
   variable(std::shared_ptr<const jlm::rvsdg::type> type, const std::string & name)
       : name_(name),
         type_(std::move(type))
@@ -94,8 +89,8 @@ class gblvariable : public variable
 public:
   virtual ~gblvariable();
 
-  inline gblvariable(const jlm::rvsdg::type & type, const std::string & name)
-      : variable(type, name)
+  inline gblvariable(std::shared_ptr<const jlm::rvsdg::type> type, const std::string & name)
+      : variable(std::move(type), name)
   {}
 };
 

--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -79,8 +79,8 @@ StoreTest2::SetupRvsdg()
 
   auto csize = jlm::rvsdg::create_bitconstant(fct->subregion(), 32, 4);
 
-  auto a = alloca_op::create(*jlm::rvsdg::bittype::Create(32), csize, 4);
-  auto b = alloca_op::create(*jlm::rvsdg::bittype::Create(32), csize, 4);
+  auto a = alloca_op::create(jlm::rvsdg::bittype::Create(32), csize, 4);
+  auto b = alloca_op::create(jlm::rvsdg::bittype::Create(32), csize, 4);
   auto x = alloca_op::create(pointerType, csize, 4);
   auto y = alloca_op::create(pointerType, csize, 4);
   auto p = alloca_op::create(pointerType, csize, 4);
@@ -140,7 +140,7 @@ LoadTest1::SetupRvsdg()
 
   auto ld1 =
       LoadNonVolatileNode::Create(fct->fctargument(0), { fct->fctargument(1) }, pointerType, 4);
-  auto ld2 = LoadNonVolatileNode::Create(ld1[0], { ld1[1] }, *jlm::rvsdg::bittype::Create(32), 4);
+  auto ld2 = LoadNonVolatileNode::Create(ld1[0], { ld1[1] }, jlm::rvsdg::bittype::Create(32), 4);
 
   fct->finalize(ld2);
 
@@ -175,8 +175,8 @@ LoadTest2::SetupRvsdg()
 
   auto csize = jlm::rvsdg::create_bitconstant(fct->subregion(), 32, 4);
 
-  auto a = alloca_op::create(*jlm::rvsdg::bittype::Create(32), csize, 4);
-  auto b = alloca_op::create(*jlm::rvsdg::bittype::Create(32), csize, 4);
+  auto a = alloca_op::create(jlm::rvsdg::bittype::Create(32), csize, 4);
+  auto b = alloca_op::create(jlm::rvsdg::bittype::Create(32), csize, 4);
   auto x = alloca_op::create(pointerType, csize, 4);
   auto y = alloca_op::create(pointerType, csize, 4);
   auto p = alloca_op::create(pointerType, csize, 4);
@@ -244,7 +244,7 @@ LoadFromUndefTest::SetupRvsdg()
   auto loadResults = LoadNonVolatileNode::Create(
       undefValue,
       { Lambda_->fctargument(0) },
-      *jlm::rvsdg::bittype::Create(32),
+      jlm::rvsdg::bittype::Create(32),
       4);
 
   Lambda_->finalize(loadResults);
@@ -271,7 +271,7 @@ GetElementPtrTest::SetupRvsdg()
 
   auto & declaration = module->AddStructTypeDeclaration(StructType::Declaration::Create(
       { jlm::rvsdg::bittype::Create(32), jlm::rvsdg::bittype::Create(32) }));
-  StructType structType(false, declaration);
+  auto structType = StructType::Create(false, declaration);
 
   auto mt = MemoryStateType::Create();
   auto pointerType = PointerType::Create();
@@ -285,16 +285,16 @@ GetElementPtrTest::SetupRvsdg()
   auto one = jlm::rvsdg::create_bitconstant(fct->subregion(), 32, 1);
 
   auto gepx =
-      GetElementPtrOperation::Create(fct->fctargument(0), { zero, zero }, structType, *pointerType);
+      GetElementPtrOperation::Create(fct->fctargument(0), { zero, zero }, structType, pointerType);
   auto ldx = LoadNonVolatileNode::Create(
       gepx,
       { fct->fctargument(1) },
-      *jlm::rvsdg::bittype::Create(32),
+      jlm::rvsdg::bittype::Create(32),
       4);
 
   auto gepy =
-      GetElementPtrOperation::Create(fct->fctargument(0), { zero, one }, structType, *pointerType);
-  auto ldy = LoadNonVolatileNode::Create(gepy, { ldx[1] }, *jlm::rvsdg::bittype::Create(32), 4);
+      GetElementPtrOperation::Create(fct->fctargument(0), { zero, one }, structType, pointerType);
+  auto ldy = LoadNonVolatileNode::Create(gepy, { ldx[1] }, jlm::rvsdg::bittype::Create(32), 4);
 
   auto sum = jlm::rvsdg::bitadd_op::create(32, ldx[0], ldy[0]);
 
@@ -490,12 +490,12 @@ CallTest1::SetupRvsdg()
     auto ld1 = LoadNonVolatileNode::Create(
         pointerArgument1,
         { memoryStateArgument },
-        *jlm::rvsdg::bittype::Create(32),
+        jlm::rvsdg::bittype::Create(32),
         4);
     auto ld2 = LoadNonVolatileNode::Create(
         pointerArgument2,
         { ld1[1] },
-        *jlm::rvsdg::bittype::Create(32),
+        jlm::rvsdg::bittype::Create(32),
         4);
 
     auto sum = jlm::rvsdg::bitadd_op::create(32, ld1[0], ld2[0]);
@@ -526,12 +526,12 @@ CallTest1::SetupRvsdg()
     auto ld1 = LoadNonVolatileNode::Create(
         pointerArgument1,
         { memoryStateArgument },
-        *jlm::rvsdg::bittype::Create(32),
+        jlm::rvsdg::bittype::Create(32),
         4);
     auto ld2 = LoadNonVolatileNode::Create(
         pointerArgument2,
         { ld1[1] },
-        *jlm::rvsdg::bittype::Create(32),
+        jlm::rvsdg::bittype::Create(32),
         4);
 
     auto diff = jlm::rvsdg::bitsub_op::create(32, ld1[0], ld2[0]);
@@ -558,9 +558,9 @@ CallTest1::SetupRvsdg()
 
     auto size = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
 
-    auto x = alloca_op::create(*jlm::rvsdg::bittype::Create(32), size, 4);
-    auto y = alloca_op::create(*jlm::rvsdg::bittype::Create(32), size, 4);
-    auto z = alloca_op::create(*jlm::rvsdg::bittype::Create(32), size, 4);
+    auto x = alloca_op::create(jlm::rvsdg::bittype::Create(32), size, 4);
+    auto y = alloca_op::create(jlm::rvsdg::bittype::Create(32), size, 4);
+    auto z = alloca_op::create(jlm::rvsdg::bittype::Create(32), size, 4);
 
     auto mx = MemoryStateMergeOperation::Create(
         std::vector<jlm::rvsdg::output *>({ x[1], memoryStateArgument }));
@@ -876,7 +876,7 @@ IndirectCallTest2::SetupRvsdg()
   {
     auto delta = delta::node::Create(
         graph->root(),
-        *jlm::rvsdg::bittype::Create(32),
+        jlm::rvsdg::bittype::Create(32),
         "g1",
         linkage::external_linkage,
         "",
@@ -891,7 +891,7 @@ IndirectCallTest2::SetupRvsdg()
   {
     auto delta = delta::node::Create(
         graph->root(),
-        *jlm::rvsdg::bittype::Create(32),
+        jlm::rvsdg::bittype::Create(32),
         "g2",
         linkage::external_linkage,
         "",
@@ -992,8 +992,8 @@ IndirectCallTest2::SetupRvsdg()
 
     auto constantSize = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
 
-    auto pxAlloca = alloca_op::create(*jlm::rvsdg::bittype::Create(32), constantSize, 4);
-    auto pyAlloca = alloca_op::create(*jlm::rvsdg::bittype::Create(32), constantSize, 4);
+    auto pxAlloca = alloca_op::create(jlm::rvsdg::bittype::Create(32), constantSize, 4);
+    auto pyAlloca = alloca_op::create(jlm::rvsdg::bittype::Create(32), constantSize, 4);
 
     auto pxMerge = MemoryStateMergeOperation::Create({ pxAlloca[1], memoryStateArgument });
     auto pyMerge = MemoryStateMergeOperation::Create(
@@ -1012,10 +1012,10 @@ IndirectCallTest2::SetupRvsdg()
     auto loadG1 = LoadNonVolatileNode::Create(
         globalG1Cv,
         { callY.GetMemoryStateOutput() },
-        *jlm::rvsdg::bittype::Create(32),
+        jlm::rvsdg::bittype::Create(32),
         4);
     auto loadG2 =
-        LoadNonVolatileNode::Create(globalG2Cv, { loadG1[1] }, *jlm::rvsdg::bittype::Create(32), 4);
+        LoadNonVolatileNode::Create(globalG2Cv, { loadG1[1] }, jlm::rvsdg::bittype::Create(32), 4);
 
     auto sum = jlm::rvsdg::bitadd_op::create(32, callX.Result(0), callY.Result(0));
     sum = jlm::rvsdg::bitadd_op::create(32, sum, loadG1[0]);
@@ -1048,7 +1048,7 @@ IndirectCallTest2::SetupRvsdg()
 
     auto constantSize = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
 
-    auto pzAlloca = alloca_op::create(*jlm::rvsdg::bittype::Create(32), constantSize, 4);
+    auto pzAlloca = alloca_op::create(jlm::rvsdg::bittype::Create(32), constantSize, 4);
     auto pzMerge = MemoryStateMergeOperation::Create({ pzAlloca[1], memoryStateArgument });
 
     auto functionXCv = lambda->add_ctxvar(&functionX);
@@ -1243,7 +1243,7 @@ ExternalCallTest2::SetupRvsdg()
 
   auto twentyFour = jlm::rvsdg::create_bitconstant(LambdaG_->subregion(), 64, 24);
 
-  auto allocaResults = alloca_op::create(*structType, twentyFour, 16);
+  auto allocaResults = alloca_op::create(structType, twentyFour, 16);
   auto memoryState = MemoryStateMergeOperation::Create({ allocaResults[1], memoryStateArgument });
 
   auto & callLLvmLifetimeStart = CallNode::CreateNode(
@@ -1332,9 +1332,9 @@ GammaTest::SetupRvsdg()
   auto ld1 = LoadNonVolatileNode::Create(
       tmp1,
       { fct->fctargument(5) },
-      *jlm::rvsdg::bittype::Create(32),
+      jlm::rvsdg::bittype::Create(32),
       4);
-  auto ld2 = LoadNonVolatileNode::Create(tmp2, { ld1[1] }, *jlm::rvsdg::bittype::Create(32), 4);
+  auto ld2 = LoadNonVolatileNode::Create(tmp2, { ld1[1] }, jlm::rvsdg::bittype::Create(32), 4);
   auto sum = jlm::rvsdg::bitadd_op::create(32, ld1[0], ld2[0]);
 
   fct->finalize({ sum, ld2[1] });
@@ -1380,7 +1380,7 @@ GammaTest2::SetupRvsdg()
       auto loadXResults = LoadNonVolatileNode::Create(
           gammaInputX->argument(0),
           { gammaInputMemoryState->argument(0) },
-          *jlm::rvsdg::bittype::Create(32),
+          jlm::rvsdg::bittype::Create(32),
           4);
 
       auto one = rvsdg::create_bitconstant(gammaNode->subregion(0), 32, 1);
@@ -1391,7 +1391,7 @@ GammaTest2::SetupRvsdg()
       auto loadYResults = LoadNonVolatileNode::Create(
           gammaInputY->argument(1),
           { gammaInputMemoryState->argument(1) },
-          *jlm::rvsdg::bittype::Create(32),
+          jlm::rvsdg::bittype::Create(32),
           4);
 
       auto two = rvsdg::create_bitconstant(gammaNode->subregion(1), 32, 2);
@@ -1445,7 +1445,7 @@ GammaTest2::SetupRvsdg()
     auto loadZResults = LoadNonVolatileNode::Create(
         allocaZResults[0],
         { gammaOutputMemoryState },
-        *jlm::rvsdg::bittype::Create(32),
+        jlm::rvsdg::bittype::Create(32),
         4);
 
     auto sum = jlm::rvsdg::bitadd_op::create(32, gammaOutputA, loadZResults[0]);
@@ -1479,7 +1479,7 @@ GammaTest2::SetupRvsdg()
 
     auto size = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
 
-    auto allocaXResults = alloca_op::create(*rvsdg::bittype::Create(32), size, 4);
+    auto allocaXResults = alloca_op::create(rvsdg::bittype::Create(32), size, 4);
     auto allocaYResults = alloca_op::create(pointerType, size, 4);
 
     auto memoryState =
@@ -1611,7 +1611,7 @@ DeltaTest1::SetupRvsdg()
   {
     auto dfNode = delta::node::Create(
         graph->root(),
-        *jlm::rvsdg::bittype::Create(32),
+        jlm::rvsdg::bittype::Create(32),
         "f",
         linkage::external_linkage,
         "",
@@ -1639,7 +1639,7 @@ DeltaTest1::SetupRvsdg()
     auto ld = LoadNonVolatileNode::Create(
         pointerArgument,
         { memoryStateArgument },
-        *jlm::rvsdg::bittype::Create(32),
+        jlm::rvsdg::bittype::Create(32),
         4);
 
     return lambda->finalize({ ld[0], iOStateArgument, ld[1] });
@@ -1703,7 +1703,7 @@ DeltaTest2::SetupRvsdg()
   {
     auto delta = delta::node::Create(
         graph->root(),
-        *jlm::rvsdg::bittype::Create(32),
+        jlm::rvsdg::bittype::Create(32),
         "d1",
         linkage::external_linkage,
         "",
@@ -1718,7 +1718,7 @@ DeltaTest2::SetupRvsdg()
   {
     auto delta = delta::node::Create(
         graph->root(),
-        *jlm::rvsdg::bittype::Create(32),
+        jlm::rvsdg::bittype::Create(32),
         "d2",
         linkage::external_linkage,
         "",
@@ -1810,7 +1810,7 @@ DeltaTest3::SetupRvsdg()
   {
     auto delta = delta::node::Create(
         graph->root(),
-        *jlm::rvsdg::bittype::Create(32),
+        jlm::rvsdg::bittype::Create(32),
         "g1",
         linkage::external_linkage,
         "",
@@ -1853,7 +1853,7 @@ DeltaTest3::SetupRvsdg()
         StoreNonVolatileNode::Create(g2CtxVar, loadResults[0], { loadResults[1] }, 8);
 
     loadResults =
-        LoadNonVolatileNode::Create(g1CtxVar, storeResults, *jlm::rvsdg::bittype::Create(32), 8);
+        LoadNonVolatileNode::Create(g1CtxVar, storeResults, jlm::rvsdg::bittype::Create(32), 8);
     auto truncResult = trunc_op::create(16, loadResults[0]);
 
     return lambda->finalize({ truncResult, iOStateArgument, loadResults[1] });
@@ -1965,9 +1965,9 @@ ImportTest::SetupRvsdg()
   };
 
   auto d1 =
-      graph->add_import(impport(*jlm::rvsdg::bittype::Create(32), "d1", linkage::external_linkage));
+      graph->add_import(impport(jlm::rvsdg::bittype::Create(32), "d1", linkage::external_linkage));
   auto d2 =
-      graph->add_import(impport(*jlm::rvsdg::bittype::Create(32), "d2", linkage::external_linkage));
+      graph->add_import(impport(jlm::rvsdg::bittype::Create(32), "d2", linkage::external_linkage));
 
   auto f1 = SetupF1(d1);
   auto [f2, callF1] = SetupF2(f1, d1, d2);
@@ -1995,7 +1995,7 @@ PhiTest1::SetupRvsdg()
   auto nf = graph->node_normal_form(typeid(jlm::rvsdg::operation));
   nf->set_mutable(false);
 
-  PointerType pbit64;
+  auto pbit64 = PointerType::Create();
   auto iOStateType = iostatetype::Create();
   auto memoryStateType = MemoryStateType::Create();
   auto fibFunctionType = FunctionType::Create(
@@ -2053,21 +2053,21 @@ PhiTest1::SetupRvsdg()
     auto gepnm1 = GetElementPtrOperation::Create(
         resultev->argument(0),
         { nm1 },
-        *jlm::rvsdg::bittype::Create(64),
+        jlm::rvsdg::bittype::Create(64),
         pbit64);
     auto ldnm1 = LoadNonVolatileNode::Create(
         gepnm1,
         { callFibm2.GetMemoryStateOutput() },
-        *jlm::rvsdg::bittype::Create(64),
+        jlm::rvsdg::bittype::Create(64),
         8);
 
     auto gepnm2 = GetElementPtrOperation::Create(
         resultev->argument(0),
         { nm2 },
-        *jlm::rvsdg::bittype::Create(64),
+        jlm::rvsdg::bittype::Create(64),
         pbit64);
     auto ldnm2 =
-        LoadNonVolatileNode::Create(gepnm2, { ldnm1[1] }, *jlm::rvsdg::bittype::Create(64), 8);
+        LoadNonVolatileNode::Create(gepnm2, { ldnm1[1] }, jlm::rvsdg::bittype::Create(64), 8);
 
     auto sum = jlm::rvsdg::bitadd_op::create(64, ldnm1[0], ldnm2[0]);
 
@@ -2082,7 +2082,7 @@ PhiTest1::SetupRvsdg()
     auto gepn = GetElementPtrOperation::Create(
         pointerArgument,
         { valueArgument },
-        *jlm::rvsdg::bittype::Create(64),
+        jlm::rvsdg::bittype::Create(64),
         pbit64);
     auto store = StoreNonVolatileNode::Create(gepn, sumex, { gOMemoryState }, 8);
 
@@ -2096,8 +2096,8 @@ PhiTest1::SetupRvsdg()
 
   auto SetupTestFunction = [&](phi::node * phiNode)
   {
-    arraytype at(jlm::rvsdg::bittype::Create(64), 10);
-    PointerType pbit64;
+    auto at = arraytype::Create(jlm::rvsdg::bittype::Create(64), 10);
+    auto pbit64 = PointerType::Create();
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
     auto functionType = FunctionType::Create(
@@ -2226,7 +2226,7 @@ PhiTest2::SetupRvsdg()
     auto storeNode = StoreNonVolatileNode::Create(pointerArgument, one, { memoryStateArgument }, 4);
 
     auto four = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
-    auto paAlloca = alloca_op::create(*jlm::rvsdg::bittype::Create(32), four, 4);
+    auto paAlloca = alloca_op::create(jlm::rvsdg::bittype::Create(32), four, 4);
     auto paMerge = MemoryStateMergeOperation::Create(
         std::vector<jlm::rvsdg::output *>({ paAlloca[1], storeNode[0] }));
 
@@ -2271,7 +2271,7 @@ PhiTest2::SetupRvsdg()
     auto storeNode = StoreNonVolatileNode::Create(pointerArgument, two, { memoryStateArgument }, 4);
 
     auto four = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
-    auto pbAlloca = alloca_op::create(*jlm::rvsdg::bittype::Create(32), four, 4);
+    auto pbAlloca = alloca_op::create(jlm::rvsdg::bittype::Create(32), four, 4);
     auto pbMerge = MemoryStateMergeOperation::Create(
         std::vector<jlm::rvsdg::output *>({ pbAlloca[1], storeNode[0] }));
 
@@ -2311,7 +2311,7 @@ PhiTest2::SetupRvsdg()
     auto storeNode = StoreNonVolatileNode::Create(xArgument, three, { memoryStateArgument }, 4);
 
     auto four = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
-    auto pcAlloca = alloca_op::create(*jlm::rvsdg::bittype::Create(32), four, 4);
+    auto pcAlloca = alloca_op::create(jlm::rvsdg::bittype::Create(32), four, 4);
     auto pcMerge = MemoryStateMergeOperation::Create(
         std::vector<jlm::rvsdg::output *>({ pcAlloca[1], storeNode[0] }));
 
@@ -2323,7 +2323,7 @@ PhiTest2::SetupRvsdg()
     auto loadX = LoadNonVolatileNode::Create(
         xArgument,
         { callA.GetMemoryStateOutput() },
-        *jlm::rvsdg::bittype::Create(32),
+        jlm::rvsdg::bittype::Create(32),
         4);
 
     auto sum = jlm::rvsdg::bitadd_op::create(32, callA.Result(0), loadX[0]);
@@ -2349,7 +2349,7 @@ PhiTest2::SetupRvsdg()
     auto four = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
     auto storeNode = StoreNonVolatileNode::Create(xArgument, four, { memoryStateArgument }, 4);
 
-    auto pdAlloca = alloca_op::create(*jlm::rvsdg::bittype::Create(32), four, 4);
+    auto pdAlloca = alloca_op::create(jlm::rvsdg::bittype::Create(32), four, 4);
     auto pdMerge = MemoryStateMergeOperation::Create(
         std::vector<jlm::rvsdg::output *>({ pdAlloca[1], storeNode[0] }));
 
@@ -2430,7 +2430,7 @@ PhiTest2::SetupRvsdg()
     auto functionACv = lambda->add_ctxvar(&functionA);
 
     auto four = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
-    auto pTestAlloca = alloca_op::create(*jlm::rvsdg::bittype::Create(32), four, 4);
+    auto pTestAlloca = alloca_op::create(jlm::rvsdg::bittype::Create(32), four, 4);
     auto pTestMerge = MemoryStateMergeOperation::Create(
         std::vector<jlm::rvsdg::output *>({ pTestAlloca[1], memoryStateArgument }));
 
@@ -2600,7 +2600,7 @@ EscapedMemoryTest1::SetupRvsdg()
   {
     auto deltaNode = delta::node::Create(
         rvsdg->root(),
-        *jlm::rvsdg::bittype::Create(32),
+        jlm::rvsdg::bittype::Create(32),
         "a",
         linkage::external_linkage,
         "",
@@ -2615,7 +2615,7 @@ EscapedMemoryTest1::SetupRvsdg()
   {
     auto deltaNode = delta::node::Create(
         rvsdg->root(),
-        *jlm::rvsdg::bittype::Create(32),
+        jlm::rvsdg::bittype::Create(32),
         "b",
         linkage::external_linkage,
         "",
@@ -2675,7 +2675,7 @@ EscapedMemoryTest1::SetupRvsdg()
     auto loadResults2 = LoadNonVolatileNode::Create(
         loadResults1[0],
         { loadResults1[1] },
-        *jlm::rvsdg::bittype::Create(32),
+        jlm::rvsdg::bittype::Create(32),
         4);
 
     auto five = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 5);
@@ -2840,7 +2840,7 @@ EscapedMemoryTest2::SetupRvsdg()
     auto loadResults = LoadNonVolatileNode::Create(
         call.Result(0),
         { call.GetMemoryStateOutput() },
-        *jlm::rvsdg::bittype::Create(32),
+        jlm::rvsdg::bittype::Create(32),
         4);
 
     auto lambdaOutput =
@@ -2912,7 +2912,7 @@ EscapedMemoryTest3::SetupRvsdg()
   {
     auto delta = delta::node::Create(
         rvsdg->root(),
-        *jlm::rvsdg::bittype::Create(32),
+        jlm::rvsdg::bittype::Create(32),
         "global",
         linkage::external_linkage,
         "",
@@ -2950,7 +2950,7 @@ EscapedMemoryTest3::SetupRvsdg()
     auto loadResults = LoadNonVolatileNode::Create(
         call.Result(0),
         { call.GetMemoryStateOutput() },
-        *jlm::rvsdg::bittype::Create(32),
+        jlm::rvsdg::bittype::Create(32),
         4);
 
     auto lambdaOutput =
@@ -3063,7 +3063,7 @@ MemcpyTest::SetupRvsdg()
     auto storeResults = StoreNonVolatileNode::Create(gep, six, { memoryStateArgument }, 8);
 
     auto loadResults =
-        LoadNonVolatileNode::Create(gep, { storeResults[0] }, *jlm::rvsdg::bittype::Create(32), 8);
+        LoadNonVolatileNode::Create(gep, { storeResults[0] }, jlm::rvsdg::bittype::Create(32), 8);
 
     auto lambdaOutput = lambda->finalize({ loadResults[0], iOStateArgument, loadResults[1] });
 
@@ -3264,7 +3264,7 @@ MemcpyTest3::SetupRvsdg()
   auto minusFive = jlm::rvsdg::create_bitconstant(Lambda_->subregion(), 64, -5);
   auto three = jlm::rvsdg::create_bitconstant(Lambda_->subregion(), 64, 3);
 
-  auto allocaResults = alloca_op::create(*structType, eight, 8);
+  auto allocaResults = alloca_op::create(structType, eight, 8);
   auto memoryState = MemoryStateMergeOperation::Create({ allocaResults[1], memoryStateArgument });
 
   auto memcpyResults =
@@ -3392,7 +3392,7 @@ AllMemoryNodesTest::SetupRvsdg()
 
   // Create imported symbol "imported"
   Import_ = graph->add_import(
-      impport(*jlm::rvsdg::bittype::Create(32), "imported", linkage::external_linkage));
+      impport(jlm::rvsdg::bittype::Create(32), "imported", linkage::external_linkage));
 
   // Create global variable "global"
   Delta_ = delta::node::Create(
@@ -3443,7 +3443,7 @@ AllMemoryNodesTest::SetupRvsdg()
   auto loadImportedOutputs = LoadNonVolatileNode::Create(
       importContextVar,
       { loadAllocaOutputs[1] },
-      *jlm::rvsdg::bittype::Create(32),
+      jlm::rvsdg::bittype::Create(32),
       4);
 
   // Store the loaded value from imported, into the address loaded from the alloca (aka. the malloc
@@ -3492,7 +3492,7 @@ NAllocaNodesTest::SetupRvsdg()
 
   for (size_t i = 0; i < NumAllocaNodes_; i++)
   {
-    auto allocaOutputs = alloca_op::create(*jlm::rvsdg::bittype::Create(32), allocaSize, 4);
+    auto allocaOutputs = alloca_op::create(jlm::rvsdg::bittype::Create(32), allocaSize, 4);
     auto allocaNode = jlm::rvsdg::node_output::node(allocaOutputs[0]);
 
     AllocaNodes_.push_back(allocaNode);
@@ -3514,7 +3514,7 @@ EscapingLocalFunctionTest::SetupRvsdg()
 {
   using namespace jlm::llvm;
 
-  rvsdg::bittype uint32Type = *rvsdg::bittype::Create(32);
+  auto uint32Type = rvsdg::bittype::Create(32);
   auto mt = MemoryStateType::Create();
   auto pointerType = PointerType::Create();
   auto localFuncType = FunctionType::Create(
@@ -3668,7 +3668,7 @@ LambdaCallArgumentMismatch::SetupRvsdg()
 
     auto vaList = valist_op::Create(*lambda->subregion(), {});
 
-    auto allocaResults = alloca_op::create(*rvsdg::bittype::Create(32), one, 4);
+    auto allocaResults = alloca_op::create(rvsdg::bittype::Create(32), one, 4);
 
     auto memoryState = MemoryStateMergeOperation::Create(
         std::vector<rvsdg::output *>{ memoryStateArgument, allocaResults[1] });
@@ -3676,7 +3676,7 @@ LambdaCallArgumentMismatch::SetupRvsdg()
     auto storeResults = StoreNonVolatileNode::Create(allocaResults[0], six, { memoryState }, 4);
 
     auto loadResults =
-        LoadNonVolatileNode::Create(allocaResults[0], storeResults, *rvsdg::bittype::Create(32), 4);
+        LoadNonVolatileNode::Create(allocaResults[0], storeResults, rvsdg::bittype::Create(32), 4);
 
     auto & call = CallNode::CreateNode(
         lambdaGArgument,
@@ -3764,7 +3764,7 @@ VariadicFunctionTest1::SetupRvsdg()
     auto one = jlm::rvsdg::create_bitconstant(LambdaG_->subregion(), 32, 1);
     auto five = jlm::rvsdg::create_bitconstant(LambdaG_->subregion(), 32, 5);
 
-    auto allocaResults = alloca_op::create(*jlm::rvsdg::bittype::Create(32), one, 4);
+    auto allocaResults = alloca_op::create(jlm::rvsdg::bittype::Create(32), one, 4);
     auto merge = MemoryStateMergeOperation::Create({ allocaResults[1], memoryStateArgument });
     AllocaNode_ = rvsdg::node_output::node(allocaResults[0]);
 
@@ -3799,7 +3799,7 @@ VariadicFunctionTest2::SetupRvsdg()
                                         PointerType::Create(),
                                         PointerType::Create() }));
   auto structType = StructType::Create("struct.__va_list_tag", false, structDeclaration);
-  arraytype arrayType(structType, 1);
+  auto arrayType = arraytype::Create(structType, 1);
   auto iOStateType = iostatetype::Create();
   auto memoryStateType = MemoryStateType::Create();
   auto varArgType = varargtype::Create();
@@ -3869,7 +3869,7 @@ VariadicFunctionTest2::SetupRvsdg()
     auto loadResults = LoadNonVolatileNode::Create(
         allocaResults[0],
         { callVaStart.GetMemoryStateOutput() },
-        *rvsdg::bittype::Create(32),
+        rvsdg::bittype::Create(32),
         16);
     auto icmpResult = rvsdg::bitult_op::create(32, loadResults[0], fortyOne);
     auto matchResult = rvsdg::match_op::Create(*icmpResult, { { 1, 1 } }, 0, 2);
@@ -3929,7 +3929,7 @@ VariadicFunctionTest2::SetupRvsdg()
     loadResults = LoadNonVolatileNode::Create(
         gammaAddress,
         { gammaOutputMemoryState },
-        *rvsdg::bittype::Create(32),
+        rvsdg::bittype::Create(32),
         4);
     auto & callVaEnd = CallNode::CreateNode(
         llvmVaEndArgument,

--- a/tests/jlm/hls/backend/rvsdg2rhls/TestTheta.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/TestTheta.cpp
@@ -48,7 +48,7 @@ TestUnknownBoundaries()
   theta->set_predicate(match);
 
   auto f = lambda->finalize({ theta->output(0), theta->output(1), theta->output(2) });
-  rm.Rvsdg().add_export(f, { f->type().copy(), "" });
+  rm.Rvsdg().add_export(f, { f->Type(), "" });
 
   jlm::rvsdg::view(rm.Rvsdg(), stdout);
 

--- a/tests/jlm/llvm/backend/llvm/jlm-llvm/LoadTests.cpp
+++ b/tests/jlm/llvm/backend/llvm/jlm-llvm/LoadTests.cpp
@@ -35,7 +35,7 @@ LoadConversion()
   auto loadTac = basicBlock->append_last(LoadNonVolatileOperation::Create(
       addressArgument,
       memoryStateArgument,
-      *jlm::rvsdg::bittype::Create(64),
+      jlm::rvsdg::bittype::Create(64),
       alignment));
 
   cfg->exit()->divert_inedges(basicBlock);
@@ -79,7 +79,7 @@ LoadVolatileConversion()
   auto pointerType = PointerType::Create();
   auto ioStateType = iostatetype::Create();
   auto memoryStateType = MemoryStateType::Create();
-  jlm::rvsdg::bittype bit64Type(64);
+  auto bit64Type = jlm::rvsdg::bittype::Create(64);
   auto functionType = FunctionType::Create(
       { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() },
       { jlm::rvsdg::bittype::Create(64), iostatetype::Create(), MemoryStateType::Create() });

--- a/tests/jlm/llvm/backend/llvm/r2j/test-recursive-data.cpp
+++ b/tests/jlm/llvm/backend/llvm/r2j/test-recursive-data.cpp
@@ -39,7 +39,7 @@ test()
   jlm::rvsdg::output *delta1, *delta2;
   {
     auto delta =
-        delta::node::Create(region, *vt, "test-delta1", linkage::external_linkage, "", false);
+        delta::node::Create(region, vt, "test-delta1", linkage::external_linkage, "", false);
     auto dep1 = delta->add_ctxvar(r2->argument());
     auto dep2 = delta->add_ctxvar(dep);
     delta1 =
@@ -48,7 +48,7 @@ test()
 
   {
     auto delta =
-        delta::node::Create(region, *vt, "test-delta2", linkage::external_linkage, "", false);
+        delta::node::Create(region, vt, "test-delta2", linkage::external_linkage, "", false);
     auto dep1 = delta->add_ctxvar(r1->argument());
     auto dep2 = delta->add_ctxvar(dep);
     delta2 =

--- a/tests/jlm/llvm/frontend/llvm/ThreeAddressCodeConversionTests.cpp
+++ b/tests/jlm/llvm/frontend/llvm/ThreeAddressCodeConversionTests.cpp
@@ -87,7 +87,7 @@ LoadVolatileConversion()
 
   // Arrange
   auto valueType = jlm::tests::valuetype::Create();
-  LoadVolatileOperation operation(*valueType, 3, 4);
+  LoadVolatileOperation operation(valueType, 3, 4);
   auto ipgModule = SetupFunctionWithThreeAddressCode(operation);
 
   // Act

--- a/tests/jlm/llvm/frontend/llvm/test-export.cpp
+++ b/tests/jlm/llvm/frontend/llvm/test-export.cpp
@@ -23,7 +23,7 @@ test()
 
   ipgraph_module im(jlm::util::filepath(""), "", "");
 
-  auto d = data_node::Create(im.ipgraph(), "d", *vt, linkage::external_linkage, "", false);
+  auto d = data_node::Create(im.ipgraph(), "d", vt, linkage::external_linkage, "", false);
   auto f = function_node::create(im.ipgraph(), "f", ft, linkage::external_linkage);
 
   im.create_global_value(d);

--- a/tests/jlm/llvm/frontend/llvm/test-recursive-data.cpp
+++ b/tests/jlm/llvm/frontend/llvm/test-recursive-data.cpp
@@ -22,10 +22,10 @@ test()
   auto vt = jlm::tests::valuetype::Create();
   ipgraph_module im(jlm::util::filepath(""), "", "");
 
-  auto d0 = data_node::Create(im.ipgraph(), "d0", *vt, linkage::external_linkage, "", false);
+  auto d0 = data_node::Create(im.ipgraph(), "d0", vt, linkage::external_linkage, "", false);
 
-  auto d1 = data_node::Create(im.ipgraph(), "d1", *vt, linkage::external_linkage, "", false);
-  auto d2 = data_node::Create(im.ipgraph(), "d2", *vt, linkage::external_linkage, "", false);
+  auto d1 = data_node::Create(im.ipgraph(), "d1", vt, linkage::external_linkage, "", false);
+  auto d2 = data_node::Create(im.ipgraph(), "d2", vt, linkage::external_linkage, "", false);
 
   auto v0 = im.create_global_value(d0);
   auto v1 = im.create_global_value(d1);

--- a/tests/jlm/llvm/ir/operators/LoadTests.cpp
+++ b/tests/jlm/llvm/ir/operators/LoadTests.cpp
@@ -22,8 +22,8 @@ OperationEquality()
 
   // Arrange
   MemoryStateType memoryType;
-  jlm::tests::valuetype valueType;
-  PointerType pointerType;
+  auto valueType = jlm::tests::valuetype::Create();
+  auto pointerType = PointerType::Create();
 
   LoadNonVolatileOperation operation1(valueType, 2, 4);
   LoadNonVolatileOperation operation2(pointerType, 2, 4);
@@ -62,7 +62,7 @@ TestCopy()
   auto address2 = graph.add_import({ pointerType, "address2" });
   auto memoryState2 = graph.add_import({ memoryType, "memoryState2" });
 
-  auto loadResults = LoadNonVolatileNode::Create(address1, { memoryState1 }, *valueType, 4);
+  auto loadResults = LoadNonVolatileNode::Create(address1, { memoryState1 }, valueType, 4);
 
   // Act
   auto node = jlm::rvsdg::node_output::node(loadResults[0]);
@@ -135,7 +135,7 @@ TestMultipleOriginReduction()
   auto a = graph.add_import({ pt, "a" });
   auto s = graph.add_import({ mt, "s" });
 
-  auto load = LoadNonVolatileNode::Create(a, { s, s, s, s }, *vt, 4)[0];
+  auto load = LoadNonVolatileNode::Create(a, { s, s, s, s }, vt, 4)[0];
 
   auto ex = graph.add_export(load, { load->Type(), "l" });
 
@@ -220,7 +220,7 @@ TestLoadStoreReduction()
   auto s = graph.add_import({ mt, "state" });
 
   auto s1 = StoreNonVolatileNode::Create(a, v, { s }, 4)[0];
-  auto load = LoadNonVolatileNode::Create(a, { s1 }, *vt, 4);
+  auto load = LoadNonVolatileNode::Create(a, { s1 }, vt, 4);
 
   auto x1 = graph.add_export(load[0], { load[0]->Type(), "value" });
   auto x2 = graph.add_export(load[1], { load[1]->Type(), "state" });
@@ -323,7 +323,7 @@ LoadVolatileOperationEquality()
   // Arrange
   MemoryStateType memoryType;
   auto valueType = jlm::tests::valuetype::Create();
-  PointerType pointerType;
+  auto pointerType = PointerType::Create();
 
   LoadVolatileOperation operation1(valueType, 2, 4);
   LoadVolatileOperation operation2(pointerType, 2, 4);
@@ -383,7 +383,7 @@ OperationAccessors()
   LoadVolatileOperation operation(valueType, numMemoryStates, alignment);
 
   // Assert
-  assert(operation.GetLoadedType() == *valueType);
+  assert(operation.GetLoadedType() == valueType);
   assert(operation.NumMemoryStates() == numMemoryStates);
   assert(operation.GetAlignment() == alignment);
   assert(operation.narguments() == numMemoryStates + 2); // [address, ioState, memoryStates]

--- a/tests/jlm/llvm/ir/operators/MemCpyTests.cpp
+++ b/tests/jlm/llvm/ir/operators/MemCpyTests.cpp
@@ -16,8 +16,8 @@ OperationEquality()
 
   // Arrange
   auto valueType = jlm::tests::valuetype::Create();
-  jlm::rvsdg::bittype bit32Type(32);
-  jlm::rvsdg::bittype bit64Type(64);
+  auto bit32Type = jlm::rvsdg::bittype::Create(32);
+  auto bit64Type = jlm::rvsdg::bittype::Create(64);
 
   MemCpyNonVolatileOperation operation1(bit32Type, 1);
   MemCpyNonVolatileOperation operation2(bit64Type, 4);

--- a/tests/jlm/llvm/ir/operators/StoreTests.cpp
+++ b/tests/jlm/llvm/ir/operators/StoreTests.cpp
@@ -22,7 +22,7 @@ StoreNonVolatileOperationEquality()
   // Arrange
   MemoryStateType memoryType;
   auto valueType = jlm::tests::valuetype::Create();
-  PointerType pointerType;
+  auto pointerType = PointerType::Create();
 
   StoreNonVolatileOperation operation1(valueType, 2, 4);
   StoreNonVolatileOperation operation2(pointerType, 2, 4);
@@ -52,7 +52,7 @@ StoreVolatileOperationEquality()
   // Arrange
   MemoryStateType memoryType;
   auto valueType = jlm::tests::valuetype::Create();
-  PointerType pointerType;
+  auto pointerType = PointerType::Create();
 
   StoreVolatileOperation operation1(valueType, 2, 4);
   StoreVolatileOperation operation2(pointerType, 2, 4);

--- a/tests/jlm/llvm/ir/operators/TestCall.cpp
+++ b/tests/jlm/llvm/ir/operators/TestCall.cpp
@@ -122,11 +122,11 @@ TestCallTypeClassifierIndirectCall()
 
     auto one = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 1);
 
-    auto alloca = alloca_op::create(*PointerType::Create(), one, 8);
+    auto alloca = alloca_op::create(PointerType::Create(), one, 8);
 
     auto store = StoreNonVolatileNode::Create(alloca[0], lambda->fctargument(0), { alloca[1] }, 8);
 
-    auto load = LoadNonVolatileNode::Create(alloca[0], store, *PointerType::Create(), 8);
+    auto load = LoadNonVolatileNode::Create(alloca[0], store, PointerType::Create(), 8);
 
     auto callResults =
         CallNode::Create(load[0], fcttype1, { iOStateArgument, memoryStateArgument });
@@ -374,7 +374,7 @@ TestCallTypeClassifierRecursiveDirectCall()
 
   auto SetupFib = [&]()
   {
-    PointerType pbit64;
+    auto pbit64 = PointerType::Create();
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
     auto functionType = FunctionType::Create(
@@ -426,21 +426,21 @@ TestCallTypeClassifierRecursiveDirectCall()
     auto gepnm1 = GetElementPtrOperation::Create(
         resultev->argument(0),
         { nm1 },
-        *jlm::rvsdg::bittype::Create(64),
+        jlm::rvsdg::bittype::Create(64),
         pbit64);
     auto ldnm1 = LoadNonVolatileNode::Create(
         gepnm1,
         { callfibm2Results[1] },
-        *jlm::rvsdg::bittype::Create(64),
+        jlm::rvsdg::bittype::Create(64),
         8);
 
     auto gepnm2 = GetElementPtrOperation::Create(
         resultev->argument(0),
         { nm2 },
-        *jlm::rvsdg::bittype::Create(64),
+        jlm::rvsdg::bittype::Create(64),
         pbit64);
     auto ldnm2 =
-        LoadNonVolatileNode::Create(gepnm2, { ldnm1[1] }, *jlm::rvsdg::bittype::Create(64), 8);
+        LoadNonVolatileNode::Create(gepnm2, { ldnm1[1] }, jlm::rvsdg::bittype::Create(64), 8);
 
     auto sum = jlm::rvsdg::bitadd_op::create(64, ldnm1[0], ldnm2[0]);
 
@@ -454,7 +454,7 @@ TestCallTypeClassifierRecursiveDirectCall()
     auto gepn = GetElementPtrOperation::Create(
         pointerArgument,
         { valueArgument },
-        *jlm::rvsdg::bittype::Create(64),
+        jlm::rvsdg::bittype::Create(64),
         pbit64);
     auto store = StoreNonVolatileNode::Create(gepn, sumex, { gOMemoryState }, 8);
 

--- a/tests/jlm/llvm/ir/operators/test-delta.cpp
+++ b/tests/jlm/llvm/ir/operators/test-delta.cpp
@@ -26,7 +26,7 @@ TestDeltaCreation()
 
   auto delta1 = delta::node::Create(
       rvsdgModule.Rvsdg().root(),
-      *valueType,
+      valueType,
       "test-delta1",
       linkage::external_linkage,
       "",
@@ -37,7 +37,7 @@ TestDeltaCreation()
 
   auto delta2 = delta::node::Create(
       rvsdgModule.Rvsdg().root(),
-      *valueType,
+      valueType,
       "test-delta2",
       linkage::internal_linkage,
       "",
@@ -74,7 +74,7 @@ TestRemoveDeltaInputsWhere()
 
   auto deltaNode = delta::node::Create(
       rvsdgModule.Rvsdg().root(),
-      *valueType,
+      valueType,
       "delta",
       linkage::external_linkage,
       "",
@@ -141,7 +141,7 @@ TestPruneDeltaInputs()
 
   auto deltaNode = delta::node::Create(
       rvsdgModule.Rvsdg().root(),
-      *valueType,
+      valueType,
       "delta",
       linkage::external_linkage,
       "",

--- a/tests/jlm/llvm/opt/TestDeadNodeElimination.cpp
+++ b/tests/jlm/llvm/opt/TestDeadNodeElimination.cpp
@@ -401,7 +401,7 @@ TestDelta()
   auto z = rvsdg.add_import({ valueType, "z" });
 
   auto deltaNode =
-      delta::node::Create(rvsdg.root(), *valueType, "delta", linkage::external_linkage, "", false);
+      delta::node::Create(rvsdg.root(), valueType, "delta", linkage::external_linkage, "", false);
 
   auto xArgument = deltaNode->add_ctxvar(x);
   deltaNode->add_ctxvar(y);

--- a/tests/jlm/llvm/opt/TestLoadStoreReduction.cpp
+++ b/tests/jlm/llvm/opt/TestLoadStoreReduction.cpp
@@ -34,7 +34,7 @@ TestLoadStoreReductionWithDifferentValueOperandType()
 
   auto storeResults = StoreNonVolatileNode::Create(address, value, { memoryState }, 4);
   auto loadResults =
-      LoadNonVolatileNode::Create(address, storeResults, *jlm::rvsdg::bittype::Create(8), 4);
+      LoadNonVolatileNode::Create(address, storeResults, jlm::rvsdg::bittype::Create(8), 4);
 
   auto exportedValue = graph.add_export(loadResults[0], { jlm::rvsdg::bittype::Create(8), "v" });
   graph.add_export(loadResults[1], { memoryStateType, "s" });


### PR DESCRIPTION
Convert all remaining llvm operators to operator on std::shared_ptr<type>, remove any method that requires copying types.