### PR TITLE
[AndersenAgnostic] Add difference propagation

### DIFF
--- a/jlm/llvm/Makefile.sub
+++ b/jlm/llvm/Makefile.sub
@@ -69,7 +69,7 @@ libllvm_HEADERS = \
 	jlm/llvm/opt/inlining.hpp \
 	jlm/llvm/opt/cne.hpp \
 	jlm/llvm/opt/push.hpp \
-	jlm/llvm/opt/alias-analyses/DifferencePropagation.hpp
+	jlm/llvm/opt/alias-analyses/DifferencePropagation.hpp \
 	jlm/llvm/opt/alias-analyses/LazyCycleDetection.hpp \
 	jlm/llvm/opt/alias-analyses/MemoryNodeProvider.hpp \
 	jlm/llvm/opt/alias-analyses/OnlineCycleDetection.hpp \
@@ -179,6 +179,7 @@ libllvm_TESTS += \
 	tests/jlm/llvm/ir/TestAnnotation \
 	tests/jlm/llvm/opt/alias-analyses/TestAgnosticMemoryNodeProvider \
 	tests/jlm/llvm/opt/alias-analyses/TestAndersen \
+	tests/jlm/llvm/opt/alias-analyses/TestDifferencePropagation \
 	tests/jlm/llvm/opt/alias-analyses/TestLazyCycleDetection \
 	tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder \
 	tests/jlm/llvm/opt/alias-analyses/TestPointerObjectSet \

--- a/jlm/llvm/Makefile.sub
+++ b/jlm/llvm/Makefile.sub
@@ -69,6 +69,7 @@ libllvm_HEADERS = \
 	jlm/llvm/opt/inlining.hpp \
 	jlm/llvm/opt/cne.hpp \
 	jlm/llvm/opt/push.hpp \
+	jlm/llvm/opt/alias-analyses/DifferencePropagation.hpp
 	jlm/llvm/opt/alias-analyses/LazyCycleDetection.hpp \
 	jlm/llvm/opt/alias-analyses/MemoryNodeProvider.hpp \
 	jlm/llvm/opt/alias-analyses/OnlineCycleDetection.hpp \

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -47,6 +47,8 @@ Andersen::Configuration::ToString() const
       str << "HybridCD_";
     if (EnableLazyCycleDetection_)
       str << "LazyCD_";
+    if (EnableDifferencePropagation_)
+      str << "DP_";
   }
   else
   {
@@ -62,13 +64,19 @@ std::vector<Andersen::Configuration>
 Andersen::Configuration::GetAllConfigurations()
 {
   std::vector<Configuration> configs;
-
+  auto PickDifferencePropagation = [&](Configuration config)
+  {
+    config.EnableDifferencePropagation(false);
+    configs.push_back(config);
+    config.EnableDifferencePropagation(true);
+    configs.push_back(config);
+  };
   auto PickLazyCycleDetection = [&](Configuration config)
   {
     config.EnableLazyCycleDetection(false);
-    configs.push_back(config);
+    PickDifferencePropagation(config);
     config.EnableLazyCycleDetection(true);
-    configs.push_back(config);
+    PickDifferencePropagation(config);
   };
   auto PickHybridCycleDetection = [&](Configuration config)
   {
@@ -1113,7 +1121,8 @@ Andersen::SolveConstraints(
         config.GetWorklistSoliverPolicy(),
         config.IsOnlineCycleDetectionEnabled(),
         config.IsHybridCycleDetectionEnabled(),
-        config.IsLazyCycleDetectionEnabled());
+        config.IsLazyCycleDetectionEnabled(),
+        config.IsDifferencePropagationEnabled());
     statistics.StopConstraintSolvingWorklistStatistics(worklistStatistics);
   }
   else

--- a/jlm/llvm/opt/alias-analyses/Andersen.hpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.hpp
@@ -250,7 +250,7 @@ public:
     bool EnableOnlineCycleDetection_ = false;
     bool EnableHybridCycleDetection_ = false;
     bool EnableLazyCycleDetection_ = false;
-    bool EnabledDifferencePropagation_ = false;
+    bool EnableDifferencePropagation_ = false;
   };
 
   ~Andersen() noexcept override = default;

--- a/jlm/llvm/opt/alias-analyses/Andersen.hpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.hpp
@@ -178,6 +178,23 @@ public:
       return EnableLazyCycleDetection_;
     }
 
