### PR TITLE
Remove expport class

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -212,7 +212,7 @@ convert_alloca(jlm::rvsdg::region * region)
         cout = jlm::rvsdg::simple_node::create_normalized(db->subregion(), cop, {})[0];
       }
       auto delta = db->finalize(cout);
-      region->graph()->add_export(delta, { delta_type, delta_name });
+      jlm::llvm::GraphExport::Create(*delta, delta_name);
       auto delta_local = route_to_region(delta, region);
       node->output(0)->divert_users(delta_local);
       // TODO: check that the input to alloca is a bitconst 1
@@ -375,7 +375,7 @@ split_hls_function(llvm::RvsdgModule & rm, const std::string & function_name)
           smap.insert(ln->input(i)->origin(), &graphImport);
           // add export for delta to rm
           // TODO: check if not already exported and maybe adjust linkage?
-          rm.Rvsdg().add_export(odn->output(), { odn->output()->Type(), odn->name() });
+          jlm::llvm::GraphExport::Create(*odn->output(), odn->name());
         }
         else
         {

--- a/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
+++ b/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
@@ -1116,7 +1116,7 @@ ConvertStronglyConnectedComponent(
     regionalizedVariableMap.GetTopVariableMap().insert(ipgNodeVariable, output);
 
     if (requiresExport(*ipgNode))
-      graph.add_export(output, { output->Type(), ipgNodeVariable->name() });
+      GraphExport::Create(*output, ipgNodeVariable->name());
 
     return;
   }
@@ -1179,7 +1179,7 @@ ConvertStronglyConnectedComponent(
     auto recursionVariable = recursionVariables[ipgNodeVariable];
     regionalizedVariableMap.GetTopVariableMap().insert(ipgNodeVariable, recursionVariable);
     if (requiresExport(*ipgNode))
-      graph.add_export(recursionVariable, { recursionVariable->Type(), ipgNodeVariable->name() });
+      GraphExport::Create(*recursionVariable, ipgNodeVariable->name());
   }
 }
 

--- a/jlm/llvm/ir/RvsdgModule.cpp
+++ b/jlm/llvm/ir/RvsdgModule.cpp
@@ -18,7 +18,7 @@ GraphExport &
 GraphExport::Copy(rvsdg::output & origin, rvsdg::structural_output * output)
 {
   JLM_ASSERT(output == nullptr);
-  return GraphExport::Create(*origin.region()->graph(), origin, Name());
+  return GraphExport::Create(origin, Name());
 }
 
 }

--- a/jlm/llvm/ir/RvsdgModule.cpp
+++ b/jlm/llvm/ir/RvsdgModule.cpp
@@ -14,4 +14,11 @@ GraphImport::Copy(rvsdg::region & region, rvsdg::structural_input * input)
   return GraphImport::Create(*region.graph(), ValueType(), Name(), Linkage());
 }
 
+GraphExport &
+GraphExport::Copy(rvsdg::output & origin, rvsdg::structural_output * output)
+{
+  JLM_ASSERT(output == nullptr);
+  return GraphExport::Create(*origin.region()->graph(), origin, Name());
+}
+
 }

--- a/jlm/llvm/ir/RvsdgModule.hpp
+++ b/jlm/llvm/ir/RvsdgModule.hpp
@@ -65,7 +65,10 @@ private:
   std::shared_ptr<const rvsdg::valuetype> ValueType_;
 };
 
-// FIXME: add documentation
+/**
+ * Represents an export from the RVSDG of an internal entity.
+ * It is used to model externally visible entities from LLVM modules.
+ */
 class GraphExport final : public rvsdg::GraphExport
 {
 private:

--- a/jlm/llvm/ir/RvsdgModule.hpp
+++ b/jlm/llvm/ir/RvsdgModule.hpp
@@ -65,6 +65,27 @@ private:
   std::shared_ptr<const rvsdg::valuetype> ValueType_;
 };
 
+// FIXME: add documentation
+class GraphExport final : public rvsdg::GraphExport
+{
+private:
+  GraphExport(rvsdg::graph & graph, rvsdg::output & origin, std::string name)
+      : rvsdg::GraphExport(graph, origin, std::move(name))
+  {}
+
+public:
+  GraphExport &
+  Copy(rvsdg::output & origin, rvsdg::structural_output * output) override;
+
+  static GraphExport &
+  Create(rvsdg::graph & graph, rvsdg::output & origin, std::string name)
+  {
+    auto graphExport = new GraphExport(graph, origin, std::move(name));
+    graph.root()->append_result(graphExport);
+    return *graphExport;
+  }
+};
+
 static inline bool
 is_export(const jlm::rvsdg::input * input)
 {

--- a/jlm/llvm/ir/RvsdgModule.hpp
+++ b/jlm/llvm/ir/RvsdgModule.hpp
@@ -86,15 +86,6 @@ public:
   }
 };
 
-static inline bool
-is_export(const jlm::rvsdg::input * input)
-{
-  auto graph = input->region()->graph();
-
-  auto result = dynamic_cast<const jlm::rvsdg::result *>(input);
-  return result && result->region() == graph->root();
-}
-
 /**
  * An LLVM module utilizing the RVSDG representation.
  */

--- a/jlm/llvm/ir/RvsdgModule.hpp
+++ b/jlm/llvm/ir/RvsdgModule.hpp
@@ -69,8 +69,8 @@ private:
 class GraphExport final : public rvsdg::GraphExport
 {
 private:
-  GraphExport(rvsdg::graph & graph, rvsdg::output & origin, std::string name)
-      : rvsdg::GraphExport(graph, origin, std::move(name))
+  GraphExport(rvsdg::output & origin, std::string name)
+      : rvsdg::GraphExport(origin, std::move(name))
   {}
 
 public:
@@ -78,10 +78,10 @@ public:
   Copy(rvsdg::output & origin, rvsdg::structural_output * output) override;
 
   static GraphExport &
-  Create(rvsdg::graph & graph, rvsdg::output & origin, std::string name)
+  Create(rvsdg::output & origin, std::string name)
   {
-    auto graphExport = new GraphExport(graph, origin, std::move(name));
-    graph.root()->append_result(graphExport);
+    auto graphExport = new GraphExport(origin, std::move(name));
+    origin.region()->graph()->root()->append_result(graphExport);
     return *graphExport;
   }
 };

--- a/jlm/rvsdg/graph.cpp
+++ b/jlm/rvsdg/graph.cpp
@@ -27,26 +27,6 @@ GraphExport::GraphExport(rvsdg::output & origin, std::string name)
       Name_(std::move(name))
 {}
 
