### PR TITLE
Finalize type shared_ptr support

### DIFF
--- a/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.cpp
+++ b/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.cpp
@@ -697,7 +697,7 @@ RhlsToFirrtlConverter::MlirGenHlsMemReq(const jlm::rvsdg::simple_node * node)
 
   auto reqType = dynamic_cast<const bundletype *>(&node->output(0)->type());
   // TODO: more robust check
-  auto hasWrite = reqType->elements_->size() == 5;
+  auto hasWrite = reqType->elements_.size() == 5;
 
   mlir::BlockArgument memReq = GetOutPort(module, 0);
   mlir::Value memReqData;
@@ -3867,9 +3867,9 @@ RhlsToFirrtlConverter::GetFirrtlType(const jlm::rvsdg::type * type)
   {
     using BundleElement = circt::firrtl::BundleType::BundleElement;
     ::llvm::SmallVector<BundleElement> elements;
-    for (size_t i = 0; i < bt->elements_->size(); ++i)
+    for (size_t i = 0; i < bt->elements_.size(); ++i)
     {
-      auto t = &bt->elements_->at(i);
+      auto t = &bt->elements_.at(i);
       elements.push_back(
           BundleElement(Builder_->getStringAttr(t->first), false, GetFirrtlType(t->second.get())));
     }

--- a/jlm/hls/backend/rhls2firrtl/json-hls.cpp
+++ b/jlm/hls/backend/rhls2firrtl/json-hls.cpp
@@ -53,7 +53,7 @@ JsonHLS::get_text(llvm::RvsdgModule & rm)
     }
     auto req_bt = dynamic_cast<const bundletype *>(&mem_reqs[i]->type());
     auto resp_bt = dynamic_cast<const bundletype *>(&mem_resps[i]->type());
-    auto size = JlmSize(resp_bt->get_element_type("data"));
+    auto size = JlmSize(&*resp_bt->get_element_type("data"));
     auto has_write = req_bt->get_element_type("write") != nullptr;
     json << "{ \"size\": " << size << ", \"has_write\": " << has_write << "}";
   }

--- a/jlm/hls/backend/rvsdg2rhls/UnusedStateRemoval.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/UnusedStateRemoval.cpp
@@ -40,12 +40,12 @@ RemoveUnusedStatesFromLambda(llvm::lambda::node & lambdaNode)
   for (size_t i = 0; i < oldFunctionType.NumArguments(); ++i)
   {
     auto argument = lambdaNode.subregion()->argument(i);
-    auto & argumentType = oldFunctionType.ArgumentType(i);
-    JLM_ASSERT(argumentType == argument->type());
+    auto argumentType = oldFunctionType.Arguments()[i];
+    JLM_ASSERT(*argumentType == argument->type());
 
     if (!IsPassthroughArgument(*argument))
     {
-      newArgumentTypes.push_back(argumentType.copy());
+      newArgumentTypes.push_back(argumentType);
     }
   }
 
@@ -53,12 +53,12 @@ RemoveUnusedStatesFromLambda(llvm::lambda::node & lambdaNode)
   for (size_t i = 0; i < oldFunctionType.NumResults(); ++i)
   {
     auto result = lambdaNode.subregion()->result(i);
-    auto & resultType = oldFunctionType.ResultType(i);
-    JLM_ASSERT(resultType == result->type());
+    auto resultType = oldFunctionType.Results()[i];
+    JLM_ASSERT(*resultType == result->type());
 
     if (!IsPassthroughResult(*result))
     {
-      newResultTypes.push_back(resultType.copy());
+      newResultTypes.push_back(resultType);
     }
   }
 

--- a/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
@@ -19,7 +19,7 @@ get_trigger(jlm::rvsdg::region * region)
 {
   for (size_t i = 0; i < region->narguments(); ++i)
   {
-    if (region->argument(i)->type() == hls::trigger)
+    if (region->argument(i)->type() == *hls::triggertype::Create())
     {
       return region->argument(i);
     }
@@ -28,19 +28,19 @@ get_trigger(jlm::rvsdg::region * region)
 }
 
 jlm::llvm::lambda::node *
-add_lambda_argument(llvm::lambda::node * ln, const jlm::rvsdg::type * type)
+add_lambda_argument(llvm::lambda::node * ln, std::shared_ptr<const jlm::rvsdg::type> type)
 {
   auto old_fcttype = ln->type();
   std::vector<std::shared_ptr<const jlm::rvsdg::type>> new_argument_types;
   for (size_t i = 0; i < old_fcttype.NumArguments(); ++i)
   {
-    new_argument_types.push_back(old_fcttype.ArgumentType(i).copy());
+    new_argument_types.push_back(old_fcttype.Arguments()[i]);
   }
-  new_argument_types.push_back(type->copy());
+  new_argument_types.push_back(std::move(type));
   std::vector<std::shared_ptr<const jlm::rvsdg::type>> new_result_types;
   for (size_t i = 0; i < old_fcttype.NumResults(); ++i)
   {
-    new_result_types.push_back(old_fcttype.ResultType(i).copy());
+    new_result_types.push_back(old_fcttype.Results()[i]);
   }
   auto new_fcttype = llvm::FunctionType::Create(new_argument_types, new_result_types);
   auto new_lambda = llvm::lambda::node::create(
@@ -95,7 +95,7 @@ add_triggers(jlm::rvsdg::region * region)
         // check here in order not to process removed and re-added node twice
         if (!get_trigger(ln->subregion()))
         {
-          auto new_lambda = add_lambda_argument(ln, &(hls::trigger));
+          auto new_lambda = add_lambda_argument(ln, hls::triggertype::Create());
           add_triggers(new_lambda->subregion());
         }
       }

--- a/jlm/hls/backend/rvsdg2rhls/alloca-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/alloca-conv.cpp
@@ -138,12 +138,12 @@ alloca_conv(jlm::rvsdg::region * region)
       JLM_ASSERT(constant_operation);
       JLM_ASSERT(constant_operation->value().to_uint() == 1);
       // ensure that the alloca is an array type
-      auto at = dynamic_cast<const jlm::llvm::arraytype *>(&po->value_type());
+      auto at = std::dynamic_pointer_cast<const jlm::llvm::arraytype>(po->ValueType());
       JLM_ASSERT(at);
       // detect loads and stores attached to alloca
       TraceAllocaUses ta(node->output(0));
       // create memory + response
-      auto mem_outs = local_mem_op::create(*at, node->region());
+      auto mem_outs = local_mem_op::create(at, node->region());
       auto resp_outs = local_mem_resp_op::create(*mem_outs[0], ta.load_nodes.size());
       std::cout << "alloca converted " << at->debug_string() << std::endl;
       // replace gep outputs (convert pointer to index calculation)

--- a/jlm/hls/backend/rvsdg2rhls/dae-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/dae-conv.cpp
@@ -240,7 +240,7 @@ decouple_load(
           jlm::rvsdg::argument * new_arg;
           if (auto be = dynamic_cast<backedge_argument *>(arg))
           {
-            new_arg = new_loop->add_backedge(arg->type());
+            new_arg = new_loop->add_backedge(arg->Type());
             backedge_args.push_back(be);
           }
           else

--- a/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
@@ -129,11 +129,11 @@ instrument_ref(llvm::RvsdgModule & rm)
       root,
       newLambda->subregion()->argument(ioStateArgumentIndex),
       reference_load,
-      *loadFunctionType,
+      loadFunctionType,
       reference_store,
-      *storeFunctionType,
+      storeFunctionType,
       reference_alloca,
-      *allocaFunctionType);
+      allocaFunctionType);
 }
 
 void
