### PR TITLE
New firrtl2verilog HLS backend

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -112,7 +112,44 @@ CXXFLAGS_NO_COMMENT=""
 if [ "${ENABLE_HLS}" == "yes" ] ; then
 	CPPFLAGS_CIRCT="-I${CIRCT_PATH}/include"
 	CXXFLAGS_NO_COMMENT="-Wno-error=comment"
-	CIRCT_LDFLAGS="-L${CIRCT_PATH}/lib -lMLIR -lCIRCTAnalysisTestPasses -lCIRCTDependenceAnalysis -lCIRCTExportFIRRTL -lCIRCTFIRRTL -lCIRCTFIRRTLTransforms -lCIRCTScheduling -lCIRCTSchedulingAnalysis -lCIRCTSeq -lCIRCTSupport -lCIRCTTransforms -lCIRCTHW -lCIRCTOM"
+	CIRCT_LDFLAGS_ARRAY=(
+		"-L${CIRCT_PATH}/lib"
+		"-lMLIR"
+		"-lMLIRBytecodeReader"
+		"-lMLIRBytecodeWriter"
+		"-lMLIRParser"
+		"-lMLIRSupport"
+		"-lMLIRIR"
+		"-lMLIROptLib"
+		"-lMLIRFuncDialect"
+		"-lMLIRTransforms"
+		"-lCIRCTAnalysisTestPasses"
+		"-lCIRCTDependenceAnalysis"
+		"-lCIRCTExportFIRRTL"
+		"-lCIRCTScheduling"
+		"-lCIRCTSchedulingAnalysis"
+		"-lCIRCTFirtool"
+		"-lCIRCTFIRRTLReductions"
+		"-lCIRCTFIRRTLToHW"
+		"-lCIRCTExportVerilog"
+		"-lCIRCTImportFIRFile"
+		"-lCIRCTFIRRTLTransforms"
+		"-lCIRCTHWTransforms"
+		"-lCIRCTSVTransforms"
+		"-lCIRCTTransforms"
+		"-lCIRCTSV"
+		"-lCIRCTComb"
+		"-lCIRCTLTL"
+		"-lCIRCTVerif"
+		"-lCIRCTFIRRTL"
+		"-lCIRCTSeq"
+		"-lCIRCTSeqTransforms"
+		"-lCIRCTHW"
+		"-lCIRCTVerifToSV"
+		"-lCIRCTExportChiselInterface"
+		"-lCIRCTOM"
+		"-lCIRCTSupport"
+	)
 fi
 
 CPPFLAGS_MLIR=""
