### PR TITLE
Remove static output_node::node() method

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -276,7 +276,7 @@ rename_delta(llvm::delta::node * odn)
 
   odn->output()->divert_users(data);
   jlm::rvsdg::remove(odn);
-  return static_cast<llvm::delta::node *>(jlm::rvsdg::node_output::node(data));
+  return static_cast<llvm::delta::node *>(jlm::rvsdg::output::GetNode(*data));
 }
 
 llvm::lambda::node *

--- a/jlm/hls/ir/hls.cpp
+++ b/jlm/hls/ir/hls.cpp
@@ -185,7 +185,7 @@ loop_node::create(rvsdg::Region * parent, bool init)
 void
 loop_node::set_predicate(jlm::rvsdg::output * p)
 {
-  auto node = jlm::rvsdg::node_output::node(predicate()->origin());
+  auto node = jlm::rvsdg::output::GetNode(*predicate()->origin());
   predicate()->origin()->divert_users(p);
   if (node && !node->has_users())
     remove(node);

--- a/jlm/hls/opt/cne.cpp
+++ b/jlm/hls/opt/cne.cpp
@@ -198,8 +198,8 @@ congruent(jlm::rvsdg::output * o1, jlm::rvsdg::output * o2, vset & vs, cnectx & 
     return congruent(output1, output2, vs, ctx);
   }
 
-  auto n1 = jlm::rvsdg::node_output::node(o1);
-  auto n2 = jlm::rvsdg::node_output::node(o2);
+  auto n1 = jlm::rvsdg::output::GetNode(*o1);
+  auto n2 = jlm::rvsdg::output::GetNode(*o2);
   if (is<jlm::rvsdg::ThetaOperation>(n1) && is<jlm::rvsdg::ThetaOperation>(n2) && n1 == n2)
   {
     auto so1 = static_cast<jlm::rvsdg::structural_output *>(o1);

--- a/jlm/llvm/backend/rvsdg2jlm/rvsdg2jlm.cpp
+++ b/jlm/llvm/backend/rvsdg2jlm/rvsdg2jlm.cpp
@@ -202,7 +202,7 @@ convert_empty_gamma_node(const rvsdg::GammaNode * gamma, context & ctx)
       continue;
     }
 
-    auto matchnode = rvsdg::node_output::node(predicate);
+    auto matchnode = rvsdg::output::GetNode(*predicate);
     if (is<rvsdg::match_op>(matchnode))
     {
       auto matchop = static_cast<const rvsdg::match_op *>(&matchnode->operation());
@@ -282,7 +282,7 @@ convert_gamma_node(const rvsdg::node & node, context & ctx)
     auto output = gamma->output(n);
 
     bool invariant = true;
-    auto matchnode = rvsdg::node_output::node(predicate);
+    auto matchnode = rvsdg::output::GetNode(*predicate);
     bool select = (gamma->nsubregions() == 2) && is<rvsdg::match_op>(matchnode);
     std::vector<std::pair<const variable *, cfg_node *>> arguments;
     for (size_t r = 0; r < gamma->nsubregions(); r++)
@@ -292,7 +292,7 @@ convert_gamma_node(const rvsdg::node & node, context & ctx)
       auto v = ctx.variable(origin);
       arguments.push_back(std::make_pair(v, phi_nodes[r]));
       invariant &= (v == ctx.variable(gamma->subregion(0)->result(n)->origin()));
-      auto tmp = rvsdg::node_output::node(origin);
+      auto tmp = rvsdg::output::GetNode(*origin);
       select &= (tmp == nullptr && origin->region()->node() == &node);
     }
 
@@ -306,7 +306,7 @@ convert_gamma_node(const rvsdg::node & node, context & ctx)
     if (select)
     {
       /* use select instead of phi */
-      auto matchnode = rvsdg::node_output::node(predicate);
+      auto matchnode = rvsdg::output::GetNode(*predicate);
       auto matchop = static_cast<const rvsdg::match_op *>(&matchnode->operation());
       auto d = matchop->default_alternative();
       auto c = ctx.variable(matchnode->input(0)->origin());
@@ -442,7 +442,7 @@ convert_phi_node(const rvsdg::node & node, context & ctx)
   for (size_t n = 0; n < subregion->nresults(); n++)
   {
     JLM_ASSERT(subregion->argument(n)->input() == nullptr);
-    auto node = rvsdg::node_output::node(subregion->result(n)->origin());
+    auto node = rvsdg::output::GetNode(*subregion->result(n)->origin());
 
     if (auto lambda = dynamic_cast<const lambda::node *>(node))
     {
@@ -469,7 +469,7 @@ convert_phi_node(const rvsdg::node & node, context & ctx)
   {
     JLM_ASSERT(subregion->argument(n)->input() == nullptr);
     auto result = subregion->result(n);
-    auto node = rvsdg::node_output::node(result->origin());
+    auto node = rvsdg::output::GetNode(*result->origin());
 
     if (auto lambda = dynamic_cast<const lambda::node *>(node))
     {

--- a/jlm/llvm/ir/operators/Store.cpp
+++ b/jlm/llvm/ir/operators/Store.cpp
@@ -167,13 +167,13 @@ is_store_mux_reducible(const std::vector<jlm::rvsdg::output *> & operands)
 {
   JLM_ASSERT(operands.size() > 2);
 
-  auto memStateMergeNode = jlm::rvsdg::node_output::node(operands[2]);
+  auto memStateMergeNode = jlm::rvsdg::output::GetNode(*operands[2]);
   if (!is<MemoryStateMergeOperation>(memStateMergeNode))
     return false;
 
   for (size_t n = 2; n < operands.size(); n++)
   {
-    auto node = jlm::rvsdg::node_output::node(operands[n]);
+    auto node = jlm::rvsdg::output::GetNode(*operands[n]);
     if (node != memStateMergeNode)
       return false;
   }
@@ -188,7 +188,7 @@ is_store_store_reducible(
 {
   JLM_ASSERT(operands.size() > 2);
 
-  auto storenode = jlm::rvsdg::node_output::node(operands[2]);
+  auto storenode = jlm::rvsdg::output::GetNode(*operands[2]);
   if (!is<StoreNonVolatileOperation>(storenode))
     return false;
 
@@ -201,7 +201,7 @@ is_store_store_reducible(
 
   for (size_t n = 2; n < operands.size(); n++)
   {
-    if (jlm::rvsdg::node_output::node(operands[n]) != storenode || operands[n]->nusers() != 1)
+    if (jlm::rvsdg::output::GetNode(*operands[n]) != storenode || operands[n]->nusers() != 1)
       return false;
   }
 
@@ -216,7 +216,7 @@ is_store_alloca_reducible(const std::vector<jlm::rvsdg::output *> & operands)
   if (operands.size() == 3)
     return false;
 
-  auto alloca = jlm::rvsdg::node_output::node(operands[0]);
+  auto alloca = jlm::rvsdg::output::GetNode(*operands[0]);
   if (!alloca || !is<alloca_op>(alloca->operation()))
     return false;
 
@@ -246,7 +246,7 @@ perform_store_mux_reduction(
     const StoreNonVolatileOperation & op,
     const std::vector<jlm::rvsdg::output *> & operands)
 {
-  auto memStateMergeNode = jlm::rvsdg::node_output::node(operands[2]);
+  auto memStateMergeNode = jlm::rvsdg::output::GetNode(*operands[2]);
   auto memStateMergeOperands = jlm::rvsdg::operands(memStateMergeNode);
 
   auto states = StoreNonVolatileNode::Create(
@@ -263,7 +263,7 @@ perform_store_store_reduction(
     const std::vector<jlm::rvsdg::output *> & operands)
 {
   JLM_ASSERT(is_store_store_reducible(op, operands));
-  auto storenode = jlm::rvsdg::node_output::node(operands[2]);
+  auto storenode = jlm::rvsdg::output::GetNode(*operands[2]);
 
   auto storeops = jlm::rvsdg::operands(storenode);
   std::vector<jlm::rvsdg::output *> states(std::next(std::next(storeops.begin())), storeops.end());
@@ -277,7 +277,7 @@ perform_store_alloca_reduction(
 {
   auto value = operands[1];
   auto address = operands[0];
-  auto alloca_state = jlm::rvsdg::node_output::node(address)->output(1);
+  auto alloca_state = jlm::rvsdg::output::GetNode(*address)->output(1);
   std::unordered_set<jlm::rvsdg::output *> states(
       std::next(std::next(operands.begin())),
       operands.end());
@@ -358,7 +358,7 @@ store_normal_form::normalize_node(jlm::rvsdg::node * node) const
   if (get_multiple_origin_reducible() && is_multiple_origin_reducible(operands))
   {
     auto outputs = perform_multiple_origin_reduction(*op, operands);
-    auto new_node = jlm::rvsdg::node_output::node(outputs[0]);
+    auto new_node = jlm::rvsdg::output::GetNode(*outputs[0]);
 
     std::unordered_map<jlm::rvsdg::output *, jlm::rvsdg::output *> origin2output;
     for (size_t n = 0; n < outputs.size(); n++)

--- a/jlm/llvm/ir/operators/call.cpp
+++ b/jlm/llvm/ir/operators/call.cpp
@@ -166,7 +166,7 @@ CallNode::TraceFunctionInput(const CallNode & callNode)
     if (is<rvsdg::GraphImport>(origin))
       return origin;
 
-    if (is<rvsdg::simple_op>(rvsdg::node_output::node(origin)))
+    if (is<rvsdg::simple_op>(rvsdg::output::GetNode(*origin)))
       return origin;
 
     if (is<phi::rvargument>(origin))

--- a/jlm/llvm/ir/operators/call.hpp
+++ b/jlm/llvm/ir/operators/call.hpp
@@ -388,7 +388,7 @@ public:
   [[nodiscard]] static rvsdg::simple_node *
   GetMemoryStateEntryMerge(const CallNode & callNode) noexcept
   {
-    auto node = rvsdg::node_output::node(callNode.GetMemoryStateInput()->origin());
+    auto node = rvsdg::output::GetNode(*callNode.GetMemoryStateInput()->origin());
     return is<CallEntryMemoryStateMergeOperation>(node) ? dynamic_cast<rvsdg::simple_node *>(node)
                                                         : nullptr;
   }

--- a/jlm/llvm/ir/operators/lambda.cpp
+++ b/jlm/llvm/ir/operators/lambda.cpp
@@ -171,7 +171,7 @@ node::GetMemoryStateExitMerge(const lambda::node & lambdaNode) noexcept
 {
   auto & result = lambdaNode.GetMemoryStateRegionResult();
 
-  auto node = rvsdg::node_output::node(result.origin());
+  auto node = rvsdg::output::GetNode(*result.origin());
   return is<LambdaExitMemoryStateMergeOperation>(node) ? dynamic_cast<rvsdg::simple_node *>(node)
                                                        : nullptr;
 }

--- a/jlm/llvm/ir/operators/operators.cpp
+++ b/jlm/llvm/ir/operators/operators.cpp
@@ -439,7 +439,7 @@ zext_op::reduce_operand(rvsdg::unop_reduction_path_t path, rvsdg::output * opera
   {
     auto c = static_cast<const rvsdg::bitconstant_op *>(&producer(operand)->operation());
     return create_bitconstant(
-        rvsdg::node_output::node(operand)->region(),
+        rvsdg::output::GetNode(*operand)->region(),
         c->value().zext(ndstbits() - nsrcbits()));
   }
 

--- a/jlm/llvm/ir/operators/sext.cpp
+++ b/jlm/llvm/ir/operators/sext.cpp
@@ -17,19 +17,19 @@ static const rvsdg::unop_reduction_path_t sext_reduction_bitbinary = 129;
 static bool
 is_bitunary_reducible(const rvsdg::output * operand)
 {
-  return rvsdg::is<rvsdg::bitunary_op>(rvsdg::node_output::node(operand));
+  return rvsdg::is<rvsdg::bitunary_op>(rvsdg::output::GetNode(*operand));
 }
 
 static bool
 is_bitbinary_reducible(const rvsdg::output * operand)
 {
-  return rvsdg::is<rvsdg::bitbinary_op>(rvsdg::node_output::node(operand));
+  return rvsdg::is<rvsdg::bitbinary_op>(rvsdg::output::GetNode(*operand));
 }
 
 static bool
 is_inverse_reducible(const sext_op & op, const rvsdg::output * operand)
 {
-  auto node = rvsdg::node_output::node(operand);
+  auto node = rvsdg::output::GetNode(*operand);
   if (!node)
     return false;
 
@@ -41,7 +41,7 @@ static rvsdg::output *
 perform_bitunary_reduction(const sext_op & op, rvsdg::output * operand)
 {
   JLM_ASSERT(is_bitunary_reducible(operand));
-  auto unary = rvsdg::node_output::node(operand);
+  auto unary = rvsdg::output::GetNode(*operand);
   auto region = operand->region();
   auto uop = static_cast<const rvsdg::bitunary_op *>(&unary->operation());
 
@@ -53,7 +53,7 @@ static rvsdg::output *
 perform_bitbinary_reduction(const sext_op & op, rvsdg::output * operand)
 {
   JLM_ASSERT(is_bitbinary_reducible(operand));
-  auto binary = rvsdg::node_output::node(operand);
+  auto binary = rvsdg::output::GetNode(*operand);
   auto region = operand->region();
   auto bop = static_cast<const rvsdg::bitbinary_op *>(&binary->operation());
 
@@ -71,7 +71,7 @@ static rvsdg::output *
 perform_inverse_reduction(const sext_op & op, rvsdg::output * operand)
 {
   JLM_ASSERT(is_inverse_reducible(op, operand));
-  return rvsdg::node_output::node(operand)->input(0)->origin();
+  return rvsdg::output::GetNode(*operand)->input(0)->origin();
 }
 
 sext_op::~sext_op()

--- a/jlm/llvm/opt/InvariantValueRedirection.cpp
+++ b/jlm/llvm/opt/InvariantValueRedirection.cpp
@@ -216,7 +216,7 @@ InvariantValueRedirection::RedirectCallOutputs(CallNode & callNode)
       for (size_t i = 0; i < lambdaExitMerge->ninputs(); i++)
       {
         auto lambdaExitMergeInput = lambdaExitMerge->input(i);
-        auto node = rvsdg::node_output::node(lambdaExitMergeInput->origin());
+        auto node = rvsdg::output::GetNode(*lambdaExitMergeInput->origin());
         if (node == lambdaEntrySplit)
         {
           auto callExitSplitOutput = callExitSplit->output(lambdaExitMergeInput->index());

--- a/jlm/llvm/opt/alias-analyses/PointsToGraph.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraph.cpp
@@ -481,7 +481,7 @@ PointsToGraph::RegisterNode::~RegisterNode() noexcept = default;
 std::string
 PointsToGraph::RegisterNode::ToString(const rvsdg::output & output)
 {
-  auto node = jlm::rvsdg::node_output::node(&output);
+  auto node = jlm::rvsdg::output::GetNode(*&output);
 
   if (node != nullptr)
     return util::strfmt(node->operation().debug_string(), ":o", output.index());

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -199,7 +199,7 @@ public:
   [[nodiscard]] std::string
   DebugString() const noexcept override
   {
-    auto node = jlm::rvsdg::node_output::node(Output_);
+    auto node = jlm::rvsdg::output::GetNode(*Output_);
     auto index = Output_->index();
 
     if (jlm::rvsdg::is<jlm::rvsdg::simple_op>(node))
@@ -241,13 +241,13 @@ public:
 
     if (is<rvsdg::ThetaOutput>(Output_))
     {
-      auto dbgstr = jlm::rvsdg::node_output::node(Output_)->operation().debug_string();
+      auto dbgstr = jlm::rvsdg::output::GetNode(*Output_)->operation().debug_string();
       return jlm::util::strfmt(dbgstr, ":out", index);
     }
 
     if (is<rvsdg::GammaOutput>(Output_))
     {
-      auto dbgstr = jlm::rvsdg::node_output::node(Output_)->operation().debug_string();
+      auto dbgstr = jlm::rvsdg::output::GetNode(*Output_)->operation().debug_string();
       return jlm::util::strfmt(dbgstr, ":out", index);
     }
 
@@ -269,7 +269,7 @@ public:
     }
 
     return jlm::util::strfmt(
-        jlm::rvsdg::node_output::node(Output_)->operation().debug_string(),
+        jlm::rvsdg::output::GetNode(*Output_)->operation().debug_string(),
         ":",
         index);
   }

--- a/jlm/llvm/opt/cne.cpp
+++ b/jlm/llvm/opt/cne.cpp
@@ -195,8 +195,8 @@ congruent(jlm::rvsdg::output * o1, jlm::rvsdg::output * o2, vset & vs, cnectx & 
     return congruent(output1, output2, vs, ctx);
   }
 
-  auto n1 = jlm::rvsdg::node_output::node(o1);
-  auto n2 = jlm::rvsdg::node_output::node(o2);
+  auto n1 = jlm::rvsdg::output::GetNode(*o1);
+  auto n2 = jlm::rvsdg::output::GetNode(*o2);
   if (is<rvsdg::ThetaOperation>(n1) && is<rvsdg::ThetaOperation>(n2) && n1 == n2)
   {
     auto so1 = static_cast<jlm::rvsdg::structural_output *>(o1);

--- a/jlm/llvm/opt/inversion.cpp
+++ b/jlm/llvm/opt/inversion.cpp
@@ -51,7 +51,7 @@ public:
 static rvsdg::GammaNode *
 is_applicable(const rvsdg::ThetaNode * theta)
 {
-  auto matchnode = jlm::rvsdg::node_output::node(theta->predicate()->origin());
+  auto matchnode = jlm::rvsdg::output::GetNode(*theta->predicate()->origin());
   if (!jlm::rvsdg::is<jlm::rvsdg::match_op>(matchnode))
     return nullptr;
 
@@ -79,7 +79,7 @@ pullin(rvsdg::GammaNode * gamma, rvsdg::ThetaNode * theta)
   pullin_bottom(gamma);
   for (const auto & lv : *theta)
   {
-    if (jlm::rvsdg::node_output::node(lv->result()->origin()) != gamma)
+    if (jlm::rvsdg::output::GetNode(*lv->result()->origin()) != gamma)
     {
       auto ev = gamma->add_entryvar(lv->result()->origin());
       JLM_ASSERT(ev->narguments() == 2);

--- a/jlm/llvm/opt/pull.cpp
+++ b/jlm/llvm/opt/pull.cpp
@@ -131,8 +131,8 @@ pullin_top(rvsdg::GammaNode * gamma)
   auto ev = gamma->begin_entryvar();
   while (ev != gamma->end_entryvar())
   {
-    auto node = jlm::rvsdg::node_output::node(ev->origin());
-    auto tmp = jlm::rvsdg::node_output::node(gamma->predicate()->origin());
+    auto node = jlm::rvsdg::output::GetNode(*ev->origin());
+    auto tmp = jlm::rvsdg::output::GetNode(*gamma->predicate()->origin());
     if (node && tmp != node && single_successor(node))
     {
       pullin_node(gamma, node);
@@ -178,7 +178,7 @@ pullin_bottom(rvsdg::GammaNode * gamma)
       for (size_t i = 0; i < node->ninputs(); i++)
       {
         auto input = node->input(i);
-        if (jlm::rvsdg::node_output::node(input->origin()) == gamma)
+        if (jlm::rvsdg::output::GetNode(*input->origin()) == gamma)
         {
           auto output = static_cast<jlm::rvsdg::structural_output *>(input->origin());
           operands.push_back(gamma->subregion(r)->result(output->index())->origin());
@@ -251,13 +251,13 @@ pull(rvsdg::GammaNode * gamma)
   if (gamma->nsubregions() == 2 && empty(gamma))
     return;
 
-  auto prednode = jlm::rvsdg::node_output::node(gamma->predicate()->origin());
+  auto prednode = jlm::rvsdg::output::GetNode(*gamma->predicate()->origin());
 
   /* FIXME: This is inefficient. We can do better. */
   auto ev = gamma->begin_entryvar();
   while (ev != gamma->end_entryvar())
   {
-    auto node = jlm::rvsdg::node_output::node(ev->origin());
+    auto node = jlm::rvsdg::output::GetNode(*ev->origin());
     if (!node || prednode == node || !single_successor(node))
     {
       ev++;

--- a/jlm/llvm/opt/push.cpp
+++ b/jlm/llvm/opt/push.cpp
@@ -355,7 +355,7 @@ pushout_store(jlm::rvsdg::node * storenode)
     std::unordered_set<jlm::rvsdg::input *> users;
     for (const auto & user : *states[n])
     {
-      if (jlm::rvsdg::input::GetNode(*user) != jlm::rvsdg::node_output::node(nstates[0]))
+      if (jlm::rvsdg::input::GetNode(*user) != jlm::rvsdg::output::GetNode(*nstates[0]))
         users.insert(user);
     }
 
@@ -371,7 +371,7 @@ push_bottom(rvsdg::ThetaNode * theta)
 {
   for (const auto & lv : *theta)
   {
-    auto storenode = jlm::rvsdg::node_output::node(lv->result()->origin());
+    auto storenode = jlm::rvsdg::output::GetNode(*lv->result()->origin());
     if (jlm::rvsdg::is<StoreNonVolatileOperation>(storenode) && is_movable_store(storenode))
     {
       pushout_store(storenode);

--- a/jlm/llvm/opt/unroll.cpp
+++ b/jlm/llvm/opt/unroll.cpp
@@ -62,7 +62,7 @@ is_theta_invariant(const jlm::rvsdg::output * output)
 {
   JLM_ASSERT(is<rvsdg::ThetaOperation>(output->region()->node()));
 
-  if (jlm::rvsdg::is<jlm::rvsdg::bitconstant_op>(jlm::rvsdg::node_output::node(output)))
+  if (jlm::rvsdg::is<jlm::rvsdg::bitconstant_op>(jlm::rvsdg::output::GetNode(*output)))
     return true;
 
   auto argument = dynamic_cast<const rvsdg::RegionArgument *>(output);
@@ -79,7 +79,7 @@ push_from_theta(jlm::rvsdg::output * output)
   if (argument)
     return argument;
 
-  auto tmp = jlm::rvsdg::node_output::node(output);
+  auto tmp = jlm::rvsdg::output::GetNode(*output);
   JLM_ASSERT(jlm::rvsdg::is<jlm::rvsdg::bitconstant_op>(tmp));
   JLM_ASSERT(is<rvsdg::ThetaOperation>(tmp->region()->node()));
   auto theta = static_cast<rvsdg::ThetaNode *>(tmp->region()->node());
@@ -104,7 +104,7 @@ is_idv(jlm::rvsdg::input * input)
     return false;
 
   auto tinput = static_cast<const ThetaInput *>(a->input());
-  return jlm::rvsdg::node_output::node(tinput->result()->origin()) == node;
+  return jlm::rvsdg::output::GetNode(*tinput->result()->origin()) == node;
 }
 
 std::unique_ptr<jlm::rvsdg::bitvalue_repr>
@@ -135,11 +135,11 @@ unrollinfo::create(rvsdg::ThetaNode * theta)
 {
   using namespace jlm::rvsdg;
 
-  auto matchnode = jlm::rvsdg::node_output::node(theta->predicate()->origin());
+  auto matchnode = jlm::rvsdg::output::GetNode(*theta->predicate()->origin());
   if (!is<match_op>(matchnode))
     return nullptr;
 
-  auto cmpnode = jlm::rvsdg::node_output::node(matchnode->input(0)->origin());
+  auto cmpnode = jlm::rvsdg::output::GetNode(*matchnode->input(0)->origin());
   if (!is<bitcompare_op>(cmpnode))
     return nullptr;
 
@@ -149,7 +149,7 @@ unrollinfo::create(rvsdg::ThetaNode * theta)
   if (!end)
     return nullptr;
 
-  auto armnode = jlm::rvsdg::node_output::node((end == o0 ? o1 : o0));
+  auto armnode = jlm::rvsdg::output::GetNode(*(end == o0 ? o1 : o0));
   if (!is<bitadd_op>(armnode) && !is<bitsub_op>(armnode))
     return nullptr;
   if (armnode->ninputs() != 2)
@@ -242,7 +242,7 @@ unroll_theta(const unrollinfo & ui, rvsdg::SubstitutionMap & smap, size_t factor
       to a multiple of the step value.
     */
     auto cmpnode = ui.cmpnode();
-    auto cmp = jlm::rvsdg::node_output::node(smap.lookup(cmpnode->output(0)));
+    auto cmp = jlm::rvsdg::output::GetNode(*smap.lookup(cmpnode->output(0)));
     auto input = cmp->input(0)->origin() == smap.lookup(ui.end()) ? cmp->input(0) : cmp->input(1);
     JLM_ASSERT(input->origin() == smap.lookup(ui.end()));
 
@@ -356,7 +356,7 @@ create_unrolled_theta_predicate(
   using namespace jlm::rvsdg;
 
   auto region = smap.lookup(ui.cmpnode()->output(0))->region();
-  auto cmpnode = jlm::rvsdg::node_output::node(smap.lookup(ui.cmpnode()->output(0)));
+  auto cmpnode = jlm::rvsdg::output::GetNode(*smap.lookup(ui.cmpnode()->output(0)));
   auto step = smap.lookup(ui.step());
   auto end = smap.lookup(ui.end());
   auto nbits = ui.nbits();

--- a/jlm/mlir/frontend/MlirToJlmConverter.cpp
+++ b/jlm/mlir/frontend/MlirToJlmConverter.cpp
@@ -109,43 +109,43 @@ MlirToJlmConverter::ConvertCmpIOp(
 {
   if (CompOp.getPredicate() == ::mlir::arith::CmpIPredicate::eq)
   {
-    return rvsdg::node_output::node(rvsdg::biteq_op::create(nbits, inputs[0], inputs[1]));
+    return rvsdg::output::GetNode(*rvsdg::biteq_op::create(nbits, inputs[0], inputs[1]));
   }
   else if (CompOp.getPredicate() == ::mlir::arith::CmpIPredicate::ne)
   {
-    return rvsdg::node_output::node(rvsdg::bitne_op::create(nbits, inputs[0], inputs[1]));
+    return rvsdg::output::GetNode(*rvsdg::bitne_op::create(nbits, inputs[0], inputs[1]));
   }
   else if (CompOp.getPredicate() == ::mlir::arith::CmpIPredicate::sge)
   {
-    return rvsdg::node_output::node(rvsdg::bitsge_op::create(nbits, inputs[0], inputs[1]));
+    return rvsdg::output::GetNode(*rvsdg::bitsge_op::create(nbits, inputs[0], inputs[1]));
   }
   else if (CompOp.getPredicate() == ::mlir::arith::CmpIPredicate::sgt)
   {
-    return rvsdg::node_output::node(rvsdg::bitsgt_op::create(nbits, inputs[0], inputs[1]));
+    return rvsdg::output::GetNode(*rvsdg::bitsgt_op::create(nbits, inputs[0], inputs[1]));
   }
   else if (CompOp.getPredicate() == ::mlir::arith::CmpIPredicate::sle)
   {
-    return rvsdg::node_output::node(rvsdg::bitsle_op::create(nbits, inputs[0], inputs[1]));
+    return rvsdg::output::GetNode(*rvsdg::bitsle_op::create(nbits, inputs[0], inputs[1]));
   }
   else if (CompOp.getPredicate() == ::mlir::arith::CmpIPredicate::slt)
   {
-    return rvsdg::node_output::node(rvsdg::bitslt_op::create(nbits, inputs[0], inputs[1]));
+    return rvsdg::output::GetNode(*rvsdg::bitslt_op::create(nbits, inputs[0], inputs[1]));
   }
   else if (CompOp.getPredicate() == ::mlir::arith::CmpIPredicate::uge)
   {
-    return rvsdg::node_output::node(rvsdg::bituge_op::create(nbits, inputs[0], inputs[1]));
+    return rvsdg::output::GetNode(*rvsdg::bituge_op::create(nbits, inputs[0], inputs[1]));
   }
   else if (CompOp.getPredicate() == ::mlir::arith::CmpIPredicate::ugt)
   {
-    return rvsdg::node_output::node(rvsdg::bitugt_op::create(nbits, inputs[0], inputs[1]));
+    return rvsdg::output::GetNode(*rvsdg::bitugt_op::create(nbits, inputs[0], inputs[1]));
   }
   else if (CompOp.getPredicate() == ::mlir::arith::CmpIPredicate::ule)
   {
-    return rvsdg::node_output::node(rvsdg::bitule_op::create(nbits, inputs[0], inputs[1]));
+    return rvsdg::output::GetNode(*rvsdg::bitule_op::create(nbits, inputs[0], inputs[1]));
   }
   else if (CompOp.getPredicate() == ::mlir::arith::CmpIPredicate::ult)
   {
-    return rvsdg::node_output::node(rvsdg::bitult_op::create(nbits, inputs[0], inputs[1]));
+    return rvsdg::output::GetNode(*rvsdg::bitult_op::create(nbits, inputs[0], inputs[1]));
   }
   else
   {
@@ -162,91 +162,91 @@ MlirToJlmConverter::ConvertBitBinaryNode(
     return nullptr;
   if (auto castedOp = ::mlir::dyn_cast<::mlir::arith::AddIOp>(&mlirOperation))
   {
-    return rvsdg::node_output::node(rvsdg::bitadd_op::create(
+    return rvsdg::output::GetNode(*rvsdg::bitadd_op::create(
         static_cast<size_t>(castedOp.getType().cast<::mlir::IntegerType>().getWidth()),
         inputs[0],
         inputs[1]));
   }
   else if (auto castedOp = ::mlir::dyn_cast<::mlir::arith::AndIOp>(&mlirOperation))
   {
-    return rvsdg::node_output::node(rvsdg::bitand_op::create(
+    return rvsdg::output::GetNode(*rvsdg::bitand_op::create(
         static_cast<size_t>(castedOp.getType().cast<::mlir::IntegerType>().getWidth()),
         inputs[0],
         inputs[1]));
   }
   else if (auto castedOp = ::mlir::dyn_cast<::mlir::arith::ShRUIOp>(&mlirOperation))
   {
-    return rvsdg::node_output::node(rvsdg::bitashr_op::create(
+    return rvsdg::output::GetNode(*rvsdg::bitashr_op::create(
         static_cast<size_t>(castedOp.getType().cast<::mlir::IntegerType>().getWidth()),
         inputs[0],
         inputs[1]));
   }
   else if (auto castedOp = ::mlir::dyn_cast<::mlir::arith::MulIOp>(&mlirOperation))
   {
-    return rvsdg::node_output::node(rvsdg::bitmul_op::create(
+    return rvsdg::output::GetNode(*rvsdg::bitmul_op::create(
         static_cast<size_t>(castedOp.getType().cast<::mlir::IntegerType>().getWidth()),
         inputs[0],
         inputs[1]));
   }
   else if (auto castedOp = ::mlir::dyn_cast<::mlir::arith::OrIOp>(&mlirOperation))
   {
-    return rvsdg::node_output::node(rvsdg::bitor_op::create(
+    return rvsdg::output::GetNode(*rvsdg::bitor_op::create(
         static_cast<size_t>(castedOp.getType().cast<::mlir::IntegerType>().getWidth()),
         inputs[0],
         inputs[1]));
   }
   else if (auto castedOp = ::mlir::dyn_cast<::mlir::arith::DivSIOp>(&mlirOperation))
   {
-    return rvsdg::node_output::node(rvsdg::bitsdiv_op::create(
+    return rvsdg::output::GetNode(*rvsdg::bitsdiv_op::create(
         static_cast<size_t>(castedOp.getType().cast<::mlir::IntegerType>().getWidth()),
         inputs[0],
         inputs[1]));
   }
   else if (auto castedOp = ::mlir::dyn_cast<::mlir::arith::ShLIOp>(&mlirOperation))
   {
-    return rvsdg::node_output::node(rvsdg::bitshl_op::create(
+    return rvsdg::output::GetNode(*rvsdg::bitshl_op::create(
         static_cast<size_t>(castedOp.getType().cast<::mlir::IntegerType>().getWidth()),
         inputs[0],
         inputs[1]));
   }
   else if (auto castedOp = ::mlir::dyn_cast<::mlir::arith::ShRUIOp>(&mlirOperation))
   {
-    return rvsdg::node_output::node(rvsdg::bitshr_op::create(
+    return rvsdg::output::GetNode(*rvsdg::bitshr_op::create(
         static_cast<size_t>(castedOp.getType().cast<::mlir::IntegerType>().getWidth()),
         inputs[0],
         inputs[1]));
   }
   else if (auto castedOp = ::mlir::dyn_cast<::mlir::arith::RemSIOp>(&mlirOperation))
   {
-    return rvsdg::node_output::node(rvsdg::bitsmod_op::create(
+    return rvsdg::output::GetNode(*rvsdg::bitsmod_op::create(
         static_cast<size_t>(castedOp.getType().cast<::mlir::IntegerType>().getWidth()),
         inputs[0],
         inputs[1]));
   }
   else if (auto castedOp = ::mlir::dyn_cast<::mlir::arith::SubIOp>(&mlirOperation))
   {
-    return rvsdg::node_output::node(rvsdg::bitsub_op::create(
+    return rvsdg::output::GetNode(*rvsdg::bitsub_op::create(
         static_cast<size_t>(castedOp.getType().cast<::mlir::IntegerType>().getWidth()),
         inputs[0],
         inputs[1]));
   }
   else if (auto castedOp = ::mlir::dyn_cast<::mlir::arith::DivUIOp>(&mlirOperation))
   {
-    return rvsdg::node_output::node(rvsdg::bitudiv_op::create(
+    return rvsdg::output::GetNode(*rvsdg::bitudiv_op::create(
         static_cast<size_t>(castedOp.getType().cast<::mlir::IntegerType>().getWidth()),
         inputs[0],
         inputs[1]));
   }
   else if (auto castedOp = ::mlir::dyn_cast<::mlir::arith::RemUIOp>(&mlirOperation))
   {
-    return rvsdg::node_output::node(rvsdg::bitumod_op::create(
+    return rvsdg::output::GetNode(*rvsdg::bitumod_op::create(
         static_cast<size_t>(castedOp.getType().cast<::mlir::IntegerType>().getWidth()),
         inputs[0],
         inputs[1]));
   }
   else if (auto castedOp = ::mlir::dyn_cast<::mlir::arith::XOrIOp>(&mlirOperation))
   {
-    return rvsdg::node_output::node(rvsdg::bitxor_op::create(
+    return rvsdg::output::GetNode(*rvsdg::bitxor_op::create(
         static_cast<size_t>(castedOp.getType().cast<::mlir::IntegerType>().getWidth()),
         inputs[0],
         inputs[1]));
@@ -275,7 +275,7 @@ MlirToJlmConverter::ConvertOperation(
     if (!st)
       JLM_ASSERT("frontend : expected bitstring type for ExtUIOp operation.");
     ::mlir::Type type = castedOp.getType();
-    return rvsdg::node_output::node(&llvm::zext_op::Create(*(inputs[0]), ConvertType(type)));
+    return rvsdg::output::GetNode(*&llvm::zext_op::Create(*(inputs[0]), ConvertType(type)));
   }
 
   else if (::mlir::isa<::mlir::rvsdg::OmegaNode>(&mlirOperation))
@@ -294,8 +294,8 @@ MlirToJlmConverter::ConvertOperation(
     JLM_ASSERT(type.getTypeID() == ::mlir::IntegerType::getTypeID());
     auto integerType = ::mlir::cast<::mlir::IntegerType>(type);
 
-    return rvsdg::node_output::node(
-        rvsdg::create_bitconstant(&rvsdgRegion, integerType.getWidth(), constant.value()));
+    return rvsdg::output::GetNode(
+        *rvsdg::create_bitconstant(&rvsdgRegion, integerType.getWidth(), constant.value()));
   }
 
   // Binary Integer Comparision operations
@@ -312,7 +312,7 @@ MlirToJlmConverter::ConvertOperation(
   else if (auto MlirCtrlConst = ::mlir::dyn_cast<::mlir::rvsdg::ConstantCtrl>(&mlirOperation))
   {
     JLM_ASSERT(::mlir::isa<::mlir::rvsdg::RVSDG_CTRLType>(MlirCtrlConst.getType()));
-    return rvsdg::node_output::node(rvsdg::control_constant(
+    return rvsdg::output::GetNode(*rvsdg::control_constant(
         &rvsdgRegion,
         ::mlir::cast<::mlir::rvsdg::RVSDG_CTRLType>(MlirCtrlConst.getType()).getNumOptions(),
         MlirCtrlConst.getValue()));
@@ -369,7 +369,7 @@ MlirToJlmConverter::ConvertOperation(
       mapping[matchRuleAttr.getValues().front()] = matchRuleAttr.getIndex();
     }
 
-    return rvsdg::node_output::node(rvsdg::match_op::Create(
+    return rvsdg::output::GetNode(*rvsdg::match_op::Create(
         *(inputs[0]),                 // predicate
         mapping,                      // mapping
         defaultAlternative,           // defaultAlternative

--- a/jlm/rvsdg/bitstring/concat.cpp
+++ b/jlm/rvsdg/bitstring/concat.cpp
@@ -35,8 +35,8 @@ namespace
 jlm::rvsdg::output *
 concat_reduce_arg_pair(jlm::rvsdg::output * arg1, jlm::rvsdg::output * arg2)
 {
-  auto node1 = node_output::node(arg1);
-  auto node2 = node_output::node(arg2);
+  auto node1 = output::GetNode(*arg1);
+  auto node2 = output::GetNode(*arg2);
   if (!node1 || !node2)
     return nullptr;
 
@@ -112,7 +112,7 @@ public:
           {
             // FIXME: switch to comparing operator, not just typeid, after
             // converting "concat" to not be a binary operator anymore
-            return is<bitconcat_op>(node_output::node(arg));
+            return is<bitconcat_op>(output::GetNode(*arg));
           });
     }
     else
@@ -160,7 +160,7 @@ public:
           {
             // FIXME: switch to comparing operator, not just typeid, after
             // converting "concat" to not be a binary operator anymore
-            return is<bitconcat_op>(node_output::node(arg));
+            return is<bitconcat_op>(output::GetNode(*arg));
           });
     }
     else
@@ -282,8 +282,8 @@ bitconcat_op::can_reduce_operand_pair(
     const jlm::rvsdg::output * arg1,
     const jlm::rvsdg::output * arg2) const noexcept
 {
-  auto node1 = node_output::node(arg1);
-  auto node2 = node_output::node(arg2);
+  auto node1 = output::GetNode(*arg1);
+  auto node2 = output::GetNode(*arg2);
 
   if (!node1 || !node2)
     return binop_reduction_none;

--- a/jlm/rvsdg/bitstring/slice.cpp
+++ b/jlm/rvsdg/bitstring/slice.cpp
@@ -31,7 +31,7 @@ bitslice_op::debug_string() const
 unop_reduction_path_t
 bitslice_op::can_reduce_operand(const jlm::rvsdg::output * arg) const noexcept
 {
-  auto node = node_output::node(arg);
+  auto node = output::GetNode(*arg);
   auto & arg_type = *dynamic_cast<const bittype *>(&arg->type());
 
   if ((low() == 0) && (high() == arg_type.nbits()))

--- a/jlm/rvsdg/gamma.cpp
+++ b/jlm/rvsdg/gamma.cpp
@@ -16,7 +16,7 @@ namespace jlm::rvsdg
 static bool
 is_predicate_reducible(const GammaNode * gamma)
 {
-  auto constant = node_output::node(gamma->predicate()->origin());
+  auto constant = output::GetNode(*gamma->predicate()->origin());
   return constant && is_ctlconstant_op(constant->operation());
 }
 
@@ -73,7 +73,7 @@ static std::unordered_set<jlm::rvsdg::structural_output *>
 is_control_constant_reducible(GammaNode * gamma)
 {
   /* check gamma predicate */
-  auto match = node_output::node(gamma->predicate()->origin());
+  auto match = output::GetNode(*gamma->predicate()->origin());
   if (!is<match_op>(match))
     return {};
 
@@ -96,7 +96,7 @@ is_control_constant_reducible(GammaNode * gamma)
     size_t n;
     for (n = 0; n < it->nresults(); n++)
     {
-      auto node = node_output::node(it->result(n)->origin());
+      auto node = output::GetNode(*it->result(n)->origin());
       if (!is<ctlconstant_op>(node))
         break;
 

--- a/jlm/rvsdg/graph.cpp
+++ b/jlm/rvsdg/graph.cpp
@@ -103,7 +103,7 @@ graph::ExtractTailNodes(const graph & rvsdg)
     auto output = rootRegion.result(n)->origin();
     if (IsOnlyExported(*output))
     {
-      nodes.push_back(rvsdg::node_output::node(output));
+      nodes.push_back(rvsdg::output::GetNode(*output));
     }
   }
 

--- a/jlm/rvsdg/node.cpp
+++ b/jlm/rvsdg/node.cpp
@@ -109,7 +109,7 @@ output::remove_user(jlm::rvsdg::input * user)
 
   users_.erase(user);
 
-  if (auto node = node_output::node(this))
+  if (auto node = output::GetNode(*this))
   {
     if (!node->has_users())
       region()->bottom_nodes.push_back(node);
@@ -121,7 +121,7 @@ output::add_user(jlm::rvsdg::input * user)
 {
   JLM_ASSERT(users_.find(user) == users_.end());
 
-  if (auto node = node_output::node(this))
+  if (auto node = output::GetNode(*this))
   {
     if (!node->has_users())
       region()->bottom_nodes.erase(node);
@@ -196,7 +196,7 @@ node::~node()
 node_input *
 node::add_input(std::unique_ptr<node_input> input)
 {
-  auto producer = node_output::node(input->origin());
+  auto producer = output::GetNode(*input->origin());
 
   if (ninputs() == 0)
   {
@@ -218,7 +218,7 @@ void
 node::RemoveInput(size_t index)
 {
   JLM_ASSERT(index < ninputs());
-  auto producer = node_output::node(input(index)->origin());
+  auto producer = output::GetNode(*input(index)->origin());
 
   /* remove input */
   for (size_t n = index; n < ninputs() - 1; n++)
@@ -271,7 +271,7 @@ node::recompute_depth() noexcept
   size_t new_depth = 0;
   for (size_t n = 0; n < ninputs(); n++)
   {
-    auto producer = node_output::node(input(n)->origin());
+    auto producer = output::GetNode(*input(n)->origin());
     new_depth = std::max(new_depth, producer ? producer->depth() + 1 : 0);
   }
   if (new_depth == depth())
@@ -309,7 +309,7 @@ node::copy(rvsdg::Region * region, const std::vector<jlm::rvsdg::output *> & ope
 jlm::rvsdg::node *
 producer(const jlm::rvsdg::output * output) noexcept
 {
-  if (auto node = node_output::node(output))
+  if (auto node = output::GetNode(*output))
     return node;
 
   JLM_ASSERT(dynamic_cast<const RegionArgument *>(output));

--- a/jlm/rvsdg/reduction-helpers.hpp
+++ b/jlm/rvsdg/reduction-helpers.hpp
@@ -161,7 +161,7 @@ associative_flatten(std::vector<jlm::rvsdg::output *> args, const FlattenTester 
     {
       auto arg = args[n];
       JLM_ASSERT(is<node_output>(arg));
-      auto sub_args = jlm::rvsdg::operands(node_output::node(arg));
+      auto sub_args = jlm::rvsdg::operands(output::GetNode(*arg));
       args[n] = sub_args[0];
       args.insert(args.begin() + n + 1, sub_args.begin() + 1, sub_args.end());
     }

--- a/jlm/rvsdg/statemux.cpp
+++ b/jlm/rvsdg/statemux.cpp
@@ -44,7 +44,7 @@ is_mux_mux_reducible(const std::vector<jlm::rvsdg::output *> & ops)
 
   for (const auto & operand : operands)
   {
-    auto node = node_output::node(operand);
+    auto node = output::GetNode(*operand);
     if (!node || !is_mux_op(node->operation()))
       continue;
 
@@ -90,7 +90,7 @@ perform_mux_mux_reduction(
   std::vector<jlm::rvsdg::output *> new_operands;
   for (const auto & operand : old_operands)
   {
-    if (jlm::rvsdg::node_output::node(operand) == muxnode && !reduced)
+    if (jlm::rvsdg::output::GetNode(*operand) == muxnode && !reduced)
     {
       reduced = true;
       auto tmp = operands(muxnode);
@@ -98,7 +98,7 @@ perform_mux_mux_reduction(
       continue;
     }
 
-    if (jlm::rvsdg::node_output::node(operand) != muxnode)
+    if (jlm::rvsdg::output::GetNode(*operand) != muxnode)
       new_operands.push_back(operand);
   }
 

--- a/jlm/rvsdg/theta.hpp
+++ b/jlm/rvsdg/theta.hpp
@@ -114,7 +114,7 @@ public:
   inline void
   set_predicate(jlm::rvsdg::output * p)
   {
-    auto node = node_output::node(predicate()->origin());
+    auto node = output::GetNode(*predicate()->origin());
 
     predicate()->divert_to(p);
     if (node && !node->has_users())

--- a/jlm/rvsdg/traverser.cpp
+++ b/jlm/rvsdg/traverser.cpp
@@ -52,7 +52,7 @@ topdown_traverser::predecessors_visited(const jlm::rvsdg::node * node) noexcept
 {
   for (size_t n = 0; n < node->ninputs(); n++)
   {
-    auto predecessor = node_output::node(node->input(n)->origin());
+    auto predecessor = output::GetNode(*node->input(n)->origin());
     if (!predecessor)
       continue;
 
@@ -133,7 +133,7 @@ bottomup_traverser::bottomup_traverser(rvsdg::Region * region, bool revisit)
 
   for (size_t n = 0; n < region->nresults(); n++)
   {
-    auto node = node_output::node(region->result(n)->origin());
+    auto node = output::GetNode(*region->result(n)->origin());
     if (node && !node->has_successors())
       tracker_.set_nodestate(node, traversal_nodestate::frontier);
   }
@@ -156,7 +156,7 @@ bottomup_traverser::next()
   tracker_.set_nodestate(node, traversal_nodestate::behind);
   for (size_t n = 0; n < node->ninputs(); n++)
   {
-    auto producer = node_output::node(node->input(n)->origin());
+    auto producer = output::GetNode(*node->input(n)->origin());
     if (producer && tracker_.get_nodestate(producer) == traversal_nodestate::ahead)
       tracker_.set_nodestate(producer, traversal_nodestate::frontier);
   }
@@ -180,7 +180,7 @@ bottomup_traverser::node_destroy(jlm::rvsdg::node * node)
 
   for (size_t n = 0; n < node->ninputs(); n++)
   {
-    auto producer = node_output::node(node->input(n)->origin());
+    auto producer = output::GetNode(*node->input(n)->origin());
     if (producer && tracker_.get_nodestate(producer) == traversal_nodestate::ahead)
       tracker_.set_nodestate(producer, traversal_nodestate::frontier);
   }
@@ -192,7 +192,7 @@ bottomup_traverser::input_change(input * in, output * old_origin, output * new_o
   if (in->region() != region() || !is<node_input>(*in) || !is<node_output>(old_origin))
     return;
 
-  auto node = node_output::node(old_origin);
+  auto node = output::GetNode(*old_origin);
   traversal_nodestate state = tracker_.get_nodestate(node);
 
   /* ignore nodes that have been traversed already, or that are already

--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -51,12 +51,12 @@ StoreTest1::SetupRvsdg()
 
   this->lambda = fct;
 
-  this->size = jlm::rvsdg::node_output::node(csize);
+  this->size = jlm::rvsdg::output::GetNode(*csize);
 
-  this->alloca_a = jlm::rvsdg::node_output::node(a[0]);
-  this->alloca_b = jlm::rvsdg::node_output::node(b[0]);
-  this->alloca_c = jlm::rvsdg::node_output::node(c[0]);
-  this->alloca_d = jlm::rvsdg::node_output::node(d[0]);
+  this->alloca_a = jlm::rvsdg::output::GetNode(*a[0]);
+  this->alloca_b = jlm::rvsdg::output::GetNode(*b[0]);
+  this->alloca_c = jlm::rvsdg::output::GetNode(*c[0]);
+  this->alloca_d = jlm::rvsdg::output::GetNode(*d[0]);
 
   return module;
 }
@@ -108,13 +108,13 @@ StoreTest2::SetupRvsdg()
 
   this->lambda = fct;
 
-  this->size = jlm::rvsdg::node_output::node(csize);
+  this->size = jlm::rvsdg::output::GetNode(*csize);
 
-  this->alloca_a = jlm::rvsdg::node_output::node(a[0]);
-  this->alloca_b = jlm::rvsdg::node_output::node(b[0]);
-  this->alloca_x = jlm::rvsdg::node_output::node(x[0]);
-  this->alloca_y = jlm::rvsdg::node_output::node(y[0]);
-  this->alloca_p = jlm::rvsdg::node_output::node(p[0]);
+  this->alloca_a = jlm::rvsdg::output::GetNode(*a[0]);
+  this->alloca_b = jlm::rvsdg::output::GetNode(*b[0]);
+  this->alloca_x = jlm::rvsdg::output::GetNode(*x[0]);
+  this->alloca_y = jlm::rvsdg::output::GetNode(*y[0]);
+  this->alloca_p = jlm::rvsdg::output::GetNode(*p[0]);
 
   return module;
 }
@@ -150,8 +150,8 @@ LoadTest1::SetupRvsdg()
 
   this->lambda = fct;
 
-  this->load_p = jlm::rvsdg::node_output::node(ld1[0]);
-  this->load_x = jlm::rvsdg::node_output::node(ld2[0]);
+  this->load_p = jlm::rvsdg::output::GetNode(*ld1[0]);
+  this->load_x = jlm::rvsdg::output::GetNode(*ld2[0]);
 
   return module;
 }
@@ -207,16 +207,16 @@ LoadTest2::SetupRvsdg()
 
   this->lambda = fct;
 
-  this->size = jlm::rvsdg::node_output::node(csize);
+  this->size = jlm::rvsdg::output::GetNode(*csize);
 
-  this->alloca_a = jlm::rvsdg::node_output::node(a[0]);
-  this->alloca_b = jlm::rvsdg::node_output::node(b[0]);
-  this->alloca_x = jlm::rvsdg::node_output::node(x[0]);
-  this->alloca_y = jlm::rvsdg::node_output::node(y[0]);
-  this->alloca_p = jlm::rvsdg::node_output::node(p[0]);
+  this->alloca_a = jlm::rvsdg::output::GetNode(*a[0]);
+  this->alloca_b = jlm::rvsdg::output::GetNode(*b[0]);
+  this->alloca_x = jlm::rvsdg::output::GetNode(*x[0]);
+  this->alloca_y = jlm::rvsdg::output::GetNode(*y[0]);
+  this->alloca_p = jlm::rvsdg::output::GetNode(*p[0]);
 
-  this->load_x = jlm::rvsdg::node_output::node(ld1[0]);
-  this->load_a = jlm::rvsdg::node_output::node(ld2[0]);
+  this->load_x = jlm::rvsdg::output::GetNode(*ld1[0]);
+  this->load_a = jlm::rvsdg::output::GetNode(*ld2[0]);
 
   return module;
 }
@@ -253,7 +253,7 @@ LoadFromUndefTest::SetupRvsdg()
   /*
    * Extract nodes
    */
-  UndefValueNode_ = jlm::rvsdg::node_output::node(undefValue);
+  UndefValueNode_ = jlm::rvsdg::output::GetNode(*undefValue);
 
   return rvsdgModule;
 }
@@ -307,8 +307,8 @@ GetElementPtrTest::SetupRvsdg()
    */
   this->lambda = fct;
 
-  this->getElementPtrX = jlm::rvsdg::node_output::node(gepx);
-  this->getElementPtrY = jlm::rvsdg::node_output::node(gepy);
+  this->getElementPtrX = jlm::rvsdg::output::GetNode(*gepx);
+  this->getElementPtrY = jlm::rvsdg::output::GetNode(*gepy);
 
   return module;
 }
@@ -339,7 +339,7 @@ BitCastTest::SetupRvsdg()
    * Assign nodes
    */
   this->lambda = fct;
-  this->bitCast = jlm::rvsdg::node_output::node(cast);
+  this->bitCast = jlm::rvsdg::output::GetNode(*cast);
 
   return module;
 }
@@ -374,7 +374,7 @@ Bits2PtrTest::SetupRvsdg()
 
     lambda->finalize({ cast, iOStateArgument, memoryStateArgument });
 
-    return std::make_tuple(lambda, jlm::rvsdg::node_output::node(cast));
+    return std::make_tuple(lambda, jlm::rvsdg::output::GetNode(*cast));
   };
 
   auto setupTestFunction = [&](lambda::output * b2p)
@@ -453,7 +453,7 @@ ConstantPointerNullTest::SetupRvsdg()
    * Assign nodes
    */
   this->lambda = fct;
-  this->constantPointerNullNode = jlm::rvsdg::node_output::node(constantPointerNullResult);
+  this->constantPointerNullNode = jlm::rvsdg::output::GetNode(*constantPointerNullResult);
 
   return module;
 }
@@ -586,9 +586,9 @@ CallTest1::SetupRvsdg()
     lambda->finalize({ sum, callG.GetIoStateOutput(), callG.GetMemoryStateOutput() });
     GraphExport::Create(*lambda->output(), "h");
 
-    auto allocaX = jlm::rvsdg::node_output::node(x[0]);
-    auto allocaY = jlm::rvsdg::node_output::node(y[0]);
-    auto allocaZ = jlm::rvsdg::node_output::node(z[0]);
+    auto allocaX = jlm::rvsdg::output::GetNode(*x[0]);
+    auto allocaY = jlm::rvsdg::output::GetNode(*y[0]);
+    auto allocaZ = jlm::rvsdg::output::GetNode(*z[0]);
 
     return std::make_tuple(lambda, allocaX, allocaY, allocaZ, &callF, &callG);
   };
@@ -650,7 +650,7 @@ CallTest2::SetupRvsdg()
 
     lambda->finalize({ cast, iOStateArgument, mx });
 
-    auto mallocNode = jlm::rvsdg::node_output::node(alloc[0]);
+    auto mallocNode = jlm::rvsdg::output::GetNode(*alloc[0]);
     return std::make_tuple(lambda, mallocNode);
   };
 
@@ -674,7 +674,7 @@ CallTest2::SetupRvsdg()
 
     lambda->finalize({ freeResults[1], freeResults[0] });
 
-    auto freeNode = jlm::rvsdg::node_output::node(freeResults[0]);
+    auto freeNode = jlm::rvsdg::output::GetNode(*freeResults[0]);
     return std::make_tuple(lambda, freeNode);
   };
 
@@ -1029,10 +1029,9 @@ IndirectCallTest2::SetupRvsdg()
         lambdaOutput,
         &callX,
         &callY,
+        jlm::util::AssertedCast<jlm::rvsdg::simple_node>(jlm::rvsdg::output::GetNode(*pxAlloca[0])),
         jlm::util::AssertedCast<jlm::rvsdg::simple_node>(
-            jlm::rvsdg::node_output::node(pxAlloca[0])),
-        jlm::util::AssertedCast<jlm::rvsdg::simple_node>(
-            jlm::rvsdg::node_output::node(pyAlloca[0])));
+            jlm::rvsdg::output::GetNode(*pyAlloca[0])));
   };
 
   auto SetupTest2Function = [&](lambda::output & functionX)
@@ -1065,7 +1064,7 @@ IndirectCallTest2::SetupRvsdg()
         lambdaOutput,
         &callX,
         jlm::util::AssertedCast<jlm::rvsdg::simple_node>(
-            jlm::rvsdg::node_output::node(pzAlloca[0])));
+            jlm::rvsdg::output::GetNode(*pzAlloca[0])));
   };
 
   auto deltaG1 = SetupG1();
@@ -1455,7 +1454,7 @@ GammaTest2::SetupRvsdg()
     return std::make_tuple(
         lambda->output(),
         gammaOutputA->node(),
-        rvsdg::node_output::node(allocaZResults[0]));
+        rvsdg::output::GetNode(*allocaZResults[0]));
   };
 
   auto SetupLambdaGH = [&](lambda::output & lambdaF,
@@ -1508,8 +1507,8 @@ GammaTest2::SetupRvsdg()
     return std::make_tuple(
         lambda->output(),
         &call,
-        rvsdg::node_output::node(allocaXResults[0]),
-        rvsdg::node_output::node(allocaYResults[1]));
+        rvsdg::output::GetNode(*allocaXResults[0]),
+        rvsdg::output::GetNode(*allocaYResults[1]));
   };
 
   auto [lambdaF, gammaNode, allocaZ] = SetupLambdaF();
@@ -1591,7 +1590,7 @@ ThetaTest::SetupRvsdg()
    */
   this->lambda = fct;
   this->theta = thetanode;
-  this->gep = jlm::rvsdg::node_output::node(gepnode);
+  this->gep = jlm::rvsdg::output::GetNode(*gepnode);
 
   return module;
 }
@@ -1667,7 +1666,7 @@ DeltaTest1::SetupRvsdg()
     auto lambdaOutput = lambda->finalize(callG.Results());
     GraphExport::Create(*lambda->output(), "h");
 
-    return std::make_tuple(lambdaOutput, &callG, jlm::rvsdg::node_output::node(five));
+    return std::make_tuple(lambdaOutput, &callG, jlm::rvsdg::output::GetNode(*five));
   };
 
   auto f = SetupGlobalF();
@@ -2129,7 +2128,7 @@ PhiTest1::SetupRvsdg()
     auto lambdaOutput = lambda->finalize(call.Results());
     GraphExport::Create(*lambdaOutput, "test");
 
-    return std::make_tuple(lambdaOutput, &call, jlm::rvsdg::node_output::node(allocaResults[0]));
+    return std::make_tuple(lambdaOutput, &call, jlm::rvsdg::output::GetNode(*allocaResults[0]));
   };
 
   auto [phiNode, fibfct, gammaNode, callFib1, callFib2] = SetupFib();
@@ -2256,7 +2255,7 @@ PhiTest2::SetupRvsdg()
         &callB,
         &callD,
         jlm::util::AssertedCast<jlm::rvsdg::simple_node>(
-            jlm::rvsdg::node_output::node(paAlloca[0])));
+            jlm::rvsdg::output::GetNode(*paAlloca[0])));
   };
 
   auto SetupB = [&](jlm::rvsdg::Region & region,
@@ -2301,7 +2300,7 @@ PhiTest2::SetupRvsdg()
         &callI,
         &callC,
         jlm::util::AssertedCast<jlm::rvsdg::simple_node>(
-            jlm::rvsdg::node_output::node(pbAlloca[0])));
+            jlm::rvsdg::output::GetNode(*pbAlloca[0])));
   };
 
   auto SetupC = [&](jlm::rvsdg::Region & region, phi::rvargument & functionA)
@@ -2340,7 +2339,7 @@ PhiTest2::SetupRvsdg()
         lambdaOutput,
         &callA,
         jlm::util::AssertedCast<jlm::rvsdg::simple_node>(
-            jlm::rvsdg::node_output::node(pcAlloca[0])));
+            jlm::rvsdg::output::GetNode(*pcAlloca[0])));
   };
 
   auto SetupD = [&](jlm::rvsdg::Region & region, phi::rvargument & functionA)
@@ -2370,7 +2369,7 @@ PhiTest2::SetupRvsdg()
         lambdaOutput,
         &callA,
         jlm::util::AssertedCast<jlm::rvsdg::simple_node>(
-            jlm::rvsdg::node_output::node(pdAlloca[0])));
+            jlm::rvsdg::output::GetNode(*pdAlloca[0])));
   };
 
   auto SetupPhi = [&](lambda::output & lambdaEight, lambda::output & lambdaI)
@@ -2452,7 +2451,7 @@ PhiTest2::SetupRvsdg()
         lambdaOutput,
         &callA,
         jlm::util::AssertedCast<jlm::rvsdg::simple_node>(
-            jlm::rvsdg::node_output::node(pTestAlloca[0])));
+            jlm::rvsdg::output::GetNode(*pTestAlloca[0])));
   };
 
   auto lambdaEight = SetupEight();
@@ -2482,13 +2481,13 @@ PhiTest2::SetupRvsdg()
   this->LambdaEight_ = lambdaEight->node();
   this->LambdaI_ = lambdaI->node();
   this->LambdaA_ = jlm::util::AssertedCast<lambda::node>(
-      jlm::rvsdg::node_output::node(lambdaA->result()->origin()));
+      jlm::rvsdg::output::GetNode(*lambdaA->result()->origin()));
   this->LambdaB_ = jlm::util::AssertedCast<lambda::node>(
-      jlm::rvsdg::node_output::node(lambdaB->result()->origin()));
+      jlm::rvsdg::output::GetNode(*lambdaB->result()->origin()));
   this->LambdaC_ = jlm::util::AssertedCast<lambda::node>(
-      jlm::rvsdg::node_output::node(lambdaC->result()->origin()));
+      jlm::rvsdg::output::GetNode(*lambdaC->result()->origin()));
   this->LambdaD_ = jlm::util::AssertedCast<lambda::node>(
-      jlm::rvsdg::node_output::node(lambdaD->result()->origin()));
+      jlm::rvsdg::output::GetNode(*lambdaD->result()->origin()));
   this->LambdaTest_ = lambdaTest->node();
 
   this->CallAFromTest_ = callAFromTest;
@@ -2695,7 +2694,7 @@ EscapedMemoryTest1::SetupRvsdg()
     return std::make_tuple(
         lambdaOutput,
         jlm::util::AssertedCast<LoadNonVolatileNode>(
-            jlm::rvsdg::node_output::node(loadResults1[0])));
+            jlm::rvsdg::output::GetNode(*loadResults1[0])));
   };
 
   auto deltaA = SetupDeltaA();
@@ -2787,7 +2786,7 @@ EscapedMemoryTest2::SetupRvsdg()
 
     GraphExport::Create(*lambdaOutput, "ReturnAddress");
 
-    return std::make_tuple(lambdaOutput, jlm::rvsdg::node_output::node(mallocResults[0]));
+    return std::make_tuple(lambdaOutput, jlm::rvsdg::output::GetNode(*mallocResults[0]));
   };
 
   auto SetupCallExternalFunction1 = [&](jlm::rvsdg::RegionArgument * externalFunction1Argument)
@@ -2823,7 +2822,7 @@ EscapedMemoryTest2::SetupRvsdg()
 
     GraphExport::Create(*lambdaOutput, "CallExternalFunction1");
 
-    return std::make_tuple(lambdaOutput, &call, jlm::rvsdg::node_output::node(mallocResults[0]));
+    return std::make_tuple(lambdaOutput, &call, jlm::rvsdg::output::GetNode(*mallocResults[0]));
   };
 
   auto SetupCallExternalFunction2 = [&](jlm::rvsdg::RegionArgument * externalFunction2Argument)
@@ -2864,7 +2863,7 @@ EscapedMemoryTest2::SetupRvsdg()
         lambdaOutput,
         &call,
         jlm::util::AssertedCast<jlm::llvm::LoadNonVolatileNode>(
-            jlm::rvsdg::node_output::node(loadResults[0])));
+            jlm::rvsdg::output::GetNode(*loadResults[0])));
   };
 
   auto externalFunction1 = SetupExternalFunction1Declaration();
@@ -2977,7 +2976,7 @@ EscapedMemoryTest3::SetupRvsdg()
         lambdaOutput,
         &call,
         jlm::util::AssertedCast<jlm::llvm::LoadNonVolatileNode>(
-            jlm::rvsdg::node_output::node(loadResults[0])));
+            jlm::rvsdg::output::GetNode(*loadResults[0])));
   };
 
   auto importExternalFunction = SetupExternalFunctionDeclaration();
@@ -3124,7 +3123,7 @@ MemcpyTest::SetupRvsdg()
 
     GraphExport::Create(*lambdaOutput, "g");
 
-    return std::make_tuple(lambdaOutput, &call, jlm::rvsdg::node_output::node(memcpyResults[0]));
+    return std::make_tuple(lambdaOutput, &call, jlm::rvsdg::output::GetNode(*memcpyResults[0]));
   };
 
   auto localArray = SetupLocalArray();
@@ -3194,7 +3193,7 @@ MemcpyTest2::SetupRvsdg()
 
     auto lambdaOutput = lambda->finalize({ iOStateArgument, memcpyResults[0] });
 
-    return std::make_tuple(lambdaOutput, jlm::rvsdg::node_output::node(memcpyResults[0]));
+    return std::make_tuple(lambdaOutput, jlm::rvsdg::output::GetNode(*memcpyResults[0]));
   };
 
   auto SetupFunctionF = [&](lambda::output & functionF)
@@ -3298,8 +3297,8 @@ MemcpyTest3::SetupRvsdg()
 
   GraphExport::Create(*lambdaOutput, "f");
 
-  Alloca_ = rvsdg::node_output::node(allocaResults[0]);
-  Memcpy_ = rvsdg::node_output::node(memcpyResults[0]);
+  Alloca_ = rvsdg::output::GetNode(*allocaResults[0]);
+  Memcpy_ = rvsdg::output::GetNode(*memcpyResults[0]);
 
   return rvsdgModule;
 }
@@ -3374,7 +3373,7 @@ LinkedListTest::SetupRvsdg()
     auto lambdaOutput = lambda->finalize({ load4[0], iOStateArgument, load4[1] });
     GraphExport::Create(*lambdaOutput, "next");
 
-    return std::make_tuple(jlm::rvsdg::node_output::node(alloca[0]), lambdaOutput);
+    return std::make_tuple(jlm::rvsdg::output::GetNode(*alloca[0]), lambdaOutput);
   };
 
   auto deltaMyList = SetupDeltaMyList();
@@ -3433,7 +3432,7 @@ AllMemoryNodesTest::SetupRvsdg()
   // Create alloca node
   auto allocaSize = jlm::rvsdg::create_bitconstant(Lambda_->subregion(), 32, 1);
   auto allocaOutputs = alloca_op::create(pointerType, allocaSize, 8);
-  Alloca_ = jlm::rvsdg::node_output::node(allocaOutputs[0]);
+  Alloca_ = jlm::rvsdg::output::GetNode(*allocaOutputs[0]);
 
   auto afterAllocaMemoryState = MemoryStateMergeOperation::Create(
       std::vector<jlm::rvsdg::output *>{ entryMemoryState, allocaOutputs[1] });
@@ -3441,7 +3440,7 @@ AllMemoryNodesTest::SetupRvsdg()
   // Create malloc node
   auto mallocSize = jlm::rvsdg::create_bitconstant(Lambda_->subregion(), 32, 4);
   auto mallocOutputs = malloc_op::create(mallocSize);
-  Malloc_ = jlm::rvsdg::node_output::node(mallocOutputs[0]);
+  Malloc_ = jlm::rvsdg::output::GetNode(*mallocOutputs[0]);
 
   auto afterMallocMemoryState = MemoryStateMergeOperation::Create(
       std::vector<jlm::rvsdg::output *>{ afterAllocaMemoryState, mallocOutputs[1] });
@@ -3511,7 +3510,7 @@ NAllocaNodesTest::SetupRvsdg()
   for (size_t i = 0; i < NumAllocaNodes_; i++)
   {
     auto allocaOutputs = alloca_op::create(jlm::rvsdg::bittype::Create(32), allocaSize, 4);
-    auto allocaNode = jlm::rvsdg::node_output::node(allocaOutputs[0]);
+    auto allocaNode = jlm::rvsdg::output::GetNode(*allocaOutputs[0]);
 
     AllocaNodes_.push_back(allocaNode);
 
@@ -3566,7 +3565,7 @@ EscapingLocalFunctionTest::SetupRvsdg()
 
   const auto allocaSize = rvsdg::create_bitconstant(LocalFunc_->subregion(), 32, 1);
   const auto allocaOutputs = alloca_op::create(uint32Type, allocaSize, 4);
-  LocalFuncParamAllocaNode_ = rvsdg::node_output::node(allocaOutputs[0]);
+  LocalFuncParamAllocaNode_ = rvsdg::output::GetNode(*allocaOutputs[0]);
 
   // Merge function's input Memory State and alloca node's memory state
   rvsdg::output * mergedMemoryState = MemoryStateMergeOperation::Create(
@@ -3784,7 +3783,7 @@ VariadicFunctionTest1::SetupRvsdg()
 
     auto allocaResults = alloca_op::create(jlm::rvsdg::bittype::Create(32), one, 4);
     auto merge = MemoryStateMergeOperation::Create({ allocaResults[1], memoryStateArgument });
-    AllocaNode_ = rvsdg::node_output::node(allocaResults[0]);
+    AllocaNode_ = rvsdg::output::GetNode(*allocaResults[0]);
 
     auto storeResults = StoreNonVolatileNode::Create(allocaResults[0], five, { merge }, 4);
 
@@ -3872,7 +3871,7 @@ VariadicFunctionTest2::SetupRvsdg()
 
     auto allocaResults = alloca_op::create(arrayType, one, 16);
     auto memoryState = MemoryStateMergeOperation::Create({ allocaResults[1], memoryStateArgument });
-    AllocaNode_ = rvsdg::node_output::node(allocaResults[0]);
+    AllocaNode_ = rvsdg::output::GetNode(*allocaResults[0]);
 
     auto & callLLvmLifetimeStart = CallNode::CreateNode(
         llvmLifetimeStartArgument,

--- a/tests/jlm/llvm/frontend/llvm/ThreeAddressCodeConversionTests.cpp
+++ b/tests/jlm/llvm/frontend/llvm/ThreeAddressCodeConversionTests.cpp
@@ -97,7 +97,7 @@ LoadVolatileConversion()
 
   // Assert
   auto lambdaOutput = rvsdgModule->Rvsdg().root()->result(0)->origin();
-  auto lambda = dynamic_cast<const lambda::node *>(jlm::rvsdg::node_output::node(lambdaOutput));
+  auto lambda = dynamic_cast<const lambda::node *>(jlm::rvsdg::output::GetNode(*lambdaOutput));
 
   auto loadVolatileNode = lambda->subregion()->nodes.first();
   assert(dynamic_cast<const LoadVolatileNode *>(loadVolatileNode));
@@ -126,7 +126,7 @@ StoreVolatileConversion()
 
   // Assert
   auto lambdaOutput = rvsdgModule->Rvsdg().root()->result(0)->origin();
-  auto lambda = dynamic_cast<const lambda::node *>(jlm::rvsdg::node_output::node(lambdaOutput));
+  auto lambda = dynamic_cast<const lambda::node *>(jlm::rvsdg::output::GetNode(*lambdaOutput));
 
   auto storeVolatileNode = lambda->subregion()->nodes.first();
   assert(dynamic_cast<const StoreVolatileNode *>(storeVolatileNode));

--- a/tests/jlm/llvm/ir/operators/LoadTests.cpp
+++ b/tests/jlm/llvm/ir/operators/LoadTests.cpp
@@ -66,7 +66,7 @@ TestCopy()
   auto loadResults = LoadNonVolatileNode::Create(address1, { memoryState1 }, valueType, 4);
 
   // Act
-  auto node = jlm::rvsdg::node_output::node(loadResults[0]);
+  auto node = jlm::rvsdg::output::GetNode(*loadResults[0]);
   auto loadNode = jlm::util::AssertedCast<const LoadNonVolatileNode>(node);
   auto copiedNode = loadNode->copy(graph.root(), { address2, memoryState2 });
 
@@ -111,7 +111,7 @@ TestLoadAllocaReduction()
   //	jlm::rvsdg::view(graph.root(), stdout);
 
   // Assert
-  auto node = jlm::rvsdg::node_output::node(ex.origin());
+  auto node = jlm::rvsdg::output::GetNode(*ex.origin());
   assert(is<LoadNonVolatileOperation>(node));
   assert(node->ninputs() == 3);
   assert(node->input(1)->origin() == alloca1[1]);
@@ -150,7 +150,7 @@ TestMultipleOriginReduction()
   //	jlm::rvsdg::view(graph.root(), stdout);
 
   // Assert
-  auto node = jlm::rvsdg::node_output::node(ex.origin());
+  auto node = jlm::rvsdg::output::GetNode(*ex.origin());
   assert(is<LoadNonVolatileOperation>(node));
   assert(node->ninputs() == 2);
 }
@@ -192,11 +192,11 @@ TestLoadStoreStateReduction()
   //	jlm::rvsdg::view(graph.root(), stdout);
 
   // Assert
-  auto node = jlm::rvsdg::node_output::node(ex1.origin());
+  auto node = jlm::rvsdg::output::GetNode(*ex1.origin());
   assert(is<LoadNonVolatileOperation>(node));
   assert(node->ninputs() == 2);
 
-  node = jlm::rvsdg::node_output::node(ex2.origin());
+  node = jlm::rvsdg::output::GetNode(*ex2.origin());
   assert(is<LoadNonVolatileOperation>(node));
   assert(node->ninputs() == 2);
 }
@@ -286,15 +286,15 @@ TestLoadLoadReduction()
   // Assert
   assert(graph.root()->nnodes() == 6);
 
-  auto ld = jlm::rvsdg::node_output::node(x1.origin());
+  auto ld = jlm::rvsdg::output::GetNode(*x1.origin());
   assert(is<LoadNonVolatileOperation>(ld));
 
-  auto mx1 = jlm::rvsdg::node_output::node(x2.origin());
+  auto mx1 = jlm::rvsdg::output::GetNode(*x2.origin());
   assert(is<MemoryStateMergeOperation>(mx1) && mx1->ninputs() == 2);
   assert(mx1->input(0)->origin() == ld1[1] || mx1->input(0)->origin() == ld->output(2));
   assert(mx1->input(1)->origin() == ld1[1] || mx1->input(1)->origin() == ld->output(2));
 
-  auto mx2 = jlm::rvsdg::node_output::node(x3.origin());
+  auto mx2 = jlm::rvsdg::output::GetNode(*x3.origin());
   assert(is<MemoryStateMergeOperation>(mx2) && mx2->ninputs() == 2);
   assert(mx2->input(0)->origin() == ld2[1] || mx2->input(0)->origin() == ld->output(3));
   assert(mx2->input(1)->origin() == ld2[1] || mx2->input(1)->origin() == ld->output(3));

--- a/tests/jlm/llvm/ir/operators/StoreTests.cpp
+++ b/tests/jlm/llvm/ir/operators/StoreTests.cpp
@@ -194,7 +194,7 @@ TestCopy()
   auto storeResults = StoreNonVolatileNode::Create(address1, value1, { memoryState1 }, 4);
 
   // Act
-  auto node = jlm::rvsdg::node_output::node(storeResults[0]);
+  auto node = jlm::rvsdg::output::GetNode(*storeResults[0]);
   auto storeNode = jlm::util::AssertedCast<const StoreNonVolatileNode>(node);
   auto copiedNode = storeNode->copy(graph.root(), { address2, value2, memoryState2 });
 
@@ -242,12 +242,12 @@ TestStoreMuxReduction()
   //	jlm::rvsdg::view(graph.root(), stdout);
 
   // Assert
-  auto muxnode = jlm::rvsdg::node_output::node(ex.origin());
+  auto muxnode = jlm::rvsdg::output::GetNode(*ex.origin());
   assert(is<MemoryStateMergeOperation>(muxnode));
   assert(muxnode->ninputs() == 3);
-  auto n0 = jlm::rvsdg::node_output::node(muxnode->input(0)->origin());
-  auto n1 = jlm::rvsdg::node_output::node(muxnode->input(1)->origin());
-  auto n2 = jlm::rvsdg::node_output::node(muxnode->input(2)->origin());
+  auto n0 = jlm::rvsdg::output::GetNode(*muxnode->input(0)->origin());
+  auto n1 = jlm::rvsdg::output::GetNode(*muxnode->input(1)->origin());
+  auto n2 = jlm::rvsdg::output::GetNode(*muxnode->input(2)->origin());
   assert(jlm::rvsdg::is<StoreNonVolatileOperation>(n0->operation()));
   assert(jlm::rvsdg::is<StoreNonVolatileOperation>(n1->operation()));
   assert(jlm::rvsdg::is<StoreNonVolatileOperation>(n2->operation()));
@@ -288,7 +288,7 @@ TestMultipleOriginReduction()
   //	jlm::rvsdg::view(graph.root(), stdout);
 
   // Assert
-  auto node = jlm::rvsdg::node_output::node(ex.origin());
+  auto node = jlm::rvsdg::output::GetNode(*ex.origin());
   assert(jlm::rvsdg::is<StoreNonVolatileOperation>(node->operation()) && node->ninputs() == 3);
 }
 
@@ -374,7 +374,7 @@ TestStoreStoreReduction()
 
   // Assert
   assert(graph.root()->nnodes() == 1);
-  assert(jlm::rvsdg::node_output::node(ex.origin())->input(1)->origin() == v2);
+  assert(jlm::rvsdg::output::GetNode(*ex.origin())->input(1)->origin() == v2);
 }
 
 static int

--- a/tests/jlm/llvm/ir/operators/TestCall.cpp
+++ b/tests/jlm/llvm/ir/operators/TestCall.cpp
@@ -40,7 +40,7 @@ TestCopy()
   auto callResults = CallNode::Create(function1, functionType, { value1, iOState1, memoryState1 });
 
   // Act
-  auto node = jlm::rvsdg::node_output::node(callResults[0]);
+  auto node = jlm::rvsdg::output::GetNode(*callResults[0]);
   auto callNode = jlm::util::AssertedCast<const CallNode>(node);
   auto copiedNode = callNode->copy(rvsdg.root(), { function2, value2, iOState2, memoryState2 });
 
@@ -71,7 +71,7 @@ TestCallNodeAccessors()
 
   // Act
   auto results = CallNode::Create(f, functionType, { v, i, m });
-  auto & callNode = *jlm::util::AssertedCast<CallNode>(jlm::rvsdg::node_output::node(results[0]));
+  auto & callNode = *jlm::util::AssertedCast<CallNode>(jlm::rvsdg::output::GetNode(*results[0]));
 
   // Assert
   assert(callNode.NumArguments() == 3);
@@ -137,7 +137,7 @@ TestCallTypeClassifierIndirectCall()
     GraphExport::Create(*lambda->output(), "f");
 
     return std::make_tuple(
-        jlm::util::AssertedCast<CallNode>(jlm::rvsdg::node_output::node(callResults[0])),
+        jlm::util::AssertedCast<CallNode>(jlm::rvsdg::output::GetNode(*callResults[0])),
         load[0]);
   };
 
@@ -229,7 +229,7 @@ TestCallTypeClassifierNonRecursiveDirectCall()
 
     return std::make_tuple(
         lambda,
-        jlm::util::AssertedCast<CallNode>(jlm::rvsdg::node_output::node(callResults[0])));
+        jlm::util::AssertedCast<CallNode>(jlm::rvsdg::output::GetNode(*callResults[0])));
   };
 
   auto g = SetupFunctionG();
@@ -317,7 +317,7 @@ TestCallTypeClassifierNonRecursiveDirectCallTheta()
           thetaOutputValue,
           thetaOutputIoState,
           thetaOutputMemoryState,
-          jlm::util::AssertedCast<CallNode>(jlm::rvsdg::node_output::node(callResults[0])));
+          jlm::util::AssertedCast<CallNode>(jlm::rvsdg::output::GetNode(*callResults[0])));
     };
 
     auto vt = jlm::tests::valuetype::Create();
@@ -468,8 +468,8 @@ TestCallTypeClassifierRecursiveDirectCall()
 
     return std::make_tuple(
         lambdaOutput,
-        jlm::util::AssertedCast<CallNode>(jlm::rvsdg::node_output::node(callfibm1Results[0])),
-        jlm::util::AssertedCast<CallNode>(jlm::rvsdg::node_output::node(callfibm2Results[0])));
+        jlm::util::AssertedCast<CallNode>(jlm::rvsdg::output::GetNode(*callfibm1Results[0])),
+        jlm::util::AssertedCast<CallNode>(jlm::rvsdg::output::GetNode(*callfibm2Results[0])));
   };
 
   auto [fibfct, callFib1, callFib2] = SetupFib();

--- a/tests/jlm/llvm/ir/operators/test-sext.cpp
+++ b/tests/jlm/llvm/ir/operators/test-sext.cpp
@@ -37,7 +37,7 @@ test_bitunary_reduction()
 
   // jlm::rvsdg::view(graph, stdout);
 
-  assert(jlm::rvsdg::is<jlm::rvsdg::bitnot_op>(jlm::rvsdg::node_output::node(ex.origin())));
+  assert(jlm::rvsdg::is<jlm::rvsdg::bitnot_op>(jlm::rvsdg::output::GetNode(*ex.origin())));
 }
 
 static inline void
@@ -65,7 +65,7 @@ test_bitbinary_reduction()
 
   //	jlm::rvsdg::view(graph, stdout);
 
-  assert(jlm::rvsdg::is<jlm::rvsdg::bitadd_op>(jlm::rvsdg::node_output::node(ex.origin())));
+  assert(jlm::rvsdg::is<jlm::rvsdg::bitadd_op>(jlm::rvsdg::output::GetNode(*ex.origin())));
 }
 
 static inline void

--- a/tests/jlm/llvm/opt/TestLoadMuxReduction.cpp
+++ b/tests/jlm/llvm/opt/TestLoadMuxReduction.cpp
@@ -50,19 +50,19 @@ TestSuccess()
   // jlm::rvsdg::view(graph.root(), stdout);
 
   // Assert
-  auto load = jlm::rvsdg::node_output::node(ex1.origin());
+  auto load = jlm::rvsdg::output::GetNode(*ex1.origin());
   assert(is<LoadNonVolatileOperation>(load));
   assert(load->ninputs() == 4);
   assert(load->input(1)->origin() == s1);
   assert(load->input(2)->origin() == s2);
   assert(load->input(3)->origin() == s3);
 
-  auto merge = jlm::rvsdg::node_output::node(ex2.origin());
+  auto merge = jlm::rvsdg::output::GetNode(*ex2.origin());
   assert(is<MemoryStateMergeOperation>(merge));
   assert(merge->ninputs() == 3);
   for (size_t n = 0; n < merge->ninputs(); n++)
   {
-    auto node = jlm::rvsdg::node_output::node(merge->input(n)->origin());
+    auto node = jlm::rvsdg::output::GetNode(*merge->input(n)->origin());
     assert(node == load);
   }
 }
@@ -144,7 +144,7 @@ TestLoadWithoutStates()
   jlm::rvsdg::view(graph.root(), stdout);
 
   // Assert
-  auto load = jlm::rvsdg::node_output::node(ex.origin());
+  auto load = jlm::rvsdg::output::GetNode(*ex.origin());
   assert(is<LoadNonVolatileOperation>(load));
   assert(load->ninputs() == 1);
 }

--- a/tests/jlm/llvm/opt/TestLoadStoreReduction.cpp
+++ b/tests/jlm/llvm/opt/TestLoadStoreReduction.cpp
@@ -52,10 +52,10 @@ TestLoadStoreReductionWithDifferentValueOperandType()
   jlm::rvsdg::view(graph.root(), stdout);
 
   // Assert
-  auto load = jlm::rvsdg::node_output::node(exportedValue.origin());
+  auto load = jlm::rvsdg::output::GetNode(*exportedValue.origin());
   assert(is<LoadNonVolatileOperation>(load));
   assert(load->ninputs() == 2);
-  auto store = jlm::rvsdg::node_output::node(load->input(1)->origin());
+  auto store = jlm::rvsdg::output::GetNode(*load->input(1)->origin());
   assert(is<StoreNonVolatileOperation>(store));
 
   return 0;

--- a/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
@@ -79,7 +79,7 @@ ValidateStoreTest1SteensgaardAgnostic(const jlm::tests::StoreTest1 & test)
 
   assert(test.lambda->subregion()->nnodes() == 10);
 
-  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
+  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 6, 1));
 
   assert(test.alloca_d->output(1)->nusers() == 1);
@@ -112,7 +112,7 @@ ValidateStoreTest1SteensgaardRegionAware(const jlm::tests::StoreTest1 & test)
 
   assert(test.lambda->subregion()->nnodes() == 9);
 
-  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
+  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 4, 1));
 
   assert(test.alloca_d->output(1)->nusers() == 1);
@@ -145,12 +145,12 @@ ValidateStoreTest1SteensgaardAgnosticTopDown(const jlm::tests::StoreTest1 & test
 
   assert(test.lambda->subregion()->nnodes() == 2);
 
-  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
+  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
-  auto lambdaEntrySplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+  auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
-  assert(lambdaEntrySplit == jlm::rvsdg::node_output::node(lambdaExitMerge->input(1)->origin()));
+  assert(lambdaEntrySplit == jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(1)->origin()));
 }
 
 static void
@@ -160,7 +160,7 @@ ValidateStoreTest2SteensgaardAgnostic(const jlm::tests::StoreTest2 & test)
 
   assert(test.lambda->subregion()->nnodes() == 12);
 
-  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
+  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 7, 1));
 
   assert(test.alloca_a->output(1)->nusers() == 1);
@@ -179,8 +179,8 @@ ValidateStoreTest2SteensgaardAgnostic(const jlm::tests::StoreTest2 & test)
   auto storeB = jlm::rvsdg::input::GetNode(**test.alloca_b->output(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeB, 4, 2));
   assert(storeB->input(0)->origin() == test.alloca_y->output(0));
-  assert(jlm::rvsdg::node_output::node(storeB->input(2)->origin()) == storeA);
-  assert(jlm::rvsdg::node_output::node(storeB->input(3)->origin()) == storeA);
+  assert(jlm::rvsdg::output::GetNode(*storeB->input(2)->origin()) == storeA);
+  assert(jlm::rvsdg::output::GetNode(*storeB->input(3)->origin()) == storeA);
 
   auto storeX = jlm::rvsdg::input::GetNode(**test.alloca_p->output(1)->begin());
   assert(is<StoreNonVolatileOperation>(*storeX, 3, 1));
@@ -200,7 +200,7 @@ ValidateStoreTest2SteensgaardRegionAware(const jlm::tests::StoreTest2 & test)
 
   assert(test.lambda->subregion()->nnodes() == 11);
 
-  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
+  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
 
   assert(test.alloca_a->output(1)->nusers() == 1);
@@ -219,8 +219,8 @@ ValidateStoreTest2SteensgaardRegionAware(const jlm::tests::StoreTest2 & test)
   auto storeB = jlm::rvsdg::input::GetNode(**test.alloca_b->output(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeB, 4, 2));
   assert(storeB->input(0)->origin() == test.alloca_y->output(0));
-  assert(jlm::rvsdg::node_output::node(storeB->input(2)->origin()) == storeA);
-  assert(jlm::rvsdg::node_output::node(storeB->input(3)->origin()) == storeA);
+  assert(jlm::rvsdg::output::GetNode(*storeB->input(2)->origin()) == storeA);
+  assert(jlm::rvsdg::output::GetNode(*storeB->input(3)->origin()) == storeA);
 
   auto storeX = jlm::rvsdg::input::GetNode(**test.alloca_p->output(1)->begin());
   assert(is<StoreNonVolatileOperation>(*storeX, 3, 1));
@@ -240,12 +240,12 @@ ValidateStoreTest2SteensgaardAgnosticTopDown(const jlm::tests::StoreTest2 & test
 
   assert(test.lambda->subregion()->nnodes() == 2);
 
-  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
+  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
-  auto lambdaEntrySplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+  auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
-  assert(lambdaEntrySplit == jlm::rvsdg::node_output::node(lambdaExitMerge->input(1)->origin()));
+  assert(lambdaEntrySplit == jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(1)->origin()));
 }
 
 static void
@@ -255,21 +255,21 @@ ValidateLoadTest1SteensgaardAgnostic(const jlm::tests::LoadTest1 & test)
 
   assert(test.lambda->subregion()->nnodes() == 4);
 
-  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(1)->origin());
+  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(1)->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
   auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda->fctargument(1)->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 
-  auto loadA = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
-  auto loadX = jlm::rvsdg::node_output::node(loadA->input(0)->origin());
+  auto loadA = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
+  auto loadX = jlm::rvsdg::output::GetNode(*loadA->input(0)->origin());
 
   assert(is<LoadNonVolatileOperation>(*loadA, 3, 3));
-  assert(jlm::rvsdg::node_output::node(loadA->input(1)->origin()) == loadX);
+  assert(jlm::rvsdg::output::GetNode(*loadA->input(1)->origin()) == loadX);
 
   assert(is<LoadNonVolatileOperation>(*loadX, 3, 3));
   assert(loadX->input(0)->origin() == test.lambda->fctargument(0));
-  assert(jlm::rvsdg::node_output::node(loadX->input(1)->origin()) == lambdaEntrySplit);
+  assert(jlm::rvsdg::output::GetNode(*loadX->input(1)->origin()) == lambdaEntrySplit);
 }
 
 static void
@@ -279,21 +279,21 @@ ValidateLoadTest1SteensgaardRegionAware(const jlm::tests::LoadTest1 & test)
 
   assert(test.lambda->subregion()->nnodes() == 4);
 
-  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(1)->origin());
+  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(1)->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
   auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda->fctargument(1)->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 
-  auto loadA = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
-  auto loadX = jlm::rvsdg::node_output::node(loadA->input(0)->origin());
+  auto loadA = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
+  auto loadX = jlm::rvsdg::output::GetNode(*loadA->input(0)->origin());
 
   assert(is<LoadNonVolatileOperation>(*loadA, 3, 3));
-  assert(jlm::rvsdg::node_output::node(loadA->input(1)->origin()) == loadX);
+  assert(jlm::rvsdg::output::GetNode(*loadA->input(1)->origin()) == loadX);
 
   assert(is<LoadNonVolatileOperation>(*loadX, 3, 3));
   assert(loadX->input(0)->origin() == test.lambda->fctargument(0));
-  assert(jlm::rvsdg::node_output::node(loadX->input(1)->origin()) == lambdaEntrySplit);
+  assert(jlm::rvsdg::output::GetNode(*loadX->input(1)->origin()) == lambdaEntrySplit);
 }
 
 static void
@@ -303,21 +303,21 @@ ValidateLoadTest1SteensgaardAgnosticTopDown(const jlm::tests::LoadTest1 & test)
 
   assert(test.lambda->subregion()->nnodes() == 4);
 
-  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(1)->origin());
+  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(1)->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
   auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda->fctargument(1)->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 
-  auto loadA = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
-  auto loadX = jlm::rvsdg::node_output::node(loadA->input(0)->origin());
+  auto loadA = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
+  auto loadX = jlm::rvsdg::output::GetNode(*loadA->input(0)->origin());
 
   assert(is<LoadNonVolatileOperation>(*loadA, 3, 3));
-  assert(jlm::rvsdg::node_output::node(loadA->input(1)->origin()) == loadX);
+  assert(jlm::rvsdg::output::GetNode(*loadA->input(1)->origin()) == loadX);
 
   assert(is<LoadNonVolatileOperation>(*loadX, 3, 3));
   assert(loadX->input(0)->origin() == test.lambda->fctargument(0));
-  assert(jlm::rvsdg::node_output::node(loadX->input(1)->origin()) == lambdaEntrySplit);
+  assert(jlm::rvsdg::output::GetNode(*loadX->input(1)->origin()) == lambdaEntrySplit);
 }
 
 static void
@@ -327,7 +327,7 @@ ValidateLoadTest2SteensgaardAgnostic(const jlm::tests::LoadTest2 & test)
 
   assert(test.lambda->subregion()->nnodes() == 14);
 
-  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
+  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 7, 1));
 
   assert(test.alloca_a->output(1)->nusers() == 1);
@@ -346,8 +346,8 @@ ValidateLoadTest2SteensgaardAgnostic(const jlm::tests::LoadTest2 & test)
   auto storeB = jlm::rvsdg::input::GetNode(**test.alloca_b->output(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeB, 4, 2));
   assert(storeB->input(0)->origin() == test.alloca_y->output(0));
-  assert(jlm::rvsdg::node_output::node(storeB->input(2)->origin()) == storeA);
-  assert(jlm::rvsdg::node_output::node(storeB->input(3)->origin()) == storeA);
+  assert(jlm::rvsdg::output::GetNode(*storeB->input(2)->origin()) == storeA);
+  assert(jlm::rvsdg::output::GetNode(*storeB->input(3)->origin()) == storeA);
 
   auto storeX = jlm::rvsdg::input::GetNode(**test.alloca_p->output(1)->begin());
   assert(is<StoreNonVolatileOperation>(*storeX, 3, 1));
@@ -360,14 +360,14 @@ ValidateLoadTest2SteensgaardAgnostic(const jlm::tests::LoadTest2 & test)
 
   auto loadXY = jlm::rvsdg::input::GetNode(**loadP->output(0)->begin());
   assert(is<LoadNonVolatileOperation>(*loadXY, 3, 3));
-  assert(jlm::rvsdg::node_output::node(loadXY->input(1)->origin()) == storeB);
-  assert(jlm::rvsdg::node_output::node(loadXY->input(2)->origin()) == storeB);
+  assert(jlm::rvsdg::output::GetNode(*loadXY->input(1)->origin()) == storeB);
+  assert(jlm::rvsdg::output::GetNode(*loadXY->input(2)->origin()) == storeB);
 
   auto storeY = jlm::rvsdg::input::GetNode(**loadXY->output(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeY, 4, 2));
   assert(storeY->input(0)->origin() == test.alloca_y->output(0));
-  assert(jlm::rvsdg::node_output::node(storeY->input(2)->origin()) == loadXY);
-  assert(jlm::rvsdg::node_output::node(storeY->input(3)->origin()) == loadXY);
+  assert(jlm::rvsdg::output::GetNode(*storeY->input(2)->origin()) == loadXY);
+  assert(jlm::rvsdg::output::GetNode(*storeY->input(3)->origin()) == loadXY);
 }
 
 static void
@@ -377,7 +377,7 @@ ValidateLoadTest2SteensgaardRegionAware(const jlm::tests::LoadTest2 & test)
 
   assert(test.lambda->subregion()->nnodes() == 13);
 
-  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
+  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
 
   assert(test.alloca_a->output(1)->nusers() == 1);
@@ -393,8 +393,8 @@ ValidateLoadTest2SteensgaardRegionAware(const jlm::tests::LoadTest2 & test)
   auto storeB = jlm::rvsdg::input::GetNode(**test.alloca_b->output(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeB, 4, 2));
   assert(storeB->input(0)->origin() == test.alloca_y->output(0));
-  assert(jlm::rvsdg::node_output::node(storeB->input(2)->origin()) == storeA);
-  assert(jlm::rvsdg::node_output::node(storeB->input(3)->origin()) == storeA);
+  assert(jlm::rvsdg::output::GetNode(*storeB->input(2)->origin()) == storeA);
+  assert(jlm::rvsdg::output::GetNode(*storeB->input(3)->origin()) == storeA);
 
   auto storeX = jlm::rvsdg::input::GetNode(**test.alloca_p->output(1)->begin());
   assert(is<StoreNonVolatileOperation>(*storeX, 3, 1));
@@ -407,14 +407,14 @@ ValidateLoadTest2SteensgaardRegionAware(const jlm::tests::LoadTest2 & test)
 
   auto loadXY = jlm::rvsdg::input::GetNode(**loadP->output(0)->begin());
   assert(is<LoadNonVolatileOperation>(*loadXY, 3, 3));
-  assert(jlm::rvsdg::node_output::node(loadXY->input(1)->origin()) == storeB);
-  assert(jlm::rvsdg::node_output::node(loadXY->input(2)->origin()) == storeB);
+  assert(jlm::rvsdg::output::GetNode(*loadXY->input(1)->origin()) == storeB);
+  assert(jlm::rvsdg::output::GetNode(*loadXY->input(2)->origin()) == storeB);
 
   auto storeY = jlm::rvsdg::input::GetNode(**loadXY->output(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeY, 4, 2));
   assert(storeY->input(0)->origin() == test.alloca_y->output(0));
-  assert(jlm::rvsdg::node_output::node(storeY->input(2)->origin()) == loadXY);
-  assert(jlm::rvsdg::node_output::node(storeY->input(3)->origin()) == loadXY);
+  assert(jlm::rvsdg::output::GetNode(*storeY->input(2)->origin()) == loadXY);
+  assert(jlm::rvsdg::output::GetNode(*storeY->input(3)->origin()) == loadXY);
 }
 
 static void