@@ -141,11 +141,11 @@ instrument_ref(
     jlm::rvsdg::region * region,
     jlm::rvsdg::output * ioState,
     jlm::rvsdg::output * load_func,
-    const jlm::llvm::FunctionType & loadFunctionType,
+    const std::shared_ptr<const jlm::llvm::FunctionType> & loadFunctionType,
     jlm::rvsdg::output * store_func,
-    const jlm::llvm::FunctionType & storeFunctionType,
+    const std::shared_ptr<const jlm::llvm::FunctionType> & storeFunctionType,
     jlm::rvsdg::output * alloca_func,
-    const jlm::llvm::FunctionType & allocaFunctionType)
+    const std::shared_ptr<const jlm::llvm::FunctionType> & allocaFunctionType)
 {
   load_func = route_to_region(load_func, region);
   store_func = route_to_region(store_func, region);
@@ -188,7 +188,7 @@ instrument_ref(
       auto memstate = node->input(1)->origin();
       auto callOp = jlm::llvm::CallNode::Create(
           load_func,
-          std::static_pointer_cast<const llvm::FunctionType>(loadFunctionType.copy()),
+          loadFunctionType,
           { addr, width, ioState, memstate });
       // Divert the memory state of the load to the new memstate from the call operation
       node->input(1)->divert_to(callOp[1]);
@@ -220,7 +220,7 @@ instrument_ref(
       auto memstate = node->output(1);
       auto callOp = jlm::llvm::CallNode::Create(
           alloca_func,
-          std::static_pointer_cast<const llvm::FunctionType>(allocaFunctionType.copy()),
+          allocaFunctionType,
           { addr, size, ioState, memstate });
       for (auto ou : old_users)
       {
@@ -254,7 +254,7 @@ instrument_ref(
       auto memstate = node->input(2)->origin();
       auto callOp = jlm::llvm::CallNode::Create(
           store_func,
-          std::static_pointer_cast<const llvm::FunctionType>(storeFunctionType.copy()),
+          storeFunctionType,
           { addr, data, width, ioState, memstate });
       // Divert the memory state of the load to the new memstate from the call operation
       node->input(2)->divert_to(callOp[1]);

--- a/jlm/hls/backend/rvsdg2rhls/instrument-ref.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/instrument-ref.hpp
@@ -20,11 +20,11 @@ instrument_ref(
     jlm::rvsdg::region * region,
     jlm::rvsdg::output * ioState,
     jlm::rvsdg::output * load_func,
-    const llvm::FunctionType & loadFunctionType,
+    const std::shared_ptr<const llvm::FunctionType> & loadFunctionType,
     jlm::rvsdg::output * store_func,
-    const llvm::FunctionType & storeFunctionType,
+    const std::shared_ptr<const llvm::FunctionType> & storeFunctionType,
     jlm::rvsdg::output * alloca_func,
-    const llvm::FunctionType & allocaFunctionType);
+    const std::shared_ptr<const llvm::FunctionType> & allocaFunctionType);
 
 } // namespace jlm::hls
 

--- a/jlm/hls/backend/rvsdg2rhls/mem-queue.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-queue.cpp
@@ -167,7 +167,7 @@ route_to_region(jlm::rvsdg::region * target, jlm::rvsdg::output * out)
   // route out to convergence point from out
   jlm::rvsdg::output * common_out = jlm::hls::route_request(common_region, out);
   // add a backedge to prevent cycles
-  auto arg = common_loop->add_backedge(out->type());
+  auto arg = common_loop->add_backedge(out->Type());
   arg->result()->divert_to(common_out);
   // route inwards from convergence point to target
   auto result = jlm::hls::route_response(target, arg);

--- a/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
@@ -178,11 +178,11 @@ remove_lambda_passthrough(llvm::lambda::node * ln)
   for (size_t i = 0; i < old_fcttype.NumArguments(); ++i)
   {
     auto arg = ln->subregion()->argument(i);
-    auto argtype = &old_fcttype.ArgumentType(i);
+    auto argtype = old_fcttype.Arguments()[i];
     JLM_ASSERT(*argtype == arg->type());
     if (!is_passthrough(arg))
     {
-      new_argument_types.push_back(argtype->copy());
+      new_argument_types.push_back(argtype);
     }
   }
   std::vector<std::shared_ptr<const jlm::rvsdg::type>> new_result_types;
@@ -193,7 +193,7 @@ remove_lambda_passthrough(llvm::lambda::node * ln)
     JLM_ASSERT(*restype == res->type());
     if (!is_passthrough(res))
     {
-      new_result_types.push_back(old_fcttype.ResultType(i).copy());
+      new_result_types.push_back(old_fcttype.Results()[i]);
     }
   }
   auto new_fcttype = llvm::FunctionType::Create(new_argument_types, new_result_types);

--- a/jlm/hls/ir/hls.hpp
+++ b/jlm/hls/ir/hls.hpp
@@ -419,12 +419,6 @@ public:
     return type;
   };
 
-  std::shared_ptr<const jlm::rvsdg::type>
-  copy() const override
-  {
-    return std::make_shared<triggertype>(*this);
-  }
-
   static std::shared_ptr<const triggertype>
   Create();
 
@@ -723,12 +717,6 @@ public:
     }
     // TODO: do something different?
     return {};
-  }
-
-  std::shared_ptr<const jlm::rvsdg::type>
-  copy() const override
-  {
-    return std::make_shared<bundletype>(*this);
   }
 
   virtual std::string

--- a/jlm/hls/ir/hls.hpp
+++ b/jlm/hls/ir/hls.hpp
@@ -23,10 +23,10 @@ namespace jlm::hls
 class branch_op final : public jlm::rvsdg::simple_op
 {
 private:
-  branch_op(size_t nalternatives, const jlm::rvsdg::type & type, bool loop)
+  branch_op(size_t nalternatives, const std::shared_ptr<const jlm::rvsdg::type> & type, bool loop)
       : jlm::rvsdg::simple_op(
-          { jlm::rvsdg::ctltype::Create(nalternatives), type.copy() },
-          { nalternatives, type.copy() }),
+          { jlm::rvsdg::ctltype::Create(nalternatives), type },
+          { nalternatives, type }),
         loop(loop)
   {}
 
@@ -63,7 +63,7 @@ public:
       throw util::error("Predicate needs to be a ctltype.");
 
     auto region = predicate.region();
-    branch_op op(ctl->nalternatives(), value.type(), loop);
+    branch_op op(ctl->nalternatives(), value.Type(), loop);
     return jlm::rvsdg::simple_node::create_normalized(region, op, { &predicate, &value });
   }
 
@@ -76,8 +76,8 @@ public:
   virtual ~fork_op()
   {}
 
-  fork_op(size_t nalternatives, const jlm::rvsdg::type & type)
-      : jlm::rvsdg::simple_op({ type.copy() }, { nalternatives, type.copy() })
+  fork_op(size_t nalternatives, const std::shared_ptr<const jlm::rvsdg::type> & type)
+      : jlm::rvsdg::simple_op({ type }, { nalternatives, type })
   {}
 
   bool
@@ -105,7 +105,7 @@ public:
   {
 
     auto region = value.region();
-    fork_op op(nalternatives, value.type());
+    fork_op op(nalternatives, value.Type());
     return jlm::rvsdg::simple_node::create_normalized(region, op, { &value });
   }
 };
@@ -116,8 +116,8 @@ public:
   virtual ~merge_op()
   {}
 
-  merge_op(size_t nalternatives, const jlm::rvsdg::type & type)
-      : jlm::rvsdg::simple_op({ nalternatives, type.copy() }, { type.copy() })
+  merge_op(size_t nalternatives, const std::shared_ptr<const jlm::rvsdg::type> & type)
+      : jlm::rvsdg::simple_op({ nalternatives, type }, { type })
   {}
 
   bool
@@ -146,7 +146,7 @@ public:
       throw util::error("Insufficient number of operands.");
 
     auto region = alternatives.front()->region();
-    merge_op op(alternatives.size(), alternatives.front()->type());
+    merge_op op(alternatives.size(), alternatives.front()->Type());
     return jlm::rvsdg::simple_node::create_normalized(region, op, alternatives);
   }
 };
@@ -157,8 +157,12 @@ public:
   virtual ~mux_op()
   {}
 
-  mux_op(size_t nalternatives, const jlm::rvsdg::type & type, bool discarding, bool loop)
-      : jlm::rvsdg::simple_op(create_typevector(nalternatives, type.copy()), { type.copy() }),
+  mux_op(
+      size_t nalternatives,
+      const std::shared_ptr<const jlm::rvsdg::type> & type,
+      bool discarding,
+      bool loop)
+      : jlm::rvsdg::simple_op(create_typevector(nalternatives, type), { type }),
         discarding(discarding),
         loop(loop)
   {}
@@ -203,7 +207,7 @@ public:
     auto operands = std::vector<jlm::rvsdg::output *>();
     operands.push_back(&predicate);
     operands.insert(operands.end(), alternatives.begin(), alternatives.end());
-    mux_op op(alternatives.size(), alternatives.front()->type(), discarding, loop);
+    mux_op op(alternatives.size(), alternatives.front()->Type(), discarding, loop);
     return jlm::rvsdg::simple_node::create_normalized(region, op, operands);
   }
 
@@ -226,8 +230,8 @@ public:
   virtual ~sink_op()
   {}
 
-  sink_op(const jlm::rvsdg::type & type)
-      : jlm::rvsdg::simple_op({ type.copy() }, {})
+  explicit sink_op(const std::shared_ptr<const jlm::rvsdg::type> & type)
+      : jlm::rvsdg::simple_op({ type }, {})
   {}
 
   bool
@@ -253,7 +257,7 @@ public:
   create(jlm::rvsdg::output & value)
   {
     auto region = value.region();
-    sink_op op(value.type());
+    sink_op op(value.Type());
     return jlm::rvsdg::simple_node::create_normalized(region, op, { &value });
   }
 };
@@ -264,8 +268,8 @@ public:
   virtual ~predicate_buffer_op()
   {}
 
-  predicate_buffer_op(const jlm::rvsdg::ctltype & type)
-      : jlm::rvsdg::simple_op({ type.copy() }, { type.copy() })
+  explicit predicate_buffer_op(const std::shared_ptr<const jlm::rvsdg::ctltype> & type)
+      : jlm::rvsdg::simple_op({ type }, { type })
   {}
 
   bool
@@ -291,10 +295,10 @@ public:
   create(jlm::rvsdg::output & predicate)
   {
     auto region = predicate.region();
-    auto ctl = dynamic_cast<const jlm::rvsdg::ctltype *>(&predicate.type());
+    auto ctl = std::dynamic_pointer_cast<const jlm::rvsdg::ctltype>(predicate.Type());
     if (!ctl)
       throw util::error("Predicate needs to be a ctltype.");
-    predicate_buffer_op op(*ctl);
+    predicate_buffer_op op(ctl);
     return jlm::rvsdg::simple_node::create_normalized(region, op, { &predicate });
   }
 };
@@ -305,8 +309,10 @@ public:
   virtual ~loop_constant_buffer_op()
   {}
 
