### PR TITLE
rvsdg2dot use argument and result index as label

### DIFF
--- a/jlm/llvm/backend/dot/DotWriter.cpp
+++ b/jlm/llvm/backend/dot/DotWriter.cpp
@@ -145,7 +145,6 @@ CreateGraphNodes(util::Graph & graph, rvsdg::Region & region, util::Graph * type
     AttachNodeOutput(node, argument, typeGraph);
 
     // Give the argument a label using its local index, not the global argument index
-    // Use an uppercase A to distinguish
     node.SetLabel(util::strfmt("a", n));
 
     // If this argument corresponds to one of the structural node's inputs, reference it

--- a/jlm/llvm/backend/dot/DotWriter.cpp
+++ b/jlm/llvm/backend/dot/DotWriter.cpp
@@ -146,14 +146,14 @@ CreateGraphNodes(util::Graph & graph, rvsdg::Region & region, util::Graph * type
 
     // Give the argument a label using its local index, not the global argument index
     // Use an uppercase A to distinguish
-    node.SetLabel(util::strfmt("#", n));
+    node.SetLabel(util::strfmt("a", n));
 
     // If this argument corresponds to one of the structural node's inputs, reference it
     if (argument.input())
     {
       node.SetAttributeObject("input", *argument.input());
       // Include the local index of the node's input in the label
-      node.AppendToLabel(util::strfmt("(", argument.input()->index(), ")"), " ");
+      node.AppendToLabel(util::strfmt("<- i", argument.input()->index()), " ");
     }
   }
 
@@ -191,14 +191,14 @@ CreateGraphNodes(util::Graph & graph, rvsdg::Region & region, util::Graph * type
     AttachNodeInput(node, result);
 
     // Use the result's local index as the label
-    node.SetLabel(util::strfmt("#", n));
+    node.SetLabel(util::strfmt("r", n));
 
     // If this result corresponds to one of the structural node's outputs, reference it
     if (result.output())
     {
       node.SetAttributeObject("output", *result.output());
       // Include the local index of the node's output in the label
-      node.AppendToLabel(util::strfmt("(", result.output()->index(), ")"), " ");
+      node.AppendToLabel(util::strfmt("-> o", result.output()->index()), " ");
     }
   }
 }

--- a/jlm/llvm/backend/dot/DotWriter.cpp
+++ b/jlm/llvm/backend/dot/DotWriter.cpp
@@ -146,14 +146,14 @@ CreateGraphNodes(util::Graph & graph, rvsdg::Region & region, util::Graph * type
 
     // Give the argument a label using its local index, not the global argument index
     // Use an uppercase A to distinguish
-    node.SetLabel(util::strfmt("A", n));
+    node.SetLabel(util::strfmt("#", n));
 
     // If this argument corresponds to one of the structural node's inputs, reference it
     if (argument.input())
     {
       node.SetAttributeObject("input", *argument.input());
       // Include the local index of the node's input in the label
-      node.AppendToLabel(util::strfmt("(I", argument.input()->index(), ")"), " ");
+      node.AppendToLabel(util::strfmt("(", argument.input()->index(), ")"), " ");
     }
   }
 
@@ -191,14 +191,14 @@ CreateGraphNodes(util::Graph & graph, rvsdg::Region & region, util::Graph * type
     AttachNodeInput(node, result);
 
     // Use the result's local index as the label
-    node.SetLabel(util::strfmt("R", n));
+    node.SetLabel(util::strfmt("#", n));
 
     // If this result corresponds to one of the structural node's outputs, reference it
     if (result.output())
     {
       node.SetAttributeObject("output", *result.output());
       // Include the local index of the node's output in the label
-      node.AppendToLabel(util::strfmt("(O", result.output()->index(), ")"), " ");
+      node.AppendToLabel(util::strfmt("(", result.output()->index(), ")"), " ");
     }
   }
 }

--- a/jlm/llvm/backend/dot/DotWriter.cpp
+++ b/jlm/llvm/backend/dot/DotWriter.cpp
@@ -144,9 +144,17 @@ CreateGraphNodes(util::Graph & graph, rvsdg::Region & region, util::Graph * type
     auto & argument = *region.argument(n);
     AttachNodeOutput(node, argument, typeGraph);
 
+    // Give the argument a label using its local index, not the global argument index
+    // Use an uppercase A to distinguish
+    node.SetLabel(util::strfmt("A", n));
+
     // If this argument corresponds to one of the structural node's inputs, reference it
     if (argument.input())
+    {
       node.SetAttributeObject("input", *argument.input());
+      // Include the local index of the node's input in the label
+      node.AppendToLabel(util::strfmt("(I", argument.input()->index(), ")"), " ");
+    }
   }
 
   // Create a node for each node in the region in topological order.
@@ -182,9 +190,16 @@ CreateGraphNodes(util::Graph & graph, rvsdg::Region & region, util::Graph * type
     auto & result = *region.result(n);
     AttachNodeInput(node, result);
 
+    // Use the result's local index as the label
+    node.SetLabel(util::strfmt("R", n));
+
     // If this result corresponds to one of the structural node's outputs, reference it
     if (result.output())
+    {
       node.SetAttributeObject("output", *result.output());
+      // Include the local index of the node's output in the label
+      node.AppendToLabel(util::strfmt("(O", result.output()->index(), ")"), " ");
+    }
   }
 }
 

