### PR TITLE
Add copy() method to result class

### DIFF
--- a/jlm/hls/ir/hls.cpp
+++ b/jlm/hls/ir/hls.cpp
@@ -42,6 +42,13 @@ backedge_argument::Copy(rvsdg::region & region, jlm::rvsdg::structural_input * i
   return *backedge_argument::create(&region, Type());
 }
 
+backedge_result &
+backedge_result::Copy(rvsdg::output & origin, jlm::rvsdg::structural_output * output)
+{
+  JLM_ASSERT(output == nullptr);
+  return *backedge_result::create(&origin);
+}
+
 jlm::rvsdg::structural_output *
 loop_node::add_loopvar(jlm::rvsdg::output * origin, jlm::rvsdg::output ** buffer)
 {

--- a/jlm/hls/ir/hls.hpp
+++ b/jlm/hls/ir/hls.hpp
@@ -659,6 +659,9 @@ public:
     return argument_;
   }
 
+  backedge_result &
+  Copy(rvsdg::output & origin, jlm::rvsdg::structural_output * output) override;
+
 private:
   backedge_result(jlm::rvsdg::output * origin)
       : jlm::rvsdg::result(origin->region(), origin, nullptr, origin->port()),

--- a/jlm/llvm/ir/operators/Phi.cpp
+++ b/jlm/llvm/ir/operators/Phi.cpp
@@ -192,5 +192,12 @@ cvargument::Copy(rvsdg::region & region, rvsdg::structural_input * input)
 rvresult::~rvresult()
 {}
 
+rvresult &
+rvresult::Copy(rvsdg::output & origin, jlm::rvsdg::structural_output * output)
+{
+  auto phiOutput = util::AssertedCast<rvoutput>(output);
+  return *rvresult::create(origin.region(), &origin, phiOutput, origin.Type());
+}
+
 }
 }

--- a/jlm/llvm/ir/operators/Phi.hpp
+++ b/jlm/llvm/ir/operators/Phi.hpp
@@ -814,6 +814,9 @@ private:
   rvresult &
   operator=(rvresult &&) = delete;
 
+  rvresult &
+  Copy(rvsdg::output & origin, jlm::rvsdg::structural_output * output) override;
+
   static rvresult *
   create(
       jlm::rvsdg::region * region,

--- a/jlm/llvm/ir/operators/delta.cpp
+++ b/jlm/llvm/ir/operators/delta.cpp
@@ -184,5 +184,12 @@ cvargument::Copy(rvsdg::region & region, jlm::rvsdg::structural_input * input)
 result::~result()
 {}
 
+result &
+result::Copy(rvsdg::output & origin, jlm::rvsdg::structural_output * output)
+{
+  JLM_ASSERT(output == nullptr);
+  return *result::create(&origin);
+}
+
 }
 }

--- a/jlm/llvm/ir/operators/delta.hpp
+++ b/jlm/llvm/ir/operators/delta.hpp
@@ -457,6 +457,9 @@ class result final : public rvsdg::result
 public:
   ~result() override;
 
+  result &
+  Copy(rvsdg::output & origin, jlm::rvsdg::structural_output * output) override;
+
 private:
   result(rvsdg::output * origin)
       : rvsdg::result(origin->region(), origin, nullptr, origin->port())

--- a/jlm/llvm/ir/operators/lambda.cpp
+++ b/jlm/llvm/ir/operators/lambda.cpp
@@ -440,4 +440,11 @@ cvargument::Copy(rvsdg::region & region, jlm::rvsdg::structural_input * input)
 
 result::~result() = default;
 
+result &
+result::Copy(rvsdg::output & origin, jlm::rvsdg::structural_output * output)
+{
+  JLM_ASSERT(output == nullptr);
+  return *result::create(&origin);
+}
+
 }

--- a/jlm/llvm/ir/operators/lambda.hpp
+++ b/jlm/llvm/ir/operators/lambda.hpp
@@ -635,6 +635,9 @@ class result final : public jlm::rvsdg::result
 public:
   ~result() override;
 
+  result &
+  Copy(rvsdg::output & origin, jlm::rvsdg::structural_output * output) override;
+
 private:
   explicit result(jlm::rvsdg::output * origin)
       : jlm::rvsdg::result(origin->region(), origin, nullptr, origin->port())

--- a/jlm/rvsdg/gamma.cpp
+++ b/jlm/rvsdg/gamma.cpp
@@ -386,6 +386,13 @@ GammaArgument::Copy(rvsdg::region & region, structural_input * input)
 
 GammaResult::~GammaResult() noexcept = default;
 
+GammaResult &
+GammaResult::Copy(rvsdg::output & origin, jlm::rvsdg::structural_output * output)
+{
+  auto gammaOutput = util::AssertedCast<gamma_output>(output);
+  return GammaResult::Create(*origin.region(), origin, *gammaOutput);
+}
+
 }
 
 jlm::rvsdg::node_normal_form *

--- a/jlm/rvsdg/gamma.hpp
+++ b/jlm/rvsdg/gamma.hpp
@@ -501,6 +501,9 @@ private:
       : result(&region, &origin, &gammaOutput, origin.Type())
   {}
 
+  GammaResult &
+  Copy(rvsdg::output & origin, jlm::rvsdg::structural_output * output) override;
+
   static GammaResult &
   Create(rvsdg::region & region, rvsdg::output & origin, gamma_output & gammaOutput)
   {

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -138,6 +138,21 @@ public:
     return output_;
   }
 
