### PR TITLE
Header consistency checking

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -113,6 +113,9 @@ endif
 echo-depends:
 	echo $(DEPEND)
 
+check-headers: depend
+	@scripts/check_headers.sh $(DEPEND) -h $(HEADERS) -s $(SOURCES)
+
 ################################################################################
 # Unit testing rules
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ make coverage
 ```
 The report will be available in build/coverage/coverage.html.
 
+To ensure that all build information in the makefiles are correct, it is also
+advisable to check that all headers used are declared (this is quite easy
+to forget). To do this, you can run:
+```
+make check-headers
+```
+
 ## High-level synthesis (HLS) backend
 The HLS backend uses the MLIR FIRRTL dialect from CIRCT to convert llvm IR to FIRRTL code.
 

--- a/jlm/hls/Makefile.sub
+++ b/jlm/hls/Makefile.sub
@@ -65,6 +65,7 @@ libhls_HEADERS = \
 	jlm/hls/backend/rvsdg2rhls/mem-queue.hpp \
 	jlm/hls/backend/rvsdg2rhls/mem-sep.hpp \
 	jlm/hls/backend/rvsdg2rhls/memstate-conv.hpp \
+	jlm/hls/backend/rvsdg2rhls/merge-gamma.hpp \
 	jlm/hls/backend/rvsdg2rhls/remove-redundant-buf.hpp \
 	jlm/hls/backend/rvsdg2rhls/remove-unused-state.hpp \
 	jlm/hls/backend/rvsdg2rhls/rhls-dne.hpp \

--- a/jlm/llvm/Makefile.sub
+++ b/jlm/llvm/Makefile.sub
@@ -71,13 +71,19 @@ libllvm_HEADERS = \
 	jlm/llvm/opt/inlining.hpp \
 	jlm/llvm/opt/cne.hpp \
 	jlm/llvm/opt/push.hpp \
+	jlm/llvm/opt/alias-analyses/Andersen.hpp \
 	jlm/llvm/opt/alias-analyses/DifferencePropagation.hpp \
+	jlm/llvm/opt/alias-analyses/EliminatedMemoryNodeProvider.hpp \
 	jlm/llvm/opt/alias-analyses/LazyCycleDetection.hpp \
 	jlm/llvm/opt/alias-analyses/MemoryNodeProvider.hpp \
 	jlm/llvm/opt/alias-analyses/OnlineCycleDetection.hpp \
 	jlm/llvm/opt/alias-analyses/Optimization.hpp \
+	jlm/llvm/opt/alias-analyses/MemoryNodeEliminator.hpp \
+	jlm/llvm/opt/alias-analyses/MemoryNodeProvisioning.hpp \
 	jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp \
 	jlm/llvm/opt/alias-analyses/Steensgaard.hpp \
+	jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.hpp \
+	jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp \
 	jlm/llvm/opt/alias-analyses/AgnosticMemoryNodeProvider.hpp \
 	jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.hpp \
 	jlm/llvm/opt/alias-analyses/PointsToGraph.hpp \
@@ -87,6 +93,7 @@ libllvm_HEADERS = \
 	jlm/llvm/opt/reduction.hpp \
 	jlm/llvm/opt/InvariantValueRedirection.hpp \
 	jlm/llvm/opt/inversion.hpp \
+	jlm/llvm/opt/OptimizationSequence.hpp \
 	jlm/llvm/opt/RvsdgTreePrinter.hpp \
 	jlm/llvm/frontend/LlvmModuleConversion.hpp \
 	jlm/llvm/frontend/LlvmTypeConversion.hpp \

--- a/scripts/check_headers.sh
+++ b/scripts/check_headers.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+function headers_from_deps() {
+	cat $* | \
+	sed -E -e "s/ /\\n/g" | \
+	sed -E \
+		-e "/^.*:/d" \
+		-e "s/\\\\\$//" \
+		-e "/^jlm/p" \
+		-e "/^test/p" \
+		-e "d" | \
+	sort -u
+}
+
+declare DEPFILES=()
+while [[ "$#" -ge 1 ]] ; do
+	if [ "$1" == "-h" ] ; then
+		shift
+		break
+	fi
+	DEPFILES+=("$1")
+	shift
+done
+
+declare HEADERS=()
+while [[ "$#" -ge 1 ]] ; do
+	if [ "$1" == "-s" ] ; then
+		shift
+		break
+	fi
+	HEADERS+=("$1")
+	shift
+done
+
+declare SOURCES=()
+while [[ "$#" -ge 1 ]] ; do
+	SOURCES+=("$1")
+	shift
+done
+
+TMPDIR=`mktemp -d`
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+headers_from_deps "${DEPFILES[*]}" > "${TMPDIR}/headers_used"
+(IFS='
+' ; echo "${HEADERS[*]}" ; echo "${SOURCES[*]}" ) | sort -u > "${TMPDIR}/headers_declared"
+
+if grep -f "${TMPDIR}/headers_declared" -v "${TMPDIR}/headers_used" > "${TMPDIR}/headers_undeclared" ; then
+	echo "*** The following headers are used but not declared in build rules: ***"
+	cat "${TMPDIR}/headers_undeclared"
+	echo "Hint: the list may be inaccurate if dependence information is stale".
+	echo "If you think this is the case, please try running 'make depclean ; make depend'."
+	exit 1
+else
+	exit 0
+fi

--- a/tests/Makefile.sub
+++ b/tests/Makefile.sub
@@ -7,6 +7,10 @@ libjlmtest_SOURCES = \
 
 libjlmtest_HEADERS = \
 	tests/test-operation.hpp \
+	tests/test-registry.hpp \
+	tests/test-types.hpp \
+	tests/test-util.hpp \
+	tests/TestRvsdgs.hpp \
 
 $(eval $(call common_library,libjlmtest))
 


### PR DESCRIPTION
make target for header consistency checking

Provide a "check-headers" target that verifies whether all header files
are correctly correctly declared for the build system. This avoids cases
when a header is used, but not declared in any library build rule.

In principle, the build system should always be aware of every single file
used during build. Otherwise, this can cause problems, e.g. when a library
is built but the "install" rule misses headers that should go without,
hence publishing a broken package.

The present checking does not verify if the header is "assigned" to the library
that "uses" it (or some dependent library) -- that is difficult to express
in "make", but this check should be sufficient for the purposes of manually
rectifying any oversight.

Fix missing headers detected by check-headers target

Add all headers detected missing by the build target to declarations
in the makefiles.
