### PR TITLE
Generalize the memory response and request nodes to handle multiple memory ports

### DIFF
--- a/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.cpp
+++ b/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.cpp
@@ -794,7 +794,7 @@ RhlsToFirrtlConverter::MlirGenHlsMemReq(const jlm::rvsdg::simple_node * node)
   ::llvm::SmallVector<mlir::Value> storeGranted(storeTypes->size(), zeroBitValue);
   for (size_t j = 0; j < node->noutputs(); ++j)
   {
-    auto reqType = util::AssertedCast<const jlm::hls::bundletype>(& node->output(j)->type());
+    auto reqType = util::AssertedCast<const jlm::hls::bundletype>(&node->output(j)->type());
     auto hasWrite = reqType->elements_.size() == 5;
     mlir::BlockArgument memReq = GetOutPort(module, j);
     mlir::Value memReqData;

--- a/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.cpp
+++ b/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.cpp
@@ -794,8 +794,7 @@ RhlsToFirrtlConverter::MlirGenHlsMemReq(const jlm::rvsdg::simple_node * node)
   ::llvm::SmallVector<mlir::Value> storeGranted(storeTypes->size(), zeroBitValue);
   for (size_t j = 0; j < node->noutputs(); ++j)
   {
-    auto reqType = dynamic_cast<const jlm::hls::bundletype *>(&node->output(j)->type());
-    // TODO: more robust check
+    auto reqType = util::AssertedCast<const jlm::hls::bundletype>(& node->output(j)->type());
     auto hasWrite = reqType->elements_.size() == 5;
     mlir::BlockArgument memReq = GetOutPort(module, j);
     mlir::Value memReqData;

--- a/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.hpp
+++ b/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.hpp
@@ -121,8 +121,20 @@ private:
   MlirGenStateGate(const jlm::rvsdg::simple_node * node);
   circt::firrtl::FModuleOp
   MlirGenMem(const jlm::rvsdg::simple_node * node);
+  /**
+   * Generate a FIRRTL module for a HLS memory response node that implements the functionality for
+   * retreiving memory responses.
+   * @param node The HLS memory response node.
+   * @return The generated FIRRTL module.
+   */
   circt::firrtl::FModuleOp
   MlirGenHlsMemResp(const jlm::rvsdg::simple_node * node);
+  /**
+   * Generate a FIRRTL module for a HLS memory request node that implements the functionality for
+   * performing memory requests.
+   * @param node The HLS memory request node.
+   * @return The generated FIRRTL module.
+   */
   circt::firrtl::FModuleOp
   MlirGenHlsMemReq(const jlm::rvsdg::simple_node * node);
   circt::firrtl::FModuleOp


### PR DESCRIPTION
Provides support for memories with multiple read and/or write ports, e.g., BRAMs in AMD FPGAs.