### PR TITLE
[AndersenAgnostic] Add the topological worklist solver to Andersen

### DIFF
--- a/jlm/llvm/frontend/ControlFlowRestructuring.cpp
+++ b/jlm/llvm/frontend/ControlFlowRestructuring.cpp
@@ -496,7 +496,7 @@ RestructureControlFlow(llvm::cfg * cfg)
 
   for (const auto & l : tcloops)
     reinsert_tcloop(l);
-  
+
   JLM_ASSERT(is_proper_structured(*cfg));
 }
 

--- a/jlm/llvm/frontend/ControlFlowRestructuring.cpp
+++ b/jlm/llvm/frontend/ControlFlowRestructuring.cpp
@@ -496,8 +496,7 @@ RestructureControlFlow(llvm::cfg * cfg)
 
   for (const auto & l : tcloops)
     reinsert_tcloop(l);
-
-  // TODO: SLOW
+  
   JLM_ASSERT(is_proper_structured(*cfg));
 }
 

--- a/jlm/llvm/frontend/ControlFlowRestructuring.cpp
+++ b/jlm/llvm/frontend/ControlFlowRestructuring.cpp
@@ -497,6 +497,7 @@ RestructureControlFlow(llvm::cfg * cfg)
   for (const auto & l : tcloops)
     reinsert_tcloop(l);
 
+  // TODO: SLOW
   JLM_ASSERT(is_proper_structured(*cfg));
 }
 

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -117,6 +117,8 @@ Andersen::Configuration::GetAllConfigurations()
     PickOnlineCycleDetection(config);
     config.SetWorklistSolverPolicy(Policy::FirstInFirstOut);
     PickOnlineCycleDetection(config);
+    config.SetWorklistSolverPolicy(Policy::TopologicalSort);
+    PickDifferencePropagation(config); // With topo, skip all cycle detection
   };
   auto PickOfflineNormalization = [&](Configuration config)
   {
@@ -180,6 +182,7 @@ class Andersen::Statistics final : public util::Statistics
       "#WorklistSolverWorkItemsPopped";
   static constexpr const char * NumWorklistSolverWorkItemsNewPointees_ =
       "#WorklistSolverWorkItemsNewPointees";
+  static constexpr const char * NumTopologicalWorklistSweeps_ = "#TopologicalWorklistSweeps";
 
   // Online technique statistics
   static constexpr const char * NumOnlineCyclesDetected_ = "#OnlineCyclesDetected";
@@ -327,6 +330,9 @@ public:
     // How many work items were popped from the worklist in total
     AddMeasurement(NumWorklistSolverWorkItemsPopped_, statistics.NumWorkItemsPopped);
     AddMeasurement(NumWorklistSolverWorkItemsNewPointees_, statistics.NumWorkItemNewPointees);
+
+    if (statistics.NumTopologicalWorklistSweeps)
+      AddMeasurement(NumTopologicalWorklistSweeps_, *statistics.NumTopologicalWorklistSweeps);
 
     if (statistics.NumOnlineCyclesDetected)
       AddMeasurement(NumOnlineCyclesDetected_, *statistics.NumOnlineCyclesDetected);

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
@@ -1961,12 +1961,13 @@ PointerObjectConstraintSet::RunWorklistSolver(WorklistStatistics & statistics)
     FlushNewSupersetEdges();
   };
 
-  // The dummy worklist only contains one bit of state: "has anything been pushed since last reset?"
+  // The observer worklist only contains one bit of state:
+  //   "has anything been pushed since last reset?"
   // It does not provide an iteration order, so if any work item need to be revisited,
   // we do a topological traversal over all work items instead, called a "sweep".
   // Performing topological sorting also detects all cycles, which are unified away.
   constexpr bool useTopologicalTraversal =
