### PR TITLE
Generalize CIRCT and MLIR jlm dialect build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Makefile.custom
 docs/html
 build
 build-*
+usr

--- a/configure.sh
+++ b/configure.sh
@@ -114,15 +114,6 @@ if [ "${ENABLE_HLS}" == "yes" ] ; then
 	CXXFLAGS_NO_COMMENT="-Wno-error=comment"
 	CIRCT_LDFLAGS_ARRAY=(
 		"-L${CIRCT_PATH}/lib"
-		"-lMLIR"
-		"-lMLIRBytecodeReader"
-		"-lMLIRBytecodeWriter"
-		"-lMLIRParser"
-		"-lMLIRSupport"
-		"-lMLIRIR"
-		"-lMLIROptLib"
-		"-lMLIRFuncDialect"
-		"-lMLIRTransforms"
 		"-lCIRCTAnalysisTestPasses"
 		"-lCIRCTDependenceAnalysis"
 		"-lCIRCTExportFIRRTL"
@@ -149,6 +140,7 @@ if [ "${ENABLE_HLS}" == "yes" ] ; then
 		"-lCIRCTExportChiselInterface"
 		"-lCIRCTOM"
 		"-lCIRCTSupport"
+		"-lMLIR"
 	)
 fi
 
@@ -156,7 +148,7 @@ CPPFLAGS_MLIR=""
 if [ "${ENABLE_MLIR}" == "yes" ] ; then
 	CPPFLAGS_MLIR="-I${MLIR_PATH}/include -DENABLE_MLIR"
 	CXXFLAGS_NO_COMMENT="-Wno-error=comment"
-	MLIR_LDFLAGS="-L${MLIR_PATH}/lib -lMLIR -lMLIRJLM -lMLIRRVSDG"
+	MLIR_LDFLAGS="-L${MLIR_PATH}/lib -lMLIRJLM -lMLIRRVSDG -lMLIR"
 fi
 
 if [ "${ENABLE_COVERAGE}" == "yes" ] ; then
@@ -181,7 +173,7 @@ MLIR_LDFLAGS=${MLIR_LDFLAGS}
 LLVMCONFIG=${LLVM_CONFIG_BIN}
 LLVM_VERSION=${LLVM_VERSION}
 ENABLE_COVERAGE=${ENABLE_COVERAGE}
-LD_LIBRARY_PATH=$(${LLVM_CONFIG_BIN} --libdir)
+export LD_LIBRARY_PATH=$(${LLVM_CONFIG_BIN} --libdir)
 EOF
 	if [ ! -z "${CXX-}" ] ; then
 		echo "CXX=${CXX}"

--- a/jlm/hls/backend/rvsdg2rhls/mem-sep.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-sep.cpp
@@ -17,6 +17,8 @@
 #include <jlm/rvsdg/traverser.hpp>
 #include <jlm/rvsdg/view.hpp>
 
