### PR TITLE
Add Copy() method to argument class

### DIFF
--- a/jlm/hls/ir/hls.cpp
+++ b/jlm/hls/ir/hls.cpp
@@ -38,6 +38,7 @@ bundletype::ComputeHash() const noexcept
 backedge_argument &
 backedge_argument::Copy(rvsdg::region & region, jlm::rvsdg::structural_input * input)
 {
+  JLM_ASSERT(input == nullptr);
   return *backedge_argument::create(&region, Type());
 }
 

--- a/jlm/hls/ir/hls.cpp
+++ b/jlm/hls/ir/hls.cpp
@@ -36,7 +36,7 @@ bundletype::ComputeHash() const noexcept
 }
 
 backedge_argument &
-backedge_argument::CopyTo(rvsdg::region & region, jlm::rvsdg::structural_input * input)
+backedge_argument::Copy(rvsdg::region & region, jlm::rvsdg::structural_input * input)
 {
   return *backedge_argument::create(&region, Type());
 }

--- a/jlm/hls/ir/hls.cpp
+++ b/jlm/hls/ir/hls.cpp
@@ -35,6 +35,12 @@ bundletype::ComputeHash() const noexcept
   return seed;
 }
 
+backedge_argument &
+backedge_argument::CopyTo(rvsdg::region & region, jlm::rvsdg::structural_input * input)
+{
+  return *backedge_argument::create(&region, Type());
+}
+
 jlm::rvsdg::structural_output *
 loop_node::add_loopvar(jlm::rvsdg::output * origin, jlm::rvsdg::output ** buffer)
 {

--- a/jlm/hls/ir/hls.hpp
+++ b/jlm/hls/ir/hls.hpp
@@ -623,6 +623,9 @@ public:
     return result_;
   }
 
+  backedge_argument &
+  CopyTo(rvsdg::region & region, jlm::rvsdg::structural_input * input) override;
+
 private:
   backedge_argument(
       jlm::rvsdg::region * region,

--- a/jlm/hls/ir/hls.hpp
+++ b/jlm/hls/ir/hls.hpp
@@ -624,7 +624,7 @@ public:
   }
 
   backedge_argument &
-  CopyTo(rvsdg::region & region, jlm::rvsdg::structural_input * input) override;
+  Copy(rvsdg::region & region, jlm::rvsdg::structural_input * input) override;
 
 private:
   backedge_argument(

--- a/jlm/llvm/ir/operators/Phi.cpp
+++ b/jlm/llvm/ir/operators/Phi.cpp
@@ -169,8 +169,9 @@ rvargument::~rvargument()
 {}
 
 rvargument &
-rvargument::Copy(rvsdg::region & region, rvsdg::structural_input *)
+rvargument::Copy(rvsdg::region & region, rvsdg::structural_input * input)
 {
+  JLM_ASSERT(input == nullptr);
   return *rvargument::create(&region, Type());
 }
 

--- a/jlm/llvm/ir/operators/Phi.cpp
+++ b/jlm/llvm/ir/operators/Phi.cpp
@@ -168,10 +168,23 @@ rvoutput::~rvoutput()
 rvargument::~rvargument()
 {}
 
+rvargument &
+rvargument::CopyTo(rvsdg::region & region, rvsdg::structural_input *)
+{
+  return *rvargument::create(&region, Type());
+}
+
 /* phi context variable argument class */
 
 cvargument::~cvargument()
 {}
+
+cvargument &
+cvargument::CopyTo(rvsdg::region & region, rvsdg::structural_input * input)
+{
+  auto phiInput = util::AssertedCast<cvinput>(input);
+  return *cvargument::create(&region, phiInput, Type());
+}
 
 /* phi recursion variable result class */
 

--- a/jlm/llvm/ir/operators/Phi.cpp
+++ b/jlm/llvm/ir/operators/Phi.cpp
@@ -169,7 +169,7 @@ rvargument::~rvargument()
 {}
 
 rvargument &
-rvargument::CopyTo(rvsdg::region & region, rvsdg::structural_input *)
+rvargument::Copy(rvsdg::region & region, rvsdg::structural_input *)
 {
   return *rvargument::create(&region, Type());
 }
@@ -180,7 +180,7 @@ cvargument::~cvargument()
 {}
 
 cvargument &
-cvargument::CopyTo(rvsdg::region & region, rvsdg::structural_input * input)
+cvargument::Copy(rvsdg::region & region, rvsdg::structural_input * input)
 {
   auto phiInput = util::AssertedCast<cvinput>(input);
   return *cvargument::create(&region, phiInput, Type());

--- a/jlm/llvm/ir/operators/Phi.hpp
+++ b/jlm/llvm/ir/operators/Phi.hpp
@@ -710,6 +710,9 @@ public:
     return output()->result();
   }
 
+  rvargument &
+  CopyTo(rvsdg::region & region, rvsdg::structural_input * input) override;
+
 private:
   rvoutput * output_;
 };