-  loop_constant_buffer_op(const jlm::rvsdg::ctltype & ctltype, const jlm::rvsdg::type & type)
-      : jlm::rvsdg::simple_op({ ctltype.copy(), type.copy() }, { type.copy() })
+  loop_constant_buffer_op(
+      const std::shared_ptr<const jlm::rvsdg::ctltype> & ctltype,
+      const std::shared_ptr<const jlm::rvsdg::type> & type)
+      : jlm::rvsdg::simple_op({ ctltype, type }, { type })
   {}
 
   bool
@@ -333,10 +339,10 @@ public:
   create(jlm::rvsdg::output & predicate, jlm::rvsdg::output & value)
   {
     auto region = predicate.region();
-    auto ctl = dynamic_cast<const jlm::rvsdg::ctltype *>(&predicate.type());
+    auto ctl = std::dynamic_pointer_cast<const jlm::rvsdg::ctltype>(predicate.Type());
     if (!ctl)
       throw util::error("Predicate needs to be a ctltype.");
-    loop_constant_buffer_op op(*ctl, value.type());
+    loop_constant_buffer_op op(ctl, value.Type());
     return jlm::rvsdg::simple_node::create_normalized(region, op, { &predicate, &value });
   }
 };
@@ -347,8 +353,11 @@ public:
   virtual ~buffer_op()
   {}
 
-  buffer_op(const jlm::rvsdg::type & type, size_t capacity, bool pass_through)
-      : jlm::rvsdg::simple_op({ type.copy() }, { type.copy() }),
+  buffer_op(
+      const std::shared_ptr<const jlm::rvsdg::type> & type,
+      size_t capacity,
+      bool pass_through)
+      : jlm::rvsdg::simple_op({ type }, { type }),
         capacity(capacity),
         pass_through(pass_through)
   {}
@@ -377,7 +386,7 @@ public:
   create(jlm::rvsdg::output & value, size_t capacity, bool pass_through = false)
   {
     auto region = value.region();
-    buffer_op op(value.type(), capacity, pass_through);
+    buffer_op op(value.Type(), capacity, pass_through);
     return jlm::rvsdg::simple_node::create_normalized(region, op, { &value });
   }
 
@@ -416,10 +425,11 @@ public:
     return std::make_shared<triggertype>(*this);
   }
 
+  static std::shared_ptr<const triggertype>
+  Create();
+
 private:
 };
-
-const triggertype trigger;
 
 class trigger_op final : public jlm::rvsdg::simple_op
 {
@@ -427,8 +437,8 @@ public:
   virtual ~trigger_op()
   {}
 
-  trigger_op(const jlm::rvsdg::type & type)
-      : jlm::rvsdg::simple_op({ trigger.copy(), type.copy() }, { type.copy() })
+  explicit trigger_op(const std::shared_ptr<const jlm::rvsdg::type> & type)
+      : jlm::rvsdg::simple_op({ triggertype::Create(), type }, { type })
   {}
 
   bool
@@ -455,11 +465,11 @@ public:
   static std::vector<jlm::rvsdg::output *>
   create(jlm::rvsdg::output & tg, jlm::rvsdg::output & value)
   {
-    if (tg.type() != trigger)
+    if (!rvsdg::is<triggertype>(tg.Type()))
       throw util::error("Trigger needs to be a triggertype.");
 
     auto region = value.region();
-    trigger_op op(value.type());
+    trigger_op op(value.Type());
     return jlm::rvsdg::simple_node::create_normalized(region, op, { &tg, &value });
   }
 };
@@ -473,8 +483,8 @@ public:
   virtual ~print_op()
   {}
 
-  print_op(const jlm::rvsdg::type & type)
-      : jlm::rvsdg::simple_op({ type.copy() }, { type.copy() })
+  explicit print_op(const std::shared_ptr<const jlm::rvsdg::type> & type)
+      : jlm::rvsdg::simple_op({ type }, { type })
   {
     static size_t common_id{ 0 };
     _id = common_id++;
@@ -514,7 +524,7 @@ public:
   {
 
     auto region = value.region();
-    print_op op(value.type());
+    print_op op(value.Type());
     return jlm::rvsdg::simple_node::create_normalized(region, op, { &value });
   }
 };
@@ -557,15 +567,17 @@ public:
   }
 
 private:
-  backedge_argument(jlm::rvsdg::region * region, const jlm::rvsdg::type & type)
-      : jlm::rvsdg::argument(region, nullptr, type.copy()),
+  backedge_argument(
+      jlm::rvsdg::region * region,
+      const std::shared_ptr<const jlm::rvsdg::type> & type)
+      : jlm::rvsdg::argument(region, nullptr, type),
         result_(nullptr)
   {}
 
   static backedge_argument *
-  create(jlm::rvsdg::region * region, const jlm::rvsdg::type & type)
+  create(jlm::rvsdg::region * region, std::shared_ptr<const jlm::rvsdg::type> type)
   {
-    auto argument = new backedge_argument(region, type);
+    auto argument = new backedge_argument(region, std::move(type));
     region->append_argument(argument);
     return argument;
   }
@@ -645,7 +657,7 @@ public:
   set_predicate(jlm::rvsdg::output * p);
 
   backedge_argument *
-  add_backedge(const jlm::rvsdg::type & type);
+  add_backedge(std::shared_ptr<const jlm::rvsdg::type> type);
 
   jlm::rvsdg::structural_output *
   add_loopvar(jlm::rvsdg::output * origin, jlm::rvsdg::output ** buffer = nullptr);
@@ -664,7 +676,7 @@ public:
   {}
 
   bundletype(
-      const std::vector<std::pair<std::string, std::shared_ptr<const jlm::rvsdg::type>>> * elements)
+      const std::vector<std::pair<std::string, std::shared_ptr<const jlm::rvsdg::type>>> elements)
       : jlm::rvsdg::valuetype(),
         elements_(std::move(elements))
   {}
@@ -684,14 +696,14 @@ public:
   {
     auto type = dynamic_cast<const bundletype *>(&other);
     // TODO: better comparison?
-    if (!type || type->elements_->size() != elements_->size())
+    if (!type || type->elements_.size() != elements_.size())
     {
       return false;
     }
-    for (size_t i = 0; i < elements_->size(); ++i)
+    for (size_t i = 0; i < elements_.size(); ++i)
     {
-      if (type->elements_->at(i).first != elements_->at(i).first
-          || *type->elements_->at(i).second != *elements_->at(i).second)
+      if (type->elements_.at(i).first != elements_.at(i).first
+          || *type->elements_.at(i).second != *elements_.at(i).second)
       {
         return false;
       }
@@ -699,18 +711,18 @@ public:
     return true;
   };
 
-  const jlm::rvsdg::type *
+  std::shared_ptr<const jlm::rvsdg::type>
   get_element_type(std::string element) const
   {
-    for (size_t i = 0; i < elements_->size(); ++i)
+    for (size_t i = 0; i < elements_.size(); ++i)
     {
-      if (elements_->at(i).first == element)
+      if (elements_.at(i).first == element)
       {
-        return elements_->at(i).second.get();
+        return elements_.at(i).second;
       }
     }
     // TODO: do something different?
-    return nullptr;
+    return {};
   }
 
   std::shared_ptr<const jlm::rvsdg::type>
@@ -727,14 +739,14 @@ public:
 
   //        private:
   // TODO: fix memory leak
-  const std::vector<std::pair<std::string, std::shared_ptr<const jlm::rvsdg::type>>> * elements_;
+  const std::vector<std::pair<std::string, std::shared_ptr<const jlm::rvsdg::type>>> elements_;
 };
 
 std::shared_ptr<const bundletype>
-get_mem_req_type(const rvsdg::valuetype & elementType, bool write);
+get_mem_req_type(std::shared_ptr<const rvsdg::valuetype> elementType, bool write);
 
 std::shared_ptr<const bundletype>
-get_mem_res_type(const jlm::rvsdg::valuetype & dataType);
+get_mem_res_type(std::shared_ptr<const jlm::rvsdg::valuetype> dataType);
 
 class load_op final : public jlm::rvsdg::simple_op
 {
@@ -742,7 +754,7 @@ public:
   virtual ~load_op()
   {}
 
-  load_op(const rvsdg::valuetype & pointeeType, size_t numStates)
+  load_op(const std::shared_ptr<const rvsdg::valuetype> & pointeeType, size_t numStates)
       : simple_op(CreateInTypes(pointeeType, numStates), CreateOutTypes(pointeeType, numStates))
   {}
 
@@ -756,7 +768,7 @@ public:
   }
 
   static std::vector<std::shared_ptr<const jlm::rvsdg::type>>
-  CreateInTypes(const rvsdg::valuetype & pointeeType, size_t numStates)
+  CreateInTypes(std::shared_ptr<const rvsdg::valuetype> pointeeType, size_t numStates)
   {
     std::vector<std::shared_ptr<const jlm::rvsdg::type>> types(
         1,
@@ -765,14 +777,14 @@ public:
         numStates,
         llvm::MemoryStateType::Create());
     types.insert(types.end(), states.begin(), states.end());
-    types.emplace_back(pointeeType.copy()); // result
+    types.emplace_back(std::move(pointeeType)); // result
     return types;
   }
 
   static std::vector<std::shared_ptr<const jlm::rvsdg::type>>
