### PR TITLE
[AndersenAgnostic] Add lazy cycle detection as an optional technique for Andersen

### DIFF
--- a/jlm/llvm/Makefile.sub
+++ b/jlm/llvm/Makefile.sub
@@ -69,6 +69,7 @@ libllvm_HEADERS = \
 	jlm/llvm/opt/inlining.hpp \
 	jlm/llvm/opt/cne.hpp \
 	jlm/llvm/opt/push.hpp \
+	jlm/llvm/opt/alias-analyses/LazyCycleDetection.hpp \
 	jlm/llvm/opt/alias-analyses/MemoryNodeProvider.hpp \
 	jlm/llvm/opt/alias-analyses/OnlineCycleDetection.hpp \
 	jlm/llvm/opt/alias-analyses/Optimization.hpp \
@@ -177,6 +178,7 @@ libllvm_TESTS += \
 	tests/jlm/llvm/ir/TestAnnotation \
 	tests/jlm/llvm/opt/alias-analyses/TestAgnosticMemoryNodeProvider \
 	tests/jlm/llvm/opt/alias-analyses/TestAndersen \
+	tests/jlm/llvm/opt/alias-analyses/TestLazyCycleDetection \
 	tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder \
 	tests/jlm/llvm/opt/alias-analyses/TestPointerObjectSet \
 	tests/jlm/llvm/opt/alias-analyses/TestPointsToGraph \

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -45,6 +45,8 @@ Andersen::Configuration::ToString() const
       str << "OnlineCD_";
     if (EnableHybridCycleDetection_)
       str << "HybridCD_";
+    if (EnableLazyCycleDetection_)
+      str << "LazyCD_";
   }
   else
   {
@@ -61,15 +63,22 @@ Andersen::Configuration::GetAllConfigurations()
 {
   std::vector<Configuration> configs;
 
+  auto PickLazyCycleDetection = [&](Configuration config)
+  {
+    config.EnableLazyCycleDetection(false);
+    configs.push_back(config);
+    config.EnableLazyCycleDetection(true);
+    configs.push_back(config);
+  };
   auto PickHybridCycleDetection = [&](Configuration config)
   {
     config.EnableHybridCycleDetection(false);
-    configs.push_back(config);
+    PickLazyCycleDetection(config);
     // Hybrid Cycle Detection can only be enabled when OVS is enabled
     if (config.IsOfflineVariableSubstitutionEnabled())
     {
       config.EnableHybridCycleDetection(true);
-      configs.push_back(config);
+      PickLazyCycleDetection(config);
     }
   };
   auto PickOnlineCycleDetection = [&](Configuration config)
@@ -77,7 +86,7 @@ Andersen::Configuration::GetAllConfigurations()
     config.EnableOnlineCycleDetection(false);
     PickHybridCycleDetection(config);
     config.EnableOnlineCycleDetection(true);
-    // OnlineCD can not be combined with HybridCD
+    // OnlineCD can not be combined with HybridCD or LazyCD
     configs.push_back(config);
   };
   auto PickWorklistPolicy = [&](Configuration config)
@@ -160,6 +169,10 @@ class Andersen::Statistics final : public util::Statistics
   static constexpr const char * NumOnlineCycleUnifications_ = "#OnlineCycleUnifications";
 
   static constexpr const char * NumHybridCycleUnifications_ = "#HybridCycleUnifications";
+
+  static constexpr const char * NumLazyCycleDetectionAttempts_ = "#LazyCycleDetectionAttempts";
+  static constexpr const char * NumLazyCyclesDetected_ = "#LazyCyclesDetected";
+  static constexpr const char * NumLazyCycleUnifications_ = "#LazyCycleUnifications";
 
   // After solving statistics
   static constexpr const char * NumEscapedMemoryObjects_ = "#EscapedMemoryObjects";
@@ -304,6 +317,15 @@ public:
 
     if (statistics.NumHybridCycleUnifications)
       AddMeasurement(NumHybridCycleUnifications_, *statistics.NumHybridCycleUnifications);
+
+    if (statistics.NumLazyCyclesDetectionAttempts)
+      AddMeasurement(NumLazyCycleDetectionAttempts_, *statistics.NumLazyCyclesDetectionAttempts);
+
+    if (statistics.NumLazyCyclesDetected)
+      AddMeasurement(NumLazyCyclesDetected_, *statistics.NumLazyCyclesDetected);
+
+    if (statistics.NumLazyCycleUnifications)
+      AddMeasurement(NumLazyCycleUnifications_, *statistics.NumLazyCycleUnifications);
   }
 
   void
