### PR TITLE
Move CFG conversion to ascii to cfg class

### DIFF
--- a/jlm/llvm/Makefile.sub
+++ b/jlm/llvm/Makefile.sub
@@ -190,6 +190,7 @@ libllvm_TESTS += \
     tests/jlm/llvm/ir/test-ssa-destruction \
     tests/jlm/llvm/ir/TestTypes \
     tests/jlm/llvm/ir/TestAnnotation \
+    tests/jlm/llvm/ir/ThreeAddressCodeTests \
     tests/jlm/llvm/opt/alias-analyses/TestAgnosticMemoryNodeProvider \
     tests/jlm/llvm/opt/alias-analyses/TestAndersen \
     tests/jlm/llvm/opt/alias-analyses/TestDifferencePropagation \

--- a/jlm/llvm/ir/cfg.cpp
+++ b/jlm/llvm/ir/cfg.cpp
@@ -69,6 +69,111 @@ cfg::remove_node(basic_block * bb)
   return remove_node(it);
 }
 
+std::string
+cfg::ToAscii(const cfg & controlFlowGraph)
+{
+  std::string str;
+  auto nodes = breadth_first(controlFlowGraph);
+  for (const auto & node : nodes)
+  {
+    str += CreateLabel(*node) + ":";
+    str += (is<basic_block>(node) ? "\n" : " ");
+
+    if (auto entryNode = dynamic_cast<const entry_node *>(node))
+    {
+      str += ToAscii(*entryNode);
+    }
+    else if (auto exitNode = dynamic_cast<const exit_node *>(node))
+    {
+      str += ToAscii(*exitNode);
+    }
+    else if (auto basicBlock = dynamic_cast<const basic_block *>(node))
+    {
+      str += ToAscii(*basicBlock);
+    }
+    else
+    {
+      JLM_UNREACHABLE("Unhandled control flow graph node type!");
+    }
+  }
+
+  return str;
+}
+
+std::string
+cfg::ToAscii(const entry_node & entryNode)
+{
+  std::string str;
+  for (size_t n = 0; n < entryNode.narguments(); n++)
+  {
+    str += entryNode.argument(n)->debug_string() + " ";
+  }
+
+  return str + "\n";
+}
+
+std::string
+cfg::ToAscii(const exit_node & exitNode)
+{
+  std::string str;
+  for (size_t n = 0; n < exitNode.nresults(); n++)
+  {
+    str += exitNode.result(n)->debug_string() + " ";
+  }
+
+  return str;
+}
+
+std::string
+cfg::ToAscii(const basic_block & basicBlock)
+{
+  auto & threeAddressCodes = basicBlock.tacs();
+
+  std::string str;
+  for (const auto & tac : threeAddressCodes)
+  {
+    str += "\t" + tac::ToAscii(*tac);
+    if (tac != threeAddressCodes.last())
+      str += "\n";
+  }
+
+  if (threeAddressCodes.last())
+  {
+    if (is<branch_op>(threeAddressCodes.last()->operation()))
+      str += " " + CreateTargets(basicBlock);
+    else
+      str += "\n\t" + CreateTargets(basicBlock);
+  }
+  else
+  {
+    str += "\t" + CreateTargets(basicBlock);
+  }
+
+  return str + "\n";
+}
+
+std::string
+cfg::CreateTargets(const cfg_node & node)
+{
+  size_t n = 0;
+  std::string str("[");
+  for (auto it = node.begin_outedges(); it != node.end_outedges(); it++, n++)
+  {
+    str += CreateLabel(*it->sink());
+    if (n != node.noutedges() - 1)
+      str += ", ";
+  }
+  str += "]";
+
+  return str;
+}
+
+std::string
+cfg::CreateLabel(const cfg_node & node)
+{
+  return util::strfmt(&node);
+}
+
 /* supporting functions */
 
 std::vector<cfg_node *>

--- a/jlm/llvm/ir/cfg.hpp
+++ b/jlm/llvm/ir/cfg.hpp
@@ -376,7 +376,25 @@ public:
     return std::unique_ptr<cfg>(new cfg(im));
   }
 
