### PR TITLE
Ensure deterministic basic block name in LLVM output

### DIFF
--- a/jlm/llvm/backend/jlm2llvm/jlm2llvm.cpp
+++ b/jlm/llvm/backend/jlm2llvm/jlm2llvm.cpp
@@ -361,6 +361,7 @@ ConvertBasicBlocks(
 {
   auto nodes = breadth_first(controlFlowGraph);
 
+  uint64_t basicBlockCounter = 0;
   for (const auto & node : nodes)
   {
     if (node == controlFlowGraph.entry())
@@ -368,7 +369,7 @@ ConvertBasicBlocks(
     if (node == controlFlowGraph.exit())
       continue;
 
-    auto name = util::strfmt("bb", &node);
+    auto name = util::strfmt("bb", basicBlockCounter++);
     auto * basicBlock = ::llvm::BasicBlock::Create(function.getContext(), name, &function);
     context.insert(node, basicBlock);
   }

--- a/jlm/llvm/backend/jlm2llvm/jlm2llvm.cpp
+++ b/jlm/llvm/backend/jlm2llvm/jlm2llvm.cpp
@@ -353,6 +353,29 @@ convert_attributes(const function_node & f, context & ctx)
   return ::llvm::AttributeList::get(llvmctx, fctset, retset, argsets);
 }
 
+static std::vector<cfg_node *>
+ConvertBasicBlocks(
+    const llvm::cfg & controlFlowGraph,
+    ::llvm::Function & function,
+    jlm2llvm::context & context)
+{
+  auto nodes = breadth_first(controlFlowGraph);
+
+  for (const auto & node : nodes)
+  {
+    if (node == controlFlowGraph.entry())
+      continue;
+    if (node == controlFlowGraph.exit())
+      continue;
+
+    auto name = util::strfmt("bb", &node);
+    auto * basicBlock = ::llvm::BasicBlock::Create(function.getContext(), name, &function);
+    context.insert(node, basicBlock);
+  }
+
+  return nodes;
+}
+
 static inline void
 convert_cfg(llvm::cfg & cfg, ::llvm::Function & f, context & ctx)
 {
@@ -369,17 +392,8 @@ convert_cfg(llvm::cfg & cfg, ::llvm::Function & f, context & ctx)
   };
 
   straighten(cfg);
-  auto nodes = breadth_first(cfg);
 
-  /* create basic blocks */
-  for (const auto & node : nodes)
-  {
-    if (node == cfg.entry() || node == cfg.exit())
-      continue;
-
-    auto bb = ::llvm::BasicBlock::Create(f.getContext(), util::strfmt("bb", &node), &f);
-    ctx.insert(node, bb);
-  }
+  auto nodes = ConvertBasicBlocks(cfg, f, ctx);
 
   add_arguments(cfg, f, ctx);
 


### PR DESCRIPTION
1. Cleans up the basic block conversion in the LLVM backend
2. Assigns name "bb[0...]" to the basic block in the output

This PR is required for #586 in order to better follow the output. It is also part of the effort in #529.

Example output:

```
; Function Attrs: noinline nounwind optnone uwtable
define i64 @fac(i64 noundef %0) #0 {
bb0:
  %1 = alloca i64, align 8
  %2 = alloca i64, align 8
  store i64 %0, ptr %2, align 8
  store i64 1, ptr %1, align 8
  br label %bb1

bb1:                                              ; preds = %bb4, %bb0
  %3 = load i64, ptr %1, align 8
  %4 = load i64, ptr %2, align 8
  %5 = icmp ugt i64 %4, 1
  br i1 %5, label %bb3, label %bb2

bb2:                                              ; preds = %bb1
  br label %bb4

bb3:                                              ; preds = %bb1
  %6 = mul i64 %3, %4
  store i64 %6, ptr %1, align 8
  %7 = load i64, ptr %2, align 8
  %8 = add i64 %7, -1
  store i64 %8, ptr %2, align 8
  br label %bb4

bb4:                                              ; preds = %bb3, %bb2
  %9 = phi i1 [ false, %bb2 ], [ true, %bb3 ]
  br i1 %9, label %bb1, label %bb5

bb5:                                              ; preds = %bb4
  %10 = load i64, ptr %1, align 8
  ret i64 %10
}
``` 