@@ -137,7 +174,7 @@ CXXFLAGS=${CXXFLAGS-} ${CXXFLAGS_COMMON} ${CXXFLAGS_TARGET} ${CXXFLAGS_NO_COMMEN
 CPPFLAGS=${CPPFLAGS-} ${CPPFLAGS_COMMON} ${CPPFLAGS_LLVM} ${CPPFLAGS_ASSERTS} ${CPPFLAGS_CIRCT} ${CPPFLAGS_MLIR}
 ENABLE_HLS=${ENABLE_HLS}
 CIRCT_PATH=${CIRCT_PATH}
-CIRCT_LDFLAGS=${CIRCT_LDFLAGS}
+CIRCT_LDFLAGS=${CIRCT_LDFLAGS_ARRAY[*]}
 ENABLE_MLIR=${ENABLE_MLIR}
 MLIR_PATH=${MLIR_PATH}
 MLIR_LDFLAGS=${MLIR_LDFLAGS}

--- a/jlm/hls/Makefile.sub
+++ b/jlm/hls/Makefile.sub
@@ -2,6 +2,8 @@
 # See COPYING for terms of redistribution.
 
 libhls_SOURCES = \
+    jlm/hls/backend/firrtl2verilog/FirrtlToVerilogConverter.cpp \
+    \
     jlm/hls/backend/rhls2firrtl/base-hls.cpp \
     jlm/hls/backend/rhls2firrtl/dot-hls.cpp \
     jlm/hls/backend/rhls2firrtl/firrtl-hls.cpp \

--- a/jlm/hls/Makefile.sub
+++ b/jlm/hls/Makefile.sub
@@ -38,7 +38,7 @@ libhls_SOURCES = \
     jlm/hls/util/view.cpp \
 
 libhls_HEADERS = \
-    jlm/hls/backend/firrtl2verilog/FirrtlToVerilogConverter.hpp \
+	jlm/hls/backend/firrtl2verilog/FirrtlToVerilogConverter.hpp \
 	\
 	jlm/hls/backend/rhls2firrtl/base-hls.hpp \
 	jlm/hls/backend/rhls2firrtl/dot-hls.hpp \

--- a/jlm/hls/Makefile.sub
+++ b/jlm/hls/Makefile.sub
@@ -38,7 +38,7 @@ libhls_SOURCES = \
     jlm/hls/util/view.cpp \
 
 libhls_HEADERS = \
-        jlm/hls/backend/firrtl2verilog/FirrtlToVerilogConverter.cpp \
+    jlm/hls/backend/firrtl2verilog/FirrtlToVerilogConverter.hpp \
 	\
 	jlm/hls/backend/rhls2firrtl/base-hls.hpp \
 	jlm/hls/backend/rhls2firrtl/dot-hls.hpp \

--- a/jlm/hls/Makefile.sub
+++ b/jlm/hls/Makefile.sub
@@ -38,6 +38,8 @@ libhls_SOURCES = \
     jlm/hls/util/view.cpp \
 
 libhls_HEADERS = \
+        jlm/hls/backend/firrtl2verilog/FirrtlToVerilogConverter.cpp \
+	\
 	jlm/hls/backend/rhls2firrtl/base-hls.hpp \
 	jlm/hls/backend/rhls2firrtl/dot-hls.hpp \
 	jlm/hls/backend/rhls2firrtl/firrtl-hls.hpp \

--- a/jlm/hls/backend/firrtl2verilog/FirrtlToVerilogConverter.cpp
+++ b/jlm/hls/backend/firrtl2verilog/FirrtlToVerilogConverter.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2024 Magnus Sjalander <work@sjalander.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <jlm/hls/backend/firrtl2verilog/FirrtlToVerilogConverter.hpp>
+
+#include <circt/Conversion/ExportVerilog.h>
+#include <circt/Dialect/FIRRTL/FIRParser.h>
+#include <circt/Dialect/HW/HWOps.h>
+#include <circt/Dialect/SV/SVPasses.h>
+#include <circt/Firtool/Firtool.h>
+#include <llvm/Support/SourceMgr.h>
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/Support/FileUtilities.h>
+
+namespace jlm::hls
+{
+
+using namespace circt;
+using namespace llvm;
+
+bool
+FirrtlToVerilogConverter::Convert(
+    const util::filepath inputFirrtlFile,
+    const util::filepath outputVerilogFile)
+{
+  mlir::MLIRContext context;
+  mlir::TimingScope ts;
+
+  // Set up and read the input FIRRTL file
+  std::string errorMessage;
+  auto input = mlir::openInputFile(inputFirrtlFile.to_str(), &errorMessage);
+  if (!input)
+  {
+    std::cerr << errorMessage << std::endl;
+    return false;
+  }
+  llvm::SourceMgr sourceMgr;
+  sourceMgr.AddNewSourceBuffer(std::move(input), llvm::SMLoc());
+  mlir::SourceMgrDiagnosticVerifierHandler sourceMgrHandler(sourceMgr, &context);
+
+  firrtl::FIRParserOptions options;
+  options.infoLocatorHandling = firrtl::FIRParserOptions::InfoLocHandling::IgnoreInfo;
+  options.numAnnotationFiles = 0;
+  options.scalarizeExtModules = true;
+  auto module = importFIRFile(sourceMgr, &context, ts, options);
+  if (!module)
+  {
+    std::cerr << "Failed to parse FIRRTL input" << std::endl;
+    return false;
+  }
+
+  // Manually set up the options for the firtool
+  cl::OptionCategory mainCategory("firtool Options");
+  firtool::FirtoolOptions firtoolOptions(mainCategory);
+  firtoolOptions.preserveAggregate = firrtl::PreserveAggregate::PreserveMode::None;
+  firtoolOptions.preserveMode = firrtl::PreserveValues::PreserveMode::None;
+  firtoolOptions.buildMode = firtool::FirtoolOptions::BuildModeRelease;
+  firtoolOptions.exportChiselInterface = false;
+
+  // Populate the pass manager and apply them to the module
+  mlir::PassManager pm(&context);
+
+  // Firtool sets a blackBoxRoot based on the inputFilename path, but this functionality is not used
+  // so we set it to an empty string (the final argument)
+  if (failed(firtool::populateCHIRRTLToLowFIRRTL(pm, firtoolOptions, *module, "")))
+  {
+    std::cerr << "Failed to populate CHIRRTL to LowFIRRTL" << std::endl;
+    return false;
+  }
+  if (failed(firtool::populateLowFIRRTLToHW(pm, firtoolOptions)))
+  {
+    std::cerr << "Failed to populate LowFIRRTL to HW" << std::endl;
+    return false;
+  }
+  if (failed(firtool::populateHWToSV(pm, firtoolOptions)))
+  {
+    std::cerr << "Failed to populate HW to SV" << std::endl;
+    return false;
+  }
+
+  if (failed(pm.run(module.get())))
+  {
+    std::cerr << "Failed to run pass manager" << std::endl;
+    return false;
+  }
+
+  mlir::PassManager exportPm(&context);
+
+  // Legalize unsupported operations within the modules.
+  exportPm.nest<hw::HWModuleOp>().addPass(sv::createHWLegalizeModulesPass());
+
+  // Tidy up the IR to improve verilog emission quality.
+  exportPm.nest<hw::HWModuleOp>().addPass(sv::createPrettifyVerilogPass());
+
+  std::error_code errorCode;
+  llvm::raw_fd_ostream os(outputVerilogFile.to_str(), errorCode);
+  exportPm.addPass(createExportVerilogPass(os));
+
+  if (failed(exportPm.run(module.get())))
+  {
+    std::cerr << "Failed to run export pass manager" << std::endl;
+    return false;
+  }
+
+  (void)module.release();
+  return true;
+}
+
+} // namespace jlm::hls

--- a/jlm/hls/backend/firrtl2verilog/FirrtlToVerilogConverter.hpp
+++ b/jlm/hls/backend/firrtl2verilog/FirrtlToVerilogConverter.hpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2024 Magnus Sjalander <work@sjalander.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#ifndef JLM_HLS_BACKEND_FIRRTL2VERILOG_FIRRTLTOVERILOGCONVERTER_HPP
+#define JLM_HLS_BACKEND_FIRRTL2VERILOG_FIRRTLTOVERILOGCONVERTER_HPP
+
+#include <jlm/util/file.hpp>
+
+#include <circt/Conversion/ExportVerilog.h>
+#include <circt/Dialect/FIRRTL/FIRParser.h>
+#include <circt/Dialect/HW/HWOps.h>
+#include <circt/Dialect/SV/SVPasses.h>
+#include <circt/Firtool/Firtool.h>
+#include <llvm/Support/SourceMgr.h>
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/Support/FileUtilities.h>
+
+namespace jlm::hls
+{
+
+using namespace circt;
+using namespace llvm;
+
+/**
+ * Converts FIRRTL to Verilog by reading FIRRTL from a file and writing the converted Verilog to another file.
+ * The functionality is heavily inspired by the processBuffer() function of the firtool in the CIRCT project.
+ *
+ * \param inputFirrtlFile The complete path to the FIRRTL file to convert to Verilog.
+ * \param outputVerilogFile The complete path to the Verilog file to write the converted Verilog to.
+ */
+static void
+FirrtlToVerilogConverter(const std::string inputFirrtlFile, const std::string outputVerilogFile)
+{
+  mlir::MLIRContext context;
+  mlir::TimingScope ts;
+
+  // Set up and read the input FIRRTL file
+  std::string errorMessage;
+  auto input = mlir::openInputFile(inputFirrtlFile, &errorMessage);
+  if (!input) {
+    llvm::errs() << errorMessage << "\n";
+    exit(1);
+  }
+  llvm::SourceMgr sourceMgr;
+  sourceMgr.AddNewSourceBuffer(std::move(input), llvm::SMLoc());
+  mlir::SourceMgrDiagnosticVerifierHandler sourceMgrHandler(sourceMgr, &context);
+
+  firrtl::FIRParserOptions options;
+  options.infoLocatorHandling = firrtl::FIRParserOptions::InfoLocHandling::IgnoreInfo;
+  options.numAnnotationFiles = 0;
+  options.scalarizeExtModules = true;
+  auto module = importFIRFile(sourceMgr, &context, ts, options);
+  if (!module)
+  {
+    llvm::errs() << "Failed to parse FIRRTL input\n";
+    exit(1);
+  }
+
+  // Manually set up the options for the firtool
+  cl::OptionCategory mainCategory("firtool Options");
+  firtool::FirtoolOptions firtoolOptions(mainCategory);
+  firtoolOptions.preserveAggregate = firrtl::PreserveAggregate::PreserveMode::None;
+  firtoolOptions.preserveMode = firrtl::PreserveValues::PreserveMode::None;
+  firtoolOptions.buildMode = firtool::FirtoolOptions::BuildModeRelease;
+  firtoolOptions.exportChiselInterface = false;
+  seq::ExternalizeClockGateOptions clockOptions;
+  clockOptions.moduleName = "EICG_wrapper";
+  clockOptions.inputName = "in";
+  clockOptions.outputName = "out";
+  clockOptions.enableName = "en";
+  clockOptions.testEnableName = "test_en";
+  clockOptions.instName = "ckg";
+  firtoolOptions.clockGateOpts = clockOptions;
+
+  // Populate the pass manager and apply them to the module
+  mlir::PassManager pm(&context);
+
+  if (failed(firtool::populateCHIRRTLToLowFIRRTL(pm, firtoolOptions, *module, inputFirrtlFile)))
+  {
+    llvm::errs() << "Failed to populate CHIRRTL to LowFIRRTL\n";
+    exit(1);
+  }
+  if (failed(firtool::populateLowFIRRTLToHW(pm, firtoolOptions)))
+  {
+    llvm::errs() << "Failed to populate LowFIRRTL to HW\n";
+    exit(1);
+  }
+  if (failed(firtool::populateHWToSV(pm, firtoolOptions)))
+  {
+    llvm::errs() << "Failed to populate HW to SV\n";
+    exit(1);
+  }
+
+  if (failed(pm.run(module.get())))
+  {
+    llvm::errs() << "Failed to run pass manager\n";
+    exit(1);
+  }
+
+  mlir::PassManager exportPm(&context);
+
+  // Legalize unsupported operations within the modules.
+  exportPm.nest<hw::HWModuleOp>().addPass(sv::createHWLegalizeModulesPass());
+
+  // Tidy up the IR to improve verilog emission quality.
+  exportPm.nest<hw::HWModuleOp>().addPass(sv::createPrettifyVerilogPass());
+
+  std::error_code errorCode;
+  llvm::raw_fd_ostream os(outputVerilogFile, errorCode);
+  exportPm.addPass(createExportVerilogPass(os));
+
+  if (failed(exportPm.run(module.get())))
+  {
+    llvm::errs() << "Failed to run export pass manager\n";
+    exit(1);
+  }
+
+  (void)module.release();
+}
+
+} // namespace jlm::hls
+
+#endif // JLM_HLS_BACKEND_FIRRTL2VERILOG_FIRRTLTOVERILOGCONVERTER_HPP

--- a/jlm/hls/backend/firrtl2verilog/FirrtlToVerilogConverter.hpp
+++ b/jlm/hls/backend/firrtl2verilog/FirrtlToVerilogConverter.hpp
@@ -8,117 +8,26 @@
 
 #include <jlm/util/file.hpp>
 
-#include <circt/Conversion/ExportVerilog.h>
-#include <circt/Dialect/FIRRTL/FIRParser.h>
-#include <circt/Dialect/HW/HWOps.h>
-#include <circt/Dialect/SV/SVPasses.h>
-#include <circt/Firtool/Firtool.h>
-#include <llvm/Support/SourceMgr.h>
-#include <mlir/IR/BuiltinOps.h>
-#include <mlir/Support/FileUtilities.h>
-
 namespace jlm::hls
 {
 
-using namespace circt;
-using namespace llvm;
-
-/**
- * Converts FIRRTL to Verilog by reading FIRRTL from a file and writing the converted Verilog to
- * another file. The functionality is heavily inspired by the processBuffer() function of the
- * firtool in the CIRCT project.
- *
- * \param inputFirrtlFile The complete path to the FIRRTL file to convert to Verilog.
- * \param outputVerilogFile The complete path to the Verilog file to write the converted Verilog to.
- * \return True if the conversion was successful, false otherwise.
- */
-static bool
-FirrtlToVerilogConverter(
-    const util::filepath inputFirrtlFile,
-    const util::filepath outputVerilogFile)
+class FirrtlToVerilogConverter
 {
-  mlir::MLIRContext context;
-  mlir::TimingScope ts;
+public:
+  FirrtlToVerilogConverter() = delete;
 
-  // Set up and read the input FIRRTL file
-  std::string errorMessage;
-  auto input = mlir::openInputFile(inputFirrtlFile.to_str(), &errorMessage);
-  if (!input)
-  {
-    std::cerr << errorMessage << std::endl;
-    return false;
-  }
-  llvm::SourceMgr sourceMgr;
-  sourceMgr.AddNewSourceBuffer(std::move(input), llvm::SMLoc());
-  mlir::SourceMgrDiagnosticVerifierHandler sourceMgrHandler(sourceMgr, &context);
-
-  firrtl::FIRParserOptions options;
-  options.infoLocatorHandling = firrtl::FIRParserOptions::InfoLocHandling::IgnoreInfo;
-  options.numAnnotationFiles = 0;
-  options.scalarizeExtModules = true;
-  auto module = importFIRFile(sourceMgr, &context, ts, options);
-  if (!module)
-  {
-    std::cerr << "Failed to parse FIRRTL input" << std::endl;
-    return false;
-  }
-
-  // Manually set up the options for the firtool
-  cl::OptionCategory mainCategory("firtool Options");
-  firtool::FirtoolOptions firtoolOptions(mainCategory);
-  firtoolOptions.preserveAggregate = firrtl::PreserveAggregate::PreserveMode::None;
-  firtoolOptions.preserveMode = firrtl::PreserveValues::PreserveMode::None;
-  firtoolOptions.buildMode = firtool::FirtoolOptions::BuildModeRelease;
-  firtoolOptions.exportChiselInterface = false;
-
-  // Populate the pass manager and apply them to the module
-  mlir::PassManager pm(&context);
-
-  // Firtool sets a blackBoxRoot based on the inputFilename path, but this functionality is not used
-  // so we set it to an empty string (the final argument)
-  if (failed(firtool::populateCHIRRTLToLowFIRRTL(pm, firtoolOptions, *module, "")))
-  {
-    std::cerr << "Failed to populate CHIRRTL to LowFIRRTL" << std::endl;
-    return false;
-  }
-  if (failed(firtool::populateLowFIRRTLToHW(pm, firtoolOptions)))
-  {
-    std::cerr << "Failed to populate LowFIRRTL to HW" << std::endl;
-    return false;
-  }
-  if (failed(firtool::populateHWToSV(pm, firtoolOptions)))
-  {
-    std::cerr << "Failed to populate HW to SV" << std::endl;
-    return false;
-  }
-
-  if (failed(pm.run(module.get())))
-  {
-    std::cerr << "Failed to run pass manager" << std::endl;
-    return false;
-  }
-
-  mlir::PassManager exportPm(&context);
-
-  // Legalize unsupported operations within the modules.
-  exportPm.nest<hw::HWModuleOp>().addPass(sv::createHWLegalizeModulesPass());
-
-  // Tidy up the IR to improve verilog emission quality.
-  exportPm.nest<hw::HWModuleOp>().addPass(sv::createPrettifyVerilogPass());
-
-  std::error_code errorCode;
-  llvm::raw_fd_ostream os(outputVerilogFile.to_str(), errorCode);
-  exportPm.addPass(createExportVerilogPass(os));
-
-  if (failed(exportPm.run(module.get())))
-  {
-    std::cerr << "Failed to run export pass manager" << std::endl;
-    return false;
-  }
-
-  (void)module.release();
-  return true;
-}
+  /**
+   * Converts FIRRTL to Verilog by reading FIRRTL from a file and writing the converted Verilog to
+   * another file. The functionality is heavily inspired by the processBuffer() function of the
+   * firtool in the CIRCT project.
+   *
+   * \param inputFirrtlFile The complete path to the FIRRTL file to convert to Verilog.
+   * \param outputVerilogFile The complete path to the Verilog file to write the converted Verilog
+   * to. \return True if the conversion was successful, false otherwise.
+   */
+  static bool
+  Convert(const util::filepath inputFirrtlFile, const util::filepath outputVerilogFile);
+};
 
 } // namespace jlm::hls
 

