### PR TITLE
Remove lambda::cvinput

### DIFF
--- a/jlm/hls/backend/rhls2firrtl/verilator-harness-hls.cpp
+++ b/jlm/hls/backend/rhls2firrtl/verilator-harness-hls.cpp
@@ -490,10 +490,10 @@ VerilatorHarnessHLS::get_text(llvm::RvsdgModule & rm)
     cpp << "    top->i_data_" << i << " = (uint64_t) a" << i << ";\n";
     register_ix++;
   }
-  for (size_t i = 0; i < ln->ncvarguments(); ++i)
+  for (const auto & ctxvar : ln->GetContextVars())
   {
     std::string name;
-    if (auto graphImport = dynamic_cast<const llvm::GraphImport *>(ln->input(i)->origin()))
+    if (auto graphImport = dynamic_cast<const llvm::GraphImport *>(ctxvar.input->origin()))
     {
       name = graphImport->Name();
     }

--- a/jlm/hls/backend/rvsdg2rhls/UnusedStateRemoval.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/UnusedStateRemoval.cpp
@@ -71,12 +71,12 @@ RemoveUnusedStatesFromLambda(llvm::lambda::node & lambdaNode)
       lambdaNode.attributes());
 
   rvsdg::SubstitutionMap substitutionMap;
-  for (size_t i = 0; i < lambdaNode.ncvarguments(); ++i)
+  for (const auto & ctxvar : lambdaNode.GetContextVars())
   {
-    auto oldArgument = lambdaNode.cvargument(i);
-    auto origin = oldArgument->input()->origin();
+    auto oldArgument = ctxvar.inner;
+    auto origin = ctxvar.inner->input()->origin();
 
-    auto newArgument = newLambda->add_ctxvar(origin);
+    auto newArgument = newLambda->AddContextVar(origin).inner;
     substitutionMap.insert(oldArgument, newArgument);
   }
 

--- a/jlm/hls/backend/rvsdg2rhls/add-prints.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-prints.cpp
@@ -88,7 +88,7 @@ route_to_region(jlm::rvsdg::output * output, rvsdg::Region * region)
   }
   else if (auto lambda = dynamic_cast<llvm::lambda::node *>(region->node()))
   {
-    output = lambda->add_ctxvar(output);
+    output = lambda->AddContextVar(output).inner;
   }
   else
   {

--- a/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
@@ -51,10 +51,10 @@ add_lambda_argument(llvm::lambda::node * ln, std::shared_ptr<const jlm::rvsdg::t
       ln->attributes());
 
   rvsdg::SubstitutionMap smap;
-  for (size_t i = 0; i < ln->ncvarguments(); ++i)
+  for (const auto & ctxvar : ln->GetContextVars())
   {
-    // copy over cvarguments
-    smap.insert(ln->cvargument(i), new_lambda->add_ctxvar(ln->cvargument(i)->input()->origin()));
+    // copy over context vars
+    smap.insert(ctxvar.inner, new_lambda->AddContextVar(ctxvar.input->origin()).inner);
   }
   for (size_t i = 0; i < ln->nfctarguments(); ++i)
   {

--- a/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
@@ -28,11 +28,11 @@ change_function_name(llvm::lambda::node * ln, const std::string & name)
 
   /* add context variables */
   rvsdg::SubstitutionMap subregionmap;
-  for (auto & cv : ln->ctxvars())
+  for (const auto & cv : ln->GetContextVars())
   {
-    auto origin = cv.origin();
-    auto newcv = lambda->add_ctxvar(origin);
-    subregionmap.insert(cv.argument(), newcv);
+    auto origin = cv.input->origin();
+    auto newcv = lambda->AddContextVar(origin);
+    subregionmap.insert(cv.inner, newcv.inner);
   }
 
   /* collect function arguments */

--- a/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
@@ -205,10 +205,10 @@ remove_lambda_passthrough(llvm::lambda::node * ln)
       ln->attributes());
 
   rvsdg::SubstitutionMap smap;
-  for (size_t i = 0; i < ln->ncvarguments(); ++i)
+  for (const auto & ctxvar : ln->GetContextVars())
   {
-    // copy over cvarguments
-    smap.insert(ln->cvargument(i), new_lambda->add_ctxvar(ln->cvargument(i)->input()->origin()));
+    // copy over context vars
+    smap.insert(ctxvar.inner, new_lambda->AddContextVar(ctxvar.input->origin()).inner);
   }
 
   size_t new_i = 0;

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -287,11 +287,11 @@ change_linkage(llvm::lambda::node * ln, llvm::linkage link)
 
   /* add context variables */
   rvsdg::SubstitutionMap subregionmap;
-  for (auto & cv : ln->ctxvars())
+  for (const auto & cv : ln->GetContextVars())
   {
-    auto origin = cv.origin();
-    auto newcv = lambda->add_ctxvar(origin);
-    subregionmap.insert(cv.argument(), newcv);
+    auto origin = cv.input->origin();
+    auto newcv = lambda->AddContextVar(origin);
+    subregionmap.insert(cv.inner, newcv.inner);
   }
 
   /* collect function arguments */

--- a/jlm/llvm/backend/rvsdg2jlm/rvsdg2jlm.cpp
+++ b/jlm/llvm/backend/rvsdg2jlm/rvsdg2jlm.cpp
@@ -135,10 +135,10 @@ create_cfg(const lambda::node & lambda, context & ctx)
   }
 
   /* add context variables */
-  for (auto & cv : lambda.ctxvars())
+  for (const auto & cv : lambda.GetContextVars())
   {
-    auto v = ctx.variable(cv.origin());
-    ctx.insert(cv.argument(), v);
+    auto v = ctx.variable(cv.input->origin());
+    ctx.insert(cv.inner, v);
   }
 
   convert_region(*lambda.subregion(), ctx);