@@ -424,12 +424,12 @@ ValidateLoadTest2SteensgaardAgnosticTopDown(const jlm::tests::LoadTest2 & test)
 
   assert(test.lambda->subregion()->nnodes() == 2);
 
-  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
+  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
-  auto lambdaEntrySplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+  auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
-  assert(lambdaEntrySplit == jlm::rvsdg::node_output::node(lambdaExitMerge->input(1)->origin()));
+  assert(lambdaEntrySplit == jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(1)->origin()));
 }
 
 static void
@@ -439,10 +439,10 @@ ValidateLoadFromUndefSteensgaardAgnostic(const jlm::tests::LoadFromUndefTest & t
 
   assert(test.Lambda().subregion()->nnodes() == 4);
 
-  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.Lambda().fctresult(1)->origin());
+  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.Lambda().fctresult(1)->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
-  auto load = jlm::rvsdg::node_output::node(test.Lambda().fctresult(0)->origin());
+  auto load = jlm::rvsdg::output::GetNode(*test.Lambda().fctresult(0)->origin());
   assert(is<LoadNonVolatileOperation>(*load, 1, 1));
 
   auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.Lambda().fctargument(0)->begin());
@@ -456,10 +456,10 @@ ValidateLoadFromUndefSteensgaardRegionAware(const jlm::tests::LoadFromUndefTest 
 
   assert(test.Lambda().subregion()->nnodes() == 3);
 
-  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.Lambda().fctresult(1)->origin());
+  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.Lambda().fctresult(1)->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 0, 1));
 
