### PR TITLE
Make result class abstract

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/UnusedStateRemoval.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/UnusedStateRemoval.cpp
@@ -109,12 +109,9 @@ RemoveUnusedStatesFromLambda(llvm::lambda::node & lambdaNode)
 
   JLM_ASSERT(lambdaNode.output()->nusers() == 1);
   lambdaNode.region()->RemoveResult((*lambdaNode.output()->begin())->index());
+  auto oldExport = lambdaNode.ComputeCallSummary()->GetRvsdgExport();
+  jlm::llvm::GraphExport::Create(*newLambdaOutput, oldExport ? oldExport->Name() : "");
   remove(&lambdaNode);
-  jlm::rvsdg::result::create(
-      newLambda->region(),
-      newLambdaOutput,
-      nullptr,
-      newLambdaOutput->Type());
 }
 
 static void

--- a/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
@@ -77,7 +77,8 @@ add_lambda_argument(llvm::lambda::node * ln, std::shared_ptr<const jlm::rvsdg::t
 
   //            ln->output()->divert_users(new_out);
   ln->region()->RemoveResult((*ln->output()->begin())->index());
-  jlm::llvm::GraphExport::Create(*new_out, ln->ComputeCallSummary()->GetRvsdgExport()->Name());
+  auto oldExport = ln->ComputeCallSummary()->GetRvsdgExport();
+  jlm::llvm::GraphExport::Create(*new_out, oldExport ? oldExport->Name() : "");
   remove(ln);
   return new_lambda;
 }

--- a/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
@@ -77,8 +77,8 @@ add_lambda_argument(llvm::lambda::node * ln, std::shared_ptr<const jlm::rvsdg::t
 
   //            ln->output()->divert_users(new_out);
   ln->region()->RemoveResult((*ln->output()->begin())->index());
+  jlm::llvm::GraphExport::Create(*new_out, ln->ComputeCallSummary()->GetRvsdgExport()->Name());
   remove(ln);
-  jlm::rvsdg::result::create(new_lambda->region(), new_out, nullptr, new_out->Type());
   return new_lambda;
 }
 

--- a/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
@@ -693,7 +693,7 @@ jlm::hls::MemoryConverter(jlm::llvm::RvsdgModule & rm)
   }
   originalResults.insert(originalResults.end(), newResults.begin(), newResults.end());
   auto newOut = newLambda->finalize(originalResults);
-  jlm::rvsdg::result::create(newLambda->region(), newOut, nullptr, newOut->Type());
+  llvm::GraphExport::Create(*newOut, lambda->ComputeCallSummary()->GetRvsdgExport()->Name());
 
   JLM_ASSERT(lambda->output()->nusers() == 1);
   lambda->region()->RemoveResult((*lambda->output()->begin())->index());

--- a/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
@@ -693,7 +693,8 @@ jlm::hls::MemoryConverter(jlm::llvm::RvsdgModule & rm)
   }
   originalResults.insert(originalResults.end(), newResults.begin(), newResults.end());
   auto newOut = newLambda->finalize(originalResults);
-  llvm::GraphExport::Create(*newOut, lambda->ComputeCallSummary()->GetRvsdgExport()->Name());
+  auto oldExport = lambda->ComputeCallSummary()->GetRvsdgExport();
+  llvm::GraphExport::Create(*newOut, oldExport ? oldExport->Name() : "");
 
   JLM_ASSERT(lambda->output()->nusers() == 1);
   lambda->region()->RemoveResult((*lambda->output()->begin())->index());

--- a/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
@@ -241,7 +241,8 @@ remove_lambda_passthrough(llvm::lambda::node * ln)
   //	ln->output()->divert_users(new_out); // can't divert since the type changed
   JLM_ASSERT(ln->output()->nusers() == 1);
   ln->region()->RemoveResult((*ln->output()->begin())->index());
-  jlm::llvm::GraphExport::Create(*new_out, ln->ComputeCallSummary()->GetRvsdgExport()->Name());
+  auto oldExport = ln->ComputeCallSummary()->GetRvsdgExport();
+  jlm::llvm::GraphExport::Create(*new_out, oldExport ? oldExport->Name() : "");
   remove(ln);
   return new_lambda;
 }