-  CreateOutTypes(const rvsdg::valuetype & pointeeType, size_t numStates)
+  CreateOutTypes(std::shared_ptr<const rvsdg::valuetype> pointeeType, size_t numStates)
   {
-    std::vector<std::shared_ptr<const jlm::rvsdg::type>> types(1, pointeeType.copy());
+    std::vector<std::shared_ptr<const jlm::rvsdg::type>> types(1, std::move(pointeeType));
     std::vector<std::shared_ptr<const jlm::rvsdg::type>> states(
         numStates,
         llvm::MemoryStateType::Create());
@@ -800,7 +812,9 @@ public:
       jlm::rvsdg::output & load_result)
   {
     auto region = addr.region();
-    load_op op(*dynamic_cast<const rvsdg::valuetype *>(&load_result.type()), states.size());
+    load_op op(
+        std::dynamic_pointer_cast<const rvsdg::valuetype>(load_result.Type()),
+        states.size());
     std::vector<jlm::rvsdg::output *> inputs;
     inputs.push_back(&addr);
     inputs.insert(inputs.end(), states.begin(), states.end());
@@ -814,10 +828,10 @@ public:
     return *util::AssertedCast<const llvm::PointerType>(&argument(0).type());
   }
 
-  [[nodiscard]] const rvsdg::valuetype &
+  [[nodiscard]] std::shared_ptr<const rvsdg::valuetype>
   GetLoadedType() const noexcept
   {
-    return *util::AssertedCast<const rvsdg::valuetype>(&result(0).type());
+    return std::dynamic_pointer_cast<const rvsdg::valuetype>(result(0).Type());
   }
 };
 
@@ -827,7 +841,10 @@ public:
   virtual ~addr_queue_op()
   {}
 
-  addr_queue_op(const llvm::PointerType & pointerType, size_t capacity, bool combinatorial)
+  addr_queue_op(
+      const std::shared_ptr<const llvm::PointerType> & pointerType,
+      size_t capacity,
+      bool combinatorial)
       : simple_op(CreateInTypes(pointerType), CreateOutTypes(pointerType)),
         combinatorial(combinatorial),
         capacity(capacity)
@@ -843,18 +860,18 @@ public:
   }
 
   static std::vector<std::shared_ptr<const jlm::rvsdg::type>>
-  CreateInTypes(const llvm::PointerType & pointerType)
+  CreateInTypes(std::shared_ptr<const llvm::PointerType> pointerType)
   {
     // check, enq
-    std::vector<std::shared_ptr<const jlm::rvsdg::type>> types(2, pointerType.copy());
+    std::vector<std::shared_ptr<const jlm::rvsdg::type>> types(2, std::move(pointerType));
     types.emplace_back(llvm::MemoryStateType::Create()); // deq
     return types;
   }
 
   static std::vector<std::shared_ptr<const jlm::rvsdg::type>>
-  CreateOutTypes(const llvm::PointerType & pointerType)
+  CreateOutTypes(std::shared_ptr<const llvm::PointerType> pointerType)
   {
-    return { pointerType.copy() };
+    return { std::move(pointerType) };
   }
 
   std::string
@@ -882,8 +899,8 @@ public:
       size_t capacity = 10)
   {
     auto region = check.region();
-    auto pointerType = dynamic_cast<const llvm::PointerType *>(&check.type());
-    addr_queue_op op(*pointerType, capacity, combinatorial);
+    auto pointerType = std::dynamic_pointer_cast<const llvm::PointerType>(check.Type());
+    addr_queue_op op(pointerType, capacity, combinatorial);
     return jlm::rvsdg::simple_node::create_normalized(region, op, { &check, &enq, &deq })[0];
   }
 
@@ -897,7 +914,7 @@ public:
   virtual ~state_gate_op()
   {}
 
-  state_gate_op(const jlm::rvsdg::type & type, size_t numStates)
+  state_gate_op(const std::shared_ptr<const jlm::rvsdg::type> & type, size_t numStates)
       : simple_op(CreateInOutTypes(type, numStates), CreateInOutTypes(type, numStates))
   {}
 
@@ -910,9 +927,9 @@ public:
   }
 
   static std::vector<std::shared_ptr<const jlm::rvsdg::type>>
-  CreateInOutTypes(const jlm::rvsdg::type & type, size_t numStates)
+  CreateInOutTypes(const std::shared_ptr<const jlm::rvsdg::type> & type, size_t numStates)
   {
-    std::vector<std::shared_ptr<const jlm::rvsdg::type>> types(1, type.copy());
+    std::vector<std::shared_ptr<const jlm::rvsdg::type>> types(1, type);
     std::vector<std::shared_ptr<const jlm::rvsdg::type>> states(
         numStates,
         llvm::MemoryStateType::Create());
@@ -936,7 +953,7 @@ public:
   create(jlm::rvsdg::output & addr, const std::vector<jlm::rvsdg::output *> & states)
   {
     auto region = addr.region();
-    state_gate_op op(addr.type(), states.size());
+    state_gate_op op(addr.Type(), states.size());
     std::vector<jlm::rvsdg::output *> inputs;
     inputs.push_back(&addr);
     inputs.insert(inputs.end(), states.begin(), states.end());
@@ -950,7 +967,7 @@ public:
   virtual ~decoupled_load_op()
   {}
 
-  decoupled_load_op(const rvsdg::valuetype & pointeeType)
+  decoupled_load_op(const std::shared_ptr<const rvsdg::valuetype> & pointeeType)
       : simple_op(CreateInTypes(pointeeType), CreateOutTypes(pointeeType))
   {}
 
@@ -963,17 +980,17 @@ public:
   }
 
   static std::vector<std::shared_ptr<const jlm::rvsdg::type>>
-  CreateInTypes(const rvsdg::valuetype & pointeeType)
+  CreateInTypes(std::shared_ptr<const rvsdg::valuetype> pointeeType)
   {
     std::vector<std::shared_ptr<const jlm::rvsdg::type>> types(1, llvm::PointerType::Create());
-    types.emplace_back(pointeeType.copy()); // result
+    types.emplace_back(std::move(pointeeType)); // result
     return types;
   }
 
   static std::vector<std::shared_ptr<const jlm::rvsdg::type>>
-  CreateOutTypes(const rvsdg::valuetype & pointeeType)
+  CreateOutTypes(std::shared_ptr<const rvsdg::valuetype> pointeeType)
   {
-    std::vector<std::shared_ptr<const jlm::rvsdg::type>> types(1, pointeeType.copy());
+    std::vector<std::shared_ptr<const jlm::rvsdg::type>> types(1, std::move(pointeeType));
     types.emplace_back(llvm::PointerType::Create()); // addr
     return types;
   }
@@ -993,7 +1010,7 @@ public:
   static std::vector<jlm::rvsdg::output *>
   create(jlm::rvsdg::output & addr, jlm::rvsdg::output & load_result)
   {
-    decoupled_load_op op(*dynamic_cast<const rvsdg::valuetype *>(&load_result.type()));
+    decoupled_load_op op(std::dynamic_pointer_cast<const rvsdg::valuetype>(load_result.Type()));
     std::vector<jlm::rvsdg::output *> inputs;
     inputs.push_back(&addr);
     inputs.push_back(&load_result);
@@ -1006,10 +1023,10 @@ public:
     return *util::AssertedCast<const llvm::PointerType>(&argument(0).type());
   }
 
-  [[nodiscard]] const rvsdg::valuetype &
+  [[nodiscard]] std::shared_ptr<const rvsdg::valuetype>
   GetLoadedType() const noexcept
   {
-    return *util::AssertedCast<const rvsdg::valuetype>(&result(0).type());
+    return std::dynamic_pointer_cast<const rvsdg::valuetype>(result(0).Type());
   }
 };
 
@@ -1019,7 +1036,7 @@ public:
   virtual ~mem_resp_op()
   {}
 
-  mem_resp_op(const std::vector<const rvsdg::valuetype *> & output_types)
+  explicit mem_resp_op(const std::vector<std::shared_ptr<const rvsdg::valuetype>> & output_types)
       : simple_op(CreateInTypes(output_types), CreateOutTypes(output_types))
   {}
 
@@ -1033,7 +1050,7 @@ public:
   }
 
   static std::vector<std::shared_ptr<const jlm::rvsdg::type>>
-  CreateInTypes(const std::vector<const rvsdg::valuetype *> & output_types)
+  CreateInTypes(const std::vector<std::shared_ptr<const rvsdg::valuetype>> & output_types)
   {
     size_t max_width = 64;
     // TODO: calculate size onece JlmSize is moved
@@ -1043,18 +1060,18 @@ public:
     //                    max_width = sz>max_width?sz:max_width;
     //                }
     std::vector<std::shared_ptr<const jlm::rvsdg::type>> types;
-    types.emplace_back(get_mem_res_type(jlm::rvsdg::bittype(max_width)));
+    types.emplace_back(get_mem_res_type(jlm::rvsdg::bittype::Create(max_width)));
     return types;
   }
 
   static std::vector<std::shared_ptr<const jlm::rvsdg::type>>
-  CreateOutTypes(const std::vector<const rvsdg::valuetype *> & output_types)
+  CreateOutTypes(const std::vector<std::shared_ptr<const rvsdg::valuetype>> & output_types)
   {
     std::vector<std::shared_ptr<const jlm::rvsdg::type>> types;
     types.reserve(output_types.size());
     for (auto outputType : output_types)
     {
-      types.emplace_back(outputType->copy());
+      types.emplace_back(outputType);
     }
     return types;
   }
@@ -1072,7 +1089,9 @@ public:
   }
 
   static std::vector<jlm::rvsdg::output *>