-  auto load = jlm::rvsdg::node_output::node(test.Lambda().fctresult(0)->origin());
+  auto load = jlm::rvsdg::output::GetNode(*test.Lambda().fctresult(0)->origin());
   assert(is<LoadNonVolatileOperation>(*load, 1, 1));
 }
 
@@ -470,10 +470,10 @@ ValidateLoadFromUndefSteensgaardAgnosticTopDown(const jlm::tests::LoadFromUndefT
 
   assert(test.Lambda().subregion()->nnodes() == 4);
 
-  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.Lambda().fctresult(1)->origin());
+  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.Lambda().fctresult(1)->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
-  auto load = jlm::rvsdg::node_output::node(test.Lambda().fctresult(0)->origin());
+  auto load = jlm::rvsdg::output::GetNode(*test.Lambda().fctresult(0)->origin());
   assert(is<LoadNonVolatileOperation>(*load, 1, 1));
 
   auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.Lambda().fctargument(0)->begin());
@@ -488,7 +488,7 @@ ValidateCallTest1SteensgaardAgnostic(const jlm::tests::CallTest1 & test)
   /* validate f */
   {
     auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_f->fctargument(3)->begin());
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda_f->fctresult(2)->origin());
+    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda_f->fctresult(2)->origin());
     auto loadX = jlm::rvsdg::input::GetNode(**test.lambda_f->fctargument(0)->begin());
     auto loadY = jlm::rvsdg::input::GetNode(**test.lambda_f->fctargument(1)->begin());
 
