### PR TITLE
Make argument class abstract

### DIFF
--- a/jlm/rvsdg/region.cpp
+++ b/jlm/rvsdg/region.cpp
@@ -43,23 +43,6 @@ argument::argument(
   }
 }
 
-argument &
-argument::Copy(rvsdg::region & region, structural_input * input)
-{
-  return *argument::create(&region, input, Type());
-}
-
-jlm::rvsdg::argument *
-argument::create(
-    jlm::rvsdg::region * region,
-    structural_input * input,
-    std::shared_ptr<const jlm::rvsdg::type> type)
-{
-  auto argument = new jlm::rvsdg::argument(region, input, std::move(type));
-  region->append_argument(argument);
-  return argument;
-}
-
 result::~result() noexcept
 {
   on_input_destroy(this);

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -31,23 +31,31 @@ class structural_op;
 class structural_output;
 class substitution_map;
 
+/**
+ * \brief Represents the argument of a region.
+ *
+ * Region arguments represent the initial values of the region's acyclic graph. These values
+ * are mapped to the arguments throughout the execution, and the concrete semantics of this mapping
+ * depends on the structural node the region is part of. A region argument is either linked
+ * with a \ref structural_input or is a standalone argument.
+ */
 class argument : public output
 {
-  jlm::util::intrusive_list_anchor<jlm::rvsdg::argument> structural_input_anchor_;
+  util::intrusive_list_anchor<argument> structural_input_anchor_;
 
 public:
-  typedef jlm::util::
-      intrusive_list_accessor<jlm::rvsdg::argument, &jlm::rvsdg::argument::structural_input_anchor_>
-          structural_input_accessor;
+  typedef util::intrusive_list_accessor<argument, &argument::structural_input_anchor_>
+      structural_input_accessor;
 
-  virtual ~argument() noexcept;
+  ~argument() noexcept override;
 
 protected:
   argument(
-      jlm::rvsdg::region * region,
-      jlm::rvsdg::structural_input * input,
+      rvsdg::region * region,
+      structural_input * input,
       std::shared_ptr<const rvsdg::type> type);
 
+public:
   argument(const argument &) = delete;
 
   argument(argument &&) = delete;
@@ -58,8 +66,7 @@ protected:
   argument &
   operator=(argument &&) = delete;
 
-public:
-  inline jlm::rvsdg::structural_input *
+  [[nodiscard]] structural_input *
   input() const noexcept
   {
     return input_;
@@ -72,21 +79,12 @@ public:
    * @param input  The structural_input to the argument, if any.
    *
    * @return A reference to the copied argument.
-   *
-   * FIXME: This method should be made abstract once we enforced that no instances of argument
-   * itself can be created any longer.
    */
   virtual argument &
-  Copy(rvsdg::region & region, structural_input * input);
-
-  static jlm::rvsdg::argument *
-  create(
-      jlm::rvsdg::region * region,
-      structural_input * input,
-      std::shared_ptr<const jlm::rvsdg::type> type);
+  Copy(rvsdg::region & region, structural_input * input) = 0;
 
 private:
-  jlm::rvsdg::structural_input * input_;
+  structural_input * input_;
 };
 
 class result : public input

--- a/tests/jlm/rvsdg/ArgumentTests.cpp
+++ b/tests/jlm/rvsdg/ArgumentTests.cpp
@@ -16,6 +16,7 @@ static int
 ArgumentNodeMismatch()
 {
   using namespace jlm::rvsdg;
+  using namespace jlm::tests;
 
   // Arrange
   auto valueType = jlm::tests::valuetype::Create();
@@ -32,7 +33,7 @@ ArgumentNodeMismatch()
   bool inputErrorHandlerCalled = false;
   try
   {
-    argument::create(structuralNode2->subregion(0), structuralInput, valueType);
+    TestGraphArgument::Create(*structuralNode2->subregion(0), structuralInput, valueType);
   }
   catch (jlm::util::error & e)
   {
@@ -67,7 +68,7 @@ ArgumentInputTypeMismatch()
   bool exceptionWasCaught = false;
   try
   {
-    jlm::rvsdg::argument::create(structuralNode->subregion(0), structuralInput, stateType);
+    TestGraphArgument::Create(*structuralNode->subregion(0), structuralInput, stateType);
     // The line below should not be executed as the line above is expected to throw an exception.
     assert(false);
   }
@@ -80,7 +81,7 @@ ArgumentInputTypeMismatch()
   exceptionWasCaught = false;
   try
   {
-    jlm::rvsdg::argument::create(structuralNode->subregion(0), structuralInput, stateType);
+    TestGraphArgument::Create(*structuralNode->subregion(0), structuralInput, stateType);
     // The line below should not be executed as the line above is expected to throw an exception.
     assert(false);
   }

--- a/tests/jlm/rvsdg/RegionTests.cpp
+++ b/tests/jlm/rvsdg/RegionTests.cpp
@@ -28,15 +28,15 @@ Contains()
 
   auto structuralNode1 = structural_node::create(graph.root(), 1);
   auto structuralInput1 = jlm::rvsdg::structural_input::create(structuralNode1, import, valueType);
-  auto regionArgument1 =
-      jlm::rvsdg::argument::create(structuralNode1->subregion(0), structuralInput1, valueType);
-  unary_op::create(structuralNode1->subregion(0), valueType, regionArgument1, valueType);
+  auto & regionArgument1 =
+      TestGraphArgument::Create(*structuralNode1->subregion(0), structuralInput1, valueType);
+  unary_op::create(structuralNode1->subregion(0), valueType, &regionArgument1, valueType);
 
   auto structuralNode2 = structural_node::create(graph.root(), 1);
   auto structuralInput2 = jlm::rvsdg::structural_input::create(structuralNode2, import, valueType);
-  auto regionArgument2 =
-      jlm::rvsdg::argument::create(structuralNode2->subregion(0), structuralInput2, valueType);
-  binary_op::create(valueType, valueType, regionArgument2, regionArgument2);
+  auto & regionArgument2 =
+      TestGraphArgument::Create(*structuralNode2->subregion(0), structuralInput2, valueType);
+  binary_op::create(valueType, valueType, &regionArgument2, &regionArgument2);
 
   // Act & Assert
   assert(jlm::rvsdg::region::Contains<structural_op>(*graph.root(), false));
@@ -169,22 +169,24 @@ JLM_UNIT_TEST_REGISTER("jlm/rvsdg/RegionTests-RemoveResultsWhere", RemoveResults
 static int
 RemoveArgumentsWhere()
 {
+  using namespace jlm::tests;
+
   // Arrange
   jlm::rvsdg::graph rvsdg;
   jlm::rvsdg::region region(rvsdg.root(), &rvsdg);
 
   auto valueType = jlm::tests::valuetype::Create();
-  auto argument0 = jlm::rvsdg::argument::create(&region, nullptr, valueType);
-  auto argument1 = jlm::rvsdg::argument::create(&region, nullptr, valueType);
-  auto argument2 = jlm::rvsdg::argument::create(&region, nullptr, valueType);
+  auto & argument0 = TestGraphArgument::Create(region, nullptr, valueType);
+  auto & argument1 = TestGraphArgument::Create(region, nullptr, valueType);
+  auto & argument2 = TestGraphArgument::Create(region, nullptr, valueType);
 
-  auto node = jlm::tests::test_op::Create(&region, { valueType }, { argument1 }, { valueType });
+  auto node = jlm::tests::test_op::Create(&region, { valueType }, { &argument1 }, { valueType });
 
   // Act & Arrange
   assert(region.narguments() == 3);
-  assert(argument0->index() == 0);
-  assert(argument1->index() == 1);
-  assert(argument2->index() == 2);
+  assert(argument0.index() == 0);
+  assert(argument1.index() == 1);
+  assert(argument2.index() == 2);
 
   region.RemoveArgumentsWhere(
       [](const jlm::rvsdg::argument & argument)
@@ -192,7 +194,7 @@ RemoveArgumentsWhere()
         return true;
       });
   assert(region.narguments() == 1);
-  assert(argument1->index() == 0);
+  assert(argument1.index() == 0);
 
   region.remove_node(node);
   region.RemoveArgumentsWhere(
@@ -201,7 +203,7 @@ RemoveArgumentsWhere()
         return false;
       });
   assert(region.narguments() == 1);
-  assert(argument1->index() == 0);
+  assert(argument1.index() == 0);
 
   region.RemoveArgumentsWhere(
       [](const jlm::rvsdg::argument & argument)
@@ -221,19 +223,21 @@ JLM_UNIT_TEST_REGISTER("jlm/rvsdg/RegionTests-RemoveArgumentsWhere", RemoveArgum
 static int
 PruneArguments()
 {
+  using namespace jlm::tests;
+
   // Arrange
   jlm::rvsdg::graph rvsdg;
   jlm::rvsdg::region region(rvsdg.root(), &rvsdg);
 
   auto valueType = jlm::tests::valuetype::Create();
-  auto argument0 = jlm::rvsdg::argument::create(&region, nullptr, valueType);
-  jlm::rvsdg::argument::create(&region, nullptr, valueType);
-  auto argument2 = jlm::rvsdg::argument::create(&region, nullptr, valueType);
+  auto & argument0 = TestGraphArgument::Create(region, nullptr, valueType);
+  TestGraphArgument::Create(region, nullptr, valueType);
+  auto & argument2 = TestGraphArgument::Create(region, nullptr, valueType);
 
   auto node = jlm::tests::test_op::Create(
       &region,
       { valueType, valueType },
-      { argument0, argument2 },
+      { &argument0, &argument2 },
       { valueType });
 
   // Act & Arrange
@@ -241,8 +245,8 @@ PruneArguments()
 
   region.PruneArguments();
   assert(region.narguments() == 2);
-  assert(argument0->index() == 0);
-  assert(argument2->index() == 1);
+  assert(argument0.index() == 0);
+  assert(argument2.index() == 1);
 
   region.remove_node(node);
   region.PruneArguments();

--- a/tests/jlm/rvsdg/ResultTests.cpp
+++ b/tests/jlm/rvsdg/ResultTests.cpp
@@ -16,6 +16,7 @@ static int
 ResultNodeMismatch()
 {
   using namespace jlm::rvsdg;
+  using namespace jlm::tests;
 
   // Arrange
   auto valueType = jlm::tests::valuetype::Create();
@@ -28,14 +29,15 @@ ResultNodeMismatch()
 
   auto structuralInput = structural_input::create(structuralNode1, import, valueType);
 
-  auto argument = argument::create(structuralNode1->subregion(0), structuralInput, valueType);
+  auto & argument =
+      TestGraphArgument::Create(*structuralNode1->subregion(0), structuralInput, valueType);
   auto structuralOutput = structural_output::create(structuralNode1, valueType);
 
   // Act
   bool outputErrorHandlerCalled = false;
   try
   {
-    result::create(structuralNode2->subregion(0), argument, structuralOutput, valueType);
+    result::create(structuralNode2->subregion(0), &argument, structuralOutput, valueType);
   }
   catch (jlm::util::error & e)
   {

--- a/tests/jlm/rvsdg/test-graph.cpp
+++ b/tests/jlm/rvsdg/test-graph.cpp
@@ -29,6 +29,7 @@ static int
 test_recursive_prune()
 {
   using namespace jlm::rvsdg;
+  using namespace jlm::tests;
 
   auto t = jlm::tests::valuetype::Create();
 
@@ -40,9 +41,9 @@ test_recursive_prune()
 
   auto n3 = jlm::tests::structural_node::create(graph.root(), 1);
   structural_input::create(n3, imp, t);
-  auto a1 = argument::create(n3->subregion(0), nullptr, t);
-  auto n4 = jlm::tests::test_op::create(n3->subregion(0), { a1 }, { t });
-  auto n5 = jlm::tests::test_op::create(n3->subregion(0), { a1 }, { t });
+  auto & a1 = TestGraphArgument::Create(*n3->subregion(0), nullptr, t);
+  auto n4 = jlm::tests::test_op::create(n3->subregion(0), { &a1 }, { t });
+  auto n5 = jlm::tests::test_op::create(n3->subregion(0), { &a1 }, { t });
   result::create(n3->subregion(0), n4->output(0), nullptr, t);
   auto o1 = structural_output::create(n3, t);
 
@@ -146,7 +147,7 @@ Copy()
   auto valueType = jlm::tests::valuetype::Create();
 
   jlm::rvsdg::graph graph;
-  auto & argument = TestGraphArgument::Create(*graph.root(), valueType);
+  auto & argument = TestGraphArgument::Create(*graph.root(), nullptr, valueType);
   auto node = test_op::create(graph.root(), { &argument }, { valueType });
   TestGraphResult::Create(*node->output(0));
 

--- a/tests/jlm/rvsdg/test-nodes.cpp
+++ b/tests/jlm/rvsdg/test-nodes.cpp
@@ -13,6 +13,7 @@ static void
 test_node_copy(void)
 {
   using namespace jlm::rvsdg;
+  using namespace jlm::tests;
 
   auto stype = jlm::tests::statetype::Create();
   auto vtype = jlm::tests::valuetype::Create();
@@ -27,11 +28,11 @@ test_node_copy(void)
   auto o1 = structural_output::create(n1, stype);
   auto o2 = structural_output::create(n1, vtype);
 
-  auto a1 = argument::create(n1->subregion(0), i1, stype);
-  auto a2 = argument::create(n1->subregion(0), i2, vtype);
+  auto & a1 = TestGraphArgument::Create(*n1->subregion(0), i1, stype);
+  auto & a2 = TestGraphArgument::Create(*n1->subregion(0), i2, vtype);
 
-  auto n2 = jlm::tests::test_op::create(n1->subregion(0), { a1 }, { stype });
-  auto n3 = jlm::tests::test_op::create(n1->subregion(0), { a2 }, { vtype });
+  auto n2 = jlm::tests::test_op::create(n1->subregion(0), { &a1 }, { stype });
+  auto n3 = jlm::tests::test_op::create(n1->subregion(0), { &a2 }, { vtype });
 
   result::create(n1->subregion(0), n2->output(0), o1, stype);
   result::create(n1->subregion(0), n3->output(0), o2, vtype);
@@ -61,10 +62,10 @@ test_node_copy(void)
 
   /* copy second into third region only with arguments */
   jlm::rvsdg::substitution_map smap2;
-  auto a3 = argument::create(n1->subregion(2), i1, stype);
-  auto a4 = argument::create(n1->subregion(2), i2, vtype);
-  smap2.insert(r2->argument(0), a3);
-  smap2.insert(r2->argument(1), a4);
+  auto & a3 = TestGraphArgument::Create(*n1->subregion(2), i1, stype);
+  auto & a4 = TestGraphArgument::Create(*n1->subregion(2), i2, vtype);
+  smap2.insert(r2->argument(0), &a3);
+  smap2.insert(r2->argument(1), &a4);
 
   smap2.insert(o1, o1);
   smap2.insert(o2, o2);

--- a/tests/test-operation.hpp
+++ b/tests/test-operation.hpp
@@ -347,22 +347,27 @@ create_testop(
 class TestGraphArgument final : public jlm::rvsdg::argument
 {
 private:
-  TestGraphArgument(jlm::rvsdg::region & region, std::shared_ptr<const jlm::rvsdg::type> type)
-      : jlm::rvsdg::argument(&region, nullptr, type)
+  TestGraphArgument(
+      jlm::rvsdg::region & region,
+      jlm::rvsdg::structural_input * input,
+      std::shared_ptr<const jlm::rvsdg::type> type)
+      : jlm::rvsdg::argument(&region, input, type)
   {}
 
 public:
   TestGraphArgument &
   Copy(jlm::rvsdg::region & region, jlm::rvsdg::structural_input * input) override
   {
-    JLM_ASSERT(input == nullptr);
-    return Create(region, Type());
+    return Create(region, input, Type());
   }
 
   static TestGraphArgument &
-  Create(jlm::rvsdg::region & region, std::shared_ptr<const jlm::rvsdg::type> type)
+  Create(
+      jlm::rvsdg::region & region,
+      jlm::rvsdg::structural_input * input,
+      std::shared_ptr<const jlm::rvsdg::type> type)
   {
-    auto graphArgument = new TestGraphArgument(region, std::move(type));
+    auto graphArgument = new TestGraphArgument(region, input, std::move(type));
     region.append_argument(graphArgument);
     return *graphArgument;
   }


### PR DESCRIPTION
1. Replaces all usages of `argument::create()` with `TestGraphArgument::Create()` in the unit tests.
2. Makes the argument class abstract
3. Minor clean ups in the argument class
4. Add documentation to argument class