--- a/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
@@ -241,8 +241,8 @@ remove_lambda_passthrough(llvm::lambda::node * ln)
   //	ln->output()->divert_users(new_out); // can't divert since the type changed
   JLM_ASSERT(ln->output()->nusers() == 1);
   ln->region()->RemoveResult((*ln->output()->begin())->index());
+  jlm::llvm::GraphExport::Create(*new_out, ln->ComputeCallSummary()->GetRvsdgExport()->Name());
   remove(ln);
-  jlm::rvsdg::result::create(new_lambda->region(), new_out, nullptr, new_out->Type());
   return new_lambda;
 }
 

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -385,9 +385,8 @@ split_hls_function(llvm::RvsdgModule & rm, const std::string & function_name)
       // copy function into rhls
       auto new_ln = ln->copy(rhls->Rvsdg().root(), smap);
       new_ln = change_linkage(new_ln, llvm::linkage::external_linkage);
-      jlm::llvm::GraphExport::Create(
-          *new_ln->output(),
-          ln->ComputeCallSummary()->GetRvsdgExport()->Name());
+      auto oldExport = ln->ComputeCallSummary()->GetRvsdgExport();
+      jlm::llvm::GraphExport::Create(*new_ln->output(), oldExport ? oldExport->Name() : "");
       // add function as input to rm and remove it
       auto & graphImport = llvm::GraphImport::Create(
           rm.Rvsdg(),

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -385,11 +385,9 @@ split_hls_function(llvm::RvsdgModule & rm, const std::string & function_name)
       // copy function into rhls
       auto new_ln = ln->copy(rhls->Rvsdg().root(), smap);
       new_ln = change_linkage(new_ln, llvm::linkage::external_linkage);
-      jlm::rvsdg::result::create(
-          rhls->Rvsdg().root(),
-          new_ln->output(),
-          nullptr,
-          new_ln->output()->Type());
+      jlm::llvm::GraphExport::Create(
+          *new_ln->output(),
+          ln->ComputeCallSummary()->GetRvsdgExport()->Name());
       // add function as input to rm and remove it
       auto & graphImport = llvm::GraphImport::Create(
           rm.Rvsdg(),

--- a/jlm/llvm/ir/operators/lambda.cpp
+++ b/jlm/llvm/ir/operators/lambda.cpp
@@ -287,7 +287,7 @@ node::ComputeCallSummary() const
   worklist.insert(worklist.end(), output()->begin(), output()->end());
 
   std::vector<CallNode *> directCalls;
-  rvsdg::result * rvsdgExport = nullptr;
+  GraphExport * rvsdgExport = nullptr;
   std::vector<rvsdg::input *> otherUsers;
 
   while (!worklist.empty())
@@ -373,10 +373,9 @@ node::ComputeCallSummary() const
       continue;
     }
 
-    auto result = dynamic_cast<rvsdg::result *>(input);
-    if (result != nullptr && input->region() == graph()->root())
+    if (auto graphExport = dynamic_cast<GraphExport *>(input))
     {
-      rvsdgExport = result;
+      rvsdgExport = graphExport;
       continue;
     }
 

--- a/jlm/llvm/ir/operators/lambda.hpp
+++ b/jlm/llvm/ir/operators/lambda.hpp
@@ -8,6 +8,7 @@
 
 #include <jlm/llvm/ir/attribute.hpp>
 #include <jlm/llvm/ir/linkage.hpp>
+#include <jlm/llvm/ir/RvsdgModule.hpp>
 #include <jlm/llvm/ir/types.hpp>
 #include <jlm/rvsdg/graph.hpp>
 #include <jlm/rvsdg/structural-node.hpp>
@@ -714,7 +715,7 @@ class node::CallSummary final
 
 public:
   CallSummary(
-      rvsdg::result * rvsdgExport,
+      GraphExport * rvsdgExport,
       std::vector<CallNode *> directCalls,
       std::vector<rvsdg::input *> otherUsers)
       : RvsdgExport_(rvsdgExport),
@@ -816,7 +817,7 @@ public:
    *
    * @return The export of the lambda from the RVSDG root region.
    */
-  [[nodiscard]] rvsdg::result *
+  [[nodiscard]] GraphExport *
   GetRvsdgExport() const noexcept
   {
     return RvsdgExport_;
@@ -857,7 +858,7 @@ public:
    */
   static std::unique_ptr<CallSummary>
   Create(
-      rvsdg::result * rvsdgExport,
+      GraphExport * rvsdgExport,
       std::vector<CallNode *> directCalls,
       std::vector<rvsdg::input *> otherUsers)
   {
@@ -868,7 +869,7 @@ public:
   }
 
 private:
-  rvsdg::result * RvsdgExport_;
+  GraphExport * RvsdgExport_;
   std::vector<CallNode *> DirectCalls_;
   std::vector<rvsdg::input *> OtherUsers_;
 };

--- a/jlm/rvsdg/region.cpp
+++ b/jlm/rvsdg/region.cpp
@@ -73,26 +73,6 @@ result::result(
   }
 }
 