-      std::is_same_v<Worklist, util::DummyWorklist<PointerObjectIndex>>;
+      std::is_same_v<Worklist, util::ObserverWorklist<PointerObjectIndex>>;
 
   if constexpr (useTopologicalTraversal)
   {
@@ -2059,7 +2060,7 @@ PointerObjectConstraintSet::SolveUsingWorklist(
     constexpr bool vPreferImplicitPointees = decltype(tPreferImplicitPointees)::value;
 
     if constexpr (
-        std::is_same_v<Worklist, util::DummyWorklist<PointerObjectIndex>>
+        std::is_same_v<Worklist, util::ObserverWorklist<PointerObjectIndex>>
         && (vOnlineCycleDetection || vHybridCycleDetection || vLazyCycleDetection))
     {
       JLM_UNREACHABLE("Can not enable online, hybrid or lazy cycle detection with the topo policy");
@@ -2085,7 +2086,7 @@ PointerObjectConstraintSet::SolveUsingWorklist(
   std::variant<
       typename util::LrfWorklist<PointerObjectIndex> *,
       typename util::TwoPhaseLrfWorklist<PointerObjectIndex> *,
-      typename util::DummyWorklist<PointerObjectIndex> *,
+      typename util::ObserverWorklist<PointerObjectIndex> *,
       typename util::LifoWorklist<PointerObjectIndex> *,
       typename util::FifoWorklist<PointerObjectIndex> *>
       policyVariant;
@@ -2095,7 +2096,7 @@ PointerObjectConstraintSet::SolveUsingWorklist(
   else if (policy == WorklistSolverPolicy::TwoPhaseLeastRecentlyFired)
     policyVariant = (util::TwoPhaseLrfWorklist<PointerObjectIndex> *)nullptr;
   else if (policy == WorklistSolverPolicy::TopologicalSort)
-    policyVariant = (util::DummyWorklist<PointerObjectIndex> *)nullptr;
+    policyVariant = (util::ObserverWorklist<PointerObjectIndex> *)nullptr;
   else if (policy == WorklistSolverPolicy::LastInFirstOut)
     policyVariant = (util::LifoWorklist<PointerObjectIndex> *)nullptr;
   else if (policy == WorklistSolverPolicy::FirstInFirstOut)

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
@@ -785,6 +785,16 @@ public:
     TwoPhaseLeastRecentlyFired,
 
     /**
+     * Not a real worklist policy.
+     * For each "sweep", all nodes are visited in topological order.
+     * Any cycles found during topological sorting are eliminated.
+     * This continues until a full sweep has been done with no attempts at pushing to the worklist.
+     * Described by:
+     *   Pearce 2007: "Efficient field-sensitive pointer analysis of C"
+     */
+    TopologicalSort,
+
+    /**
      * A worklist policy based on a queue.
      * @see jlm::util::FifoWorklist
      */
@@ -824,6 +834,12 @@ public:
      * If Difference Propagation is not enabled, all pointees are always regarded as new.
      */
     size_t NumWorkItemNewPointees{};
+
+    /**
+     * The number of times the topological worklist orders the whole set of work items
+     * and visits them all in topological order.
+     */
+    std::optional<size_t> NumTopologicalWorklistSweeps;
 
     /**
      * The number of cycles detected by online cycle detection,

--- a/jlm/util/Worklist.hpp
+++ b/jlm/util/Worklist.hpp
@@ -45,7 +45,7 @@ public:
    * @return true if there are work items left to be visited
    */
   [[nodiscard]] virtual bool
-  HasMoreWorkItems() = 0;
+  HasMoreWorkItems() const noexcept = 0;
 
   /**
    * Removes one work item from the worklist.
@@ -78,8 +78,8 @@ public:
 
   LifoWorklist() = default;
 
-  bool
-  HasMoreWorkItems() override
+  [[nodiscard]] bool
+  HasMoreWorkItems() const noexcept override
   {
     return !WorkItems_.empty();
   }
@@ -123,8 +123,8 @@ public:
 
   FifoWorklist() = default;
 
-  bool
-  HasMoreWorkItems() override
+  [[nodiscard]] bool
+  HasMoreWorkItems() const noexcept override
   {
     return !WorkItems_.empty();
   }
@@ -173,8 +173,8 @@ public:
 
   LrfWorklist() = default;
 
-  bool
-  HasMoreWorkItems() override
+  [[nodiscard]] bool
+  HasMoreWorkItems() const noexcept override
   {
     return !WorkItems_.empty();
   }
@@ -240,8 +240,8 @@ public:
 
   TwoPhaseLrfWorklist() = default;
 
-  bool
-  HasMoreWorkItems() override
+  [[nodiscard]] bool
+  HasMoreWorkItems() const noexcept override
   {
     return !Current_.empty() || !Next_.empty();
   }
@@ -302,15 +302,15 @@ private:
  * @see Worklist
  */
 template<typename T>
-class DummyWorklist final : public Worklist<T>
+class ObserverWorklist final : public Worklist<T>
 {
 public:
-  ~DummyWorklist() override = default;
+  ~ObserverWorklist() override = default;
 
-  DummyWorklist() = default;
+  ObserverWorklist() = default;
 
-  bool
-  HasMoreWorkItems() override
+  [[nodiscard]] bool
+  HasMoreWorkItems() const noexcept override
   {
     JLM_UNREACHABLE("Dummy worklist");
   }
@@ -332,7 +332,7 @@ public:
    * ResetPush() was called.
    */
   [[nodiscard]] bool
-  HasPushBeenMade()
+  HasPushBeenMade() const noexcept
   {
     return PushMade_;
   }

--- a/jlm/util/Worklist.hpp
+++ b/jlm/util/Worklist.hpp
@@ -294,6 +294,62 @@ private:
   std::unordered_map<T, size_t> LastFire_;
 };
 
+/**
+ * A fake worklist that only holds a single bit of information:
+ *  "Has any item been pushed since the last reset?"
+ * Used to implement the Topological worklist policy, which is not technically a worklist policy
+ * @tparam T the type of the work items.
+ * @see Worklist
+ */
+template<typename T>
+class DummyWorklist final : public Worklist<T>
+{
+public:
+  ~DummyWorklist() override = default;
+
+  DummyWorklist() = default;
+
+  bool
+  HasMoreWorkItems() override
+  {
+    JLM_UNREACHABLE("Dummy worklist");
+  }
+
+  T
+  PopWorkItem() override
+  {
+    JLM_UNREACHABLE("Dummy worklist");
+  }
+
+  void
+  PushWorkItem(T item [[maybe_unused]]) override
+  {
+    PushMade_ = true;
+  }
+
+  /**
+   * @return true if the PushWorkItem method has been called since the last time
+   * ResetPush() was called.
+   */
+  [[nodiscard]] bool
+  HasPushBeenMade()
+  {
+    return PushMade_;
+  }
+
+  /**
+   * Makes the dummy worklist forget about being pushed to.
+   */
+  void
+  ResetPush()
+  {
+    PushMade_ = false;
+  }
+
+private:
+  bool PushMade_ = false;
+};
+
 }
 
 #endif // JLM_UTIL_WORKLIST_HPP

--- a/tests/jlm/util/TestWorklist.cpp
+++ b/tests/jlm/util/TestWorklist.cpp
@@ -133,3 +133,24 @@ TestTwoPhaseLrfWorklist()
 JLM_UNIT_TEST_REGISTER(
     "jlm/llvm/opt/alias-analyses/TestWorklist-TestTwoPhaseLrfWorklist",
     TestTwoPhaseLrfWorklist)
+
+static int
+TestDummyWorklist()
+{
+  jlm::util::DummyWorklist<size_t> wl;
+  assert(!wl.HasPushBeenMade());
+  wl.PushWorkItem(7);
+  assert(wl.HasPushBeenMade());
+  wl.ResetPush();
+  assert(!wl.HasPushBeenMade());
+  wl.ResetPush();
+  assert(!wl.HasPushBeenMade());
+  wl.PushWorkItem(7);
+  assert(wl.HasPushBeenMade());
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER(
+    "jlm/llvm/opt/alias-analyses/TestWorklist-TestDummyWorklist",
+    TestDummyWorklist)

--- a/tests/jlm/util/TestWorklist.cpp
+++ b/tests/jlm/util/TestWorklist.cpp
@@ -135,9 +135,9 @@ JLM_UNIT_TEST_REGISTER(
     TestTwoPhaseLrfWorklist)
 
 static int
-TestDummyWorklist()
+TestObserverWorklist()
 {
-  jlm::util::DummyWorklist<size_t> wl;
+  jlm::util::ObserverWorklist<size_t> wl;
   assert(!wl.HasPushBeenMade());
   wl.PushWorkItem(7);
   assert(wl.HasPushBeenMade());
@@ -152,5 +152,5 @@ TestDummyWorklist()
 }
 
 JLM_UNIT_TEST_REGISTER(
-    "jlm/llvm/opt/alias-analyses/TestWorklist-TestDummyWorklist",
-    TestDummyWorklist)
+    "jlm/llvm/opt/alias-analyses/TestWorklist-TestObserverWorklist",
+    TestObserverWorklist)


### PR DESCRIPTION
Adds the dummy worklist, which only remembers if /anything/ has been pushed.

When given this "worklist", the solver instead performs topological sweeps across all work items.