@@ -1090,7 +1112,8 @@ Andersen::SolveConstraints(
     auto worklistStatistics = constraints.SolveUsingWorklist(
         config.GetWorklistSoliverPolicy(),
         config.IsOnlineCycleDetectionEnabled(),
-        config.IsHybridCycleDetectionEnabled());
+        config.IsHybridCycleDetectionEnabled(),
+        config.IsLazyCycleDetectionEnabled());
     statistics.StopConstraintSolvingWorklistStatistics(worklistStatistics);
   }
   else

--- a/jlm/llvm/opt/alias-analyses/Andersen.hpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.hpp
@@ -161,6 +161,23 @@ public:
       return EnableHybridCycleDetection_;
     }
 
+    /**
+     * Enables or disables lazy cycle detection in the Worklist solver, as described by
+     *   Hardekopf and Lin, 2007: "The Ant & the Grasshopper"
+     * It detects some cycles, so it can not be combined with techniques that find all cycles.
+     */
+    void
+    EnableLazyCycleDetection(bool enable) noexcept
+    {
+      EnableLazyCycleDetection_ = enable;
+    }
+
+    [[nodiscard]] bool
+    IsLazyCycleDetectionEnabled() const noexcept
+    {
+      return EnableLazyCycleDetection_;
+    }
+
     [[nodiscard]] std::string
     ToString() const;
 
@@ -179,6 +196,7 @@ public:
           PointerObjectConstraintSet::WorklistSolverPolicy::LeastRecentlyFired);
       config.EnableOnlineCycleDetection(false);
       config.EnableHybridCycleDetection(true);
+      config.EnableLazyCycleDetection(true);
       return config;
     }
 
@@ -213,6 +231,7 @@ public:
         PointerObjectConstraintSet::WorklistSolverPolicy::LeastRecentlyFired;
     bool EnableOnlineCycleDetection_ = false;
     bool EnableHybridCycleDetection_ = false;
+    bool EnableLazyCycleDetection_ = false;
   };
 
   ~Andersen() noexcept override = default;

--- a/jlm/llvm/opt/alias-analyses/LazyCycleDetection.hpp
+++ b/jlm/llvm/opt/alias-analyses/LazyCycleDetection.hpp
@@ -47,7 +47,7 @@ public:
   }
 
   bool
-  IsInitialized() const
+  IsInitialized() const noexcept
   {
     return NodeStates_.size() == Set_.NumPointerObjects();
   }