-result &
-result::Copy(rvsdg::output & origin, jlm::rvsdg::structural_output * output)
-{
-  return *result::create(origin.region(), &origin, output, Type());
-}
-
-jlm::rvsdg::result *
-result::create(
-    jlm::rvsdg::region * region,
-    jlm::rvsdg::output * origin,
-    jlm::rvsdg::structural_output * output,
-    std::shared_ptr<const jlm::rvsdg::type> type)
-{
-  auto result = new jlm::rvsdg::result(region, origin, output, std::move(type));
-  region->append_result(result);
-  return result;
-}
-
-/* region */
-
 region::~region()
 {
   on_region_destroy(this);

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -87,24 +87,33 @@ private:
   structural_input * input_;
 };
 
+/**
+ * \brief Represents the result of a region.
+ *
+ * Region results represent the final values of the region's acyclic graph. The result values
+ * can be mapped back to the region arguments or the corresponding structural outputs
+ * throughout the execution, but the concrete semantics of this mapping
+ * depends on the structural node the region is part of. A region result is either linked
+ * with a \ref structural_output or is a standalone result.
+ */
 class result : public input
 {
-  jlm::util::intrusive_list_anchor<jlm::rvsdg::result> structural_output_anchor_;
+  util::intrusive_list_anchor<result> structural_output_anchor_;
 
 public:
-  typedef jlm::util::
-      intrusive_list_accessor<jlm::rvsdg::result, &jlm::rvsdg::result::structural_output_anchor_>
-          structural_output_accessor;
+  typedef util::intrusive_list_accessor<result, &result::structural_output_anchor_>
+      structural_output_accessor;
 
-  virtual ~result() noexcept;
+  ~result() noexcept override;
 
 protected:
   result(
-      jlm::rvsdg::region * region,
-      jlm::rvsdg::output * origin,
-      jlm::rvsdg::structural_output * output,
+      rvsdg::region * region,
+      rvsdg::output * origin,
+      structural_output * output,
       std::shared_ptr<const rvsdg::type> type);
 
+public:
   result(const result &) = delete;
 
   result(result &&) = delete;
@@ -115,8 +124,7 @@ protected:
   result &
   operator=(result &&) = delete;
 
-public:
-  inline jlm::rvsdg::structural_output *
+  [[nodiscard]] structural_output *
   output() const noexcept
   {
     return output_;
@@ -130,22 +138,12 @@ public:
    * @param output The structural_output to the result, if any.
    *
    * @return A reference to the copied result.
-   *
-   * FIXME: This method should be made abstract once we enforced that no instances of result
-   * itself can be created any longer.
    */
   virtual result &
-  Copy(rvsdg::output & origin, structural_output * output);
-
-  static jlm::rvsdg::result *
-  create(
-      jlm::rvsdg::region * region,
-      jlm::rvsdg::output * origin,
-      jlm::rvsdg::structural_output * output,
-      std::shared_ptr<const jlm::rvsdg::type> type);
+  Copy(rvsdg::output & origin, structural_output * output) = 0;
 
 private:
-  jlm::rvsdg::structural_output * output_;
+  structural_output * output_;
 };
 
 class region

--- a/tests/jlm/rvsdg/RegionTests.cpp
+++ b/tests/jlm/rvsdg/RegionTests.cpp
@@ -116,6 +116,8 @@ JLM_UNIT_TEST_REGISTER("jlm/rvsdg/RegionTests-NumRegions_NonEmptyRvsdg", NumRegi
 static int
 RemoveResultsWhere()
 {
+  using namespace jlm::tests;
+
   // Arrange
   jlm::rvsdg::graph rvsdg;
   jlm::rvsdg::region region(rvsdg.root(), &rvsdg);
@@ -123,15 +125,15 @@ RemoveResultsWhere()
   auto valueType = jlm::tests::valuetype::Create();
   auto node = jlm::tests::test_op::Create(&region, {}, {}, { valueType });
 
-  auto result0 = jlm::rvsdg::result::create(&region, node->output(0), nullptr, valueType);
-  auto result1 = jlm::rvsdg::result::create(&region, node->output(0), nullptr, valueType);
-  auto result2 = jlm::rvsdg::result::create(&region, node->output(0), nullptr, valueType);
+  auto & result0 = TestGraphResult::Create(*node->output(0), nullptr);
+  auto & result1 = TestGraphResult::Create(*node->output(0), nullptr);
+  auto & result2 = TestGraphResult::Create(*node->output(0), nullptr);
 
   // Act & Arrange
   assert(region.nresults() == 3);
-  assert(result0->index() == 0);
-  assert(result1->index() == 1);
-  assert(result2->index() == 2);
+  assert(result0.index() == 0);
+  assert(result1.index() == 1);
+  assert(result2.index() == 2);
 
   region.RemoveResultsWhere(
       [](const jlm::rvsdg::result & result)
@@ -139,8 +141,8 @@ RemoveResultsWhere()
         return result.index() == 1;
       });
   assert(region.nresults() == 2);
-  assert(result0->index() == 0);
-  assert(result2->index() == 1);
+  assert(result0.index() == 0);
+  assert(result2.index() == 1);
 
   region.RemoveResultsWhere(
       [](const jlm::rvsdg::result & result)
@@ -148,8 +150,8 @@ RemoveResultsWhere()
         return false;
       });
   assert(region.nresults() == 2);
-  assert(result0->index() == 0);
-  assert(result2->index() == 1);
+  assert(result0.index() == 0);
+  assert(result2.index() == 1);
 
   region.RemoveResultsWhere(
       [](const jlm::rvsdg::result & result)

--- a/tests/jlm/rvsdg/ResultTests.cpp
+++ b/tests/jlm/rvsdg/ResultTests.cpp
@@ -37,7 +37,8 @@ ResultNodeMismatch()
   bool outputErrorHandlerCalled = false;
   try
   {
-    result::create(structuralNode2->subregion(0), &argument, structuralOutput, valueType);
+    // Region mismatch
+    TestGraphResult::Create(*structuralNode2->subregion(0), argument, structuralOutput);
   }
   catch (jlm::util::error & e)
   {
@@ -72,29 +73,9 @@ ResultInputTypeMismatch()
   try
   {
     auto simpleNode = test_op::create(structuralNode->subregion(0), {}, { stateType });
-    jlm::rvsdg::result::create(
-        structuralNode->subregion(0),
-        simpleNode->output(0),
-        structuralOutput,
-        stateType);
-    // The line below should not be executed as the line above is expected to throw an exception.
-    assert(false);
-  }
-  catch (type_error &)
-  {
-    exceptionWasCaught = true;
-  }
-  assert(exceptionWasCaught);
 
-  exceptionWasCaught = false;
-  try
-  {
-    auto simpleNode = test_op::create(structuralNode->subregion(0), {}, { stateType });
-    jlm::rvsdg::result::create(
-        structuralNode->subregion(0),
-        simpleNode->output(0),
-        structuralOutput,
-        stateType);
+    // Type mismatch between simple node output and structural output
+    TestGraphResult::Create(*simpleNode->output(0), structuralOutput);
     // The line below should not be executed as the line above is expected to throw an exception.
     assert(false);
   }

--- a/tests/jlm/rvsdg/test-graph.cpp
+++ b/tests/jlm/rvsdg/test-graph.cpp
@@ -44,7 +44,7 @@ test_recursive_prune()
   auto & a1 = TestGraphArgument::Create(*n3->subregion(0), nullptr, t);
   auto n4 = jlm::tests::test_op::create(n3->subregion(0), { &a1 }, { t });
   auto n5 = jlm::tests::test_op::create(n3->subregion(0), { &a1 }, { t });
-  result::create(n3->subregion(0), n4->output(0), nullptr, t);
+  TestGraphResult::Create(*n4->output(0), nullptr);
   auto o1 = structural_output::create(n3, t);
 
   auto n6 = jlm::tests::structural_node::create(n3->subregion(0), 1);
@@ -149,7 +149,7 @@ Copy()
   jlm::rvsdg::graph graph;
   auto & argument = TestGraphArgument::Create(*graph.root(), nullptr, valueType);
   auto node = test_op::create(graph.root(), { &argument }, { valueType });
-  TestGraphResult::Create(*node->output(0));
+  TestGraphResult::Create(*node->output(0), nullptr);
 
   // Act
   auto newGraph = graph.copy();

--- a/tests/jlm/rvsdg/test-nodes.cpp
+++ b/tests/jlm/rvsdg/test-nodes.cpp
@@ -34,8 +34,8 @@ test_node_copy(void)
   auto n2 = jlm::tests::test_op::create(n1->subregion(0), { &a1 }, { stype });
   auto n3 = jlm::tests::test_op::create(n1->subregion(0), { &a2 }, { vtype });
 
-  result::create(n1->subregion(0), n2->output(0), o1, stype);
-  result::create(n1->subregion(0), n3->output(0), o2, vtype);
+  TestGraphResult::Create(*n2->output(0), o1);
+  TestGraphResult::Create(*n3->output(0), o2);
 
   jlm::rvsdg::view(graph.root(), stdout);
 

--- a/tests/test-operation.hpp
+++ b/tests/test-operation.hpp
@@ -376,24 +376,39 @@ public:
 class TestGraphResult final : public jlm::rvsdg::result
 {
 private:
-  explicit TestGraphResult(jlm::rvsdg::output & origin)
-      : jlm::rvsdg::result(origin.region(), &origin, nullptr, origin.Type())
+  TestGraphResult(
+      jlm::rvsdg::region & region,
+      jlm::rvsdg::output & origin,
+      jlm::rvsdg::structural_output * output)
+      : jlm::rvsdg::result(&region, &origin, output, origin.Type())
+  {}
+
+  TestGraphResult(jlm::rvsdg::output & origin, jlm::rvsdg::structural_output * output)
+      : TestGraphResult(*origin.region(), origin, output)
   {}
 
 public:
   TestGraphResult &
   Copy(jlm::rvsdg::output & origin, jlm::rvsdg::structural_output * output) override
   {
-    JLM_ASSERT(output == nullptr);
-    return Create(origin);
+    return Create(origin, output);
   }
 
   static TestGraphResult &
-  Create(jlm::rvsdg::output & origin)
+  Create(
+      jlm::rvsdg::region & region,
+      jlm::rvsdg::output & origin,
+      jlm::rvsdg::structural_output * output)
   {
-    auto graphResult = new TestGraphResult(origin);
+    auto graphResult = new TestGraphResult(region, origin, output);
     origin.region()->append_result(graphResult);
     return *graphResult;
+  }
+
+  static TestGraphResult &
+  Create(jlm::rvsdg::output & origin, jlm::rvsdg::structural_output * output)
+  {
+    return Create(*origin.region(), origin, output);
   }
 };
 


### PR DESCRIPTION
1. Replaces all usages of `result::create()` in the unit tests with the appropriate subclasses.
2. Makes the result class abstract
3. Minor clean ups in the result class
4. Add documentation to result class