@@ -496,16 +496,16 @@ ValidateCallTest1SteensgaardAgnostic(const jlm::tests::CallTest1 & test)
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 7));
 
     assert(is<LoadNonVolatileOperation>(*loadX, 2, 2));
-    assert(jlm::rvsdg::node_output::node(loadX->input(1)->origin()) == lambdaEntrySplit);
+    assert(jlm::rvsdg::output::GetNode(*loadX->input(1)->origin()) == lambdaEntrySplit);
 
     assert(is<LoadNonVolatileOperation>(*loadY, 2, 2));
-    assert(jlm::rvsdg::node_output::node(loadY->input(1)->origin()) == lambdaEntrySplit);
+    assert(jlm::rvsdg::output::GetNode(*loadY->input(1)->origin()) == lambdaEntrySplit);
   }
 
   /* validate g */
   {
     auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(3)->begin());
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda_g->fctresult(2)->origin());
+    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda_g->fctresult(2)->origin());
     auto loadX = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(0)->begin());
     auto loadY = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(1)->begin());
 
@@ -513,21 +513,21 @@ ValidateCallTest1SteensgaardAgnostic(const jlm::tests::CallTest1 & test)
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 7));
 
     assert(is<LoadNonVolatileOperation>(*loadX, 2, 2));
-    assert(jlm::rvsdg::node_output::node(loadX->input(1)->origin()) == lambdaEntrySplit);
+    assert(jlm::rvsdg::output::GetNode(*loadX->input(1)->origin()) == lambdaEntrySplit);
 
     assert(is<LoadNonVolatileOperation>(*loadY, 2, 2));
