### PR TITLE
Remove is_gamma_argument() function

### DIFF
--- a/jlm/llvm/ir/operators/call.cpp
+++ b/jlm/llvm/ir/operators/call.cpp
@@ -190,9 +190,9 @@ CallNode::TraceFunctionInput(const CallNode & callNode)
       return origin;
     }
 
-    if (auto argument = is_gamma_argument(origin))
+    if (auto gammaArgument = dynamic_cast<const rvsdg::GammaArgument *>(origin))
     {
-      origin = argument->input()->origin();
+      origin = gammaArgument->input()->origin();
       continue;
     }
 

--- a/jlm/llvm/ir/operators/gamma.hpp
+++ b/jlm/llvm/ir/operators/gamma.hpp
@@ -14,21 +14,6 @@ namespace jlm::llvm
 /*
   FIXME: This should be defined in librvsdg.
 */
-static inline const rvsdg::argument *
-is_gamma_argument(const rvsdg::output * output)
-{
-  using namespace rvsdg;
-
-  auto a = dynamic_cast<const rvsdg::argument *>(output);
-  if (a && is<gamma_op>(a->region()->node()))
-    return a;
-
-  return nullptr;
-}
-
-/*
-  FIXME: This should be defined in librvsdg.
-*/
 static inline const rvsdg::result *
 is_gamma_result(const rvsdg::input * input)
 {

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -213,9 +213,9 @@ DeadNodeElimination::MarkOutput(const jlm::rvsdg::output & output)
     return;
   }
 
-  if (auto argument = is_gamma_argument(&output))
+  if (auto gammaArgument = dynamic_cast<const rvsdg::GammaArgument *>(&output))
   {
-    MarkOutput(*argument->input()->origin());
+    MarkOutput(*gammaArgument->input()->origin());
     return;
   }
 

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -225,7 +225,7 @@ public:
       return jlm::util::strfmt(dbgstr, ":cv:", index);
     }
 
-    if (is_gamma_argument(Output_))
+    if (is<rvsdg::GammaArgument>(Output_))
     {
       auto dbgstr = Output_->region()->node()->operation().debug_string();
       return jlm::util::strfmt(dbgstr, ":arg", index);

--- a/jlm/llvm/opt/cne.cpp
+++ b/jlm/llvm/opt/cne.cpp
@@ -221,7 +221,7 @@ congruent(jlm::rvsdg::output * o1, jlm::rvsdg::output * o2, vset & vs, cnectx & 
     return true;
   }
 
-  if (is_gamma_argument(o1) && is_gamma_argument(o2))
+  if (is<rvsdg::GammaArgument>(o1) && is<rvsdg::GammaArgument>(o2))
   {
     JLM_ASSERT(o1->region()->node() == o2->region()->node());
     auto a1 = static_cast<jlm::rvsdg::argument *>(o1);

--- a/jlm/rvsdg/gamma.cpp
+++ b/jlm/rvsdg/gamma.cpp
@@ -375,6 +375,8 @@ gamma_node::copy(jlm::rvsdg::region * region, jlm::rvsdg::substitution_map & sma
   return gamma;
 }
 
+GammaArgument::~GammaArgument() noexcept = default;
+
 }
 
 jlm::rvsdg::node_normal_form *

--- a/jlm/rvsdg/gamma.hpp
+++ b/jlm/rvsdg/gamma.hpp
@@ -465,6 +465,33 @@ inline gamma_node::gamma_node(jlm::rvsdg::output * predicate, size_t nalternativ
       new gamma_input(this, predicate, ctltype::Create(nalternatives))));
 }
 
+/**
+ * Represents a region argument in a gamma subregion.
+ */
+class GammaArgument final : public argument
+{
+  friend gamma_node;
+
+public:
+  ~GammaArgument() noexcept override;
+
+private:
+  GammaArgument(
+      rvsdg::region & region,
+      structural_input & input,
+      std::shared_ptr<const rvsdg::type> type)
+      : argument(&region, &input, std::move(type))
+  {}
+
+  static GammaArgument &
+  Create(rvsdg::region & region, structural_input & input, std::shared_ptr<const rvsdg::type> type)
+  {
+    auto gammaArgument = new GammaArgument(region, input, std::move(type));
+    region.append_argument(gammaArgument);
+    return *gammaArgument;
+  }
+};
+
 inline jlm::rvsdg::gamma_input *
 gamma_node::predicate() const noexcept
 {
@@ -489,7 +516,9 @@ gamma_node::add_entryvar(jlm::rvsdg::output * origin)
   node::add_input(std::unique_ptr<node_input>(new gamma_input(this, origin, origin->Type())));
 
   for (size_t n = 0; n < nsubregions(); n++)
-    argument::create(subregion(n), input(ninputs() - 1), origin->Type());
+  {
+    GammaArgument::Create(*subregion(n), *input(ninputs() - 1), origin->Type());
+  }
 
   return static_cast<jlm::rvsdg::gamma_input *>(input(ninputs() - 1));
 }

--- a/jlm/rvsdg/gamma.hpp
+++ b/jlm/rvsdg/gamma.hpp
@@ -476,17 +476,14 @@ public:
   ~GammaArgument() noexcept override;
 
 private:
-  GammaArgument(
-      rvsdg::region & region,
-      structural_input & input,
-      std::shared_ptr<const rvsdg::type> type)
-      : argument(&region, &input, std::move(type))
+  GammaArgument(rvsdg::region & region, gamma_input & input)
+      : argument(&region, &input, input.Type())
   {}
 
   static GammaArgument &
-  Create(rvsdg::region & region, structural_input & input, std::shared_ptr<const rvsdg::type> type)
+  Create(rvsdg::region & region, gamma_input & input)
   {
-    auto gammaArgument = new GammaArgument(region, input, std::move(type));
+    auto gammaArgument = new GammaArgument(region, input);
     region.append_argument(gammaArgument);
     return *gammaArgument;
   }
@@ -513,14 +510,16 @@ gamma_node::exitvar(size_t index) const noexcept
 inline jlm::rvsdg::gamma_input *
 gamma_node::add_entryvar(jlm::rvsdg::output * origin)
 {
-  node::add_input(std::unique_ptr<node_input>(new gamma_input(this, origin, origin->Type())));
+  auto input =
+      node::add_input(std::unique_ptr<node_input>(new gamma_input(this, origin, origin->Type())));
+  auto gammaInput = static_cast<jlm::rvsdg::gamma_input *>(input);
 
   for (size_t n = 0; n < nsubregions(); n++)
   {
-    GammaArgument::Create(*subregion(n), *input(ninputs() - 1), origin->Type());
+    GammaArgument::Create(*subregion(n), *gammaInput);
   }
 
-  return static_cast<jlm::rvsdg::gamma_input *>(input(ninputs() - 1));
+  return gammaInput;
 }
 
 inline jlm::rvsdg::gamma_output *


### PR DESCRIPTION
This PR does the following:
1. Introduces the GammaArgument class, which represents a region argument in a gamma subregion.
2. Removes the is_gamma_argument() function.