### PR TITLE
Removed symlink to libMLIR in CI

### DIFF
--- a/.github/actions/InstallPackages/action.yml
+++ b/.github/actions/InstallPackages/action.yml
@@ -84,10 +84,6 @@ runs:
       if: ${{inputs.install-mlir == 'true'}}
       run: |
         sudo apt-get install libmlir-${{inputs.llvm-version}}-dev mlir-${{inputs.llvm-version}}-tools
-        if ! [ -f /usr/lib/x86_64-linux-gnu/libMLIR.so ]; then
-          sudo ln -s /usr/lib/llvm-${{inputs.llvm-version}}/lib/libMLIR.so.${{inputs.llvm-version}} /usr/lib/x86_64-linux-gnu/
-          sudo ln -s /usr/lib/llvm-${{inputs.llvm-version}}/lib/libMLIR.so.${{inputs.llvm-version}} /usr/lib/x86_64-linux-gnu/libMLIR.so
-        fi
       shell: bash
 
     - name: "Install clang-format package"


### PR DESCRIPTION
Symlinks are no longer needed thanks to Earlier improvements of the configuration script.