@@ -747,6 +750,9 @@ private:
 
   cvargument &
   operator=(cvargument &&) = delete;
+
+  cvargument &
+  CopyTo(rvsdg::region & region, rvsdg::structural_input * input) override;
 
   static cvargument *
   create(jlm::rvsdg::region * region, phi::cvinput * input, const jlm::rvsdg::port & port)

--- a/jlm/llvm/ir/operators/Phi.hpp
+++ b/jlm/llvm/ir/operators/Phi.hpp
@@ -711,7 +711,7 @@ public:
   }
 
   rvargument &
-  CopyTo(rvsdg::region & region, rvsdg::structural_input * input) override;
+  Copy(rvsdg::region & region, rvsdg::structural_input * input) override;
 
 private:
   rvoutput * output_;
@@ -752,7 +752,7 @@ private:
   operator=(cvargument &&) = delete;
 
   cvargument &
-  CopyTo(rvsdg::region & region, rvsdg::structural_input * input) override;
+  Copy(rvsdg::region & region, rvsdg::structural_input * input) override;
 
   static cvargument *
   create(jlm::rvsdg::region * region, phi::cvinput * input, const jlm::rvsdg::port & port)

--- a/jlm/llvm/ir/operators/delta.cpp
+++ b/jlm/llvm/ir/operators/delta.cpp
@@ -172,6 +172,13 @@ output::~output()
 cvargument::~cvargument()
 {}
 
+cvargument &
+cvargument::CopyTo(rvsdg::region & region, jlm::rvsdg::structural_input * input)
+{
+  auto deltaInput = util::AssertedCast<delta::cvinput>(input);
+  return *cvargument::create(&region, deltaInput);
+}
+
 /* delta result class */
 
 result::~result()

--- a/jlm/llvm/ir/operators/delta.cpp
+++ b/jlm/llvm/ir/operators/delta.cpp
@@ -173,7 +173,7 @@ cvargument::~cvargument()
 {}
 
 cvargument &