+    /**
+     * Enables or disables difference propagation in the Worklist solver, as described by
+     *   Pearce, 2003: "Online cycle detection and difference propagation for pointer analysis"
+     * Only used by the worklist solver.
+     */
+    void
+    EnableDifferencePropagation(bool enable) noexcept
+    {
+      EnableDifferencePropagation_ = enable;
+    }
+
+    [[nodiscard]] bool
+    IsDifferencePropagationEnabled() const noexcept
+    {
+      return EnableDifferencePropagation_;
+    }
+
     [[nodiscard]] std::string
     ToString() const;
 
@@ -197,6 +214,7 @@ public:
       config.EnableOnlineCycleDetection(false);
       config.EnableHybridCycleDetection(true);
       config.EnableLazyCycleDetection(true);
+      config.EnableDifferencePropagation(true);
       return config;
     }
 
@@ -232,6 +250,7 @@ public:
     bool EnableOnlineCycleDetection_ = false;
     bool EnableHybridCycleDetection_ = false;
     bool EnableLazyCycleDetection_ = false;
+    bool EnabledDifferencePropagation_ = false;
   };
 
   ~Andersen() noexcept override = default;

--- a/jlm/llvm/opt/alias-analyses/DifferencePropagation.hpp
+++ b/jlm/llvm/opt/alias-analyses/DifferencePropagation.hpp
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2024 Håvard Krogstie <krogstie.havard@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#ifndef JLM_LLVM_OPT_ALIAS_ANALYSES_DIFFERENCEPROPAGATION_HPP
+#define JLM_LLVM_OPT_ALIAS_ANALYSES_DIFFERENCEPROPAGATION_HPP
+
+#include <jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp>
+
+#include <vector>
+
+namespace jlm::llvm::aa
+{
+
+class DifferencePropagation
+{
+
+public:
+  explicit DifferencePropagation(PointerObjectSet & set)
+      : Set_(set)
+  {}
+
+  /**
+   * Must be called before using any other methods.
+   */
+  void
+  Initialize()
+  {
+    NewPointees_.resize(Set_.NumPointerObjects());
+    NewPointeesTracked_.resize(Set_.NumPointerObjects(), false);
+    PointsToExternalFlagSeen_.resize(Set_.NumPointerObjects(), false);
+    PointeesEscapeFlagSeen_.resize(Set_.NumPointerObjects(), false);
+  }
+
+  [[nodiscard]] bool
+  IsInitialized() const noexcept
+  {
+    return NewPointees_.size() == Set_.NumPointerObjects();
+  }
+
+  /**
+   * Starts tracking any pointees added to \p index from this point onwards.
+   * @param index the index of the PointerObject, must be a unification root.
+   */
+  void
+  ClearNewPointees(PointerObjectIndex index)
+  {
+    JLM_ASSERT(IsInitialized());
+    JLM_ASSERT(Set_.IsUnificationRoot(index));
+
+    NewPointees_[index].Clear();
+    NewPointeesTracked_[index] = true;
+  };
+
+  /**
+   * Makes P(pointer) contain pointee
+   * @param pointer the PointerObject which should contain pointee in its points-to set.
+   *   Must be a unification root.
+   * @param pointee the PointerObject which should be pointed to by pointer
+   * @return true if this operation added a new pointee to P(pointer)
+   */
+  bool
+  AddToPointsToSet(PointerObjectIndex pointer, PointerObjectIndex pointee)
+  {
+    JLM_ASSERT(IsInitialized());
+    JLM_ASSERT(Set_.IsUnificationRoot(pointer));
+
+    // If pointees added to the superset are being tracked, use the tracking version
+    bool newPointee = Set_.AddToPointsToSet(pointer, pointee);
+    if (newPointee && NewPointeesTracked_[pointer])
+      return NewPointees_[pointer].Insert(pointee);
+
+    return newPointee;
+  }
+
+  /**
+   * Makes P(superset) a superset of P(subset), and propagates the PointsToExternal flag if set.
+   * @param superset the PointerObject which should point to everything the subset points to
+   *   Must be a unification root.
+   * @param subset a PointerObject which should have all its pointees also be pointees of superset.
+   * @return true if this operation adds any pointees or flags to superset.
+   */
+  bool
+  MakePointsToSetSuperset(PointerObjectIndex superset, PointerObjectIndex subset)
+  {
+    JLM_ASSERT(IsInitialized());
+    JLM_ASSERT(Set_.IsUnificationRoot(superset));
+
+    // If pointees added to the superset are being tracked, use the tracking version
+    if (NewPointeesTracked_[superset])
+      return Set_.MakePointsToSetSuperset(superset, subset, NewPointees_[superset]);
+    else
+      return Set_.MakePointsToSetSuperset(superset, subset);
+  }
+
+  /**
+   * Gets the pointees of a PointerObject that have been added since the last time
+   * ClearNewPointees(index) was called.
+   * If new pointees of index are not being tracked, all pointees are returned.
+   * @param index the index of the PointerObject, must be a unification root.
+   * @return a reference to either all new pointees, or all pointees of index.
+   */
+  [[nodiscard]] const util::HashSet<PointerObjectIndex> &
+  GetNewPointees(PointerObjectIndex index) const
+  {
+    JLM_ASSERT(IsInitialized());
+    JLM_ASSERT(Set_.IsUnificationRoot(index));
+    if (NewPointeesTracked_[index])
+      return NewPointees_[index];
+    return Set_.GetPointsToSet(index);
+  }
+
+  /**
+   * Clears the tracked set of new pointees of \p index, and stops tracking it.
+   * @param index the index of the PointerObject, must be a unification root.
+   */
+  void
+  OnRemoveAllPointees(PointerObjectIndex index)
+  {
+    NewPointeesTracked_[index] = false;
+    NewPointees_[index].Clear();
+  }
+
+  /**
+   * If the given PointerObject has the PointsToExternal flag now,
+   * and MarkPointsToExternalAsHandled(index) has not been called, return true. Otherwise false.
+   * An exception is if the PointerObject has been unified with other PointerObjects,
+   * and some of the other PointerObjects did not have that flag handled already.
+   * @param index the index of the PointerObject being queried. Must be a unification root
+   * @return true if the PointerObject is newly flagged as PointsToExternal.
+   */
+  [[nodiscard]] bool
+  PointsToExternalIsNew(PointerObjectIndex index)
+  {
+    JLM_ASSERT(IsInitialized());
+    JLM_ASSERT(Set_.IsUnificationRoot(index));
+    if (!Set_.IsPointingToExternal(index))
+      return false;
+    return !PointsToExternalFlagSeen_[index];
+  }
+
+  /**
+   * Call once the addition of the new flag PointsToExternal has been handled.
+   * After this call, PointsToExternalIsNew(index) will return false (unless new unifications).
+   * @param index the index of the PointerObject whose PointsToExternal flag has been handled.
+   * Must be a unification root.
+   */
+  void
+  MarkPointsToExternalAsHandled(PointerObjectIndex index)
+  {
+    JLM_ASSERT(Set_.IsUnificationRoot(index));
+    JLM_ASSERT(Set_.IsPointingToExternal(index));
+    PointsToExternalFlagSeen_[index] = true;
+  }
+
+  /**
+   * If the given PointerObject has the PointeesEscape flag now,
+   * but didn't have it the last time ClearDifferenceTracking(index) was called, return true.
+   * An exception is if the PointerObject has been unified with other PointerObjects,
+   * and some of the other PointerObjects had not have that flag seen.
+   * @param index the index of the PointerObject being queried. Must be a unification root
+   * @return true if the PointerObject is newly flagged as AllPointeesEscape.
+   */
+  [[nodiscard]] bool
+  PointeesEscapeIsNew(PointerObjectIndex index)
+  {
+    JLM_ASSERT(IsInitialized());
+    JLM_ASSERT(Set_.IsUnificationRoot(index));
+    if (!Set_.HasPointeesEscaping(index))
+      return false;
+    return !PointeesEscapeFlagSeen_[index];
+  }
+
+  /**
+   * Call once the addition of the new flag PointeesEscape has been handled.
+   * After this call, PointeesEscapeIsNew(index) will return false (unless new unifications).
+   * @param index the index of the PointerObject whose PointeesEscape flag has been handled.
+   * Must be a unification root.
+   */
+  void
+  MarkPointeesEscapeAsHandled(PointerObjectIndex index)
+  {
+    JLM_ASSERT(Set_.IsUnificationRoot(index));
+    JLM_ASSERT(Set_.HasPointeesEscaping(index));
+    PointeesEscapeFlagSeen_[index] = true;
+  }
+
+  /**
+   * Performs conservative clearing of tracked differences, after unification.
+   * The set of tracked pointees is fully cleared, since all pointees might be new to
+   * constraints previously owned by the opposite PointerObject.
+   *
+   * If the worklist has seen the PointsToExternal and PointeesEscape flags on both operands,
+   * the flags will also be considered already seen for the resulting unification root.
+   *
+   * @param root the operand of the unification that ended up at the new root.
+   * @param nonRoot the root of the other unification, that is now no longer a root.
+   */
+  void
+  OnPointerObjectsUnified(PointerObjectIndex root, PointerObjectIndex nonRoot)
+  {
+    JLM_ASSERT(IsInitialized());
+
+    // After unification, forget everything about tracked differences in points-to sets
+    NewPointees_[nonRoot].Clear();
+    NewPointees_[root].Clear();
+    NewPointeesTracked_[root] = false;
+
+    PointsToExternalFlagSeen_[root] =
+        PointsToExternalFlagSeen_[root] && PointsToExternalFlagSeen_[nonRoot];
+    PointeesEscapeFlagSeen_[root] =
+        PointeesEscapeFlagSeen_[root] && PointeesEscapeFlagSeen_[nonRoot];
+  }
+
+private:
+  PointerObjectSet & Set_;
+
+  // Only unification roots matter in these vectors
+
+  // Tracks all new pointees added to a unification root i,
+  // since ClearNewPointees(i) was last called.
+  std::vector<util::HashSet<PointerObjectIndex>> NewPointees_;
+  // Becomes true for a unification root i when CleanNewPointees(i) is called for the first time.
+  // Becomes false again when unification fully resets difference propagation
+  std::vector<bool> NewPointeesTracked_;
+
+  // These are set to true after the _IsNew have returned true
+  // When two PointerObjects a and b are unified, the flag only remains "seen",
+  // if the flag has already been "seen" on both a and b.
+  std::vector<bool> PointsToExternalFlagSeen_;
+  std::vector<bool> PointeesEscapeFlagSeen_;
+};
+
+}
+
+#endif // JLM_LLVM_OPT_ALIAS_ANALYSES_DIFFERENCEPROPAGATION_HPP

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
@@ -163,6 +163,17 @@ class PointerObjectSet final
   [[nodiscard]] PointerObjectIndex
   AddPointerObject(PointerObjectKind kind);
 
