### PR TITLE
Add annotation support to region tree

### DIFF
--- a/jlm/rvsdg/region.cpp
+++ b/jlm/rvsdg/region.cpp
@@ -440,9 +440,9 @@ region::ToString(
     char labelValueSeparator)
 {
   std::stringstream stream;
-  for (auto it = annotations.begin(); it != annotations.end(); it++)
+  for (auto & annotation : annotations)
   {
-    auto annotationString = ToString(*it, labelValueSeparator);
+    auto annotationString = ToString(annotation, labelValueSeparator);
     stream << annotationSeparator << annotationString;
   }
 

--- a/jlm/rvsdg/region.cpp
+++ b/jlm/rvsdg/region.cpp
@@ -388,17 +388,18 @@ region::ToTree(
   static const char annotationSeparator = ' ';
   static const char labelValueSeparator = ':';
 
+  // Convert current region to a string
   auto indentationString = std::string(indentationDepth, indentationChar);
   auto regionString =
       region.IsRootRegion() ? "RootRegion" : util::strfmt("Region[", region.index(), "]");
   auto regionAnnotationString =
       GetAnnotationString(&region, annotationMap, annotationSeparator, labelValueSeparator);
 
-  // Convert current region to a string
   stream << indentationString << regionString << regionAnnotationString << '\n';
-  indentationDepth += 1;
 
   // Convert the region's structural nodes with their subregions to a string
+  indentationDepth++;
+  indentationString = std::string(indentationDepth, indentationChar);
   for (auto & node : region.nodes)
   {
     if (auto structuralNode = dynamic_cast<const rvsdg::structural_node *>(&node))

--- a/jlm/rvsdg/region.cpp
+++ b/jlm/rvsdg/region.cpp
@@ -453,9 +453,9 @@ std::string
 region::ToString(const util::Annotation & annotation, char labelValueSeparator)
 {
   std::string value;
-  if (annotation.HasValueType<std::string_view>())
+  if (annotation.HasValueType<std::string>())
   {
-    value = util::strfmt(annotation.Value<std::string_view>());
+    value = annotation.Value<std::string>();
   }
   else if (annotation.HasValueType<int64_t>())
   {

--- a/jlm/rvsdg/region.cpp
+++ b/jlm/rvsdg/region.cpp
@@ -381,22 +381,22 @@ void
 region::ToTree(
     const rvsdg::region & region,
     const util::AnnotationMap & annotationMap,
-    size_t identationDepth,
+    size_t indentationDepth,
     std::stringstream & stream) noexcept
 {
-  static const char identationChar = '-';
+  static const char indentationChar = '-';
   static const char annotationSeparator = ' ';
   static const char labelValueSeparator = ':';
 
-  auto identationString = std::string(identationDepth, identationChar);
+  auto indentationString = std::string(indentationDepth, indentationChar);
   auto regionString =
       region.IsRootRegion() ? "RootRegion" : util::strfmt("Region[", region.index(), "]");
   auto regionAnnotationString =
       GetAnnotationString(&region, annotationMap, annotationSeparator, labelValueSeparator);
 
   // Convert current region to a string
-  stream << identationString << regionString << regionAnnotationString << '\n';
-  identationDepth += 1;
+  stream << indentationString << regionString << regionAnnotationString << '\n';
+  indentationDepth += 1;
 
   // Convert the region's structural nodes with their subregions to a string
   for (auto & node : region.nodes)
@@ -409,11 +409,11 @@ region::ToTree(
           annotationMap,
           annotationSeparator,
           labelValueSeparator);
-      stream << identationString << nodeString << annotationString << '\n';
+      stream << indentationString << nodeString << annotationString << '\n';
 
       for (size_t n = 0; n < structuralNode->nsubregions(); n++)
       {
-        ToTree(*structuralNode->subregion(n), annotationMap, identationDepth + 1, stream);
+        ToTree(*structuralNode->subregion(n), annotationMap, indentationDepth + 1, stream);
       }
     }
   }

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -424,11 +424,12 @@ public:
   region_bottom_node_list bottom_nodes;
 
 private:
-  [[nodiscard]] static std::string
+  static void
   ToTree(
       const rvsdg::region & region,
       const util::AnnotationMap & annotationMap,
-      size_t identationDepth) noexcept;
+      size_t identationDepth,
+      std::stringstream & stream) noexcept;
 
   [[nodiscard]] static std::string
   GetAnnotationString(

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -454,7 +454,7 @@ private:
   ToTree(
       const rvsdg::region & region,
       const util::AnnotationMap & annotationMap,
-      size_t identationDepth,
+      size_t indentationDepth,
       std::stringstream & stream) noexcept;
 
   [[nodiscard]] static std::string

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -13,6 +13,12 @@
 #include <jlm/rvsdg/node.hpp>
 #include <jlm/util/common.hpp>
 
+namespace jlm::util
+{
+class Annotation;
+class AnnotationMap;
+}
+
 namespace jlm::rvsdg
 {
 
@@ -395,6 +401,17 @@ public:
    * ASCII format.
    *
    * @param region The top-level region that is converted
+   * @param annotationMap A map with annotations for region%s or structural_node%s.
+   * @return A string containing the ASCII tree of \p region.
+   */
+  [[nodiscard]] static std::string
+  ToTree(const rvsdg::region & region, const util::AnnotationMap & annotationMap) noexcept;
+
+  /**
+   * Converts \p region and all of its contained structural nodes with subregions to a tree in
+   * ASCII format.
+   *
+   * @param region The top-level region that is converted
    * @return A string containing the ASCII tree of \p region
    */
   [[nodiscard]] static std::string
@@ -408,7 +425,26 @@ public:
 
 private:
   [[nodiscard]] static std::string
-  ToTree(const rvsdg::region & region, size_t identationDepth) noexcept;
+  ToTree(
+      const rvsdg::region & region,
+      const util::AnnotationMap & annotationMap,
+      size_t identationDepth) noexcept;
+
+  [[nodiscard]] static std::string
+  GetAnnotationString(
+      const void * key,
+      const util::AnnotationMap & annotationMap,
+      char annotationSeparator,
+      char labelValueSeparator);
+
+  [[nodiscard]] static std::string
+  ToString(
+      const std::vector<util::Annotation> & annotations,
+      char annotationSeparator,
+      char labelValueSeparator);
+
+  [[nodiscard]] static std::string
+  ToString(const util::Annotation & annotation, char labelValueSeparator);
 
   size_t index_;
   jlm::rvsdg::graph * graph_;

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -398,7 +398,21 @@ public:
 
   /**
    * Converts \p region and all of its contained structural nodes with subregions to a tree in
-   * ASCII format.
+   * ASCII format of the following form:
+   *
+   * RootRegion
+   * -STRUCTURAL_TEST_NODE
+   * --Region[0]
+   * --Region[1]
+   * ---STRUCTURAL_TEST_NODE
+   * ----Region[0]
+   * ----Region[1]
+   * ----Region[2] NumNodes:0 NumArguments:0
+   *
+   * The above tree has a single structural node in the RVSDG's root region. This node has two
+   * subregions, where the second subregion contains another structural node with three subregions.
+   * For the third subregion, two annotations with label NumNodes and NumArguments was provided in
+   * \p annotationMap.
    *
    * @param region The top-level region that is converted
    * @param annotationMap A map with annotations for region%s or structural_node%s.
@@ -409,7 +423,19 @@ public:
 
   /**
    * Converts \p region and all of its contained structural nodes with subregions to a tree in
-   * ASCII format.
+   * ASCII format of the following form:
+   *
+   * RootRegion
+   * -STRUCTURAL_TEST_NODE
+   * --Region[0]
+   * --Region[1]
+   * ---STRUCTURAL_TEST_NODE
+   * ----Region[0]
+   * ----Region[1]
+   * ----Region[2]
+   *
+   * The above tree has a single structural node in the RVSDG's root region. This node has two
+   * subregions, where the second subregion contains another structural node with three subregions.
    *
    * @param region The top-level region that is converted
    * @return A string containing the ASCII tree of \p region

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -400,14 +400,15 @@ public:
    * Converts \p region and all of its contained structural nodes with subregions to a tree in
    * ASCII format of the following form:
    *
-   * RootRegion
-   * -STRUCTURAL_TEST_NODE
-   * --Region[0]
-   * --Region[1]
-   * ---STRUCTURAL_TEST_NODE
-   * ----Region[0]
-   * ----Region[1]
-   * ----Region[2] NumNodes:0 NumArguments:0
+   * RootRegion                              \n
+   * -STRUCTURAL_TEST_NODE                   \n
+   * --Region[0]                             \n
+   * --Region[1]                             \n
+   * ---STRUCTURAL_TEST_NODE                 \n
+   * ----Region[0]                           \n
+   * ----Region[1]                           \n
+   * ----Region[2] NumNodes:0 NumArguments:0 \n
+   *
    *
    * The above tree has a single structural node in the RVSDG's root region. This node has two
    * subregions, where the second subregion contains another structural node with three subregions.
@@ -415,7 +416,8 @@ public:
    * \p annotationMap.
    *
    * @param region The top-level region that is converted
-   * @param annotationMap A map with annotations for region%s or structural_node%s.
+   * @param annotationMap A map with annotations for instances of \ref region%s or
+   * structural_node%s.
    * @return A string containing the ASCII tree of \p region.
    */
   [[nodiscard]] static std::string
@@ -425,14 +427,15 @@ public:
    * Converts \p region and all of its contained structural nodes with subregions to a tree in
    * ASCII format of the following form:
    *
-   * RootRegion
-   * -STRUCTURAL_TEST_NODE
-   * --Region[0]
-   * --Region[1]
-   * ---STRUCTURAL_TEST_NODE
-   * ----Region[0]
-   * ----Region[1]
-   * ----Region[2]
+   * RootRegion              \n
+   * -STRUCTURAL_TEST_NODE   \n
+   * --Region[0]             \n
+   * --Region[1]             \n
+   * ---STRUCTURAL_TEST_NODE \n
+   * ----Region[0]           \n
+   * ----Region[1]           \n
+   * ----Region[2]           \n
+   *
    *
    * The above tree has a single structural node in the RVSDG's root region. This node has two
    * subregions, where the second subregion contains another structural node with three subregions.

--- a/jlm/util/AnnotationMap.hpp
+++ b/jlm/util/AnnotationMap.hpp
@@ -3,6 +3,9 @@
  * See COPYING for terms of redistribution.
  */
 
+#ifndef JLM_UTIL_ANNOTATION_MAP_HPP
+#define JLM_UTIL_ANNOTATION_MAP_HPP
+
 #include <jlm/util/common.hpp>
 #include <jlm/util/iterator_range.hpp>
 
@@ -215,3 +218,5 @@ private:
 };
 
 }
+
+#endif

--- a/jlm/util/AnnotationMap.hpp
+++ b/jlm/util/AnnotationMap.hpp
@@ -74,7 +74,7 @@ public:
   [[nodiscard]] bool
   HasValueType() const noexcept
   {
-    return std::get_if<TValue>(&Value_) != nullptr;
+    return std::holds_alternative<TValue>(&Value_);
   }
 
   bool

--- a/jlm/util/AnnotationMap.hpp
+++ b/jlm/util/AnnotationMap.hpp
@@ -18,15 +18,15 @@ namespace jlm::util
 {
 
 /**
- * Represents a simple key-value pair with a label and a value of type std::string_view, int64_t,
+ * Represents a simple key-value pair with a label and a value of type std::string, int64_t,
  * uint64_t, or double.
  */
 class Annotation final
 {
-  using AnnotationValue = std::variant<std::string_view, int64_t, uint64_t, double>;
+  using AnnotationValue = std::variant<std::string, int64_t, uint64_t, double>;
 
 public:
-  Annotation(std::string_view label, std::string_view value)
+  Annotation(std::string_view label, std::string value)
       : Label_(std::move(label)),
         Value_(std::move(value))
   {}

--- a/jlm/util/AnnotationMap.hpp
+++ b/jlm/util/AnnotationMap.hpp
@@ -74,7 +74,7 @@ public:
   [[nodiscard]] bool
   HasValueType() const noexcept
   {
-    return std::holds_alternative<TValue>(&Value_);
+    return std::holds_alternative<TValue>(Value_);
   }
 
   bool

--- a/jlm/util/AnnotationMap.hpp
+++ b/jlm/util/AnnotationMap.hpp
@@ -208,7 +208,6 @@ public:
   void
   AddAnnotation(const void * key, Annotation annotation)
   {
-    JLM_ASSERT(!HasAnnotations(key));
     Map_[key].emplace_back(std::move(annotation));
   }
 

--- a/jlm/util/AnnotationMap.hpp
+++ b/jlm/util/AnnotationMap.hpp
@@ -202,8 +202,7 @@ public:
   }
 
   /**
-   * Adds \p annotation with the given \p key to the map. Requires that \p key is not yet
-   * present.
+   * Adds \p annotation with the given \p key to the map.
    */
   void
   AddAnnotation(const void * key, Annotation annotation)

--- a/jlm/util/AnnotationMap.hpp
+++ b/jlm/util/AnnotationMap.hpp
@@ -96,7 +96,7 @@ private:
  */
 class AnnotationMap final
 {
-  using AnnotationMapType = std::unordered_map<const void *, Annotation>;
+  using AnnotationMapType = std::unordered_map<const void *, std::vector<Annotation>>;
 
   class ConstIterator final
   {
@@ -115,22 +115,22 @@ class AnnotationMap final
     {}
 
   public:
-    [[nodiscard]] const jlm::util::Annotation *
-    GetAnnotation() const noexcept
+    [[nodiscard]] const std::vector<Annotation> &
+    Annotations() const noexcept
     {
-      return &It_.operator->()->second;
+      return It_.operator->()->second;
     }
 
-    const jlm::util::Annotation &
+    const std::vector<Annotation> &
     operator*() const
     {
-      return *GetAnnotation();
+      return Annotations();
     }
 
-    const jlm::util::Annotation *
+    const std::vector<Annotation> *
     operator->() const
     {
-      return GetAnnotation();
+      return &Annotations();
     }
 
     ConstIterator &
@@ -184,7 +184,7 @@ public:
    * @return True if the annotation exists, otherwise false.
    */
   [[nodiscard]] bool
-  HasAnnotation(const void * key) const noexcept
+  HasAnnotations(const void * key) const noexcept
   {
     return Map_.find(key) != Map_.end();
   }
@@ -194,10 +194,10 @@ public:
    *
    * @return A reference to an instance of Annotation.
    */
-  [[nodiscard]] const Annotation &
-  GetAnnotation(const void * key) const noexcept
+  [[nodiscard]] const std::vector<Annotation> &
+  GetAnnotations(const void * key) const noexcept
   {
-    JLM_ASSERT(HasAnnotation(key));
+    JLM_ASSERT(HasAnnotations(key));
     return Map_.at(key);
   }
 
@@ -208,8 +208,8 @@ public:
   void
   AddAnnotation(const void * key, Annotation annotation)
   {
-    JLM_ASSERT(!HasAnnotation(key));
-    Map_.emplace(key, annotation);
+    JLM_ASSERT(!HasAnnotations(key));
+    Map_[key].emplace_back(std::move(annotation));
   }
 
 private:

--- a/jlm/util/AnnotationMap.hpp
+++ b/jlm/util/AnnotationMap.hpp
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2024 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <jlm/util/common.hpp>
+#include <jlm/util/iterator_range.hpp>
+
+#include <cstdint>
+#include <string_view>
+#include <unordered_map>
+#include <variant>
+
+namespace jlm::util
+{
+
+/**
+ * Represents a simple key-value pair with a label and a value of type std::string_view, int64_t,
+ * uint64_t, or double.
+ */
+class Annotation final
+{
+  using AnnotationValue = std::variant<std::string_view, int64_t, uint64_t, double>;
+
+public:
+  Annotation(std::string_view label, std::string_view value)
+      : Label_(std::move(label)),
+        Value_(std::move(value))
+  {}
+
+  Annotation(std::string_view label, int64_t value)
+      : Label_(std::move(label)),
+        Value_(std::move(value))
+  {}
+
+  Annotation(std::string_view label, uint64_t value)
+      : Label_(std::move(label)),
+        Value_(std::move(value))
+  {}
+
+  Annotation(std::string_view label, double value)
+      : Label_(std::move(label)),
+        Value_(std::move(value))
+  {}
+
+  /**
+   * Gets the label of the annotation.
+   */
+  [[nodiscard]] const std::string_view &
+  Label() const noexcept
+  {
+    return Label_;
+  }
+
+  /**
+   * Gets the value of the annotation. Requires the annotation value to be of type \p TValue.
+   */
+  template<typename TValue>
+  [[nodiscard]] const TValue &
+  Value() const
+  {
+    return std::get<TValue>(Value_);
+  }
+
+  /**
+   * Checks if the type of the annotation value is equivalent to \p TValue.
+   *
+   * @return True if the value type if equivalent to \p TValue, otherwise false.
+   */
+  template<typename TValue>
+  [[nodiscard]] bool
+  HasValueType() const noexcept
+  {
+    return std::get_if<TValue>(&Value_) != nullptr;
+  }
+
+  bool
+  operator==(Annotation & other) const noexcept
+  {
+    return Label_ == other.Label_ && Value_ == other.Value_;
+  }
+
+  bool
+  operator!=(Annotation & other) const noexcept
+  {
+    return !(*this == other);
+  }
+
+private:
+  std::string_view Label_ = {};
+  AnnotationValue Value_ = {};
+};
+
+/**
+ * Represents a simple map that associates pointers with Annotation%s.
+ */
+class AnnotationMap final
+{
+  using AnnotationMapType = std::unordered_map<const void *, Annotation>;
+
+  class ConstIterator final
+  {
+  public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = Annotation;
+    using difference_type = std::ptrdiff_t;
+    using pointer = Annotation *;
+    using reference = Annotation &;
+
+  private:
+    friend AnnotationMap;
+
+    explicit ConstIterator(const typename AnnotationMapType::const_iterator & it)
+        : It_(it)
+    {}
+
+  public:
+    [[nodiscard]] const jlm::util::Annotation *
+    GetAnnotation() const noexcept
+    {
+      return &It_.operator->()->second;
+    }
+
+    const jlm::util::Annotation &
+    operator*() const
+    {
+      return *GetAnnotation();
+    }
+
+    const jlm::util::Annotation *
+    operator->() const
+    {
+      return GetAnnotation();
+    }
+
+    ConstIterator &
+    operator++()
+    {
+      ++It_;
+      return *this;
+    }
+
+    ConstIterator
+    operator++(int)
+    {
+      ConstIterator tmp = *this;
+      ++*this;
+      return tmp;
+    }
+
+    bool
+    operator==(const ConstIterator & other) const
+    {
+      return It_ == other.It_;
+    }
+
+    bool
+    operator!=(const ConstIterator & other) const
+    {
+      return !operator==(other);
+    }
+
+  private:
+    typename AnnotationMapType::const_iterator It_ = {};
+  };
+
+  using AnnotationRange = iterator_range<AnnotationMap::ConstIterator>;
+
+public:
+  /**
+   * Retrieves all annotations.
+   *
+   * @return An iterator_range of all the annotations.
+   */
+  [[nodiscard]] AnnotationRange
+  Annotations() const
+  {
+    return { ConstIterator(Map_.begin()), ConstIterator(Map_.end()) };
+  }
+
+  /**
+   * Checks if an annotation with the given \p key exists.
+   *
+   * @return True if the annotation exists, otherwise false.
+   */
+  [[nodiscard]] bool
+  HasAnnotation(const void * key) const noexcept
+  {
+    return Map_.find(key) != Map_.end();
+  }
+
+  /**
+   * Retrieves the annotation for the given \p key. The key must exist.
+   *
+   * @return A reference to an instance of Annotation.
+   */
+  [[nodiscard]] const Annotation &
+  GetAnnotation(const void * key) const noexcept
+  {
+    JLM_ASSERT(HasAnnotation(key));
+    return Map_.at(key);
+  }
+
+  /**
+   * Adds \p annotation with the given \p key to the map. Requires that \p key is not yet
+   * present.
+   */
+  void
+  AddAnnotation(const void * key, Annotation annotation)
+  {
+    JLM_ASSERT(!HasAnnotation(key));
+    Map_.emplace(key, annotation);
+  }
+
+private:
+  AnnotationMapType Map_ = {};
+};
+
+}

--- a/jlm/util/Makefile.sub
+++ b/jlm/util/Makefile.sub
@@ -25,7 +25,7 @@ libutil_HEADERS = \
     jlm/util/Worklist.hpp \
 
 libutil_TESTS += \
-    tests/jlm/util/AnnotationMapTests \
+	tests/jlm/util/AnnotationMapTests \
 	tests/jlm/util/test-disjointset \
 	tests/jlm/util/test-intrusive-hash \
 	tests/jlm/util/test-intrusive-list \

--- a/jlm/util/Makefile.sub
+++ b/jlm/util/Makefile.sub
@@ -5,6 +5,7 @@ libutil_SOURCES = \
 	jlm/util/Statistics.cpp \
 
 libutil_HEADERS = \
+    jlm/util/AnnotationMap.hpp \
     jlm/util/BijectiveMap.hpp \
     jlm/util/callbacks.hpp \
     jlm/util/common.hpp \
@@ -24,6 +25,7 @@ libutil_HEADERS = \
     jlm/util/Worklist.hpp \
 
 libutil_TESTS += \
+    tests/jlm/util/AnnotationMapTests \
 	tests/jlm/util/test-disjointset \
 	tests/jlm/util/test-intrusive-hash \
 	tests/jlm/util/test-intrusive-list \

--- a/tests/jlm/rvsdg/RegionTests.cpp
+++ b/tests/jlm/rvsdg/RegionTests.cpp
@@ -7,6 +7,8 @@
 #include <test-registry.hpp>
 #include <test-types.hpp>
 
+#include <jlm/util/AnnotationMap.hpp>
+
 #include <cassert>
 
 /**
@@ -274,6 +276,32 @@ ToTree_EmptyRvsdg()
 JLM_UNIT_TEST_REGISTER("jlm/rvsdg/RegionTests-ToTree_EmptyRvsdg", ToTree_EmptyRvsdg)
 
 static int
+ToTree_EmptyRvsdgWithAnnotations()
+{
+  using namespace jlm::rvsdg;
+  using namespace jlm::util;
+
+  // Arrange
+  graph rvsdg;
+
+  AnnotationMap annotationMap;
+  annotationMap.AddAnnotation(rvsdg.root(), Annotation("NumNodes", rvsdg.root()->nodes.size()));
+
+  // Act
+  auto tree = region::ToTree(*rvsdg.root(), annotationMap);
+  std::cout << tree << std::flush;
+
+  // Assert
+  assert(tree == "RootRegion NumNodes:0\n");
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER(
+    "jlm/rvsdg/RegionTests-ToTree_EmptyRvsdgWithAnnotations",
+    ToTree_EmptyRvsdgWithAnnotations)
+
+static int
 ToTree_RvsdgWithStructuralNodes()
 {
   using namespace jlm::rvsdg;
@@ -281,6 +309,7 @@ ToTree_RvsdgWithStructuralNodes()
   // Arrange
   graph rvsdg;
   auto structuralNode = jlm::tests::structural_node::create(rvsdg.root(), 2);
+  jlm::tests::structural_node::create(structuralNode->subregion(0), 1);
   jlm::tests::structural_node::create(structuralNode->subregion(1), 3);
 
   // Act
@@ -290,8 +319,8 @@ ToTree_RvsdgWithStructuralNodes()
   // Assert
   auto numLines = std::count(tree.begin(), tree.end(), '\n');
 
-  // We should find '\n' 8 times: 1 root region + 2 structural nodes + 5 subregions
-  assert(numLines == 8);
+  // We should find '\n' 8 times: 1 root region + 3 structural nodes + 6 subregions
+  assert(numLines == 10);
 
   // Check that the last line printed looks accordingly
   auto lastLine = std::string("----Region[2]\n");
@@ -303,3 +332,40 @@ ToTree_RvsdgWithStructuralNodes()
 JLM_UNIT_TEST_REGISTER(
     "jlm/rvsdg/RegionTests-ToTree_RvsdgWithStructuralNodes",
     ToTree_RvsdgWithStructuralNodes)
+
+static int
+ToTree_RvsdgWithStructuralNodesAndAnnotations()
+{
+  using namespace jlm::rvsdg;
+  using namespace jlm::util;
+
+  // Arrange
+  graph rvsdg;
+  auto structuralNode1 = jlm::tests::structural_node::create(rvsdg.root(), 2);
+  auto structuralNode2 = jlm::tests::structural_node::create(structuralNode1->subregion(1), 3);
+  auto subregion2 = structuralNode2->subregion(2);
+
+  AnnotationMap annotationMap;
+  annotationMap.AddAnnotation(subregion2, Annotation("NumNodes", subregion2->nodes.size()));
+  annotationMap.AddAnnotation(subregion2, Annotation("NumArguments", subregion2->narguments()));
+
+  // Act
+  auto tree = region::ToTree(*rvsdg.root(), annotationMap);
+  std::cout << tree << std::flush;
+
+  // Assert
+  auto numLines = std::count(tree.begin(), tree.end(), '\n');
+
+  // We should find '\n' 8 times: 1 root region + 2 structural nodes + 5 subregions
+  assert(numLines == 8);
+
+  // Check that the last line printed looks accordingly
+  auto lastLine = std::string("----Region[2] NumNodes:0 NumArguments:0\n");
+  assert(tree.compare(tree.size() - lastLine.size(), lastLine.size(), lastLine) == 0);
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER(
+    "jlm/rvsdg/RegionTests-ToTree_RvsdgWithStructuralNodesAndAnnotations",
+    ToTree_RvsdgWithStructuralNodesAndAnnotations)

--- a/tests/jlm/util/AnnotationMapTests.cpp
+++ b/tests/jlm/util/AnnotationMapTests.cpp
@@ -92,15 +92,19 @@ AnnotationMap()
   map.AddAnnotation((const void *)&AnnotationEquality, annotation);
 
   // Act & Assert
-  assert(map.HasAnnotation((const void *)&AnnotationEquality));
-  assert(!map.HasAnnotation((const void *)&AnnotationKeyValueRetrieval));
+  assert(map.HasAnnotations((const void *)&AnnotationEquality));
+  assert(!map.HasAnnotations((const void *)&AnnotationKeyValueRetrieval));
 
-  auto retrievedAnnotation = map.GetAnnotation((const void *)&AnnotationEquality);
-  assert(retrievedAnnotation == annotation);
+  auto annotations = map.GetAnnotations((const void *)&AnnotationEquality);
+  assert(annotations.size() == 1);
+  assert(annotations[0] == annotation);
 
-  for (auto & iteratedAnnotation : map.Annotations())
+  for (auto & iteratedAnnotations : map.Annotations())
   {
-    assert(iteratedAnnotation == annotation);
+    for (auto & iteratedAnnotation : iteratedAnnotations)
+    {
+      assert(iteratedAnnotation == annotation);
+    }
   }
 
   return 0;

--- a/tests/jlm/util/AnnotationMapTests.cpp
+++ b/tests/jlm/util/AnnotationMapTests.cpp
@@ -21,8 +21,8 @@ AnnotationKeyValueRetrieval()
 
   // Act & Assert
   assert(stringAnnotation.Label() == "string");
-  assert(stringAnnotation.Value<std::string_view>() == "value");
-  assert(stringAnnotation.HasValueType<std::string_view>());
+  assert(stringAnnotation.Value<std::string>() == "value");
+  assert(stringAnnotation.HasValueType<std::string>());
   assert(!stringAnnotation.HasValueType<uint64_t>());
 
   assert(intAnnotation.Label() == "int");

--- a/tests/jlm/util/AnnotationMapTests.cpp
+++ b/tests/jlm/util/AnnotationMapTests.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2024 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <test-registry.hpp>
+#include <test-util.hpp>
+
+#include <jlm/util/AnnotationMap.hpp>
+
+static int
+AnnotationKeyValueRetrieval()
+{
+  using namespace jlm::util;
+
+  // Arrange
+  Annotation stringAnnotation("string", "value");
+  Annotation intAnnotation("int", (int64_t)-1);
+  Annotation uintAnnotation("uint", (uint64_t)1);
+  Annotation doubleAnnotation("double", 1.0);
+
+  // Act & Assert
+  assert(stringAnnotation.Label() == "string");
+  assert(stringAnnotation.Value<std::string_view>() == "value");
+  assert(stringAnnotation.HasValueType<std::string_view>());
+  assert(!stringAnnotation.HasValueType<uint64_t>());
+
+  assert(intAnnotation.Label() == "int");
+  assert(intAnnotation.Value<int64_t>() == -1);
+  assert(intAnnotation.HasValueType<int64_t>());
+  assert(!intAnnotation.HasValueType<uint64_t>());
+
+  assert(uintAnnotation.Label() == "uint");
+  assert(uintAnnotation.Value<uint64_t>() == 1);
+  assert(uintAnnotation.HasValueType<uint64_t>());
+
+  assert(doubleAnnotation.Label() == "double");
+  assert(doubleAnnotation.Value<double>() == 1.0);
+  assert(!doubleAnnotation.HasValueType<uint64_t>());
+
+  try
+  {
+    (void)doubleAnnotation.Value<uint64_t>();
+    assert(false); // the line above should have thrown an exception
+  }
+  catch (...)
+  {}
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER(
+    "jlm/util/AnnotationMapTests-AnnotationKeyValueRetrieval",
+    AnnotationKeyValueRetrieval)
+
+static int
+AnnotationEquality()
+{
+  using namespace jlm::util;
+
+  // Arrange
+  Annotation stringAnnotation("string", "value");
+  Annotation intAnnotation("int", (int64_t)-1);
+  Annotation uintAnnotation("uint", (uint64_t)1);
+  Annotation doubleAnnotation("double", 1.0);
+
+  // Act & Assert
+  assert(stringAnnotation != doubleAnnotation);
+  assert(stringAnnotation != intAnnotation);
+  assert(stringAnnotation != uintAnnotation);
+
+  Annotation otherStringAnnotation("string", "value");
+  assert(stringAnnotation == otherStringAnnotation);
+
+  Annotation otherIntAnnotation("uint", (int64_t)1);
+  assert(uintAnnotation != otherIntAnnotation);
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER("jlm/util/AnnotationMapTests-AnnotationEquality", AnnotationEquality)
+
+static int
+AnnotationMap()
+{
+  using namespace jlm::util;
+
+  // Arrange
+  Annotation annotation("foo", "bar");
+
+  jlm::util::AnnotationMap map;
+  map.AddAnnotation((const void *)&AnnotationEquality, annotation);
+
+  // Act & Assert
+  assert(map.HasAnnotation((const void *)&AnnotationEquality));
+  assert(!map.HasAnnotation((const void *)&AnnotationKeyValueRetrieval));
+
+  auto retrievedAnnotation = map.GetAnnotation((const void *)&AnnotationEquality);
+  assert(retrievedAnnotation == annotation);
+
+  for (auto & iteratedAnnotation : map.Annotations())
+  {
+    assert(iteratedAnnotation == annotation);
+  }
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER("jlm/util/AnnotationMapTests-AnnotationMap", AnnotationMap)


### PR DESCRIPTION
This PR adds support for annotations to region trees. Here is an example of how it will look like:

```
RootRegion
-STRUCTURAL_TEST_NODE
--Region[0]
--Region[1]
---STRUCTURAL_TEST_NODE
----Region[0]
----Region[1]
----Region[2] NumNodes:0 NumArguments:0
```

The plan is to use this for introducing a pass that enables the printing of RVSDG properties for debugging as well as metric gathering for pass evaluations.