--- a/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.hpp
+++ b/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.hpp
@@ -84,6 +84,18 @@ public:
     return mlirGen.toString(circuit);
   }
 
+  std::unique_ptr<mlir::ModuleOp>
+  ConvertToMduleOp(llvm::RvsdgModule & rvsdgModule)
+  {
+    auto lambdaNode = get_hls_lambda(rvsdgModule);
+    auto mlirGen = RhlsToFirrtlConverter();
+    auto circuit = mlirGen.MlirGen(lambdaNode);
+    std::unique_ptr<mlir::ModuleOp> module =
+        std::make_unique<mlir::ModuleOp>(mlir::ModuleOp::create(Builder_->getUnknownLoc()));
+    module->push_back(circuit);
+    return module;
+  }
+
 private:
   std::string
   toString(const circt::firrtl::CircuitOp circuit);

--- a/tools/jlm-hls/jlm-hls.cpp
+++ b/tools/jlm-hls/jlm-hls.cpp
@@ -78,24 +78,28 @@ main(int argc, char ** argv)
     jlm::hls::rvsdg2ref(*rvsdgModule, commandLineOptions.OutputFiles_.to_str() + ".ref.ll");
     jlm::hls::rvsdg2rhls(*rvsdgModule);
 
-    std::string output;
+    jlm::util::filepath firrtlFile(commandLineOptions.OutputFiles_.to_str() + ".fir");
     if (commandLineOptions.UseCirct_)
     {
+      // Writing the FIRRTL to a file and then reading it back in to convert to Verilog.
+      // Could potentially change to pass the FIRRTL directly to the converter, but the converter
+      // is based on CIRCT's Firtool library, which assumes that the FIRRTL is read from a file.
       jlm::hls::RhlsToFirrtlConverter hls;
-      output = hls.ToString(*rvsdgModule);
+      auto output = hls.ToString(*rvsdgModule);
+      stringToFile(output, firrtlFile.to_str());
+      jlm::util::filepath outputVerilogFile(commandLineOptions.OutputFiles_.to_str() + ".v");
+      if (!jlm::hls::FirrtlToVerilogConverter(firrtlFile, outputVerilogFile.to_str()))
+      {
+        std::cerr << "The FIRRTL to Verilog conversion failed.\n" << std::endl;
+        exit(1);
+      }
     }
     else
     {
       jlm::hls::FirrtlHLS hls;
-      output = hls.run(*rvsdgModule);
+      auto output = hls.run(*rvsdgModule);
+      stringToFile(output, firrtlFile.to_str());
     }