+  /**
+   * Internal helper function for making P(superset) a superset of P(subset), with a callback.
+   * @See MakePointsToSetSuperset
+   */
+  template<typename NewPointeeFunctor>
+  bool
+  PropagateNewPointees(
+      PointerObjectIndex superset,
+      PointerObjectIndex subset,
+      NewPointeeFunctor & onNewPointee);
+
 public:
   [[nodiscard]] size_t
   NumPointerObjects() const noexcept;
@@ -406,6 +417,16 @@ public:
    */
   bool
   MakePointsToSetSuperset(PointerObjectIndex superset, PointerObjectIndex subset);
+
+  /**
+   * A version of MakePointsToSetSuperset that adds any new pointees of \p superset,
+   * to the set \p newPointees.
+   */
+  bool
+  MakePointsToSetSuperset(
+      PointerObjectIndex superset,
+      PointerObjectIndex subset,
+      util::HashSet<PointerObjectIndex> & newPointees);
 
   /**
    * @param pointer the PointerObject possibly pointing to \p pointee
@@ -953,10 +974,12 @@ public:
    *  - Online Cycle Detection (Pearce, 2003)
    *  - Hybrid Cycle Detection (Hardekopf 2007)
    *  - Lazy Cycle Detection (Hardekopf 2007)
+   *  - Difference Propagation (Pearce, 2003)
    * @param policy the worklist iteration order policy to use
    * @param enableOnlineCycleDetection if true, online cycle detection will be performed.
    * @param enableHybridCycleDetection if true, hybrid cycle detection will be performed.
    * @param enableLazyCycleDetection if true, lazy cycle detection will be performed.
+   * @param enableDifferencePropagation if true, difference propagation will be enabled.
    * @return an instance of WorklistStatistics describing solver statistics
    */
   WorklistStatistics
