### PR TITLE
Always save CIRCT and MLIR builds

### DIFF
--- a/.github/actions/BuildCirct/action.yml
+++ b/.github/actions/BuildCirct/action.yml
@@ -14,6 +14,7 @@ runs:
       id: cache-circt
       uses: actions/cache@v4
       with:
+        save-always: true
         path: |
           ${{ github.workspace }}/build-circt/circt
         key: ${{ runner.os }}-circt-${{ steps.get-circt-hash.outputs.hash }}

--- a/.github/actions/BuildMlirDialect/action.yml
+++ b/.github/actions/BuildMlirDialect/action.yml
@@ -19,6 +19,7 @@ runs:
       id: cache-mlir
       uses: actions/cache@v4
       with:
+        save-always: true
         path: |
           ${{ github.workspace }}/lib/mlir-rvsdg
         key: ${{ runner.os }}-mlir-${{ steps.get-mlir-hash.outputs.hash }}


### PR DESCRIPTION
Enables CIRCT and MLIR builds to always be saved if their build succeeds but the workflow they are part of fails. This eliminates the need to rebuild CIRCT and MLIR for CIs that fails.