-    assert(jlm::rvsdg::node_output::node(loadY->input(1)->origin()) == loadX);
+    assert(jlm::rvsdg::output::GetNode(*loadY->input(1)->origin()) == loadX);
   }
 
   /* validate h */
   {
-    auto callEntryMerge = jlm::rvsdg::node_output::node(test.CallF().input(4)->origin());
+    auto callEntryMerge = jlm::rvsdg::output::GetNode(*test.CallF().input(4)->origin());
     auto callExitSplit = jlm::rvsdg::input::GetNode(**test.CallF().output(2)->begin());
 
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 7, 1));
     assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 7));
 
-    callEntryMerge = jlm::rvsdg::node_output::node(test.CallG().input(4)->origin());
+    callEntryMerge = jlm::rvsdg::output::GetNode(*test.CallG().input(4)->origin());
     callExitSplit = jlm::rvsdg::input::GetNode(**test.CallG().output(2)->begin());
 
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 7, 1));
@@ -543,7 +543,7 @@ ValidateCallTest1SteensgaardRegionAware(const jlm::tests::CallTest1 & test)
   /* validate f */
   {
     auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_f->fctargument(3)->begin());
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda_f->fctresult(2)->origin());
+    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda_f->fctresult(2)->origin());
     auto loadX = jlm::rvsdg::input::GetNode(**test.lambda_f->fctargument(0)->begin());
     auto loadY = jlm::rvsdg::input::GetNode(**test.lambda_f->fctargument(1)->begin());
 
@@ -551,16 +551,16 @@ ValidateCallTest1SteensgaardRegionAware(const jlm::tests::CallTest1 & test)
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 
     assert(is<LoadNonVolatileOperation>(*loadX, 2, 2));
-    assert(jlm::rvsdg::node_output::node(loadX->input(1)->origin()) == lambdaEntrySplit);
+    assert(jlm::rvsdg::output::GetNode(*loadX->input(1)->origin()) == lambdaEntrySplit);
 
     assert(is<LoadNonVolatileOperation>(*loadY, 2, 2));
-    assert(jlm::rvsdg::node_output::node(loadY->input(1)->origin()) == lambdaEntrySplit);
+    assert(jlm::rvsdg::output::GetNode(*loadY->input(1)->origin()) == lambdaEntrySplit);
   }
 
   /* validate g */
   {
     auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(3)->begin());
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda_g->fctresult(2)->origin());
+    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda_g->fctresult(2)->origin());
     auto loadX = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(0)->begin());
     auto loadY = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(1)->begin());
 
@@ -568,21 +568,21 @@ ValidateCallTest1SteensgaardRegionAware(const jlm::tests::CallTest1 & test)
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 1));
 
     assert(is<LoadNonVolatileOperation>(*loadX, 2, 2));
-    assert(jlm::rvsdg::node_output::node(loadX->input(1)->origin()) == lambdaEntrySplit);
+    assert(jlm::rvsdg::output::GetNode(*loadX->input(1)->origin()) == lambdaEntrySplit);
 
     assert(is<LoadNonVolatileOperation>(*loadY, 2, 2));
-    assert(jlm::rvsdg::node_output::node(loadY->input(1)->origin()) == loadX);
+    assert(jlm::rvsdg::output::GetNode(*loadY->input(1)->origin()) == loadX);
   }
 
   /* validate h */
   {
-    auto callEntryMerge = jlm::rvsdg::node_output::node(test.CallF().input(4)->origin());
+    auto callEntryMerge = jlm::rvsdg::output::GetNode(*test.CallF().input(4)->origin());
     auto callExitSplit = jlm::rvsdg::input::GetNode(**test.CallF().output(2)->begin());
 
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 2, 1));
     assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 2));
 
-    callEntryMerge = jlm::rvsdg::node_output::node(test.CallG().input(4)->origin());
+    callEntryMerge = jlm::rvsdg::output::GetNode(*test.CallG().input(4)->origin());
     callExitSplit = jlm::rvsdg::input::GetNode(**test.CallG().output(2)->begin());
 
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 1, 1));
@@ -598,7 +598,7 @@ ValidateCallTest1SteensgaardAgnosticTopDown(const jlm::tests::CallTest1 & test)
   // validate function f
   {
     auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_f->fctargument(3)->begin());
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda_f->fctresult(2)->origin());
+    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda_f->fctresult(2)->origin());
     auto loadX = jlm::rvsdg::input::GetNode(**test.lambda_f->fctargument(0)->begin());
     auto loadY = jlm::rvsdg::input::GetNode(**test.lambda_f->fctargument(1)->begin());
 
@@ -606,16 +606,16 @@ ValidateCallTest1SteensgaardAgnosticTopDown(const jlm::tests::CallTest1 & test)
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 7));
 
     assert(is<LoadNonVolatileOperation>(*loadX, 2, 2));
-    assert(jlm::rvsdg::node_output::node(loadX->input(1)->origin()) == lambdaEntrySplit);
+    assert(jlm::rvsdg::output::GetNode(*loadX->input(1)->origin()) == lambdaEntrySplit);
 
     assert(is<LoadNonVolatileOperation>(*loadY, 2, 2));
-    assert(jlm::rvsdg::node_output::node(loadY->input(1)->origin()) == lambdaEntrySplit);
+    assert(jlm::rvsdg::output::GetNode(*loadY->input(1)->origin()) == lambdaEntrySplit);
   }
 
   // validate function g
   {
     auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(3)->begin());
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda_g->fctresult(2)->origin());
+    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda_g->fctresult(2)->origin());
     auto loadX = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(0)->begin());
     auto loadY = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(1)->begin());
 
@@ -623,21 +623,21 @@ ValidateCallTest1SteensgaardAgnosticTopDown(const jlm::tests::CallTest1 & test)
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 7));
 
     assert(is<LoadNonVolatileOperation>(*loadX, 2, 2));
-    assert(jlm::rvsdg::node_output::node(loadX->input(1)->origin()) == lambdaEntrySplit);
+    assert(jlm::rvsdg::output::GetNode(*loadX->input(1)->origin()) == lambdaEntrySplit);
 
     assert(is<LoadNonVolatileOperation>(*loadY, 2, 2));
-    assert(jlm::rvsdg::node_output::node(loadY->input(1)->origin()) == loadX);
+    assert(jlm::rvsdg::output::GetNode(*loadY->input(1)->origin()) == loadX);
   }
 
   // validate function h
   {
-    auto callEntryMerge = jlm::rvsdg::node_output::node(test.CallF().input(4)->origin());
+    auto callEntryMerge = jlm::rvsdg::output::GetNode(*test.CallF().input(4)->origin());
     auto callExitSplit = jlm::rvsdg::input::GetNode(**test.CallF().output(2)->begin());
 
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 7, 1));
     assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 7));
 
-    callEntryMerge = jlm::rvsdg::node_output::node(test.CallG().input(4)->origin());
+    callEntryMerge = jlm::rvsdg::output::GetNode(*test.CallG().input(4)->origin());
     callExitSplit = jlm::rvsdg::input::GetNode(**test.CallG().output(2)->begin());
 
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 7, 1));
@@ -657,7 +657,7 @@ ValidateCallTest2SteensgaardAgnostic(const jlm::tests::CallTest2 & test)
     auto stateMerge = jlm::rvsdg::input::GetNode(**test.malloc->output(1)->begin());
     assert(is<MemoryStateMergeOperation>(*stateMerge, 2, 1));
 
-    auto lambdaEntrySplit = jlm::rvsdg::node_output::node(stateMerge->input(1)->origin());
+    auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*stateMerge->input(1)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
 
     auto lambdaExitMerge = jlm::rvsdg::input::GetNode(**stateMerge->output(0)->begin());
@@ -691,7 +691,7 @@ ValidateCallTest2SteensgaardRegionAware(const jlm::tests::CallTest2 & test)
     auto stateMerge = jlm::rvsdg::input::GetNode(**test.malloc->output(1)->begin());
     assert(is<MemoryStateMergeOperation>(*stateMerge, 2, 1));
 
-    auto lambdaEntrySplit = jlm::rvsdg::node_output::node(stateMerge->input(1)->origin());
+    auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*stateMerge->input(1)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 1));
 
     auto lambdaExitMerge = jlm::rvsdg::input::GetNode(**stateMerge->output(0)->begin());
@@ -725,7 +725,7 @@ ValidateCallTest2SteensgaardAgnosticTopDown(const jlm::tests::CallTest2 & test)
     auto stateMerge = jlm::rvsdg::input::GetNode(**test.malloc->output(1)->begin());
     assert(is<MemoryStateMergeOperation>(*stateMerge, 2, 1));
 
-    auto lambdaEntrySplit = jlm::rvsdg::node_output::node(stateMerge->input(1)->origin());
+    auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*stateMerge->input(1)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
 
     auto lambdaExitMerge = jlm::rvsdg::input::GetNode(**stateMerge->output(0)->begin());
@@ -753,19 +753,19 @@ ValidateIndirectCallTest1SteensgaardAgnostic(const jlm::tests::IndirectCallTest1
     assert(test.GetLambdaIndcall().subregion()->nnodes() == 5);
 
     auto lambda_exit_mux =
-        jlm::rvsdg::node_output::node(test.GetLambdaIndcall().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaIndcall().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambda_exit_mux, 5, 1));
 
-    auto call_exit_mux = jlm::rvsdg::node_output::node(lambda_exit_mux->input(0)->origin());
+    auto call_exit_mux = jlm::rvsdg::output::GetNode(*lambda_exit_mux->input(0)->origin());
     assert(is<CallExitMemoryStateSplitOperation>(*call_exit_mux, 1, 5));
 
-    auto call = jlm::rvsdg::node_output::node(call_exit_mux->input(0)->origin());
+    auto call = jlm::rvsdg::output::GetNode(*call_exit_mux->input(0)->origin());
     assert(is<CallOperation>(*call, 3, 3));
 
-    auto call_entry_mux = jlm::rvsdg::node_output::node(call->input(2)->origin());
+    auto call_entry_mux = jlm::rvsdg::output::GetNode(*call->input(2)->origin());
     assert(is<CallEntryMemoryStateMergeOperation>(*call_entry_mux, 5, 1));
 
-    auto lambda_entry_mux = jlm::rvsdg::node_output::node(call_entry_mux->input(2)->origin());
+    auto lambda_entry_mux = jlm::rvsdg::output::GetNode(*call_entry_mux->input(2)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambda_entry_mux, 1, 5));
   }
 
@@ -774,28 +774,28 @@ ValidateIndirectCallTest1SteensgaardAgnostic(const jlm::tests::IndirectCallTest1
     assert(test.GetLambdaTest().subregion()->nnodes() == 9);
 
     auto lambda_exit_mux =
-        jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaTest().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambda_exit_mux, 5, 1));
 
-    auto call_exit_mux = jlm::rvsdg::node_output::node(lambda_exit_mux->input(0)->origin());
+    auto call_exit_mux = jlm::rvsdg::output::GetNode(*lambda_exit_mux->input(0)->origin());
     assert(is<CallExitMemoryStateSplitOperation>(*call_exit_mux, 1, 5));
 
-    auto call = jlm::rvsdg::node_output::node(call_exit_mux->input(0)->origin());
+    auto call = jlm::rvsdg::output::GetNode(*call_exit_mux->input(0)->origin());
     assert(is<CallOperation>(*call, 4, 3));
 
-    auto call_entry_mux = jlm::rvsdg::node_output::node(call->input(3)->origin());
+    auto call_entry_mux = jlm::rvsdg::output::GetNode(*call->input(3)->origin());
     assert(is<CallEntryMemoryStateMergeOperation>(*call_entry_mux, 5, 1));
 
-    call_exit_mux = jlm::rvsdg::node_output::node(call_entry_mux->input(0)->origin());
+    call_exit_mux = jlm::rvsdg::output::GetNode(*call_entry_mux->input(0)->origin());
     assert(is<CallExitMemoryStateSplitOperation>(*call_exit_mux, 1, 5));
 
-    call = jlm::rvsdg::node_output::node(call_exit_mux->input(0)->origin());
+    call = jlm::rvsdg::output::GetNode(*call_exit_mux->input(0)->origin());
     assert(is<CallOperation>(*call, 4, 3));
 
-    call_entry_mux = jlm::rvsdg::node_output::node(call->input(3)->origin());
+    call_entry_mux = jlm::rvsdg::output::GetNode(*call->input(3)->origin());
     assert(is<CallEntryMemoryStateMergeOperation>(*call_entry_mux, 5, 1));
 
-    auto lambda_entry_mux = jlm::rvsdg::node_output::node(call_entry_mux->input(2)->origin());
+    auto lambda_entry_mux = jlm::rvsdg::output::GetNode(*call_entry_mux->input(2)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambda_entry_mux, 1, 5));
   }
 }
@@ -810,19 +810,19 @@ ValidateIndirectCallTest1SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(test.GetLambdaIndcall().subregion()->nnodes() == 5);
 
     auto lambdaExitMerge =
-        jlm::rvsdg::node_output::node(test.GetLambdaIndcall().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaIndcall().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 1, 1));
 
-    auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+    auto callExitSplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
     assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 1));
 
-    auto call = jlm::rvsdg::node_output::node(callExitSplit->input(0)->origin());
+    auto call = jlm::rvsdg::output::GetNode(*callExitSplit->input(0)->origin());
     assert(is<CallOperation>(*call, 3, 3));
 
-    auto callEntryMerge = jlm::rvsdg::node_output::node(call->input(2)->origin());
+    auto callEntryMerge = jlm::rvsdg::output::GetNode(*call->input(2)->origin());
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 1, 1));
 
-    auto lambdaEntrySplit = jlm::rvsdg::node_output::node(callEntryMerge->input(0)->origin());
+    auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*callEntryMerge->input(0)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 1));
   }
 
@@ -831,28 +831,28 @@ ValidateIndirectCallTest1SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(test.GetLambdaTest().subregion()->nnodes() == 9);
 
     auto lambdaExitMerge =
-        jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaTest().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 1, 1));
 
-    auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+    auto callExitSplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
     assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 1));
 
-    auto call = jlm::rvsdg::node_output::node(callExitSplit->input(0)->origin());
+    auto call = jlm::rvsdg::output::GetNode(*callExitSplit->input(0)->origin());
     assert(is<CallOperation>(*call, 4, 3));
 
-    auto callEntryMerge = jlm::rvsdg::node_output::node(call->input(3)->origin());
+    auto callEntryMerge = jlm::rvsdg::output::GetNode(*call->input(3)->origin());
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 1, 1));
 
-    callExitSplit = jlm::rvsdg::node_output::node(callEntryMerge->input(0)->origin());
+    callExitSplit = jlm::rvsdg::output::GetNode(*callEntryMerge->input(0)->origin());
     assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 1));
 
-    call = jlm::rvsdg::node_output::node(callExitSplit->input(0)->origin());
+    call = jlm::rvsdg::output::GetNode(*callExitSplit->input(0)->origin());
     assert(is<CallOperation>(*call, 4, 3));
 
-    callEntryMerge = jlm::rvsdg::node_output::node(call->input(3)->origin());
+    callEntryMerge = jlm::rvsdg::output::GetNode(*call->input(3)->origin());
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 1, 1));
 
-    auto lambdaEntrySplit = jlm::rvsdg::node_output::node(callEntryMerge->input(0)->origin());
+    auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*callEntryMerge->input(0)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 1));
   }
 }
@@ -867,19 +867,19 @@ ValidateIndirectCallTest1SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(test.GetLambdaIndcall().subregion()->nnodes() == 5);
 
     auto lambda_exit_mux =
-        jlm::rvsdg::node_output::node(test.GetLambdaIndcall().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaIndcall().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambda_exit_mux, 5, 1));
 
-    auto call_exit_mux = jlm::rvsdg::node_output::node(lambda_exit_mux->input(0)->origin());
+    auto call_exit_mux = jlm::rvsdg::output::GetNode(*lambda_exit_mux->input(0)->origin());
     assert(is<CallExitMemoryStateSplitOperation>(*call_exit_mux, 1, 5));
 
-    auto call = jlm::rvsdg::node_output::node(call_exit_mux->input(0)->origin());
+    auto call = jlm::rvsdg::output::GetNode(*call_exit_mux->input(0)->origin());
     assert(is<CallOperation>(*call, 3, 3));
 
-    auto call_entry_mux = jlm::rvsdg::node_output::node(call->input(2)->origin());
+    auto call_entry_mux = jlm::rvsdg::output::GetNode(*call->input(2)->origin());
     assert(is<CallEntryMemoryStateMergeOperation>(*call_entry_mux, 5, 1));
 
-    auto lambda_entry_mux = jlm::rvsdg::node_output::node(call_entry_mux->input(2)->origin());
+    auto lambda_entry_mux = jlm::rvsdg::output::GetNode(*call_entry_mux->input(2)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambda_entry_mux, 1, 5));
   }
 
@@ -888,28 +888,28 @@ ValidateIndirectCallTest1SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(test.GetLambdaTest().subregion()->nnodes() == 9);
 
     auto lambda_exit_mux =
-        jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaTest().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambda_exit_mux, 5, 1));
 
-    auto call_exit_mux = jlm::rvsdg::node_output::node(lambda_exit_mux->input(0)->origin());
+    auto call_exit_mux = jlm::rvsdg::output::GetNode(*lambda_exit_mux->input(0)->origin());
     assert(is<CallExitMemoryStateSplitOperation>(*call_exit_mux, 1, 5));
 
-    auto call = jlm::rvsdg::node_output::node(call_exit_mux->input(0)->origin());
+    auto call = jlm::rvsdg::output::GetNode(*call_exit_mux->input(0)->origin());
     assert(is<CallOperation>(*call, 4, 3));
 
-    auto call_entry_mux = jlm::rvsdg::node_output::node(call->input(3)->origin());
+    auto call_entry_mux = jlm::rvsdg::output::GetNode(*call->input(3)->origin());
     assert(is<CallEntryMemoryStateMergeOperation>(*call_entry_mux, 5, 1));
 
-    call_exit_mux = jlm::rvsdg::node_output::node(call_entry_mux->input(0)->origin());
+    call_exit_mux = jlm::rvsdg::output::GetNode(*call_entry_mux->input(0)->origin());
     assert(is<CallExitMemoryStateSplitOperation>(*call_exit_mux, 1, 5));
 
-    call = jlm::rvsdg::node_output::node(call_exit_mux->input(0)->origin());
+    call = jlm::rvsdg::output::GetNode(*call_exit_mux->input(0)->origin());
     assert(is<CallOperation>(*call, 4, 3));
 
-    call_entry_mux = jlm::rvsdg::node_output::node(call->input(3)->origin());
+    call_entry_mux = jlm::rvsdg::output::GetNode(*call->input(3)->origin());
     assert(is<CallEntryMemoryStateMergeOperation>(*call_entry_mux, 5, 1));
 
-    auto lambda_entry_mux = jlm::rvsdg::node_output::node(call_entry_mux->input(2)->origin());
+    auto lambda_entry_mux = jlm::rvsdg::output::GetNode(*call_entry_mux->input(2)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambda_entry_mux, 1, 5));
   }
 }