@@ -964,7 +987,8 @@ public:
       WorklistSolverPolicy policy,
       bool enableOnlineCycleDetection,
       bool enableHybridCycleDetection,
-      bool enableLazyCycleDetection);
+      bool enableLazyCycleDetection,
+      bool enableDifferencePropagation);
 
   /**
    * Iterates over and applies constraints until all points-to-sets satisfy them.
@@ -1009,13 +1033,15 @@ private:
    * @tparam EnableOnlineCycleDetection if true, online cycle detection is enabled.
    * @tparam EnableHybridCycleDetection if true, hybrid cycle detection is enabled.
    * @tparam EnableLazyCycleDetection if true, lazy cycle detection is enabled.
+   * @tparam EnableDifferencePropagation if true, difference propagation is enabled.
    * @see SolveUsingWorklist() for the public interface.
    */
   template<
       typename Worklist,
       bool EnableOnlineCycleDetection,
       bool EnableHybridCycleDetection,
-      bool EnableLazyCycleDetection>
+      bool EnableLazyCycleDetection,
+      bool EnableDifferencePropagation>
   void
   RunWorklistSolver(WorklistStatistics & statistics);
 

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
@@ -165,7 +165,7 @@ class PointerObjectSet final
 
   /**
    * Internal helper function for making P(superset) a superset of P(subset), with a callback.
-   * @See MakePointsToSetSuperset
+   * @see MakePointsToSetSuperset
    */
   template<typename NewPointeeFunctor>
   bool

