### PR TITLE
Add missing type check to result constructors

### DIFF
--- a/jlm/rvsdg/region.cpp
+++ b/jlm/rvsdg/region.cpp
@@ -100,6 +100,11 @@ result::result(
   {
     if (output->node() != region->node())
       throw jlm::util::error("Result cannot be added to output.");
+    
+    if (*Type() != *output->Type())
+    {
+      throw jlm::util::type_error(Type()->debug_string(), output->Type()->debug_string());
+    }
 
     output->results.push_back(this);
   }
@@ -117,6 +122,11 @@ result::result(
   {
     if (output->node() != region->node())
       throw jlm::util::error("Result cannot be added to output.");
+
+    if (*Type() != *output->Type())
+    {
+      throw jlm::util::type_error(Type()->debug_string(), output->Type()->debug_string());
+    }
 
     output->results.push_back(this);
   }
@@ -141,7 +151,7 @@ result::create(
     jlm::rvsdg::structural_output * output,
     std::shared_ptr<const jlm::rvsdg::type> type)
 {
-  auto result = new jlm::rvsdg::result(region, origin, output, jlm::rvsdg::port(std::move(type)));
+  auto result = new jlm::rvsdg::result(region, origin, output, std::move(type));
   region->append_result(result);
   return result;
 }

--- a/jlm/rvsdg/region.cpp
+++ b/jlm/rvsdg/region.cpp
@@ -100,7 +100,7 @@ result::result(
   {
     if (output->node() != region->node())
       throw jlm::util::error("Result cannot be added to output.");
-    
+
     if (*Type() != *output->Type())
     {
       throw jlm::util::type_error(Type()->debug_string(), output->Type()->debug_string());

--- a/tests/jlm/rvsdg/ResultTests.cpp
+++ b/tests/jlm/rvsdg/ResultTests.cpp
@@ -49,3 +49,43 @@ ResultNodeMismatch()
 }
 
 JLM_UNIT_TEST_REGISTER("jlm/rvsdg/ResultTests-ResultNodeMismatch", ResultNodeMismatch)
+
+static int
+ResultInputTypeMismatch()
+{
+  using namespace jlm::tests;
+  using namespace jlm::util;
+
+  // Arrange
+  auto valueType = jlm::tests::valuetype::Create();
+  auto stateType = jlm::tests::statetype::Create();
+
+  jlm::rvsdg::graph rvsdg;
+
+  auto structuralNode = structural_node::create(rvsdg.root(), 1);
+  auto structuralOutput = jlm::rvsdg::structural_output::create(structuralNode, valueType);
+
+  // Act & Assert
+  bool exceptionWasCaught = false;
+  try
+  {
+    auto simpleNode = test_op::create(structuralNode->subregion(0), {}, { stateType });
+    jlm::rvsdg::result::create(
+        structuralNode->subregion(0),
+        simpleNode->output(0),
+        structuralOutput,
+        stateType);
+    // The line below should not be executed as the line above is expected to throw an exception.
+    assert(false);
+  }
+  catch (type_error &)
+  {
+    exceptionWasCaught = true;
+  }
+
+  assert(exceptionWasCaught);
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER("jlm/rvsdg/ResultTests-ResultInputTypeMismatch", ResultInputTypeMismatch)

--- a/tests/jlm/rvsdg/ResultTests.cpp
+++ b/tests/jlm/rvsdg/ResultTests.cpp
@@ -82,7 +82,24 @@ ResultInputTypeMismatch()
   {
     exceptionWasCaught = true;
   }
+  assert(exceptionWasCaught);
 
+  exceptionWasCaught = false;
+  try
+  {
+    auto simpleNode = test_op::create(structuralNode->subregion(0), {}, { stateType });
+    jlm::rvsdg::result::create(
+        structuralNode->subregion(0),
+        simpleNode->output(0),
+        structuralOutput,
+        jlm::rvsdg::port(stateType));
+    // The line below should not be executed as the line above is expected to throw an exception.
+    assert(false);
+  }
+  catch (type_error &)
+  {
+    exceptionWasCaught = true;
+  }
   assert(exceptionWasCaught);
 
   return 0;


### PR DESCRIPTION
The result constructors did not check whether the type of the provided output is the same as the handed in type. In the future, these constructors should be refactored such that we either hand in an output or a simple type, but not both at the same time. This would avoid this check altogether.

Closes #556 