### PR TITLE
Add jlm-opt support for RVSDG tree annotations

### DIFF
--- a/jlm/llvm/opt/RvsdgTreePrinter.cpp
+++ b/jlm/llvm/opt/RvsdgTreePrinter.cpp
@@ -142,8 +142,7 @@ RvsdgTreePrinter::GetOutputFileNameCounter(const RvsdgModule & rvsdgModule)
 {
   static std::unordered_map<std::string_view, uint64_t> RvsdgModuleCounterMap_;
 
-  auto key = util::strfmt(&rvsdgModule, rvsdgModule.SourceFileName().to_str());
-  return RvsdgModuleCounterMap_[key]++;
+  return RvsdgModuleCounterMap_[rvsdgModule.SourceFileName().to_str()]++;
 }
 
 }

--- a/jlm/llvm/opt/RvsdgTreePrinter.cpp
+++ b/jlm/llvm/opt/RvsdgTreePrinter.cpp
@@ -140,9 +140,10 @@ RvsdgTreePrinter::CreateOutputFile(const RvsdgModule & rvsdgModule) const
 uint64_t
 RvsdgTreePrinter::GetOutputFileNameCounter(const RvsdgModule & rvsdgModule)
 {
-  static std::unordered_map<const RvsdgModule *, uint64_t> RvsdgModuleCounterMap_;
+  static std::unordered_map<std::string_view, uint64_t> RvsdgModuleCounterMap_;
 
-  return RvsdgModuleCounterMap_[&rvsdgModule]++;
+  auto key = util::strfmt(&rvsdgModule, rvsdgModule.SourceFileName().to_str());
+  return RvsdgModuleCounterMap_[key]++;
 }
 
 }

--- a/jlm/llvm/opt/RvsdgTreePrinter.hpp
+++ b/jlm/llvm/opt/RvsdgTreePrinter.hpp
@@ -116,7 +116,7 @@ public:
 
 private:
   /**
-   * Computes a map with annotations based on the required \ref Annotation%s in the \ref
+   * Computes a map with annotations based on the required \ref jlm::util::Annotation%s in the \ref
    * Configuration for the individual regions and structural nodes of the region tree.
    *
    * @param rvsdg The RVSDG for which to compute the annotations.

--- a/jlm/llvm/opt/RvsdgTreePrinter.hpp
+++ b/jlm/llvm/opt/RvsdgTreePrinter.hpp
@@ -115,9 +115,25 @@ public:
   run(RvsdgModule & rvsdgModule);
 
 private:
+  /**
+   * Computes a map with annotations based on the required \ref Annotation%s in the \ref
+   * Configuration for the individual regions and structural nodes of the region tree.
+   *
+   * @param rvsdg The RVSDG for which to compute the annotations.
+   * @return An instance of \ref AnnotationMap.
+   */
   [[nodiscard]] util::AnnotationMap
   ComputeAnnotationMap(const rvsdg::graph & rvsdg) const;
 
+  /**
+   * Adds an annotation to \p annotationMap that indicates the number of RVSDG nodes for regions
+   * and structural nodes.
+   *
+   * @param rvsdg The RVSDG for which to compute the annotation.
+   * @param annotationMap The annotation map in which the annotation is inserted.
+   *
+   * @see NumRvsdgNodes
+   */
   static void
   AnnotateNumRvsdgNodes(const rvsdg::graph & rvsdg, util::AnnotationMap & annotationMap);
 

--- a/jlm/tooling/CommandGraphGenerator.cpp
+++ b/jlm/tooling/CommandGraphGenerator.cpp
@@ -142,7 +142,7 @@ JlcCommandGraphGenerator::GenerateCommandGraph(const JlcCommandLineOptions & com
           CreateJlmOptCommandOutputFile(compilation.InputFile()),
           JlmOptCommandLineOptions::OutputFormat::Llvm,
           statisticsCollectorSettings,
-          jlm::llvm::RvsdgTreePrinter::Configuration(tempDirectory),
+          jlm::llvm::RvsdgTreePrinter::Configuration(tempDirectory, {}),
           commandLineOptions.JlmOptOptimizations_);
 
       auto & jlmOptCommandNode =

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -939,6 +939,15 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, const char * const 
               "Loop Unrolling")),
       cl::desc("Perform optimization"));
 