--- a/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
+++ b/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
@@ -630,7 +630,7 @@ Convert(
   {
     if (outerVariableMap.contains(&v))
     {
-      topVariableMap.insert(&v, lambdaNode.add_ctxvar(outerVariableMap.lookup(&v)));
+      topVariableMap.insert(&v, lambdaNode.AddContextVar(outerVariableMap.lookup(&v)).inner);
     }
     else
     {

--- a/jlm/llvm/ir/operators/lambda.hpp
+++ b/jlm/llvm/ir/operators/lambda.hpp
@@ -15,6 +15,7 @@
 #include <jlm/rvsdg/substitution.hpp>
 #include <jlm/util/iterator_range.hpp>
 
+#include <optional>
 #include <utility>
 
 namespace jlm::llvm
@@ -102,7 +103,6 @@ private:
 };
 
 class cvargument;
-class cvinput;
 class fctargument;
 class output;
 class result;
@@ -112,16 +112,17 @@ class result;
  * A lambda node represents a lambda expression in the RVSDG. Its creation requires the invocation
  * of two functions: \ref create() and \ref finalize(). First, a node with only the function
  * arguments is created by invoking \ref create(). The free variables of the lambda expression can
- * then be added to the lambda node using the \ref add_ctxvar() method, and the body of the lambda
- * node can be created. Finally, the lambda node can be finalized by invoking \ref finalize().
+ * then be added to the lambda node using the \ref AddContextVar() method, and the body of the
+ * lambda node can be created. Finally, the lambda node can be finalized by invoking \ref
+ * finalize().
  *
  * The following snippet illustrates the creation of lambda nodes:
  *
  * \code{.cpp}
  *   auto lambda = lambda::node::create(...);
  *   ...
- *   auto cv1 = lambda->add_ctxvar(...);
- *   auto cv2 = lambda->add_ctxvar(...);
+ *   auto cv1 = lambda->AddContextVar(...);
+ *   auto cv2 = lambda->AddContextVar(...);
  *   ...
  *   // generate lambda body
  *   ...
@@ -134,9 +135,6 @@ public:
   class CallSummary;
 
 private:
-  class cviterator;
-  class cvconstiterator;
-
   class fctargiterator;
   class fctargconstiterator;
 
@@ -145,9 +143,6 @@ private:
 
   using fctargument_range = jlm::util::iterator_range<fctargiterator>;
   using fctargument_constrange = jlm::util::iterator_range<fctargconstiterator>;
-
-  using ctxvar_range = jlm::util::iterator_range<cviterator>;
-  using ctxvar_constrange = jlm::util::iterator_range<cvconstiterator>;
 
   using fctresult_range = jlm::util::iterator_range<fctresiterator>;
   using fctresult_constrange = jlm::util::iterator_range<fctresconstiterator>;
@@ -161,20 +156,29 @@ private:
   {}
 
 public:
-  [[nodiscard]] fctargument_range
-  fctarguments();
+  /**
+   * \brief Bound context variable
+   *
+   * Context variables may be bound at the point of creation of a
+   * lambda abstraction. These are represented as inputs to the
+   * lambda node itself, and made accessible to the body of the
+   * lambda in the form of an initial argument to the subregion.
+   */
+  struct ContextVar
+  {
+    /**
+     * \brief Input variable bound into lambda (input to lambda node)
+     */
+    rvsdg::input * input;
+
+    /**
+     * \brief Formal argument to access to bound object in subregion.
+     */
+    rvsdg::RegionArgument * inner;
+  };
 
   [[nodiscard]] fctargument_constrange
   fctarguments() const;
-
-  ctxvar_range
-  ctxvars();
-
-  [[nodiscard]] ctxvar_constrange
-  ctxvars() const;
-
-  fctresult_range
-  fctresults();
 
   [[nodiscard]] fctresult_constrange
   fctresults() const;
@@ -222,12 +226,6 @@ public:
   }
 
   [[nodiscard]] size_t
-  ncvarguments() const noexcept
-  {
-    return ninputs();
-  }
-
-  [[nodiscard]] size_t
   nfctarguments() const noexcept
   {
     return subregion()->narguments() - ninputs();
@@ -240,20 +238,95 @@ public:
   }
 
   /**
-   * Adds a context/free variable to the lambda node. The \p origin must be from the same region
-   * as the lambda node.
+   * \brief Adds a context/free variable to the lambda node.
    *
-   * \return The context variable argument from the lambda region.
+   * \param origin
+   *   The value to be bound into the lambda node.
+   *
+   * \pre
+   *   \p origin must be from the same region as the lambda node.
+   *
+   * \return The context variable argument of the lambda abstraction.
    */
-  lambda::cvargument *
-  add_ctxvar(jlm::rvsdg::output * origin);
+  ContextVar
+  AddContextVar(jlm::rvsdg::output * origin);
+
+  /**
+   * \brief Maps input to context variable.
+   *
+   * \param input
+   *   Input to the lambda node.
+   *
+   * \returns
+   *   The context variable description corresponding to the input.
+   *
+   * \pre
+   *   \p input must be input to this node.
+   *
+   * Returns the context variable description corresponding
+   * to this input of the lambda node. All inputs to the lambda
+   * node are by definition bound context variables that are
+   * accessible in the subregion through the corresponding
+   * argument.
+   */
+  [[nodiscard]] ContextVar
+  MapInputContextVar(const rvsdg::input & input) const noexcept;
+
+  /**
+   * \brief Maps bound variable reference to context variable
+   *
+   * \param output
+   *   Region argument to lambda subregion
+   *
+   * \returns
+   *   The context variable description corresponding to the argument
+   *
+   * \pre
+   *   \p output must be an argument to the subregion of this nodeinput must be input to this node
+   *
+   * Returns the context variable description corresponding
+   * to this bound variable reference in the lambda node region.
+   * Note that some arguments of the region are formal call arguments
+   * and do not have an associated context variable description.
+   */
+  [[nodiscard]] std::optional<ContextVar>
+  MapBinderContextVar(const rvsdg::output & output) const noexcept;
+
+  /**
+   * \brief Gets bound context variable description
+   *
+   * \param index
+   *   Index of context variable to be retrieved.
+   *
+   * \returns
+   *   The context variable description corresponding to the argument.
+   *
+   * \pre
+   *   \p index must be a valid index.
+   *
+   * Returns the context variable description corresponding
+   * to the given index.
+   */
+  [[nodiscard]] ContextVar
+  GetContextVar(size_t index) const noexcept;
+
+  /**
+   * \brief Gets all bound context variables
+   *
+   * \returns
+   *   The context variable descriptions.
+   *
+   * Returns the context variable descriptions.
+   */
+  [[nodiscard]] std::vector<ContextVar>
+  GetContextVars() const noexcept;
 
   /**
    * Remove lambda inputs and their respective arguments.
    *
    * An input must match the condition specified by \p match and its argument must be dead.
    *
-   * @tparam F A type that supports the function call operator: bool operator(const cvinput&)
+   * @tparam F A type that supports the function call operator: bool operator(const rvsdg::input&)
    * @param match Defines the condition of the elements to remove.
    * @return The number of removed inputs.
    *
@@ -273,7 +346,7 @@ public:
   size_t
   PruneLambdaInputs()
   {
-    auto match = [](const cvinput &)
+    auto match = [](const rvsdg::input &)
     {
       return true;
     };
@@ -281,17 +354,11 @@ public:
     return RemoveLambdaInputsWhere(match);
   }
 
-  [[nodiscard]] cvinput *
-  input(size_t n) const noexcept;
-
   [[nodiscard]] lambda::output *
   output() const noexcept;
 
   [[nodiscard]] lambda::fctargument *
   fctargument(size_t n) const noexcept;
-
-  [[nodiscard]] lambda::cvargument *
-  cvargument(size_t n) const noexcept;
 
   [[nodiscard]] lambda::result *
   fctresult(size_t n) const noexcept;
@@ -341,8 +408,8 @@ public:
   /**
    * Creates a lambda node in the region \p parent with the function type \p type and name \p name.
    * After the invocation of \ref create(), the lambda node only features the function arguments.
-   * Free variables can be added to the function node using \ref add_ctxvar(). The generation of the
-   * node can be finished using the \ref finalize() method.
+   * Free variables can be added to the function node using \ref AddContextVar(). The generation of
+   * the node can be finished using the \ref finalize() method.
    *
    * \param parent The region where the lambda node is created.
    * \param type The lambda node's type.
@@ -401,78 +468,6 @@ public:
    */
   [[nodiscard]] static bool
   IsExported(const lambda::node & lambdaNode);
-};
-
-/** \brief Lambda context variable input
- */
-class cvinput final : public jlm::rvsdg::structural_input
-{
-  friend ::jlm::llvm::lambda::node;
-
-public:
-  ~cvinput() override;
-
-private:
-  cvinput(lambda::node * node, jlm::rvsdg::output * origin)
-      : structural_input(node, origin, origin->Type())
-  {}
-
-  static cvinput *
-  create(lambda::node * node, jlm::rvsdg::output * origin)
-  {
-    auto input = std::unique_ptr<cvinput>(new cvinput(node, origin));
-    return jlm::util::AssertedCast<cvinput>(node->append_input(std::move(input)));
-  }
-
-public:
-  [[nodiscard]] cvargument *
-  argument() const noexcept;
-
-  [[nodiscard]] lambda::node *
-  node() const noexcept
-  {
-    return jlm::util::AssertedCast<lambda::node>(structural_input::node());
-  }
-};
-
-/** \brief Lambda context variable iterator
- */
-class node::cviterator final : public jlm::rvsdg::input::iterator<cvinput>
-{
-  friend ::jlm::llvm::lambda::node;
-
-  constexpr explicit cviterator(cvinput * input)
-      : jlm::rvsdg::input::iterator<cvinput>(input)
-  {}
-
-  [[nodiscard]] cvinput *
-  next() const override
-  {
-    auto node = value()->node();
-    auto index = value()->index();
-
-    return node->ninputs() > index + 1 ? node->input(index + 1) : nullptr;
-  }
-};
-
-/** \brief Lambda context variable const iterator
- */
-class node::cvconstiterator final : public jlm::rvsdg::input::constiterator<cvinput>
-{
-  friend ::jlm::llvm::lambda::node;
-
-  constexpr explicit cvconstiterator(const cvinput * input)
-      : jlm::rvsdg::input::constiterator<cvinput>(input)
-  {}
-
-  [[nodiscard]] const cvinput *
-  next() const override
-  {
-    auto node = value()->node();
-    auto index = value()->index();
-
-    return node->ninputs() > index + 1 ? node->input(index + 1) : nullptr;
-  }
 };
 
 /** \brief Lambda output
@@ -606,23 +601,16 @@ public:
   Copy(rvsdg::Region & region, jlm::rvsdg::structural_input * input) override;
 
 private:
-  cvargument(rvsdg::Region * region, cvinput * input)
+  cvargument(rvsdg::Region * region, rvsdg::structural_input * input)
       : rvsdg::RegionArgument(region, input, input->Type())
   {}
 
   static cvargument *
-  create(rvsdg::Region * region, lambda::cvinput * input)
+  create(rvsdg::Region * region, rvsdg::structural_input * input)
   {
     auto argument = new cvargument(region, input);
     region->append_argument(argument);
     return argument;
-  }
-
-public:
-  cvinput *
-  input() const noexcept
-  {
-    return jlm::util::AssertedCast<cvinput>(rvsdg::RegionArgument::input());
   }
 };
 
@@ -882,10 +870,10 @@ lambda::node::RemoveLambdaInputsWhere(const F & match)
   // iterate backwards to avoid the invalidation of 'n' by RemoveInput()
   for (size_t n = ninputs() - 1; n != static_cast<size_t>(-1); n--)
   {
-    auto & lambdaInput = *input(n);
-    auto & argument = *lambdaInput.argument();
+    auto lambdaInput = input(n);
+    auto & argument = *MapInputContextVar(*lambdaInput).inner;
 
-    if (argument.IsDead() && match(lambdaInput))
+    if (argument.IsDead() && match(*lambdaInput))
     {
       subregion()->RemoveArgument(argument.index());
       RemoveInput(n);

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -814,13 +814,13 @@ void
 Andersen::AnalyzeLambda(const lambda::node & lambda)
 {
   // Handle context variables
-  for (auto & cv : lambda.ctxvars())
+  for (const auto & cv : lambda.GetContextVars())
   {
-    if (!IsOrContainsPointerType(cv.type()))
+    if (!IsOrContainsPointerType(cv.input->type()))
       continue;
 
-    auto & inputRegister = *cv.origin();
-    auto & argumentRegister = *cv.argument();
+    auto & inputRegister = *cv.input->origin();
+    auto & argumentRegister = *cv.inner;
     const auto inputRegisterPO = Set_->GetRegisterPointerObject(inputRegister);
     Set_->MapRegisterToExistingPointerObject(argumentRegister, inputRegisterPO);
   }

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -1472,14 +1472,14 @@ void
 Steensgaard::AnalyzeLambda(const lambda::node & lambda)
 {
   // Handle context variables
-  for (auto & cv : lambda.ctxvars())
+  for (const auto & cv : lambda.GetContextVars())
   {
-    auto & origin = *cv.origin();
+    auto & origin = *cv.input->origin();
 
     if (HasOrContainsPointerType(origin))
     {
       auto & originLocation = Context_->GetLocation(origin);
-      auto & argumentLocation = Context_->GetOrInsertRegisterLocation(*cv.argument());
+      auto & argumentLocation = Context_->GetOrInsertRegisterLocation(*cv.inner);
       Context_->Join(originLocation, argumentLocation);
     }
   }

--- a/jlm/llvm/opt/inlining.cpp
+++ b/jlm/llvm/opt/inlining.cpp
@@ -82,7 +82,7 @@ route_to_region(jlm::rvsdg::output * output, rvsdg::Region * region)
   }
   else if (auto lambda = dynamic_cast<lambda::node *>(region->node()))
   {
-    output = lambda->add_ctxvar(output);
+    output = lambda->AddContextVar(output).inner;
   }
   else if (auto phi = dynamic_cast<phi::node *>(region->node()))
   {
@@ -119,7 +119,8 @@ inlineCall(jlm::rvsdg::simple_node * call, const lambda::node * lambda)
   JLM_ASSERT(is<CallOperation>(call));
 
   auto deps = route_dependencies(lambda, call);
-  JLM_ASSERT(lambda->ncvarguments() == deps.size());
+  auto ctxvars = lambda->GetContextVars();
+  JLM_ASSERT(ctxvars.size() == deps.size());
 
   rvsdg::SubstitutionMap smap;
   for (size_t n = 1; n < call->ninputs(); n++)
@@ -127,8 +128,8 @@ inlineCall(jlm::rvsdg::simple_node * call, const lambda::node * lambda)
     auto argument = lambda->fctargument(n - 1);
     smap.insert(argument, call->input(n)->origin());
   }
-  for (size_t n = 0; n < lambda->ncvarguments(); n++)
-    smap.insert(lambda->cvargument(n), deps[n]);
+  for (size_t n = 0; n < ctxvars.size(); n++)
+    smap.insert(ctxvars[n].inner, deps[n]);
 
   lambda->subregion()->copy(call->region(), smap, false, false);
 

--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -391,7 +391,7 @@ Bits2PtrTest::SetupRvsdg()
     auto iOStateArgument = lambda->fctargument(1);
     auto memoryStateArgument = lambda->fctargument(2);
 
-    auto cvbits2ptr = lambda->add_ctxvar(b2p);
+    auto cvbits2ptr = lambda->AddContextVar(b2p).inner;
 
     auto & call = CallNode::CreateNode(
         cvbits2ptr,
@@ -553,8 +553,8 @@ CallTest1::SetupRvsdg()
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
 
-    auto cvf = lambda->add_ctxvar(f->output());
-    auto cvg = lambda->add_ctxvar(g->output());
+    auto cvf = lambda->AddContextVar(f->output()).inner;
+    auto cvg = lambda->AddContextVar(g->output()).inner;
 
     auto size = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
 
@@ -691,8 +691,8 @@ CallTest2::SetupRvsdg()
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
 
-    auto create_cv = lambda->add_ctxvar(lambdaCreate->output());
-    auto destroy_cv = lambda->add_ctxvar(lambdaDestroy->output());
+    auto create_cv = lambda->AddContextVar(lambdaCreate->output()).inner;
+    auto destroy_cv = lambda->AddContextVar(lambdaDestroy->output()).inner;
 
     auto six = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 6);
     auto seven = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 7);
@@ -811,9 +811,9 @@ IndirectCallTest1::SetupRvsdg()
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
 
-    auto fctindcall_cv = lambda->add_ctxvar(fctindcall);
-    auto fctfour_cv = lambda->add_ctxvar(fctfour);
-    auto fctthree_cv = lambda->add_ctxvar(fctthree);
+    auto fctindcall_cv = lambda->AddContextVar(fctindcall).inner;
+    auto fctfour_cv = lambda->AddContextVar(fctfour).inner;
+    auto fctthree_cv = lambda->AddContextVar(fctthree).inner;
 
     auto & call_four = CallNode::CreateNode(
         fctindcall_cv,
@@ -954,8 +954,8 @@ IndirectCallTest2::SetupRvsdg()
     auto iOStateArgument = lambda->fctargument(1);
     auto memoryStateArgument = lambda->fctargument(2);
 
-    auto functionICv = lambda->add_ctxvar(&functionI);
-    auto argumentFunctionCv = lambda->add_ctxvar(&argumentFunction);
+    auto functionICv = lambda->AddContextVar(&functionI).inner;
+    auto argumentFunctionCv = lambda->AddContextVar(&argumentFunction).inner;
 
     auto five = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, n);
     auto storeNode =
@@ -985,10 +985,10 @@ IndirectCallTest2::SetupRvsdg()
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
 
-    auto functionXCv = lambda->add_ctxvar(&functionX);
-    auto functionYCv = lambda->add_ctxvar(&functionY);
-    auto globalG1Cv = lambda->add_ctxvar(&globalG1);
-    auto globalG2Cv = lambda->add_ctxvar(&globalG2);
+    auto functionXCv = lambda->AddContextVar(&functionX).inner;
+    auto functionYCv = lambda->AddContextVar(&functionY).inner;
+    auto globalG1Cv = lambda->AddContextVar(&globalG1).inner;
+    auto globalG2Cv = lambda->AddContextVar(&globalG2).inner;
 
     auto constantSize = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
 
@@ -1051,7 +1051,7 @@ IndirectCallTest2::SetupRvsdg()
     auto pzAlloca = alloca_op::create(jlm::rvsdg::bittype::Create(32), constantSize, 4);
     auto pzMerge = MemoryStateMergeOperation::Create({ pzAlloca[1], memoryStateArgument });
 
-    auto functionXCv = lambda->add_ctxvar(&functionX);
+    auto functionXCv = lambda->AddContextVar(&functionX).inner;
 
     auto & callX = CallNode::CreateNode(
         functionXCv,
@@ -1150,7 +1150,7 @@ ExternalCallTest1::SetupRvsdg()
     auto iOStateArgument = lambda->fctargument(2);
     auto memoryStateArgument = lambda->fctargument(3);
 
-    auto functionGCv = lambda->add_ctxvar(functionG);
+    auto functionGCv = lambda->AddContextVar(functionG).inner;
 
     auto size = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
 
@@ -1237,9 +1237,9 @@ ExternalCallTest2::SetupRvsdg()
   LambdaG_ = lambda::node::create(rvsdg.root(), lambdaGType, "g", linkage::external_linkage);
   auto iOStateArgument = LambdaG_->fctargument(0);
   auto memoryStateArgument = LambdaG_->fctargument(1);
-  auto llvmLifetimeStartArgument = LambdaG_->add_ctxvar(llvmLifetimeStart);
-  auto llvmLifetimeEndArgument = LambdaG_->add_ctxvar(llvmLifetimeEnd);
-  auto lambdaFArgument = LambdaG_->add_ctxvar(ExternalFArgument_);
+  auto llvmLifetimeStartArgument = LambdaG_->AddContextVar(llvmLifetimeStart).inner;
+  auto llvmLifetimeEndArgument = LambdaG_->AddContextVar(llvmLifetimeEnd).inner;
+  auto lambdaFArgument = LambdaG_->AddContextVar(ExternalFArgument_).inner;
 
   auto twentyFour = jlm::rvsdg::create_bitconstant(LambdaG_->subregion(), 64, 24);
 
@@ -1475,7 +1475,7 @@ GammaTest2::SetupRvsdg()
         lambda::node::create(rvsdg->root(), functionType, functionName, linkage::external_linkage);
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
-    auto lambdaFArgument = lambda->add_ctxvar(&lambdaF);
+    auto lambdaFArgument = lambda->AddContextVar(&lambdaF).inner;
 
     auto size = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
 
@@ -1657,8 +1657,8 @@ DeltaTest1::SetupRvsdg()
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
 
-    auto cvf = lambda->add_ctxvar(f);
-    auto cvg = lambda->add_ctxvar(g);
+    auto cvf = lambda->AddContextVar(f).inner;
+    auto cvg = lambda->AddContextVar(g).inner;
 
     auto five = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 5);
     auto st = StoreNonVolatileNode::Create(cvf, five, { memoryStateArgument }, 4);
@@ -1742,7 +1742,7 @@ DeltaTest2::SetupRvsdg()
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
 
-    auto cvd1 = lambda->add_ctxvar(d1);
+    auto cvd1 = lambda->AddContextVar(d1).inner;
     auto b2 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 2);
     auto st = StoreNonVolatileNode::Create(cvd1, b2, { memoryStateArgument }, 4);
 
@@ -1762,9 +1762,9 @@ DeltaTest2::SetupRvsdg()
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
 
-    auto cvd1 = lambda->add_ctxvar(d1);
-    auto cvd2 = lambda->add_ctxvar(d2);
-    auto cvf1 = lambda->add_ctxvar(f1);
+    auto cvd1 = lambda->AddContextVar(d1).inner;
+    auto cvd2 = lambda->AddContextVar(d2).inner;
+    auto cvf1 = lambda->AddContextVar(f1).inner;
 
     auto b5 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 5);
     auto b42 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 42);
@@ -1844,8 +1844,8 @@ DeltaTest3::SetupRvsdg()
     auto lambda = lambda::node::create(graph->root(), functionType, "f", linkage::external_linkage);
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
-    auto g1CtxVar = lambda->add_ctxvar(&g1);
-    auto g2CtxVar = lambda->add_ctxvar(&g2);
+    auto g1CtxVar = lambda->AddContextVar(&g1).inner;
+    auto g2CtxVar = lambda->AddContextVar(&g2).inner;
 
     auto loadResults =
         LoadNonVolatileNode::Create(g2CtxVar, { memoryStateArgument }, PointerType::Create(), 8);
@@ -1872,7 +1872,7 @@ DeltaTest3::SetupRvsdg()
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
 
-    auto lambdaFArgument = lambda->add_ctxvar(&lambdaF);
+    auto lambdaFArgument = lambda->AddContextVar(&lambdaF).inner;
 
     auto & call = CallNode::CreateNode(
         lambdaFArgument,
@@ -1928,7 +1928,7 @@ ImportTest::SetupRvsdg()
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
 
-    auto cvd1 = lambda->add_ctxvar(d1);
+    auto cvd1 = lambda->AddContextVar(d1).inner;
 
     auto b5 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 5);
     auto st = StoreNonVolatileNode::Create(cvd1, b5, { memoryStateArgument }, 4);
@@ -1949,9 +1949,9 @@ ImportTest::SetupRvsdg()
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
 
-    auto cvd1 = lambda->add_ctxvar(d1);
-    auto cvd2 = lambda->add_ctxvar(d2);
-    auto cvf1 = lambda->add_ctxvar(f1);
+    auto cvd1 = lambda->AddContextVar(d1).inner;
+    auto cvd2 = lambda->AddContextVar(d2).inner;
+    auto cvf1 = lambda->AddContextVar(f1).inner;
     auto b2 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 2);
     auto b21 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 21);
     auto st = StoreNonVolatileNode::Create(cvd1, b2, { memoryStateArgument }, 4);
@@ -2025,7 +2025,7 @@ PhiTest1::SetupRvsdg()
     auto pointerArgument = lambda->fctargument(1);
     auto iOStateArgument = lambda->fctargument(2);
     auto memoryStateArgument = lambda->fctargument(3);
-    auto ctxVarFib = lambda->add_ctxvar(fibrv->argument());
+    auto ctxVarFib = lambda->AddContextVar(fibrv->argument()).inner;
 
     auto two = jlm::rvsdg::create_bitconstant(lambda->subregion(), 64, 2);
     auto bitult = jlm::rvsdg::bitult_op::create(64, valueArgument, two);
@@ -2114,7 +2114,7 @@ PhiTest1::SetupRvsdg()
         lambda::node::create(graph->root(), functionType, "test", linkage::external_linkage);
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
-    auto fibcv = lambda->add_ctxvar(phiNode->output(0));
+    auto fibcv = lambda->AddContextVar(phiNode->output(0)).inner;
 
     auto ten = jlm::rvsdg::create_bitconstant(lambda->subregion(), 64, 10);
     auto allocaResults = alloca_op::create(at, ten, 16);
@@ -2225,8 +2225,8 @@ PhiTest2::SetupRvsdg()
     auto iOStateArgument = lambda->fctargument(1);
     auto memoryStateArgument = lambda->fctargument(2);
 
-    auto functionBCv = lambda->add_ctxvar(&functionB);
-    auto functionDCv = lambda->add_ctxvar(&functionD);
+    auto functionBCv = lambda->AddContextVar(&functionB).inner;
+    auto functionDCv = lambda->AddContextVar(&functionD).inner;
 
     auto one = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 1);
     auto storeNode = StoreNonVolatileNode::Create(pointerArgument, one, { memoryStateArgument }, 4);
@@ -2269,9 +2269,9 @@ PhiTest2::SetupRvsdg()
     auto iOStateArgument = lambda->fctargument(1);
     auto memoryStateArgument = lambda->fctargument(2);
 
-    auto functionICv = lambda->add_ctxvar(&functionI);
-    auto functionCCv = lambda->add_ctxvar(&functionC);
-    auto functionEightCv = lambda->add_ctxvar(&functionEight);
+    auto functionICv = lambda->AddContextVar(&functionI).inner;
+    auto functionCCv = lambda->AddContextVar(&functionC).inner;
+    auto functionEightCv = lambda->AddContextVar(&functionEight).inner;
 
     auto two = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 2);
     auto storeNode = StoreNonVolatileNode::Create(pointerArgument, two, { memoryStateArgument }, 4);
@@ -2311,7 +2311,7 @@ PhiTest2::SetupRvsdg()
     auto iOStateArgument = lambda->fctargument(1);
     auto memoryStateArgument = lambda->fctargument(2);
 
-    auto functionACv = lambda->add_ctxvar(&functionA);
+    auto functionACv = lambda->AddContextVar(&functionA).inner;
 
     auto three = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 3);
     auto storeNode = StoreNonVolatileNode::Create(xArgument, three, { memoryStateArgument }, 4);
@@ -2350,7 +2350,7 @@ PhiTest2::SetupRvsdg()
     auto iOStateArgument = lambda->fctargument(1);
     auto memoryStateArgument = lambda->fctargument(2);
 
-    auto functionACv = lambda->add_ctxvar(&functionA);
+    auto functionACv = lambda->AddContextVar(&functionA).inner;
 
     auto four = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
     auto storeNode = StoreNonVolatileNode::Create(xArgument, four, { memoryStateArgument }, 4);
@@ -2433,7 +2433,7 @@ PhiTest2::SetupRvsdg()
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
 
-    auto functionACv = lambda->add_ctxvar(&functionA);
+    auto functionACv = lambda->AddContextVar(&functionA).inner;
 
     auto four = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
     auto pTestAlloca = alloca_op::create(jlm::rvsdg::bittype::Create(32), four, 4);
@@ -2674,7 +2674,7 @@ EscapedMemoryTest1::SetupRvsdg()
     auto iOStateArgument = lambda->fctargument(1);
     auto memoryStateArgument = lambda->fctargument(2);
 
-    auto contextVariableB = lambda->add_ctxvar(&deltaB);
+    auto contextVariableB = lambda->AddContextVar(&deltaB).inner;
 
     auto loadResults1 =
         LoadNonVolatileNode::Create(pointerArgument, { memoryStateArgument }, pointerType, 4);
@@ -2806,7 +2806,7 @@ EscapedMemoryTest2::SetupRvsdg()
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
 
-    auto externalFunction1 = lambda->add_ctxvar(externalFunction1Argument);
+    auto externalFunction1 = lambda->AddContextVar(externalFunction1Argument).inner;
 
     auto eight = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 8);
 
@@ -2842,7 +2842,7 @@ EscapedMemoryTest2::SetupRvsdg()
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
 
-    auto externalFunction2 = lambda->add_ctxvar(externalFunction2Argument);
+    auto externalFunction2 = lambda->AddContextVar(externalFunction2Argument).inner;
 
     auto & call = CallNode::CreateNode(
         externalFunction2,
@@ -2955,7 +2955,7 @@ EscapedMemoryTest3::SetupRvsdg()
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
 
-    auto externalFunction = lambda->add_ctxvar(externalFunctionArgument);
+    auto externalFunction = lambda->AddContextVar(externalFunctionArgument).inner;
 
     auto & call = CallNode::CreateNode(
         externalFunction,
@@ -3063,7 +3063,7 @@ MemcpyTest::SetupRvsdg()
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
 
-    auto globalArrayArgument = lambda->add_ctxvar(&globalArray);
+    auto globalArrayArgument = lambda->AddContextVar(&globalArray).inner;
 
     auto zero = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 0);
     auto two = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 2);
@@ -3100,9 +3100,9 @@ MemcpyTest::SetupRvsdg()
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
 
-    auto localArrayArgument = lambda->add_ctxvar(&localArray);
-    auto globalArrayArgument = lambda->add_ctxvar(&globalArray);
-    auto functionFArgument = lambda->add_ctxvar(&lambdaF);
+    auto localArrayArgument = lambda->AddContextVar(&localArray).inner;
+    auto globalArrayArgument = lambda->AddContextVar(&globalArray).inner;
+    auto functionFArgument = lambda->AddContextVar(&lambdaF).inner;
 
     auto bcLocalArray = bitcast_op::create(localArrayArgument, PointerType::Create());
     auto bcGlobalArray = bitcast_op::create(globalArrayArgument, PointerType::Create());
@@ -3214,7 +3214,7 @@ MemcpyTest2::SetupRvsdg()
     auto iOStateArgument = lambda->fctargument(2);
     auto memoryStateArgument = lambda->fctargument(3);
 
-    auto functionFArgument = lambda->add_ctxvar(&functionF);
+    auto functionFArgument = lambda->AddContextVar(&functionF).inner;
 
     auto c0 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 0);
 
@@ -3352,7 +3352,7 @@ LinkedListTest::SetupRvsdg()
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
 
-    auto myListArgument = lambda->add_ctxvar(&myList);
+    auto myListArgument = lambda->AddContextVar(&myList).inner;
 
     auto zero = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 0);
     auto size = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
@@ -3427,8 +3427,8 @@ AllMemoryNodesTest::SetupRvsdg()
   // Start of function "f"
   Lambda_ = lambda::node::create(graph->root(), fcttype, "f", linkage::external_linkage);
   auto entryMemoryState = Lambda_->fctargument(0);
-  auto deltaContextVar = Lambda_->add_ctxvar(Delta_->output());
-  auto importContextVar = Lambda_->add_ctxvar(Import_);
+  auto deltaContextVar = Lambda_->AddContextVar(Delta_->output()).inner;
+  auto importContextVar = Lambda_->AddContextVar(Import_).inner;
 
   // Create alloca node
   auto allocaSize = jlm::rvsdg::create_bitconstant(Lambda_->subregion(), 32, 1);
@@ -3577,7 +3577,7 @@ EscapingLocalFunctionTest::SetupRvsdg()
       StoreNonVolatileNode::Create(allocaOutputs[0], LocalFuncParam_, { mergedMemoryState }, 4);
 
   // Bring in deltaOuput as a context variable
-  const auto deltaOutputCtxVar = LocalFunc_->add_ctxvar(deltaOutput);
+  const auto deltaOutputCtxVar = LocalFunc_->AddContextVar(deltaOutput).inner;
 
   // Return &global
   LocalFunc_->finalize({ deltaOutputCtxVar, storeOutputs[0] });
@@ -3590,7 +3590,7 @@ EscapingLocalFunctionTest::SetupRvsdg()
       "exportedFunc",
       linkage::external_linkage);
 
-  const auto localFuncCtxVar = ExportedFunc_->add_ctxvar(LocalFuncRegister_);
+  const auto localFuncCtxVar = ExportedFunc_->AddContextVar(LocalFuncRegister_).inner;
 
   // Return &localFunc, pass memory state directly through
   ExportedFunc_->finalize({ localFuncCtxVar, ExportedFunc_->fctargument(0) });
@@ -3679,7 +3679,7 @@ LambdaCallArgumentMismatch::SetupRvsdg()
         lambda::node::create(rvsdg.root(), functionTypeMain, "main", linkage::external_linkage);
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
-    auto lambdaGArgument = lambda->add_ctxvar(&lambdaG);
+    auto lambdaGArgument = lambda->AddContextVar(&lambdaG).inner;
 
     auto one = rvsdg::create_bitconstant(lambda->subregion(), 32, 1);
     auto six = rvsdg::create_bitconstant(lambda->subregion(), 32, 6);
@@ -3751,7 +3751,7 @@ VariadicFunctionTest1::SetupRvsdg()
     auto iArgument = LambdaF_->fctargument(0);
     auto iOStateArgument = LambdaF_->fctargument(1);
     auto memoryStateArgument = LambdaF_->fctargument(2);
-    auto lambdaHArgument = LambdaF_->add_ctxvar(ImportH_);
+    auto lambdaHArgument = LambdaF_->AddContextVar(ImportH_).inner;
 
     auto one = jlm::rvsdg::create_bitconstant(LambdaF_->subregion(), 32, 1);
     auto three = jlm::rvsdg::create_bitconstant(LambdaF_->subregion(), 32, 3);
@@ -3777,7 +3777,7 @@ VariadicFunctionTest1::SetupRvsdg()
     LambdaG_ = lambda::node::create(rvsdg.root(), lambdaGType, "g", linkage::external_linkage);
     auto iOStateArgument = LambdaG_->fctargument(0);
     auto memoryStateArgument = LambdaG_->fctargument(1);
-    auto lambdaFArgument = LambdaG_->add_ctxvar(LambdaF_->output());
+    auto lambdaFArgument = LambdaG_->AddContextVar(LambdaF_->output()).inner;
 
     auto one = jlm::rvsdg::create_bitconstant(LambdaG_->subregion(), 32, 1);
     auto five = jlm::rvsdg::create_bitconstant(LambdaG_->subregion(), 32, 5);
@@ -3861,10 +3861,10 @@ VariadicFunctionTest2::SetupRvsdg()
         lambda::node::create(rvsdg.root(), lambdaFstType, "fst", linkage::internal_linkage);
     auto iOStateArgument = LambdaFst_->fctargument(2);
     auto memoryStateArgument = LambdaFst_->fctargument(3);
-    auto llvmLifetimeStartArgument = LambdaFst_->add_ctxvar(llvmLifetimeStart);
-    auto llvmLifetimeEndArgument = LambdaFst_->add_ctxvar(llvmLifetimeEnd);
-    auto llvmVaStartArgument = LambdaFst_->add_ctxvar(llvmVaStart);
-    auto llvmVaEndArgument = LambdaFst_->add_ctxvar(llvmVaEnd);
+    auto llvmLifetimeStartArgument = LambdaFst_->AddContextVar(llvmLifetimeStart).inner;
+    auto llvmLifetimeEndArgument = LambdaFst_->AddContextVar(llvmLifetimeEnd).inner;
+    auto llvmVaStartArgument = LambdaFst_->AddContextVar(llvmVaStart).inner;
+    auto llvmVaEndArgument = LambdaFst_->AddContextVar(llvmVaEnd).inner;
 
     auto one = jlm::rvsdg::create_bitconstant(LambdaFst_->subregion(), 32, 1);
     auto twentyFour = jlm::rvsdg::create_bitconstant(LambdaFst_->subregion(), 64, 24);
@@ -3972,7 +3972,7 @@ VariadicFunctionTest2::SetupRvsdg()
     LambdaG_ = lambda::node::create(rvsdg.root(), lambdaGType, "g", linkage::external_linkage);
     auto iOStateArgument = LambdaG_->fctargument(0);
     auto memoryStateArgument = LambdaG_->fctargument(1);
-    auto lambdaFstArgument = LambdaG_->add_ctxvar(LambdaFst_->output());
+    auto lambdaFstArgument = LambdaG_->AddContextVar(LambdaFst_->output()).inner;
 
     auto zero = jlm::rvsdg::create_bitconstant(LambdaG_->subregion(), 32, 0);
     auto one = jlm::rvsdg::create_bitconstant(LambdaG_->subregion(), 32, 1);

--- a/tests/jlm/hls/backend/rvsdg2rhls/UnusedStateRemovalTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/UnusedStateRemovalTests.cpp
@@ -140,8 +140,8 @@ TestLambda()
       lambda::node::create(rvsdg.root(), functionType, "f", linkage::external_linkage);
   auto argument0 = lambdaNode->fctargument(0);
   auto argument1 = lambdaNode->fctargument(1);
-  auto argument2 = lambdaNode->add_ctxvar(x);
-  auto argument3 = lambdaNode->add_ctxvar(x);
+  auto argument2 = lambdaNode->AddContextVar(x).inner;
+  auto argument3 = lambdaNode->AddContextVar(x).inner;
 
   auto result1 =
       jlm::tests::SimpleNode::Create(*lambdaNode->subregion(), { argument1 }, { valueType })

--- a/tests/jlm/llvm/ir/operators/TestCall.cpp
+++ b/tests/jlm/llvm/ir/operators/TestCall.cpp
@@ -216,7 +216,7 @@ TestCallTypeClassifierNonRecursiveDirectCall()
         { vt, iostatetype::Create(), MemoryStateType::Create() });
 
     auto lambda = lambda::node::create(graph->root(), functionType, "f", linkage::external_linkage);
-    auto functionGArgument = lambda->add_ctxvar(g);
+    auto functionGArgument = lambda->AddContextVar(g).inner;
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
 
@@ -329,7 +329,7 @@ TestCallTypeClassifierNonRecursiveDirectCallTheta()
         { vt, iostatetype::Create(), MemoryStateType::Create() });
 
     auto lambda = lambda::node::create(graph->root(), functionType, "f", linkage::external_linkage);
-    auto functionG = lambda->add_ctxvar(g);
+    auto functionG = lambda->AddContextVar(g).inner;
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
 
@@ -396,7 +396,7 @@ TestCallTypeClassifierRecursiveDirectCall()
     auto pointerArgument = lambda->fctargument(1);
     auto iOStateArgument = lambda->fctargument(2);
     auto memoryStateArgument = lambda->fctargument(3);
-    auto ctxVarFib = lambda->add_ctxvar(fibrv->argument());
+    auto ctxVarFib = lambda->AddContextVar(fibrv->argument()).inner;
 
     auto two = jlm::rvsdg::create_bitconstant(lambda->subregion(), 64, 2);
     auto bitult = jlm::rvsdg::bitult_op::create(64, valueArgument, two);

--- a/tests/jlm/llvm/ir/operators/TestPhi.cpp
+++ b/tests/jlm/llvm/ir/operators/TestPhi.cpp
@@ -41,7 +41,7 @@ TestPhiCreation()
   auto SetupF2 = [&](jlm::rvsdg::Region * region, jlm::rvsdg::RegionArgument * f2)
   {
     auto lambda = lambda::node::create(region, f1type, "f2", linkage::external_linkage);
-    auto ctxVarF2 = lambda->add_ctxvar(f2);
+    auto ctxVarF2 = lambda->AddContextVar(f2).inner;
     auto valueArgument = lambda->fctargument(0);
     auto iOStateArgument = lambda->fctargument(1);
     auto memoryStateArgument = lambda->fctargument(2);

--- a/tests/jlm/llvm/opt/InvariantValueRedirectionTests.cpp
+++ b/tests/jlm/llvm/opt/InvariantValueRedirectionTests.cpp
@@ -192,7 +192,7 @@ TestCall()
     auto yArgument = lambdaNode->fctargument(1);
     auto ioStateArgument = lambdaNode->fctargument(2);
     auto memoryStateArgument = lambdaNode->fctargument(3);
-    auto lambdaArgumentTest1 = lambdaNode->add_ctxvar(lambdaOutputTest1);
+    auto lambdaArgumentTest1 = lambdaNode->AddContextVar(lambdaOutputTest1).inner;
 
     auto controlResult = jlm::rvsdg::control_constant(lambdaNode->subregion(), 2, 0);
 
@@ -283,7 +283,7 @@ TestCallWithMemoryStateNodes()
     auto xArgument = lambdaNode->fctargument(0);
     auto ioStateArgument = lambdaNode->fctargument(1);
     auto memoryStateArgument = lambdaNode->fctargument(2);
-    auto lambdaArgumentTest1 = lambdaNode->add_ctxvar(lambdaOutputTest1);
+    auto lambdaArgumentTest1 = lambdaNode->AddContextVar(lambdaOutputTest1).inner;
 
     auto lambdaEntrySplitResults =
         LambdaEntryMemoryStateSplitOperation::Create(*memoryStateArgument, 2);

--- a/tests/jlm/llvm/opt/TestDeadNodeElimination.cpp
+++ b/tests/jlm/llvm/opt/TestDeadNodeElimination.cpp
@@ -258,8 +258,8 @@ TestLambda()
       "f",
       linkage::external_linkage);
 
-  auto cv1 = lambda->add_ctxvar(x);
-  auto cv2 = lambda->add_ctxvar(y);
+  auto cv1 = lambda->AddContextVar(x).inner;
+  auto cv2 = lambda->AddContextVar(y).inner;
   jlm::tests::create_testop(lambda->subregion(), { lambda->fctargument(0), cv1 }, { vt });
 
   auto output = lambda->finalize({ lambda->fctargument(0), cv2 });
@@ -293,8 +293,8 @@ TestPhi()
       [&](jlm::rvsdg::Region & region, phi::rvoutput & rv2, jlm::rvsdg::RegionArgument & dx)
   {
     auto lambda1 = lambda::node::create(&region, functionType, "f1", linkage::external_linkage);
-    auto f2Argument = lambda1->add_ctxvar(rv2.argument());
-    auto xArgument = lambda1->add_ctxvar(&dx);
+    auto f2Argument = lambda1->AddContextVar(rv2.argument()).inner;
+    auto xArgument = lambda1->AddContextVar(&dx).inner;
 
     auto result = jlm::tests::SimpleNode::Create(
                       *lambda1->subregion(),
@@ -309,8 +309,8 @@ TestPhi()
       [&](jlm::rvsdg::Region & region, phi::rvoutput & rv1, jlm::rvsdg::RegionArgument & dy)
   {
     auto lambda2 = lambda::node::create(&region, functionType, "f2", linkage::external_linkage);
-    auto f1Argument = lambda2->add_ctxvar(rv1.argument());
-    lambda2->add_ctxvar(&dy);
+    auto f1Argument = lambda2->AddContextVar(rv1.argument()).inner;
+    lambda2->AddContextVar(&dy);
 
     auto result = jlm::tests::SimpleNode::Create(
                       *lambda2->subregion(),
@@ -324,7 +324,7 @@ TestPhi()
   auto setupF3 = [&](jlm::rvsdg::Region & region, jlm::rvsdg::RegionArgument & dz)
   {
     auto lambda3 = lambda::node::create(&region, functionType, "f3", linkage::external_linkage);
-    auto zArgument = lambda3->add_ctxvar(&dz);
+    auto zArgument = lambda3->AddContextVar(&dz).inner;
 
     auto result = jlm::tests::SimpleNode::Create(
                       *lambda3->subregion(),

--- a/tests/jlm/llvm/opt/alias-analyses/TestAndersen.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestAndersen.cpp
@@ -363,8 +363,8 @@ TestCall1()
   auto & lambda_g_arg0 = ptg->GetRegisterNode(*test.lambda_g->fctargument(0));
   auto & lambda_g_arg1 = ptg->GetRegisterNode(*test.lambda_g->fctargument(1));
 
-  auto & lambda_h_cv0 = ptg->GetRegisterNode(*test.lambda_h->cvargument(0));
-  auto & lambda_h_cv1 = ptg->GetRegisterNode(*test.lambda_h->cvargument(1));
+  auto & lambda_h_cv0 = ptg->GetRegisterNode(*test.lambda_h->GetContextVar(0).inner);
+  auto & lambda_h_cv1 = ptg->GetRegisterNode(*test.lambda_h->GetContextVar(1).inner);
 
   assert(TargetsExactly(palloca_x, { &alloca_x }));
   assert(TargetsExactly(palloca_y, { &alloca_y }));
@@ -409,8 +409,8 @@ TestCall2()
 
   auto & lambda_test = ptg->GetLambdaNode(*test.lambda_test);
   auto & lambda_test_out = ptg->GetRegisterNode(*test.lambda_test->output());
-  auto & lambda_test_cv1 = ptg->GetRegisterNode(*test.lambda_test->cvargument(0));
-  auto & lambda_test_cv2 = ptg->GetRegisterNode(*test.lambda_test->cvargument(1));
+  auto & lambda_test_cv1 = ptg->GetRegisterNode(*test.lambda_test->GetContextVar(0).inner);
+  auto & lambda_test_cv2 = ptg->GetRegisterNode(*test.lambda_test->GetContextVar(1).inner);
 
   auto & call_create1_out = ptg->GetRegisterNode(*test.CallCreate1().output(0));
   auto & call_create2_out = ptg->GetRegisterNode(*test.CallCreate2().output(0));
@@ -460,9 +460,9 @@ TestIndirectCall1()
 
   auto & lambda_test = ptg->GetLambdaNode(test.GetLambdaTest());
   auto & lambda_test_out = ptg->GetRegisterNode(*test.GetLambdaTest().output());
-  auto & lambda_test_cv0 = ptg->GetRegisterNode(*test.GetLambdaTest().cvargument(0));
-  auto & lambda_test_cv1 = ptg->GetRegisterNode(*test.GetLambdaTest().cvargument(1));
-  auto & lambda_test_cv2 = ptg->GetRegisterNode(*test.GetLambdaTest().cvargument(2));
+  auto & lambda_test_cv0 = ptg->GetRegisterNode(*test.GetLambdaTest().GetContextVar(0).inner);
+  auto & lambda_test_cv1 = ptg->GetRegisterNode(*test.GetLambdaTest().GetContextVar(1).inner);
+  auto & lambda_test_cv2 = ptg->GetRegisterNode(*test.GetLambdaTest().GetContextVar(2).inner);
 
   assert(TargetsExactly(lambda_three_out, { &lambda_three }));
 
@@ -629,8 +629,8 @@ TestDelta1()
 
   auto & lambda_h = ptg->GetLambdaNode(*test.lambda_h);
   auto & plambda_h = ptg->GetRegisterNode(*test.lambda_h->output());
-  auto & lambda_h_cv0 = ptg->GetRegisterNode(*test.lambda_h->cvargument(0));
-  auto & lambda_h_cv1 = ptg->GetRegisterNode(*test.lambda_h->cvargument(1));
+  auto & lambda_h_cv0 = ptg->GetRegisterNode(*test.lambda_h->GetContextVar(0).inner);
+  auto & lambda_h_cv1 = ptg->GetRegisterNode(*test.lambda_h->GetContextVar(1).inner);
 
   assert(TargetsExactly(pdelta_f, { &delta_f }));
 
@@ -666,13 +666,13 @@ TestDelta2()
 
   auto & lambda_f1 = ptg->GetLambdaNode(*test.lambda_f1);
   auto & lambda_f1_out = ptg->GetRegisterNode(*test.lambda_f1->output());
-  auto & lambda_f1_cvd1 = ptg->GetRegisterNode(*test.lambda_f1->cvargument(0));
+  auto & lambda_f1_cvd1 = ptg->GetRegisterNode(*test.lambda_f1->GetContextVar(0).inner);
 
   auto & lambda_f2 = ptg->GetLambdaNode(*test.lambda_f2);
   auto & lambda_f2_out = ptg->GetRegisterNode(*test.lambda_f2->output());
-  auto & lambda_f2_cvd1 = ptg->GetRegisterNode(*test.lambda_f2->cvargument(0));
-  auto & lambda_f2_cvd2 = ptg->GetRegisterNode(*test.lambda_f2->cvargument(1));
-  auto & lambda_f2_cvf1 = ptg->GetRegisterNode(*test.lambda_f2->cvargument(2));
+  auto & lambda_f2_cvd1 = ptg->GetRegisterNode(*test.lambda_f2->GetContextVar(0).inner);
+  auto & lambda_f2_cvd2 = ptg->GetRegisterNode(*test.lambda_f2->GetContextVar(1).inner);
+  auto & lambda_f2_cvf1 = ptg->GetRegisterNode(*test.lambda_f2->GetContextVar(2).inner);
 
   assert(TargetsExactly(delta_d1_out, { &delta_d1 }));
   assert(TargetsExactly(delta_d2_out, { &delta_d2 }));
@@ -709,13 +709,13 @@ TestImports()
 
   auto & lambda_f1 = ptg->GetLambdaNode(*test.lambda_f1);
   auto & lambda_f1_out = ptg->GetRegisterNode(*test.lambda_f1->output());
-  auto & lambda_f1_cvd1 = ptg->GetRegisterNode(*test.lambda_f1->cvargument(0));
+  auto & lambda_f1_cvd1 = ptg->GetRegisterNode(*test.lambda_f1->GetContextVar(0).inner);
 
   auto & lambda_f2 = ptg->GetLambdaNode(*test.lambda_f2);
   auto & lambda_f2_out = ptg->GetRegisterNode(*test.lambda_f2->output());
-  auto & lambda_f2_cvd1 = ptg->GetRegisterNode(*test.lambda_f2->cvargument(0));
-  auto & lambda_f2_cvd2 = ptg->GetRegisterNode(*test.lambda_f2->cvargument(1));
-  auto & lambda_f2_cvf1 = ptg->GetRegisterNode(*test.lambda_f2->cvargument(2));
+  auto & lambda_f2_cvd1 = ptg->GetRegisterNode(*test.lambda_f2->GetContextVar(0).inner);
+  auto & lambda_f2_cvd2 = ptg->GetRegisterNode(*test.lambda_f2->GetContextVar(1).inner);
+  auto & lambda_f2_cvf1 = ptg->GetRegisterNode(*test.lambda_f2->GetContextVar(2).inner);
 
   assert(TargetsExactly(import_d1, { &d1 }));
   assert(TargetsExactly(import_d2, { &d2 }));
@@ -814,7 +814,7 @@ TestEscapedMemory1()
   assert(ptg->NumMappedRegisters() == 10);
 
   auto & lambdaTestArgument0 = ptg->GetRegisterNode(*test.LambdaTest->fctargument(0));
-  auto & lambdaTestCv0 = ptg->GetRegisterNode(*test.LambdaTest->cvargument(0));
+  auto & lambdaTestCv0 = ptg->GetRegisterNode(*test.LambdaTest->GetContextVar(0).inner);
   auto & loadNode1Output = ptg->GetRegisterNode(*test.LoadNode1->output(0));
 
   auto deltaA = &ptg->GetDeltaNode(*test.DeltaA);

--- a/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
@@ -1084,10 +1084,12 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
         jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 6, 1));
 
-    auto loadG1 = jlm::rvsdg::input::GetNode(**test.GetLambdaTest().cvargument(2)->begin());
+    auto loadG1 =
+        jlm::rvsdg::input::GetNode(**test.GetLambdaTest().GetContextVar(2).inner->begin());
     assert(is<LoadNonVolatileOperation>(*loadG1, 2, 2));
 
-    auto loadG2 = jlm::rvsdg::input::GetNode(**test.GetLambdaTest().cvargument(3)->begin());
+    auto loadG2 =
+        jlm::rvsdg::input::GetNode(**test.GetLambdaTest().GetContextVar(3).inner->begin());
     assert(is<LoadNonVolatileOperation>(*loadG2, 2, 2));
 
     auto lambdaEntrySplit =
@@ -1245,7 +1247,8 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
         jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 10, 1));
 
-    auto loadG1 = jlm::rvsdg::input::GetNode(**test.GetLambdaTest().cvargument(2)->begin());
+    auto loadG1 =
+        jlm::rvsdg::input::GetNode(**test.GetLambdaTest().GetContextVar(2).inner->begin());
     assert(is<LoadNonVolatileOperation>(*loadG1, 2, 2));
 
     auto callXEntryMerge = jlm::rvsdg::node_output::node(test.GetTestCallX().input(3)->origin());
@@ -1267,7 +1270,8 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(undefNode->output(0)->nusers() == 1);
     assert(jlm::rvsdg::input::GetNode(**undefNode->output(0)->begin()) == callXEntryMerge);
 
-    auto loadG2 = jlm::rvsdg::input::GetNode(**test.GetLambdaTest().cvargument(3)->begin());
+    auto loadG2 =
+        jlm::rvsdg::input::GetNode(**test.GetLambdaTest().GetContextVar(3).inner->begin());
     assert(is<LoadNonVolatileOperation>(*loadG2, 2, 2));
 
     auto lambdaEntrySplit =
@@ -1507,18 +1511,18 @@ ValidateDeltaTest2SteensgaardAgnostic(const jlm::tests::DeltaTest2 & test)
   auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_f2->fctargument(1)->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
 
-  auto storeD1InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(0)->begin());
+  auto storeD1InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->GetContextVar(0).inner->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
   assert(jlm::rvsdg::node_output::node(storeD1InF2->input(2)->origin()) == lambdaEntrySplit);
 
   auto d1StateIndex = storeD1InF2->input(2)->origin()->index();
 
-  auto storeD1InF1 = jlm::rvsdg::input::GetNode(**test.lambda_f1->cvargument(0)->begin());
+  auto storeD1InF1 = jlm::rvsdg::input::GetNode(**test.lambda_f1->GetContextVar(0).inner->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF1, 3, 1));
 
   assert(d1StateIndex == storeD1InF1->input(2)->origin()->index());
 
-  auto storeD2InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(1)->begin());
+  auto storeD2InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->GetContextVar(1).inner->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
 
   assert(d1StateIndex != storeD2InF2->input(2)->origin()->index());
@@ -1550,11 +1554,11 @@ ValidateDeltaTest2SteensgaardRegionAware(const jlm::tests::DeltaTest2 & test)
     auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_f2->fctargument(1)->begin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 
-    auto storeD1 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(0)->begin());
+    auto storeD1 = jlm::rvsdg::input::GetNode(**test.lambda_f2->GetContextVar(0).inner->begin());
     assert(is<StoreNonVolatileOperation>(*storeD1, 3, 1));
     assert(jlm::rvsdg::node_output::node(storeD1->input(2)->origin()) == lambdaEntrySplit);
 
-    auto storeD2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(1)->begin());
+    auto storeD2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->GetContextVar(1).inner->begin());
     assert(is<StoreNonVolatileOperation>(*storeD2, 3, 1));
     assert(jlm::rvsdg::node_output::node(storeD2->input(2)->origin()) == lambdaEntrySplit);
 
@@ -1582,16 +1586,16 @@ ValidateDeltaTest2SteensgaardAgnosticTopDown(const jlm::tests::DeltaTest2 & test
   auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_f2->fctargument(1)->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
 
-  auto storeD1InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(0)->begin());
+  auto storeD1InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->GetContextVar(0).inner->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
   assert(jlm::rvsdg::node_output::node(storeD1InF2->input(2)->origin()) == lambdaEntrySplit);
 
   auto d1StateIndex = storeD1InF2->input(2)->origin()->index();
 
-  auto storeD1InF1 = jlm::rvsdg::input::GetNode(**test.lambda_f1->cvargument(0)->begin());
+  auto storeD1InF1 = jlm::rvsdg::input::GetNode(**test.lambda_f1->GetContextVar(0).inner->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF1, 3, 1));
 
-  auto storeD2InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(1)->begin());
+  auto storeD2InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->GetContextVar(1).inner->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
 
   assert(d1StateIndex != storeD2InF2->input(2)->origin()->index());
@@ -1733,18 +1737,18 @@ ValidateImportTestSteensgaardAgnostic(const jlm::tests::ImportTest & test)
   auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_f2->fctargument(1)->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
 
-  auto storeD1InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(0)->begin());
+  auto storeD1InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->GetContextVar(0).inner->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
   assert(jlm::rvsdg::node_output::node(storeD1InF2->input(2)->origin()) == lambdaEntrySplit);
 
   auto d1StateIndex = storeD1InF2->input(2)->origin()->index();
 
-  auto storeD1InF1 = jlm::rvsdg::input::GetNode(**test.lambda_f1->cvargument(0)->begin());
+  auto storeD1InF1 = jlm::rvsdg::input::GetNode(**test.lambda_f1->GetContextVar(0).inner->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF1, 3, 1));
 
   assert(d1StateIndex == storeD1InF1->input(2)->origin()->index());
 
-  auto storeD2InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(1)->begin());
+  auto storeD2InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->GetContextVar(1).inner->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
 
   assert(d1StateIndex != storeD2InF2->input(2)->origin()->index());
@@ -1776,11 +1780,11 @@ ValidateImportTestSteensgaardRegionAware(const jlm::tests::ImportTest & test)
     auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_f2->fctargument(1)->begin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 
-    auto storeD1 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(0)->begin());
+    auto storeD1 = jlm::rvsdg::input::GetNode(**test.lambda_f2->GetContextVar(0).inner->begin());
     assert(is<StoreNonVolatileOperation>(*storeD1, 3, 1));
     assert(jlm::rvsdg::node_output::node(storeD1->input(2)->origin()) == lambdaEntrySplit);
 
-    auto storeD2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(1)->begin());
+    auto storeD2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->GetContextVar(1).inner->begin());
     assert(is<StoreNonVolatileOperation>(*storeD2, 3, 1));
     assert(jlm::rvsdg::node_output::node(storeD2->input(2)->origin()) == lambdaEntrySplit);
 
@@ -1808,20 +1812,20 @@ ValidateImportTestSteensgaardAgnosticTopDown(const jlm::tests::ImportTest & test
   auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_f2->fctargument(1)->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
 
-  auto storeD1InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(0)->begin());
+  auto storeD1InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->GetContextVar(0).inner->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
   assert(jlm::rvsdg::node_output::node(storeD1InF2->input(2)->origin()) == lambdaEntrySplit);
 
   assert(storeD1InF2->output(0)->nusers() == 1);
   auto d1StateIndexEntry = (*storeD1InF2->output(0)->begin())->index();
 
-  auto storeD1InF1 = jlm::rvsdg::input::GetNode(**test.lambda_f1->cvargument(0)->begin());
+  auto storeD1InF1 = jlm::rvsdg::input::GetNode(**test.lambda_f1->GetContextVar(0).inner->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF1, 3, 1));
   assert(d1StateIndexEntry == storeD1InF1->input(2)->origin()->index());
   assert(storeD1InF1->output(0)->nusers() == 1);
   auto d1StateIndexExit = (*storeD1InF1->output(0)->begin())->index();
 
-  auto storeD2InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(1)->begin());
+  auto storeD2InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->GetContextVar(1).inner->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
 
   assert(d1StateIndexExit != storeD2InF2->input(2)->origin()->index());
@@ -2002,7 +2006,7 @@ ValidateMemcpySteensgaardRegionAware(const jlm::tests::MemcpyTest & test)
    * Validate function g
    */
   {
-    auto callNode = jlm::rvsdg::input::GetNode(**test.LambdaG().cvargument(2)->begin());
+    auto callNode = jlm::rvsdg::input::GetNode(**test.LambdaG().GetContextVar(2).inner->begin());
     assert(is<CallOperation>(*callNode, 3, 3));
 
     auto callEntryMerge = jlm::rvsdg::node_output::node(callNode->input(2)->origin());

--- a/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
@@ -408,8 +408,8 @@ TestCall1()
     auto & lambda_g_arg0 = ptg.GetRegisterNode(*test.lambda_g->fctargument(0));
     auto & lambda_g_arg1 = ptg.GetRegisterNode(*test.lambda_g->fctargument(1));
 
-    auto & lambda_h_cv0 = ptg.GetRegisterNode(*test.lambda_h->cvargument(0));
-    auto & lambda_h_cv1 = ptg.GetRegisterNode(*test.lambda_h->cvargument(1));
+    auto & lambda_h_cv0 = ptg.GetRegisterNode(*test.lambda_h->GetContextVar(0).inner);
+    auto & lambda_h_cv1 = ptg.GetRegisterNode(*test.lambda_h->GetContextVar(1).inner);
 
     assertTargets(palloca_x, { &alloca_x });
     assertTargets(palloca_y, { &alloca_y });
@@ -461,8 +461,8 @@ TestCall2()
 
     auto & lambda_test = ptg.GetLambdaNode(*test.lambda_test);
     auto & lambda_test_out = ptg.GetRegisterNode(*test.lambda_test->output());
-    auto & lambda_test_cv1 = ptg.GetRegisterNode(*test.lambda_test->cvargument(0));
-    auto & lambda_test_cv2 = ptg.GetRegisterNode(*test.lambda_test->cvargument(1));
+    auto & lambda_test_cv1 = ptg.GetRegisterNode(*test.lambda_test->GetContextVar(0).inner);
+    auto & lambda_test_cv2 = ptg.GetRegisterNode(*test.lambda_test->GetContextVar(1).inner);
 
     auto & call_create1_out = ptg.GetRegisterNode(*test.CallCreate1().output(0));
     auto & call_create2_out = ptg.GetRegisterNode(*test.CallCreate2().output(0));
@@ -519,9 +519,9 @@ TestIndirectCall()
 
     auto & lambda_test = ptg.GetLambdaNode(test.GetLambdaTest());
     auto & lambda_test_out = ptg.GetRegisterNode(*test.GetLambdaTest().output());
-    auto & lambda_test_cv0 = ptg.GetRegisterNode(*test.GetLambdaTest().cvargument(0));
-    auto & lambda_test_cv1 = ptg.GetRegisterNode(*test.GetLambdaTest().cvargument(1));
-    auto & lambda_test_cv2 = ptg.GetRegisterNode(*test.GetLambdaTest().cvargument(2));
+    auto & lambda_test_cv0 = ptg.GetRegisterNode(*test.GetLambdaTest().GetContextVar(0).inner);
+    auto & lambda_test_cv1 = ptg.GetRegisterNode(*test.GetLambdaTest().GetContextVar(1).inner);
+    auto & lambda_test_cv2 = ptg.GetRegisterNode(*test.GetLambdaTest().GetContextVar(2).inner);
 
     assertTargets(lambda_three_out, { &lambda_three, &lambda_four });
 
@@ -739,8 +739,8 @@ TestDelta1()
 
     auto & lambda_h = ptg.GetLambdaNode(*test.lambda_h);
     auto & plambda_h = ptg.GetRegisterNode(*test.lambda_h->output());
-    auto & lambda_h_cv0 = ptg.GetRegisterNode(*test.lambda_h->cvargument(0));
-    auto & lambda_h_cv1 = ptg.GetRegisterNode(*test.lambda_h->cvargument(1));
+    auto & lambda_h_cv0 = ptg.GetRegisterNode(*test.lambda_h->GetContextVar(0).inner);
+    auto & lambda_h_cv1 = ptg.GetRegisterNode(*test.lambda_h->GetContextVar(1).inner);
 
     assertTargets(pdelta_f, { &delta_f });
 
@@ -783,13 +783,13 @@ TestDelta2()
 
     auto & lambda_f1 = ptg.GetLambdaNode(*test.lambda_f1);
     auto & lambda_f1_out = ptg.GetRegisterNode(*test.lambda_f1->output());
-    auto & lambda_f1_cvd1 = ptg.GetRegisterNode(*test.lambda_f1->cvargument(0));
+    auto & lambda_f1_cvd1 = ptg.GetRegisterNode(*test.lambda_f1->GetContextVar(0).inner);
 
     auto & lambda_f2 = ptg.GetLambdaNode(*test.lambda_f2);
     auto & lambda_f2_out = ptg.GetRegisterNode(*test.lambda_f2->output());
-    auto & lambda_f2_cvd1 = ptg.GetRegisterNode(*test.lambda_f2->cvargument(0));
-    auto & lambda_f2_cvd2 = ptg.GetRegisterNode(*test.lambda_f2->cvargument(1));
-    auto & lambda_f2_cvf1 = ptg.GetRegisterNode(*test.lambda_f2->cvargument(2));
+    auto & lambda_f2_cvd1 = ptg.GetRegisterNode(*test.lambda_f2->GetContextVar(0).inner);
+    auto & lambda_f2_cvd2 = ptg.GetRegisterNode(*test.lambda_f2->GetContextVar(1).inner);
+    auto & lambda_f2_cvf1 = ptg.GetRegisterNode(*test.lambda_f2->GetContextVar(2).inner);
 
     assertTargets(delta_d1_out, { &delta_d1 });
     assertTargets(delta_d2_out, { &delta_d2 });
@@ -833,13 +833,13 @@ TestImports()
 
     auto & lambda_f1 = ptg.GetLambdaNode(*test.lambda_f1);
     auto & lambda_f1_out = ptg.GetRegisterNode(*test.lambda_f1->output());
-    auto & lambda_f1_cvd1 = ptg.GetRegisterNode(*test.lambda_f1->cvargument(0));
+    auto & lambda_f1_cvd1 = ptg.GetRegisterNode(*test.lambda_f1->GetContextVar(0).inner);
 
     auto & lambda_f2 = ptg.GetLambdaNode(*test.lambda_f2);
     auto & lambda_f2_out = ptg.GetRegisterNode(*test.lambda_f2->output());
-    auto & lambda_f2_cvd1 = ptg.GetRegisterNode(*test.lambda_f2->cvargument(0));
-    auto & lambda_f2_cvd2 = ptg.GetRegisterNode(*test.lambda_f2->cvargument(1));
-    auto & lambda_f2_cvf1 = ptg.GetRegisterNode(*test.lambda_f2->cvargument(2));
+    auto & lambda_f2_cvd1 = ptg.GetRegisterNode(*test.lambda_f2->GetContextVar(0).inner);
+    auto & lambda_f2_cvd2 = ptg.GetRegisterNode(*test.lambda_f2->GetContextVar(1).inner);
+    auto & lambda_f2_cvf1 = ptg.GetRegisterNode(*test.lambda_f2->GetContextVar(2).inner);
 
     assertTargets(import_d1, { &d1 });
     assertTargets(import_d2, { &d2 });
@@ -957,7 +957,7 @@ TestEscapedMemory1()
     assert(pointsToGraph.NumRegisterNodes() == 7);
 
     auto & lambdaTestArgument0 = pointsToGraph.GetRegisterNode(*test.LambdaTest->fctargument(0));
-    auto & lambdaTestCv0 = pointsToGraph.GetRegisterNode(*test.LambdaTest->cvargument(0));
+    auto & lambdaTestCv0 = pointsToGraph.GetRegisterNode(*test.LambdaTest->GetContextVar(0).inner);
     auto & loadNode1Output = pointsToGraph.GetRegisterNode(*test.LoadNode1->output(0));
 
     auto deltaA = &pointsToGraph.GetDeltaNode(*test.DeltaA);

--- a/tests/jlm/llvm/opt/test-cne.cpp
+++ b/tests/jlm/llvm/opt/test-cne.cpp
@@ -402,8 +402,8 @@ test_lambda()
 
   auto lambda = lambda::node::create(graph.root(), ft, "f", linkage::external_linkage);
 
-  auto d1 = lambda->add_ctxvar(x);
-  auto d2 = lambda->add_ctxvar(x);
+  auto d1 = lambda->AddContextVar(x).inner;
+  auto d2 = lambda->AddContextVar(x).inner;
 
   auto b1 = jlm::tests::create_testop(lambda->subregion(), { d1, d2 }, { vt })[0];
 
@@ -446,11 +446,11 @@ test_phi()
   auto r2 = pb.add_recvar(PointerType::Create());
 
   auto lambda1 = lambda::node::create(region, ft, "f", linkage::external_linkage);
-  auto cv1 = lambda1->add_ctxvar(d1);
+  auto cv1 = lambda1->AddContextVar(d1).inner;
   auto f1 = lambda1->finalize({ cv1 });
 
   auto lambda2 = lambda::node::create(region, ft, "f", linkage::external_linkage);
-  auto cv2 = lambda2->add_ctxvar(d2);
+  auto cv2 = lambda2->AddContextVar(d2).inner;
   auto f2 = lambda2->finalize({ cv2 });
 
   r1->set_rvorigin(f1);

--- a/tests/jlm/llvm/opt/test-inlining.cpp
+++ b/tests/jlm/llvm/opt/test-inlining.cpp
@@ -38,7 +38,7 @@ test1()
         { vt, iostatetype::Create(), MemoryStateType::Create() });
 
     auto lambda = lambda::node::create(graph.root(), functionType, "f1", linkage::external_linkage);