+  static std::string
+  ToAscii(const cfg & controlFlowGraph);
+
 private:
+  static std::string
+  ToAscii(const entry_node & entryNode);
+
+  static std::string
+  ToAscii(const exit_node & exitNode);
+
+  static std::string
+  ToAscii(const basic_block & basicBlock);
+
+  static std::string
+  CreateTargets(const cfg_node & node);
+
+  static std::string
+  CreateLabel(const cfg_node & node);
+
   ipgraph_module & module_;
   std::unique_ptr<exit_node> exit_;
   std::unique_ptr<entry_node> entry_;

--- a/jlm/llvm/ir/print.cpp
+++ b/jlm/llvm/ir/print.cpp
@@ -19,140 +19,13 @@ namespace jlm::llvm
 /* string converters */
 
 static std::string
-emit_tac(const llvm::tac &);
-
-static std::string
 emit_tacs(const tacsvector_t & tacs)
 {
   std::string str;
   for (const auto & tac : tacs)
-    str += emit_tac(*tac) + ", ";
+    str += tac::ToAscii(*tac) + ", ";
 
   return "[" + str + "]";
-}
-
-static inline std::string
-emit_entry(const cfg_node * node)
-{
-  JLM_ASSERT(is<entry_node>(node));
-  auto & en = *static_cast<const entry_node *>(node);
-
-  std::string str;
-  for (size_t n = 0; n < en.narguments(); n++)
-    str += en.argument(n)->debug_string() + " ";
-
-  return str + "\n";
-}
-
-static inline std::string
-emit_exit(const cfg_node * node)
-{
-  JLM_ASSERT(is<exit_node>(node));
-  auto & xn = *static_cast<const exit_node *>(node);
-
-  std::string str;
-  for (size_t n = 0; n < xn.nresults(); n++)
-    str += xn.result(n)->debug_string() + " ";
-
-  return str;
-}
-
-static inline std::string
-emit_tac(const llvm::tac & tac)
-{
-  /* convert results */
-  std::string results;
-  for (size_t n = 0; n < tac.nresults(); n++)
-  {
-    results += tac.result(n)->debug_string();
-    if (n != tac.nresults() - 1)
-      results += ", ";
-  }
-
-  /* convert operands */
-  std::string operands;
-  for (size_t n = 0; n < tac.noperands(); n++)
-  {
-    operands += tac.operand(n)->debug_string();
-    if (n != tac.noperands() - 1)
-      operands += ", ";
-  }
-
-  std::string op = tac.operation().debug_string();
-  return results + (results.empty() ? "" : " = ") + op + " " + operands;
-}
-
-static inline std::string
-emit_label(const cfg_node * node)
-{
-  return util::strfmt(node);
-}
-
-static inline std::string
-emit_targets(const cfg_node * node)
-{
-  size_t n = 0;
-  std::string str("[");
-  for (auto it = node->begin_outedges(); it != node->end_outedges(); it++, n++)
-  {
-    str += emit_label(it->sink());
-    if (n != node->noutedges() - 1)
-      str += ", ";
-  }
-  str += "]";
-
-  return str;
-}
-
-static inline std::string
-emit_basic_block(const cfg_node * node)
-{
-  JLM_ASSERT(is<basic_block>(node));
-  auto & tacs = static_cast<const basic_block *>(node)->tacs();
-
-  std::string str;
-  for (const auto & tac : tacs)
-  {
-    str += "\t" + emit_tac(*tac);
-    if (tac != tacs.last())
-      str += "\n";
-  }
-
-  if (tacs.last())
-  {
-    if (is<branch_op>(tacs.last()->operation()))
-      str += " " + emit_targets(node);
-    else
-      str += "\n\t" + emit_targets(node);
-  }
-  else
-  {
-    str += "\t" + emit_targets(node);
-  }
-
-  return str + "\n";
-}
-
-std::string
-to_str(const llvm::cfg & cfg)
-{
-  static std::unordered_map<std::type_index, std::string (*)(const cfg_node *)> map(
-      { { typeid(entry_node), emit_entry },
-        { typeid(exit_node), emit_exit },
-        { typeid(basic_block), emit_basic_block } });
-
-  std::string str;
-  auto nodes = breadth_first(cfg);
-  for (const auto & node : nodes)
-  {
-    str += emit_label(node) + ":";
-    str += (is<basic_block>(node) ? "\n" : " ");
-
-    JLM_ASSERT(map.find(typeid(*node)) != map.end());
-    str += map[typeid(*node)](node) + "\n";
-  }
-
-  return str;
 }
 
 static std::string
