### PR TITLE
Add NumMemoryStateInputsOutputs annotation to RvsdgTreePrinter

### DIFF
--- a/jlm/llvm/opt/RvsdgTreePrinter.cpp
+++ b/jlm/llvm/opt/RvsdgTreePrinter.cpp
@@ -123,10 +123,10 @@ RvsdgTreePrinter::AnnotateNumMemoryStateInputsOutputs(
     const rvsdg::graph & rvsdg,
     util::AnnotationMap & annotationMap)
 {
-  static std::string_view argumentLabel("NumMemoryStateTypeArguments");
-  static std::string_view resultLabel("NumMemoryStateTypeResults");
-  static std::string_view inputLabel("NumMemoryStateTypeInputs");
-  static std::string_view outputLabel("NumMemoryStateTypeOutputs");
+  std::string_view argumentLabel("NumMemoryStateTypeArguments");
+  std::string_view resultLabel("NumMemoryStateTypeResults");
+  std::string_view inputLabel("NumMemoryStateTypeInputs");
+  std::string_view outputLabel("NumMemoryStateTypeOutputs");
 
   std::function<void(const rvsdg::region &)> annotateRegion = [&](const rvsdg::region & region)
   {

--- a/jlm/llvm/opt/RvsdgTreePrinter.cpp
+++ b/jlm/llvm/opt/RvsdgTreePrinter.cpp
@@ -74,6 +74,9 @@ RvsdgTreePrinter::ComputeAnnotationMap(const rvsdg::graph & rvsdg) const
     case Configuration::Annotation::NumRvsdgNodes:
       AnnotateNumRvsdgNodes(rvsdg, annotationMap);
       break;
+    case Configuration::Annotation::NumMemoryStateInputsOutputs:
+      AnnotateNumMemoryStateInputsOutputs(rvsdg, annotationMap);
+      break;
     default:
       JLM_UNREACHABLE("Unhandled RVSDG tree annotation.");
     }
@@ -110,6 +113,78 @@ RvsdgTreePrinter::AnnotateNumRvsdgNodes(
     annotationMap.AddAnnotation(&region, { label, numNodes });
 
     return numNodes;
+  };
+
+  annotateRegion(*rvsdg.root());
+}
+
+void
+RvsdgTreePrinter::AnnotateNumMemoryStateInputsOutputs(
+    const rvsdg::graph & rvsdg,
+    util::AnnotationMap & annotationMap)
+{
+  static std::string_view argumentLabel("NumMemoryStateTypeArguments");
+  static std::string_view resultLabel("NumMemoryStateTypeResults");
+  static std::string_view inputLabel("NumMemoryStateTypeInputs");
+  static std::string_view outputLabel("NumMemoryStateTypeOutputs");
+
+  std::function<void(const rvsdg::region &)> annotateRegion = [&](const rvsdg::region & region)
+  {
+    size_t numMemoryStateArguments = 0;
+    for (size_t n = 0; n < region.narguments(); n++)
+    {
+      auto argument = region.argument(n);
+      if (rvsdg::is<MemoryStateType>(argument->type()))
+      {
+        numMemoryStateArguments++;
+      }
+    }
+    annotationMap.AddAnnotation(&region, { argumentLabel, numMemoryStateArguments });
+
+    size_t numMemoryStateResults = 0;
+    for (size_t n = 0; n < region.nresults(); n++)
+    {
+      auto result = region.result(n);
+      if (rvsdg::is<MemoryStateType>(result->type()))
+      {
+        numMemoryStateResults++;
+      }
+    }
+    annotationMap.AddAnnotation(&region, { resultLabel, numMemoryStateResults });
+
+    for (auto & node : region.nodes)
+    {
+      if (auto structuralNode = dynamic_cast<const rvsdg::structural_node *>(&node))
+      {
+        size_t numMemoryStateInputs = 0;
+        for (size_t n = 0; n < structuralNode->ninputs(); n++)
+        {
+          auto input = structuralNode->input(n);
+          if (rvsdg::is<MemoryStateType>(input->type()))
+          {
+            numMemoryStateInputs++;
+          }
+        }
+        annotationMap.AddAnnotation(structuralNode, { inputLabel, numMemoryStateInputs });
+
+        size_t numMemoryStateOutputs = 0;
+        for (size_t n = 0; n < structuralNode->noutputs(); n++)
+        {
+          auto output = structuralNode->output(n);
+          if (rvsdg::is<MemoryStateType>(output->type()))
+          {
+            numMemoryStateOutputs++;
+          }
+        }
+        annotationMap.AddAnnotation(structuralNode, { outputLabel, numMemoryStateOutputs });
+
+        for (size_t n = 0; n < structuralNode->nsubregions(); n++)
+        {
+          auto subregion = structuralNode->subregion(n);
+          annotateRegion(*subregion);
+        }
+      }
+    }
   };
 
   annotateRegion(*rvsdg.root());

--- a/jlm/llvm/opt/RvsdgTreePrinter.hpp
+++ b/jlm/llvm/opt/RvsdgTreePrinter.hpp
@@ -54,6 +54,12 @@ public:
       NumRvsdgNodes,
 
       /**
+       * Annotate region and structural nodes with the number of inputs/outputs of type
+       * MemoryStateType.
+       */
+      NumMemoryStateInputsOutputs,
+
+      /**
        * Must always be the last enum value. Used for iteration.
        */
       LastEnumValue
@@ -136,6 +142,20 @@ private:
    */
   static void
   AnnotateNumRvsdgNodes(const rvsdg::graph & rvsdg, util::AnnotationMap & annotationMap);
+
+  /**
+   * Adds an annotation to \p annotationMap that indicates the number of inputs/outputs of type
+   * MemoryStateType.
+   *
+   * @param rvsdg The RVSDG for which to compute the annotation.
+   * @param annotationMap The annotation map in which the annotation is inserted.
+   *
+   * @see NumMemoryStateInputsOutputs
+   */
+  static void
+  AnnotateNumMemoryStateInputsOutputs(
+      const rvsdg::graph & rvsdg,
+      util::AnnotationMap & annotationMap);
 
   void
   WriteTreeToFile(const RvsdgModule & rvsdgModule, const std::string & tree) const;

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -888,6 +888,10 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, const char * const 
           llvm::RvsdgTreePrinter::Configuration::Annotation::NumRvsdgNodes,
           "NumRvsdgNodes",
           "Annotate number of RVSDG nodes")),