-    lambda->add_ctxvar(i);
+    lambda->AddContextVar(i);
 
     auto t = jlm::tests::test_op::create(lambda->subregion(), { lambda->fctargument(0) }, { vt });
 
@@ -56,7 +56,7 @@ test1()
         { vt, iostatetype::Create(), MemoryStateType::Create() });
 
     auto lambda = lambda::node::create(graph.root(), functionType, "f1", linkage::external_linkage);
-    auto d = lambda->add_ctxvar(f1);
+    auto d = lambda->AddContextVar(f1).inner;
     auto controlArgument = lambda->fctargument(0);
     auto valueArgument = lambda->fctargument(1);
     auto iOStateArgument = lambda->fctargument(2);
@@ -138,8 +138,8 @@ test2()
         { iostatetype::Create(), MemoryStateType::Create() });
 
     auto lambda = lambda::node::create(graph.root(), functionType, "f2", linkage::external_linkage);
-    auto cvi = lambda->add_ctxvar(i);
-    auto cvf1 = lambda->add_ctxvar(f1);
+    auto cvi = lambda->AddContextVar(i).inner;
+    auto cvf1 = lambda->AddContextVar(f1).inner;
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
 


### PR DESCRIPTION
Remove lambad::cvinput and introduce a new API to map inputs to associated region arguments.

The only reason all these subclasses exist is to provide an API for mapping, however the data held
in these inputs is entirely redundant as the node already provides (and needs to provide) the
correct mapping semantic.