-    stringToFile(output, commandLineOptions.OutputFiles_.to_str() + ".fir");
-
-    // Currently writing the FIRRTL to a file and then reading it back in to convert to Verilog.
-    // Could be optimized by directly passing FIRRTL to the converter.
-    jlm::hls::FirrtlToVerilogConverter(
-        commandLineOptions.OutputFiles_.to_str() + ".fir",
-        commandLineOptions.OutputFiles_.to_str() + ".v");
 
     jlm::hls::VerilatorHarnessHLS vhls;
     stringToFile(vhls.run(*rvsdgModule), commandLineOptions.OutputFiles_.to_str() + ".harness.cpp");
@@ -116,5 +120,6 @@ main(int argc, char ** argv)
   {
     JLM_UNREACHABLE("Format not supported.\n");
   }
+
   return 0;
 }

--- a/tools/jlm-hls/jlm-hls.cpp
+++ b/tools/jlm-hls/jlm-hls.cpp
@@ -88,7 +88,7 @@ main(int argc, char ** argv)
       auto output = hls.ToString(*rvsdgModule);
       stringToFile(output, firrtlFile.to_str());
       jlm::util::filepath outputVerilogFile(commandLineOptions.OutputFiles_.to_str() + ".v");
-      if (!jlm::hls::FirrtlToVerilogConverter(firrtlFile, outputVerilogFile))
+      if (!jlm::hls::FirrtlToVerilogConverter::Convert(firrtlFile, outputVerilogFile))
       {
         std::cerr << "The FIRRTL to Verilog conversion failed.\n" << std::endl;
         exit(1);

--- a/tools/jlm-hls/jlm-hls.cpp
+++ b/tools/jlm-hls/jlm-hls.cpp
@@ -88,7 +88,7 @@ main(int argc, char ** argv)
       auto output = hls.ToString(*rvsdgModule);
       stringToFile(output, firrtlFile.to_str());
       jlm::util::filepath outputVerilogFile(commandLineOptions.OutputFiles_.to_str() + ".v");
-      if (!jlm::hls::FirrtlToVerilogConverter(firrtlFile, outputVerilogFile.to_str()))
+      if (!jlm::hls::FirrtlToVerilogConverter(firrtlFile, outputVerilogFile))
       {
         std::cerr << "The FIRRTL to Verilog conversion failed.\n" << std::endl;
         exit(1);

--- a/tools/jlm-hls/jlm-hls.cpp
+++ b/tools/jlm-hls/jlm-hls.cpp
@@ -3,6 +3,7 @@
  * See COPYING for terms of redistribution.
  */
 
+#include <jlm/hls/backend/firrtl2verilog/FirrtlToVerilogConverter.hpp>
 #include <jlm/hls/backend/rhls2firrtl/dot-hls.hpp>
 #include <jlm/hls/backend/rhls2firrtl/firrtl-hls.hpp>
 #include <jlm/hls/backend/rhls2firrtl/json-hls.hpp>
@@ -89,6 +90,12 @@ main(int argc, char ** argv)
       output = hls.run(*rvsdgModule);
     }
     stringToFile(output, commandLineOptions.OutputFiles_.to_str() + ".fir");
+
+    // Currently writing the FIRRTL to a file and then reading it back in to convert to Verilog.
+    // Could be optimized by directly passing FIRRTL to the converter.
+    jlm::hls::FirrtlToVerilogConverter(
+        commandLineOptions.OutputFiles_.to_str() + ".fir",
+        commandLineOptions.OutputFiles_.to_str() + ".v");
 
     jlm::hls::VerilatorHarnessHLS vhls;
     stringToFile(vhls.run(*rvsdgModule), commandLineOptions.OutputFiles_.to_str() + ".harness.cpp");


### PR DESCRIPTION
Enables jlm-hls to directly generate Verilog as output.