-/* expport */
-
-expport::~expport()
-{}
-
-bool
-expport::operator==(const port & other) const noexcept
-{
-  auto p = dynamic_cast<const expport *>(&other);
-  return p && p->type() == type() && p->name() == name();
-}
-
-std::unique_ptr<port>
-expport::copy() const
-{
-  return std::unique_ptr<port>(new expport(*this));
-}
-
-/* graph */
-
 graph::~graph()
 {
   JLM_ASSERT(!has_active_trackers(this));

--- a/jlm/rvsdg/graph.cpp
+++ b/jlm/rvsdg/graph.cpp
@@ -22,8 +22,8 @@ GraphImport::GraphImport(
       Name_(std::move(name))
 {}
 
-GraphExport::GraphExport(rvsdg::graph & graph, rvsdg::output & origin, std::string name)
-    : result(graph.root(), &origin, nullptr, std::move(origin.Type())),
+GraphExport::GraphExport(rvsdg::output & origin, std::string name)
+    : result(origin.region()->graph()->root(), &origin, nullptr, origin.Type()),
       Name_(std::move(name))
 {}
 

--- a/jlm/rvsdg/graph.cpp
+++ b/jlm/rvsdg/graph.cpp
@@ -22,6 +22,11 @@ GraphImport::GraphImport(
       Name_(std::move(name))
 {}
 
+GraphExport::GraphExport(rvsdg::graph & graph, rvsdg::output & origin, std::string name)
+    : result(graph.root(), &origin, nullptr, std::move(origin.Type())),
+      Name_(std::move(name))
+{}
+
 /* expport */
 
 expport::~expport()

--- a/jlm/rvsdg/graph.hpp
+++ b/jlm/rvsdg/graph.hpp
@@ -45,7 +45,7 @@ private:
 class GraphExport : public result
 {
 protected:
-  GraphExport(rvsdg::graph & graph, rvsdg::output & origin, std::string name);
+  GraphExport(rvsdg::output & origin, std::string name);
 
 public:
   [[nodiscard]] const std::string &

--- a/jlm/rvsdg/graph.hpp
+++ b/jlm/rvsdg/graph.hpp
@@ -58,52 +58,6 @@ private:
   std::string Name_;
 };
 
-/* expport class */
-
-class expport : public port
-{
-public:
-  virtual ~expport();
-
-  expport(std::shared_ptr<const jlm::rvsdg::type> type, const std::string & name)
-      : port(std::move(type)),
-        name_(name)
-  {}
-
-  expport(const expport & other)
-      : port(other),
-        name_(other.name_)
-  {}
-
-  expport(expport && other)
-      : port(other),
-        name_(std::move(other.name_))
-  {}
-
-  expport &
-  operator=(const expport &) = delete;
-
-  expport &
-  operator=(expport &&) = delete;
-
-  const std::string &
-  name() const noexcept
-  {
-    return name_;
-  }
-
-  virtual bool
-  operator==(const port &) const noexcept override;
-
-  virtual std::unique_ptr<port>
-  copy() const override;
-
-private:
-  std::string name_;
-};
-
-/* graph */
-
 class graph
 {
 public:
@@ -135,12 +89,6 @@ public:
 
   jlm::rvsdg::node_normal_form *
   node_normal_form(const std::type_info & type) noexcept;
-
-  inline jlm::rvsdg::input *
-  add_export(jlm::rvsdg::output * operand, const expport & port)
-  {
-    return result::create(root(), operand, nullptr, port);
-  }
 
   inline void
   prune()

--- a/jlm/rvsdg/graph.hpp
+++ b/jlm/rvsdg/graph.hpp
@@ -41,7 +41,9 @@ private:
   std::string Name_;
 };
 
-// FIXME: add documentation
+/**
+ * Represents an export from the RVSDG of an internal entity.
+ */
 class GraphExport : public result
 {
 protected:

--- a/jlm/rvsdg/graph.hpp
+++ b/jlm/rvsdg/graph.hpp
@@ -41,6 +41,23 @@ private:
   std::string Name_;
 };
 
+// FIXME: add documentation
+class GraphExport : public result
+{
+protected:
+  GraphExport(rvsdg::graph & graph, rvsdg::output & origin, std::string name);
+
+public:
+  [[nodiscard]] const std::string &
+  Name() const noexcept
+  {
+    return Name_;
+  }
+
+private:
+  std::string Name_;
+};
+
 /* expport class */
 
 class expport : public port

--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -45,7 +45,7 @@ StoreTest1::SetupRvsdg()
 
   fct->finalize({ c_amp_d[0] });
 
-  graph->add_export(fct->output(), { pointerType, "f" });
+  GraphExport::Create(*fct->output(), "f");
 
   /* extract nodes */
 
@@ -102,7 +102,7 @@ StoreTest2::SetupRvsdg()
 
   fct->finalize({ p_amp_y[0] });
 
-  graph->add_export(fct->output(), { pointerType, "f" });
+  GraphExport::Create(*fct->output(), "f");
 
   /* extract nodes */
 
@@ -144,7 +144,7 @@ LoadTest1::SetupRvsdg()
 
   fct->finalize(ld2);
 
-  graph->add_export(fct->output(), { pointerType, "f" });
+  GraphExport::Create(*fct->output(), "f");
 
   /* extract nodes */
 
@@ -201,7 +201,7 @@ LoadTest2::SetupRvsdg()
 
   fct->finalize({ y_star_p[0] });
 
-  graph->add_export(fct->output(), { pointerType, "f" });
+  GraphExport::Create(*fct->output(), "f");
 
   /* extract nodes */
 
@@ -248,7 +248,7 @@ LoadFromUndefTest::SetupRvsdg()
       4);
 
   Lambda_->finalize(loadResults);
-  rvsdg.add_export(Lambda_->output(), { pointerType, "f" });
+  GraphExport::Create(*Lambda_->output(), "f");
 
   /*
    * Extract nodes
@@ -300,7 +300,7 @@ GetElementPtrTest::SetupRvsdg()
 
   fct->finalize({ sum, ldy[1] });
 
-  graph->add_export(fct->output(), { pointerType, "f" });
+  GraphExport::Create(*fct->output(), "f");
 
   /*
    * Assign nodes
@@ -333,7 +333,7 @@ BitCastTest::SetupRvsdg()
 
   fct->finalize({ cast });
 
-  graph->add_export(fct->output(), { pointerType, "f" });
+  GraphExport::Create(*fct->output(), "f");
 
   /*
    * Assign nodes
@@ -399,7 +399,7 @@ Bits2PtrTest::SetupRvsdg()
         { valueArgument, iOStateArgument, memoryStateArgument });
 
     lambda->finalize({ call.GetIoStateOutput(), call.GetMemoryStateOutput() });
-    graph->add_export(lambda->output(), { PointerType::Create(), "testfct" });
+    GraphExport::Create(*lambda->output(), "testfct");
 
     return std::make_tuple(lambda, &call);
   };
@@ -447,7 +447,7 @@ ConstantPointerNullTest::SetupRvsdg()
 
   fct->finalize({ st[0] });
 
-  graph->add_export(fct->output(), { pointerType, "f" });
+  GraphExport::Create(*fct->output(), "f");
 
   /*
    * Assign nodes
@@ -584,7 +584,7 @@ CallTest1::SetupRvsdg()
     auto sum = jlm::rvsdg::bitadd_op::create(32, callF.Result(0), callG.Result(0));
 
     lambda->finalize({ sum, callG.GetIoStateOutput(), callG.GetMemoryStateOutput() });
-    graph->add_export(lambda->output(), { PointerType::Create(), "h" });
+    GraphExport::Create(*lambda->output(), "h");
 
     auto allocaX = jlm::rvsdg::node_output::node(x[0]);
     auto allocaY = jlm::rvsdg::node_output::node(y[0]);
@@ -716,7 +716,7 @@ CallTest2::SetupRvsdg()
         { create2.Result(0), destroy1.GetIoStateOutput(), destroy1.GetMemoryStateOutput() });
 
     lambda->finalize({ destroy2.GetIoStateOutput(), destroy2.GetMemoryStateOutput() });
-    graph->add_export(lambda->output(), { PointerType::Create(), "test" });
+    GraphExport::Create(*lambda->output(), "test");
 
     return std::make_tuple(lambda, &create1, &create2, &destroy1, &destroy2);
   };
@@ -828,7 +828,7 @@ IndirectCallTest1::SetupRvsdg()
 
     auto lambdaOutput =
         lambda->finalize({ add, call_three.GetIoStateOutput(), call_three.GetMemoryStateOutput() });
-    graph->add_export(lambda->output(), { pointerType, "test" });
+    GraphExport::Create(*lambda->output(), "test");
 
     return std::make_tuple(lambdaOutput, &call_three, &call_four);
   };
@@ -1023,7 +1023,7 @@ IndirectCallTest2::SetupRvsdg()
 
     auto lambdaOutput =
         lambda->finalize({ sum, callY.GetIoStateOutput(), callY.GetMemoryStateOutput() });
-    graph->add_export(lambdaOutput, { PointerType::Create(), "test" });
+    GraphExport::Create(*lambdaOutput, "test");
 
     return std::make_tuple(
         lambdaOutput,
@@ -1059,7 +1059,7 @@ IndirectCallTest2::SetupRvsdg()
         { pzAlloca[0], iOStateArgument, pzMerge });
 
     auto lambdaOutput = lambda->finalize(callX.Results());
-    graph->add_export(lambdaOutput, { PointerType::Create(), "test2" });
+    GraphExport::Create(*lambdaOutput, "test2");
 
     return std::make_tuple(
         lambdaOutput,
@@ -1173,7 +1173,7 @@ ExternalCallTest1::SetupRvsdg()
         { loadPath[0], loadMode[0], iOStateArgument, loadMode[1] });
 
     lambda->finalize(callG.Results());
-    rvsdg->add_export(lambda->output(), { pointerType, "f" });
+    GraphExport::Create(*lambda->output(), "f");
 
     return std::make_tuple(lambda, &callG);
   };
@@ -1339,7 +1339,7 @@ GammaTest::SetupRvsdg()
 
   fct->finalize({ sum, ld2[1] });
 
-  graph->add_export(fct->output(), { PointerType::Create(), "f" });
+  GraphExport::Create(*fct->output(), "f");
 
   /*
    * Assign nodes
@@ -1503,7 +1503,7 @@ GammaTest2::SetupRvsdg()
         { predicate, allocaXResults[0], allocaYResults[0], iOStateArgument, storeYResults[0] });
 
     lambda->finalize(call.Results());
-    rvsdg->add_export(lambda->output(), { PointerType::Create(), functionName });
+    GraphExport::Create(*lambda->output(), functionName);
 
     return std::make_tuple(
         lambda->output(),
@@ -1584,7 +1584,7 @@ ThetaTest::SetupRvsdg()
   thetanode->set_predicate(predicate);
 
   fct->finalize({ s });
-  graph->add_export(fct->output(), { PointerType::Create(), "f" });
+  GraphExport::Create(*fct->output(), "f");
 
   /*
    * Assign nodes
@@ -1665,7 +1665,7 @@ DeltaTest1::SetupRvsdg()
     auto & callG = CallNode::CreateNode(cvg, g->node()->Type(), { cvf, iOStateArgument, st[0] });
 
     auto lambdaOutput = lambda->finalize(callG.Results());
-    graph->add_export(lambda->output(), { PointerType::Create(), "h" });
+    GraphExport::Create(*lambda->output(), "h");
 
     return std::make_tuple(lambdaOutput, &callG, jlm::rvsdg::node_output::node(five));
   };
@@ -1773,7 +1773,7 @@ DeltaTest2::SetupRvsdg()
     st = StoreNonVolatileNode::Create(cvd2, b42, { call.GetMemoryStateOutput() }, 4);
 
     auto lambdaOutput = lambda->finalize(call.Results());
-    graph->add_export(lambdaOutput, { PointerType::Create(), "f2" });
+    GraphExport::Create(*lambdaOutput, "f2");
 
     return std::make_tuple(lambdaOutput, &call);
   };
@@ -1880,7 +1880,7 @@ DeltaTest3::SetupRvsdg()
         { iOStateArgument, memoryStateArgument });
 
     auto lambdaOutput = lambda->finalize({ call.GetIoStateOutput(), call.GetMemoryStateOutput() });
-    graph->add_export(lambdaOutput, { PointerType::Create(), "test" });
+    GraphExport::Create(*lambdaOutput, "test");
 
     return std::make_tuple(lambdaOutput, &call);
   };
@@ -1959,7 +1959,7 @@ ImportTest::SetupRvsdg()
     st = StoreNonVolatileNode::Create(cvd2, b21, { call.GetMemoryStateOutput() }, 4);
 
     auto lambdaOutput = lambda->finalize(call.Results());
-    graph->add_export(lambda->output(), { PointerType::Create(), "f2" });
+    GraphExport::Create(*lambda->output(), "f2");
 
     return std::make_tuple(lambdaOutput, &call);
   };
@@ -2127,7 +2127,7 @@ PhiTest1::SetupRvsdg()
         CallNode::CreateNode(fibcv, fibFunctionType, { ten, gep, iOStateArgument, state });
 
     auto lambdaOutput = lambda->finalize(call.Results());
-    graph->add_export(lambdaOutput, { PointerType::Create(), "test" });
+    GraphExport::Create(*lambdaOutput, "test");
 
     return std::make_tuple(lambdaOutput, &call, jlm::rvsdg::node_output::node(allocaResults[0]));
   };
@@ -2446,7 +2446,7 @@ PhiTest2::SetupRvsdg()
         { pTestAlloca[0], iOStateArgument, pTestMerge });
 
     auto lambdaOutput = lambda->finalize(callA.Results());
-    graph->add_export(lambdaOutput, { PointerType::Create(), "test" });
+    GraphExport::Create(*lambdaOutput, "test");
 
     return std::make_tuple(
         lambdaOutput,
@@ -2549,7 +2549,7 @@ PhiWithDeltaTest::SetupRvsdg()
   myArrayRecVar->result()->divert_to(deltaOutput);
 
   auto phiNode = pb.end();
-  rvsdg.add_export(phiNode->output(0), { PointerType::Create(), "myArray" });
+  GraphExport::Create(*phiNode->output(0), "myArray");
 
   return rvsdgModule;
 }
@@ -2586,7 +2586,7 @@ ExternalMemoryTest::SetupRvsdg()
   auto storeTwo = StoreNonVolatileNode::Create(y, two, { storeOne[0] }, 4);
 
   LambdaF->finalize(storeTwo);
-  graph->add_export(LambdaF->output(), { pointerType, "f" });
+  GraphExport::Create(*LambdaF->output(), "f");
 
   return module;
 }
@@ -2654,7 +2654,7 @@ EscapedMemoryTest1::SetupRvsdg()
     auto contextVariableX = deltaNode->add_ctxvar(&deltaX);
 
     auto deltaOutput = deltaNode->finalize(contextVariableX);
-    rvsdg->add_export(deltaOutput, { pointerType, "y" });
+    GraphExport::Create(*deltaOutput, "y");
 
     return deltaOutput;
   };
@@ -2690,7 +2690,7 @@ EscapedMemoryTest1::SetupRvsdg()
 
     auto lambdaOutput = lambda->finalize({ loadResults2[0], iOStateArgument, storeResults[0] });
 
-    rvsdg->add_export(lambdaOutput, { pointerType, "test" });
+    GraphExport::Create(*lambdaOutput, "test");
 
     return std::make_tuple(
         lambdaOutput,
@@ -2785,7 +2785,7 @@ EscapedMemoryTest2::SetupRvsdg()
 
     auto lambdaOutput = lambda->finalize({ mallocResults[0], iOStateArgument, mergeResults });
 
-    rvsdg->add_export(lambdaOutput, { pointerType, "ReturnAddress" });
+    GraphExport::Create(*lambdaOutput, "ReturnAddress");
 
     return std::make_tuple(lambdaOutput, jlm::rvsdg::node_output::node(mallocResults[0]));
   };
@@ -2821,7 +2821,7 @@ EscapedMemoryTest2::SetupRvsdg()
 
     auto lambdaOutput = lambda->finalize(call.Results());
 
-    rvsdg->add_export(lambdaOutput, { pointerType, "CallExternalFunction1" });
+    GraphExport::Create(*lambdaOutput, "CallExternalFunction1");
 
     return std::make_tuple(lambdaOutput, &call, jlm::rvsdg::node_output::node(mallocResults[0]));
   };
@@ -2858,7 +2858,7 @@ EscapedMemoryTest2::SetupRvsdg()
     auto lambdaOutput =
         lambda->finalize({ loadResults[0], call.GetIoStateOutput(), loadResults[1] });
 
-    rvsdg->add_export(lambdaOutput, { pointerType, "CallExternalFunction2" });
+    GraphExport::Create(*lambdaOutput, "CallExternalFunction2");
 
     return std::make_tuple(
         lambdaOutput,
@@ -2937,7 +2937,7 @@ EscapedMemoryTest3::SetupRvsdg()
 
     auto deltaOutput = delta->finalize(constant);
 
-    rvsdg->add_export(deltaOutput, { pointerType, "global" });
+    GraphExport::Create(*deltaOutput, "global");
 
     return deltaOutput;
   };
@@ -2971,7 +2971,7 @@ EscapedMemoryTest3::SetupRvsdg()
     auto lambdaOutput =
         lambda->finalize({ loadResults[0], call.GetIoStateOutput(), loadResults[1] });
 
-    rvsdg->add_export(lambdaOutput, { pointerType, "test" });
+    GraphExport::Create(*lambdaOutput, "test");
 
     return std::make_tuple(
         lambdaOutput,
@@ -3027,7 +3027,7 @@ MemcpyTest::SetupRvsdg()
 
     auto deltaOutput = delta->finalize(constantDataArray);
 
-    rvsdg->add_export(deltaOutput, { PointerType::Create(), "localArray" });
+    GraphExport::Create(*deltaOutput, "localArray");
 
     return deltaOutput;
   };
@@ -3046,7 +3046,7 @@ MemcpyTest::SetupRvsdg()
 
     auto deltaOutput = delta->finalize(constantAggregateZero);
 
-    rvsdg->add_export(deltaOutput, { PointerType::Create(), "globalArray" });
+    GraphExport::Create(*deltaOutput, "globalArray");
 
     return deltaOutput;
   };
@@ -3082,7 +3082,7 @@ MemcpyTest::SetupRvsdg()
 
     auto lambdaOutput = lambda->finalize({ loadResults[0], iOStateArgument, loadResults[1] });
 
-    rvsdg->add_export(lambdaOutput, { PointerType::Create(), "f" });
+    GraphExport::Create(*lambdaOutput, "f");
 
     return lambdaOutput;
   };
@@ -3122,7 +3122,7 @@ MemcpyTest::SetupRvsdg()
 
     auto lambdaOutput = lambda->finalize(call.Results());
 
-    rvsdg->add_export(lambdaOutput, { PointerType::Create(), "g" });
+    GraphExport::Create(*lambdaOutput, "g");
 
     return std::make_tuple(lambdaOutput, &call, jlm::rvsdg::node_output::node(memcpyResults[0]));
   };
@@ -3231,7 +3231,7 @@ MemcpyTest2::SetupRvsdg()
 
     auto lambdaOutput = lambda->finalize(call.Results());
 
-    rvsdg->add_export(lambdaOutput, { PointerType::Create(), "f" });
+    GraphExport::Create(*lambdaOutput, "f");
 
     return std::make_tuple(lambdaOutput, &call);
   };
@@ -3296,7 +3296,7 @@ MemcpyTest3::SetupRvsdg()
 
   auto lambdaOutput = Lambda_->finalize({ iOStateArgument, memcpyResults[0] });
 
-  rvsdg->add_export(lambdaOutput, { PointerType::Create(), "f" });
+  GraphExport::Create(*lambdaOutput, "f");
 
   Alloca_ = rvsdg::node_output::node(allocaResults[0]);
   Memcpy_ = rvsdg::node_output::node(memcpyResults[0]);
@@ -3334,7 +3334,7 @@ LinkedListTest::SetupRvsdg()
         ConstantPointerNullOperation::Create(delta->subregion(), pointerType);
 
     auto deltaOutput = delta->finalize(constantPointerNullResult);
-    rvsdg.add_export(deltaOutput, { PointerType::Create(), "myList" });
+    GraphExport::Create(*deltaOutput, "myList");
 
     return deltaOutput;
   };
@@ -3372,7 +3372,7 @@ LinkedListTest::SetupRvsdg()
     auto load4 = LoadNonVolatileNode::Create(alloca[0], { store2[0] }, pointerType, 4);
 
     auto lambdaOutput = lambda->finalize({ load4[0], iOStateArgument, load4[1] });
-    rvsdg.add_export(lambdaOutput, { pointerType, "next" });
+    GraphExport::Create(*lambdaOutput, "next");
 
     return std::make_tuple(jlm::rvsdg::node_output::node(alloca[0]), lambdaOutput);
   };
@@ -3481,8 +3481,8 @@ AllMemoryNodesTest::SetupRvsdg()
 
   Lambda_->finalize({ storeOutputs[0] });
 
-  graph->add_export(Delta_->output(), { pointerType, "global" });
-  graph->add_export(Lambda_->output(), { pointerType, "f" });
+  GraphExport::Create(*Delta_->output(), "global");
+  GraphExport::Create(*Lambda_->output(), "f");
 
   return module;
 }
@@ -3522,7 +3522,7 @@ NAllocaNodesTest::SetupRvsdg()
 
   Function_->finalize({ latestMemoryState });
 
-  graph->add_export(Function_->output(), { pointerType, "f" });
+  GraphExport::Create(*Function_->output(), "f");
 
   return module;
 }
@@ -3595,7 +3595,7 @@ EscapingLocalFunctionTest::SetupRvsdg()
   // Return &localFunc, pass memory state directly through
   ExportedFunc_->finalize({ localFuncCtxVar, ExportedFunc_->fctargument(0) });
 
-  graph->add_export(ExportedFunc_->output(), { pointerType, "exportedFunc" });
+  GraphExport::Create(*ExportedFunc_->output(), "exportedFunc");
 
   return module;
 }
@@ -3628,7 +3628,7 @@ FreeNullTest::SetupRvsdg()
 
   LambdaMain_->finalize({ FreeResults[1], FreeResults[0] });
 
-  graph->add_export(LambdaMain_->output(), { PointerType::Create(), "main" });
+  GraphExport::Create(*LambdaMain_->output(), "main");
 
   return module;
 }
@@ -3703,7 +3703,7 @@ LambdaCallArgumentMismatch::SetupRvsdg()
 
     auto lambdaOutput = lambda->finalize(call.Results());
 
-    rvsdg.add_export(lambdaOutput, { PointerType::Create(), "main" });
+    GraphExport::Create(*lambdaOutput, "main");
 
     return std::make_tuple(lambdaOutput, &call);
   };

--- a/tests/jlm/hls/backend/rvsdg2rhls/DeadNodeEliminationTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/DeadNodeEliminationTests.cpp
@@ -71,7 +71,7 @@ TestDeadLoopNodeOutput()
 
   auto lambdaOutput = lambdaNode->finalize({ output0 });
 
-  rvsdg.add_export(lambdaOutput, { jlm::llvm::PointerType::Create(), "f" });
+  jlm::llvm::GraphExport::Create(*lambdaOutput, "f");
 
   // Act
   EliminateDeadNodes(rvsdgModule);

--- a/tests/jlm/hls/backend/rvsdg2rhls/TestFork.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/TestFork.cpp
@@ -46,7 +46,7 @@ TestFork()
   loop->set_predicate(match);
 
   auto f = lambda->finalize({ loop->output(0), loop->output(1), loop->output(2) });
-  rm.Rvsdg().add_export(f, { f->Type(), "" });
+  jlm::llvm::GraphExport::Create(*f, "");
 
   rvsdg::view(rm.Rvsdg(), stdout);
 
@@ -112,7 +112,7 @@ TestConstantFork()
   loop->set_predicate(match);
 
   auto f = lambda->finalize({ loop->output(0) });
-  rm.Rvsdg().add_export(f, { f->Type(), "" });
+  jlm::llvm::GraphExport::Create(*f, "");
 
   rvsdg::view(rm.Rvsdg(), stdout);
 

--- a/tests/jlm/hls/backend/rvsdg2rhls/TestGamma.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/TestGamma.cpp
@@ -35,7 +35,7 @@ TestWithMatch()
   auto ex = gamma->add_exitvar({ ev1->argument(0), ev2->argument(1) });
 
   auto f = lambda->finalize({ ex });
-  rm.Rvsdg().add_export(f, { f->Type(), "" });
+  jlm::llvm::GraphExport::Create(*f, "");
 
   jlm::rvsdg::view(rm.Rvsdg(), stdout);
 
@@ -71,7 +71,7 @@ TestWithoutMatch()
   auto ex = gamma->add_exitvar({ ev1->argument(0), ev2->argument(1) });
 
   auto f = lambda->finalize({ ex });
-  rm.Rvsdg().add_export(f, { f->Type(), "" });
+  jlm::llvm::GraphExport::Create(*f, "");
 
   jlm::rvsdg::view(rm.Rvsdg(), stdout);
 

--- a/tests/jlm/hls/backend/rvsdg2rhls/TestTheta.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/TestTheta.cpp
@@ -48,7 +48,7 @@ TestUnknownBoundaries()
   theta->set_predicate(match);
 
   auto f = lambda->finalize({ theta->output(0), theta->output(1), theta->output(2) });
-  rm.Rvsdg().add_export(f, { f->Type(), "" });
+  jlm::llvm::GraphExport::Create(*f, "");
 
   jlm::rvsdg::view(rm.Rvsdg(), stdout);
 

--- a/tests/jlm/hls/backend/rvsdg2rhls/UnusedStateRemovalTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/UnusedStateRemovalTests.cpp
@@ -51,11 +51,11 @@ TestGamma()
   auto gammaOutput5 =
       gammaNode->add_exitvar({ gammaInput6->argument(0), gammaInput7->argument(1) });
 
-  rvsdg.add_export(gammaOutput1, { valueType, "" });
-  rvsdg.add_export(gammaOutput2, { valueType, "" });
-  rvsdg.add_export(gammaOutput3, { valueType, "" });
-  rvsdg.add_export(gammaOutput4, { valueType, "" });
-  rvsdg.add_export(gammaOutput5, { valueType, "" });
+  GraphExport::Create(*gammaOutput1, "");
+  GraphExport::Create(*gammaOutput2, "");
+  GraphExport::Create(*gammaOutput3, "");
+  GraphExport::Create(*gammaOutput4, "");
+  GraphExport::Create(*gammaOutput5, "");
 
   // Act
   jlm::hls::RemoveUnusedStates(*rvsdgModule);
@@ -106,7 +106,7 @@ TestTheta()
                     { valueType })
                     .output(0);
 
-  rvsdg.add_export(result, { valueType, "f" });
+  GraphExport::Create(*result, "f");
 
   // Act
   jlm::hls::RemoveUnusedStates(*rvsdgModule);
@@ -152,7 +152,7 @@ TestLambda()
 
   auto lambdaOutput = lambdaNode->finalize({ argument0, result1, argument2, result3 });
 
-  rvsdg.add_export(lambdaOutput, { PointerType::Create(), "f" });
+  GraphExport::Create(*lambdaOutput, "f");
 
   // Act
   jlm::hls::RemoveUnusedStates(*rvsdgModule);

--- a/tests/jlm/hls/backend/rvsdg2rhls/test-loop-passthrough.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/test-loop-passthrough.cpp
@@ -55,7 +55,7 @@ test()
   auto loop_out = loop->add_loopvar(lambda->fctargument(1));
 
   auto f = lambda->finalize({ loop_out });
-  rm.Rvsdg().add_export(f, { f->Type(), "" });
+  jlm::llvm::GraphExport::Create(*f, "");
 
   rvsdg::view(rm.Rvsdg(), stdout);
   hls::DotHLS dhls;

--- a/tests/jlm/llvm/backend/llvm/r2j/test-empty-gamma.cpp
+++ b/tests/jlm/llvm/backend/llvm/r2j/test-empty-gamma.cpp
@@ -41,7 +41,7 @@ test_with_match()
   auto ex = gamma->add_exitvar({ ev1->argument(0), ev2->argument(1) });
 
   auto f = lambda->finalize({ ex });
-  rm.Rvsdg().add_export(f, { f->Type(), "" });
+  GraphExport::Create(*f, "");
 
   jlm::rvsdg::view(rm.Rvsdg(), stdout);
 
@@ -83,7 +83,7 @@ test_without_match()
   auto ex = gamma->add_exitvar({ ev1->argument(0), ev2->argument(1) });
 
   auto f = lambda->finalize({ ex });
-  rm.Rvsdg().add_export(f, { f->Type(), "" });
+  GraphExport::Create(*f, "");
 
   jlm::rvsdg::view(rm.Rvsdg(), stdout);
 
@@ -128,7 +128,7 @@ test_gamma3()
   auto ex = gamma->add_exitvar({ ev1->argument(0), ev1->argument(1), ev2->argument(2) });
 
   auto f = lambda->finalize({ ex });
-  rm.Rvsdg().add_export(f, { f->Type(), "" });
+  GraphExport::Create(*f, "");
 
   jlm::rvsdg::view(rm.Rvsdg(), stdout);
 

--- a/tests/jlm/llvm/backend/llvm/r2j/test-partial-gamma.cpp
+++ b/tests/jlm/llvm/backend/llvm/r2j/test-partial-gamma.cpp
@@ -39,7 +39,7 @@ test()
 
   auto f = lambda->finalize({ ex });
 
-  rm.Rvsdg().add_export(f, { f->Type(), "" });
+  GraphExport::Create(*f, "");
 
   jlm::rvsdg::view(rm.Rvsdg(), stdout);
 

--- a/tests/jlm/llvm/backend/llvm/r2j/test-recursive-data.cpp
+++ b/tests/jlm/llvm/backend/llvm/r2j/test-recursive-data.cpp
@@ -59,7 +59,7 @@ test()
   r2->set_rvorigin(delta2);
 
   auto phi = pb.end();
-  rm.Rvsdg().add_export(phi->output(0), { phi->output(0)->Type(), "" });
+  GraphExport::Create(*phi->output(0), "");
 
   jlm::rvsdg::view(rm.Rvsdg(), stdout);
 

--- a/tests/jlm/llvm/ir/operators/StoreTests.cpp
+++ b/tests/jlm/llvm/ir/operators/StoreTests.cpp
@@ -13,6 +13,7 @@
 #include <jlm/llvm/ir/operators/alloca.hpp>
 #include <jlm/llvm/ir/operators/MemoryStateOperations.hpp>
 #include <jlm/llvm/ir/operators/Store.hpp>
+#include <jlm/llvm/ir/RvsdgModule.hpp>
 
 static int
 StoreNonVolatileOperationEquality()
@@ -228,7 +229,7 @@ TestStoreMuxReduction()
   auto mux = MemoryStateMergeOperation::Create({ s1, s2, s3 });
   auto state = StoreNonVolatileNode::Create(a, v, { mux }, 4);
 
-  auto ex = graph.add_export(state[0], { state[0]->Type(), "s" });
+  auto & ex = GraphExport::Create(*state[0], "s");
 
   //	jlm::rvsdg::view(graph.root(), stdout);
 
@@ -241,7 +242,7 @@ TestStoreMuxReduction()
   //	jlm::rvsdg::view(graph.root(), stdout);
 
   // Assert
-  auto muxnode = jlm::rvsdg::node_output::node(ex->origin());
+  auto muxnode = jlm::rvsdg::node_output::node(ex.origin());
   assert(is<MemoryStateMergeOperation>(muxnode));
   assert(muxnode->ninputs() == 3);
   auto n0 = jlm::rvsdg::node_output::node(muxnode->input(0)->origin());
@@ -274,7 +275,7 @@ TestMultipleOriginReduction()
 
   auto states = StoreNonVolatileNode::Create(a, v, { s, s, s, s }, 4);
 
-  auto ex = graph.add_export(states[0], { states[0]->Type(), "s" });
+  auto & ex = GraphExport::Create(*states[0], "s");
 
   //	jlm::rvsdg::view(graph.root(), stdout);
 
@@ -287,7 +288,7 @@ TestMultipleOriginReduction()
   //	jlm::rvsdg::view(graph.root(), stdout);
 
   // Assert
-  auto node = jlm::rvsdg::node_output::node(ex->origin());
+  auto node = jlm::rvsdg::node_output::node(ex.origin());
   assert(jlm::rvsdg::is<StoreNonVolatileOperation>(node->operation()) && node->ninputs() == 3);
 }
 
@@ -316,9 +317,9 @@ TestStoreAllocaReduction()
   auto states1 = StoreNonVolatileNode::Create(alloca1[0], value, { alloca1[1], alloca2[1], s }, 4);
   auto states2 = StoreNonVolatileNode::Create(alloca2[0], value, states1, 4);
 
-  graph.add_export(states2[0], { states2[0]->Type(), "s1" });
-  graph.add_export(states2[1], { states2[1]->Type(), "s2" });
-  graph.add_export(states2[2], { states2[2]->Type(), "s3" });
+  GraphExport::Create(*states2[0], "s1");
+  GraphExport::Create(*states2[1], "s2");
+  GraphExport::Create(*states2[2], "s3");
 
   //	jlm::rvsdg::view(graph.root(), stdout);
 
@@ -359,7 +360,7 @@ TestStoreStoreReduction()
   auto s1 = StoreNonVolatileNode::Create(a, v1, { s }, 4)[0];
   auto s2 = StoreNonVolatileNode::Create(a, v2, { s1 }, 4)[0];
 
-  auto ex = graph.add_export(s2, { s2->Type(), "state" });
+  auto & ex = GraphExport::Create(*s2, "state");
 
   jlm::rvsdg::view(graph.root(), stdout);
 
@@ -373,7 +374,7 @@ TestStoreStoreReduction()
 
   // Assert
   assert(graph.root()->nnodes() == 1);
-  assert(jlm::rvsdg::node_output::node(ex->origin())->input(1)->origin() == v2);
+  assert(jlm::rvsdg::node_output::node(ex.origin())->input(1)->origin() == v2);
 }
 
 static int

--- a/tests/jlm/llvm/ir/operators/TestCall.cpp
+++ b/tests/jlm/llvm/ir/operators/TestCall.cpp
@@ -134,7 +134,7 @@ TestCallTypeClassifierIndirectCall()
 
     lambda->finalize(callResults);
 
-    graph->add_export(lambda->output(), { PointerType::Create(), "f" });
+    GraphExport::Create(*lambda->output(), "f");
 
     return std::make_tuple(
         jlm::util::AssertedCast<CallNode>(jlm::rvsdg::node_output::node(callResults[0])),
@@ -235,7 +235,7 @@ TestCallTypeClassifierNonRecursiveDirectCall()
   auto g = SetupFunctionG();
   auto [f, callNode] = SetupFunctionF(g);
 
-  graph->add_export(f->output(), { PointerType::Create(), "f" });
+  GraphExport::Create(*f->output(), "f");
 
   //	jlm::rvsdg::view(graph->root(), stdout);
 
@@ -349,7 +349,7 @@ TestCallTypeClassifierNonRecursiveDirectCallTheta()
 
   auto g = SetupFunctionG();
   auto [f, callNode] = SetupFunctionF(g);
-  graph->add_export(f, { PointerType::Create(), "f" });
+  GraphExport::Create(*f, "f");
 
   jlm::rvsdg::view(graph->root(), stdout);
 
@@ -464,7 +464,7 @@ TestCallTypeClassifierRecursiveDirectCall()
     fibrv->result()->divert_to(lambdaOutput);
     pb.end();
 
-    graph->add_export(fibrv, { pt, "fib" });
+    GraphExport::Create(*fibrv, "fib");
 
     return std::make_tuple(
         lambdaOutput,

--- a/tests/jlm/llvm/ir/operators/TestLambda.cpp
+++ b/tests/jlm/llvm/ir/operators/TestLambda.cpp
@@ -275,7 +275,7 @@ TestCallSummaryComputationExport()
   auto result = tests::create_testop(lambdaNode->subregion(), {}, { vt })[0];
 
   auto lambdaOutput = lambdaNode->finalize({ result });
-  auto rvsdgExport = rvsdg.add_export(lambdaOutput, { jlm::llvm::PointerType::Create(), "f" });
+  auto & rvsdgExport = jlm::llvm::GraphExport::Create(*lambdaOutput, "f");
 
   // Act
   auto callSummary = lambdaNode->ComputeCallSummary();
@@ -283,7 +283,7 @@ TestCallSummaryComputationExport()
   // Assert
   assert(callSummary->IsExported());
   assert(callSummary->IsOnlyExported());
-  assert(callSummary->GetRvsdgExport() == rvsdgExport);
+  assert(callSummary->GetRvsdgExport() == &rvsdgExport);
 
   assert(callSummary->IsDead() == false);
   assert(callSummary->HasOnlyDirectCalls() == false);
@@ -335,7 +335,7 @@ TestCallSummaryComputationDirectCalls()
         { iOStateArgument, memoryStateArgument });
 
     auto lambdaOutput = lambdaNode->finalize(callResults);
-    rvsdg.add_export(lambdaOutput, { jlm::llvm::PointerType::Create(), "y" });
+    jlm::llvm::GraphExport::Create(*lambdaOutput, "y");
 
     return lambdaOutput;
   };
@@ -365,7 +365,7 @@ TestCallSummaryComputationDirectCalls()
         { vt })[0];
 
     auto lambdaOutput = lambdaNode->finalize({ result, callYResults[1], callYResults[2] });
-    rvsdg.add_export(lambdaOutput, { jlm::llvm::PointerType::Create(), "z" });
+    jlm::llvm::GraphExport::Create(*lambdaOutput, "z");
 
     return lambdaOutput;
   };
@@ -471,7 +471,7 @@ TestCallSummaryComputationFunctionPointerInDelta()
   auto argument = deltaNode->add_ctxvar(lambdaNode->output());
   deltaNode->finalize(argument);
 
-  rvsdg->add_export(deltaNode->output(), { PointerType::Create(), "fp" });
+  GraphExport::Create(*deltaNode->output(), "fp");
 
   // Act
   auto callSummary = lambdaNode->ComputeCallSummary();
@@ -506,7 +506,7 @@ TestCallSummaryComputationLambdaResult()
   auto lambdaGArgument = lambdaNodeF->add_ctxvar(lambdaOutputG);
   auto lambdaOutputF = lambdaNodeF->finalize({ lambdaGArgument });
 
-  rvsdg.add_export(lambdaOutputF, { pointerType, "f" });
+  GraphExport::Create(*lambdaOutputF, "f");
 
   // Act
   auto callSummary = lambdaNodeG->ComputeCallSummary();

--- a/tests/jlm/llvm/ir/operators/TestPhi.cpp
+++ b/tests/jlm/llvm/ir/operators/TestPhi.cpp
@@ -67,7 +67,7 @@ TestPhiCreation()
   rv3->set_rvorigin(lambdaOutput2);
 
   auto phi = pb.end();
-  graph.add_export(phi->output(0), { phi->output(0)->Type(), "dummy" });
+  GraphExport::Create(*phi->output(0), "dummy");
 
   graph.normalize();
   graph.prune();

--- a/tests/jlm/llvm/ir/operators/test-delta.cpp
+++ b/tests/jlm/llvm/ir/operators/test-delta.cpp
@@ -44,8 +44,8 @@ TestDeltaCreation()
       false);
   auto d2 = delta2->finalize(jlm::tests::create_testop(delta2->subregion(), {}, { valueType })[0]);
 
-  rvsdgModule.Rvsdg().add_export(d1, { d1->Type(), "" });
-  rvsdgModule.Rvsdg().add_export(d2, { d2->Type(), "" });
+  GraphExport::Create(*d1, "");
+  GraphExport::Create(*d2, "");
 
   jlm::rvsdg::view(rvsdgModule.Rvsdg(), stdout);
 

--- a/tests/jlm/llvm/ir/operators/test-sext.cpp
+++ b/tests/jlm/llvm/ir/operators/test-sext.cpp
@@ -11,6 +11,7 @@
 
 #include <jlm/llvm/ir/operators/operators.hpp>
 #include <jlm/llvm/ir/operators/sext.hpp>
+#include <jlm/llvm/ir/RvsdgModule.hpp>
 
 static inline void
 test_bitunary_reduction()
@@ -26,7 +27,7 @@ test_bitunary_reduction()
   auto y = jlm::rvsdg::bitnot_op::create(32, x);
   auto z = jlm::llvm::sext_op::create(64, y);
 
-  auto ex = graph.add_export(z, { z->Type(), "x" });
+  auto & ex = jlm::llvm::GraphExport::Create(*z, "x");
 
   // jlm::rvsdg::view(graph, stdout);
 
@@ -36,7 +37,7 @@ test_bitunary_reduction()
 
   // jlm::rvsdg::view(graph, stdout);
 
-  assert(jlm::rvsdg::is<jlm::rvsdg::bitnot_op>(jlm::rvsdg::node_output::node(ex->origin())));
+  assert(jlm::rvsdg::is<jlm::rvsdg::bitnot_op>(jlm::rvsdg::node_output::node(ex.origin())));
 }
 
 static inline void
@@ -54,7 +55,7 @@ test_bitbinary_reduction()
   auto z = jlm::rvsdg::bitadd_op::create(32, x, y);
   auto w = jlm::llvm::sext_op::create(64, z);
 
-  auto ex = graph.add_export(w, { w->Type(), "x" });
+  auto & ex = jlm::llvm::GraphExport::Create(*w, "x");
 
   //	jlm::rvsdg::view(graph, stdout);
 
@@ -64,7 +65,7 @@ test_bitbinary_reduction()
 
   //	jlm::rvsdg::view(graph, stdout);
 
-  assert(jlm::rvsdg::is<jlm::rvsdg::bitadd_op>(jlm::rvsdg::node_output::node(ex->origin())));
+  assert(jlm::rvsdg::is<jlm::rvsdg::bitadd_op>(jlm::rvsdg::node_output::node(ex.origin())));
 }
 
 static inline void
@@ -83,7 +84,7 @@ test_inverse_reduction()
   auto y = jlm::llvm::trunc_op::create(32, x);
   auto z = jlm::llvm::sext_op::create(64, y);
 
-  auto ex = graph.add_export(z, { z->Type(), "x" });
+  auto & ex = jlm::llvm::GraphExport::Create(*z, "x");
 
   jlm::rvsdg::view(graph, stdout);
 
@@ -93,7 +94,7 @@ test_inverse_reduction()
 
   jlm::rvsdg::view(graph, stdout);
 
-  assert(ex->origin() == x);
+  assert(ex.origin() == x);
 }
 
 static int

--- a/tests/jlm/llvm/opt/InvariantValueRedirectionTests.cpp
+++ b/tests/jlm/llvm/opt/InvariantValueRedirectionTests.cpp
@@ -66,7 +66,7 @@ TestGamma()
 
   auto lambdaOutput = lambdaNode->finalize({ gammaNode1->output(0), gammaNode1->output(1) });
 
-  rvsdg.add_export(lambdaOutput, { lambdaOutput->Type(), "test" });
+  GraphExport::Create(*lambdaOutput, "test");
 
   // Act
   RunInvariantValueRedirection(*rvsdgModule);
@@ -119,7 +119,7 @@ TestTheta()
 
   auto lambdaOutput = lambdaNode->finalize({ thetaOutput1, thetaOutput2, thetaOutput3 });
 
-  rvsdg.add_export(lambdaOutput, { lambdaOutput->Type(), "test" });
+  GraphExport::Create(*lambdaOutput, "test");
 
   // Act
   RunInvariantValueRedirection(*rvsdgModule);
@@ -202,7 +202,7 @@ TestCall()
         { controlResult, xArgument, yArgument, ioStateArgument, memoryStateArgument });
 
     lambdaOutputTest2 = lambdaNode->finalize(outputs(&callNode));
-    rvsdg.add_export(lambdaOutputTest2, { lambdaOutputTest2->Type(), "test2" });
+    GraphExport::Create(*lambdaOutputTest2, "test2");
   }
 
   // Act
@@ -307,7 +307,7 @@ TestCallWithMemoryStateNodes()
 
     lambdaOutputTest2 = lambdaNode->finalize(
         { callNode.output(0), callNode.GetIoStateOutput(), &lambdaExitMergeResult });
-    rvsdg.add_export(lambdaOutputTest2, { lambdaOutputTest2->Type(), "test2" });
+    GraphExport::Create(*lambdaOutputTest2, "test2");
   }
 
   // Act

--- a/tests/jlm/llvm/opt/TestDeadNodeElimination.cpp
+++ b/tests/jlm/llvm/opt/TestDeadNodeElimination.cpp
@@ -36,7 +36,7 @@ TestRoot()
 
   jlm::tests::GraphImport::Create(graph, jlm::tests::valuetype::Create(), "x");
   auto y = &jlm::tests::GraphImport::Create(graph, jlm::tests::valuetype::Create(), "y");
-  graph.add_export(y, { y->Type(), "z" });
+  GraphExport::Create(*y, "z");
 
   //	jlm::rvsdg::view(graph.root(), stdout);
   RunDeadNodeElimination(rm);
@@ -70,8 +70,8 @@ TestGamma()
   gamma->add_exitvar({ ev2->argument(0), t });
   gamma->add_exitvar({ ev3->argument(0), ev1->argument(1) });
 
-  graph.add_export(gamma->output(0), { gamma->output(0)->Type(), "z" });
-  graph.add_export(gamma->output(2), { gamma->output(2)->Type(), "w" });
+  GraphExport::Create(*gamma->output(0), "z");
+  GraphExport::Create(*gamma->output(2), "w");
 
   //	jlm::rvsdg::view(graph.root(), stdout);
   RunDeadNodeElimination(rm);
@@ -105,7 +105,7 @@ TestGamma2()
 
   gamma->add_exitvar({ n1, n2 });
 
-  graph.add_export(gamma->output(0), { gamma->output(0)->Type(), "x" });
+  GraphExport::Create(*gamma->output(0), "x");
 
   //	jlm::rvsdg::view(graph, stdout);
   RunDeadNodeElimination(rm);
@@ -145,8 +145,8 @@ TestTheta()
   auto c = jlm::tests::create_testop(theta->subregion(), {}, { ct })[0];
   theta->set_predicate(c);
 
-  graph.add_export(theta->output(0), { theta->output(0)->Type(), "a" });
-  graph.add_export(theta->output(3), { theta->output(0)->Type(), "b" });
+  GraphExport::Create(*theta->output(0), "a");
+  GraphExport::Create(*theta->output(3), "b");
 
   //	jlm::rvsdg::view(graph.root(), stdout);
   RunDeadNodeElimination(rm);
@@ -192,7 +192,7 @@ TestNestedTheta()
 
   otheta->set_predicate(lvo1->argument());
 
-  graph.add_export(otheta->output(2), { otheta->output(2)->Type(), "y" });
+  GraphExport::Create(*otheta->output(2), "y");
 
   //	jlm::rvsdg::view(graph, stdout);
   RunDeadNodeElimination(rm);
@@ -231,7 +231,7 @@ TestEvolvingTheta()
 
   theta->set_predicate(lv0->argument());
 
-  graph.add_export(lv1, { lv1->Type(), "x1" });
+  GraphExport::Create(*lv1, "x1");
 
   //	jlm::rvsdg::view(graph, stdout);
   RunDeadNodeElimination(rm);
@@ -264,7 +264,7 @@ TestLambda()
 
   auto output = lambda->finalize({ lambda->fctargument(0), cv2 });
 
-  graph.add_export(output, { output->Type(), "f" });
+  GraphExport::Create(*output, "f");
 
   //	jlm::rvsdg::view(graph.root(), stdout);
   RunDeadNodeElimination(rm);
@@ -362,8 +362,8 @@ TestPhi()
   rv4->set_rvorigin(f4);
   auto phiNode = phiBuilder.end();
 
-  rvsdg.add_export(phiNode->output(0), { phiNode->output(0)->Type(), "f1" });
-  rvsdg.add_export(phiNode->output(3), { phiNode->output(3)->Type(), "f4" });
+  GraphExport::Create(*phiNode->output(0), "f1");
+  GraphExport::Create(*phiNode->output(3), "f4");
 
   // Act
   RunDeadNodeElimination(rvsdgModule);
@@ -415,7 +415,7 @@ TestDelta()
   jlm::tests::SimpleNode::Create(*deltaNode->subregion(), { zArgument }, {});
 
   auto deltaOutput = deltaNode->finalize(result);
-  rvsdg.add_export(deltaOutput, { PointerType::Create(), "" });
+  GraphExport::Create(*deltaOutput, "");
 
   // Act
   RunDeadNodeElimination(rvsdgModule);

--- a/tests/jlm/llvm/opt/TestLoadStoreReduction.cpp
+++ b/tests/jlm/llvm/opt/TestLoadStoreReduction.cpp
@@ -8,6 +8,7 @@
 
 #include <jlm/llvm/ir/operators/Load.hpp>
 #include <jlm/llvm/ir/operators/Store.hpp>
+#include <jlm/llvm/ir/RvsdgModule.hpp>
 #include <jlm/rvsdg/bitstring.hpp>
 #include <jlm/rvsdg/view.hpp>
 
@@ -37,8 +38,8 @@ TestLoadStoreReductionWithDifferentValueOperandType()
   auto loadResults =
       LoadNonVolatileNode::Create(address, storeResults, jlm::rvsdg::bittype::Create(8), 4);
 
-  auto exportedValue = graph.add_export(loadResults[0], { jlm::rvsdg::bittype::Create(8), "v" });
-  graph.add_export(loadResults[1], { memoryStateType, "s" });
+  auto & exportedValue = GraphExport::Create(*loadResults[0], "v");
+  GraphExport::Create(*loadResults[1], "s");
 
   jlm::rvsdg::view(graph.root(), stdout);
 
@@ -51,7 +52,7 @@ TestLoadStoreReductionWithDifferentValueOperandType()
   jlm::rvsdg::view(graph.root(), stdout);
 
   // Assert
-  auto load = jlm::rvsdg::node_output::node(exportedValue->origin());
+  auto load = jlm::rvsdg::node_output::node(exportedValue.origin());
   assert(is<LoadNonVolatileOperation>(load));
   assert(load->ninputs() == 2);
   auto store = jlm::rvsdg::node_output::node(load->input(1)->origin());

--- a/tests/jlm/llvm/opt/test-cne.cpp
+++ b/tests/jlm/llvm/opt/test-cne.cpp
@@ -45,13 +45,13 @@ test_simple()
   auto b3 = jlm::tests::create_testop(graph.root(), { n1, z }, { vt })[0];
   auto b4 = jlm::tests::create_testop(graph.root(), { n2, z }, { vt })[0];
 
-  graph.add_export(n1, { n1->Type(), "n1" });
-  graph.add_export(n2, { n2->Type(), "n2" });
-  graph.add_export(u1, { n2->Type(), "u1" });
-  graph.add_export(b1, { n2->Type(), "b1" });
-  graph.add_export(b2, { n2->Type(), "b2" });
-  graph.add_export(b3, { n2->Type(), "b3" });
-  graph.add_export(b4, { n2->Type(), "b4" });
+  GraphExport::Create(*n1, "n1");
+  GraphExport::Create(*n2, "n2");
+  GraphExport::Create(*u1, "u1");
+  GraphExport::Create(*b1, "b1");
+  GraphExport::Create(*b2, "b2");
+  GraphExport::Create(*b3, "b3");
+  GraphExport::Create(*b4, "b4");
 
   //	jlm::rvsdg::view(graph.root(), stdout);
   jlm::llvm::cne cne;
@@ -104,9 +104,9 @@ test_gamma()
   gamma->add_exitvar({ n3, ev3->argument(1) });
   gamma->add_exitvar({ ev5->argument(0), ev4->argument(1) });
 
-  graph.add_export(gamma->output(0), { gamma->output(0)->Type(), "x1" });
-  graph.add_export(gamma->output(1), { gamma->output(1)->Type(), "x2" });
-  graph.add_export(gamma->output(2), { gamma->output(2)->Type(), "y" });
+  GraphExport::Create(*gamma->output(0), "x1");
+  GraphExport::Create(*gamma->output(1), "x2");
+  GraphExport::Create(*gamma->output(2), "y");
 
   //	jlm::rvsdg::view(graph.root(), stdout);
   jlm::llvm::cne cne;
@@ -161,9 +161,9 @@ test_theta()
 
   theta->set_predicate(lv1->argument());
 
-  graph.add_export(theta->output(1), { theta->output(1)->Type(), "lv2" });
-  graph.add_export(theta->output(2), { theta->output(2)->Type(), "lv3" });
-  graph.add_export(theta->output(3), { theta->output(3)->Type(), "lv4" });
+  GraphExport::Create(*theta->output(1), "lv2");
+  GraphExport::Create(*theta->output(2), "lv3");
+  GraphExport::Create(*theta->output(3), "lv4");
 
   //	jlm::rvsdg::view(graph.root(), stdout);
   jlm::llvm::cne cne;
@@ -212,8 +212,8 @@ test_theta2()
 
   theta->set_predicate(lv1->argument());
 
-  graph.add_export(theta->output(1), { theta->output(1)->Type(), "lv2" });
-  graph.add_export(theta->output(2), { theta->output(2)->Type(), "lv3" });
+  GraphExport::Create(*theta->output(1), "lv2");
+  GraphExport::Create(*theta->output(2), "lv3");
 
   //	jlm::rvsdg::view(graph, stdout);
   jlm::llvm::cne cne;
@@ -266,9 +266,9 @@ test_theta3()
 
   theta1->set_predicate(lv1->argument());
 
-  graph.add_export(theta1->output(1), { theta1->output(1)->Type(), "lv2" });
-  graph.add_export(theta1->output(2), { theta1->output(2)->Type(), "lv3" });
-  graph.add_export(theta1->output(3), { theta1->output(3)->Type(), "lv4" });
+  GraphExport::Create(*theta1->output(1), "lv2");
+  GraphExport::Create(*theta1->output(2), "lv3");
+  GraphExport::Create(*theta1->output(3), "lv4");
 
   //	jlm::rvsdg::view(graph, stdout);
   jlm::llvm::cne cne;
@@ -321,17 +321,17 @@ test_theta4()
 
   theta->set_predicate(lv1->argument());
 
-  auto ex1 = graph.add_export(theta->output(1), { theta->output(1)->Type(), "lv2" });
-  auto ex2 = graph.add_export(theta->output(2), { theta->output(2)->Type(), "lv3" });
-  graph.add_export(theta->output(3), { theta->output(3)->Type(), "lv4" });
-  graph.add_export(theta->output(4), { theta->output(4)->Type(), "lv5" });
+  auto & ex1 = GraphExport::Create(*theta->output(1), "lv2");
+  auto & ex2 = GraphExport::Create(*theta->output(2), "lv3");
+  GraphExport::Create(*theta->output(3), "lv4");
+  GraphExport::Create(*theta->output(4), "lv5");
 
   //	jlm::rvsdg::view(graph, stdout);
   jlm::llvm::cne cne;
   cne.run(rm, statisticsCollector);
   //	jlm::rvsdg::view(graph, stdout);
 
-  assert(ex1->origin() != ex2->origin());
+  assert(ex1.origin() != ex2.origin());
   assert(lv2->argument()->nusers() != 0 && lv3->argument()->nusers() != 0);
   assert(lv6->result()->origin() == lv7->result()->origin());
 }
@@ -367,18 +367,18 @@ test_theta5()
 
   theta->set_predicate(lv0->argument());
 
-  auto ex1 = graph.add_export(theta->output(1), { theta->output(1)->Type(), "lv1" });
-  auto ex2 = graph.add_export(theta->output(2), { theta->output(2)->Type(), "lv2" });
-  auto ex3 = graph.add_export(theta->output(3), { theta->output(3)->Type(), "lv3" });
-  auto ex4 = graph.add_export(theta->output(4), { theta->output(4)->Type(), "lv4" });
+  auto & ex1 = GraphExport::Create(*theta->output(1), "lv1");
+  auto & ex2 = GraphExport::Create(*theta->output(2), "lv2");
+  auto & ex3 = GraphExport::Create(*theta->output(3), "lv3");
+  auto & ex4 = GraphExport::Create(*theta->output(4), "lv4");
 
   //	jlm::rvsdg::view(graph, stdout);
   jlm::llvm::cne cne;
   cne.run(rm, statisticsCollector);
   //	jlm::rvsdg::view(graph, stdout);
 
-  assert(ex1->origin() == ex2->origin());
-  assert(ex3->origin() == ex4->origin());
+  assert(ex1.origin() == ex2.origin());
+  assert(ex3.origin() == ex4.origin());
   assert(region->result(4)->origin() == region->result(5)->origin());
   assert(region->result(2)->origin() == region->result(3)->origin());
 }
@@ -407,7 +407,7 @@ test_lambda()
 
   auto output = lambda->finalize({ b1 });
 
-  graph.add_export(output, { output->Type(), "f" });
+  GraphExport::Create(*output, "f");
 
   //	jlm::rvsdg::view(graph.root(), stdout);
   jlm::llvm::cne cne;
@@ -456,8 +456,8 @@ test_phi()
 
   auto phi = pb.end();
 
-  graph.add_export(phi->output(0), { phi->output(0)->Type(), "f1" });
-  graph.add_export(phi->output(1), { phi->output(1)->Type(), "f2" });
+  GraphExport::Create(*phi->output(0), "f1");
+  GraphExport::Create(*phi->output(1), "f2");
 
   //	jlm::rvsdg::view(graph.root(), stdout);
   jlm::llvm::cne cne;

--- a/tests/jlm/llvm/opt/test-inlining.cpp
+++ b/tests/jlm/llvm/opt/test-inlining.cpp
@@ -87,7 +87,7 @@ test1()
   auto f1 = SetupF1();
   auto f2 = SetupF2(f1);
 
-  graph.add_export(f2, { f2->Type(), "f2" });
+  GraphExport::Create(*f2, "f2");
 
   //	jlm::rvsdg::view(graph.root(), stdout);
 
@@ -152,7 +152,7 @@ test2()
   auto f1 = SetupF1(functionType1);
   auto f2 = SetupF2(f1);
 
-  graph.add_export(f2, { f2->Type(), "f2" });
+  GraphExport::Create(*f2, "f2");
 
   jlm::rvsdg::view(graph.root(), stdout);
 

--- a/tests/jlm/llvm/opt/test-inversion.cpp
+++ b/tests/jlm/llvm/opt/test-inversion.cpp
@@ -61,18 +61,18 @@ test1()
 
   theta->set_predicate(predicate);
 
-  auto ex1 = graph.add_export(theta->output(0), { theta->output(0)->Type(), "x" });
-  auto ex2 = graph.add_export(theta->output(1), { theta->output(1)->Type(), "y" });
-  auto ex3 = graph.add_export(theta->output(2), { theta->output(2)->Type(), "z" });
+  auto & ex1 = GraphExport::Create(*theta->output(0), "x");
+  auto & ex2 = GraphExport::Create(*theta->output(1), "y");
+  auto & ex3 = GraphExport::Create(*theta->output(2), "z");
 
   //	jlm::rvsdg::view(graph.root(), stdout);
   jlm::llvm::tginversion tginversion;
   tginversion.run(rm, statisticsCollector);
   //	jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(jlm::rvsdg::is<jlm::rvsdg::gamma_op>(jlm::rvsdg::node_output::node(ex1->origin())));
-  assert(jlm::rvsdg::is<jlm::rvsdg::gamma_op>(jlm::rvsdg::node_output::node(ex2->origin())));
-  assert(jlm::rvsdg::is<jlm::rvsdg::gamma_op>(jlm::rvsdg::node_output::node(ex3->origin())));
+  assert(jlm::rvsdg::is<jlm::rvsdg::gamma_op>(jlm::rvsdg::node_output::node(ex1.origin())));
+  assert(jlm::rvsdg::is<jlm::rvsdg::gamma_op>(jlm::rvsdg::node_output::node(ex2.origin())));
+  assert(jlm::rvsdg::is<jlm::rvsdg::gamma_op>(jlm::rvsdg::node_output::node(ex3.origin())));
 }
 
 static inline void
@@ -110,14 +110,14 @@ test2()
 
   theta->set_predicate(predicate);
 
-  auto ex = graph.add_export(theta->output(0), { theta->output(0)->Type(), "x" });
+  auto & ex = GraphExport::Create(*theta->output(0), "x");
 
   //	jlm::rvsdg::view(graph.root(), stdout);
   jlm::llvm::tginversion tginversion;
   tginversion.run(rm, statisticsCollector);
   //	jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(jlm::rvsdg::is<jlm::rvsdg::gamma_op>(jlm::rvsdg::node_output::node(ex->origin())));
+  assert(jlm::rvsdg::is<jlm::rvsdg::gamma_op>(jlm::rvsdg::node_output::node(ex.origin())));
 }
 
 static int

--- a/tests/jlm/llvm/opt/test-pull.cpp
+++ b/tests/jlm/llvm/opt/test-pull.cpp
@@ -45,8 +45,8 @@ test_pullin_top()
   auto ev = gamma->add_entryvar(n5);
   gamma->add_exitvar({ ev->argument(0), ev->argument(1) });
 
-  graph.add_export(gamma->output(0), { gamma->output(0)->Type(), "x" });
-  graph.add_export(n2, { n2->Type(), "y" });
+  GraphExport::Create(*gamma->output(0), "x");
+  GraphExport::Create(*n2, "y");
 
   //	jlm::rvsdg::view(graph, stdout);
   pullin_top(gamma);
@@ -74,13 +74,13 @@ test_pullin_bottom()
   auto b1 = jlm::tests::create_testop(graph.root(), { gamma->output(0), x }, { vt })[0];
   auto b2 = jlm::tests::create_testop(graph.root(), { gamma->output(0), b1 }, { vt })[0];
 
-  auto xp = graph.add_export(b2, { b2->Type(), "x" });
+  auto & xp = jlm::llvm::GraphExport::Create(*b2, "x");
 
   //	jlm::rvsdg::view(graph, stdout);
   jlm::llvm::pullin_bottom(gamma);
   //	jlm::rvsdg::view(graph, stdout);
 
-  assert(jlm::rvsdg::node_output::node(xp->origin()) == gamma);
+  assert(jlm::rvsdg::node_output::node(xp.origin()) == gamma);
   assert(gamma->subregion(0)->nnodes() == 2);
   assert(gamma->subregion(1)->nnodes() == 2);
 }
@@ -113,7 +113,7 @@ test_pull()
 
   auto g1xv = gamma1->add_exitvar({ cg1, g2xv });
 
-  graph.add_export(g1xv, { g1xv->Type(), "" });
+  GraphExport::Create(*g1xv, "");
 
   jlm::rvsdg::view(graph, stdout);
   jlm::llvm::pullin pullin;

--- a/tests/jlm/llvm/opt/test-push.cpp
+++ b/tests/jlm/llvm/opt/test-push.cpp
@@ -44,7 +44,7 @@ test_gamma()
 
   gamma->add_exitvar({ state, evs->argument(1) });
 
-  graph.add_export(gamma->output(0), { gamma->output(0)->Type(), "x" });
+  GraphExport::Create(*gamma->output(0), "x");
 
   //	jlm::rvsdg::view(graph.root(), stdout);
   jlm::llvm::pushout pushout;
@@ -92,7 +92,7 @@ test_theta()
 
   theta->set_predicate(lv1->argument());
 
-  graph.add_export(theta->output(0), { theta->output(0)->Type(), "c" });
+  GraphExport::Create(*theta->output(0), "c");
 
   //	jlm::rvsdg::view(graph.root(), stdout);
   jlm::llvm::pushout pushout;
@@ -130,13 +130,13 @@ test_push_theta_bottom()
   lvs->result()->divert_to(s1);
   theta->set_predicate(lvc->argument());
 
-  auto ex = graph.add_export(lvs, { lvs->Type(), "s" });
+  auto & ex = GraphExport::Create(*lvs, "s");
 
   jlm::rvsdg::view(graph, stdout);
   jlm::llvm::push_bottom(theta);
   jlm::rvsdg::view(graph, stdout);
 
-  auto storenode = jlm::rvsdg::node_output::node(ex->origin());
+  auto storenode = jlm::rvsdg::node_output::node(ex.origin());
   assert(jlm::rvsdg::is<StoreNonVolatileOperation>(storenode));
   assert(storenode->input(0)->origin() == a);
   assert(jlm::rvsdg::is<jlm::rvsdg::theta_op>(

--- a/tests/jlm/llvm/opt/test-unroll.cpp
+++ b/tests/jlm/llvm/opt/test-unroll.cpp
@@ -255,14 +255,14 @@ test_unknown_boundaries()
 
   theta->set_predicate(match);
 
-  auto ex1 = graph.add_export(lv1, { lv1->Type(), "x" });
+  auto & ex1 = GraphExport::Create(*lv1, "x");
 
   //	jlm::rvsdg::view(graph, stdout);
   jlm::llvm::loopunroll loopunroll(2);
   loopunroll.run(rm, statisticsCollector);
   //	jlm::rvsdg::view(graph, stdout);
 
-  auto node = jlm::rvsdg::node_output::node(ex1->origin());
+  auto node = jlm::rvsdg::node_output::node(ex1.origin());
   assert(jlm::rvsdg::is<jlm::rvsdg::gamma_op>(node));
   node = jlm::rvsdg::node_output::node(node->input(1)->origin());
   assert(jlm::rvsdg::is<jlm::rvsdg::gamma_op>(node));

--- a/tests/jlm/rvsdg/bitstring/bitstring.cpp
+++ b/tests/jlm/rvsdg/bitstring/bitstring.cpp
@@ -30,8 +30,8 @@ types_bitstring_arithmetic_test_bitand(void)
   auto and0 = bitand_op::create(32, s0, s1);
   auto and1 = bitand_op::create(32, c0, c1);
 
-  graph.add_export(and0, { and0->Type(), "dummy" });
-  graph.add_export(and1, { and1->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*and0, "dummy");
+  jlm::tests::GraphExport::Create(*and1, "dummy");
 
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
@@ -63,11 +63,11 @@ types_bitstring_arithmetic_test_bitashr(void)
   auto ashr3 = bitashr_op::create(32, c1, c2);
   auto ashr4 = bitashr_op::create(32, c1, c3);
 
-  graph.add_export(ashr0, { ashr0->Type(), "dummy" });
-  graph.add_export(ashr1, { ashr1->Type(), "dummy" });
-  graph.add_export(ashr2, { ashr2->Type(), "dummy" });
-  graph.add_export(ashr3, { ashr3->Type(), "dummy" });
-  graph.add_export(ashr4, { ashr4->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*ashr0, "dummy");
+  jlm::tests::GraphExport::Create(*ashr1, "dummy");
+  jlm::tests::GraphExport::Create(*ashr2, "dummy");
+  jlm::tests::GraphExport::Create(*ashr3, "dummy");
+  jlm::tests::GraphExport::Create(*ashr4, "dummy");
 
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
@@ -93,7 +93,7 @@ types_bitstring_arithmetic_test_bitdifference(void)
 
   auto diff = bitsub_op::create(32, s0, s1);
 
-  graph.add_export(diff, { diff->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*diff, "dummy");
 
   graph.normalize();
   graph.prune();
@@ -118,9 +118,9 @@ types_bitstring_arithmetic_test_bitnegate(void)
   auto neg1 = bitneg_op::create(32, c0);
   auto neg2 = bitneg_op::create(32, neg1);
 
-  graph.add_export(neg0, { neg0->Type(), "dummy" });
-  graph.add_export(neg1, { neg1->Type(), "dummy" });
-  graph.add_export(neg2, { neg2->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*neg0, "dummy");
+  jlm::tests::GraphExport::Create(*neg1, "dummy");
+  jlm::tests::GraphExport::Create(*neg2, "dummy");
 
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
@@ -146,9 +146,9 @@ types_bitstring_arithmetic_test_bitnot(void)
   auto not1 = bitnot_op::create(32, c0);
   auto not2 = bitnot_op::create(32, not1);
 
-  graph.add_export(not0, { not0->Type(), "dummy" });
-  graph.add_export(not1, { not1->Type(), "dummy" });
-  graph.add_export(not2, { not2->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*not0, "dummy");
+  jlm::tests::GraphExport::Create(*not1, "dummy");
+  jlm::tests::GraphExport::Create(*not2, "dummy");
 
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
@@ -176,8 +176,8 @@ types_bitstring_arithmetic_test_bitor(void)
   auto or0 = bitor_op::create(32, s0, s1);
   auto or1 = bitor_op::create(32, c0, c1);
 
-  graph.add_export(or0, { or0->Type(), "dummy" });
-  graph.add_export(or1, { or1->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*or0, "dummy");
+  jlm::tests::GraphExport::Create(*or1, "dummy");
 
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
@@ -204,8 +204,8 @@ types_bitstring_arithmetic_test_bitproduct(void)
   auto product0 = bitmul_op::create(32, s0, s1);
   auto product1 = bitmul_op::create(32, c0, c1);
 
-  graph.add_export(product0, { product0->Type(), "dummy" });
-  graph.add_export(product1, { product1->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*product0, "dummy");
+  jlm::tests::GraphExport::Create(*product1, "dummy");
 
   graph.normalize();
   graph.prune();
@@ -229,7 +229,7 @@ types_bitstring_arithmetic_test_bitshiproduct(void)
 
   auto shiproduct = bitsmulh_op::create(32, s0, s1);
 
-  graph.add_export(shiproduct, { shiproduct->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*shiproduct, "dummy");
 
   graph.normalize();
   graph.prune();
@@ -258,9 +258,9 @@ types_bitstring_arithmetic_test_bitshl(void)
   auto shl1 = bitshl_op::create(32, c0, c1);
   auto shl2 = bitshl_op::create(32, c0, c2);
 
-  graph.add_export(shl0, { shl0->Type(), "dummy" });
-  graph.add_export(shl1, { shl1->Type(), "dummy" });
-  graph.add_export(shl2, { shl2->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*shl0, "dummy");
+  jlm::tests::GraphExport::Create(*shl1, "dummy");
+  jlm::tests::GraphExport::Create(*shl2, "dummy");
 
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
@@ -290,9 +290,9 @@ types_bitstring_arithmetic_test_bitshr(void)
   auto shr1 = bitshr_op::create(32, c0, c1);
   auto shr2 = bitshr_op::create(32, c0, c2);
 
-  graph.add_export(shr0, { shr0->Type(), "dummy" });
-  graph.add_export(shr1, { shr1->Type(), "dummy" });
-  graph.add_export(shr2, { shr2->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*shr0, "dummy");
+  jlm::tests::GraphExport::Create(*shr1, "dummy");
+  jlm::tests::GraphExport::Create(*shr2, "dummy");
 
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
@@ -320,8 +320,8 @@ types_bitstring_arithmetic_test_bitsmod(void)
   auto smod0 = bitsmod_op::create(32, s0, s1);
   auto smod1 = bitsmod_op::create(32, c0, c1);
 
-  graph.add_export(smod0, { smod0->Type(), "dummy" });
-  graph.add_export(smod1, { smod1->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*smod0, "dummy");
+  jlm::tests::GraphExport::Create(*smod1, "dummy");
 
   graph.normalize();
   graph.prune();
@@ -349,8 +349,8 @@ types_bitstring_arithmetic_test_bitsquotient(void)
   auto squot0 = bitsdiv_op::create(32, s0, s1);
   auto squot1 = bitsdiv_op::create(32, c0, c1);
 
-  graph.add_export(squot0, { squot0->Type(), "dummy" });
-  graph.add_export(squot1, { squot1->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*squot0, "dummy");
+  jlm::tests::GraphExport::Create(*squot1, "dummy");
 
   graph.normalize();
   graph.prune();
@@ -378,8 +378,8 @@ types_bitstring_arithmetic_test_bitsum(void)
   auto sum0 = bitadd_op::create(32, s0, s1);
   auto sum1 = bitadd_op::create(32, c0, c1);
 
-  graph.add_export(sum0, { sum0->Type(), "dummy" });
-  graph.add_export(sum1, { sum1->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*sum0, "dummy");
+  jlm::tests::GraphExport::Create(*sum1, "dummy");
 
   graph.normalize();
   graph.prune();
@@ -403,7 +403,7 @@ types_bitstring_arithmetic_test_bituhiproduct(void)
 
   auto uhiproduct = bitumulh_op::create(32, s0, s1);
 
-  graph.add_export(uhiproduct, { uhiproduct->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*uhiproduct, "dummy");
 
   graph.normalize();
   graph.prune();
@@ -430,8 +430,8 @@ types_bitstring_arithmetic_test_bitumod(void)
   auto umod0 = bitumod_op::create(32, s0, s1);
   auto umod1 = bitumod_op::create(32, c0, c1);
 
-  graph.add_export(umod0, { umod0->Type(), "dummy" });
-  graph.add_export(umod1, { umod1->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*umod0, "dummy");
+  jlm::tests::GraphExport::Create(*umod1, "dummy");
 
   graph.normalize();
   graph.prune();
@@ -459,8 +459,8 @@ types_bitstring_arithmetic_test_bituquotient(void)
   auto uquot0 = bitudiv_op::create(32, s0, s1);
   auto uquot1 = bitudiv_op::create(32, c0, c1);
 
-  graph.add_export(uquot0, { uquot0->Type(), "dummy" });
-  graph.add_export(uquot1, { uquot1->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*uquot0, "dummy");
+  jlm::tests::GraphExport::Create(*uquot1, "dummy");
 
   graph.normalize();
   graph.prune();
@@ -488,8 +488,8 @@ types_bitstring_arithmetic_test_bitxor(void)
   auto xor0 = bitxor_op::create(32, s0, s1);
   auto xor1 = bitxor_op::create(32, c0, c1);
 
-  graph.add_export(xor0, { xor0->Type(), "dummy" });
-  graph.add_export(xor1, { xor1->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*xor0, "dummy");
+  jlm::tests::GraphExport::Create(*xor1, "dummy");
 
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
@@ -534,10 +534,10 @@ types_bitstring_comparison_test_bitequal(void)
   auto equal2 = biteq_op::create(32, c0, c1);
   auto equal3 = biteq_op::create(32, c0, c2);
 
-  graph.add_export(equal0, { equal0->Type(), "dummy" });
-  graph.add_export(equal1, { equal1->Type(), "dummy" });
-  graph.add_export(equal2, { equal2->Type(), "dummy" });
-  graph.add_export(equal3, { equal3->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*equal0, "dummy");
+  jlm::tests::GraphExport::Create(*equal1, "dummy");
+  jlm::tests::GraphExport::Create(*equal2, "dummy");
+  jlm::tests::GraphExport::Create(*equal3, "dummy");
 
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
@@ -568,10 +568,10 @@ types_bitstring_comparison_test_bitnotequal(void)
   auto nequal2 = bitne_op::create(32, c0, c1);
   auto nequal3 = bitne_op::create(32, c0, c2);
 
-  graph.add_export(nequal0, { nequal0->Type(), "dummy" });
-  graph.add_export(nequal1, { nequal1->Type(), "dummy" });
-  graph.add_export(nequal2, { nequal2->Type(), "dummy" });
-  graph.add_export(nequal3, { nequal3->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*nequal0, "dummy");
+  jlm::tests::GraphExport::Create(*nequal1, "dummy");
+  jlm::tests::GraphExport::Create(*nequal2, "dummy");
+  jlm::tests::GraphExport::Create(*nequal3, "dummy");
 
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
@@ -604,11 +604,11 @@ types_bitstring_comparison_test_bitsgreater(void)
   auto sgreater3 = bitsgt_op::create(32, s0, c2);
   auto sgreater4 = bitsgt_op::create(32, c3, s1);
 
-  graph.add_export(sgreater0, { sgreater0->Type(), "dummy" });
-  graph.add_export(sgreater1, { sgreater1->Type(), "dummy" });
-  graph.add_export(sgreater2, { sgreater2->Type(), "dummy" });
-  graph.add_export(sgreater3, { sgreater3->Type(), "dummy" });
-  graph.add_export(sgreater4, { sgreater4->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*sgreater0, "dummy");
+  jlm::tests::GraphExport::Create(*sgreater1, "dummy");
+  jlm::tests::GraphExport::Create(*sgreater2, "dummy");
+  jlm::tests::GraphExport::Create(*sgreater3, "dummy");
+  jlm::tests::GraphExport::Create(*sgreater4, "dummy");
 
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
@@ -643,12 +643,12 @@ types_bitstring_comparison_test_bitsgreatereq(void)
   auto sgreatereq4 = bitsge_op::create(32, c2, s0);
   auto sgreatereq5 = bitsge_op::create(32, s1, c3);
 
-  graph.add_export(sgreatereq0, { sgreatereq0->Type(), "dummy" });
-  graph.add_export(sgreatereq1, { sgreatereq1->Type(), "dummy" });
-  graph.add_export(sgreatereq2, { sgreatereq2->Type(), "dummy" });
-  graph.add_export(sgreatereq3, { sgreatereq3->Type(), "dummy" });
-  graph.add_export(sgreatereq4, { sgreatereq4->Type(), "dummy" });
-  graph.add_export(sgreatereq5, { sgreatereq5->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*sgreatereq0, "dummy");
+  jlm::tests::GraphExport::Create(*sgreatereq1, "dummy");
+  jlm::tests::GraphExport::Create(*sgreatereq2, "dummy");
+  jlm::tests::GraphExport::Create(*sgreatereq3, "dummy");
+  jlm::tests::GraphExport::Create(*sgreatereq4, "dummy");
+  jlm::tests::GraphExport::Create(*sgreatereq5, "dummy");
 
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
@@ -683,11 +683,11 @@ types_bitstring_comparison_test_bitsless(void)
   auto sless3 = bitslt_op::create(32, c2, s0);
   auto sless4 = bitslt_op::create(32, s1, c3);
 
-  graph.add_export(sless0, { sless0->Type(), "dummy" });
-  graph.add_export(sless1, { sless1->Type(), "dummy" });
-  graph.add_export(sless2, { sless2->Type(), "dummy" });
-  graph.add_export(sless3, { sless3->Type(), "dummy" });
-  graph.add_export(sless4, { sless4->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*sless0, "dummy");
+  jlm::tests::GraphExport::Create(*sless1, "dummy");
+  jlm::tests::GraphExport::Create(*sless2, "dummy");
+  jlm::tests::GraphExport::Create(*sless3, "dummy");
+  jlm::tests::GraphExport::Create(*sless4, "dummy");
 
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
@@ -722,12 +722,12 @@ types_bitstring_comparison_test_bitslesseq(void)
   auto slesseq4 = bitsle_op::create(32, s0, c2);
   auto slesseq5 = bitsle_op::create(32, c3, s1);
 
-  graph.add_export(slesseq0, { slesseq0->Type(), "dummy" });
-  graph.add_export(slesseq1, { slesseq1->Type(), "dummy" });
-  graph.add_export(slesseq2, { slesseq2->Type(), "dummy" });
-  graph.add_export(slesseq3, { slesseq3->Type(), "dummy" });
-  graph.add_export(slesseq4, { slesseq4->Type(), "dummy" });
-  graph.add_export(slesseq5, { slesseq5->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*slesseq0, "dummy");
+  jlm::tests::GraphExport::Create(*slesseq1, "dummy");
+  jlm::tests::GraphExport::Create(*slesseq2, "dummy");
+  jlm::tests::GraphExport::Create(*slesseq3, "dummy");
+  jlm::tests::GraphExport::Create(*slesseq4, "dummy");
+  jlm::tests::GraphExport::Create(*slesseq5, "dummy");
 
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
@@ -762,11 +762,11 @@ types_bitstring_comparison_test_bitugreater(void)
   auto ugreater3 = bitugt_op::create(32, s0, c2);
   auto ugreater4 = bitugt_op::create(32, c3, s1);
 
-  graph.add_export(ugreater0, { ugreater0->Type(), "dummy" });
-  graph.add_export(ugreater1, { ugreater1->Type(), "dummy" });
-  graph.add_export(ugreater2, { ugreater2->Type(), "dummy" });
-  graph.add_export(ugreater3, { ugreater3->Type(), "dummy" });
-  graph.add_export(ugreater4, { ugreater4->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*ugreater0, "dummy");
+  jlm::tests::GraphExport::Create(*ugreater1, "dummy");
+  jlm::tests::GraphExport::Create(*ugreater2, "dummy");
+  jlm::tests::GraphExport::Create(*ugreater3, "dummy");
+  jlm::tests::GraphExport::Create(*ugreater4, "dummy");
 
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
@@ -801,12 +801,12 @@ types_bitstring_comparison_test_bitugreatereq(void)
   auto ugreatereq4 = bituge_op::create(32, c2, s0);
   auto ugreatereq5 = bituge_op::create(32, s1, c3);
 
-  graph.add_export(ugreatereq0, { ugreatereq0->Type(), "dummy" });
-  graph.add_export(ugreatereq1, { ugreatereq1->Type(), "dummy" });
-  graph.add_export(ugreatereq2, { ugreatereq2->Type(), "dummy" });
-  graph.add_export(ugreatereq3, { ugreatereq3->Type(), "dummy" });
-  graph.add_export(ugreatereq4, { ugreatereq4->Type(), "dummy" });
-  graph.add_export(ugreatereq5, { ugreatereq5->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*ugreatereq0, "dummy");
+  jlm::tests::GraphExport::Create(*ugreatereq1, "dummy");
+  jlm::tests::GraphExport::Create(*ugreatereq2, "dummy");
+  jlm::tests::GraphExport::Create(*ugreatereq3, "dummy");
+  jlm::tests::GraphExport::Create(*ugreatereq4, "dummy");
+  jlm::tests::GraphExport::Create(*ugreatereq5, "dummy");
 
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
@@ -841,11 +841,11 @@ types_bitstring_comparison_test_bituless(void)
   auto uless3 = bitult_op::create(32, c2, s0);
   auto uless4 = bitult_op::create(32, s1, c3);
 
-  graph.add_export(uless0, { uless0->Type(), "dummy" });
-  graph.add_export(uless1, { uless1->Type(), "dummy" });
-  graph.add_export(uless2, { uless2->Type(), "dummy" });
-  graph.add_export(uless3, { uless3->Type(), "dummy" });
-  graph.add_export(uless4, { uless4->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*uless0, "dummy");
+  jlm::tests::GraphExport::Create(*uless1, "dummy");
+  jlm::tests::GraphExport::Create(*uless2, "dummy");
+  jlm::tests::GraphExport::Create(*uless3, "dummy");
+  jlm::tests::GraphExport::Create(*uless4, "dummy");
 
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
@@ -880,12 +880,12 @@ types_bitstring_comparison_test_bitulesseq(void)
   auto ulesseq4 = bitule_op::create(32, s0, c2);
   auto ulesseq5 = bitule_op::create(32, c3, s1);
 
-  graph.add_export(ulesseq0, { ulesseq0->Type(), "dummy" });
-  graph.add_export(ulesseq1, { ulesseq1->Type(), "dummy" });
-  graph.add_export(ulesseq2, { ulesseq2->Type(), "dummy" });
-  graph.add_export(ulesseq3, { ulesseq3->Type(), "dummy" });
-  graph.add_export(ulesseq4, { ulesseq4->Type(), "dummy" });
-  graph.add_export(ulesseq5, { ulesseq5->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*ulesseq0, "dummy");
+  jlm::tests::GraphExport::Create(*ulesseq1, "dummy");
+  jlm::tests::GraphExport::Create(*ulesseq2, "dummy");
+  jlm::tests::GraphExport::Create(*ulesseq3, "dummy");
+  jlm::tests::GraphExport::Create(*ulesseq4, "dummy");
+  jlm::tests::GraphExport::Create(*ulesseq5, "dummy");
 
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
@@ -989,13 +989,13 @@ types_bitstring_test_normalize(void)
   assert(sum1->operation() == bitadd_op(32));
   assert(sum1->ninputs() == 2);
 
-  auto exp = graph.add_export(sum1->output(0), { sum1->output(0)->Type(), "dummy" });
+  auto & exp = jlm::tests::GraphExport::Create(*sum1->output(0), "dummy");
 
   sum_nf->set_mutable(true);
   graph.normalize();
   graph.prune();
 
-  auto origin = dynamic_cast<node_output *>(exp->origin());
+  auto origin = dynamic_cast<node_output *>(exp.origin());
   assert(origin->node()->operation() == bitadd_op(32));
   assert(origin->node()->ninputs() == 2);
   auto op1 = origin->node()->input(0)->origin();

--- a/tests/jlm/rvsdg/test-binary.cpp
+++ b/tests/jlm/rvsdg/test-binary.cpp
@@ -29,7 +29,7 @@ test_flattened_binary_reduction()
     auto o2 = simple_node::create_normalized(graph.root(), op, { o1, i2 })[0];
     auto o3 = simple_node::create_normalized(graph.root(), op, { o2, i3 })[0];
 
-    auto ex = graph.add_export(o3, { o3->Type(), "" });
+    auto & ex = jlm::tests::GraphExport::Create(*o3, "");
     graph.prune();
 
     jlm::rvsdg::view(graph, stdout);
@@ -41,7 +41,7 @@ test_flattened_binary_reduction()
 
     assert(graph.root()->nnodes() == 3);
 
-    auto node0 = node_output::node(ex->origin());
+    auto node0 = node_output::node(ex.origin());
     assert(is<jlm::tests::binary_op>(node0));
 
     auto node1 = node_output::node(node0->input(0)->origin());
@@ -63,7 +63,7 @@ test_flattened_binary_reduction()
     auto o2 = simple_node::create_normalized(graph.root(), op, { o1, i2 })[0];
     auto o3 = simple_node::create_normalized(graph.root(), op, { o2, i3 })[0];
 
-    auto ex = graph.add_export(o3, { o3->Type(), "" });
+    auto & ex = jlm::tests::GraphExport::Create(*o3, "");
     graph.prune();
 
     jlm::rvsdg::view(graph, stdout);
@@ -75,7 +75,7 @@ test_flattened_binary_reduction()
 
     assert(graph.root()->nnodes() == 3);
 
-    auto node0 = node_output::node(ex->origin());
+    auto node0 = node_output::node(ex.origin());
     assert(is<jlm::tests::binary_op>(node0));
 
     auto node1 = node_output::node(node0->input(0)->origin());

--- a/tests/jlm/rvsdg/test-bottomup.cpp
+++ b/tests/jlm/rvsdg/test-bottomup.cpp
@@ -17,7 +17,7 @@ test_initialization()
   auto n1 = jlm::tests::test_op::create(graph.root(), {}, {});
   auto n2 = jlm::tests::test_op::create(graph.root(), {}, { vtype });
 
-  graph.add_export(n2->output(0), { n2->output(0)->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*n2->output(0), "dummy");
 
   bool n1_visited = false;
   bool n2_visited = false;
@@ -41,7 +41,7 @@ test_basic_traversal()
   auto n1 = jlm::tests::test_op::create(graph.root(), {}, { type, type });
   auto n2 = jlm::tests::test_op::create(graph.root(), { n1->output(0), n1->output(1) }, { type });
 
-  graph.add_export(n2->output(0), { n2->output(0)->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*n2->output(0), "dummy");
 
   {
     jlm::rvsdg::node * tmp;

--- a/tests/jlm/rvsdg/test-cse.cpp
+++ b/tests/jlm/rvsdg/test-cse.cpp
@@ -20,8 +20,8 @@ test_main()
   auto o1 = jlm::tests::test_op::create(graph.root(), {}, { t })->output(0);
   auto o2 = jlm::tests::test_op::create(graph.root(), { i }, { t })->output(0);
 
-  auto e1 = graph.add_export(o1, { o1->Type(), "o1" });
-  auto e2 = graph.add_export(o2, { o2->Type(), "o2" });
+  auto & e1 = jlm::tests::GraphExport::Create(*o1, "o1");
+  auto & e2 = jlm::tests::GraphExport::Create(*o2, "o2");
 
   auto nf = dynamic_cast<jlm::rvsdg::simple_normal_form *>(
       graph.node_normal_form(typeid(jlm::tests::test_op)));
@@ -30,27 +30,27 @@ test_main()
   auto o3 = jlm::tests::create_testop(graph.root(), {}, { t })[0];
   auto o4 = jlm::tests::create_testop(graph.root(), { i }, { t })[0];
 
-  auto e3 = graph.add_export(o3, { o3->Type(), "o3" });
-  auto e4 = graph.add_export(o4, { o4->Type(), "o4" });
+  auto & e3 = jlm::tests::GraphExport::Create(*o3, "o3");
+  auto & e4 = jlm::tests::GraphExport::Create(*o4, "o4");
 
   nf->set_mutable(true);
   graph.normalize();
-  assert(e1->origin() == e3->origin());
-  assert(e2->origin() == e4->origin());
+  assert(e1.origin() == e3.origin());
+  assert(e2.origin() == e4.origin());
 
   auto o5 = jlm::tests::create_testop(graph.root(), {}, { t })[0];
-  assert(o5 == e1->origin());
+  assert(o5 == e1.origin());
 
   auto o6 = jlm::tests::create_testop(graph.root(), { i }, { t })[0];
-  assert(o6 == e2->origin());
+  assert(o6 == e2.origin());
 
   nf->set_cse(false);
 
   auto o7 = jlm::tests::create_testop(graph.root(), {}, { t })[0];
-  assert(o7 != e1->origin());
+  assert(o7 != e1.origin());
 
   graph.normalize();
-  assert(o7 != e1->origin());
+  assert(o7 != e1.origin());
 
   return 0;
 }

--- a/tests/jlm/rvsdg/test-gamma.cpp
+++ b/tests/jlm/rvsdg/test-gamma.cpp
@@ -31,7 +31,7 @@ test_gamma(void)
   auto ev2 = gamma->add_entryvar(v2);
   gamma->add_exitvar({ ev0->argument(0), ev1->argument(1), ev2->argument(2) });
 
-  graph.add_export(gamma->output(0), { gamma->output(0)->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*gamma->output(0), "dummy");
 
   assert(gamma && gamma->operation() == jlm::rvsdg::gamma_op(3));
 
@@ -70,11 +70,11 @@ test_predicate_reduction(void)
   auto ev2 = gamma->add_entryvar(v2);
   gamma->add_exitvar({ ev0->argument(0), ev1->argument(1), ev2->argument(2) });
 
-  auto r = graph.add_export(gamma->output(0), { gamma->output(0)->Type(), "" });
+  auto & r = jlm::tests::GraphExport::Create(*gamma->output(0), "");
 
   graph.normalize();
   //	jlm::rvsdg::view(graph.root(), stdout);
-  assert(r->origin() == v1);
+  assert(r.origin() == v1);
 
   graph.prune();
   assert(graph.root()->nnodes() == 0);
@@ -97,11 +97,11 @@ test_invariant_reduction(void)
   auto ev = gamma->add_entryvar(v);
   gamma->add_exitvar({ ev->argument(0), ev->argument(1) });
 
-  auto r = graph.add_export(gamma->output(0), { gamma->output(0)->Type(), "" });
+  auto & r = jlm::tests::GraphExport::Create(*gamma->output(0), "");
 
   graph.normalize();
   //	jlm::rvsdg::view(graph.root(), stdout);
-  assert(r->origin() == v);
+  assert(r.origin() == v);
 
   graph.prune();
   assert(graph.root()->nnodes() == 0);
@@ -130,19 +130,19 @@ test_control_constant_reduction()
   auto xv1 = gamma->add_exitvar({ t, f });
   auto xv2 = gamma->add_exitvar({ n0, n1 });
 
-  auto ex1 = graph.add_export(xv1, { xv1->Type(), "" });
-  auto ex2 = graph.add_export(xv2, { xv2->Type(), "" });
+  auto & ex1 = jlm::tests::GraphExport::Create(*xv1, "");
+  auto & ex2 = jlm::tests::GraphExport::Create(*xv2, "");
 
   jlm::rvsdg::view(graph.root(), stdout);
   graph.normalize();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  auto match = node_output::node(ex1->origin());
+  auto match = node_output::node(ex1.origin());
   assert(match && is<match_op>(match->operation()));
   auto & match_op = to_match_op(match->operation());
   assert(match_op.default_alternative() == 0);
 
-  assert(node_output::node(ex2->origin()) == gamma);
+  assert(node_output::node(ex2.origin()) == gamma);
 }
 
 static void
@@ -166,13 +166,13 @@ test_control_constant_reduction2()
 
   auto xv = gamma->add_exitvar({ t1, t2, t3, f });
 
-  auto ex = graph.add_export(xv, { xv->Type(), "" });
+  auto & ex = jlm::tests::GraphExport::Create(*xv, "");
 
   jlm::rvsdg::view(graph.root(), stdout);
   graph.normalize();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  auto match = node_output::node(ex->origin());
+  auto match = node_output::node(ex.origin());
   assert(is<match_op>(match));
 }
 
@@ -207,8 +207,8 @@ TestRemoveGammaOutputsWhere()
   auto gammaOutput3 =
       gammaNode->add_exitvar({ gammaInput3->argument(0), gammaInput3->argument(1) });
 
-  rvsdg.add_export(gammaOutput0, { gammaOutput0->Type(), "" });
-  rvsdg.add_export(gammaOutput2, { gammaOutput2->Type(), "" });
+  jlm::tests::GraphExport::Create(*gammaOutput0, "");
+  jlm::tests::GraphExport::Create(*gammaOutput2, "");
 
   // Act & Assert
   assert(gammaNode->noutputs() == 4);
@@ -267,8 +267,8 @@ TestPruneOutputs()
       gammaNode->add_exitvar({ gammaInput2->argument(0), gammaInput2->argument(1) });
   gammaNode->add_exitvar({ gammaInput3->argument(0), gammaInput3->argument(1) });
 
-  rvsdg.add_export(gammaOutput0, { gammaOutput0->Type(), "" });
-  rvsdg.add_export(gammaOutput2, { gammaOutput2->Type(), "" });
+  jlm::tests::GraphExport::Create(*gammaOutput0, "");
+  jlm::tests::GraphExport::Create(*gammaOutput2, "");
 
   // Act
   gammaNode->PruneOutputs();

--- a/tests/jlm/rvsdg/test-graph.cpp
+++ b/tests/jlm/rvsdg/test-graph.cpp
@@ -48,8 +48,8 @@ test_recursive_prune()
 
   auto n6 = jlm::tests::structural_node::create(n3->subregion(0), 1);
 
-  graph.add_export(n2->output(0), { n2->output(0)->Type(), "n2" });
-  graph.add_export(o1, { o1->Type(), "n3" });
+  jlm::tests::GraphExport::Create(*n2->output(0), "n2");
+  jlm::tests::GraphExport::Create(*o1, "n3");
 
   jlm::rvsdg::view(graph.root(), stdout);
   graph.prune();
@@ -97,8 +97,8 @@ test_prune_replace(void)
   auto n2 = jlm::tests::test_op::create(graph.root(), { n1->output(0) }, { type });
   auto n3 = jlm::tests::test_op::create(graph.root(), { n2->output(0) }, { type });
 
-  graph.add_export(n2->output(0), { n2->output(0)->Type(), "n2" });
-  graph.add_export(n3->output(0), { n2->output(0)->Type(), "n3" });
+  jlm::tests::GraphExport::Create(*n2->output(0), "n2");
+  jlm::tests::GraphExport::Create(*n3->output(0), "n3");
 
   auto n4 = jlm::tests::test_op::create(graph.root(), { n1->output(0) }, { type });
 

--- a/tests/jlm/rvsdg/test-nodes.cpp
+++ b/tests/jlm/rvsdg/test-nodes.cpp
@@ -102,7 +102,7 @@ test_node_depth()
   auto bin = jlm::tests::test_op::create(graph.root(), { null->output(0), x }, { vt });
   auto un = jlm::tests::test_op::create(graph.root(), { bin->output(0) }, { vt });
 
-  graph.add_export(un->output(0), { un->output(0)->Type(), "x" });
+  jlm::tests::GraphExport::Create(*un->output(0), "x");
 
   jlm::rvsdg::view(graph.root(), stdout);
 

--- a/tests/jlm/rvsdg/test-statemux.cpp
+++ b/tests/jlm/rvsdg/test-statemux.cpp
@@ -34,7 +34,7 @@ test_mux_mux_reduction()
   auto mux2 = jlm::rvsdg::create_state_split(st, z, 2);
   auto mux3 = jlm::rvsdg::create_state_merge(st, { mux1, mux2[0], mux2[1], z });
 
-  auto ex = graph.add_export(mux3, { mux3->Type(), "m" });
+  auto & ex = jlm::tests::GraphExport::Create(*mux3, "m");
 
   //	jlm::rvsdg::view(graph.root(), stdout);
 
@@ -45,7 +45,7 @@ test_mux_mux_reduction()
 
   //	jlm::rvsdg::view(graph.root(), stdout);
 
-  auto node = node_output::node(ex->origin());
+  auto node = node_output::node(ex.origin());
   assert(node->ninputs() == 4);
   assert(node->input(0)->origin() == x);
   assert(node->input(1)->origin() == y);
@@ -68,7 +68,7 @@ test_multiple_origin_reduction()
 
   auto x = &jlm::tests::GraphImport::Create(graph, st, "x");
   auto mux1 = jlm::rvsdg::create_state_merge(st, { x, x });
-  auto ex = graph.add_export(mux1, { mux1->Type(), "m" });
+  auto & ex = jlm::tests::GraphExport::Create(*mux1, "m");
 
   view(graph.root(), stdout);
 
@@ -79,7 +79,7 @@ test_multiple_origin_reduction()
 
   view(graph.root(), stdout);
 
-  assert(node_output::node(ex->origin())->ninputs() == 1);
+  assert(node_output::node(ex.origin())->ninputs() == 1);
 }
 
 static int

--- a/tests/jlm/rvsdg/test-theta.cpp
+++ b/tests/jlm/rvsdg/test-theta.cpp
@@ -32,7 +32,7 @@ TestThetaCreation()
   lv3->result()->divert_to(lv3->argument());
   theta->set_predicate(lv1->argument());
 
-  graph.add_export(theta->output(0), { theta->output(0)->Type(), "exp" });
+  jlm::tests::GraphExport::Create(*theta->output(0), "exp");
   auto theta2 =
       static_cast<jlm::rvsdg::structural_node *>(theta)->copy(graph.root(), { imp1, imp2, imp3 });
   jlm::rvsdg::view(graph.root(), stdout);
@@ -68,7 +68,7 @@ TestRemoveThetaOutputsWhere()
   auto thetaOutput2 = thetaNode->add_loopvar(y);
   thetaNode->set_predicate(thetaOutput0->argument());
 
-  rvsdg.add_export(thetaOutput0, { ctltype::Create(2), "" });
+  jlm::tests::GraphExport::Create(*thetaOutput0, "");
 
   // Act & Assert
   auto deadInputs = thetaNode->RemoveThetaOutputsWhere(
@@ -118,7 +118,7 @@ TestPruneThetaOutputs()
   thetaNode->add_loopvar(y);
   thetaNode->set_predicate(thetaOutput0->argument());
 
-  rvsdg.add_export(thetaOutput0, { ctltype::Create(2), "" });
+  jlm::tests::GraphExport::Create(*thetaOutput0, "");
 
   // Act
   auto deadInputs = thetaNode->PruneThetaOutputs();
@@ -159,7 +159,7 @@ TestRemoveThetaInputsWhere()
   thetaOutput1->result()->divert_to(result);
   thetaOutput2->result()->divert_to(result);
 
-  rvsdg.add_export(thetaOutput0, { ctltype::Create(2), "" });
+  jlm::tests::GraphExport::Create(*thetaOutput0, "");
 
   // Act & Assert
   auto deadOutputs = thetaNode->RemoveThetaInputsWhere(
@@ -215,7 +215,7 @@ TestPruneThetaInputs()
   thetaOutput1->result()->divert_to(result);
   thetaOutput2->result()->divert_to(result);
 
-  rvsdg.add_export(thetaOutput0, { ctltype::Create(2), "" });
+  jlm::tests::GraphExport::Create(*thetaOutput0, "");
 
   // Act
   auto deadOutputs = thetaNode->PruneThetaInputs();

--- a/tests/jlm/rvsdg/test-topdown.cpp
+++ b/tests/jlm/rvsdg/test-topdown.cpp
@@ -21,9 +21,9 @@ test_initialization()
   auto unary = jlm::tests::test_op::create(graph.root(), { i }, { vtype });
   auto binary = jlm::tests::test_op::create(graph.root(), { i, unary->output(0) }, { vtype });
 
-  graph.add_export(constant->output(0), { constant->output(0)->Type(), "c" });
-  graph.add_export(unary->output(0), { unary->output(0)->Type(), "u" });
-  graph.add_export(binary->output(0), { binary->output(0)->Type(), "b" });
+  jlm::tests::GraphExport::Create(*constant->output(0), "c");
+  jlm::tests::GraphExport::Create(*unary->output(0), "u");
+  jlm::tests::GraphExport::Create(*binary->output(0), "b");
 
   bool unary_visited = false;
   bool binary_visited = false;
@@ -52,7 +52,7 @@ test_basic_traversal()
   auto n1 = jlm::tests::test_op::create(graph.root(), {}, { type, type });
   auto n2 = jlm::tests::test_op::create(graph.root(), { n1->output(0), n1->output(1) }, { type });
 
-  graph.add_export(n2->output(0), { n2->output(0)->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*n2->output(0), "dummy");
 
   {
     jlm::rvsdg::node * tmp;
@@ -105,7 +105,7 @@ test_traversal_insertion()
   auto n1 = jlm::tests::test_op::create(graph.root(), {}, { type, type });
   auto n2 = jlm::tests::test_op::create(graph.root(), { n1->output(0), n1->output(1) }, { type });
 
-  graph.add_export(n2->output(0), { n2->output(0)->Type(), "dummy" });
+  jlm::tests::GraphExport::Create(*n2->output(0), "dummy");
 
   {
     jlm::rvsdg::node * node;

--- a/tests/test-operation.cpp
+++ b/tests/test-operation.cpp
@@ -14,6 +14,13 @@ GraphImport::Copy(rvsdg::region & region, rvsdg::structural_input * input)
   return GraphImport::Create(*region.graph(), Type(), Name());
 }
 
+GraphExport &
+GraphExport::Copy(rvsdg::output & origin, rvsdg::structural_output * output)
+{
+  JLM_ASSERT(output == nullptr);
+  return GraphExport::Create(origin, Name());
+}
+
 /* unary operation */
 
 unary_op::~unary_op() noexcept

--- a/tests/test-operation.hpp
+++ b/tests/test-operation.hpp
@@ -43,7 +43,10 @@ public:
   }
 };
 
