### PR TITLE
Add printing of rvsdg tree to jlm-opt

### DIFF
--- a/jlm/tooling/Command.cpp
+++ b/jlm/tooling/Command.cpp
@@ -471,6 +471,28 @@ JlmOptCommand::PrintAsMlir(
 }
 
 void
+JlmOptCommand::PrintAsRvsdgTree(
+    const llvm::RvsdgModule & rvsdgModule,
+    const util::filepath & outputFile,
+    util::StatisticsCollector &)
+{
+  auto & rootRegion = *rvsdgModule.Rvsdg().root();
+  auto tree = rvsdg::region::ToTree(rootRegion);
+
+  if (outputFile == "")
+  {
+    std::cout << tree << std::flush;
+  }
+  else
+  {
+    std::ofstream fs;
+    fs.open(outputFile.to_str());
+    fs << tree;
+    fs.close();
+  }
+}
+
+void
 JlmOptCommand::PrintRvsdgModule(
     llvm::RvsdgModule & rvsdgModule,
     const util::filepath & outputFile,
@@ -492,6 +514,10 @@ JlmOptCommand::PrintRvsdgModule(
   else if (outputFormat == tooling::JlmOptCommandLineOptions::OutputFormat::Mlir)
   {
     PrintAsMlir(rvsdgModule, outputFile, statisticsCollector);
+  }
+  else if (outputFormat == tooling::JlmOptCommandLineOptions::OutputFormat::Tree)
+  {
+    PrintAsRvsdgTree(rvsdgModule, outputFile, statisticsCollector);
   }
   else
   {

--- a/jlm/tooling/Command.hpp
+++ b/jlm/tooling/Command.hpp
@@ -369,6 +369,13 @@ public:
     return CommandLineOptions_;
   }
 
+  static void
+  PrintRvsdgModule(
+      llvm::RvsdgModule & rvsdgModule,
+      const util::filepath & outputFile,
+      const JlmOptCommandLineOptions::OutputFormat & outputFormat,
+      util::StatisticsCollector & statisticsCollector);
+
 private:
   std::unique_ptr<llvm::RvsdgModule>
   ParseInputFile(
@@ -383,13 +390,6 @@ private:
   std::unique_ptr<llvm::RvsdgModule>
   ParseMlirIrFile(const util::filepath & inputFile, util::StatisticsCollector & statisticsCollector)
       const;
-
-  static void
-  PrintRvsdgModule(
-      llvm::RvsdgModule & rvsdgModule,
-      const util::filepath & outputFile,
-      const JlmOptCommandLineOptions::OutputFormat & outputFormat,
-      util::StatisticsCollector & statisticsCollector);
 
   static void
   PrintAsAscii(
@@ -411,6 +411,12 @@ private:
 
   static void
   PrintAsMlir(
+      const llvm::RvsdgModule & rvsdgModule,
+      const util::filepath & outputFile,
+      util::StatisticsCollector & statisticsCollector);
+
+  static void
+  PrintAsRvsdgTree(
       const llvm::RvsdgModule & rvsdgModule,
       const util::filepath & outputFile,
       util::StatisticsCollector & statisticsCollector);

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -846,7 +846,7 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, char ** argv)
 #endif
           CreateOutputFormatOption(
               JlmOptCommandLineOptions::OutputFormat::Tree,
-              "Output Rvsdg Region Tree"),
+              "Output Rvsdg Tree"),
           CreateOutputFormatOption(JlmOptCommandLineOptions::OutputFormat::Xml, "Output XML")),
       cl::init(JlmOptCommandLineOptions::OutputFormat::Llvm));
 

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -308,6 +308,7 @@ JlmOptCommandLineOptions::GetOutputFormatCommandLineArguments()
     { OutputFormat::Ascii, "ascii" },
     { OutputFormat::Llvm, "llvm" },
     { OutputFormat::Mlir, "mlir" },
+    { OutputFormat::Tree, "tree" },
     { OutputFormat::Xml, "xml" }
   };
 
@@ -843,6 +844,9 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, char ** argv)
 #ifdef ENABLE_MLIR
           CreateOutputFormatOption(JlmOptCommandLineOptions::OutputFormat::Mlir, "Output MLIR"),
 #endif
+          CreateOutputFormatOption(
+              JlmOptCommandLineOptions::OutputFormat::Tree,
+              "Output Rvsdg Region Tree"),
           CreateOutputFormatOption(JlmOptCommandLineOptions::OutputFormat::Xml, "Output XML")),
       cl::init(JlmOptCommandLineOptions::OutputFormat::Llvm));
 

--- a/jlm/tooling/CommandLine.hpp
+++ b/jlm/tooling/CommandLine.hpp
@@ -54,6 +54,7 @@ public:
     Ascii,
     Llvm,
     Mlir,
+    Tree,
     Xml,
 
     LastEnumValue // must always be the last enum value, used for iteration

--- a/tests/jlm/tooling/TestJlmOptCommand.cpp
+++ b/tests/jlm/tooling/TestJlmOptCommand.cpp
@@ -5,8 +5,11 @@
 
 #include <test-registry.hpp>
 
+#include <jlm/llvm/ir/RvsdgModule.hpp>
 #include <jlm/tooling/Command.hpp>
 #include <jlm/util/strfmt.hpp>
+
+#include <fstream>
 
 static void
 TestStatistics()
@@ -56,3 +59,33 @@ TestJlmOptCommand()
 }
 
 JLM_UNIT_TEST_REGISTER("jlm/tooling/TestJlmOptCommand", TestJlmOptCommand)
+
+static int
+PrintRvsdgTreeToFile()
+{
+  using namespace jlm;
+
+  // Arrange
+  util::filepath outputFile("/tmp/RvsdgTree");
+
+  jlm::llvm::RvsdgModule rvsdgModule(jlm::util::filepath(""), "", "");
+  util::StatisticsCollector statisticsCollector;
+
+  // Act
+  tooling::JlmOptCommand::PrintRvsdgModule(
+      rvsdgModule,
+      outputFile,
+      tooling::JlmOptCommandLineOptions::OutputFormat::Tree,
+      statisticsCollector);
+
+  // Assert
+  std::stringstream buffer;
+  std::ifstream istream(outputFile.to_str());
+  buffer << istream.rdbuf();
+
+  assert(buffer.str() == "RootRegion\n");
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER("jlm/tooling/TestJlmOptCommand-PrintRvsdgTreeToFile", PrintRvsdgTreeToFile)


### PR DESCRIPTION
This PR adds the capability to print the region tree to `jlm-opt`. Here is an example output:

```
RootRegion
-DELTA[.str.3]
-DELTA[array2]
-DELTA[.str.2]
-DELTA[array]
-DELTA[__PRETTY_FUNCTION__.main]
-DELTA[.str.1]
-DELTA[.str]
-DELTA[points]
-LAMBDA[main]
--THETA
---GAMMA
----Region[0]
----Region[1]
--GAMMA
---Region[0]
---Region[1]
----GAMMA
-----Region[0]
-----Region[1]
------GAMMA
-------Region[0]
-------Region[1]
--------GAMMA
---------Region[0]
---------Region[1]
--------GAMMA
---------Region[0]
---------Region[1]
--GAMMA
---Region[0]
---Region[1]

```