-  create(rvsdg::output & result, const std::vector<const rvsdg::valuetype *> & output_types)
+  create(
+      rvsdg::output & result,
+      const std::vector<std::shared_ptr<const rvsdg::valuetype>> & output_types)
   {
     auto region = result.region();
     // TODO: verify port here
@@ -1086,46 +1105,25 @@ public:
 class mem_req_op final : public jlm::rvsdg::simple_op
 {
 public:
-  virtual ~mem_req_op()
-  {
-    delete LoadTypes_;
-    delete StoreTypes_;
-  }
+  virtual ~mem_req_op() = default;
 
   mem_req_op(
-      const std::vector<const rvsdg::valuetype *> & load_types,
-      const std::vector<const rvsdg::valuetype *> & store_types)
+      const std::vector<std::shared_ptr<const rvsdg::valuetype>> & load_types,
+      const std::vector<std::shared_ptr<const rvsdg::valuetype>> & store_types)
       : simple_op(CreateInTypes(load_types, store_types), CreateOutTypes(load_types, store_types))
   {
-    LoadTypes_ = new std::vector<std::shared_ptr<const rvsdg::type>>();
-    StoreTypes_ = new std::vector<std::shared_ptr<const rvsdg::type>>();
     for (auto loadType : load_types)
     {
-      JLM_ASSERT(
-          dynamic_cast<const rvsdg::bittype *>(loadType)
-          || dynamic_cast<const llvm::PointerType *>(loadType));
-      LoadTypes_->emplace_back(loadType->copy());
+      JLM_ASSERT(rvsdg::is<rvsdg::bittype>(loadType) || rvsdg::is<llvm::PointerType>(loadType));
+      LoadTypes_.emplace_back(loadType);
     }
     for (auto storeType : store_types)
     {
-      StoreTypes_->emplace_back(storeType->copy());
+      StoreTypes_.emplace_back(storeType);
     }
   }
 
-  mem_req_op(const mem_req_op & other)
-      : simple_op(other)
-  {
-    LoadTypes_ = new std::vector<std::shared_ptr<const rvsdg::type>>();
-    StoreTypes_ = new std::vector<std::shared_ptr<const rvsdg::type>>();
-    for (auto & loadType : *other.LoadTypes_)
-    {
-      LoadTypes_->push_back(loadType->copy());
-    }
-    for (auto & storeType : *other.StoreTypes_)
-    {
-      StoreTypes_->push_back(storeType->copy());
-    }
-  }
+  mem_req_op(const mem_req_op & other) = default;
 
   bool
   operator==(const jlm::rvsdg::operation & other) const noexcept override
@@ -1140,8 +1138,8 @@ public:
 
   static std::vector<std::shared_ptr<const jlm::rvsdg::type>>
   CreateInTypes(
-      const std::vector<const rvsdg::valuetype *> & load_types,
-      const std::vector<const rvsdg::valuetype *> & store_types)
+      const std::vector<std::shared_ptr<const rvsdg::valuetype>> & load_types,
+      const std::vector<std::shared_ptr<const rvsdg::valuetype>> & store_types)
   {
     std::vector<std::shared_ptr<const jlm::rvsdg::type>> types;
     for (size_t i = 0; i < load_types.size(); i++)
@@ -1151,15 +1149,15 @@ public:
     for (auto storeType : store_types)
     {
       types.emplace_back(llvm::PointerType::Create()); // addr
-      types.emplace_back(storeType->copy());           // data
+      types.emplace_back(storeType);                   // data
     }
     return types;
   }
 
   static std::vector<std::shared_ptr<const jlm::rvsdg::type>>
   CreateOutTypes(
-      const std::vector<const rvsdg::valuetype *> & load_types,
-      const std::vector<const rvsdg::valuetype *> & store_types)
+      const std::vector<std::shared_ptr<const rvsdg::valuetype>> & load_types,
+      const std::vector<std::shared_ptr<const rvsdg::valuetype>> & store_types)
   {
     size_t max_width = 64;
     // TODO: fix once JlmSize is moved
@@ -1173,7 +1171,8 @@ public:
     //                    max_width = sz>max_width?sz:max_width;
     //                }
     std::vector<std::shared_ptr<const jlm::rvsdg::type>> types;
-    types.emplace_back(get_mem_req_type(jlm::rvsdg::bittype(max_width), !store_types.empty()));
+    types.emplace_back(
+        get_mem_req_type(jlm::rvsdg::bittype::Create(max_width), !store_types.empty()));
     return types;
   }
 
@@ -1192,17 +1191,18 @@ public:
   static std::vector<jlm::rvsdg::output *>
   create(
       const std::vector<jlm::rvsdg::output *> & load_operands,
-      const std::vector<const rvsdg::valuetype *> & loadTypes,
+      const std::vector<std::shared_ptr<const rvsdg::valuetype>> & loadTypes,
       const std::vector<jlm::rvsdg::output *> & store_operands,
       jlm::rvsdg::region * region)
   {
     // Stores have both addr and data operand
     // But we are only interested in the data operand type
     JLM_ASSERT(store_operands.size() % 2 == 0);
-    std::vector<const rvsdg::valuetype *> storeTypes;
+    std::vector<std::shared_ptr<const rvsdg::valuetype>> storeTypes;
     for (size_t i = 1; i < store_operands.size(); i += 2)
     {
-      storeTypes.push_back(dynamic_cast<const rvsdg::valuetype *>(&store_operands[i]->type()));
+      storeTypes.push_back(
+          std::dynamic_pointer_cast<const rvsdg::valuetype>(store_operands[i]->Type()));
     }
     mem_req_op op(loadTypes, storeTypes);
     std::vector<jlm::rvsdg::output *> operands(load_operands);
@@ -1213,24 +1213,24 @@ public:
   size_t
   get_nloads() const
   {
-    return LoadTypes_->size();
+    return LoadTypes_.size();
   }
 
-  std::vector<std::shared_ptr<const rvsdg::type>> *
+  const std::vector<std::shared_ptr<const rvsdg::type>> *
   GetLoadTypes() const
   {
-    return LoadTypes_;
+    return &LoadTypes_;
   }
 
-  std::vector<std::shared_ptr<const rvsdg::type>> *
+  const std::vector<std::shared_ptr<const rvsdg::type>> *
   GetStoreTypes() const
   {
-    return StoreTypes_;
+    return &StoreTypes_;
   }
 
 private:
-  std::vector<std::shared_ptr<const rvsdg::type>> * LoadTypes_;
-  std::vector<std::shared_ptr<const rvsdg::type>> * StoreTypes_;
+  std::vector<std::shared_ptr<const rvsdg::type>> LoadTypes_;
+  std::vector<std::shared_ptr<const rvsdg::type>> StoreTypes_;
 };
 
 class store_op final : public jlm::rvsdg::simple_op
@@ -1239,7 +1239,7 @@ public:
   virtual ~store_op()
   {}
 
-  store_op(const rvsdg::valuetype & pointeeType, size_t numStates)
+  store_op(const std::shared_ptr<const rvsdg::valuetype> & pointeeType, size_t numStates)
       : simple_op(CreateInTypes(pointeeType, numStates), CreateOutTypes(pointeeType, numStates))
   {}
 
@@ -1253,10 +1253,10 @@ public:
   }
 
   static std::vector<std::shared_ptr<const jlm::rvsdg::type>>
-  CreateInTypes(const rvsdg::valuetype & pointeeType, size_t numStates)
+  CreateInTypes(const std::shared_ptr<const rvsdg::valuetype> & pointeeType, size_t numStates)
   {
     std::vector<std::shared_ptr<const jlm::rvsdg::type>> types(
-        { llvm::PointerType::Create(), pointeeType.copy() });
+        { llvm::PointerType::Create(), pointeeType });
     std::vector<std::shared_ptr<const jlm::rvsdg::type>> states(
         numStates,
         llvm::MemoryStateType::Create());
@@ -1265,13 +1265,13 @@ public:
   }
 
   static std::vector<std::shared_ptr<const jlm::rvsdg::type>>
-  CreateOutTypes(const rvsdg::valuetype & pointeeType, size_t numStates)
+  CreateOutTypes(const std::shared_ptr<const rvsdg::valuetype> & pointeeType, size_t numStates)
   {
     std::vector<std::shared_ptr<const jlm::rvsdg::type>> types(
         numStates,
         llvm::MemoryStateType::Create());
     types.emplace_back(llvm::PointerType::Create()); // addr
-    types.emplace_back(pointeeType.copy());          // data
+    types.emplace_back(pointeeType);                 // data
     return types;
   }
 
@@ -1293,7 +1293,7 @@ public:
       jlm::rvsdg::output & value,
       const std::vector<jlm::rvsdg::output *> & states)
   {
-    store_op op(*dynamic_cast<const rvsdg::valuetype *>(&value.type()), states.size());
+    store_op op(std::dynamic_pointer_cast<const rvsdg::valuetype>(value.Type()), states.size());
     std::vector<jlm::rvsdg::output *> inputs;
     inputs.push_back(&addr);
     inputs.push_back(&value);
@@ -1320,8 +1320,8 @@ public:
   virtual ~local_mem_op()
   {}
 
-  local_mem_op(const llvm::arraytype & at)
-      : simple_op({}, CreateOutTypes(at))
+  explicit local_mem_op(std::shared_ptr<const llvm::arraytype> at)
+      : simple_op({}, CreateOutTypes(std::move(at)))
   {}
 
   bool
@@ -1334,9 +1334,9 @@ public:
   }
 
   static std::vector<std::shared_ptr<const jlm::rvsdg::type>>