+  cl::list<llvm::RvsdgTreePrinter::Configuration::Annotation> rvsdgTreePrinterAnnotations(
+      "annotations",
+      cl::values(::clEnumValN(
+          llvm::RvsdgTreePrinter::Configuration::Annotation::NumRvsdgNodes,
+          "NumRvsdgNodes",
+          "Annotate number of RVSDG nodes")),
+      cl::CommaSeparated,
+      cl::desc("Comma separated list of RVSDG tree printer annotations"));
+
   cl::ParseCommandLineOptions(argc, argv);
 
   jlm::util::filepath statisticsDirectoryFilePath(statisticDirectory);
@@ -961,13 +970,18 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, const char * const 
       statisticsFilePath,
       demandedStatistics);
 
+  util::HashSet<llvm::RvsdgTreePrinter::Configuration::Annotation> demandedAnnotations(
+      { rvsdgTreePrinterAnnotations.begin(), rvsdgTreePrinterAnnotations.end() });
+
   CommandLineOptions_ = JlmOptCommandLineOptions::Create(
       std::move(inputFilePath),
       inputFormat,
       outputFile,
       outputFormat,
       std::move(statisticsCollectorSettings),
-      llvm::RvsdgTreePrinter::Configuration(statisticsDirectoryFilePath),
+      llvm::RvsdgTreePrinter::Configuration(
+          statisticsDirectoryFilePath,
+          std::move(demandedAnnotations)),
       std::move(optimizationIds));
 
   return *CommandLineOptions_;

--- a/tests/jlm/tooling/TestJlmOptCommand.cpp
+++ b/tests/jlm/tooling/TestJlmOptCommand.cpp
@@ -32,7 +32,7 @@ TestStatistics()
       jlm::util::filepath("outputFile.ll"),
       JlmOptCommandLineOptions::OutputFormat::Llvm,
       statisticsCollectorSettings,
-      RvsdgTreePrinter::Configuration(filepath(std::filesystem::temp_directory_path())),
+      RvsdgTreePrinter::Configuration({ std::filesystem::temp_directory_path() }, {}),
       { JlmOptCommandLineOptions::OptimizationId::DeadNodeElimination,
         JlmOptCommandLineOptions::OptimizationId::LoopUnrolling });
 

--- a/tests/jlm/tooling/TestJlmOptCommandLineParser.cpp
+++ b/tests/jlm/tooling/TestJlmOptCommandLineParser.cpp
@@ -75,7 +75,7 @@ TestOptimizationIdToOptimizationTranslation()
       filepath(""),
       JlmOptCommandLineOptions::OutputFormat::Llvm,
       StatisticsCollectorSettings(),
-      jlm::llvm::RvsdgTreePrinter::Configuration(filepath(std::filesystem::temp_directory_path())),
+      jlm::llvm::RvsdgTreePrinter::Configuration({ std::filesystem::temp_directory_path() }, {}),
       std::vector<JlmOptCommandLineOptions::OptimizationId>());
 
   // Act & Assert


### PR DESCRIPTION
This PR does the following:
1. Adds support for annotating the number of RVSDG nodes to the RVSDG tree in the RvsdgTreePrinter pass.
2. Adds support for controlling the annotations from jlm-opt
3. Adds a unit test for the printing of the introduced annotation

Usage: `jlm-opt --RvsdgTreePrinter -s /tmp --annotations=NumRvsdgNodes input.ll`

Example output:
```
RootRegion NumRvsdgNodes:2
-STRUCTURAL_TEST_NODE NumRvsdgNodes:2
--Region[0] NumRvsdgNodes:1
--Region[1] NumRvsdgNodes:1
```