-cvargument::CopyTo(rvsdg::region & region, jlm::rvsdg::structural_input * input)
+cvargument::Copy(rvsdg::region & region, jlm::rvsdg::structural_input * input)
 {
   auto deltaInput = util::AssertedCast<delta::cvinput>(input);
   return *cvargument::create(&region, deltaInput);

--- a/jlm/llvm/ir/operators/delta.hpp
+++ b/jlm/llvm/ir/operators/delta.hpp
@@ -424,6 +424,9 @@ class cvargument final : public rvsdg::argument
 public:
   ~cvargument() override;
 
+  cvargument &
+  CopyTo(rvsdg::region & region, jlm::rvsdg::structural_input * input) override;
+
 private:
   cvargument(rvsdg::region * region, cvinput * input)
       : rvsdg::argument(region, input, input->port())

--- a/jlm/llvm/ir/operators/delta.hpp
+++ b/jlm/llvm/ir/operators/delta.hpp
@@ -425,7 +425,7 @@ public:
   ~cvargument() override;
 
   cvargument &
-  CopyTo(rvsdg::region & region, jlm::rvsdg::structural_input * input) override;
+  Copy(rvsdg::region & region, jlm::rvsdg::structural_input * input) override;
 
 private:
   cvargument(rvsdg::region * region, cvinput * input)

--- a/jlm/llvm/ir/operators/lambda.cpp
+++ b/jlm/llvm/ir/operators/lambda.cpp
@@ -418,9 +418,22 @@ output::~output() = default;
 
 fctargument::~fctargument() = default;
 
+fctargument &
+fctargument::CopyTo(rvsdg::region & region, rvsdg::structural_input * input)
+{
+  return *fctargument::create(&region, Type());
+}
+
 /* lambda context variable argument class */
 
 cvargument::~cvargument() = default;
+
+cvargument &
+cvargument::CopyTo(rvsdg::region & region, jlm::rvsdg::structural_input * input)
+{
+  auto lambdaInput = util::AssertedCast<lambda::cvinput>(input);
+  return *cvargument::create(&region, lambdaInput);
+}
 
 /* lambda result class */
 

--- a/jlm/llvm/ir/operators/lambda.cpp
+++ b/jlm/llvm/ir/operators/lambda.cpp
@@ -421,6 +421,7 @@ fctargument::~fctargument() = default;
 fctargument &
 fctargument::Copy(rvsdg::region & region, rvsdg::structural_input * input)
 {
+  JLM_ASSERT(input == nullptr);
   return *fctargument::create(&region, Type());
 }
 

--- a/jlm/llvm/ir/operators/lambda.cpp
+++ b/jlm/llvm/ir/operators/lambda.cpp
@@ -419,7 +419,7 @@ output::~output() = default;
 fctargument::~fctargument() = default;
 
 fctargument &
-fctargument::CopyTo(rvsdg::region & region, rvsdg::structural_input * input)
+fctargument::Copy(rvsdg::region & region, rvsdg::structural_input * input)
 {
   return *fctargument::create(&region, Type());
 }
@@ -429,7 +429,7 @@ fctargument::CopyTo(rvsdg::region & region, rvsdg::structural_input * input)
 cvargument::~cvargument() = default;
 
 cvargument &
-cvargument::CopyTo(rvsdg::region & region, jlm::rvsdg::structural_input * input)
+cvargument::Copy(rvsdg::region & region, jlm::rvsdg::structural_input * input)
 {
   auto lambdaInput = util::AssertedCast<lambda::cvinput>(input);
   return *cvargument::create(&region, lambdaInput);

--- a/jlm/llvm/ir/operators/lambda.hpp
+++ b/jlm/llvm/ir/operators/lambda.hpp
@@ -526,7 +526,7 @@ public:
   }
 
   fctargument &
-  CopyTo(rvsdg::region & region, rvsdg::structural_input * input) override;
+  Copy(rvsdg::region & region, rvsdg::structural_input * input) override;
 
 private:
   fctargument(jlm::rvsdg::region * region, std::shared_ptr<const jlm::rvsdg::type> type)
@@ -603,7 +603,7 @@ public:
   ~cvargument() override;
 
   cvargument &
-  CopyTo(rvsdg::region & region, jlm::rvsdg::structural_input * input) override;
+  Copy(rvsdg::region & region, jlm::rvsdg::structural_input * input) override;
 
 private:
   cvargument(jlm::rvsdg::region * region, cvinput * input)

--- a/jlm/llvm/ir/operators/lambda.hpp
+++ b/jlm/llvm/ir/operators/lambda.hpp
@@ -525,6 +525,9 @@ public:
     attributes_ = attributes;
   }
 
+  fctargument &
+  CopyTo(rvsdg::region & region, rvsdg::structural_input * input) override;
+
 private:
   fctargument(jlm::rvsdg::region * region, std::shared_ptr<const jlm::rvsdg::type> type)
       : jlm::rvsdg::argument(region, nullptr, std::move(type))
@@ -598,6 +601,9 @@ class cvargument final : public jlm::rvsdg::argument
 
 public:
   ~cvargument() override;
+
+  cvargument &
+  CopyTo(rvsdg::region & region, jlm::rvsdg::structural_input * input) override;
 
 private:
   cvargument(jlm::rvsdg::region * region, cvinput * input)