@@ -103,7 +103,7 @@ public:
       else if (NodeStates_[node] == NodeStateVisited)
       {
         DfsStack_.pop();
-        NodeStates_[node] = NodeStateLeft;
+        NodeStates_[node] = NodeStatePopped;
 
         // Check if any successors are unified with the subset. If so, join it!
         for (auto successor : GetSuccessors_(node))
@@ -138,7 +138,7 @@ public:
    * @return the number of DFSs performed to look for cycles
    */
   [[nodiscard]] size_t
-  NumCycleDetectionAttempts()
+  NumCycleDetectionAttempts() const noexcept
   {
     return NumCycleDetectAttempts_;
   }
@@ -147,7 +147,7 @@ public:
    * @return the number of cycles detected by Lazy cycle detection
    */
   [[nodiscard]] size_t
-  NumCyclesDetected()
+  NumCyclesDetected() const noexcept
   {
     return NumCyclesDetected_;
   }
@@ -156,7 +156,7 @@ public:
    * @return the number of unifications made while eliminating found cycles
    */
   [[nodiscard]] size_t
-  NumCycleUnifications()
+  NumCycleUnifications() const noexcept
   {
     return NumCycleUnifications_;
   }
@@ -174,7 +174,7 @@ private:
   // Possible states of nodes during the DFS
   static constexpr uint8_t NodeStateNotVisited = 0;
   static constexpr uint8_t NodeStateVisited = 1;
-  static constexpr uint8_t NodeStateLeft = 2;
+  static constexpr uint8_t NodeStatePopped = 2;
   std::vector<uint8_t> NodeStates_;
 
   size_t NumCycleDetectAttempts_ = 0;

--- a/jlm/llvm/opt/alias-analyses/LazyCycleDetection.hpp
+++ b/jlm/llvm/opt/alias-analyses/LazyCycleDetection.hpp
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2024 Håvard Krogstie <krogstie.havard@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#ifndef JLM_LLVM_OPT_ALIAS_ANALYSES_LAZYCYCLEDETECTION_HPP
+#define JLM_LLVM_OPT_ALIAS_ANALYSES_LAZYCYCLEDETECTION_HPP
+
+#include <jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp>
+#include <jlm/util/HashSet.hpp>
+
+#include <limits>
+#include <optional>
+#include <stack>
+#include <vector>
+
+namespace jlm::llvm::aa
+{
+
+/**
+ * Implements Lazy Cycle Detection, as described by
+ *   Hardekopf and Lin, 2007: "The And and the Grasshopper"
+ * @tparam GetSuccessorsFunctor is a function returning the superset edge successors of a given node
+ * @tparam UnifyPointerObjectsFunctor the functor to be called to unify a cycle, when found
+ */
+template<typename GetSuccessorsFunctor, typename UnifyPointerObjectsFunctor>
+class LazyCycleDetector
+{
+
+public:
+  LazyCycleDetector(
+      PointerObjectSet & set,
+      const GetSuccessorsFunctor & GetSuccessors,
+      const UnifyPointerObjectsFunctor & unifyPointerObjects)
+      : Set_(set),
+        GetSuccessors_(GetSuccessors),
+        UnifyPointerObjects_(unifyPointerObjects)
+  {}
+
+  /**
+   * Call before calling any other method
+   */
+  void
+  Initialize()
+  {
+    NodeStates_.resize(Set_.NumPointerObjects(), NodeStateNotVisited);
+  }
+
+  bool
+  IsInitialized() const
+  {
+    return NodeStates_.size() == Set_.NumPointerObjects();
+  }
+
+  /**
+   * Call when an edge subset -> superset was visited, and zero pointees had to be propagated.
+   * Only call if subset has at least one new pointee.
+   * If a path from superset to subset is found, there is a cycle, that gets unified.
+   * @param subset the tail of the added edge, must be unification root
+   * @param superset the head of the added edge, must be unification root
+   * @return the root of the unification if unification happened, otherwise nullopt
+   */
+  std::optional<PointerObjectIndex>
+  OnPropagatedNothing(PointerObjectIndex subset, PointerObjectIndex superset)
+  {
+    JLM_ASSERT(IsInitialized());
+    JLM_ASSERT(Set_.IsUnificationRoot(subset));
+    JLM_ASSERT(Set_.IsUnificationRoot(superset));
+
+    // Add this edge to the list of checked edges, or return if it was already there
+    if (!CheckedEdges_.Insert({ subset, superset }))
+      return std::nullopt;
+
+    NumCycleDetectAttempts_++;
+
+    JLM_ASSERT(DfsStack_.empty());
+    DfsStack_.push(superset);
+
+    // Reset all node states
+    std::fill(NodeStates_.begin(), NodeStates_.end(), NodeStateNotVisited);
+
+    while (!DfsStack_.empty())
+    {
+      auto node = DfsStack_.top();
+      if (NodeStates_[node] == NodeStateNotVisited)
+      {
+        NodeStates_[node] = NodeStateVisited;
+        // Make sure all successors get visited
+        for (auto successor : GetSuccessors_(node))
+        {
+          auto successorRoot = Set_.GetUnificationRoot(successor);
+
+          // Cycle found! Do not add the subset to the dfs stack
+          if (successorRoot == subset)
+            continue;
+
+          if (NodeStates_[successorRoot] != NodeStateNotVisited)
+            continue;
+
+          DfsStack_.push(successorRoot);
+        }
+      }
+      else if (NodeStates_[node] == NodeStateVisited)
+      {
+        DfsStack_.pop();
+        NodeStates_[node] = NodeStateLeft;
+
+        // Check if any successors are unified with the subset. If so, join it!
+        for (auto successor : GetSuccessors_(node))
+        {
+          auto successorRoot = Set_.GetUnificationRoot(successor);
+          if (successorRoot == subset)
+          {
+            subset = UnifyPointerObjects_(node, subset);
+            NumCycleUnifications_++;
+            break;
+          }
+        }
+      }
+      else
+      {
+        // The node has already been visited for a second time
+        DfsStack_.pop();
+      }
+    }
+
+    JLM_ASSERT(Set_.IsUnificationRoot(subset));
+    superset = Set_.GetUnificationRoot(superset);
+    if (subset == superset)
+    {
+      NumCyclesDetected_++;
+      return subset;
+    }
+    return std::nullopt;
+  }
+
+  /**
+   * @return the number of DFSs performed to look for cycles
+   */
+  [[nodiscard]] size_t
+  NumCycleDetectionAttempts()
+  {
+    return NumCycleDetectAttempts_;
+  }
+
+  /**
+   * @return the number of cycles detected by Lazy cycle detection
+   */
+  [[nodiscard]] size_t
+  NumCyclesDetected()
+  {
+    return NumCyclesDetected_;
+  }
+
+  /**
+   * @return the number of unifications made while eliminating found cycles
+   */
+  [[nodiscard]] size_t
+  NumCycleUnifications()
+  {
+    return NumCycleUnifications_;
+  }
+
+private:
+  PointerObjectSet & Set_;
+  const GetSuccessorsFunctor & GetSuccessors_;
+  const UnifyPointerObjectsFunctor & UnifyPointerObjects_;
+
+  // A set of all checked simple edges first -> second, to avoid checking again
+  util::HashSet<std::pair<PointerObjectIndex, PointerObjectIndex>> CheckedEdges_;
+
+  // The dfs stack, which may contain the same node multiple times
+  std::stack<PointerObjectIndex> DfsStack_;
+  // Possible states of nodes during the DFS
+  static constexpr uint8_t NodeStateNotVisited = 0;
+  static constexpr uint8_t NodeStateVisited = 1;
+  static constexpr uint8_t NodeStateLeft = 2;
+  std::vector<uint8_t> NodeStates_;
+
+  size_t NumCycleDetectAttempts_ = 0;
+  size_t NumCyclesDetected_ = 0;
+  size_t NumCycleUnifications_ = 0;
+};
+
+}
+
+#endif // JLM_LLVM_OPT_ALIAS_ANALYSES_LAZYCYCLEDETECTION_HPP

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
@@ -1499,7 +1499,7 @@ PointerObjectConstraintSet::RunWorklistSolver(WorklistStatistics & statistics)
 
     if constexpr (EnableHybridCycleDetection)
     {
-      // When unifying, keep at least one of the ref node unification roots
+      // If the new root did not have a ref node unification target, check if the other node has one
       if (RefNodeUnificationRoot_.count(root) == 0)
       {
         const auto nonRootRefUnification = RefNodeUnificationRoot_.find(nonRoot);
@@ -1835,9 +1835,9 @@ PointerObjectConstraintSet::SolveUsingWorklist(
     constexpr bool vHybridCycleDetection = decltype(tHybridCycleDetection)::value;
     constexpr bool vLazyCycleDetection = decltype(tLazyCycleDetection)::value;
 
-    if constexpr (vOnlineCycleDetection && (vLazyCycleDetection || vHybridCycleDetection))
+    if constexpr (vOnlineCycleDetection && (vHybridCycleDetection || vLazyCycleDetection))
     {
-      JLM_UNREACHABLE("Can not enable lazy or hybrid cycle detection with online cycle detection");
+      JLM_UNREACHABLE("Can not enable hybrid or lazy cycle detection with online cycle detection");
     }
     else
     {

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
@@ -6,6 +6,7 @@
 #include <jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp>
 
 #include <jlm/llvm/ir/operators/call.hpp>
+#include <jlm/llvm/opt/alias-analyses/LazyCycleDetection.hpp>
 #include <jlm/llvm/opt/alias-analyses/OnlineCycleDetection.hpp>
 #include <jlm/util/Worklist.hpp>
 
@@ -1387,7 +1388,11 @@ PointerObjectConstraintSet::NormalizeConstraints()
   return reduction;
 }
 
-template<typename Worklist, bool EnableOnlineCycleDetection, bool EnableHybridCycleDetection>
+template<
+    typename Worklist,
+    bool EnableOnlineCycleDetection,
+    bool EnableHybridCycleDetection,
+    bool EnableLazyCycleDetection>
 void
 PointerObjectConstraintSet::RunWorklistSolver(WorklistStatistics & statistics)
 {
@@ -1398,6 +1403,7 @@ PointerObjectConstraintSet::RunWorklistSolver(WorklistStatistics & statistics)
   if constexpr (EnableOnlineCycleDetection)
   {
     static_assert(!EnableHybridCycleDetection, "OnlineCD can not be combined with HybridCD");
+    static_assert(!EnableLazyCycleDetection, "OnlineCD can not be combined with LazyCD");
   }
 
   // Create auxiliary subset graph.
@@ -1493,7 +1499,7 @@ PointerObjectConstraintSet::RunWorklistSolver(WorklistStatistics & statistics)
 
     if constexpr (EnableHybridCycleDetection)
     {
-      // If the new root did not have a ref node unification target, check if the other node has one
+      // When unifying, keep at least one of the ref node unification roots
       if (RefNodeUnificationRoot_.count(root) == 0)
       {
         const auto nonRootRefUnification = RefNodeUnificationRoot_.find(nonRoot);
@@ -1517,6 +1523,11 @@ PointerObjectConstraintSet::RunWorklistSolver(WorklistStatistics & statistics)
   OnlineCycleDetector onlineCycleDetector(Set_, GetSupersetEdgeSuccessors, UnifyPointerObjects);
   if constexpr (EnableOnlineCycleDetection)
     onlineCycleDetector.InitializeTopologicalOrdering();
+
+  // If lazy cycle detection is enabled, initialize it here
+  LazyCycleDetector lazyCycleDetector(Set_, GetSupersetEdgeSuccessors, UnifyPointerObjects);
+  if constexpr (EnableLazyCycleDetection)
+    lazyCycleDetector.Initialize();
 
   if constexpr (EnableHybridCycleDetection)
     statistics.NumHybridCycleUnifications = 0;
@@ -1573,8 +1584,17 @@ PointerObjectConstraintSet::RunWorklistSolver(WorklistStatistics & statistics)
     }
 
     // A new edge was added, propagate points to-sets. If the superset changes, add to the worklist
-    if (MakePointsToSetSuperset(superset, subset))
+    bool anyPropagation = MakePointsToSetSuperset(superset, subset);
+    if (anyPropagation)
       worklist.PushWorkItem(superset);
+
+    // If nothing was propagated by adding the edge, try lazy cycle detection
+    if (EnableLazyCycleDetection && !Set_.GetPointsToSet(subset).IsEmpty() && !anyPropagation)
+    {
+      const auto optUnificationRoot = lazyCycleDetector.OnPropagatedNothing(subset, superset);
+      if (optUnificationRoot)
+        worklist.PushWorkItem(*optUnificationRoot);
+    }
   };
 
   // A temporary place to store new subset edges, to avoid modifying sets while they are iterated
@@ -1701,8 +1721,23 @@ PointerObjectConstraintSet::RunWorklistSolver(WorklistStatistics & statistics)
       // The current it-edge should be kept as is, prepare "it" for the next iteration.
       ++it;
 
-      if (MakePointsToSetSuperset(supersetParent, node))
+      bool modified = MakePointsToSetSuperset(supersetParent, node);
+
+      if (modified)
         worklist.PushWorkItem(supersetParent);
+
+      if (EnableLazyCycleDetection && !nodePointees.IsEmpty() && !modified)
+      {
+        // If nothing was propagated along this edge, check if there is a cycle
+        // If a cycle is detected, this function eliminates it by unifying, and returns the root
+        auto optUnificationRoot = lazyCycleDetector.OnPropagatedNothing(node, supersetParent);
+        if (optUnificationRoot)
+        {
+          // The new unification root is pushed, and handling of the current work item is aborted.
+          worklist.PushWorkItem(*optUnificationRoot);
+          return;
+        }
+      }
     }
 
     // Stores on the form *n = value.
@@ -1770,13 +1805,21 @@ PointerObjectConstraintSet::RunWorklistSolver(WorklistStatistics & statistics)
     statistics.NumOnlineCyclesDetected = onlineCycleDetector.NumOnlineCyclesDetected();
     statistics.NumOnlineCycleUnifications = onlineCycleDetector.NumOnlineCycleUnifications();
   }
+
+  if constexpr (EnableLazyCycleDetection)
+  {
+    statistics.NumLazyCyclesDetectionAttempts = lazyCycleDetector.NumCycleDetectionAttempts();
+    statistics.NumLazyCyclesDetected = lazyCycleDetector.NumCyclesDetected();
+    statistics.NumLazyCycleUnifications = lazyCycleDetector.NumCycleUnifications();
+  }
 }
 
 PointerObjectConstraintSet::WorklistStatistics
 PointerObjectConstraintSet::SolveUsingWorklist(
     WorklistSolverPolicy policy,
     bool enableOnlineCycleDetection,
-    bool enableHybridCycleDetection)
+    bool enableHybridCycleDetection,
+    bool enableLazyCycleDetection)
 {
 
   // Takes all parameters as compile time types.
@@ -1784,20 +1827,26 @@ PointerObjectConstraintSet::SolveUsingWorklist(
   // the rest are instances of std::bool_constant, either std::true_type or std::false_type
   const auto Dispatch = [&](auto tWorklist,
                             auto tOnlineCycleDetection,
-                            auto tHybridCycleDetection) -> WorklistStatistics
+                            auto tHybridCycleDetection,
+                            auto tLazyCycleDetection) -> WorklistStatistics
   {
     using Worklist = std::remove_pointer_t<decltype(tWorklist)>;
     constexpr bool vOnlineCycleDetection = decltype(tOnlineCycleDetection)::value;
     constexpr bool vHybridCycleDetection = decltype(tHybridCycleDetection)::value;
+    constexpr bool vLazyCycleDetection = decltype(tLazyCycleDetection)::value;
 
-    if constexpr (vOnlineCycleDetection && vHybridCycleDetection)
+    if constexpr (vOnlineCycleDetection && (vLazyCycleDetection || vHybridCycleDetection))
     {
-      JLM_UNREACHABLE("Can not enable hybrid cycle detection with online cycle detection");
+      JLM_UNREACHABLE("Can not enable lazy or hybrid cycle detection with online cycle detection");
     }
     else
     {
       WorklistStatistics statistics(policy);
-      RunWorklistSolver<Worklist, vOnlineCycleDetection, vHybridCycleDetection>(statistics);
+      RunWorklistSolver<
+          Worklist,
+          vOnlineCycleDetection,
+          vHybridCycleDetection,
+          vLazyCycleDetection>(statistics);
       return statistics;
     }
   };
@@ -1832,11 +1881,18 @@ PointerObjectConstraintSet::SolveUsingWorklist(
   else
     hybridCycleDetectionVariant = std::false_type{};
 
+  std::variant<std::true_type, std::false_type> lazyCycleDetectionVariant;
+  if (enableLazyCycleDetection)
+    lazyCycleDetectionVariant = std::true_type{};
+  else
+    lazyCycleDetectionVariant = std::false_type{};
+
   return std::visit(
       Dispatch,
       policyVariant,
       onlineCycleDetectionVariant,
-      hybridCycleDetectionVariant);
+      hybridCycleDetectionVariant,
+      lazyCycleDetectionVariant);
 }
 
 const char *

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
@@ -812,6 +812,16 @@ public:
      * The number of unifications performed due to hybrid cycle detection.
      */
     std::optional<size_t> NumHybridCycleUnifications;
+
+    /**
+     * The number of DFSs started in attempts at detecting cycles,
+     * the number of cycles detected by lazy cycle detection,
+     * and number of unifications made to eliminate the cycles,
+     * if Lazy Cycle Detection is enabled.
+     */
+    std::optional<size_t> NumLazyCyclesDetectionAttempts;
+    std::optional<size_t> NumLazyCyclesDetected;
+    std::optional<size_t> NumLazyCycleUnifications;
   };
 
   explicit PointerObjectConstraintSet(PointerObjectSet & set)