@@ -924,7 +924,7 @@ ValidateIndirectCallTest2SteensgaardAgnostic(const jlm::tests::IndirectCallTest2
     assert(test.GetLambdaThree().subregion()->nnodes() == 3);
 
     auto lambdaExitMerge =
-        jlm::rvsdg::node_output::node(test.GetLambdaThree().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaThree().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 13, 1));
 
     auto lambdaEntrySplit =
@@ -937,7 +937,7 @@ ValidateIndirectCallTest2SteensgaardAgnostic(const jlm::tests::IndirectCallTest2
     assert(test.GetLambdaFour().subregion()->nnodes() == 3);
 
     auto lambdaExitMerge =
-        jlm::rvsdg::node_output::node(test.GetLambdaFour().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaFour().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 13, 1));
 
     auto lambdaEntrySplit =
@@ -949,16 +949,16 @@ ValidateIndirectCallTest2SteensgaardAgnostic(const jlm::tests::IndirectCallTest2
   {
     assert(test.GetLambdaI().subregion()->nnodes() == 5);
 
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaI().fctresult(2)->origin());
+    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.GetLambdaI().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 13, 1));
 
-    auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+    auto callExitSplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
     assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 13));
 
-    auto callEntryMerge = jlm::rvsdg::node_output::node(test.GetIndirectCall().input(2)->origin());
+    auto callEntryMerge = jlm::rvsdg::output::GetNode(*test.GetIndirectCall().input(2)->origin());
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 13, 1));
 
-    auto lambdaEntrySplit = jlm::rvsdg::node_output::node(callEntryMerge->input(0)->origin());
+    auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*callEntryMerge->input(0)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 13));
   }
 }
@@ -973,7 +973,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(test.GetLambdaThree().subregion()->nnodes() == 2);
 
     auto lambdaExitMerge =
-        jlm::rvsdg::node_output::node(test.GetLambdaThree().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaThree().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 0, 1));
   }
 
@@ -982,7 +982,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(test.GetLambdaFour().subregion()->nnodes() == 2);
 
     auto lambdaExitMerge =
-        jlm::rvsdg::node_output::node(test.GetLambdaFour().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaFour().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 0, 1));
   }
 
@@ -990,16 +990,16 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
   {
     assert(test.GetLambdaI().subregion()->nnodes() == 5);
 
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaI().fctresult(2)->origin());
+    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.GetLambdaI().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 6, 1));
 
-    auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+    auto callExitSplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
     assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 6));
 
-    auto callEntryMerge = jlm::rvsdg::node_output::node(test.GetIndirectCall().input(2)->origin());
+    auto callEntryMerge = jlm::rvsdg::output::GetNode(*test.GetIndirectCall().input(2)->origin());
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 6, 1));
 
-    auto lambdaEntrySplit = jlm::rvsdg::node_output::node(callEntryMerge->input(0)->origin());
+    auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*callEntryMerge->input(0)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 6));
   }
 
@@ -1007,21 +1007,20 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
   {
     assert(test.GetLambdaX().subregion()->nnodes() == 7);
 
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaX().fctresult(2)->origin());
+    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.GetLambdaX().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 6, 1));
 
-    auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+    auto callExitSplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
     assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 6));
 
-    auto callEntryMerge =
-        jlm::rvsdg::node_output::node(test.GetCallIWithThree().input(3)->origin());
+    auto callEntryMerge = jlm::rvsdg::output::GetNode(*test.GetCallIWithThree().input(3)->origin());
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 6, 1));
 
     const jlm::rvsdg::node * storeNode = nullptr;
     const jlm::rvsdg::node * lambdaEntrySplit = nullptr;
     for (size_t n = 0; n < callEntryMerge->ninputs(); n++)
     {
-      auto node = jlm::rvsdg::node_output::node(callEntryMerge->input(n)->origin());
+      auto node = jlm::rvsdg::output::GetNode(*callEntryMerge->input(n)->origin());
       if (is<StoreNonVolatileOperation>(node))
       {
         storeNode = node;
@@ -1044,20 +1043,20 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
   {
     assert(test.GetLambdaY().subregion()->nnodes() == 7);
 
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaY().fctresult(2)->origin());
+    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.GetLambdaY().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 6, 1));
 
-    auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+    auto callExitSplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
     assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 6));
 
-    auto callEntryMerge = jlm::rvsdg::node_output::node(test.GetCallIWithFour().input(3)->origin());
+    auto callEntryMerge = jlm::rvsdg::output::GetNode(*test.GetCallIWithFour().input(3)->origin());
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 6, 1));
 
     const jlm::rvsdg::node * storeNode = nullptr;
     const jlm::rvsdg::node * lambdaEntrySplit = nullptr;
     for (size_t n = 0; n < callEntryMerge->ninputs(); n++)
     {
-      auto node = jlm::rvsdg::node_output::node(callEntryMerge->input(n)->origin());
+      auto node = jlm::rvsdg::output::GetNode(*callEntryMerge->input(n)->origin());
       if (is<StoreNonVolatileOperation>(node))
       {
         storeNode = node;
@@ -1081,7 +1080,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(test.GetLambdaTest().subregion()->nnodes() == 16);
 
     auto lambdaExitMerge =
-        jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaTest().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 6, 1));
 
     auto loadG1 = jlm::rvsdg::input::GetNode(**test.GetLambdaTest().cvargument(2)->begin());
@@ -1100,7 +1099,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(test.GetLambdaTest2().subregion()->nnodes() == 7);
 
     auto lambdaExitMerge =
-        jlm::rvsdg::node_output::node(test.GetLambdaTest2().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaTest2().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 6, 1));
 
     auto lambdaEntrySplit =
@@ -1119,7 +1118,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(test.GetLambdaThree().subregion()->nnodes() == 3);
 
     auto lambdaExitMerge =
-        jlm::rvsdg::node_output::node(test.GetLambdaThree().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaThree().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 13, 1));
 
     auto lambdaEntrySplit =
@@ -1132,7 +1131,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(test.GetLambdaFour().subregion()->nnodes() == 3);
 
     auto lambdaExitMerge =
-        jlm::rvsdg::node_output::node(test.GetLambdaFour().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaFour().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 13, 1));
 
     auto lambdaEntrySplit =
@@ -1144,16 +1143,16 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
   {
     assert(test.GetLambdaI().subregion()->nnodes() == 5);
 
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaI().fctresult(2)->origin());
+    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.GetLambdaI().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 13, 1));
 
-    auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+    auto callExitSplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
     assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 13));
 
-    auto callEntryMerge = jlm::rvsdg::node_output::node(test.GetIndirectCall().input(2)->origin());
+    auto callEntryMerge = jlm::rvsdg::output::GetNode(*test.GetIndirectCall().input(2)->origin());
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 13, 1));
 
-    auto lambdaEntrySplit = jlm::rvsdg::node_output::node(callEntryMerge->input(0)->origin());
+    auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*callEntryMerge->input(0)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 13));
   }
 
@@ -1161,21 +1160,20 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
   {
     assert(test.GetLambdaX().subregion()->nnodes() == 7);
 
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaX().fctresult(2)->origin());
+    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.GetLambdaX().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 13, 1));
 
-    auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+    auto callExitSplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
     assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 13));
 
-    auto callEntryMerge =
-        jlm::rvsdg::node_output::node(test.GetCallIWithThree().input(3)->origin());
+    auto callEntryMerge = jlm::rvsdg::output::GetNode(*test.GetCallIWithThree().input(3)->origin());
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 13, 1));
 
     const jlm::rvsdg::node * storeNode = nullptr;
     const jlm::rvsdg::node * lambdaEntrySplit = nullptr;
     for (size_t n = 0; n < callEntryMerge->ninputs(); n++)
     {
-      auto node = jlm::rvsdg::node_output::node(callEntryMerge->input(n)->origin());
+      auto node = jlm::rvsdg::output::GetNode(*callEntryMerge->input(n)->origin());
       if (is<StoreNonVolatileOperation>(node))
       {
         storeNode = node;
@@ -1198,13 +1196,13 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
   {
     assert(test.GetLambdaY().subregion()->nnodes() == 8);
 
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.GetLambdaY().fctresult(2)->origin());
+    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.GetLambdaY().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 12, 1));
 
-    auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+    auto callExitSplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
     assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 13));
 
-    auto callEntryMerge = jlm::rvsdg::node_output::node(test.GetCallIWithFour().input(3)->origin());
+    auto callEntryMerge = jlm::rvsdg::output::GetNode(*test.GetCallIWithFour().input(3)->origin());
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 13, 1));
 
     jlm::rvsdg::node * undefNode = nullptr;
@@ -1212,7 +1210,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     const jlm::rvsdg::node * lambdaEntrySplit = nullptr;
     for (size_t n = 0; n < callEntryMerge->ninputs(); n++)
     {
-      auto node = jlm::rvsdg::node_output::node(callEntryMerge->input(n)->origin());
+      auto node = jlm::rvsdg::output::GetNode(*callEntryMerge->input(n)->origin());
       if (is<StoreNonVolatileOperation>(node))
       {
         assert(storeNode == nullptr);
@@ -1242,13 +1240,13 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(test.GetLambdaTest().subregion()->nnodes() == 17);
 
     auto lambdaExitMerge =
-        jlm::rvsdg::node_output::node(test.GetLambdaTest().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaTest().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 10, 1));
 
     auto loadG1 = jlm::rvsdg::input::GetNode(**test.GetLambdaTest().cvargument(2)->begin());
     assert(is<LoadNonVolatileOperation>(*loadG1, 2, 2));
 
-    auto callXEntryMerge = jlm::rvsdg::node_output::node(test.GetTestCallX().input(3)->origin());
+    auto callXEntryMerge = jlm::rvsdg::output::GetNode(*test.GetTestCallX().input(3)->origin());
     assert(is<CallEntryMemoryStateMergeOperation>(*callXEntryMerge, 13, 1));
 
     auto callXExitSplit = jlm::rvsdg::input::GetNode(**test.GetTestCallX().output(2)->begin());
@@ -1280,10 +1278,10 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(test.GetLambdaTest2().subregion()->nnodes() == 8);
 
     auto lambdaExitMerge =
-        jlm::rvsdg::node_output::node(test.GetLambdaTest2().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaTest2().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 10, 1));
 
-    auto callXEntryMerge = jlm::rvsdg::node_output::node(test.GetTest2CallX().input(3)->origin());
+    auto callXEntryMerge = jlm::rvsdg::output::GetNode(*test.GetTest2CallX().input(3)->origin());
     assert(is<CallEntryMemoryStateMergeOperation>(*callXEntryMerge, 13, 1));
 
     auto callXExitSplit = jlm::rvsdg::input::GetNode(**test.GetTest2CallX().output(2)->begin());
@@ -1316,16 +1314,16 @@ ValidateGammaTestSteensgaardAgnostic(const jlm::tests::GammaTest & test)
 {
   using namespace jlm::llvm;
 
-  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(1)->origin());
+  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(1)->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
-  auto loadTmp2 = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+  auto loadTmp2 = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
   assert(is<LoadNonVolatileOperation>(*loadTmp2, 3, 3));
 
-  auto loadTmp1 = jlm::rvsdg::node_output::node(loadTmp2->input(1)->origin());
+  auto loadTmp1 = jlm::rvsdg::output::GetNode(*loadTmp2->input(1)->origin());
   assert(is<LoadNonVolatileOperation>(*loadTmp1, 3, 3));
 
-  auto gamma = jlm::rvsdg::node_output::node(loadTmp1->input(1)->origin());
+  auto gamma = jlm::rvsdg::output::GetNode(*loadTmp1->input(1)->origin());
   assert(gamma == test.gamma);
 }
 
@@ -1334,16 +1332,16 @@ ValidateGammaTestSteensgaardRegionAware(const jlm::tests::GammaTest & test)
 {
   using namespace jlm::llvm;
 
-  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(1)->origin());
+  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(1)->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
-  auto loadTmp2 = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+  auto loadTmp2 = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
   assert(is<LoadNonVolatileOperation>(*loadTmp2, 3, 3));
 
-  auto loadTmp1 = jlm::rvsdg::node_output::node(loadTmp2->input(1)->origin());
+  auto loadTmp1 = jlm::rvsdg::output::GetNode(*loadTmp2->input(1)->origin());
   assert(is<LoadNonVolatileOperation>(*loadTmp1, 3, 3));
 
-  auto lambdaEntrySplit = jlm::rvsdg::node_output::node(loadTmp1->input(1)->origin());
+  auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*loadTmp1->input(1)->origin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 }
 
@@ -1352,16 +1350,16 @@ ValidateGammaTestSteensgaardAgnosticTopDown(const jlm::tests::GammaTest & test)
 {
   using namespace jlm::llvm;
 
-  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(1)->origin());
+  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(1)->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
-  auto loadTmp2 = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+  auto loadTmp2 = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
   assert(is<LoadNonVolatileOperation>(*loadTmp2, 3, 3));
 
-  auto loadTmp1 = jlm::rvsdg::node_output::node(loadTmp2->input(1)->origin());
+  auto loadTmp1 = jlm::rvsdg::output::GetNode(*loadTmp2->input(1)->origin());
   assert(is<LoadNonVolatileOperation>(*loadTmp1, 3, 3));
 
-  auto gamma = jlm::rvsdg::node_output::node(loadTmp1->input(1)->origin());
+  auto gamma = jlm::rvsdg::output::GetNode(*loadTmp1->input(1)->origin());
   assert(gamma == test.gamma);
 }
 
@@ -1372,20 +1370,20 @@ ValidateThetaTestSteensgaardAgnostic(const jlm::tests::ThetaTest & test)
 
   assert(test.lambda->subregion()->nnodes() == 4);
 
-  auto lambda_exit_mux = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
+  auto lambda_exit_mux = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambda_exit_mux, 2, 1));
 
   auto thetaOutput =
       jlm::util::AssertedCast<jlm::rvsdg::ThetaOutput>(lambda_exit_mux->input(0)->origin());
-  auto theta = jlm::rvsdg::node_output::node(thetaOutput);
+  auto theta = jlm::rvsdg::output::GetNode(*thetaOutput);
   assert(theta == test.theta);
 
   auto storeStateOutput = thetaOutput->result()->origin();
-  auto store = jlm::rvsdg::node_output::node(storeStateOutput);
+  auto store = jlm::rvsdg::output::GetNode(*storeStateOutput);
   assert(is<StoreNonVolatileOperation>(*store, 4, 2));
   assert(store->input(storeStateOutput->index() + 2)->origin() == thetaOutput->argument());
 
-  auto lambda_entry_mux = jlm::rvsdg::node_output::node(thetaOutput->input()->origin());
+  auto lambda_entry_mux = jlm::rvsdg::output::GetNode(*thetaOutput->input()->origin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambda_entry_mux, 1, 2));
 }
 
@@ -1396,20 +1394,20 @@ ValidateThetaTestSteensgaardRegionAware(const jlm::tests::ThetaTest & test)
 
   assert(test.lambda->subregion()->nnodes() == 4);
 
-  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
+  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
   auto thetaOutput =
       jlm::util::AssertedCast<jlm::rvsdg::ThetaOutput>(lambdaExitMerge->input(0)->origin());
-  auto theta = jlm::rvsdg::node_output::node(thetaOutput);
+  auto theta = jlm::rvsdg::output::GetNode(*thetaOutput);
   assert(theta == test.theta);
 
   auto storeStateOutput = thetaOutput->result()->origin();
-  auto store = jlm::rvsdg::node_output::node(storeStateOutput);
+  auto store = jlm::rvsdg::output::GetNode(*storeStateOutput);
   assert(is<StoreNonVolatileOperation>(*store, 4, 2));
   assert(store->input(storeStateOutput->index() + 2)->origin() == thetaOutput->argument());
 
-  auto lambdaEntrySplit = jlm::rvsdg::node_output::node(thetaOutput->input()->origin());
+  auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*thetaOutput->input()->origin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 }
 
@@ -1420,20 +1418,20 @@ ValidateThetaTestSteensgaardAgnosticTopDown(const jlm::tests::ThetaTest & test)
 
   assert(test.lambda->subregion()->nnodes() == 4);
 
-  auto lambda_exit_mux = jlm::rvsdg::node_output::node(test.lambda->fctresult(0)->origin());
+  auto lambda_exit_mux = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambda_exit_mux, 2, 1));
 
   auto thetaOutput =
       jlm::util::AssertedCast<jlm::rvsdg::ThetaOutput>(lambda_exit_mux->input(0)->origin());
-  auto theta = jlm::rvsdg::node_output::node(thetaOutput);
+  auto theta = jlm::rvsdg::output::GetNode(*thetaOutput);
   assert(theta == test.theta);
 
   auto storeStateOutput = thetaOutput->result()->origin();
-  auto store = jlm::rvsdg::node_output::node(storeStateOutput);
+  auto store = jlm::rvsdg::output::GetNode(*storeStateOutput);
   assert(is<StoreNonVolatileOperation>(*store, 4, 2));
   assert(store->input(storeStateOutput->index() + 2)->origin() == thetaOutput->argument());
 
-  auto lambda_entry_mux = jlm::rvsdg::node_output::node(thetaOutput->input()->origin());
+  auto lambda_entry_mux = jlm::rvsdg::output::GetNode(*thetaOutput->input()->origin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambda_entry_mux, 1, 2));
 }
 
@@ -1449,7 +1447,7 @@ ValidateDeltaTest1SteensgaardAgnostic(const jlm::tests::DeltaTest1 & test)
 
   auto storeF = jlm::rvsdg::input::GetNode(**test.constantFive->output(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeF, 3, 1));
-  assert(jlm::rvsdg::node_output::node(storeF->input(2)->origin()) == lambdaEntrySplit);
+  assert(jlm::rvsdg::output::GetNode(*storeF->input(2)->origin()) == lambdaEntrySplit);
 
   auto deltaStateIndex = storeF->input(2)->origin()->index();
 
@@ -1470,7 +1468,7 @@ ValidateDeltaTest1SteensgaardRegionAware(const jlm::tests::DeltaTest1 & test)
 
   auto storeF = jlm::rvsdg::input::GetNode(**test.constantFive->output(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeF, 3, 1));
-  assert(jlm::rvsdg::node_output::node(storeF->input(2)->origin()) == lambdaEntrySplit);
+  assert(jlm::rvsdg::output::GetNode(*storeF->input(2)->origin()) == lambdaEntrySplit);
 
   auto deltaStateIndex = storeF->input(2)->origin()->index();
 
@@ -1491,7 +1489,7 @@ ValidateDeltaTest1SteensgaardAgnosticTopDown(const jlm::tests::DeltaTest1 & test
 
   auto storeF = jlm::rvsdg::input::GetNode(**test.constantFive->output(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeF, 3, 1));
-  assert(jlm::rvsdg::node_output::node(storeF->input(2)->origin()) == lambdaEntrySplit);
+  assert(jlm::rvsdg::output::GetNode(*storeF->input(2)->origin()) == lambdaEntrySplit);
 
   auto loadF = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(0)->begin());
   assert(is<LoadNonVolatileOperation>(*loadF, 2, 2));
@@ -1509,7 +1507,7 @@ ValidateDeltaTest2SteensgaardAgnostic(const jlm::tests::DeltaTest2 & test)
 
   auto storeD1InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
-  assert(jlm::rvsdg::node_output::node(storeD1InF2->input(2)->origin()) == lambdaEntrySplit);
+  assert(jlm::rvsdg::output::GetNode(*storeD1InF2->input(2)->origin()) == lambdaEntrySplit);
 
   auto d1StateIndex = storeD1InF2->input(2)->origin()->index();
 
@@ -1533,13 +1531,13 @@ ValidateDeltaTest2SteensgaardRegionAware(const jlm::tests::DeltaTest2 & test)
   {
     assert(test.lambda_f1->subregion()->nnodes() == 4);
 
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda_f1->fctresult(1)->origin());
+    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda_f1->fctresult(1)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 1, 1));
 
-    auto storeNode = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+    auto storeNode = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
     assert(is<StoreNonVolatileOperation>(*storeNode, 3, 1));
 
-    auto lambdaEntrySplit = jlm::rvsdg::node_output::node(storeNode->input(2)->origin());
+    auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*storeNode->input(2)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 1));
   }
 
@@ -1552,11 +1550,11 @@ ValidateDeltaTest2SteensgaardRegionAware(const jlm::tests::DeltaTest2 & test)
 
     auto storeD1 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(0)->begin());
     assert(is<StoreNonVolatileOperation>(*storeD1, 3, 1));
-    assert(jlm::rvsdg::node_output::node(storeD1->input(2)->origin()) == lambdaEntrySplit);
+    assert(jlm::rvsdg::output::GetNode(*storeD1->input(2)->origin()) == lambdaEntrySplit);
 
     auto storeD2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(1)->begin());
     assert(is<StoreNonVolatileOperation>(*storeD2, 3, 1));
-    assert(jlm::rvsdg::node_output::node(storeD2->input(2)->origin()) == lambdaEntrySplit);
+    assert(jlm::rvsdg::output::GetNode(*storeD2->input(2)->origin()) == lambdaEntrySplit);
 
     auto callEntryMerge = jlm::rvsdg::input::GetNode(**storeD1->output(0)->begin());
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 1, 1));
@@ -1584,7 +1582,7 @@ ValidateDeltaTest2SteensgaardAgnosticTopDown(const jlm::tests::DeltaTest2 & test
 
   auto storeD1InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
-  assert(jlm::rvsdg::node_output::node(storeD1InF2->input(2)->origin()) == lambdaEntrySplit);
+  assert(jlm::rvsdg::output::GetNode(*storeD1InF2->input(2)->origin()) == lambdaEntrySplit);
 
   auto d1StateIndex = storeD1InF2->input(2)->origin()->index();
 
@@ -1606,23 +1604,23 @@ ValidateDeltaTest3SteensgaardAgnostic(const jlm::tests::DeltaTest3 & test)
   {
     assert(test.LambdaF().subregion()->nnodes() == 6);
 
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.LambdaF().fctresult(2)->origin());
+    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.LambdaF().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
 
-    auto truncNode = jlm::rvsdg::node_output::node(test.LambdaF().fctresult(0)->origin());
+    auto truncNode = jlm::rvsdg::output::GetNode(*test.LambdaF().fctresult(0)->origin());
     assert(is<trunc_op>(*truncNode, 1, 1));
 
-    auto loadG1Node = jlm::rvsdg::node_output::node(truncNode->input(0)->origin());
+    auto loadG1Node = jlm::rvsdg::output::GetNode(*truncNode->input(0)->origin());
     assert(is<LoadNonVolatileOperation>(*loadG1Node, 2, 2));
 
-    auto lambdaEntrySplit = jlm::rvsdg::node_output::node(loadG1Node->input(1)->origin());
+    auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*loadG1Node->input(1)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
 
     jlm::rvsdg::node * storeG2Node = nullptr;
     for (size_t n = 0; n < lambdaExitMerge->ninputs(); n++)
     {
       auto input = lambdaExitMerge->input(n);
-      auto node = jlm::rvsdg::node_output::node(input->origin());
+      auto node = jlm::rvsdg::output::GetNode(*input->origin());
       if (is<StoreNonVolatileOperation>(node))
       {
         storeG2Node = node;
@@ -1631,10 +1629,10 @@ ValidateDeltaTest3SteensgaardAgnostic(const jlm::tests::DeltaTest3 & test)
     }
     assert(storeG2Node != nullptr);
 
-    auto loadG2Node = jlm::rvsdg::node_output::node(storeG2Node->input(2)->origin());
+    auto loadG2Node = jlm::rvsdg::output::GetNode(*storeG2Node->input(2)->origin());
     assert(is<LoadNonVolatileOperation>(*loadG2Node, 2, 2));
 
-    auto node = jlm::rvsdg::node_output::node(loadG2Node->input(1)->origin());
+    auto node = jlm::rvsdg::output::GetNode(*loadG2Node->input(1)->origin());
     assert(node == lambdaEntrySplit);
   }
 }
