### PR TITLE
Simplify annotation computations in RvsdgTreePrinter class

### DIFF
--- a/jlm/llvm/opt/RvsdgTreePrinter.cpp
+++ b/jlm/llvm/opt/RvsdgTreePrinter.cpp
@@ -130,26 +130,10 @@ RvsdgTreePrinter::AnnotateNumMemoryStateInputsOutputs(
 
   std::function<void(const rvsdg::Region &)> annotateRegion = [&](const rvsdg::Region & region)
   {
-    size_t numMemoryStateArguments = 0;
-    for (size_t n = 0; n < region.narguments(); n++)
-    {
-      auto argument = region.argument(n);
-      if (rvsdg::is<MemoryStateType>(argument->type()))
-      {
-        numMemoryStateArguments++;
-      }
-    }
+    auto numMemoryStateArguments = region.Arguments().CountWhere(IsMemoryStateOutput);
     annotationMap.AddAnnotation(&region, { argumentLabel, numMemoryStateArguments });
 
-    size_t numMemoryStateResults = 0;
-    for (size_t n = 0; n < region.nresults(); n++)
-    {
-      auto result = region.result(n);
-      if (rvsdg::is<MemoryStateType>(result->type()))
-      {
-        numMemoryStateResults++;
-      }
-    }
+    auto numMemoryStateResults = region.Results().CountWhere(IsMemoryStateInput);
     annotationMap.AddAnnotation(&region, { resultLabel, numMemoryStateResults });
 
     for (auto & node : region.nodes)
@@ -218,6 +202,18 @@ RvsdgTreePrinter::GetOutputFileNameCounter(const RvsdgModule & rvsdgModule)
   static std::unordered_map<std::string_view, uint64_t> RvsdgModuleCounterMap_;
 
   return RvsdgModuleCounterMap_[rvsdgModule.SourceFileName().to_str()]++;
+}
+
+bool
+RvsdgTreePrinter::IsMemoryStateInput(const rvsdg::input * input) noexcept
+{
+  return rvsdg::is<MemoryStateType>(input->Type());
+}
+
+bool
+RvsdgTreePrinter::IsMemoryStateOutput(const rvsdg::output * output) noexcept
+{
+  return rvsdg::is<MemoryStateType>(output->Type());
 }
 
 }

--- a/jlm/llvm/opt/RvsdgTreePrinter.cpp
+++ b/jlm/llvm/opt/RvsdgTreePrinter.cpp
@@ -130,10 +130,14 @@ RvsdgTreePrinter::AnnotateNumMemoryStateInputsOutputs(
 
   std::function<void(const rvsdg::Region &)> annotateRegion = [&](const rvsdg::Region & region)
   {
-    auto numMemoryStateArguments = region.Arguments().CountWhere(IsMemoryStateOutput);
+    auto argumentRange = region.Arguments();
+    auto numMemoryStateArguments =
+        std::count_if(argumentRange.begin(), argumentRange.end(), IsMemoryStateOutput);
     annotationMap.AddAnnotation(&region, { argumentLabel, numMemoryStateArguments });
 
-    auto numMemoryStateResults = region.Results().CountWhere(IsMemoryStateInput);
+    auto resultRange = region.Results();
+    auto numMemoryStateResults =
+        std::count_if(resultRange.begin(), resultRange.end(), IsMemoryStateInput);
     annotationMap.AddAnnotation(&region, { resultLabel, numMemoryStateResults });
 
     for (auto & node : region.nodes)

--- a/jlm/llvm/opt/RvsdgTreePrinter.hpp
+++ b/jlm/llvm/opt/RvsdgTreePrinter.hpp
@@ -14,6 +14,8 @@
 namespace jlm::rvsdg
 {
 class graph;
+class input;
+class output;
 }
 
 namespace jlm::util
@@ -165,6 +167,12 @@ private:
 
   static uint64_t
   GetOutputFileNameCounter(const RvsdgModule & rvsdgModule);
+
+  [[nodiscard]] static bool
+  IsMemoryStateInput(const rvsdg::input * input) noexcept;
+
+  [[nodiscard]] static bool
+  IsMemoryStateOutput(const rvsdg::output * output) noexcept;
 
   Configuration Configuration_;
 };

--- a/jlm/util/iterator_range.hpp
+++ b/jlm/util/iterator_range.hpp
@@ -42,30 +42,6 @@ public:
     return end_;
   }
 
-  /**
-   * Count all elements in this range that match the specified condition \p match.
-   *
-   * @tparam F A type that supports the function call operator bool operator(const E e), where E
-   * is the element type returned by the dereference operator of the iterators in this range.
-   * @param match Defines the condition for the elements to be counted.
-   * @return The number of times an element in the range fulfilled the condition \p match.
-   */
-  template<typename F>
-  std::size_t
-  CountWhere(const F & match)
-  {
-    std::size_t count = 0;
-    for (auto it = begin(); it != end(); it++)
-    {
-      if (match(*it))
-      {
-        count++;
-      }
-    }
-
-    return count;
-  }
-
 private:
   T begin_, end_;
 };

--- a/jlm/util/iterator_range.hpp
+++ b/jlm/util/iterator_range.hpp
@@ -42,6 +42,30 @@ public:
     return end_;
   }
 
+  /**
+   * Count all elements in this range that match the specified condition \p match.
+   *
+   * @tparam F A type that supports the function call operator bool operator(const E e), where E
+   * is the element type returned by the dereference operator of the iterators in this range.
+   * @param match Defines the condition for the elements to be counted.
+   * @return The number of times an element in the range fulfilled the condition \p match.
+   */
+  template<typename F>
+  std::size_t
+  CountWhere(const F & match)
+  {
+    std::size_t count = 0;
+    for (auto it = begin(); it != end(); it++)
+    {
+      if (match(*it))
+      {
+        count++;
+      }
+    }
+
+    return count;
+  }
+
 private:
   T begin_, end_;
 };


### PR DESCRIPTION
Use `std::count_if()` instead of explicit iteration to compute relevant annotations in `RvsdgTreePrinter` class.