@@ -183,7 +56,7 @@ emit_function_node(const ipgraph_node & clg_node)
   }
   operands += ">";
 
-  std::string cfg = node.cfg() ? to_str(*node.cfg()) : "";
+  std::string cfg = node.cfg() ? cfg::ToAscii(*node.cfg()) : "";
   std::string exported = !is_externally_visible(node.linkage()) ? "static" : "";
 
   return exported + results + " " + node.name() + " " + operands + "\n{\n" + cfg + "}\n";
@@ -261,7 +134,7 @@ emit_basic_block(const cfg_node & node)
 
   std::string str;
   for (const auto & tac : tacs)
-    str += emit_tac(*tac) + "\\n";
+    str += tac::ToAscii(*tac) + "\\n";
 
   return str;
 }

--- a/jlm/llvm/ir/print.hpp
+++ b/jlm/llvm/ir/print.hpp
@@ -22,17 +22,7 @@ class ipgraph_module;
 /* control flow graph */
 
 std::string
-to_str(const llvm::cfg & cfg);
-
-std::string
 to_dot(const llvm::cfg & cfg);
-
-static inline void
-print_ascii(const llvm::cfg & cfg, FILE * out)
-{
-  fputs(to_str(cfg).c_str(), out);
-  fflush(out);
-}
 
 static inline void
 print_dot(const llvm::cfg & cfg, FILE * out)

--- a/jlm/llvm/ir/tac.cpp
+++ b/jlm/llvm/ir/tac.cpp
@@ -122,26 +122,27 @@ tac::replace(
 std::string
 tac::ToAscii(const jlm::llvm::tac & threeAddressCode)
 {
-  // convert results
-  std::string results;
+  std::string resultString;
   for (size_t n = 0; n < threeAddressCode.nresults(); n++)
   {
-    results += threeAddressCode.result(n)->debug_string();
+    resultString += threeAddressCode.result(n)->debug_string();
     if (n != threeAddressCode.nresults() - 1)
-      results += ", ";
-  }
-  
-  // convert operands
-  std::string operands;
-  for (size_t n = 0; n < threeAddressCode.noperands(); n++)
-  {
-    operands += threeAddressCode.operand(n)->debug_string();
-    if (n != threeAddressCode.noperands() - 1)
-      operands += ", ";
+      resultString += ", ";
   }
 
-  std::string op = threeAddressCode.operation().debug_string();
-  return results + (results.empty() ? "" : " = ") + op + " " + operands;
+  std::string operandString;
+  for (size_t n = 0; n < threeAddressCode.noperands(); n++)
+  {
+    operandString += threeAddressCode.operand(n)->debug_string();
+    if (n != threeAddressCode.noperands() - 1)
+      operandString += ", ";
+  }
+
+  std::string operationString = threeAddressCode.operation().debug_string();
+  std::string resultOperationSeparator = resultString.empty() ? "" : " = ";
+  std::string operationOperandSeparator = operandString.empty() ? "" : " ";
+  return resultString + resultOperationSeparator + operationString + operationOperandSeparator
+       + operandString;
 }
 
 }

--- a/jlm/llvm/ir/tac.cpp
+++ b/jlm/llvm/ir/tac.cpp
@@ -119,4 +119,29 @@ tac::replace(
   operation_ = operation.copy();
 }
 