@@ -1648,23 +1646,23 @@ ValidateDeltaTest3SteensgaardRegionAware(const jlm::tests::DeltaTest3 & test)
   {
     assert(test.LambdaF().subregion()->nnodes() == 6);
 
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.LambdaF().fctresult(2)->origin());
+    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.LambdaF().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
-    auto truncNode = jlm::rvsdg::node_output::node(test.LambdaF().fctresult(0)->origin());
+    auto truncNode = jlm::rvsdg::output::GetNode(*test.LambdaF().fctresult(0)->origin());
     assert(is<trunc_op>(*truncNode, 1, 1));
 
-    auto loadG1Node = jlm::rvsdg::node_output::node(truncNode->input(0)->origin());
+    auto loadG1Node = jlm::rvsdg::output::GetNode(*truncNode->input(0)->origin());
     assert(is<LoadNonVolatileOperation>(*loadG1Node, 2, 2));
 
-    auto lambdaEntrySplit = jlm::rvsdg::node_output::node(loadG1Node->input(1)->origin());
+    auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*loadG1Node->input(1)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 
     jlm::rvsdg::node * storeG2Node = nullptr;
     for (size_t n = 0; n < lambdaExitMerge->ninputs(); n++)
     {
       auto input = lambdaExitMerge->input(n);
-      auto node = jlm::rvsdg::node_output::node(input->origin());
+      auto node = jlm::rvsdg::output::GetNode(*input->origin());
       if (is<StoreNonVolatileOperation>(node))
       {
         storeG2Node = node;
@@ -1673,10 +1671,10 @@ ValidateDeltaTest3SteensgaardRegionAware(const jlm::tests::DeltaTest3 & test)
     }
     assert(storeG2Node != nullptr);
 
-    auto loadG2Node = jlm::rvsdg::node_output::node(storeG2Node->input(2)->origin());
+    auto loadG2Node = jlm::rvsdg::output::GetNode(*storeG2Node->input(2)->origin());
     assert(is<LoadNonVolatileOperation>(*loadG2Node, 2, 2));
 
-    auto node = jlm::rvsdg::node_output::node(loadG2Node->input(1)->origin());
+    auto node = jlm::rvsdg::output::GetNode(*loadG2Node->input(1)->origin());
     assert(node == lambdaEntrySplit);
   }
 }
@@ -1690,23 +1688,23 @@ ValidateDeltaTest3SteensgaardAgnosticTopDown(const jlm::tests::DeltaTest3 & test
   {
     assert(test.LambdaF().subregion()->nnodes() == 6);
 
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.LambdaF().fctresult(2)->origin());
+    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.LambdaF().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
 
-    auto truncNode = jlm::rvsdg::node_output::node(test.LambdaF().fctresult(0)->origin());
+    auto truncNode = jlm::rvsdg::output::GetNode(*test.LambdaF().fctresult(0)->origin());
     assert(is<trunc_op>(*truncNode, 1, 1));
 
-    auto loadG1Node = jlm::rvsdg::node_output::node(truncNode->input(0)->origin());
+    auto loadG1Node = jlm::rvsdg::output::GetNode(*truncNode->input(0)->origin());
     assert(is<LoadNonVolatileOperation>(*loadG1Node, 2, 2));
 
-    auto lambdaEntrySplit = jlm::rvsdg::node_output::node(loadG1Node->input(1)->origin());
+    auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*loadG1Node->input(1)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
 
     jlm::rvsdg::node * storeG2Node = nullptr;
     for (size_t n = 0; n < lambdaExitMerge->ninputs(); n++)
     {
       auto input = lambdaExitMerge->input(n);
-      auto node = jlm::rvsdg::node_output::node(input->origin());
+      auto node = jlm::rvsdg::output::GetNode(*input->origin());
       if (is<StoreNonVolatileOperation>(node))
       {
         storeG2Node = node;
@@ -1715,10 +1713,10 @@ ValidateDeltaTest3SteensgaardAgnosticTopDown(const jlm::tests::DeltaTest3 & test
     }
     assert(storeG2Node != nullptr);
 
-    auto loadG2Node = jlm::rvsdg::node_output::node(storeG2Node->input(2)->origin());
+    auto loadG2Node = jlm::rvsdg::output::GetNode(*storeG2Node->input(2)->origin());
     assert(is<LoadNonVolatileOperation>(*loadG2Node, 2, 2));
 
-    auto node = jlm::rvsdg::node_output::node(loadG2Node->input(1)->origin());
+    auto node = jlm::rvsdg::output::GetNode(*loadG2Node->input(1)->origin());
     assert(node == lambdaEntrySplit);
   }
 }
@@ -1735,7 +1733,7 @@ ValidateImportTestSteensgaardAgnostic(const jlm::tests::ImportTest & test)
 
   auto storeD1InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
-  assert(jlm::rvsdg::node_output::node(storeD1InF2->input(2)->origin()) == lambdaEntrySplit);
+  assert(jlm::rvsdg::output::GetNode(*storeD1InF2->input(2)->origin()) == lambdaEntrySplit);
 
   auto d1StateIndex = storeD1InF2->input(2)->origin()->index();
 
@@ -1759,13 +1757,13 @@ ValidateImportTestSteensgaardRegionAware(const jlm::tests::ImportTest & test)
   {
     assert(test.lambda_f1->subregion()->nnodes() == 4);
 
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda_f1->fctresult(1)->origin());
+    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda_f1->fctresult(1)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 1, 1));
 
-    auto storeNode = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+    auto storeNode = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
     assert(is<StoreNonVolatileOperation>(*storeNode, 3, 1));
 
-    auto lambdaEntrySplit = jlm::rvsdg::node_output::node(storeNode->input(2)->origin());
+    auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*storeNode->input(2)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 1));
   }
 
@@ -1778,11 +1776,11 @@ ValidateImportTestSteensgaardRegionAware(const jlm::tests::ImportTest & test)
 
     auto storeD1 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(0)->begin());
     assert(is<StoreNonVolatileOperation>(*storeD1, 3, 1));
-    assert(jlm::rvsdg::node_output::node(storeD1->input(2)->origin()) == lambdaEntrySplit);
+    assert(jlm::rvsdg::output::GetNode(*storeD1->input(2)->origin()) == lambdaEntrySplit);
 
     auto storeD2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(1)->begin());
     assert(is<StoreNonVolatileOperation>(*storeD2, 3, 1));
-    assert(jlm::rvsdg::node_output::node(storeD2->input(2)->origin()) == lambdaEntrySplit);
+    assert(jlm::rvsdg::output::GetNode(*storeD2->input(2)->origin()) == lambdaEntrySplit);
 
     auto callEntryMerge = jlm::rvsdg::input::GetNode(**storeD1->output(0)->begin());
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 1, 1));
@@ -1810,7 +1808,7 @@ ValidateImportTestSteensgaardAgnosticTopDown(const jlm::tests::ImportTest & test
 
   auto storeD1InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
-  assert(jlm::rvsdg::node_output::node(storeD1InF2->input(2)->origin()) == lambdaEntrySplit);
+  assert(jlm::rvsdg::output::GetNode(*storeD1InF2->input(2)->origin()) == lambdaEntrySplit);
 
   assert(storeD1InF2->output(0)->nusers() == 1);
   auto d1StateIndexEntry = (*storeD1InF2->output(0)->begin())->index();
@@ -1834,22 +1832,22 @@ ValidatePhiTestSteensgaardAgnostic(const jlm::tests::PhiTest1 & test)
 
   auto arrayStateIndex = (*test.alloca->output(1)->begin())->index();
 
-  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda_fib->fctresult(1)->origin());
+  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda_fib->fctresult(1)->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 4, 1));
 
-  auto store = jlm::rvsdg::node_output::node(lambdaExitMerge->input(arrayStateIndex)->origin());
+  auto store = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(arrayStateIndex)->origin());
   assert(is<StoreNonVolatileOperation>(*store, 3, 1));
 
-  auto gamma = jlm::rvsdg::node_output::node(store->input(2)->origin());
+  auto gamma = jlm::rvsdg::output::GetNode(*store->input(2)->origin());
   assert(gamma == test.gamma);
 
   auto gammaStateIndex = store->input(2)->origin()->index();
 
   auto load1 =
-      jlm::rvsdg::node_output::node(test.gamma->exitvar(gammaStateIndex)->result(0)->origin());
+      jlm::rvsdg::output::GetNode(*test.gamma->exitvar(gammaStateIndex)->result(0)->origin());
   assert(is<LoadNonVolatileOperation>(*load1, 2, 2));
 
-  auto load2 = jlm::rvsdg::node_output::node(load1->input(1)->origin());
+  auto load2 = jlm::rvsdg::output::GetNode(*load1->input(1)->origin());
   assert(is<LoadNonVolatileOperation>(*load2, 2, 2));
 
   assert(load2->input(1)->origin()->index() == arrayStateIndex);
@@ -1862,22 +1860,22 @@ ValidatePhiTestSteensgaardRegionAware(const jlm::tests::PhiTest1 & test)
 
   auto arrayStateIndex = (*test.alloca->output(1)->begin())->index();
 
-  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda_fib->fctresult(1)->origin());
+  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda_fib->fctresult(1)->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 1, 1));
 
-  auto store = jlm::rvsdg::node_output::node(lambdaExitMerge->input(arrayStateIndex)->origin());
+  auto store = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(arrayStateIndex)->origin());
   assert(is<StoreNonVolatileOperation>(*store, 3, 1));
 
-  auto gamma = jlm::rvsdg::node_output::node(store->input(2)->origin());
+  auto gamma = jlm::rvsdg::output::GetNode(*store->input(2)->origin());
   assert(gamma == test.gamma);
 
   auto gammaStateIndex = store->input(2)->origin()->index();
 
   auto load1 =
-      jlm::rvsdg::node_output::node(test.gamma->exitvar(gammaStateIndex)->result(0)->origin());
+      jlm::rvsdg::output::GetNode(*test.gamma->exitvar(gammaStateIndex)->result(0)->origin());
   assert(is<LoadNonVolatileOperation>(*load1, 2, 2));
 
-  auto load2 = jlm::rvsdg::node_output::node(load1->input(1)->origin());
+  auto load2 = jlm::rvsdg::output::GetNode(*load1->input(1)->origin());
   assert(is<LoadNonVolatileOperation>(*load2, 2, 2));
 
   assert(load2->input(1)->origin()->index() == arrayStateIndex);
@@ -1888,14 +1886,14 @@ ValidatePhiTestSteensgaardAgnosticTopDown(const jlm::tests::PhiTest1 & test)
 {
   using namespace jlm::llvm;
 
-  auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.lambda_fib->fctresult(1)->origin());
+  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda_fib->fctresult(1)->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 4, 1));
 
   const StoreNonVolatileNode * storeNode = nullptr;
   const jlm::rvsdg::GammaNode * gammaNode = nullptr;
   for (size_t n = 0; n < lambdaExitMerge->ninputs(); n++)
   {
-    auto node = jlm::rvsdg::node_output::node(lambdaExitMerge->input(n)->origin());
+    auto node = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(n)->origin());
     if (auto castedStoreNode = dynamic_cast<const StoreNonVolatileNode *>(node))
     {
       storeNode = castedStoreNode;
@@ -1916,10 +1914,10 @@ ValidatePhiTestSteensgaardAgnosticTopDown(const jlm::tests::PhiTest1 & test)
   auto gammaStateIndex = storeNode->input(2)->origin()->index();
 
   auto load1 =
-      jlm::rvsdg::node_output::node(test.gamma->exitvar(gammaStateIndex)->result(0)->origin());
+      jlm::rvsdg::output::GetNode(*test.gamma->exitvar(gammaStateIndex)->result(0)->origin());
   assert(is<LoadNonVolatileOperation>(*load1, 2, 2));
 
-  auto load2 = jlm::rvsdg::node_output::node(load1->input(1)->origin());
+  auto load2 = jlm::rvsdg::output::GetNode(*load1->input(1)->origin());
   assert(is<LoadNonVolatileOperation>(*load2, 2, 2));
 }
 
@@ -1932,16 +1930,16 @@ ValidateMemcpySteensgaardAgnostic(const jlm::tests::MemcpyTest & test)
    * Validate function f
    */
   {
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.LambdaF().fctresult(2)->origin());
+    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.LambdaF().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
 
-    auto load = jlm::rvsdg::node_output::node(test.LambdaF().fctresult(0)->origin());
+    auto load = jlm::rvsdg::output::GetNode(*test.LambdaF().fctresult(0)->origin());
     assert(is<LoadNonVolatileOperation>(*load, 3, 3));
 
-    auto store = jlm::rvsdg::node_output::node(load->input(1)->origin());
+    auto store = jlm::rvsdg::output::GetNode(*load->input(1)->origin());
     assert(is<StoreNonVolatileOperation>(*store, 4, 2));
 
-    auto lambdaEntrySplit = jlm::rvsdg::node_output::node(store->input(2)->origin());
+    auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*store->input(2)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
   }
 
@@ -1949,29 +1947,29 @@ ValidateMemcpySteensgaardAgnostic(const jlm::tests::MemcpyTest & test)
    * Validate function g
    */
   {
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.LambdaG().fctresult(2)->origin());
+    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.LambdaG().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
 
-    auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+    auto callExitSplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
     assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 5));
 
-    auto call = jlm::rvsdg::node_output::node(callExitSplit->input(0)->origin());
+    auto call = jlm::rvsdg::output::GetNode(*callExitSplit->input(0)->origin());
     assert(is<CallOperation>(*call, 3, 3));
 
-    auto callEntryMerge = jlm::rvsdg::node_output::node(call->input(2)->origin());
+    auto callEntryMerge = jlm::rvsdg::output::GetNode(*call->input(2)->origin());
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 5, 1));
 
     jlm::rvsdg::node * memcpy = nullptr;
     for (size_t n = 0; n < callEntryMerge->ninputs(); n++)
     {
-      auto node = jlm::rvsdg::node_output::node(callEntryMerge->input(n)->origin());
+      auto node = jlm::rvsdg::output::GetNode(*callEntryMerge->input(n)->origin());
       if (is<MemCpyNonVolatileOperation>(node))
         memcpy = node;
     }
     assert(memcpy != nullptr);
     assert(is<MemCpyNonVolatileOperation>(*memcpy, 7, 4));
 
-    auto lambdaEntrySplit = jlm::rvsdg::node_output::node(memcpy->input(5)->origin());
+    auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*memcpy->input(5)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
   }
 }
@@ -1985,16 +1983,16 @@ ValidateMemcpySteensgaardRegionAware(const jlm::tests::MemcpyTest & test)
    * Validate function f
    */
   {
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.LambdaF().fctresult(2)->origin());
+    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.LambdaF().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
-    auto load = jlm::rvsdg::node_output::node(test.LambdaF().fctresult(0)->origin());
+    auto load = jlm::rvsdg::output::GetNode(*test.LambdaF().fctresult(0)->origin());
     assert(is<LoadNonVolatileOperation>(*load, 3, 3));
 
-    auto store = jlm::rvsdg::node_output::node(load->input(1)->origin());
+    auto store = jlm::rvsdg::output::GetNode(*load->input(1)->origin());
     assert(is<StoreNonVolatileOperation>(*store, 4, 2));
 
-    auto lambdaEntrySplit = jlm::rvsdg::node_output::node(store->input(2)->origin());
+    auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*store->input(2)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
   }
 
@@ -2005,18 +2003,18 @@ ValidateMemcpySteensgaardRegionAware(const jlm::tests::MemcpyTest & test)
     auto callNode = jlm::rvsdg::input::GetNode(**test.LambdaG().cvargument(2)->begin());
     assert(is<CallOperation>(*callNode, 3, 3));
 
-    auto callEntryMerge = jlm::rvsdg::node_output::node(callNode->input(2)->origin());
+    auto callEntryMerge = jlm::rvsdg::output::GetNode(*callNode->input(2)->origin());
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 2, 1));
 
     auto callExitSplit = jlm::rvsdg::input::GetNode(**callNode->output(2)->begin());
     assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 2));
 
-    auto memcpyNode = jlm::rvsdg::node_output::node(callEntryMerge->input(0)->origin());
+    auto memcpyNode = jlm::rvsdg::output::GetNode(*callEntryMerge->input(0)->origin());
     assert(is<MemCpyNonVolatileOperation>(*memcpyNode, 7, 4));
 
-    auto lambdaEntrySplit = jlm::rvsdg::node_output::node(memcpyNode->input(4)->origin());
+    auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*memcpyNode->input(4)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
-    assert(jlm::rvsdg::node_output::node(memcpyNode->input(5)->origin()) == lambdaEntrySplit);
+    assert(jlm::rvsdg::output::GetNode(*memcpyNode->input(5)->origin()) == lambdaEntrySplit);
 
     auto lambdaExitMerge = jlm::rvsdg::input::GetNode(**callExitSplit->output(0)->begin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
@@ -2030,44 +2028,44 @@ ValidateMemcpyTestSteensgaardAgnosticTopDown(const jlm::tests::MemcpyTest & test
 
   // Validate function f
   {
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.LambdaF().fctresult(2)->origin());
+    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.LambdaF().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
 
-    auto load = jlm::rvsdg::node_output::node(test.LambdaF().fctresult(0)->origin());
+    auto load = jlm::rvsdg::output::GetNode(*test.LambdaF().fctresult(0)->origin());
     assert(is<LoadNonVolatileOperation>(*load, 3, 3));
 
-    auto store = jlm::rvsdg::node_output::node(load->input(1)->origin());
+    auto store = jlm::rvsdg::output::GetNode(*load->input(1)->origin());
     assert(is<StoreNonVolatileOperation>(*store, 4, 2));
 
-    auto lambdaEntrySplit = jlm::rvsdg::node_output::node(store->input(2)->origin());
+    auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*store->input(2)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
   }
 
   // Validate function g
   {
-    auto lambdaExitMerge = jlm::rvsdg::node_output::node(test.LambdaG().fctresult(2)->origin());
+    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.LambdaG().fctresult(2)->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
 
-    auto callExitSplit = jlm::rvsdg::node_output::node(lambdaExitMerge->input(0)->origin());
+    auto callExitSplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
     assert(is<CallExitMemoryStateSplitOperation>(*callExitSplit, 1, 5));
 
-    auto call = jlm::rvsdg::node_output::node(callExitSplit->input(0)->origin());
+    auto call = jlm::rvsdg::output::GetNode(*callExitSplit->input(0)->origin());
     assert(is<CallOperation>(*call, 3, 3));
 
-    auto callEntryMerge = jlm::rvsdg::node_output::node(call->input(2)->origin());
+    auto callEntryMerge = jlm::rvsdg::output::GetNode(*call->input(2)->origin());
     assert(is<CallEntryMemoryStateMergeOperation>(*callEntryMerge, 5, 1));
 
     jlm::rvsdg::node * memcpy = nullptr;
     for (size_t n = 0; n < callEntryMerge->ninputs(); n++)
     {
-      auto node = jlm::rvsdg::node_output::node(callEntryMerge->input(n)->origin());
+      auto node = jlm::rvsdg::output::GetNode(*callEntryMerge->input(n)->origin());
       if (is<MemCpyNonVolatileOperation>(node))
         memcpy = node;
     }
     assert(memcpy != nullptr);
     assert(is<MemCpyNonVolatileOperation>(*memcpy, 7, 4));
 
-    auto lambdaEntrySplit = jlm::rvsdg::node_output::node(memcpy->input(5)->origin());
+    auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*memcpy->input(5)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
   }
 }
@@ -2078,13 +2076,14 @@ ValidateFreeNullTestSteensgaardAgnostic(const jlm::tests::FreeNullTest & test)
   using namespace jlm::llvm;
   using namespace jlm::rvsdg;
 
-  auto lambdaExitMerge = node_output::node(test.LambdaMain().GetMemoryStateRegionResult().origin());
+  auto lambdaExitMerge =
+      jlm::rvsdg::output::GetNode(*test.LambdaMain().GetMemoryStateRegionResult().origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
-  auto free = node_output::node(test.LambdaMain().fctresult(0)->origin());
+  auto free = jlm::rvsdg::output::GetNode(*test.LambdaMain().fctresult(0)->origin());
   assert(is<FreeOperation>(*free, 2, 1));
 
-  auto lambdaEntrySplit = node_output::node(lambdaExitMerge->input(0)->origin());
+  auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 }
 

--- a/tests/jlm/llvm/opt/test-cne.cpp
+++ b/tests/jlm/llvm/opt/test-cne.cpp
@@ -172,9 +172,9 @@ test_theta()
   cne.run(rm, statisticsCollector);
   //	jlm::rvsdg::view(graph.root(), stdout);
 
-  auto un1 = jlm::rvsdg::node_output::node(u1);
-  auto un2 = jlm::rvsdg::node_output::node(u2);
-  auto bn1 = jlm::rvsdg::node_output::node(b1);
+  auto un1 = jlm::rvsdg::output::GetNode(*u1);
+  auto un2 = jlm::rvsdg::output::GetNode(*u2);
+  auto bn1 = jlm::rvsdg::output::GetNode(*b1);
   assert(un1->input(0)->origin() == un2->input(0)->origin());
   assert(bn1->input(0)->origin() == un1->input(0)->origin());
   assert(bn1->input(1)->origin() == region->argument(3));
@@ -416,7 +416,7 @@ test_lambda()
   cne.run(rm, statisticsCollector);
   //	jlm::rvsdg::view(graph.root(), stdout);
 
-  auto bn1 = jlm::rvsdg::node_output::node(b1);
+  auto bn1 = jlm::rvsdg::output::GetNode(*b1);
   assert(bn1->input(0)->origin() == bn1->input(1)->origin());
 }
 

--- a/tests/jlm/llvm/opt/test-inlining.cpp
+++ b/tests/jlm/llvm/opt/test-inlining.cpp
@@ -166,7 +166,7 @@ test2()
 
   // Assert
   // Function f1 should not have been inlined.
-  assert(is<CallOperation>(jlm::rvsdg::node_output::node(f2->node()->fctresult(0)->origin())));
+  assert(is<CallOperation>(jlm::rvsdg::output::GetNode(*f2->node()->fctresult(0)->origin())));
 }
 
 static int

--- a/tests/jlm/llvm/opt/test-inversion.cpp
+++ b/tests/jlm/llvm/opt/test-inversion.cpp
@@ -70,9 +70,9 @@ test1()
   tginversion.run(rm, statisticsCollector);
   //	jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(jlm::rvsdg::is<jlm::rvsdg::GammaOperation>(jlm::rvsdg::node_output::node(ex1.origin())));
-  assert(jlm::rvsdg::is<jlm::rvsdg::GammaOperation>(jlm::rvsdg::node_output::node(ex2.origin())));
-  assert(jlm::rvsdg::is<jlm::rvsdg::GammaOperation>(jlm::rvsdg::node_output::node(ex3.origin())));
+  assert(jlm::rvsdg::is<jlm::rvsdg::GammaOperation>(jlm::rvsdg::output::GetNode(*ex1.origin())));
+  assert(jlm::rvsdg::is<jlm::rvsdg::GammaOperation>(jlm::rvsdg::output::GetNode(*ex2.origin())));
+  assert(jlm::rvsdg::is<jlm::rvsdg::GammaOperation>(jlm::rvsdg::output::GetNode(*ex3.origin())));
 }
 
 static inline void
@@ -117,7 +117,7 @@ test2()
   tginversion.run(rm, statisticsCollector);
   //	jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(jlm::rvsdg::is<jlm::rvsdg::GammaOperation>(jlm::rvsdg::node_output::node(ex.origin())));
+  assert(jlm::rvsdg::is<jlm::rvsdg::GammaOperation>(jlm::rvsdg::output::GetNode(*ex.origin())));
 }
 
 static int

--- a/tests/jlm/llvm/opt/test-pull.cpp
+++ b/tests/jlm/llvm/opt/test-pull.cpp
@@ -80,7 +80,7 @@ test_pullin_bottom()
   jlm::llvm::pullin_bottom(gamma);
   //	jlm::rvsdg::view(graph, stdout);
 
-  assert(jlm::rvsdg::node_output::node(xp.origin()) == gamma);
+  assert(jlm::rvsdg::output::GetNode(*xp.origin()) == gamma);
   assert(gamma->subregion(0)->nnodes() == 2);
   assert(gamma->subregion(1)->nnodes() == 2);
 }