-// FIXME: add implementation
+/**
+ * Represents an export from the RVSDG of an internal entity.
+ * It can be used for testing of graph exports.
+ */
 class GraphExport final : public rvsdg::GraphExport
 {
   GraphExport(rvsdg::output & origin, std::string name)

--- a/tests/test-operation.hpp
+++ b/tests/test-operation.hpp
@@ -43,6 +43,26 @@ public:
   }
 };
 
+// FIXME: add implementation
+class GraphExport final : public rvsdg::GraphExport
+{
+  GraphExport(rvsdg::output & origin, std::string name)
+      : rvsdg::GraphExport(origin, std::move(name))
+  {}
+
+public:
+  GraphExport &
+  Copy(rvsdg::output & origin, rvsdg::structural_output * output) override;
+
+  static GraphExport &
+  Create(rvsdg::output & origin, std::string name)
+  {
+    auto graphExport = new GraphExport(origin, std::move(name));
+    origin.region()->graph()->root()->append_result(graphExport);
+    return *graphExport;
+  }
+};
+
 /* unary operation */
 
 class unary_op final : public rvsdg::unary_op


### PR DESCRIPTION
This PR does the following:

1. Introduces the GraphExport class and its subclasses to model the export
of internal entities from the module. These classes serve as a replacement for the old
expport class.
2. Replaces all usages of expport with GraphExport
3. Removes old expport classes.

This is one of the steps necessary in order to completely remove ports
from the code base.