+std::string
+tac::ToAscii(const jlm::llvm::tac & threeAddressCode)
+{
+  // convert results
+  std::string results;
+  for (size_t n = 0; n < threeAddressCode.nresults(); n++)
+  {
+    results += threeAddressCode.result(n)->debug_string();
+    if (n != threeAddressCode.nresults() - 1)
+      results += ", ";
+  }
+  
+  // convert operands
+  std::string operands;
+  for (size_t n = 0; n < threeAddressCode.noperands(); n++)
+  {
+    operands += threeAddressCode.operand(n)->debug_string();
+    if (n != threeAddressCode.noperands() - 1)
+      operands += ", ";
+  }
+
+  std::string op = threeAddressCode.operation().debug_string();
+  return results + (results.empty() ? "" : " = ") + op + " " + operands;
+}
+
 }

--- a/jlm/llvm/ir/tac.hpp
+++ b/jlm/llvm/ir/tac.hpp
@@ -126,6 +126,9 @@ public:
   void
   convert(const jlm::rvsdg::simple_op & operation, const std::vector<const variable *> & operands);
 
+  static std::string
+  ToAscii(const tac & threeAddressCode);
+
   static std::unique_ptr<llvm::tac>
   create(const jlm::rvsdg::simple_op & operation, const std::vector<const variable *> & operands)
   {

--- a/tests/jlm/llvm/backend/llvm/r2j/GammaTests.cpp
+++ b/tests/jlm/llvm/backend/llvm/r2j/GammaTests.cpp
@@ -221,7 +221,7 @@ PartialEmptyGamma()
   assert(ipg.nnodes() == 1);
 
   auto cfg = dynamic_cast<const function_node &>(*ipg.begin()).cfg();
-  print_ascii(*cfg, stdout);
+  std::cout << cfg::ToAscii(*cfg) << std::flush;
 
   assert(!is_proper_structured(*cfg));
   assert(is_structured(*cfg));

--- a/tests/jlm/llvm/ir/ThreeAddressCodeTests.cpp
+++ b/tests/jlm/llvm/ir/ThreeAddressCodeTests.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 Håvard Krogstie <krogstie.havard@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <test-operation.hpp>
+#include <test-registry.hpp>
+#include <test-types.hpp>
+
+static int
+ToAscii()
+{
+  using namespace jlm::llvm;
+  using namespace jlm::tests;
+
+  // Arrange
+  auto valueType = valuetype::Create();
+
+  variable v0(valueType, "v0");
+  variable v1(valueType, "v1");
+
+  auto tac0 = create_testop_tac({}, {});
+  auto tac1 = create_testop_tac({ &v0 }, {});
+  auto tac2 = create_testop_tac({ &v0, &v1 }, {});
+  auto tac3 = create_testop_tac({}, { valueType });
+  auto tac4 = create_testop_tac({}, { valueType, valueType });
+  auto tac5 = create_testop_tac({ &v0, &v1 }, { valueType, valueType });
+
+  // Act
+  auto tac0String = tac::ToAscii(*tac0);
+  std::cout << tac0String << "\n" << std::flush;
+
+  auto tac1String = tac::ToAscii(*tac1);
+  std::cout << tac1String << "\n" << std::flush;
+
+  auto tac2String = tac::ToAscii(*tac2);
+  std::cout << tac2String << "\n" << std::flush;
+
+  auto tac3String = tac::ToAscii(*tac3);
+  std::cout << tac3String << "\n" << std::flush;
+
+  auto tac4String = tac::ToAscii(*tac4);
+  std::cout << tac4String << "\n" << std::flush;
+
+  auto tac5String = tac::ToAscii(*tac5);
+  std::cout << tac5String << "\n" << std::flush;
+
+  // Assert
+  assert(tac0String == "test_op");
+  assert(tac1String == "test_op v0");
+  assert(tac2String == "test_op v0, v1");
+  assert(tac3String == "tv0 = test_op");
+  assert(tac4String == "tv1, tv2 = test_op");
+  assert(tac5String == "tv3, tv4 = test_op v0, v1");
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER("jlm/llvm/ir/ThreeAddressCodeTests-ToAscii", ToAscii);

--- a/tests/jlm/llvm/ir/ThreeAddressCodeTests.cpp
+++ b/tests/jlm/llvm/ir/ThreeAddressCodeTests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Håvard Krogstie <krogstie.havard@gmail.com>
+ * Copyright 2024 Nico Reißmann <nico.reissmann@gmail.com>
  * See COPYING for terms of redistribution.
  */
 

--- a/tests/jlm/llvm/ir/test-cfg-node.cpp
+++ b/tests/jlm/llvm/ir/test-cfg-node.cpp
@@ -26,7 +26,7 @@ test_divert_inedges()
   bb0->add_outedge(bb0);
   bb0->add_outedge(cfg.exit());
 
-  print_ascii(cfg, stdout);
+  std::cout << cfg::ToAscii(cfg) << std::flush;
 
   /* verify inedge diversion */
 

--- a/tests/jlm/llvm/ir/test-cfg-prune.cpp
+++ b/tests/jlm/llvm/ir/test-cfg-prune.cpp
@@ -38,12 +38,12 @@ test()
   bb1->add_outedge(cfg.exit());
   cfg.exit()->append_result(bb1->last()->result(0));
 
-  print_ascii(cfg, stdout);
+  std::cout << cfg::ToAscii(cfg) << std::flush;
 
   /* verify pruning */
 
   prune(cfg);
-  print_ascii(cfg, stdout);
+  std::cout << cfg::ToAscii(cfg) << std::flush;
 
   assert(cfg.nnodes() == 1);
 

--- a/tests/jlm/llvm/ir/test-cfg-purge.cpp
+++ b/tests/jlm/llvm/ir/test-cfg-purge.cpp
@@ -30,7 +30,7 @@ test()
   bb0->add_outedge(cfg.exit());
   bb1->add_outedge(bb1);
 
-  print_ascii(cfg, stdout);
+  std::cout << cfg::ToAscii(cfg) << std::flush;
 
   purge(cfg);
 

--- a/tests/jlm/llvm/ir/test-cfg-structure.cpp
+++ b/tests/jlm/llvm/ir/test-cfg-structure.cpp
@@ -67,7 +67,7 @@ test_is_structured()
   bb->add_outedge(join);
   join->add_outedge(cfg.exit());
 
-  print_ascii(cfg, stdout);
+  std::cout << cfg::ToAscii(cfg) << std::flush;
   assert(is_structured(cfg));
 }
 

--- a/tests/jlm/llvm/ir/test-cfg-validity.cpp
+++ b/tests/jlm/llvm/ir/test-cfg-validity.cpp
@@ -31,7 +31,7 @@ test_single_operand_phi()
   bb0->add_outedge(cfg.exit());
   cfg.exit()->append_result(bb0->last()->result(0));
 
-  print_ascii(cfg, stdout);
+  std::cout << cfg::ToAscii(cfg) << std::flush;
 
   assert(is_valid(cfg));
 }

