### PR TITLE
make ClangFormat check HLS, and make it optional to specify CIRCT and MLIR install paths in configure.sh

### DIFF
--- a/.github/actions/BuildJlm/action.yml
+++ b/.github/actions/BuildJlm/action.yml
@@ -62,10 +62,10 @@ runs:
       run: |
         export JLM_CONFIGURE_ARGUMENTS="--target release --enable-asserts"
         if [[ "${{inputs.enable-hls}}" == "true" ]]; then
-          JLM_CONFIGURE_ARGUMENTS="$JLM_CONFIGURE_ARGUMENTS --enable-hls ${{ github.workspace }}/build-circt/circt"
+          JLM_CONFIGURE_ARGUMENTS="$JLM_CONFIGURE_ARGUMENTS --enable-hls=${{ github.workspace }}/build-circt/circt"
         fi
         if [[ "${{inputs.enable-mlir}}" == "true" ]]; then
-          JLM_CONFIGURE_ARGUMENTS="$JLM_CONFIGURE_ARGUMENTS --enable-mlir ${{ github.workspace }}/lib/mlir-rvsdg"
+          JLM_CONFIGURE_ARGUMENTS="$JLM_CONFIGURE_ARGUMENTS --enable-mlir=${{ github.workspace }}/lib/mlir-rvsdg"
         fi
         if [[ "${{inputs.enable-coverage}}" == "true" ]]; then
           JLM_CONFIGURE_ARGUMENTS="$JLM_CONFIGURE_ARGUMENTS --enable-coverage"

--- a/.github/workflows/ClangFormat.yml
+++ b/.github/workflows/ClangFormat.yml
@@ -14,7 +14,10 @@ jobs:
         with:
           install-llvm: true # Needed to configure jlm
           install-clang-format: true
+      - name: "Create fake installation dir for MLIR and HLS"
+        # Formatting does not use this installation dir, but it must still exist
+        run: mkdir -p usr
       - name: "Configure jlm with HLS and MLIR enabled"
-        run: ./configure.sh --enable-mlir /usr --enable-hls /usr
+        run: ./configure.sh --enable-mlir usr --enable-hls usr
       - name: "Check format"
         run: make format-dry-run

--- a/.github/workflows/ClangFormat.yml
+++ b/.github/workflows/ClangFormat.yml
@@ -15,6 +15,6 @@ jobs:
           install-llvm: true # Needed to configure jlm
           install-clang-format: true
       - name: "Configure jlm with HLS and MLIR enabled"
-        run: ./configure.sh --enable-mlir usr --enable-hls usr
+        run: ./configure.sh --enable-mlir /usr --enable-hls /usr
       - name: "Check format"
         run: make format-dry-run

--- a/.github/workflows/ClangFormat.yml
+++ b/.github/workflows/ClangFormat.yml
@@ -14,10 +14,7 @@ jobs:
         with:
           install-llvm: true # Needed to configure jlm
           install-clang-format: true
-      - name: "Create fake installation dir for MLIR and HLS"
-        # Formatting does not use this installation dir, but it must still exist
-        run: mkdir -p usr
       - name: "Configure jlm with HLS and MLIR enabled"
-        run: ./configure.sh --enable-mlir usr --enable-hls usr
+        run: ./configure.sh --enable-mlir --enable-hls
       - name: "Check format"
         run: make format-dry-run

--- a/.github/workflows/ClangFormat.yml
+++ b/.github/workflows/ClangFormat.yml
@@ -15,6 +15,6 @@ jobs:
           install-llvm: true # Needed to configure jlm
           install-clang-format: true
       - name: "Configure jlm with HLS and MLIR enabled"
-        run: ./configure.sh --enable-mlir --enable-hls
+        run: ./configure.sh --enable-mlir usr --enable-hls usr
       - name: "Check format"
         run: make format-dry-run

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ CIRCT and the HLS backend can be setup with the following commands:
 ```
 ./scripts/build-circt.sh --build-path <CIRCT-build-path> --install-path <path-to-CIRCT>
 
-./configure --enable-hls <path-to-CIRCT>
+./configure --enable-hls=<path-to-CIRCT>
 ```
 
 ## Publications

