### PR TITLE
Ensure jlm-opt creates only single instances of optimizations

### DIFF
--- a/jlm/llvm/opt/OptimizationSequence.hpp
+++ b/jlm/llvm/opt/OptimizationSequence.hpp
@@ -21,7 +21,7 @@ public:
 
   ~OptimizationSequence() noexcept override;
 
-  explicit OptimizationSequence(std::vector<std::unique_ptr<optimization>> optimizations)
+  explicit OptimizationSequence(std::vector<optimization *> optimizations)
       : Optimizations_(std::move(optimizations))
   {}
 
@@ -32,14 +32,14 @@ public:
   CreateAndRun(
       RvsdgModule & rvsdgModule,
       util::StatisticsCollector & statisticsCollector,
-      std::vector<std::unique_ptr<optimization>> optimizations)
+      std::vector<optimization *> optimizations)
   {
     OptimizationSequence sequentialApplication(std::move(optimizations));
     sequentialApplication.run(rvsdgModule, statisticsCollector);
   }
 
 private:
-  std::vector<std::unique_ptr<optimization>> Optimizations_;
+  std::vector<optimization *> Optimizations_;
 };
 
 }

--- a/jlm/tooling/Command.hpp
+++ b/jlm/tooling/Command.hpp
@@ -341,10 +341,7 @@ class JlmOptCommand final : public Command
 public:
   ~JlmOptCommand() override;
 
-  JlmOptCommand(std::string programName, JlmOptCommandLineOptions commandLineOptions)
-      : ProgramName_(std::move(programName)),
-        CommandLineOptions_(std::move(commandLineOptions))
-  {}
+  JlmOptCommand(std::string programName, const JlmOptCommandLineOptions & commandLineOptions);
 
   [[nodiscard]] std::string
   ToString() const override;
@@ -356,7 +353,7 @@ public:
   Create(
       CommandGraph & commandGraph,
       std::string programName,
-      JlmOptCommandLineOptions commandLineOptions)
+      const JlmOptCommandLineOptions & commandLineOptions)
   {
     auto command =
         std::make_unique<JlmOptCommand>(std::move(programName), std::move(commandLineOptions));
@@ -421,8 +418,16 @@ private:
       const util::filepath & outputFile,
       util::StatisticsCollector & statisticsCollector);
 
+  [[nodiscard]] std::vector<llvm::optimization *>
+  GetOptimizations() const;
+
+  [[nodiscard]] std::unique_ptr<llvm::optimization>
+  CreateOptimization(enum JlmOptCommandLineOptions::OptimizationId optimizationId) const;
+
   std::string ProgramName_;
   JlmOptCommandLineOptions CommandLineOptions_;