+      cl::values(::clEnumValN(
+          llvm::RvsdgTreePrinter::Configuration::Annotation::NumMemoryStateInputsOutputs,
+          "NumMemoryStateInputsOutputs",
+          "Annotate number of inputs/outputs with memory state type")),
       cl::CommaSeparated,
       cl::desc("Comma separated list of RVSDG tree printer annotations"));
 

--- a/tests/jlm/llvm/opt/RvsdgTreePrinterTests.cpp
+++ b/tests/jlm/llvm/opt/RvsdgTreePrinterTests.cpp
@@ -8,10 +8,19 @@
 #include <test-types.hpp>
 
 #include <jlm/llvm/ir/operators/lambda.hpp>
-#include <jlm/llvm/ir/RvsdgModule.hpp>
 #include <jlm/llvm/opt/RvsdgTreePrinter.hpp>
 
 #include <fstream>
+
+static std::string
+ReadFile(const std::string & outputFilePath)
+{
+  std::ifstream file(outputFilePath);
+  std::stringstream buffer;
+  buffer << file.rdbuf();
+
+  return buffer.str();
+}
 
 static int
 PrintRvsdgTree()
@@ -41,13 +50,14 @@ PrintRvsdgTree()
   printer.run(*rvsdgModule);
 
   // Assert
-  auto outputFilePath = tempDirectory.string() + "/" + fileName + "-rvsdgTree-0";
+  auto tree = ReadFile(tempDirectory.string() + "/" + fileName + "-rvsdgTree-0");
+  std::cout << tree;
 
-  std::ifstream file(outputFilePath);
-  std::stringstream buffer;
-  buffer << file.rdbuf();
+  auto expectedTree = "RootRegion\n"
+                      "-LAMBDA[f]\n"
+                      "--Region[0]\n\n";
 
-  assert(buffer.str() == "RootRegion\n-LAMBDA[f]\n--Region[0]\n\n");
+  assert(tree == expectedTree);
 
   return 0;
 }
@@ -81,16 +91,15 @@ PrintNumRvsdgNodesAnnotation()
   printer.run(*rvsdgModule);
 
   // Assert
