### PR TITLE
Remove is_theta_argument() function

### DIFF
--- a/jlm/llvm/ir/operators/call.cpp
+++ b/jlm/llvm/ir/operators/call.cpp
@@ -99,7 +99,7 @@ invariantInput(const rvsdg::output & output, InvariantOutputMap & invariantOutpu
   if (auto thetaOutput = dynamic_cast<const rvsdg::theta_output *>(&output))
     return invariantInput(*thetaOutput, invariantOutputs);
 
-  if (auto thetaArgument = is_theta_argument(&output))
+  if (auto thetaArgument = dynamic_cast<const rvsdg::ThetaArgument *>(&output))
   {
     auto thetaInput = static_cast<const rvsdg::theta_input *>(thetaArgument->input());
     return invariantInput(*thetaInput->output(), invariantOutputs);
@@ -208,9 +208,9 @@ CallNode::TraceFunctionInput(const CallNode & callNode)
       return origin;
     }
 
-    if (auto argument = is_theta_argument(origin))
+    if (auto thetaArgument = dynamic_cast<const rvsdg::ThetaArgument *>(origin))
     {
-      if (auto input = invariantInput(*argument))
+      if (auto input = invariantInput(*thetaArgument))
       {
         origin = input->origin();
         continue;

--- a/jlm/llvm/ir/operators/theta.hpp
+++ b/jlm/llvm/ir/operators/theta.hpp
@@ -14,18 +14,6 @@ namespace jlm::llvm
 /*
   FIXME: This should be defined in librvsdg.
 */
-static inline const jlm::rvsdg::argument *
-is_theta_argument(const jlm::rvsdg::output * output)
-{
-  using namespace jlm::rvsdg;
-
-  auto a = dynamic_cast<const jlm::rvsdg::argument *>(output);
-  if (a && is<theta_op>(a->region()->node()))
-    return a;
-
-  return nullptr;
-}
-
 static inline const jlm::rvsdg::result *
 is_theta_result(const jlm::rvsdg::input * input)
 {

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -228,7 +228,7 @@ DeadNodeElimination::MarkOutput(const jlm::rvsdg::output & output)
     return;
   }
 
-  if (auto thetaArgument = is_theta_argument(&output))
+  if (auto thetaArgument = dynamic_cast<const rvsdg::ThetaArgument *>(&output))
   {
     auto thetaInput = util::AssertedCast<const jlm::rvsdg::theta_input>(thetaArgument->input());
     MarkOutput(*thetaInput->output());

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -232,7 +232,7 @@ public:
       return jlm::util::strfmt(dbgstr, ":arg", index);
     }
 
-    if (is_theta_argument(Output_))
+    if (is<rvsdg::ThetaArgument>(Output_))
     {
       auto dbgstr = Output_->region()->node()->operation().debug_string();
       return jlm::util::strfmt(dbgstr, ":arg", index);

--- a/jlm/llvm/opt/cne.cpp
+++ b/jlm/llvm/opt/cne.cpp
@@ -179,7 +179,7 @@ congruent(jlm::rvsdg::output * o1, jlm::rvsdg::output * o2, vset & vs, cnectx & 
   if (o1->type() != o2->type())
     return false;
 
-  if (is_theta_argument(o1) && is_theta_argument(o2))
+  if (is<rvsdg::ThetaArgument>(o1) && is<rvsdg::ThetaArgument>(o2))
   {
     JLM_ASSERT(o1->region()->node() == o2->region()->node());
     auto a1 = static_cast<jlm::rvsdg::argument *>(o1);

--- a/jlm/rvsdg/theta.cpp
+++ b/jlm/rvsdg/theta.cpp
@@ -43,6 +43,8 @@ theta_output::~theta_output() noexcept
     input_->output_ = nullptr;
 }
 
+ThetaArgument::~ThetaArgument() noexcept = default;
+
 /* theta node */
 
 theta_node::~theta_node()
@@ -78,8 +80,8 @@ theta_node::add_loopvar(jlm::rvsdg::output * origin)
   input->output_ = output;
   output->input_ = input;
 
-  auto argument = argument::create(subregion(), input, origin->Type());
-  result::create(subregion(), argument, output, origin->Type());
+  auto & thetaArgument = ThetaArgument::Create(*subregion(), *input);
+  result::create(subregion(), &thetaArgument, output, origin->Type());
   return output;
 }
 

--- a/jlm/rvsdg/theta.hpp
+++ b/jlm/rvsdg/theta.hpp
@@ -355,6 +355,9 @@ private:
   jlm::rvsdg::theta_input * input_;
 };
 
+/**
+ * Represents a region argument in a theta subregion.
+ */
 class ThetaArgument final : public argument
 {
   friend theta_node;

--- a/jlm/rvsdg/theta.hpp
+++ b/jlm/rvsdg/theta.hpp
@@ -355,6 +355,27 @@ private:
   jlm::rvsdg::theta_input * input_;
 };
 
+class ThetaArgument final : public argument
+{
+  friend theta_node;
+
+public:
+  ~ThetaArgument() noexcept override;
+
+private:
+  ThetaArgument(rvsdg::region & region, theta_input & input)
+      : argument(&region, &input, input.Type())
+  {}
+
+  static ThetaArgument &
+  Create(rvsdg::region & region, theta_input & input)
+  {
+    auto thetaArgument = new ThetaArgument(region, input);
+    region.append_argument(thetaArgument);
+    return *thetaArgument;
+  }
+};
+
 static inline bool
 is_invariant(const jlm::rvsdg::theta_output * output) noexcept
 {

--- a/jlm/rvsdg/theta.hpp
+++ b/jlm/rvsdg/theta.hpp
@@ -368,7 +368,9 @@ public:
 private:
   ThetaArgument(rvsdg::region & region, theta_input & input)
       : argument(&region, &input, input.Type())
-  {}
+  {
+    JLM_ASSERT(is<theta_op>(region.node()));
+  }
 
   static ThetaArgument &
   Create(rvsdg::region & region, theta_input & input)


### PR DESCRIPTION
This PR does the following:
1. Introduces the ThetaArgument class, which represents a region argument in
a theta subregion.
2. Removes the is_gamma_argument() function.