@@ -941,16 +951,19 @@ public:
    * These papers also describe a set of techniques that potentially improve solving performance:
    *  - Online Cycle Detection (Pearce, 2003)
    *  - Hybrid Cycle Detection (Hardekopf 2007)
+   *  - Lazy Cycle Detection (Hardekopf 2007)
    * @param policy the worklist iteration order policy to use
    * @param enableOnlineCycleDetection if true, online cycle detection will be performed.
    * @param enableHybridCycleDetection if true, hybrid cycle detection will be performed.
+   * @param enableLazyCycleDetection if true, lazy cycle detection will be performed.
    * @return an instance of WorklistStatistics describing solver statistics
    */
   WorklistStatistics
   SolveUsingWorklist(
       WorklistSolverPolicy policy,
       bool enableOnlineCycleDetection,
-      bool enableHybridCycleDetection);
+      bool enableHybridCycleDetection,
+      bool enableLazyCycleDetection);
 
   /**
    * Iterates over and applies constraints until all points-to-sets satisfy them.
@@ -994,9 +1007,14 @@ private:
    * @tparam Worklist a type supporting the worklist interface with PointerObjectIndex as work items
    * @tparam EnableOnlineCycleDetection if true, online cycle detection is enabled.
    * @tparam EnableHybridCycleDetection if true, hybrid cycle detection is enabled.
+   * @tparam EnableLazyCycleDetection if true, lazy cycle detection is enabled.
    * @see SolveUsingWorklist() for the public interface.
    */