--- a/jlm/rvsdg/gamma.cpp
+++ b/jlm/rvsdg/gamma.cpp
@@ -378,7 +378,7 @@ gamma_node::copy(jlm::rvsdg::region * region, jlm::rvsdg::substitution_map & sma
 GammaArgument::~GammaArgument() noexcept = default;
 
 GammaArgument &
-GammaArgument::CopyTo(rvsdg::region & region, structural_input * input)
+GammaArgument::Copy(rvsdg::region & region, structural_input * input)
 {
   auto gammaInput = util::AssertedCast<gamma_input>(input);
   return Create(region, *gammaInput);

--- a/jlm/rvsdg/gamma.cpp
+++ b/jlm/rvsdg/gamma.cpp
@@ -377,6 +377,13 @@ gamma_node::copy(jlm::rvsdg::region * region, jlm::rvsdg::substitution_map & sma
 
 GammaArgument::~GammaArgument() noexcept = default;
 
+GammaArgument &
+GammaArgument::CopyTo(rvsdg::region & region, structural_input * input)
+{
+  auto gammaInput = util::AssertedCast<gamma_input>(input);
+  return Create(region, *gammaInput);
+}
+
 GammaResult::~GammaResult() noexcept = default;
 
 }

--- a/jlm/rvsdg/gamma.hpp
+++ b/jlm/rvsdg/gamma.hpp
@@ -469,6 +469,9 @@ class GammaArgument final : public argument
 public:
   ~GammaArgument() noexcept override;
 
+  GammaArgument &
+  CopyTo(rvsdg::region & region, structural_input * input) override;
+
 private:
   GammaArgument(rvsdg::region & region, gamma_input & input)
       : argument(&region, &input, input.Type())

--- a/jlm/rvsdg/gamma.hpp
+++ b/jlm/rvsdg/gamma.hpp
@@ -470,7 +470,7 @@ public:
   ~GammaArgument() noexcept override;
 
   GammaArgument &
-  CopyTo(rvsdg::region & region, structural_input * input) override;
+  Copy(rvsdg::region & region, structural_input * input) override;
 
 private:
   GammaArgument(rvsdg::region & region, gamma_input & input)

--- a/jlm/rvsdg/region.cpp
+++ b/jlm/rvsdg/region.cpp
@@ -67,7 +67,7 @@ argument::argument(
 }
 
 argument &
-argument::CopyTo(rvsdg::region & region, jlm::rvsdg::structural_input * input)
+argument::Copy(rvsdg::region & region, structural_input * input)
 {
   return *argument::create(&region, input, port());
 }
@@ -297,7 +297,7 @@ region::copy(region * target, substitution_map & smap, bool copy_arguments, bool
     {
       auto oldArgument = argument(n);
       auto input = smap.lookup(oldArgument->input());
-      auto & newArgument = oldArgument->CopyTo(*target, input);
+      auto & newArgument = oldArgument->Copy(*target, input);
       smap.insert(oldArgument, &newArgument);
     }
   }

--- a/jlm/rvsdg/region.cpp
+++ b/jlm/rvsdg/region.cpp
@@ -66,6 +66,12 @@ argument::argument(
   }
 }
 
+argument &
+argument::CopyTo(rvsdg::region & region, jlm::rvsdg::structural_input * input)
+{
+  return *argument::create(&region, input, Type());
+}
+
 jlm::rvsdg::argument *
 argument::create(
     jlm::rvsdg::region * region,
@@ -285,14 +291,14 @@ region::copy(region * target, substitution_map & smap, bool copy_arguments, bool
     context[node.depth()].push_back(&node);
   }
 
-  /* copy arguments */
   if (copy_arguments)
   {
     for (size_t n = 0; n < narguments(); n++)
     {
-      auto input = smap.lookup(argument(n)->input());
-      auto narg = argument::create(target, input, argument(n)->port());
-      smap.insert(argument(n), narg);
+      auto oldArgument = argument(n);
+      auto input = smap.lookup(oldArgument->input());
+      auto & newArgument = oldArgument->CopyTo(*target, input);
+      smap.insert(oldArgument, &newArgument);
     }
   }
 

--- a/jlm/rvsdg/region.cpp
+++ b/jlm/rvsdg/region.cpp
@@ -69,7 +69,7 @@ argument::argument(
 argument &
 argument::CopyTo(rvsdg::region & region, jlm::rvsdg::structural_input * input)
 {
-  return *argument::create(&region, input, Type());
+  return *argument::create(&region, input, port());
 }
 
 jlm::rvsdg::argument *

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -82,7 +82,7 @@ public:
    * itself can be created any longer.
    */
   virtual argument &
-  CopyTo(rvsdg::region & region, structural_input * input);
+  Copy(rvsdg::region & region, structural_input * input);
 
   static jlm::rvsdg::argument *
   create(jlm::rvsdg::region * region, structural_input * input, const jlm::rvsdg::port & port);

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -70,6 +70,20 @@ public:
     return input_;
   }
 
+  /**
+   * Creates a copy of the argument in \p region with the structural_input \p input.
+   *
+   * @param region The region where the copy of the argument is created in.
+   * @param input  The structural_input to the argument, if any.
+   *
+   * @return A reference to the copied argument.
+   *
+   * FIXME: This method should be made abstract once we enforced that no instances of argument
+   * itself can be created any longer.
+   */
+  virtual argument &
+  CopyTo(rvsdg::region & region, structural_input * input);
+
   static jlm::rvsdg::argument *
   create(jlm::rvsdg::region * region, structural_input * input, const jlm::rvsdg::port & port);
 

--- a/jlm/rvsdg/theta.cpp
+++ b/jlm/rvsdg/theta.cpp
@@ -49,8 +49,7 @@ ThetaArgument &
 ThetaArgument::CopyTo(rvsdg::region & region, structural_input * input)
 {
   auto thetaInput = util::AssertedCast<theta_input>(input);
-  auto & thetaArgument = ThetaArgument::Create(region, *thetaInput);
-  return thetaArgument;
+  return ThetaArgument::Create(region, *thetaInput);
 }
 
 ThetaResult::~ThetaResult() noexcept = default;

--- a/jlm/rvsdg/theta.cpp
+++ b/jlm/rvsdg/theta.cpp
@@ -45,6 +45,14 @@ theta_output::~theta_output() noexcept
 
 ThetaArgument::~ThetaArgument() noexcept = default;
 
+ThetaArgument &
+ThetaArgument::CopyTo(rvsdg::region & region, structural_input * input)
+{
+  auto thetaInput = util::AssertedCast<theta_input>(input);
+  auto & thetaArgument = ThetaArgument::Create(region, *thetaInput);
+  return thetaArgument;
+}
+
 ThetaResult::~ThetaResult() noexcept = default;
 
 /* theta node */

--- a/jlm/rvsdg/theta.cpp
+++ b/jlm/rvsdg/theta.cpp
@@ -46,7 +46,7 @@ theta_output::~theta_output() noexcept
 ThetaArgument::~ThetaArgument() noexcept = default;
 
 ThetaArgument &
-ThetaArgument::CopyTo(rvsdg::region & region, structural_input * input)
+ThetaArgument::Copy(rvsdg::region & region, structural_input * input)
 {
   auto thetaInput = util::AssertedCast<theta_input>(input);
   return ThetaArgument::Create(region, *thetaInput);

--- a/jlm/rvsdg/theta.hpp
+++ b/jlm/rvsdg/theta.hpp
@@ -360,7 +360,7 @@ public:
   ~ThetaArgument() noexcept override;
 
   ThetaArgument &
-  CopyTo(rvsdg::region & region, structural_input * input) override;
+  Copy(rvsdg::region & region, structural_input * input) override;
 
 private:
   ThetaArgument(rvsdg::region & region, theta_input & input)

--- a/jlm/rvsdg/theta.hpp
+++ b/jlm/rvsdg/theta.hpp
@@ -359,6 +359,9 @@ class ThetaArgument final : public argument
 public:
   ~ThetaArgument() noexcept override;
 
+  ThetaArgument &
+  CopyTo(rvsdg::region & region, structural_input * input) override;
+
 private:
   ThetaArgument(rvsdg::region & region, theta_input & input)
       : argument(&region, &input, input.Type())

--- a/tests/jlm/rvsdg/test-graph.cpp
+++ b/tests/jlm/rvsdg/test-graph.cpp
@@ -136,7 +136,6 @@ test_graph(void)
 
 JLM_UNIT_TEST_REGISTER("jlm/rvsdg/test-graph", test_graph)
 
-
 static int
 Copy()
 {

--- a/tests/jlm/rvsdg/test-graph.cpp
+++ b/tests/jlm/rvsdg/test-graph.cpp
@@ -135,3 +135,49 @@ test_graph(void)
 }
 
 JLM_UNIT_TEST_REGISTER("jlm/rvsdg/test-graph", test_graph)
+
+class TestGraphArgument final : public jlm::rvsdg::argument
+{
+private:
+  TestGraphArgument(jlm::rvsdg::region & region, std::shared_ptr<const jlm::rvsdg::type> type)
+      : jlm::rvsdg::argument(&region, nullptr, type)
+  {}
+
+public:
+  TestGraphArgument &
+  CopyTo(jlm::rvsdg::region & region, jlm::rvsdg::structural_input *) override
+  {
+    return Create(region, Type());
+  }
+
+  static TestGraphArgument &
+  Create(jlm::rvsdg::region & region, std::shared_ptr<const jlm::rvsdg::type> type)
+  {
+    auto graphArgument = new TestGraphArgument(region, std::move(type));
+    region.append_argument(graphArgument);
+    return *graphArgument;
+  }
+};
+
+static int
+CopyArgument()
+{
+  using namespace jlm::rvsdg;
+
+  // Arrange
+  auto type = jlm::tests::valuetype::Create();
+
+  jlm::rvsdg::graph graph;
+  TestGraphArgument::Create(*graph.root(), type);
+
+  // Act
+  auto newGraph = graph.copy();
+
+  // Assert
+  assert(newGraph->root()->narguments() == 1);
+  assert(is<TestGraphArgument>(newGraph->root()->argument(0)));
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER("jlm/rvsdg/test-graph-CopyArgument", CopyArgument)

--- a/tests/jlm/rvsdg/test-graph.cpp
+++ b/tests/jlm/rvsdg/test-graph.cpp
@@ -136,33 +136,12 @@ test_graph(void)
 
 JLM_UNIT_TEST_REGISTER("jlm/rvsdg/test-graph", test_graph)
 
-class TestGraphArgument final : public jlm::rvsdg::argument
-{
-private:
-  TestGraphArgument(jlm::rvsdg::region & region, std::shared_ptr<const jlm::rvsdg::type> type)
-      : jlm::rvsdg::argument(&region, nullptr, type)
-  {}
-
-public:
-  TestGraphArgument &
-  CopyTo(jlm::rvsdg::region & region, jlm::rvsdg::structural_input *) override
-  {
-    return Create(region, Type());
-  }
-
-  static TestGraphArgument &
-  Create(jlm::rvsdg::region & region, std::shared_ptr<const jlm::rvsdg::type> type)
-  {
-    auto graphArgument = new TestGraphArgument(region, std::move(type));
-    region.append_argument(graphArgument);
-    return *graphArgument;
-  }
-};
 
 static int
-CopyArgument()
+Copy()
 {
   using namespace jlm::rvsdg;
+  using namespace jlm::tests;
 
   // Arrange
   auto type = jlm::tests::valuetype::Create();
@@ -180,4 +159,4 @@ CopyArgument()
   return 0;
 }
 
-JLM_UNIT_TEST_REGISTER("jlm/rvsdg/test-graph-CopyArgument", CopyArgument)
+JLM_UNIT_TEST_REGISTER("jlm/rvsdg/test-graph-Copy", Copy)

--- a/tests/test-operation.hpp
+++ b/tests/test-operation.hpp
@@ -353,8 +353,9 @@ private:
 
 public:
   TestGraphArgument &
-  Copy(jlm::rvsdg::region & region, jlm::rvsdg::structural_input *) override
+  Copy(jlm::rvsdg::region & region, jlm::rvsdg::structural_input * input) override
   {
+    JLM_ASSERT(input == nullptr);
     return Create(region, Type());
   }
 

--- a/tests/test-operation.hpp
+++ b/tests/test-operation.hpp
@@ -344,6 +344,29 @@ create_testop(
   return rvsdg::simple_node::create_normalized(region, op, { operands });
 }
 
+class TestGraphArgument final : public jlm::rvsdg::argument
+{
+private:
+  TestGraphArgument(jlm::rvsdg::region & region, std::shared_ptr<const jlm::rvsdg::type> type)
+      : jlm::rvsdg::argument(&region, nullptr, type)
+  {}
+
+public:
+  TestGraphArgument &
+  Copy(jlm::rvsdg::region & region, jlm::rvsdg::structural_input *) override
+  {
+    return Create(region, Type());
+  }
+
+  static TestGraphArgument &
+  Create(jlm::rvsdg::region & region, std::shared_ptr<const jlm::rvsdg::type> type)
+  {
+    auto graphArgument = new TestGraphArgument(region, std::move(type));
+    region.append_argument(graphArgument);
+    return *graphArgument;
+  }
+};
+
 }
 
 #endif


### PR DESCRIPTION
This PR does the following:

1. Introduces a Copy() method to the argument class.
2. The introduced method enables us to fix a bug in the copy() method of the region. Previously, arguments were not copied according to their argument subtypes, but simply a new instance of argument was created.
3. Add unit test.

This PR is a necessary step to get rid off ports.