### PR TITLE
Build scripts fix for --get-commit-hash

### DIFF
--- a/scripts/build-circt.sh
+++ b/scripts/build-circt.sh
@@ -52,8 +52,8 @@ while [[ "$#" -ge 1 ]] ; do
 			shift
 			;;
 		--get-commit-hash)
-			commit >&2
-			exit 1
+			commit >&1
+			exit 0
 			;;
 		--help)
 			usage >&2

--- a/scripts/build-mlir.sh
+++ b/scripts/build-mlir.sh
@@ -44,8 +44,8 @@ while [[ "$#" -ge 1 ]] ; do
 			shift
 			;;
 		--get-commit-hash)
-			commit >&2
-			exit 1
+			commit >&1
+			exit 0
 			;;
 		--help)
 			usage >&2


### PR DESCRIPTION
Changed --get-commit-hash to use 'exit 0' and print to stdout instead of stderr.