--- a/tests/jlm/llvm/opt/alias-analyses/TestDifferencePropagation.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestDifferencePropagation.cpp
@@ -41,7 +41,7 @@ TestTracksDifferences()
   // Assert
   assert(differencePropagation.GetNewPointees(r0) == (util::HashSet<PointerObjectIndex>{ a0, a3 }));
 
-  // Act 2 - add another pointer/pointee relations: r1 -> a1
+  // Act 2 - add another pointer/pointee relation: r1 -> a1
   differencePropagation.AddToPointsToSet(r1, a1);
 
   // Assert that a1 is a new pointee of r1
@@ -98,7 +98,7 @@ TestTracksDifferences()
 
   // Assert that all pointees that were new to either node, are also new to the root
   // a0 and a2 were still marked as new to node r1 at the time of unification.
-  // a3 was not new to 0, but 1 has never seen it, so it must be regarded as new by the union.
+  // a3 is not new to r0, but r1 has never seen it, so it must be regarded as new by the union.
   util::HashSet<PointerObjectIndex> subset{ a0, a2, a3 };
   assert(subset.IsSubsetOf(differencePropagation.GetNewPointees(root)));
 

--- a/tests/jlm/llvm/opt/alias-analyses/TestDifferencePropagation.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestDifferencePropagation.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2024 Håvard Krogstie <krogstie.havard@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <TestRvsdgs.hpp>
+
+#include <test-registry.hpp>
+
+#include <jlm/llvm/opt/alias-analyses/DifferencePropagation.hpp>
+#include <jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp>
+
+#include <cassert>
+
+static int
+TestTracksDifferences()
+{
+  using namespace jlm;
+  using namespace jlm::llvm::aa;
+
+  // Arrange
+  tests::NAllocaNodesTest rvsdg(4);
+  rvsdg.InitializeTest();
+
+  PointerObjectSet set;
+  auto r0 = set.CreateRegisterPointerObject(rvsdg.GetAllocaOutput(0));
+  auto r1 = set.CreateRegisterPointerObject(rvsdg.GetAllocaOutput(1));
+  auto a0 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(0));
+  auto a1 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(1));
+  auto a2 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(2));
+  auto a3 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(3));
+
+  // Let r0 -> a0 and r0 -> a3 before difference tracking even begins
+  set.AddToPointsToSet(r0, a0);
+  set.AddToPointsToSet(r0, a3);
+
+  // Act
+  DifferencePropagation differencePropagation(set);
+  differencePropagation.Initialize();
+
+  // Assert
+  assert(differencePropagation.GetNewPointees(r0) == (util::HashSet<PointerObjectIndex>{ a0, a3 }));
+
+  // Act 2 - add another pointer/pointee relations: r1 -> a1
+  differencePropagation.AddToPointsToSet(r1, a1);
+
+  // Assert that a1 is a new pointee of r1
+  assert(differencePropagation.GetNewPointees(r1) == (util::HashSet<PointerObjectIndex>{ a1 }));
+
+  // Act 3 - clear difference tracking for r1
+  differencePropagation.ClearNewPointees(r1);
+
+  // Assert r1 no longer has any new pointees
+  assert(differencePropagation.GetNewPointees(r1).IsEmpty());
+  // r0 still has new pointees
+  assert(!differencePropagation.GetNewPointees(r0).IsEmpty());
+
+  // Act 4 - add more pointees to r1,
+  bool new0 = differencePropagation.AddToPointsToSet(r1, a0);
+  bool new1 = differencePropagation.AddToPointsToSet(r1, a1); // not a new pointee
+  bool new2 = differencePropagation.AddToPointsToSet(r1, a2);
+
+  // Assert that only a0 and a2 were new
+  assert(new0 && !new1 && new2);
+  assert(differencePropagation.GetNewPointees(r1) == (util::HashSet<PointerObjectIndex>{ a0, a2 }));
+
+  // Act 5 - make r0 point to a superset of r1, making r0 now point to a0, a1, a2, a3
+  // First mark the existing pointees of r0 (a0 and a3) as seen
+  differencePropagation.ClearNewPointees(r0);
+  differencePropagation.MakePointsToSetSuperset(r0, r1);
+
+  // Assert that only a1 and a2 are new to r0, as it has already marked a0 and a3 as seen
+  assert(differencePropagation.GetNewPointees(r0) == (util::HashSet<PointerObjectIndex>{ a1, a2 }));
+
+  // Act 6 - give nodes r0 and r1 flags
+  set.MarkAsPointeesEscaping(r0);
+  set.MarkAsPointingToExternal(r1);
+
+  // Assert that the flags are new, but only if they actually have the flag
+  assert(differencePropagation.PointeesEscapeIsNew(r0));
+  assert(!differencePropagation.PointsToExternalIsNew(r0));
+  assert(!differencePropagation.PointeesEscapeIsNew(r1));
+  assert(differencePropagation.PointsToExternalIsNew(r1));
+
+  // Act 7 - mark flags as seen
+  differencePropagation.MarkPointeesEscapeAsHandled(r0);
+  differencePropagation.MarkPointsToExternalAsHandled(r1);
+
+  // Assert that the flags are no longer new
+  assert(!differencePropagation.PointeesEscapeIsNew(r0));
+  assert(!differencePropagation.PointsToExternalIsNew(r1));
+
+  // Act 6 - unify 0 and 1
+  // After unification, any pointee or flag that is new to either node becomes new to the union
+  auto root = set.UnifyPointerObjects(r0, r1);
+  auto nonRoot = r0 + r1 - root;
+  differencePropagation.OnPointerObjectsUnified(root, nonRoot);
+
+  // Assert that all pointees that were new to either node, are also new to the root
+  // a0 and a2 were still marked as new to node r1 at the time of unification.
+  // a3 was not new to 0, but 1 has never seen it, so it must be regarded as new by the union.
+  util::HashSet<PointerObjectIndex> subset{ a0, a2, a3 };
+  assert(subset.IsSubsetOf(differencePropagation.GetNewPointees(root)));
+
+  // Neither flag has been seen by both nodes, so they are both new to the unification
+  assert(differencePropagation.PointeesEscapeIsNew(root));
+  assert(differencePropagation.PointsToExternalIsNew(root));
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER(
+    "jlm/llvm/opt/alias-analyses/TestDifferencePropagation-TestTracksDifferences",
+    TestTracksDifferences)

--- a/tests/jlm/llvm/opt/alias-analyses/TestPointerObjectSet.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestPointerObjectSet.cpp
@@ -891,7 +891,8 @@ TestPointerObjectSet()
         config.GetWorklistSoliverPolicy(),
         config.IsOnlineCycleDetectionEnabled(),
         config.IsHybridCycleDetectionEnabled(),
-        config.IsLazyCycleDetectionEnabled());
+        config.IsLazyCycleDetectionEnabled(),
+        config.IsDifferencePropagationEnabled());
   }
 
   TestClonePointerObjectConstraintSet();


### PR DESCRIPTION
Adds difference propagation, which is one of the more "invasive" techniques, as it needs to intercept modifications to the points-to sets. When iterating over a points-to set, you sometimes only need the set of pointees that have been added since last visit, while you other times need all pointees.

For the flags, we get away with not intercepting the setting of them. Difference propagation can just remember if the flag was set the last time the work item was visited, which only takes up 2 bits per PointerObject.