### PR TITLE
Add missing type check to argument constructors

### DIFF
--- a/jlm/rvsdg/region.cpp
+++ b/jlm/rvsdg/region.cpp
@@ -36,6 +36,11 @@ argument::argument(
     if (input->node() != region->node())
       throw jlm::util::error("Argument cannot be added to input.");
 
+    if (input->type() != *Type())
+    {
+      throw util::type_error(Type()->debug_string(), input->type().debug_string());
+    }
+
     input->arguments.push_back(this);
   }
 }

--- a/jlm/rvsdg/region.cpp
+++ b/jlm/rvsdg/region.cpp
@@ -52,6 +52,11 @@ argument::argument(
     if (input->node() != region->node())
       throw jlm::util::error("Argument cannot be added to input.");
 
+    if (input->type() != *Type())
+    {
+      throw util::type_error(Type()->debug_string(), input->type().debug_string());
+    }
+
     input->arguments.push_back(this);
   }
 }

--- a/tests/jlm/rvsdg/ArgumentTests.cpp
+++ b/tests/jlm/rvsdg/ArgumentTests.cpp
@@ -46,3 +46,35 @@ ArgumentNodeMismatch()
 }
 
 JLM_UNIT_TEST_REGISTER("jlm/rvsdg/ArgumentTests-ArgumentNodeMismatch", ArgumentNodeMismatch)
+
+static int
+ArgumentInputTypeMismatch()
+{
+  using namespace jlm::tests;
+
+  // Arrange
+  auto valueType = jlm::tests::valuetype::Create();
+  auto stateType = jlm::tests::statetype::Create();
+
+  jlm::rvsdg::graph rvsdg;
+  auto x = rvsdg.add_import({ valueType, "import" });
+
+  auto structuralNode = structural_node::create(rvsdg.root(), 1);
+  auto structuralInput = jlm::rvsdg::structural_input::create(structuralNode, x, valueType);
+
+  // Act & Assert
+  try
+  {
+    jlm::rvsdg::argument::create(structuralNode->subregion(0), structuralInput, stateType);
+    // The line below should not be executed as the line above is expected to throw an exception.
+    assert(false);
+  }
+  catch (...)
+  {}
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER(
+    "jlm/rvsdg/ArgumentTests-ArgumentInputTypeMismatch",
+    ArgumentInputTypeMismatch)

--- a/tests/jlm/rvsdg/ArgumentTests.cpp
+++ b/tests/jlm/rvsdg/ArgumentTests.cpp
@@ -51,6 +51,7 @@ static int
 ArgumentInputTypeMismatch()
 {
   using namespace jlm::tests;
+  using namespace jlm::util;
 
   // Arrange
   auto valueType = jlm::tests::valuetype::Create();
@@ -63,14 +64,19 @@ ArgumentInputTypeMismatch()
   auto structuralInput = jlm::rvsdg::structural_input::create(structuralNode, x, valueType);
 
   // Act & Assert
+  bool exceptionWasCaught = false;
   try
   {
     jlm::rvsdg::argument::create(structuralNode->subregion(0), structuralInput, stateType);
     // The line below should not be executed as the line above is expected to throw an exception.
     assert(false);
   }
-  catch (...)
-  {}
+  catch (type_error &)
+  {
+    exceptionWasCaught = true;
+  }
+
+  assert(exceptionWasCaught);
 
   return 0;
 }

--- a/tests/jlm/rvsdg/ArgumentTests.cpp
+++ b/tests/jlm/rvsdg/ArgumentTests.cpp
@@ -75,7 +75,22 @@ ArgumentInputTypeMismatch()
   {
     exceptionWasCaught = true;
   }
+  assert(exceptionWasCaught);
 
+  exceptionWasCaught = false;
+  try
+  {
+    jlm::rvsdg::argument::create(
+        structuralNode->subregion(0),
+        structuralInput,
+        jlm::rvsdg::port(stateType));
+    // The line below should not be executed as the line above is expected to throw an exception.
+    assert(false);
+  }
+  catch (type_error &)
+  {
+    exceptionWasCaught = true;
+  }
   assert(exceptionWasCaught);
 
   return 0;


### PR DESCRIPTION
The argument constructors did not check whether the type of the provided input is the same as the handed in type. In the future, these constructors should be refactored such that we either hand in an input or a simple type, but not both at the same time. This would avoid this check altogether.

Closes #555