-  auto outputFilePath = tempDirectory.string() + "/" + fileName + "-rvsdgTree-0";
+  auto tree = ReadFile(tempDirectory.string() + "/" + fileName + "-rvsdgTree-0");
+  std::cout << tree;
 
-  std::ifstream file(outputFilePath);
-  std::stringstream buffer;
-  buffer << file.rdbuf();
+  auto expectedTree = "RootRegion NumRvsdgNodes:2\n"
+                      "-STRUCTURAL_TEST_NODE NumRvsdgNodes:2\n"
+                      "--Region[0] NumRvsdgNodes:1\n"
+                      "--Region[1] NumRvsdgNodes:1\n\n";
 
-  assert(
-      buffer.str()
-      == "RootRegion NumRvsdgNodes:2\n-STRUCTURAL_TEST_NODE NumRvsdgNodes:2\n--Region[0] "
-         "NumRvsdgNodes:1\n--Region[1] NumRvsdgNodes:1\n\n");
+  assert(tree == expectedTree);
 
   return 0;
 }
@@ -98,3 +107,58 @@ PrintNumRvsdgNodesAnnotation()
 JLM_UNIT_TEST_REGISTER(
     "jlm/llvm/opt/RvsdgTreePrinterTests-PrintNumRvsdgNodesAnnotation",
     PrintNumRvsdgNodesAnnotation)
+
+static int
+PrintNumMemoryStateInputsOutputsAnnotation()
+{
+  using namespace jlm::llvm;
+  using namespace jlm::util;
+
+  // Arrange
+  auto memoryStateType = MemoryStateType::Create();
+  auto valueType = jlm::tests::valuetype::Create();
+
+  std::string fileName = "PrintNumMemoryStateInputsOutputsAnnotationTest";
+  auto rvsdgModule = RvsdgModule::Create({ fileName }, "", "");
+  auto & rvsdg = rvsdgModule->Rvsdg();
+
+  auto & x = jlm::tests::GraphImport::Create(rvsdg, memoryStateType, "x");
+  auto & y = jlm::tests::GraphImport::Create(rvsdg, valueType, "y");
+
+  auto structuralNode = jlm::tests::structural_node::create(rvsdg.root(), 2);
+  auto & ix = structuralNode->AddInputWithArguments(x);
+  auto & iy = structuralNode->AddInputWithArguments(y);
+
+  auto & ox = structuralNode->AddOutputWithResults({ &ix.Argument(0), &ix.Argument(1) });
+  auto & oy = structuralNode->AddOutputWithResults({ &iy.Argument(0), &iy.Argument(1) });
+
+  jlm::tests::GraphExport::Create(ox, "x");
+  jlm::tests::GraphExport::Create(oy, "y");
+
+  auto tempDirectory = std::filesystem::temp_directory_path();
+  RvsdgTreePrinter::Configuration configuration(
+      { tempDirectory },
+      { RvsdgTreePrinter::Configuration::Annotation::NumMemoryStateInputsOutputs });
+  RvsdgTreePrinter printer(configuration);
+
+  // Act
+  printer.run(*rvsdgModule);
+
+  // Assert
+  auto tree = ReadFile(tempDirectory.string() + "/" + fileName + "-rvsdgTree-0");
+  std::cout << tree;
+
+  auto expectedTree =
+      "RootRegion NumMemoryStateTypeArguments:1 NumMemoryStateTypeResults:1\n"
+      "-STRUCTURAL_TEST_NODE NumMemoryStateTypeInputs:1 NumMemoryStateTypeOutputs:1\n"
+      "--Region[0] NumMemoryStateTypeArguments:1 NumMemoryStateTypeResults:1\n"
+      "--Region[1] NumMemoryStateTypeArguments:1 NumMemoryStateTypeResults:1\n\n";
+
+  assert(tree == expectedTree);
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER(
+    "jlm/llvm/opt/RvsdgTreePrinterTests-PrintNumMemoryStateInputsOutputsAnnotation",
+    PrintNumMemoryStateInputsOutputsAnnotation)


### PR DESCRIPTION
1. Extends the structural test node with an interface for adding inputs/outputs/arguments/results
2. Add support for printing of memory state typed inputs/outputs to RvsdgTreePrinter class
3. Adds support for this annotation to jlm-opt