### PR TITLE
Add ExitResult for HLS loop

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/dae-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/dae-conv.cpp
@@ -297,11 +297,7 @@ decouple_load(
       auto new_res_origin = smap.lookup(res->origin());
       auto new_state_output =
           jlm::rvsdg::structural_output::create(new_loop, new_res_origin->Type());
-      jlm::rvsdg::result::create(
-          new_loop->subregion(),
-          new_res_origin,
-          new_state_output,
-          new_res_origin->Type());
+      ExitResult::Create(*new_res_origin, *new_state_output);
       res->output()->divert_users(new_state_output);
     }
   }
@@ -333,7 +329,7 @@ decouple_load(
   // create output for address
   auto load_addr = gate_out[0];
   auto addr_output = jlm::rvsdg::structural_output::create(new_loop, load_addr->Type());
-  jlm::rvsdg::result::create(new_loop->subregion(), load_addr, addr_output, load_addr->Type());
+  ExitResult::Create(*load_addr, *addr_output);
   // trace and remove loop input for mem data reponse
   auto mem_data_loop_out = new_load->input(new_load->ninputs() - 1)->origin();
   auto mem_data_loop_arg = dynamic_cast<jlm::rvsdg::argument *>(mem_data_loop_out);

--- a/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
@@ -48,7 +48,7 @@ jlm::hls::route_request(jlm::rvsdg::region * target, jlm::rvsdg::output * reques
     auto ln = dynamic_cast<jlm::hls::loop_node *>(request->region()->node());
     JLM_ASSERT(ln);
     auto output = jlm::rvsdg::structural_output::create(ln, request->Type());
-    jlm::rvsdg::result::create(request->region(), request, output, request->Type());
+    ExitResult::Create(*request, *output);
     return route_request(target, output);
   }
 }

--- a/jlm/hls/ir/hls.cpp
+++ b/jlm/hls/ir/hls.cpp
@@ -81,7 +81,7 @@ loop_node::add_loopvar(jlm::rvsdg::output * origin, jlm::rvsdg::output ** buffer
   {
     *buffer = mux;
   }
-  jlm::rvsdg::result::create(subregion(), branch[0], output, origin->Type());
+  ExitResult::Create(*branch[0], *output);
   auto result_loop = argument_loop->result();
   auto buf = hls::buffer_op::create(*branch[1], 2)[0];
   result_loop->divert_to(buf);
@@ -148,7 +148,7 @@ loop_node::copy(jlm::rvsdg::region * region, jlm::rvsdg::substitution_map & smap
     auto outp = output(i);
     auto res = outp->results.begin().ptr();
     auto origin = smap.lookup(res->origin());
-    jlm::rvsdg::result::create(loop->subregion(), origin, loop->output(i), res->Type());
+    ExitResult::Create(*origin, *loop->output(i));
   }
   nf->set_mutable(true);
   return loop;

--- a/jlm/hls/ir/hls.cpp
+++ b/jlm/hls/ir/hls.cpp
@@ -57,6 +57,14 @@ backedge_result::Copy(rvsdg::output & origin, jlm::rvsdg::structural_output * ou
   return *backedge_result::create(&origin);
 }
 
+ExitResult::~ExitResult() noexcept = default;
+
+ExitResult &
+ExitResult::Copy(rvsdg::output & origin, rvsdg::structural_output * output)
+{
+  return Create(origin, *output);
+}
+
 jlm::rvsdg::structural_output *
 loop_node::add_loopvar(jlm::rvsdg::output * origin, jlm::rvsdg::output ** buffer)
 {

--- a/jlm/hls/ir/hls.hpp
+++ b/jlm/hls/ir/hls.hpp
@@ -723,9 +723,6 @@ class ExitResult final : public rvsdg::result
 public:
   ~ExitResult() noexcept override;
 
-  ExitResult &
-  Copy(rvsdg::output & origin, rvsdg::structural_output * output) override;
-
 private:
   ExitResult(rvsdg::output & origin, rvsdg::structural_output & output)
       : rvsdg::result(origin.region(), &origin, &output, origin.Type())
@@ -733,6 +730,12 @@ private:
     JLM_ASSERT(rvsdg::is<loop_op>(origin.region()->node()));
   }
 
+public:
+  ExitResult &
+  Copy(rvsdg::output & origin, rvsdg::structural_output * output) override;
+
+  // FIXME: This should not be public, but we currently still have some transformations that use
+  // this one. Make it eventually private.
   static ExitResult &
   Create(rvsdg::output & origin, rvsdg::structural_output & output)
   {

--- a/jlm/hls/ir/hls.hpp
+++ b/jlm/hls/ir/hls.hpp
@@ -714,7 +714,7 @@ private:
 };
 
 /**
- * Represents the exit argument for the HLS loop.
+ * Represents the exit result of the HLS loop.
  */
 class ExitResult final : public rvsdg::result
 {

--- a/jlm/hls/ir/hls.hpp
+++ b/jlm/hls/ir/hls.hpp
@@ -713,6 +713,35 @@ private:
   backedge_argument * argument_;
 };
 
+/**
+ * Represents the exit argument for the HLS loop.
+ */
+class ExitResult final : public rvsdg::result
+{
+  friend loop_node;
+
+public:
+  ~ExitResult() noexcept override;
+
+  ExitResult &
+  Copy(rvsdg::output & origin, rvsdg::structural_output * output) override;
+
+private:
+  ExitResult(rvsdg::output & origin, rvsdg::structural_output & output)
+      : rvsdg::result(origin.region(), &origin, &output, origin.Type())
+  {
+    JLM_ASSERT(rvsdg::is<loop_op>(origin.region()->node()));
+  }
+
+  static ExitResult &
+  Create(rvsdg::output & origin, rvsdg::structural_output & output)
+  {
+    auto result = new ExitResult(origin, output);
+    origin.region()->append_result(result);
+    return *result;
+  }
+};
+
 class loop_node final : public jlm::rvsdg::structural_node
 {
 public:


### PR DESCRIPTION
1. Add the ExitResult class for representing result values before the HLS loop terminates
2. Replaces respective `result::create()` with `ExitResult::Create()` usages