--- a/tests/jlm/llvm/opt/test-push.cpp
+++ b/tests/jlm/llvm/opt/test-push.cpp
@@ -136,13 +136,13 @@ test_push_theta_bottom()
   jlm::llvm::push_bottom(theta);
   jlm::rvsdg::view(graph, stdout);
 
-  auto storenode = jlm::rvsdg::node_output::node(ex.origin());
+  auto storenode = jlm::rvsdg::output::GetNode(*ex.origin());
   assert(jlm::rvsdg::is<StoreNonVolatileOperation>(storenode));
   assert(storenode->input(0)->origin() == a);
   assert(jlm::rvsdg::is<jlm::rvsdg::ThetaOperation>(
-      jlm::rvsdg::node_output::node(storenode->input(1)->origin())));
+      jlm::rvsdg::output::GetNode(*storenode->input(1)->origin())));
   assert(jlm::rvsdg::is<jlm::rvsdg::ThetaOperation>(
-      jlm::rvsdg::node_output::node(storenode->input(2)->origin())));
+      jlm::rvsdg::output::GetNode(*storenode->input(2)->origin())));
 }
 
 static int

--- a/tests/jlm/llvm/opt/test-unroll.cpp
+++ b/tests/jlm/llvm/opt/test-unroll.cpp
@@ -262,9 +262,9 @@ test_unknown_boundaries()
   loopunroll.run(rm, statisticsCollector);
   //	jlm::rvsdg::view(graph, stdout);
 
-  auto node = jlm::rvsdg::node_output::node(ex1.origin());
+  auto node = jlm::rvsdg::output::GetNode(*ex1.origin());
   assert(jlm::rvsdg::is<jlm::rvsdg::GammaOperation>(node));
-  node = jlm::rvsdg::node_output::node(node->input(1)->origin());
+  node = jlm::rvsdg::output::GetNode(*node->input(1)->origin());
   assert(jlm::rvsdg::is<jlm::rvsdg::GammaOperation>(node));
 
   /* Create cleaner output */

--- a/tests/jlm/rvsdg/bitstring/bitstring.cpp
+++ b/tests/jlm/rvsdg/bitstring/bitstring.cpp
@@ -36,8 +36,8 @@ types_bitstring_arithmetic_test_bitand(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(node_output::node(and0)->operation() == bitand_op(32));
-  assert(node_output::node(and1)->operation() == int_constant_op(32, +1));
+  assert(output::GetNode(*and0)->operation() == bitand_op(32));
+  assert(output::GetNode(*and1)->operation() == int_constant_op(32, +1));
 
   return 0;
 }
@@ -72,11 +72,11 @@ types_bitstring_arithmetic_test_bitashr(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(node_output::node(ashr0)->operation() == bitashr_op(32));
-  assert(node_output::node(ashr1)->operation() == int_constant_op(32, 4));
-  assert(node_output::node(ashr2)->operation() == int_constant_op(32, 0));
-  assert(node_output::node(ashr3)->operation() == int_constant_op(32, -4));
-  assert(node_output::node(ashr4)->operation() == int_constant_op(32, -1));
+  assert(output::GetNode(*ashr0)->operation() == bitashr_op(32));
+  assert(output::GetNode(*ashr1)->operation() == int_constant_op(32, 4));
+  assert(output::GetNode(*ashr2)->operation() == int_constant_op(32, 0));
+  assert(output::GetNode(*ashr3)->operation() == int_constant_op(32, -4));
+  assert(output::GetNode(*ashr4)->operation() == int_constant_op(32, -1));
 
   return 0;
 }
@@ -99,7 +99,7 @@ types_bitstring_arithmetic_test_bitdifference(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(node_output::node(diff)->operation() == bitsub_op(32));
+  assert(output::GetNode(*diff)->operation() == bitsub_op(32));
 
   return 0;
 }
@@ -125,9 +125,9 @@ types_bitstring_arithmetic_test_bitnegate(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(node_output::node(neg0)->operation() == bitneg_op(32));
-  assert(node_output::node(neg1)->operation() == int_constant_op(32, -3));
-  assert(node_output::node(neg2)->operation() == int_constant_op(32, 3));
+  assert(output::GetNode(*neg0)->operation() == bitneg_op(32));
+  assert(output::GetNode(*neg1)->operation() == int_constant_op(32, -3));
+  assert(output::GetNode(*neg2)->operation() == int_constant_op(32, 3));
 
   return 0;
 }
@@ -153,9 +153,9 @@ types_bitstring_arithmetic_test_bitnot(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(node_output::node(not0)->operation() == bitnot_op(32));
-  assert(node_output::node(not1)->operation() == int_constant_op(32, -4));
-  assert(node_output::node(not2)->operation() == int_constant_op(32, 3));
+  assert(output::GetNode(*not0)->operation() == bitnot_op(32));
+  assert(output::GetNode(*not1)->operation() == int_constant_op(32, -4));
+  assert(output::GetNode(*not2)->operation() == int_constant_op(32, 3));
 
   return 0;
 }
@@ -182,8 +182,8 @@ types_bitstring_arithmetic_test_bitor(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(node_output::node(or0)->operation() == bitor_op(32));
-  assert(node_output::node(or1)->operation() == uint_constant_op(32, 7));
+  assert(output::GetNode(*or0)->operation() == bitor_op(32));
+  assert(output::GetNode(*or1)->operation() == uint_constant_op(32, 7));
 
   return 0;
 }
@@ -211,8 +211,8 @@ types_bitstring_arithmetic_test_bitproduct(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(node_output::node(product0)->operation() == bitmul_op(32));
-  assert(node_output::node(product1)->operation() == uint_constant_op(32, 15));
+  assert(output::GetNode(*product0)->operation() == bitmul_op(32));
+  assert(output::GetNode(*product1)->operation() == uint_constant_op(32, 15));
 
   return 0;
 }
@@ -235,7 +235,7 @@ types_bitstring_arithmetic_test_bitshiproduct(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(node_output::node(shiproduct)->operation() == bitsmulh_op(32));
+  assert(output::GetNode(*shiproduct)->operation() == bitsmulh_op(32));
 
   return 0;
 }
@@ -265,9 +265,9 @@ types_bitstring_arithmetic_test_bitshl(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(node_output::node(shl0)->operation() == bitshl_op(32));
-  assert(node_output::node(shl1)->operation() == uint_constant_op(32, 64));
-  assert(node_output::node(shl2)->operation() == uint_constant_op(32, 0));
+  assert(output::GetNode(*shl0)->operation() == bitshl_op(32));
+  assert(output::GetNode(*shl1)->operation() == uint_constant_op(32, 64));
+  assert(output::GetNode(*shl2)->operation() == uint_constant_op(32, 0));
 
   return 0;
 }
@@ -297,9 +297,9 @@ types_bitstring_arithmetic_test_bitshr(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(node_output::node(shr0)->operation() == bitshr_op(32));
-  assert(node_output::node(shr1)->operation() == uint_constant_op(32, 4));
-  assert(node_output::node(shr2)->operation() == uint_constant_op(32, 0));
+  assert(output::GetNode(*shr0)->operation() == bitshr_op(32));
+  assert(output::GetNode(*shr1)->operation() == uint_constant_op(32, 4));
+  assert(output::GetNode(*shr2)->operation() == uint_constant_op(32, 0));
 
   return 0;
 }
@@ -327,8 +327,8 @@ types_bitstring_arithmetic_test_bitsmod(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(node_output::node(smod0)->operation() == bitsmod_op(32));
-  assert(node_output::node(smod1)->operation() == int_constant_op(32, -1));
+  assert(output::GetNode(*smod0)->operation() == bitsmod_op(32));
+  assert(output::GetNode(*smod1)->operation() == int_constant_op(32, -1));
 
   return 0;
 }
@@ -356,8 +356,8 @@ types_bitstring_arithmetic_test_bitsquotient(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(node_output::node(squot0)->operation() == bitsdiv_op(32));
-  assert(node_output::node(squot1)->operation() == int_constant_op(32, -2));
+  assert(output::GetNode(*squot0)->operation() == bitsdiv_op(32));
+  assert(output::GetNode(*squot1)->operation() == int_constant_op(32, -2));
 
   return 0;
 }
@@ -385,8 +385,8 @@ types_bitstring_arithmetic_test_bitsum(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(node_output::node(sum0)->operation() == bitadd_op(32));
-  assert(node_output::node(sum1)->operation() == int_constant_op(32, 8));
+  assert(output::GetNode(*sum0)->operation() == bitadd_op(32));
+  assert(output::GetNode(*sum1)->operation() == int_constant_op(32, 8));
 
   return 0;
 }
@@ -409,7 +409,7 @@ types_bitstring_arithmetic_test_bituhiproduct(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(node_output::node(uhiproduct)->operation() == bitumulh_op(32));
+  assert(output::GetNode(*uhiproduct)->operation() == bitumulh_op(32));
 
   return 0;
 }
@@ -437,8 +437,8 @@ types_bitstring_arithmetic_test_bitumod(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(node_output::node(umod0)->operation() == bitumod_op(32));
-  assert(node_output::node(umod1)->operation() == int_constant_op(32, 1));
+  assert(output::GetNode(*umod0)->operation() == bitumod_op(32));
+  assert(output::GetNode(*umod1)->operation() == int_constant_op(32, 1));
 
   return 0;
 }
@@ -466,8 +466,8 @@ types_bitstring_arithmetic_test_bituquotient(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(node_output::node(uquot0)->operation() == bitudiv_op(32));
-  assert(node_output::node(uquot1)->operation() == int_constant_op(32, 2));
+  assert(output::GetNode(*uquot0)->operation() == bitudiv_op(32));
+  assert(output::GetNode(*uquot1)->operation() == int_constant_op(32, 2));
 
   return 0;
 }
@@ -494,8 +494,8 @@ types_bitstring_arithmetic_test_bitxor(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(node_output::node(xor0)->operation() == bitxor_op(32));
-  assert(node_output::node(xor1)->operation() == int_constant_op(32, 6));
+  assert(output::GetNode(*xor0)->operation() == bitxor_op(32));
+  assert(output::GetNode(*xor1)->operation() == int_constant_op(32, 6));
 
   return 0;
 }
@@ -503,7 +503,7 @@ types_bitstring_arithmetic_test_bitxor(void)
 static inline void
 expect_static_true(jlm::rvsdg::output * port)
 {
-  auto node = jlm::rvsdg::node_output::node(port);
+  auto node = jlm::rvsdg::output::GetNode(*port);
   auto op = dynamic_cast<const jlm::rvsdg::bitconstant_op *>(&node->operation());
   assert(op && op->value().nbits() == 1 && op->value().str() == "1");
 }
@@ -511,7 +511,7 @@ expect_static_true(jlm::rvsdg::output * port)
 static inline void
 expect_static_false(jlm::rvsdg::output * port)
 {
-  auto node = jlm::rvsdg::node_output::node(port);
+  auto node = jlm::rvsdg::output::GetNode(*port);
   auto op = dynamic_cast<const jlm::rvsdg::bitconstant_op *>(&node->operation());
   assert(op && op->value().nbits() == 1 && op->value().str() == "0");
 }
@@ -542,10 +542,10 @@ types_bitstring_comparison_test_bitequal(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(node_output::node(equal0)->operation() == biteq_op(32));
+  assert(output::GetNode(*equal0)->operation() == biteq_op(32));
   expect_static_true(equal1);
   expect_static_false(equal2);
-  assert(node_output::node(equal3)->operation() == biteq_op(32));
+  assert(output::GetNode(*equal3)->operation() == biteq_op(32));
 
   return 0;
 }
@@ -576,10 +576,10 @@ types_bitstring_comparison_test_bitnotequal(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(node_output::node(nequal0)->operation() == bitne_op(32));
+  assert(output::GetNode(*nequal0)->operation() == bitne_op(32));
   expect_static_false(nequal1);
   expect_static_true(nequal2);
-  assert(node_output::node(nequal3)->operation() == bitne_op(32));
+  assert(output::GetNode(*nequal3)->operation() == bitne_op(32));
 
   return 0;
 }
@@ -613,7 +613,7 @@ types_bitstring_comparison_test_bitsgreater(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(node_output::node(sgreater0)->operation() == bitsgt_op(32));
+  assert(output::GetNode(*sgreater0)->operation() == bitsgt_op(32));
   expect_static_false(sgreater1);
   expect_static_true(sgreater2);
   expect_static_false(sgreater3);
@@ -653,7 +653,7 @@ types_bitstring_comparison_test_bitsgreatereq(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(node_output::node(sgreatereq0)->operation() == bitsge_op(32));
+  assert(output::GetNode(*sgreatereq0)->operation() == bitsge_op(32));
   expect_static_false(sgreatereq1);
   expect_static_true(sgreatereq2);
   expect_static_true(sgreatereq3);
@@ -692,7 +692,7 @@ types_bitstring_comparison_test_bitsless(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(node_output::node(sless0)->operation() == bitslt_op(32));
+  assert(output::GetNode(*sless0)->operation() == bitslt_op(32));
   expect_static_true(sless1);
   expect_static_false(sless2);
   expect_static_false(sless3);
@@ -732,7 +732,7 @@ types_bitstring_comparison_test_bitslesseq(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(node_output::node(slesseq0)->operation() == bitsle_op(32));
+  assert(output::GetNode(*slesseq0)->operation() == bitsle_op(32));
   expect_static_true(slesseq1);
   expect_static_true(slesseq2);
   expect_static_false(slesseq3);
@@ -771,7 +771,7 @@ types_bitstring_comparison_test_bitugreater(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(node_output::node(ugreater0)->operation() == bitugt_op(32));
+  assert(output::GetNode(*ugreater0)->operation() == bitugt_op(32));
   expect_static_false(ugreater1);
   expect_static_true(ugreater2);
   expect_static_false(ugreater3);
@@ -811,7 +811,7 @@ types_bitstring_comparison_test_bitugreatereq(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(node_output::node(ugreatereq0)->operation() == bituge_op(32));
+  assert(output::GetNode(*ugreatereq0)->operation() == bituge_op(32));
   expect_static_false(ugreatereq1);
   expect_static_true(ugreatereq2);
   expect_static_true(ugreatereq3);
@@ -850,7 +850,7 @@ types_bitstring_comparison_test_bituless(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(node_output::node(uless0)->operation() == bitult_op(32));
+  assert(output::GetNode(*uless0)->operation() == bitult_op(32));
   expect_static_true(uless1);
   expect_static_false(uless2);
   expect_static_false(uless3);
@@ -890,7 +890,7 @@ types_bitstring_comparison_test_bitulesseq(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(node_output::node(ulesseq0)->operation() == bitule_op(32));
+  assert(output::GetNode(*ulesseq0)->operation() == bitule_op(32));
   expect_static_true(ulesseq1);
   expect_static_true(ulesseq2);
   expect_static_false(ulesseq3);
@@ -935,10 +935,10 @@ types_bitstring_test_constant(void)
 
   jlm::rvsdg::graph graph;
 
-  auto b1 = node_output::node(create_bitconstant(graph.root(), "00110011"));
-  auto b2 = node_output::node(create_bitconstant(graph.root(), 8, 204));
-  auto b3 = node_output::node(create_bitconstant(graph.root(), 8, 204));
-  auto b4 = node_output::node(create_bitconstant(graph.root(), "001100110"));
+  auto b1 = output::GetNode(*create_bitconstant(graph.root(), "00110011"));
+  auto b2 = output::GetNode(*create_bitconstant(graph.root(), 8, 204));
+  auto b3 = output::GetNode(*create_bitconstant(graph.root(), 8, 204));
+  auto b4 = output::GetNode(*create_bitconstant(graph.root(), "001100110"));
 
   assert(b1->operation() == uint_constant_op(8, 204));
   assert(b1->operation() == int_constant_op(8, -52));
@@ -952,11 +952,11 @@ types_bitstring_test_constant(void)
   assert(b4->operation() == uint_constant_op(9, 204));
   assert(b4->operation() == int_constant_op(9, 204));
 
-  auto plus_one_128 = node_output::node(create_bitconstant(graph.root(), ONE_64 ZERO_64));
+  auto plus_one_128 = output::GetNode(*create_bitconstant(graph.root(), ONE_64 ZERO_64));
   assert(plus_one_128->operation() == uint_constant_op(128, 1));
   assert(plus_one_128->operation() == int_constant_op(128, 1));
 
-  auto minus_one_128 = node_output::node(create_bitconstant(graph.root(), MONE_64 MONE_64));
+  auto minus_one_128 = output::GetNode(*create_bitconstant(graph.root(), MONE_64 MONE_64));
   assert(minus_one_128->operation() == int_constant_op(128, -1));
 
   jlm::rvsdg::view(graph.root(), stdout);
@@ -981,11 +981,11 @@ types_bitstring_test_normalize(void)
   assert(sum_nf);
   sum_nf->set_mutable(false);
 
-  auto sum0 = node_output::node(bitadd_op::create(32, imp, c0));
+  auto sum0 = output::GetNode(*bitadd_op::create(32, imp, c0));
   assert(sum0->operation() == bitadd_op(32));
   assert(sum0->ninputs() == 2);
 
-  auto sum1 = node_output::node(bitadd_op::create(32, sum0->output(0), c1));
+  auto sum1 = output::GetNode(*bitadd_op::create(32, sum0->output(0), c1));
   assert(sum1->operation() == bitadd_op(32));
   assert(sum1->ninputs() == 2);
 
@@ -1007,7 +1007,7 @@ types_bitstring_test_normalize(void)
     op2 = tmp;
   }
   /* FIXME: the graph traversers are currently broken, that is why it won't normalize */
-  assert(node_output::node(op1)->operation() == int_constant_op(32, 3 + 4));
+  assert(output::GetNode(*op1)->operation() == int_constant_op(32, 3 + 4));
   assert(op2 == imp);
 
   jlm::rvsdg::view(graph.root(), stdout);
@@ -1018,7 +1018,7 @@ types_bitstring_test_normalize(void)
 static void
 assert_constant(jlm::rvsdg::output * bitstr, size_t nbits, const char bits[])
 {
-  auto node = jlm::rvsdg::node_output::node(bitstr);
+  auto node = jlm::rvsdg::output::GetNode(*bitstr);
   auto op = dynamic_cast<const jlm::rvsdg::bitconstant_op &>(node->operation());
   assert(op.value() == jlm::rvsdg::bitvalue_repr(std::string(bits, nbits).c_str()));
 }
@@ -1049,7 +1049,7 @@ types_bitstring_test_reduction(void)
 
   {
     auto concat = jlm::rvsdg::bitconcat({ x, y });
-    auto node = node_output::node(jlm::rvsdg::bitslice(concat, 8, 24));
+    auto node = output::GetNode(*jlm::rvsdg::bitslice(concat, 8, 24));
     auto o0 = dynamic_cast<node_output *>(node->input(0)->origin());
     auto o1 = dynamic_cast<node_output *>(node->input(1)->origin());
     assert(dynamic_cast<const bitconcat_op *>(&node->operation()));
@@ -1093,7 +1093,7 @@ types_bitstring_test_slice_concat(void)
 
   {
     /* slice of constant */
-    auto a = node_output::node(jlm::rvsdg::bitslice(base_const1, 2, 6));
+    auto a = output::GetNode(*jlm::rvsdg::bitslice(base_const1, 2, 6));
 
     auto & op = dynamic_cast<const bitconstant_op &>(a->operation());
     assert(op.value() == bitvalue_repr("1101"));
@@ -1102,7 +1102,7 @@ types_bitstring_test_slice_concat(void)
   {
     /* slice of slice */
     auto a = jlm::rvsdg::bitslice(base_x, 2, 6);
-    auto b = node_output::node(jlm::rvsdg::bitslice(a, 1, 3));
+    auto b = output::GetNode(*jlm::rvsdg::bitslice(a, 1, 3));
 
     assert(dynamic_cast<const bitslice_op *>(&b->operation()));
     const bitslice_op * attrs;
@@ -1130,7 +1130,7 @@ types_bitstring_test_slice_concat(void)
   {
     /* concat flattening */
     auto a = jlm::rvsdg::bitconcat({ base_x, base_y });
-    auto b = node_output::node(jlm::rvsdg::bitconcat({ a, base_z }));
+    auto b = output::GetNode(*jlm::rvsdg::bitconcat({ a, base_z }));
 
     assert(dynamic_cast<const bitconcat_op *>(&b->operation()));
     assert(b->ninputs() == 3);
@@ -1157,7 +1157,7 @@ types_bitstring_test_slice_concat(void)
 
   {
     /* concat of constants */
-    auto a = node_output::node(jlm::rvsdg::bitconcat({ base_const1, base_const2 }));
+    auto a = output::GetNode(*jlm::rvsdg::bitconcat({ base_const1, base_const2 }));
 
     auto & op = dynamic_cast<const bitconstant_op &>(a->operation());
     assert(op.value() == bitvalue_repr("0011011111001000"));

--- a/tests/jlm/rvsdg/test-binary.cpp
+++ b/tests/jlm/rvsdg/test-binary.cpp
@@ -41,13 +41,13 @@ test_flattened_binary_reduction()
 
     assert(graph.root()->nnodes() == 3);
 
-    auto node0 = node_output::node(ex.origin());
+    auto node0 = output::GetNode(*ex.origin());
     assert(is<jlm::tests::binary_op>(node0));
 
-    auto node1 = node_output::node(node0->input(0)->origin());
+    auto node1 = output::GetNode(*node0->input(0)->origin());
     assert(is<jlm::tests::binary_op>(node1));
 
-    auto node2 = node_output::node(node0->input(1)->origin());
+    auto node2 = output::GetNode(*node0->input(1)->origin());
     assert(is<jlm::tests::binary_op>(node2));
   }
 
@@ -75,13 +75,13 @@ test_flattened_binary_reduction()
 
     assert(graph.root()->nnodes() == 3);
 
-    auto node0 = node_output::node(ex.origin());
+    auto node0 = output::GetNode(*ex.origin());
     assert(is<jlm::tests::binary_op>(node0));
 
-    auto node1 = node_output::node(node0->input(0)->origin());
+    auto node1 = output::GetNode(*node0->input(0)->origin());
     assert(is<jlm::tests::binary_op>(node1));
 
-    auto node2 = node_output::node(node1->input(0)->origin());
+    auto node2 = output::GetNode(*node1->input(0)->origin());
     assert(is<jlm::tests::binary_op>(node2));
   }
 }

--- a/tests/jlm/rvsdg/test-gamma.cpp
+++ b/tests/jlm/rvsdg/test-gamma.cpp
@@ -137,12 +137,12 @@ test_control_constant_reduction()
   graph.normalize();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  auto match = node_output::node(ex1.origin());
+  auto match = output::GetNode(*ex1.origin());
   assert(match && is<match_op>(match->operation()));
   auto & match_op = to_match_op(match->operation());
   assert(match_op.default_alternative() == 0);
 
-  assert(node_output::node(ex2.origin()) == gamma);
+  assert(output::GetNode(*ex2.origin()) == gamma);
 }
 
 static void
@@ -172,7 +172,7 @@ test_control_constant_reduction2()
   graph.normalize();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  auto match = node_output::node(ex.origin());
+  auto match = output::GetNode(*ex.origin());
   assert(is<match_op>(match));
 }
 

--- a/tests/jlm/rvsdg/test-statemux.cpp
+++ b/tests/jlm/rvsdg/test-statemux.cpp
@@ -45,7 +45,7 @@ test_mux_mux_reduction()
 
   //	jlm::rvsdg::view(graph.root(), stdout);
 
-  auto node = node_output::node(ex.origin());
+  auto node = output::GetNode(*ex.origin());
   assert(node->ninputs() == 4);
   assert(node->input(0)->origin() == x);
   assert(node->input(1)->origin() == y);
@@ -79,7 +79,7 @@ test_multiple_origin_reduction()
 
   view(graph.root(), stdout);
 
-  assert(node_output::node(ex.origin())->ninputs() == 1);
+  assert(output::GetNode(*ex.origin())->ninputs() == 1);
 }
 
 static int


### PR DESCRIPTION
The method was superseded by `output::GetNode()`.