--- a/tests/jlm/llvm/ir/test-cfg.cpp
+++ b/tests/jlm/llvm/ir/test-cfg.cpp
@@ -24,7 +24,7 @@ test_remove_node()
   bb0->add_outedge(bb0);
   bb0->add_outedge(cfg.exit());
 
-  print_ascii(cfg, stdout);
+  std::cout << cfg::ToAscii(cfg) << std::flush;
 
   /* verify inedge diversion */
 

--- a/tests/jlm/llvm/ir/test-ssa-destruction.cpp
+++ b/tests/jlm/llvm/ir/test-ssa-destruction.cpp
@@ -49,11 +49,11 @@ test_two_phis()
   bb4->append_last(phi_op::create({ { v1, bb2 }, { v2, bb3 } }, vt));
   bb4->append_last(phi_op::create({ { v3, bb2 }, { v4, bb3 } }, vt));
 
-  print_ascii(cfg, stdout);
+  std::cout << cfg::ToAscii(cfg) << std::flush;
 
   destruct_ssa(cfg);
 
-  print_ascii(cfg, stdout);
+  std::cout << cfg::ToAscii(cfg) << std::flush;
 }
 
 static int


### PR DESCRIPTION
The ascii output for the control flow graph is not easily readable. This is the first PR on improving it. It does the following:

1. Moves the functions for converting a CFG to ascii to the cfg class
2. Adds a unit test for the conversion of three address codes

In order to add a unit test for the CFG conversion, I first need to make the output more deterministic. This will happen in a follow up PR. This PR is part of issue #586