### PR TITLE
Make the ClangFormat action fail on format errors

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -182,5 +182,5 @@ format:
 
 format-dry-run:
 	@for FILE in $(SOURCES) $(HEADERS) ; do \
-		clang-format-$(LLVM_VERSION) --dry-run --Werror --style="file:.clang-format" --verbose -i $$FILE ;\
+		clang-format-$(LLVM_VERSION) --dry-run --Werror --style="file:.clang-format" --verbose -i $$FILE || exit 1 ;\
 	done

--- a/jlm/hls/backend/rhls2firrtl/verilator-harness-hls.hpp
+++ b/jlm/hls/backend/rhls2firrtl/verilator-harness-hls.hpp
@@ -27,7 +27,8 @@ public:
   /**
    * Construct a Verilator harness generator.
    *
-   * /param verilogFile The filename to the Verilog file that is to be used together with the generated harness as input to Verilator.
+   * /param verilogFile The filename to the Verilog file that is to be used together with the
+   * generated harness as input to Verilator.
    */
   VerilatorHarnessHLS(const util::filepath verilogFile)
       : VerilogFile_(std::move(verilogFile)){};
@@ -36,7 +37,8 @@ private:
   const util::filepath VerilogFile_;
 
   /**
-   * \return The Verilog filename that is to be used together with the generated harness as input to Verilator.
+   * \return The Verilog filename that is to be used together with the generated harness as input to
+   * Verilator.
    */
   [[nodiscard]] const util::filepath &
   GetVerilogFileName() const noexcept

--- a/jlm/tooling/Command.cpp
+++ b/jlm/tooling/Command.cpp
@@ -624,12 +624,7 @@ JlmHlsCommand::~JlmHlsCommand() noexcept = default;
 std::string
 JlmHlsCommand::ToString() const
 {
-  return util::strfmt(
-      "jlm-hls ",
-      "-o ",
-      OutputFolder_.to_str(),
-      " ",
-      InputFile_.to_str());
+  return util::strfmt("jlm-hls ", "-o ", OutputFolder_.to_str(), " ", InputFile_.to_str());
 }
 
 void

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -1159,7 +1159,10 @@ JhlsCommandLineParser::ParseCommandLineArguments(int argc, char ** argv)
 
   cl::opt<bool> generateFirrtl("firrtl", cl::ValueDisallowed, cl::desc("Generate firrtl"));
 
-  cl::opt<bool> useCirct("circt", cl::Prefix, cl::desc("DEPRACATED - CIRCT is always used to generate FIRRTL"));
+  cl::opt<bool> useCirct(
+      "circt",
+      cl::Prefix,
+      cl::desc("DEPRACATED - CIRCT is always used to generate FIRRTL"));
 
   cl::ParseCommandLineOptions(argc, argv);
 


### PR DESCRIPTION
It turns out `for` loops in `/bin/sh` will ignore the exit codes of all commands except the very last command they run. This allowed some formatting errors to sneak into `master`.