--- a/configure.sh
+++ b/configure.sh
@@ -110,6 +110,13 @@ fi
 CPPFLAGS_CIRCT=""
 CXXFLAGS_NO_COMMENT=""
 if [ "${ENABLE_HLS}" == "yes" ] ; then
+
+	# If HLS is enabled, ensure that CIRCT_PATH is not empty, and a real directory
+	if [ -z "$CIRCT_PATH" ] || [ ! -d "$CIRCT_PATH" ]; then
+		echo "error: the specified CIRCT_PATH does not exist: $CIRCT_PATH"
+	  exit 1
+	fi
+
 	CPPFLAGS_CIRCT="-I${CIRCT_PATH}/include"
 	CXXFLAGS_NO_COMMENT="-Wno-error=comment"
 	CIRCT_LDFLAGS_ARRAY=(
@@ -152,6 +159,13 @@ fi
 
 CPPFLAGS_MLIR=""
 if [ "${ENABLE_MLIR}" == "yes" ] ; then
+
+	# If MLIR is enabled, ensure that MLIR_PATH is not empty, and a real directory
+	if [ -z "$MLIR_PATH" ] || [ ! -d "$MLIR_PATH" ]; then
+		echo "error: the specified MLIR_PATH does not exist: $MLIR_PATH"
+		exit 1
+	fi
+
 	CPPFLAGS_MLIR="-I${MLIR_PATH}/include -DENABLE_MLIR"
 	CXXFLAGS_NO_COMMENT="-Wno-error=comment"
 	MLIR_LDFLAGS="-L${MLIR_PATH}/lib -lMLIRJLM -lMLIRRVSDG -lMLIR"

--- a/configure.sh
+++ b/configure.sh
@@ -114,7 +114,7 @@ if [ "${ENABLE_HLS}" == "yes" ] ; then
 	# If HLS is enabled, ensure that CIRCT_PATH is not empty, and a real directory
 	if [ -z "$CIRCT_PATH" ] || [ ! -d "$CIRCT_PATH" ]; then
 		echo "error: the specified CIRCT_PATH does not exist: $CIRCT_PATH"
-	  exit 1
+		exit 1
 	fi
 
 	CPPFLAGS_CIRCT="-I${CIRCT_PATH}/include"

--- a/jlm/hls/backend/rhls2firrtl/verilator-harness-hls.hpp
+++ b/jlm/hls/backend/rhls2firrtl/verilator-harness-hls.hpp
@@ -30,8 +30,9 @@ public:
    * /param verilogFile The filename to the Verilog file that is to be used together with the
    * generated harness as input to Verilator.
    */
-  VerilatorHarnessHLS(const util::filepath verilogFile)
-      : VerilogFile_(std::move(verilogFile)){};
+  explicit VerilatorHarnessHLS(util::filepath verilogFile)
+      : VerilogFile_(std::move(verilogFile))
+  {}
 
 private:
   const util::filepath VerilogFile_;


### PR DESCRIPTION
This PR started as a fix of formatting that changed with clang-format 18. I also noticed that the constructor had an unnecessary `const`, so I fixed that.

Looking into why this was not caught by the ClangFormat workflow, I saw that the `configure.sh` script's `--enable-mlir` "consumed" the `--enable-hls`, causing hls to not be enabled, which affects the set of files found by `make format-dry-run`.

In an attempt to make this not happen in the future, I made `configure.sh` complain and fail if the path you pass to `--enable-mlir` or `--enable-hls` is not a folder that exists. This forces the user to set up the folder first, but it should be helpful in preventing this type of mistake.

Formatting is a bit of a special case, as we want to "enable" hls and mlir without needing to install either, so I passed in `/usr` as the path, since that is a folder we know exists.