-  template<typename Worklist, bool EnableOnlineCycleDetection, bool EnableHybridCycleDetection>
+  template<
+      typename Worklist,
+      bool EnableOnlineCycleDetection,
+      bool EnableHybridCycleDetection,
+      bool EnableLazyCycleDetection>
   void
   RunWorklistSolver(WorklistStatistics & statistics);
 

--- a/tests/jlm/llvm/opt/alias-analyses/TestLazyCycleDetection.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestLazyCycleDetection.cpp
@@ -24,7 +24,7 @@ TestUnifiesCycles()
   PointerObjectSet set;
   for (int i = 0; i < 6; i++)
   {
-    (void) set.CreateDummyRegisterPointerObject();
+    (void)set.CreateDummyRegisterPointerObject();
   }
 
   // Create a graph that looks like
@@ -41,12 +41,14 @@ TestUnifiesCycles()
   successors[0].Insert(5);
   successors[5].Insert(4);
 
-  auto GetSuccessors = [&](PointerObjectIndex i) {
+  auto GetSuccessors = [&](PointerObjectIndex i)
+  {
     assert(set.IsUnificationRoot(i));
     return successors[i].Items();
   };
 
-  auto UnifyPointerObjects = [&](PointerObjectIndex a, PointerObjectIndex b) {
+  auto UnifyPointerObjects = [&](PointerObjectIndex a, PointerObjectIndex b)
+  {
     assert(set.IsUnificationRoot(a));
     assert(set.IsUnificationRoot(b));
     assert(a != b);
@@ -106,4 +108,3 @@ TestUnifiesCycles()
 JLM_UNIT_TEST_REGISTER(
     "jlm/llvm/opt/alias-analyses/TestLazyCycleDetection-TestUnifiesCycles",
     TestUnifiesCycles)
-

--- a/tests/jlm/llvm/opt/alias-analyses/TestLazyCycleDetection.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestLazyCycleDetection.cpp
@@ -3,7 +3,7 @@
  * See COPYING for terms of redistribution.
  */
 
-#include "TestRvsdgs.hpp"
+#include <TestRvsdgs.hpp>
 
 #include <test-registry.hpp>
 

--- a/tests/jlm/llvm/opt/alias-analyses/TestLazyCycleDetection.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestLazyCycleDetection.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2023, 2024 Håvard Krogstie <krogstie.havard@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include "TestRvsdgs.hpp"
+
+#include <test-registry.hpp>
+
+#include <jlm/llvm/opt/alias-analyses/LazyCycleDetection.hpp>
+#include <jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp>
+#include <jlm/util/HashSet.hpp>
+
+#include <cassert>
+#include <vector>
+
+static int
+TestUnifiesCycles()
+{
+  using namespace jlm;
+  using namespace jlm::llvm::aa;
+
+  // Arrange
+  PointerObjectSet set;
+  for (int i = 0; i < 6; i++)
+  {
+    (void) set.CreateDummyRegisterPointerObject();
+  }
+
+  // Create a graph that looks like
+  //   --> 1 --> 2 --> 3
+  //  /          |
+  // 0           |
+  //  \          V
+  //   --> 5 --> 4
+  std::vector<util::HashSet<PointerObjectIndex>> successors(set.NumPointerObjects());
+  successors[0].Insert(1);
+  successors[1].Insert(2);
+  successors[2].Insert(3);
+  successors[2].Insert(4);
+  successors[0].Insert(5);
+  successors[5].Insert(4);
+
+  auto GetSuccessors = [&](PointerObjectIndex i) {
+    assert(set.IsUnificationRoot(i));
+    return successors[i].Items();
+  };
+
+  auto UnifyPointerObjects = [&](PointerObjectIndex a, PointerObjectIndex b) {
+    assert(set.IsUnificationRoot(a));
+    assert(set.IsUnificationRoot(b));
+    assert(a != b);
+    auto newRoot = set.UnifyPointerObjects(a, b);
+    auto notRoot = a + b - newRoot;
+
+    successors[newRoot].UnionWith(successors[notRoot]);
+    return newRoot;
+  };
+
+  LazyCycleDetector lcd(set, GetSuccessors, UnifyPointerObjects);
+  lcd.Initialize();
+
+  // Act 1 - an edge that is not a part of a cycle
+  lcd.OnPropagatedNothing(0, 1);
+
+  // Assert that nothing happened
+  assert(lcd.NumCycleDetectionAttempts() == 1);
+  assert(lcd.NumCyclesDetected() == 0);
+  assert(lcd.NumCycleUnifications() == 0);
+
+  // Act 2 - Try the same edge again
+  lcd.OnPropagatedNothing(0, 1);
+
+  // Assert that the second attempt is ignored
+  assert(lcd.NumCycleDetectionAttempts() == 1);
+  assert(lcd.NumCyclesDetected() == 0);
+  assert(lcd.NumCycleUnifications() == 0);
+
+  // Act 3 - add the edge 3->1 that creates a cycle 3-1-2-3
+  successors[3].Insert(1);
+  lcd.OnPropagatedNothing(3, 1);
+
+  // Assert that the cycle was found and unified
+  assert(lcd.NumCycleDetectionAttempts() == 2);
+  assert(lcd.NumCyclesDetected() == 1);
+  assert(lcd.NumCycleUnifications() == 2);
+  assert(set.GetUnificationRoot(1) == set.GetUnificationRoot(2));
+  assert(set.GetUnificationRoot(1) == set.GetUnificationRoot(3));
+
+  // Act 4 - add the edge 4 -> 0, creating two cycles 4-0-5-4 and 4-0-(1/2/3)-4
+  successors[4].Insert(0);
+  lcd.OnPropagatedNothing(4, 0);
+
+  // Assert that both cycles were found.
+  // They are only counted as one cycle, but everything should be unified now
+  assert(lcd.NumCyclesDetected() == 2);
+  assert(lcd.NumCycleUnifications() == set.NumPointerObjects() - 1);
+  for (PointerObjectIndex i = 1; i < set.NumPointerObjects(); i++)
+  {
+    assert(set.GetUnificationRoot(0) == set.GetUnificationRoot(i));
+  }
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER(
+    "jlm/llvm/opt/alias-analyses/TestLazyCycleDetection-TestUnifiesCycles",
+    TestUnifiesCycles)
+

--- a/tests/jlm/llvm/opt/alias-analyses/TestPointerObjectSet.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestPointerObjectSet.cpp
@@ -890,7 +890,8 @@ TestPointerObjectSet()
     TestPointerObjectConstraintSetSolve<true>(
         config.GetWorklistSoliverPolicy(),
         config.IsOnlineCycleDetectionEnabled(),
-        config.IsHybridCycleDetectionEnabled());
+        config.IsHybridCycleDetectionEnabled(),
+        config.IsLazyCycleDetectionEnabled());
   }
 
   TestClonePointerObjectConstraintSet();


### PR DESCRIPTION
When propagating along the edge a->b, it is because a has something new. If b already has everything a has, that might indicate that there is a path from b to a. Lazy cycle detection looks for such a path using a DFS from b, and unifies everything that is on such a path b->*->a. It tries at most once per edge.