### PR TITLE
Add EntryArgument for HLS loop

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/dae-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/dae-conv.cpp
@@ -248,7 +248,7 @@ decouple_load(
             auto new_in =
                 jlm::rvsdg::structural_input::create(new_loop, arg->input()->origin(), arg->Type());
             smap.insert(arg->input(), new_in);
-            new_arg = jlm::rvsdg::argument::create(new_loop->subregion(), new_in, arg->Type());
+            new_arg = &EntryArgument::Create(*new_loop->subregion(), *new_in, arg->Type());
           }
           smap.insert(arg, new_arg);
           continue;
@@ -364,9 +364,9 @@ decouple_load(
   auto buf = buffer_op::create(*dload_out[0], 2, true)[0];
   // replace data output of loadNode
   auto old_data_in = jlm::rvsdg::structural_input::create(loopNode, buf, dload_out[0]->Type());
-  auto old_data_arg =
-      jlm::rvsdg::argument::create(loopNode->subregion(), old_data_in, dload_out[0]->Type());
-  loadNode->output(0)->divert_users(old_data_arg);
+  auto & old_data_arg =
+      EntryArgument::Create(*loopNode->subregion(), *old_data_in, dload_out[0]->Type());
+  loadNode->output(0)->divert_users(&old_data_arg);
   remove(loadNode);
 }
 

--- a/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
@@ -31,8 +31,8 @@ jlm::hls::route_response(jlm::rvsdg::region * target, jlm::rvsdg::output * respo
     auto ln = dynamic_cast<jlm::hls::loop_node *>(target->node());
     JLM_ASSERT(ln);
     auto input = jlm::rvsdg::structural_input::create(ln, parent_response, parent_response->Type());
-    auto argument = jlm::rvsdg::argument::create(target, input, response->Type());
-    return argument;
+    auto & argument = EntryArgument::Create(*target, *input, response->Type());
+    return &argument;
   }
 }
 

--- a/jlm/hls/ir/hls.hpp
+++ b/jlm/hls/ir/hls.hpp
@@ -607,6 +607,42 @@ class backedge_argument;
 class backedge_result;
 class loop_node;
 
+/**
+ * Represents the entry argument for the HLS loop.
+ */
+class EntryArgument : public rvsdg::argument
+{
+  friend loop_node;
+
+public:
+  ~EntryArgument() noexcept override;
+
+private:
+  EntryArgument(
+      rvsdg::region & region,
+      rvsdg::structural_input & input,
+      const std::shared_ptr<const rvsdg::type> type)
+      : rvsdg::argument(&region, &input, std::move(type))
+  {}
+
+public:
+  EntryArgument &
+  Copy(rvsdg::region & region, rvsdg::structural_input * input) override;
+
+  // FIXME: This should not be public, but we currently still have some transformations that use
+  // this one. Make it eventually private.
+  static EntryArgument &
+  Create(
+      rvsdg::region & region,
+      rvsdg::structural_input & input,
+      const std::shared_ptr<const rvsdg::type> type)
+  {
+    auto argument = new EntryArgument(region, input, std::move(type));
+    region.append_argument(argument);
+    return *argument;
+  }
+};
+
 class backedge_argument : public jlm::rvsdg::argument
 {
   friend loop_node;


### PR DESCRIPTION
This PR adds an argument subclass for the entry arguments of the HLS loop. This is necessary in order to make the `rvsdg::argument` class abstract.