+  /**
+   * Creates a copy of the result with \p origin and structural_output \p output. The
+   * result is created with the same type as \p origin and in the same region as \p origin.
+   *
+   * @param origin The origin for the result.
+   * @param output The structural_output to the result, if any.
+   *
+   * @return A reference to the copied result.
+   *
+   * FIXME: This method should be made abstract once we enforced that no instances of result
+   * itself can be created any longer.
+   */
+  virtual result &
+  Copy(rvsdg::output & origin, structural_output * output);
+
   static jlm::rvsdg::result *
   create(
       jlm::rvsdg::region * region,

--- a/jlm/rvsdg/theta.cpp
+++ b/jlm/rvsdg/theta.cpp
@@ -54,6 +54,13 @@ ThetaArgument::Copy(rvsdg::region & region, structural_input * input)
 
 ThetaResult::~ThetaResult() noexcept = default;
 
+ThetaResult &
+ThetaResult::Copy(rvsdg::output & origin, structural_output * output)
+{
+  auto thetaOutput = util::AssertedCast<theta_output>(output);
+  return ThetaResult::Create(origin, *thetaOutput);
+}
+
 /* theta node */
 
 theta_node::~theta_node()

--- a/jlm/rvsdg/theta.hpp
+++ b/jlm/rvsdg/theta.hpp
@@ -388,18 +388,21 @@ class ThetaResult final : public result
 public:
   ~ThetaResult() noexcept override;
 
+  ThetaResult &
+  Copy(rvsdg::output & origin, jlm::rvsdg::structural_output * output) override;
+
 private:
-  ThetaResult(ThetaArgument & thetaArgument, theta_output & thetaOutput)
-      : result(thetaArgument.region(), &thetaArgument, &thetaOutput, thetaArgument.Type())
+  ThetaResult(rvsdg::output & origin, theta_output & thetaOutput)
+      : result(origin.region(), &origin, &thetaOutput, origin.Type())
   {
-    JLM_ASSERT(is<theta_op>(thetaArgument.region()->node()));
+    JLM_ASSERT(is<theta_op>(origin.region()->node()));
   }
 
   static ThetaResult &
-  Create(ThetaArgument & thetaArgument, theta_output & thetaOutput)
+  Create(rvsdg::output & origin, theta_output & thetaOutput)
   {
-    auto thetaResult = new ThetaResult(thetaArgument, thetaOutput);
-    thetaArgument.region()->append_result(thetaResult);
+    auto thetaResult = new ThetaResult(origin, thetaOutput);
+    origin.region()->append_result(thetaResult);
     return *thetaResult;
   }
 };

--- a/tests/jlm/rvsdg/test-graph.cpp
+++ b/tests/jlm/rvsdg/test-graph.cpp
@@ -143,17 +143,30 @@ Copy()
   using namespace jlm::tests;
 
   // Arrange
-  auto type = jlm::tests::valuetype::Create();
+  auto valueType = jlm::tests::valuetype::Create();
 
   jlm::rvsdg::graph graph;
-  TestGraphArgument::Create(*graph.root(), type);
+  auto & argument = TestGraphArgument::Create(*graph.root(), valueType);
+  auto node = test_op::create(graph.root(), { &argument }, { valueType });
+  TestGraphResult::Create(*node->output(0));
 
   // Act
   auto newGraph = graph.copy();
 
   // Assert
   assert(newGraph->root()->narguments() == 1);
-  assert(is<TestGraphArgument>(newGraph->root()->argument(0)));
+  auto copiedArgument = newGraph->root()->argument(0);
+  assert(is<TestGraphArgument>(copiedArgument));
+
+  assert(newGraph->root()->nnodes() == 1);
+  auto copiedNode = newGraph->root()->nodes.first();
+  assert(copiedNode->ninputs() == 1 && copiedNode->noutputs() == 1);
+  assert(copiedNode->input(0)->origin() == copiedArgument);
+
+  assert(newGraph->root()->nresults() == 1);
+  auto copiedResult = newGraph->root()->result(0);
+  assert(is<TestGraphResult>(*copiedResult));
+  assert(copiedResult->origin() == copiedNode->output(0));
 
   return 0;
 }

--- a/tests/test-operation.hpp
+++ b/tests/test-operation.hpp
@@ -368,6 +368,30 @@ public:
   }
 };
 
+class TestGraphResult final : public jlm::rvsdg::result
+{
+private:
+  explicit TestGraphResult(jlm::rvsdg::output & origin)
+      : jlm::rvsdg::result(origin.region(), &origin, nullptr, origin.Type())
+  {}
+
+public:
+  TestGraphResult &
+  Copy(jlm::rvsdg::output & origin, jlm::rvsdg::structural_output * output) override
+  {
+    JLM_ASSERT(output == nullptr);
+    return Create(origin);
+  }
+
+  static TestGraphResult &
+  Create(jlm::rvsdg::output & origin)
+  {
+    auto graphResult = new TestGraphResult(origin);
+    origin.region()->append_result(graphResult);
+    return *graphResult;
+  }
+};
+
 }
 
 #endif


### PR DESCRIPTION
This PR does the following:

1. Introduces a Copy() method to the result class.
2. The introduced method enables us to fix a bug in the copy() method of
the region. Previously, results were not copied according to their
result subtypes, but simply a new instance of result was created.
3. Extend unit test.

This PR is a necessary step to get rid off ports.