-  CreateOutTypes(const llvm::arraytype & at)
+  CreateOutTypes(std::shared_ptr<const llvm::arraytype> at)
   {
-    std::vector<std::shared_ptr<const jlm::rvsdg::type>> types(2, { at.copy() });
+    std::vector<std::shared_ptr<const jlm::rvsdg::type>> types(2, std::move(at));
     return types;
   }
 
@@ -1353,9 +1353,9 @@ public:
   }
 
   static std::vector<jlm::rvsdg::output *>
-  create(const jlm::llvm::arraytype & at, jlm::rvsdg::region * region)
+  create(std::shared_ptr<const jlm::llvm::arraytype> at, jlm::rvsdg::region * region)
   {
-    local_mem_op op(at);
+    local_mem_op op(std::move(at));
     return jlm::rvsdg::simple_node::create_normalized(region, op, {});
   }
 };
@@ -1366,8 +1366,8 @@ public:
   virtual ~local_mem_resp_op()
   {}
 
-  local_mem_resp_op(const jlm::llvm::arraytype & at, size_t resp_count)
-      : simple_op({ at.copy() }, CreateOutTypes(at, resp_count))
+  local_mem_resp_op(const std::shared_ptr<const jlm::llvm::arraytype> & at, size_t resp_count)
+      : simple_op({ at }, CreateOutTypes(at, resp_count))
   {}
 
   bool
@@ -1380,9 +1380,9 @@ public:
   }
 
   static std::vector<std::shared_ptr<const jlm::rvsdg::type>>
-  CreateOutTypes(const jlm::llvm::arraytype & at, size_t resp_count)
+  CreateOutTypes(const std::shared_ptr<const jlm::llvm::arraytype> & at, size_t resp_count)
   {
-    std::vector<std::shared_ptr<const jlm::rvsdg::type>> types(resp_count, at.GetElementType());
+    std::vector<std::shared_ptr<const jlm::rvsdg::type>> types(resp_count, at->GetElementType());
     return types;
   }
 
@@ -1402,8 +1402,8 @@ public:
   create(jlm::rvsdg::output & mem, size_t resp_count)
   {
     auto region = mem.region();
-    auto at = dynamic_cast<const jlm::llvm::arraytype *>(&mem.type());
-    local_mem_resp_op op(*at, resp_count);
+    auto at = std::dynamic_pointer_cast<const jlm::llvm::arraytype>(mem.Type());
+    local_mem_resp_op op(at, resp_count);
     return jlm::rvsdg::simple_node::create_normalized(region, op, { &mem });
   }
 };
@@ -1414,7 +1414,7 @@ public:
   virtual ~local_load_op()
   {}
 
-  local_load_op(const jlm::rvsdg::valuetype & valuetype, size_t numStates)
+  local_load_op(const std::shared_ptr<const jlm::rvsdg::valuetype> & valuetype, size_t numStates)
       : simple_op(CreateInTypes(valuetype, numStates), CreateOutTypes(valuetype, numStates))
   {}
 
@@ -1428,21 +1428,21 @@ public:
   }
 
   static std::vector<std::shared_ptr<const jlm::rvsdg::type>>
-  CreateInTypes(const jlm::rvsdg::valuetype & valuetype, size_t numStates)
+  CreateInTypes(const std::shared_ptr<const jlm::rvsdg::valuetype> & valuetype, size_t numStates)
   {
     std::vector<std::shared_ptr<const jlm::rvsdg::type>> types(1, jlm::rvsdg::bittype::Create(64));
     std::vector<std::shared_ptr<const jlm::rvsdg::type>> states(
         numStates,
         llvm::MemoryStateType::Create());
     types.insert(types.end(), states.begin(), states.end());
-    types.emplace_back(valuetype.copy()); // result
+    types.emplace_back(valuetype); // result
     return types;
   }
 
   static std::vector<std::shared_ptr<const jlm::rvsdg::type>>
-  CreateOutTypes(const jlm::rvsdg::valuetype & valuetype, size_t numStates)
+  CreateOutTypes(const std::shared_ptr<const jlm::rvsdg::valuetype> & valuetype, size_t numStates)
   {
-    std::vector<std::shared_ptr<const jlm::rvsdg::type>> types(1, valuetype.copy());
+    std::vector<std::shared_ptr<const jlm::rvsdg::type>> types(1, valuetype);
     std::vector<std::shared_ptr<const jlm::rvsdg::type>> states(
         numStates,
         llvm::MemoryStateType::Create());
@@ -1470,8 +1470,8 @@ public:
       jlm::rvsdg::output & load_result)
   {
     auto region = index.region();
-    auto valuetype = dynamic_cast<const jlm::rvsdg::valuetype *>(&load_result.type());
-    local_load_op op(*valuetype, states.size());
+    auto valuetype = std::dynamic_pointer_cast<const jlm::rvsdg::valuetype>(load_result.Type());
+    local_load_op op(valuetype, states.size());
     std::vector<jlm::rvsdg::output *> inputs;
     inputs.push_back(&index);
     inputs.insert(inputs.end(), states.begin(), states.end());
@@ -1479,10 +1479,10 @@ public:
     return jlm::rvsdg::simple_node::create_normalized(region, op, inputs);
   }
 
-  [[nodiscard]] const rvsdg::valuetype &
+  [[nodiscard]] std::shared_ptr<const rvsdg::valuetype>
   GetLoadedType() const noexcept
   {
-    return *util::AssertedCast<const rvsdg::valuetype>(&result(0).type());
+    return std::dynamic_pointer_cast<const rvsdg::valuetype>(result(0).Type());
   }
 };
 
@@ -1492,7 +1492,7 @@ public:
   virtual ~local_store_op()
   {}
 
-  local_store_op(const jlm::rvsdg::valuetype & valuetype, size_t numStates)
+  local_store_op(const std::shared_ptr<const jlm::rvsdg::valuetype> & valuetype, size_t numStates)
       : simple_op(CreateInTypes(valuetype, numStates), CreateOutTypes(valuetype, numStates))
   {}
 
@@ -1506,10 +1506,10 @@ public:
   }
 
   static std::vector<std::shared_ptr<const jlm::rvsdg::type>>
-  CreateInTypes(const jlm::rvsdg::valuetype & valuetype, size_t numStates)
+  CreateInTypes(const std::shared_ptr<const jlm::rvsdg::valuetype> & valuetype, size_t numStates)
   {
     std::vector<std::shared_ptr<const jlm::rvsdg::type>> types(
-        { jlm::rvsdg::bittype::Create(64), valuetype.copy() });
+        { jlm::rvsdg::bittype::Create(64), valuetype });
     std::vector<std::shared_ptr<const jlm::rvsdg::type>> states(
         numStates,
         llvm::MemoryStateType::Create());
@@ -1518,13 +1518,13 @@ public:
   }
 
   static std::vector<std::shared_ptr<const jlm::rvsdg::type>>
-  CreateOutTypes(const jlm::rvsdg::valuetype & valuetype, size_t numStates)
+  CreateOutTypes(const std::shared_ptr<const jlm::rvsdg::valuetype> & valuetype, size_t numStates)
   {
     std::vector<std::shared_ptr<const jlm::rvsdg::type>> types(
         numStates,
         llvm::MemoryStateType::Create());
     types.emplace_back(jlm::rvsdg::bittype::Create(64)); // addr
-    types.emplace_back(valuetype.copy());                // data
+    types.emplace_back(valuetype);                       // data
     return types;
   }
 
@@ -1547,8 +1547,8 @@ public:
       const std::vector<jlm::rvsdg::output *> & states)
   {
     auto region = index.region();
-    auto valuetype = dynamic_cast<const jlm::rvsdg::valuetype *>(&value.type());
-    local_store_op op(*valuetype, states.size());
+    auto valuetype = std::dynamic_pointer_cast<const jlm::rvsdg::valuetype>(value.Type());
+    local_store_op op(valuetype, states.size());
     std::vector<jlm::rvsdg::output *> inputs;
     inputs.push_back(&index);
     inputs.push_back(&value);
@@ -1569,7 +1569,10 @@ public:
   virtual ~local_mem_req_op()
   {}
 
-  local_mem_req_op(const jlm::llvm::arraytype & at, size_t load_cnt, size_t store_cnt)
+  local_mem_req_op(
+      const std::shared_ptr<const jlm::llvm::arraytype> & at,
+      size_t load_cnt,
+      size_t store_cnt)
       : simple_op(CreateInTypes(at, load_cnt, store_cnt), {})
   {}
 
@@ -1585,9 +1588,12 @@ public:
   }
 
   static std::vector<std::shared_ptr<const jlm::rvsdg::type>>
