### PR TITLE
Improve output of Cfg::ToAscii() method

### DIFF
--- a/jlm/llvm/backend/rvsdg2jlm/rvsdg2jlm.cpp
+++ b/jlm/llvm/backend/rvsdg2jlm/rvsdg2jlm.cpp
@@ -127,9 +127,11 @@ create_cfg(const lambda::node & lambda, context & ctx)
   ctx.set_cfg(cfg.get());
 
   /* add arguments */
+  size_t n = 0;
   for (auto & fctarg : lambda.fctarguments())
   {
-    auto argument = llvm::argument::create("", fctarg.Type(), fctarg.attributes());
+    auto name = util::strfmt("_a", n++, "_");
+    auto argument = llvm::argument::create(name, fctarg.Type(), fctarg.attributes());
     auto v = cfg->entry()->append_argument(std::move(argument));
     ctx.insert(&fctarg, v);
   }

--- a/jlm/llvm/ir/cfg.hpp
+++ b/jlm/llvm/ir/cfg.hpp
@@ -387,13 +387,15 @@ private:
   ToAscii(const exit_node & exitNode);
 
   static std::string
-  ToAscii(const basic_block & basicBlock);
+  ToAscii(
+      const basic_block & basicBlock,
+      const std::unordered_map<cfg_node *, std::string> & labels);
 
   static std::string
-  CreateTargets(const cfg_node & node);
+  CreateTargets(const cfg_node & node, const std::unordered_map<cfg_node *, std::string> & labels);
 
-  static std::string
-  CreateLabel(const cfg_node & node);
+  static std::unordered_map<cfg_node *, std::string>
+  CreateLabels(const std::vector<cfg_node *> & nodes);
 
   ipgraph_module & module_;
   std::unique_ptr<exit_node> exit_;

--- a/jlm/llvm/ir/print.cpp
+++ b/jlm/llvm/ir/print.cpp
@@ -59,7 +59,7 @@ emit_function_node(const ipgraph_node & clg_node)
   std::string cfg = node.cfg() ? cfg::ToAscii(*node.cfg()) : "";
   std::string exported = !is_externally_visible(node.linkage()) ? "static" : "";
 
-  return exported + results + " " + node.name() + " " + operands + "\n{\n" + cfg + "}\n";
+  return exported + results + " " + node.name() + " " + operands + "\n{\n" + cfg + "\n}\n";
 }
 
 static std::string


### PR DESCRIPTION
The PR does the following:
1. Ensure that CFG arguments are labeled after RVSDG to CFG conversion
2. Give readable labels to CFG nodes
3. Add missing newline after CFG printing

This PR is part of issue #586 