+#include <algorithm>
+
 namespace jlm::hls
 {
 

--- a/jlm/hls/util/view.cpp
+++ b/jlm/hls/util/view.cpp
@@ -14,6 +14,8 @@
 #include <jlm/rvsdg/traverser.hpp>
 #include <jlm/rvsdg/view.hpp>
 
+#include <algorithm>
+
 namespace jlm::hls
 {
 

--- a/jlm/mlir/Makefile.sub
+++ b/jlm/mlir/Makefile.sub
@@ -21,7 +21,7 @@ libmlir_TEST_LIBS += \
 	libjlmtest \
 
 libmlir_TEST_EXTRA_LDFLAGS = \
-	$(shell $(LLVMCONFIG) --ldflags --libs --system-libs) \
 	$(MLIR_LDFLAGS) \
+	$(shell $(LLVMCONFIG) --ldflags --libs --system-libs) \
 
 $(eval $(call common_library,libmlir))

--- a/jlm/tooling/Makefile.sub
+++ b/jlm/tooling/Makefile.sub
@@ -65,7 +65,7 @@ libtooling_TEST_LIBS = \
 	libjlmtest \
 
 libtooling_TEST_EXTRA_LDFLAGS = \
-	$(shell $(LLVMCONFIG) --ldflags --libs --system-libs) \
 	$(MLIR_LDFLAGS) \
+	$(shell $(LLVMCONFIG) --ldflags --libs --system-libs) \
 
 $(eval $(call common_library,libtooling))

--- a/scripts/build-circt.sh
+++ b/scripts/build-circt.sh
@@ -1,19 +1,17 @@
 #!/bin/bash
-set -eu
+set -eux
 
 GIT_COMMIT=debf1ed774c2bbdbfc8e7bc987a21f72e8f08f65
 
 # Get the absolute path to this script and set default build and install paths
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
-JLM_ROOT_DIR=${SCRIPT_DIR}/..
-CIRCT_BUILD=${JLM_ROOT_DIR}/build-circt
-CIRCT_INSTALL=${JLM_ROOT_DIR}/usr
+JLM_ROOT_DIR="$(realpath "${SCRIPT_DIR}/..")"
+CIRCT_BUILD="${JLM_ROOT_DIR}/build-circt"
+CIRCT_INSTALL="${JLM_ROOT_DIR}/usr"
 LLVM_LIT_PATH=/usr/local/bin/lit
 
 LLVM_VERSION=17
-LLVM_CONFIG=llvm-config-${LLVM_VERSION}
-LLVM_ROOT=$(${LLVM_CONFIG} --prefix)
-LLVM_LIB=$(${LLVM_CONFIG} --libdir)
+LLVM_CONFIG_BIN=llvm-config-${LLVM_VERSION}
 
 function commit()
 {
@@ -24,6 +22,8 @@ function usage()
 {
 	echo "Usage: ./build-circt.sh [OPTION] [VAR=VALUE]"
 	echo ""
+	echo "  --llvm-config PATH    The llvm-config script used to determine up llvm"
+	echo "                        build dependencies. [${LLVM_CONFIG_BIN}]"
 	echo "  --build-path PATH     The path where to build CIRCT."
 	echo "                        [${CIRCT_BUILD}]"
 	echo "  --install-path PATH   The path where to install CIRCT."
@@ -36,6 +36,11 @@ function usage()
 
 while [[ "$#" -ge 1 ]] ; do
 	case "$1" in
+		--llvm-config)
+			shift
+			LLVM_CONFIG_BIN="$1"
+			shift
+			;;
 		--build-path)
 			shift
 			CIRCT_BUILD=$(readlink -m "$1")
@@ -62,6 +67,9 @@ while [[ "$#" -ge 1 ]] ; do
 	esac
 done
 
+LLVM_BINDIR=$(${LLVM_CONFIG_BIN} --bindir)
+LLVM_CMAKEDIR=$(${LLVM_CONFIG_BIN} --cmakedir)
+
 CIRCT_GIT_DIR=${CIRCT_BUILD}/circt.git
 CIRCT_BUILD_DIR=${CIRCT_BUILD}/build
 
@@ -69,16 +77,15 @@ if [ ! -d "$CIRCT_GIT_DIR" ] ;
 then
 	git clone https://github.com/EECS-NTNU/circt.git ${CIRCT_GIT_DIR}
 fi
-cd ${CIRCT_GIT_DIR}
-git checkout ${GIT_COMMIT}
+git -C ${CIRCT_GIT_DIR} checkout ${GIT_COMMIT}
 cmake -G Ninja \
 	${CIRCT_GIT_DIR} \
 	-B ${CIRCT_BUILD_DIR} \
-	-DCMAKE_C_COMPILER=clang-${LLVM_VERSION} \
-	-DCMAKE_CXX_COMPILER=clang++-${LLVM_VERSION} \
+	-DCMAKE_C_COMPILER=${LLVM_BINDIR}/clang \
+	-DCMAKE_CXX_COMPILER=${LLVM_BINDIR}/clang++ \
 	-DCMAKE_BUILD_TYPE=RelWithDebInfo \
-	-DLLVM_DIR=${LLVM_ROOT}/cmake/ \
-	-DMLIR_DIR=${LLVM_LIB}/cmake/mlir \
+	-DLLVM_DIR=${LLVM_CMAKEDIR} \
+	-DMLIR_DIR=${LLVM_CMAKEDIR}/../mlir \
 	-DLLVM_EXTERNAL_LIT="${LLVM_LIT_PATH}" \
 	-DLLVM_LIT_ARGS="-v --show-unsupported" \
 	-DVERILATOR_DISABLE=ON \

--- a/scripts/build-circt.sh
+++ b/scripts/build-circt.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
-set -eux
+set -eu
 
 GIT_COMMIT=debf1ed774c2bbdbfc8e7bc987a21f72e8f08f65
 
 # Get the absolute path to this script and set default build and install paths
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 JLM_ROOT_DIR="$(realpath "${SCRIPT_DIR}/..")"
-CIRCT_BUILD="${JLM_ROOT_DIR}/build-circt"
-CIRCT_INSTALL="${JLM_ROOT_DIR}/usr"
+CIRCT_BUILD=${JLM_ROOT_DIR}/build-circt
+CIRCT_INSTALL=${JLM_ROOT_DIR}/usr
 LLVM_LIT_PATH=/usr/local/bin/lit
 
 LLVM_VERSION=17

--- a/scripts/build-mlir.sh
+++ b/scripts/build-mlir.sh
@@ -6,8 +6,8 @@ GIT_COMMIT=ab630d5a881a0e8fc5bdfa63a5984186fa9096c0
 # Get the absolute path to this script and set default build and install paths
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 JLM_ROOT_DIR="$(realpath "${SCRIPT_DIR}/..")"
-MLIR_BUILD="${JLM_ROOT_DIR}/build-mlir"
-MLIR_INSTALL="${JLM_ROOT_DIR}/usr"
+MLIR_BUILD=${JLM_ROOT_DIR}/build-mlir
+MLIR_INSTALL=${JLM_ROOT_DIR}/usr
 
 LLVM_VERSION=17
 LLVM_CONFIG_BIN=llvm-config-${LLVM_VERSION}

--- a/scripts/build-mlir.sh
+++ b/scripts/build-mlir.sh
@@ -5,14 +5,12 @@ GIT_COMMIT=ab630d5a881a0e8fc5bdfa63a5984186fa9096c0
 
 # Get the absolute path to this script and set default build and install paths
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
-JLM_ROOT_DIR=${SCRIPT_DIR}/..
-MLIR_BUILD=${JLM_ROOT_DIR}/build-mlir
-MLIR_INSTALL=${JLM_ROOT_DIR}/usr
+JLM_ROOT_DIR="$(realpath "${SCRIPT_DIR}/..")"
+MLIR_BUILD="${JLM_ROOT_DIR}/build-mlir"
+MLIR_INSTALL="${JLM_ROOT_DIR}/usr"
 
 LLVM_VERSION=17
-LLVM_CONFIG=llvm-config-${LLVM_VERSION}
-LLVM_ROOT=$(${LLVM_CONFIG} --prefix)
-LLVM_LIB=$(${LLVM_CONFIG} --libdir)
+LLVM_CONFIG_BIN=llvm-config-${LLVM_VERSION}
 
 function commit()
 {
@@ -23,6 +21,8 @@ function usage()
 {
 	echo "Usage: ./build-circt.sh [OPTION] [VAR=VALUE]"
 	echo ""
+	echo "  --llvm-config PATH    The llvm-config script used to determine up llvm"
+	echo "                        build dependencies. [${LLVM_CONFIG_BIN}]"
 	echo "  --build-path PATH     The path where to build MLIR."
 	echo "                        [${MLIR_BUILD}]"
 	echo "  --install-path PATH   The path where to install MLIR."
@@ -33,6 +33,11 @@ function usage()
 
 while [[ "$#" -ge 1 ]] ; do
 	case "$1" in
+		--llvm-config)
+			shift
+			LLVM_CONFIG_BIN="$1"
+			shift
+			;;
 		--build-path)
 			shift
 			MLIR_BUILD=$(readlink -m "$1")
@@ -54,6 +59,9 @@ while [[ "$#" -ge 1 ]] ; do
 	esac
 done
 
+LLVM_BINDIR=$(${LLVM_CONFIG_BIN} --bindir)
+LLVM_CMAKEDIR=$(${LLVM_CONFIG_BIN} --cmakedir)
+
 MLIR_GIT_DIR=${MLIR_BUILD}/mlir_rvsdg.git
 MLIR_BUILD_DIR=${MLIR_BUILD}/build
 
@@ -61,16 +69,16 @@ if [ ! -d "$MLIR_GIT_DIR" ] ;
 then
 	git clone https://github.com/EECS-NTNU/mlir_rvsdg.git ${MLIR_GIT_DIR}
 fi
-cd ${MLIR_GIT_DIR}
-git checkout ${GIT_COMMIT}
+
+git -C ${MLIR_GIT_DIR} checkout ${GIT_COMMIT}
 cmake -G Ninja \
 	${MLIR_GIT_DIR} \
 	-B ${MLIR_BUILD_DIR} \
-	-DCMAKE_C_COMPILER=clang-${LLVM_VERSION} \
-	-DCMAKE_CXX_COMPILER=clang++-${LLVM_VERSION} \
-	-DLLVM_DIR=${LLVM_ROOT}/cmake/ \
-	-DMLIR_DIR=${LLVM_LIB}/cmake/mlir \
+	-DCMAKE_C_COMPILER=${LLVM_BINDIR}/clang \
+	-DCMAKE_CXX_COMPILER=${LLVM_BINDIR}/clang++ \
+	-DLLVM_DIR=${LLVM_CMAKEDIR} \
+	-DMLIR_DIR=${LLVM_CMAKEDIR}/../mlir \
 	-DCMAKE_INSTALL_PREFIX=${MLIR_INSTALL} \
 	-Wno-dev
-cmake --build ${MLIR_BUILD_DIR}
+ninja -C ${MLIR_BUILD_DIR}
 ninja -C ${MLIR_BUILD_DIR} install

--- a/scripts/build-mlir.sh
+++ b/scripts/build-mlir.sh
@@ -19,7 +19,7 @@ function commit()
 
 function usage()
 {
-	echo "Usage: ./build-circt.sh [OPTION] [VAR=VALUE]"
+	echo "Usage: ./build-mlir.sh [OPTION] [VAR=VALUE]"
 	echo ""
 	echo "  --llvm-config PATH    The llvm-config script used to determine up llvm"
 	echo "                        build dependencies. [${LLVM_CONFIG_BIN}]"

--- a/tests/jlm/rvsdg/RegionTests.cpp
+++ b/tests/jlm/rvsdg/RegionTests.cpp
@@ -9,6 +9,7 @@
 
 #include <jlm/util/AnnotationMap.hpp>
 
+#include <algorithm>
 #include <cassert>
 
 /**

--- a/tools/Makefile.sub
+++ b/tools/Makefile.sub
@@ -13,8 +13,8 @@ jlc_LIBS += \
 	libutil \
 
 jlc_EXTRA_LDFLAGS += \
-	$(shell $(LLVMCONFIG) --libs core irReader --ldflags --system-libs) \
 	${MLIR_LDFLAGS} \
+	$(shell $(LLVMCONFIG) --libs core irReader --ldflags --system-libs) \
 
 $(eval $(call common_executable,jlc))
 
@@ -29,7 +29,7 @@ jlm-opt_LIBS = \
 	libutil \
 
 jlm-opt_EXTRA_LDFLAGS = \
-	$(shell $(LLVMCONFIG) --libs core irReader --ldflags --system-libs) \
 	${MLIR_LDFLAGS} \
+	$(shell $(LLVMCONFIG) --libs core irReader --ldflags --system-libs) \
 
 $(eval $(call common_executable,jlm-opt))

--- a/tools/jhls/Makefile.sub
+++ b/tools/jhls/Makefile.sub
@@ -14,7 +14,7 @@ jhls_LIBS = \
 	libutil \
 
 jhls_EXTRA_LDFLAGS = \
-	$(shell $(LLVMCONFIG) --libs core irReader --ldflags) \
 	${MLIR_LDFLAGS} \
+	$(shell $(LLVMCONFIG) --libs core irReader --ldflags) \
 
 $(eval $(call common_executable,jhls))

--- a/tools/jlm-hls/Makefile.sub
+++ b/tools/jlm-hls/Makefile.sub
@@ -13,7 +13,7 @@ jlm-hls_LIBS = \
 	libutil \
 
 jlm-hls_EXTRA_LDFLAGS = \
+    ${CIRCT_LDFLAGS} \
     $(shell $(LLVMCONFIG) --libs core irReader --ldflags --system-libs) \
-    ${CIRCT_LDFLAGS}
 
 $(eval $(call common_executable,jlm-hls))


### PR DESCRIPTION
I was having an issue where tests of the command parser would fail due to some MLIR option, even when neither `--enable-mlir` nor `--enable-hls` are passed to `configure.sh`. That is a separate issue that should be fixed, but I thought it was about time I got MLIR and CIRCT running on my own machine anyway.

These changes should make the build scripts work no matter where LLVM is installed.

This is as a draft PR for now, to check that these changes do not break CI.

PS: Some `.cpp` files used symbols imported from the standard library indirectly, so I had to add some `#include <>` to make it work. I am on arch (btw), but I am guessing these changes will become necessary on Ubuntu eventually as well.