-  CreateInTypes(const jlm::llvm::arraytype & at, size_t load_cnt, size_t store_cnt)
+  CreateInTypes(
+      const std::shared_ptr<const jlm::llvm::arraytype> & at,
+      size_t load_cnt,
+      size_t store_cnt)
   {
-    std::vector<std::shared_ptr<const jlm::rvsdg::type>> types(1, at.copy());
+    std::vector<std::shared_ptr<const jlm::rvsdg::type>> types(1, at);
     for (size_t i = 0; i < load_cnt; ++i)
     {
       types.emplace_back(jlm::rvsdg::bittype::Create(64)); // addr
@@ -1595,7 +1601,7 @@ public:
     for (size_t i = 0; i < store_cnt; ++i)
     {
       types.emplace_back(jlm::rvsdg::bittype::Create(64)); // addr
-      types.emplace_back(at.GetElementType());             // data
+      types.emplace_back(at->GetElementType());            // data
     }
     return types;
   }
@@ -1619,9 +1625,9 @@ public:
       const std::vector<jlm::rvsdg::output *> & store_operands)
   {
     auto region = mem.region();
-    auto at = dynamic_cast<const jlm::llvm::arraytype *>(&mem.type());
+    auto at = std::dynamic_pointer_cast<const jlm::llvm::arraytype>(mem.Type());
     JLM_ASSERT(store_operands.size() % 2 == 0);
-    local_mem_req_op op(*at, load_operands.size(), store_operands.size() / 2);
+    local_mem_req_op op(at, load_operands.size(), store_operands.size() / 2);
     std::vector<jlm::rvsdg::output *> operands(1, &mem);
     operands.insert(operands.end(), load_operands.begin(), load_operands.end());
     operands.insert(operands.end(), store_operands.begin(), store_operands.end());

--- a/jlm/llvm/backend/rvsdg2jlm/rvsdg2jlm.cpp
+++ b/jlm/llvm/backend/rvsdg2jlm/rvsdg2jlm.cpp
@@ -52,17 +52,17 @@ public:
 namespace rvsdg2jlm
 {
 
-static const FunctionType *
+static std::shared_ptr<const FunctionType>
 is_function_import(const rvsdg::argument * argument)
 {
   JLM_ASSERT(argument->region()->graph()->root() == argument->region());
 
   if (auto rvsdgImport = dynamic_cast<const impport *>(&argument->port()))
   {
-    return dynamic_cast<const FunctionType *>(&rvsdgImport->GetValueType());
+    return std::dynamic_pointer_cast<const FunctionType>(rvsdgImport->Type());
   }
 
-  return nullptr;
+  return {};
 }
 
 static std::unique_ptr<data_node_init>
@@ -558,11 +558,7 @@ convert_imports(const rvsdg::graph & graph, ipgraph_module & im, context & ctx)
     auto import = static_cast<const llvm::impport *>(&argument->port());
     if (auto ftype = is_function_import(argument))
     {
-      auto f = function_node::create(
-          ipg,
-          import->name(),
-          std::static_pointer_cast<const FunctionType>(ftype->copy()),
-          import->linkage());
+      auto f = function_node::create(ipg, import->name(), ftype, import->linkage());
       auto v = im.create_variable(f);
       ctx.insert(argument, v);
     }

--- a/jlm/llvm/frontend/ControlFlowRestructuring.cpp
+++ b/jlm/llvm/frontend/ControlFlowRestructuring.cpp
@@ -67,27 +67,27 @@ reinsert_tcloop(const tcloop & l)
 }
 
 static const tacvariable *
-create_pvariable(basic_block & bb, const rvsdg::ctltype & type)
+create_pvariable(basic_block & bb, std::shared_ptr<const rvsdg::ctltype> type)
 {
   static size_t c = 0;
   auto name = util::strfmt("#p", c++, "#");
-  return bb.insert_before_branch(UndefValueOperation::Create(type.copy(), name))->result(0);
+  return bb.insert_before_branch(UndefValueOperation::Create(std::move(type), name))->result(0);
 }
 
 static const tacvariable *
-create_qvariable(basic_block & bb, const rvsdg::ctltype & type)
+create_qvariable(basic_block & bb, std::shared_ptr<const rvsdg::ctltype> type)
 {
   static size_t c = 0;
   auto name = util::strfmt("#q", c++, "#");
-  return bb.append_last(UndefValueOperation::Create(type.copy(), name))->result(0);
+  return bb.append_last(UndefValueOperation::Create(std::move(type), name))->result(0);
 }
 
 static const tacvariable *
-create_tvariable(basic_block & bb, const rvsdg::ctltype & type)
+create_tvariable(basic_block & bb, std::shared_ptr<const rvsdg::ctltype> type)
 {
   static size_t c = 0;
   auto name = util::strfmt("#q", c++, "#");
-  return bb.insert_before_branch(UndefValueOperation::Create(type.copy(), name))->result(0);
+  return bb.insert_before_branch(UndefValueOperation::Create(std::move(type), name))->result(0);
 }
 
 static const tacvariable *
@@ -261,14 +261,14 @@ restructure_loops(cfg_node * entry, cfg_node * exit, std::vector<tcloop> & loops
     if (sccstruct->nenodes() > 1)
     {
       auto bb = find_tvariable_bb(entry);
-      ev = create_tvariable(*bb, rvsdg::ctltype(sccstruct->nenodes()));
+      ev = create_tvariable(*bb, rvsdg::ctltype::Create(sccstruct->nenodes()));
     }
 
     auto rv = create_rvariable(*new_ne);
 
     const tacvariable * xv = nullptr;
     if (sccstruct->nxnodes() > 1)
-      xv = create_qvariable(*new_ne, rvsdg::ctltype(sccstruct->nxnodes()));
+      xv = create_qvariable(*new_ne, rvsdg::ctltype::Create(sccstruct->nxnodes()));
 
     append_branch(new_nr, rv);
 
@@ -427,7 +427,7 @@ restructure_branches(cfg_node * entry, cfg_node * exit)
   }
 
   /* insert new continuation point */
-  auto p = create_pvariable(hbb, rvsdg::ctltype(c.points.size()));
+  auto p = create_pvariable(hbb, rvsdg::ctltype::Create(c.points.size()));
   auto cn = basic_block::create(cfg);
   append_branch(cn, p);
   std::unordered_map<cfg_node *, size_t> indices;

--- a/jlm/llvm/ir/types.cpp
+++ b/jlm/llvm/ir/types.cpp
@@ -78,12 +78,6 @@ FunctionType::operator==(const jlm::rvsdg::type & _other) const noexcept
   return true;
 }
 
-std::shared_ptr<const jlm::rvsdg::type>
-FunctionType::copy() const
-{
-  return std::make_shared<FunctionType>(*this);
-}
-
 FunctionType &
 FunctionType::operator=(const FunctionType & rhs) = default;
 
@@ -117,12 +111,6 @@ PointerType::operator==(const jlm::rvsdg::type & other) const noexcept
   return jlm::rvsdg::is<PointerType>(other);
 }
 
-std::shared_ptr<const jlm::rvsdg::type>
-PointerType::copy() const
-{
-  return std::make_shared<PointerType>(*this);
-}
-
 std::shared_ptr<const PointerType>
 PointerType::Create()
 {
@@ -148,12 +136,6 @@ arraytype::operator==(const jlm::rvsdg::type & other) const noexcept
   return type && type->element_type() == element_type() && type->nelements() == nelements();
 }
 
-std::shared_ptr<const jlm::rvsdg::type>
-arraytype::copy() const
-{
-  return std::make_shared<arraytype>(*this);
-}
-
 /* floating point type */
 
 fptype::~fptype()
@@ -176,12 +158,6 @@ fptype::operator==(const jlm::rvsdg::type & other) const noexcept
 {
   auto type = dynamic_cast<const fptype *>(&other);
   return type && type->size() == size();
-}
-
-std::shared_ptr<const jlm::rvsdg::type>
-fptype::copy() const
-{
-  return std::make_shared<fptype>(*this);
 }
 
 std::shared_ptr<const fptype>
@@ -233,12 +209,6 @@ varargtype::debug_string() const
   return "vararg";
 }
 
-std::shared_ptr<const jlm::rvsdg::type>
-varargtype::copy() const
-{
-  return std::make_shared<varargtype>(*this);
-}
-
 std::shared_ptr<const varargtype>
 varargtype::Create()
 {
@@ -260,12 +230,6 @@ std::string
 StructType::debug_string() const
 {
   return "struct";
-}
-
-std::shared_ptr<const jlm::rvsdg::type>
-StructType::copy() const
-{
-  return std::make_shared<StructType>(*this);
 }
 
 /* vectortype */
@@ -294,12 +258,6 @@ fixedvectortype::debug_string() const
   return util::strfmt("fixedvector[", type().debug_string(), ":", size(), "]");
 }
 
-std::shared_ptr<const jlm::rvsdg::type>
-fixedvectortype::copy() const
-{
-  return std::make_shared<fixedvectortype>(*this);
-}
-
 /* scalablevectortype */
 
 scalablevectortype::~scalablevectortype()
@@ -317,12 +275,6 @@ scalablevectortype::debug_string() const
   return util::strfmt("scalablevector[", type().debug_string(), ":", size(), "]");
 }
 
-std::shared_ptr<const jlm::rvsdg::type>
-scalablevectortype::copy() const
-{
-  return std::make_shared<scalablevectortype>(*this);
-}
-
 /* I/O state type */
 
 iostatetype::~iostatetype()
@@ -338,12 +290,6 @@ std::string
 iostatetype::debug_string() const
 {
   return "iostate";
-}
-
-std::shared_ptr<const jlm::rvsdg::type>
-iostatetype::copy() const
-{
-  return std::make_shared<iostatetype>(*this);
 }
 
 std::shared_ptr<const iostatetype>
@@ -368,12 +314,6 @@ bool
 MemoryStateType::operator==(const jlm::rvsdg::type & other) const noexcept
 {
   return jlm::rvsdg::is<MemoryStateType>(other);
-}
-
-std::shared_ptr<const jlm::rvsdg::type>
-MemoryStateType::copy() const
-{
-  return std::make_shared<MemoryStateType>(*this);
 }
 
 std::shared_ptr<const MemoryStateType>