--- a/jlm/util/GraphWriter.cpp
+++ b/jlm/util/GraphWriter.cpp
@@ -597,7 +597,7 @@ InputPort::InputPort(jlm::util::InOutNode & node)
 const char *
 InputPort::GetIdPrefix() const
 {
-  return "i";
+  return "in";
 }
 
 Node &
@@ -634,7 +634,7 @@ OutputPort::OutputPort(jlm::util::InOutNode & node)
 const char *
 OutputPort::GetIdPrefix() const
 {
-  return "o";
+  return "out";
 }
 
 Node &
@@ -917,7 +917,7 @@ ArgumentNode::ArgumentNode(jlm::util::Graph & graph)
 const char *
 ArgumentNode::GetIdPrefix() const
 {
-  return "a";
+  return "arg";
 }
 
 bool
@@ -958,7 +958,7 @@ ResultNode::ResultNode(jlm::util::Graph & graph)
 const char *
 ResultNode::GetIdPrefix() const
 {
-  return "r";
+  return "res";
 }
 
 bool

--- a/jlm/util/GraphWriter.cpp
+++ b/jlm/util/GraphWriter.cpp
@@ -889,7 +889,7 @@ InOutNode::OutputDot(std::ostream & out, size_t indent) const
     for (auto & graph : SubGraphs_)
     {
       out << "\t\t\t\t\t<TD BORDER=\"1\" STYLE=\"ROUNDED\" WIDTH=\"40\" BGCOLOR=\"white\" ";
-      out << "SUBGRAPH=\"" << graph->GetFullId() << "\">";
+      out << "_SUBGRAPH=\"" << graph->GetFullId() << "\">";
       PrintStringAsHtmlText(out, graph->GetFullId(), true);
       out << "</TD>" << std::endl;
     }

--- a/scripts/build-circt.sh
+++ b/scripts/build-circt.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 JLM_ROOT_DIR="$(realpath "${SCRIPT_DIR}/..")"
 CIRCT_BUILD=${JLM_ROOT_DIR}/build-circt
 CIRCT_INSTALL=${JLM_ROOT_DIR}/usr
-LLVM_LIT_PATH=/usr/local/bin/lit
+LLVM_LIT_PATH=`which lit`
 
 LLVM_VERSION=18
 LLVM_CONFIG_BIN=llvm-config-${LLVM_VERSION}

--- a/tests/jlm/llvm/backend/dot/DotWriterTests.cpp
+++ b/tests/jlm/llvm/backend/dot/DotWriterTests.cpp
@@ -57,12 +57,15 @@ TestWriteGraphs()
   auto & argument = gammaNode.GetSubgraph(0).GetArgumentNode(0);
   auto & input = gammaNode.GetInputPort(1);
   assert(argument.GetAttributeGraphElement("input") == &input);
-  assert(argument.GetLabel().find("#0 (1)") != std::string::npos);
+  // The label also includes the attribute index and input index
+  assert(argument.GetLabel() == "a0 <- i1");
+  auto & result = argument.GetConnections().front()->GetOtherEnd(argument);
+  assert(result.GetLabel() == "r0 -> o0");
 
   // Check that the last argument is colored red to represent the memory state type
   auto & stateConnections = fctBody.GetArgumentNode(5).GetConnections();
   assert(stateConnections.size() == 1);
-  assert(stateConnections[0]->GetAttributeString("color") == "#FF0000");
+  assert(stateConnections.front()->GetAttributeString("color") == "#FF0000");
 
   return 0;
 }

--- a/tests/jlm/llvm/backend/dot/DotWriterTests.cpp
+++ b/tests/jlm/llvm/backend/dot/DotWriterTests.cpp
@@ -57,6 +57,7 @@ TestWriteGraphs()
   auto & argument = gammaNode.GetSubgraph(0).GetArgumentNode(0);
   auto & input = gammaNode.GetInputPort(1);
   assert(argument.GetAttributeGraphElement("input") == &input);
+  assert(argument.GetLabel().find("#0 (1)") != std::string::npos);
 
   // Check that the last argument is colored red to represent the memory state type
   auto & stateConnections = fctBody.GetArgumentNode(5).GetConnections();

--- a/tests/jlm/util/TestGraphWriter.cpp
+++ b/tests/jlm/util/TestGraphWriter.cpp
@@ -184,11 +184,11 @@ TestInOutNode()
   std::ostringstream out;
   node.Output(out, GraphOutputFormat::ASCII, 0);
   auto string = out.str();
-  assert(StringContains(string, "o0, o1, o2 := \"My\\nInOutNode\" o2, []"));
+  assert(StringContains(string, "out0, out1, out2 := \"My\\nInOutNode\" out2, []"));
 
   // Check that the subgraph is also printed
-  assert(StringContains(string, "ARG a0:CTX <= o2"));
-  assert(StringContains(string, "RES a0:RETURN => o0"));
+  assert(StringContains(string, "ARG arg0:CTX <= out2"));
+  assert(StringContains(string, "RES arg0:RETURN => out0"));
 
   // Check that HTML labels with newlines turn into <BR/>
   std::ostringstream out2;


### PR DESCRIPTION
In order to make it easier to read the graphs, arguments and results only get their index. The number in parenthesis is the index of the corresponding input/output of the structural node if any.

![image](https://github.com/user-attachments/assets/54b2c76a-9a79-49e0-9862-55fe9632764a)

Let me know if you prefer a different label.
Fixes #626