### PR TITLE
HLS: Configurable pointer size

### DIFF
--- a/jlm/hls/backend/rhls2firrtl/base-hls.cpp
+++ b/jlm/hls/backend/rhls2firrtl/base-hls.cpp
@@ -115,7 +115,7 @@ BaseHLS::JlmSize(const jlm::rvsdg::type * type)
   }
   else if (dynamic_cast<const llvm::PointerType *>(type))
   {
-    return 64;
+    return GetPointerSizeInBits();
   }
   else if (auto ct = dynamic_cast<const jlm::rvsdg::ctltype *>(type))
   {

--- a/jlm/hls/backend/rhls2firrtl/base-hls.hpp
+++ b/jlm/hls/backend/rhls2firrtl/base-hls.hpp
@@ -34,6 +34,15 @@ public:
   static int
   JlmSize(const jlm::rvsdg::type * type);
 
+  /**
+   * @return The size of a pointer in bits.
+   */
+  [[nodiscard]] static size_t
+  GetPointerSizeInBits()
+  {
+    return 64;
+  }
+
 private:
   virtual std::string
   extension() = 0;

--- a/jlm/hls/backend/rhls2firrtl/json-hls.cpp
+++ b/jlm/hls/backend/rhls2firrtl/json-hls.cpp
@@ -21,6 +21,7 @@ JsonHLS::get_text(llvm::RvsdgModule & rm)
   auto reg_args = get_reg_args(ln);
   auto reg_results = get_reg_results(ln);
 
+  json << "\"addr_width\": " << GetPointerSizeInBits() << ",\n";
   json << "\"arguments\": [";
   for (size_t i = 0; i < reg_args.size(); ++i)
   {


### PR DESCRIPTION
Makes it possible to manually change the size of a pointer by changing GetPointerSizeInBits() in base-hls.cpp.