--- a/jlm/llvm/ir/types.hpp
+++ b/jlm/llvm/ir/types.hpp
@@ -76,9 +76,6 @@ public:
   bool
   operator==(const jlm::rvsdg::type & other) const noexcept override;
 
-  std::shared_ptr<const jlm::rvsdg::type>
-  copy() const override;
-
   static std::shared_ptr<const FunctionType>
   Create(
       std::vector<std::shared_ptr<const jlm::rvsdg::type>> argumentTypes,
@@ -105,9 +102,6 @@ public:
 
   bool
   operator==(const jlm::rvsdg::type & other) const noexcept override;
-
-  [[nodiscard]] std::shared_ptr<const jlm::rvsdg::type>
-  copy() const override;
 
   static std::shared_ptr<const PointerType>
   Create();
@@ -141,9 +135,6 @@ public:
 
   virtual bool
   operator==(const jlm::rvsdg::type & other) const noexcept override;
-
-  std::shared_ptr<const jlm::rvsdg::type>
-  copy() const override;
 
   inline size_t
   nelements() const noexcept
@@ -200,9 +191,6 @@ public:
   virtual bool
   operator==(const jlm::rvsdg::type & other) const noexcept override;
 
-  std::shared_ptr<const jlm::rvsdg::type>
-  copy() const override;
-
   inline const fpsize &
   size() const noexcept
   {
@@ -229,9 +217,6 @@ public:
 
   virtual bool
   operator==(const jlm::rvsdg::type & other) const noexcept override;
-
-  std::shared_ptr<const jlm::rvsdg::type>
-  copy() const override;
 
   virtual std::string
   debug_string() const override;
@@ -312,9 +297,6 @@ public:
 
   bool
   operator==(const jlm::rvsdg::type & other) const noexcept override;
-
-  [[nodiscard]] std::shared_ptr<const jlm::rvsdg::type>
-  copy() const override;
 
   [[nodiscard]] std::string
   debug_string() const override;
@@ -455,9 +437,6 @@ public:
   virtual bool
   operator==(const jlm::rvsdg::type & other) const noexcept override;
 
-  std::shared_ptr<const jlm::rvsdg::type>
-  copy() const override;
-
   virtual std::string
   debug_string() const override;
 
@@ -479,9 +458,6 @@ public:
 
   virtual bool
   operator==(const jlm::rvsdg::type & other) const noexcept override;
-
-  std::shared_ptr<const jlm::rvsdg::type>
-  copy() const override;
 
   virtual std::string
   debug_string() const override;
@@ -507,9 +483,6 @@ public:
 
   virtual bool
   operator==(const jlm::rvsdg::type & other) const noexcept override;
-
-  std::shared_ptr<const jlm::rvsdg::type>
-  copy() const override;
 
   virtual std::string
   debug_string() const override;
@@ -537,9 +510,6 @@ public:
 
   bool
   operator==(const jlm::rvsdg::type & other) const noexcept override;
-
-  std::shared_ptr<const jlm::rvsdg::type>
-  copy() const override;
 
   static std::shared_ptr<const MemoryStateType>
   Create();

--- a/jlm/mlir/frontend/MlirToJlmConverter.cpp
+++ b/jlm/mlir/frontend/MlirToJlmConverter.cpp
@@ -422,12 +422,12 @@ MlirToJlmConverter::ConvertLambda(::mlir::Operation & mlirLambda, rvsdg::region 
   std::vector<std::shared_ptr<const rvsdg::type>> argumentTypes;
   for (auto argumentType : lambdaRefType.getParameterTypes())
   {
-    argumentTypes.push_back(ConvertType(argumentType)->copy());
+    argumentTypes.push_back(ConvertType(argumentType));
   }
   std::vector<std::shared_ptr<const rvsdg::type>> resultTypes;
   for (auto returnType : lambdaRefType.getReturnTypes())
   {
-    resultTypes.push_back(ConvertType(returnType)->copy());
+    resultTypes.push_back(ConvertType(returnType));
   }
   auto functionType = llvm::FunctionType::Create(std::move(argumentTypes), std::move(resultTypes));
 

--- a/jlm/rvsdg/bitstring/slice.cpp
+++ b/jlm/rvsdg/bitstring/slice.cpp
@@ -106,7 +106,7 @@ bitslice_op::copy() const
 jlm::rvsdg::output *
 bitslice(jlm::rvsdg::output * argument, size_t low, size_t high)
 {
-  auto & type = dynamic_cast<const jlm::rvsdg::bittype &>(argument->type());
+  auto type = std::dynamic_pointer_cast<const jlm::rvsdg::bittype>(argument->Type());
   jlm::rvsdg::bitslice_op op(type, low, high);
   return jlm::rvsdg::simple_node::create_normalized(argument->region(), op, { argument })[0];
 }

--- a/jlm/rvsdg/bitstring/slice.hpp
+++ b/jlm/rvsdg/bitstring/slice.hpp
@@ -19,8 +19,11 @@ class bitslice_op : public jlm::rvsdg::unary_op
 public:
   virtual ~bitslice_op() noexcept;
 
-  inline bitslice_op(const bittype & argument, size_t low, size_t high) noexcept
-      : unary_op(argument.copy(), bittype::Create(high - low)),
+  inline bitslice_op(
+      const std::shared_ptr<const bittype> & argument,
+      size_t low,
+      size_t high) noexcept
+      : unary_op(argument, bittype::Create(high - low)),
         low_(low)
   {}
 

--- a/jlm/rvsdg/bitstring/type.cpp
+++ b/jlm/rvsdg/bitstring/type.cpp
@@ -28,12 +28,6 @@ bittype::operator==(const jlm::rvsdg::type & other) const noexcept
   return type != nullptr && this->nbits() == type->nbits();
 }
 
-std::shared_ptr<const jlm::rvsdg::type>
-bittype::copy() const
-{
-  return std::make_shared<bittype>(nbits_);
-}
-
 std::shared_ptr<const bittype>
 bittype::Create(std::size_t nbits)
 {

--- a/jlm/rvsdg/bitstring/type.hpp
+++ b/jlm/rvsdg/bitstring/type.hpp
@@ -36,9 +36,6 @@ public:
   virtual bool
   operator==(const jlm::rvsdg::type & other) const noexcept override;
 
-  std::shared_ptr<const jlm::rvsdg::type>
-  copy() const override;
-
   /**
    * \brief Creates bit type of specified width
    *

--- a/jlm/rvsdg/control.cpp
+++ b/jlm/rvsdg/control.cpp
@@ -38,12 +38,6 @@ ctltype::operator==(const jlm::rvsdg::type & other) const noexcept
   return type && type->nalternatives_ == nalternatives_;
 }
 
-std::shared_ptr<const jlm::rvsdg::type>
-ctltype::copy() const
-{
-  return std::make_shared<ctltype>(*this);
-}
-
 std::shared_ptr<const ctltype>
 ctltype::Create(std::size_t nalternatives)
 {

--- a/jlm/rvsdg/control.hpp
+++ b/jlm/rvsdg/control.hpp
@@ -35,9 +35,6 @@ public:
   virtual bool
   operator==(const jlm::rvsdg::type & other) const noexcept override;
 
-  std::shared_ptr<const jlm::rvsdg::type>
-  copy() const override;
-
   inline size_t
   nalternatives() const noexcept
   {

--- a/jlm/rvsdg/type.hpp
+++ b/jlm/rvsdg/type.hpp
@@ -32,9 +32,6 @@ public:
     return !(*this == other);
   }
 
-  virtual std::shared_ptr<const type>
-  copy() const = 0;
-
   virtual std::string
   debug_string() const = 0;
 };

--- a/tests/test-types.cpp
+++ b/tests/test-types.cpp
@@ -25,12 +25,6 @@ valuetype::operator==(const rvsdg::type & other) const noexcept
   return dynamic_cast<const valuetype *>(&other) != nullptr;
 }
 
-std::shared_ptr<const jlm::rvsdg::type>
-valuetype::copy() const
-{
-  return std::make_shared<valuetype>(*this);
-}
-
 std::shared_ptr<const valuetype>
 valuetype::Create()
 {
@@ -53,12 +47,6 @@ bool
 statetype::operator==(const rvsdg::type & other) const noexcept
 {
   return dynamic_cast<const statetype *>(&other) != nullptr;
-}
-
-std::shared_ptr<const jlm::rvsdg::type>
-statetype::copy() const
-{
-  return std::make_shared<statetype>(*this);
 }
 
 std::shared_ptr<const statetype>

--- a/tests/test-types.hpp
+++ b/tests/test-types.hpp
@@ -26,9 +26,6 @@ public:
   virtual bool
   operator==(const rvsdg::type & other) const noexcept override;
 
-  std::shared_ptr<const jlm::rvsdg::type>
-  copy() const override;
-
   static std::shared_ptr<const valuetype>
   Create();
 };
@@ -47,9 +44,6 @@ public:
 
   virtual bool
   operator==(const rvsdg::type & other) const noexcept override;
-
-  std::shared_ptr<const jlm::rvsdg::type>
-  copy() const override;
 
   static std::shared_ptr<const statetype>
   Create();


### PR DESCRIPTION
Remove type copying from all remaining places, convert HLS ops. Remove
the "copy" member function from all type classes. This concludes the transition
to use shared references for types, although some API cleanup is stilll desired.