+  std::unordered_map<JlmOptCommandLineOptions::OptimizationId, std::unique_ptr<llvm::optimization>>
+      Optimizations_ = {};
 };
 
 /**

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -99,10 +99,10 @@ JlmOptCommandLineOptions::Reset() noexcept
   OptimizationIds_.clear();
 }
 
-std::vector<std::unique_ptr<llvm::optimization>>
+std::vector<llvm::optimization *>
 JlmOptCommandLineOptions::GetOptimizations() const noexcept
 {
-  std::vector<std::unique_ptr<llvm::optimization>> optimizations;
+  std::vector<llvm::optimization *> optimizations;
   optimizations.reserve(OptimizationIds_.size());
 
   for (auto & optimizationId : OptimizationIds_)
@@ -226,8 +226,23 @@ JlmOptCommandLineOptions::ToCommandLineArgument(OutputFormat outputFormat)
   return mapping.at(outputFormat).data();
 }
 
-std::unique_ptr<llvm::optimization>
+llvm::optimization *
 JlmOptCommandLineOptions::GetOptimization(enum OptimizationId optimizationId) const
+{
+  static std::unordered_map<OptimizationId, std::unique_ptr<llvm::optimization>> map;
+
+  if (auto it = map.find(optimizationId); it != map.end())
+  {
+    return it->second.get();
+  }
+
+  map[optimizationId] = CreateOptimization(optimizationId);
+
+  return map[optimizationId].get();
+}
+
+std::unique_ptr<llvm::optimization>
+JlmOptCommandLineOptions::CreateOptimization(enum OptimizationId optimizationId) const
 {
   using Andersen = llvm::aa::Andersen;
   using Steensgaard = llvm::aa::Steensgaard;

--- a/jlm/tooling/CommandLine.hpp
+++ b/jlm/tooling/CommandLine.hpp
@@ -139,7 +139,7 @@ public:
     return OptimizationIds_;
   }
 
-  [[nodiscard]] std::vector<std::unique_ptr<llvm::optimization>>
+  [[nodiscard]] std::vector<llvm::optimization *>
   GetOptimizations() const noexcept;
 
   static OptimizationId
@@ -160,7 +160,7 @@ public:
   static const char *
   ToCommandLineArgument(OutputFormat outputFormat);
 
-  [[nodiscard]] std::unique_ptr<llvm::optimization>
+  [[nodiscard]] llvm::optimization *
   GetOptimization(enum OptimizationId optimizationId) const;
 
   static std::unique_ptr<JlmOptCommandLineOptions>
@@ -184,6 +184,9 @@ public:
   }
 
 private:
+  std::unique_ptr<llvm::optimization>
+  CreateOptimization(enum OptimizationId optimizationId) const;
+
   util::filepath InputFile_;
   InputFormat InputFormat_;
   util::filepath OutputFile_;

--- a/jlm/tooling/CommandLine.hpp
+++ b/jlm/tooling/CommandLine.hpp
@@ -139,8 +139,11 @@ public:
     return OptimizationIds_;
   }
 
-  [[nodiscard]] std::vector<llvm::optimization *>
-  GetOptimizations() const noexcept;
+  [[nodiscard]] const llvm::RvsdgTreePrinter::Configuration &
+  GetRvsdgTreePrinterConfiguration() const noexcept
+  {
+    return RvsdgTreePrinterConfiguration_;
+  }
 
   static OptimizationId
   FromCommandLineArgumentToOptimizationId(const std::string & commandLineArgument);
@@ -159,9 +162,6 @@ public:
 
   static const char *
   ToCommandLineArgument(OutputFormat outputFormat);
-
-  [[nodiscard]] llvm::optimization *
-  GetOptimization(enum OptimizationId optimizationId) const;
 
   static std::unique_ptr<JlmOptCommandLineOptions>
   Create(
@@ -184,9 +184,6 @@ public:
   }
 
 private:
-  std::unique_ptr<llvm::optimization>
-  CreateOptimization(enum OptimizationId optimizationId) const;
-
   util::filepath InputFile_;
   InputFormat InputFormat_;
   util::filepath OutputFile_;

--- a/tests/jlm/tooling/TestJlmOptCommand.cpp
+++ b/tests/jlm/tooling/TestJlmOptCommand.cpp
@@ -67,6 +67,7 @@ JLM_UNIT_TEST_REGISTER("jlm/tooling/TestJlmOptCommand", TestJlmOptCommand)
 static int
 OptimizationIdToOptimizationTranslation()
 {
+  using namespace jlm::llvm;
   using namespace jlm::tooling;
   using namespace jlm::util;
 
@@ -87,7 +88,7 @@ OptimizationIdToOptimizationTranslation()
       filepath(""),
       JlmOptCommandLineOptions::OutputFormat::Llvm,
       StatisticsCollectorSettings(),
-      jlm::llvm::RvsdgTreePrinter::Configuration(filepath(std::filesystem::temp_directory_path())),
+      RvsdgTreePrinter::Configuration(filepath(std::filesystem::temp_directory_path()), {}),
       optimizationIds);
 
   // Act & Assert

--- a/tests/jlm/tooling/TestJlmOptCommand.cpp
+++ b/tests/jlm/tooling/TestJlmOptCommand.cpp
@@ -65,6 +65,44 @@ TestJlmOptCommand()
 JLM_UNIT_TEST_REGISTER("jlm/tooling/TestJlmOptCommand", TestJlmOptCommand)
 
 static int
+OptimizationIdToOptimizationTranslation()
+{
+  using namespace jlm::tooling;
+  using namespace jlm::util;
+
+  // Arrange
+  std::vector<JlmOptCommandLineOptions::OptimizationId> optimizationIds;
+  for (size_t n =
+           static_cast<std::size_t>(JlmOptCommandLineOptions::OptimizationId::FirstEnumValue) + 1;
+       n != static_cast<std::size_t>(JlmOptCommandLineOptions::OptimizationId::LastEnumValue);
+       n++)
+  {
+    auto optimizationId = static_cast<JlmOptCommandLineOptions::OptimizationId>(n);
+    optimizationIds.emplace_back(optimizationId);
+  }
+
+  JlmOptCommandLineOptions options(
+      filepath(""),
+      JlmOptCommandLineOptions::InputFormat::Llvm,
+      filepath(""),
+      JlmOptCommandLineOptions::OutputFormat::Llvm,
+      StatisticsCollectorSettings(),
+      jlm::llvm::RvsdgTreePrinter::Configuration(filepath(std::filesystem::temp_directory_path())),
+      optimizationIds);
+
+  // Act & Assert
+
+  // terminates on handled optimization id
+  JlmOptCommand command("jlm-opt", options);
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER(
+    "jlm/tooling/TestJlmOptCommand-OptimizationIdToOptimizationTranslation",
+    OptimizationIdToOptimizationTranslation)
+
+static int
 PrintRvsdgTreeToFile()
 {
   using namespace jlm;

--- a/tests/jlm/tooling/TestJlmOptCommand.cpp
+++ b/tests/jlm/tooling/TestJlmOptCommand.cpp
@@ -91,8 +91,7 @@ OptimizationIdToOptimizationTranslation()
       optimizationIds);
 
   // Act & Assert
-
-  // terminates on handled optimization id
+  // terminates on unhandled optimization id
   JlmOptCommand command("jlm-opt", options);
 
   return 0;

--- a/tests/jlm/tooling/TestJlmOptCommandLineParser.cpp
+++ b/tests/jlm/tooling/TestJlmOptCommandLineParser.cpp
@@ -62,35 +62,6 @@ TestStatisticsCommandLineArgumentConversion()
   }
 }
 
-static void
-TestOptimizationIdToOptimizationTranslation()
-{
-  using namespace jlm::tooling;
-  using namespace jlm::util;
-
-  // Arrange
-  JlmOptCommandLineOptions options(
-      filepath(""),
-      JlmOptCommandLineOptions::InputFormat::Llvm,
-      filepath(""),
-      JlmOptCommandLineOptions::OutputFormat::Llvm,
-      StatisticsCollectorSettings(),
-      jlm::llvm::RvsdgTreePrinter::Configuration(filepath(std::filesystem::temp_directory_path())),
-      std::vector<JlmOptCommandLineOptions::OptimizationId>());
-
-  // Act & Assert
-  for (size_t n =
-           static_cast<std::size_t>(JlmOptCommandLineOptions::OptimizationId::FirstEnumValue) + 1;
-       n != static_cast<std::size_t>(JlmOptCommandLineOptions::OptimizationId::LastEnumValue);
-       n++)
-  {
-    auto optimizationId = static_cast<JlmOptCommandLineOptions::OptimizationId>(n);
-
-    // terminates on unhandled optimization id
-    static_cast<void>(options.GetOptimization(optimizationId));
-  }
-}
-
 static int
 TestOutputFormatToCommandLineArgument()
 {
@@ -120,7 +91,6 @@ Test()
 {
   TestOptimizationCommandLineArgumentConversion();
   TestStatisticsCommandLineArgumentConversion();
-  TestOptimizationIdToOptimizationTranslation();
 
   return 0;
 }


### PR DESCRIPTION
PR #593 made optimizations dynamically configurable, but also screwed up the invariant that an optimization was only created once. This PR restores this invariant and moves the optimization creation from the JlmOptCommandLineOptions class to JlmOptCommand class.