### PR TITLE
[AndersenAgnostic] Backport fixes and expanded statistics for Andersen analysis

### DIFF
--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -154,9 +154,10 @@ Andersen::Configuration::GetAllConfigurations()
 class Andersen::Statistics final : public util::Statistics
 {
   static constexpr const char * NumPointerObjects_ = "#PointerObjects";
-  static constexpr const char * NumPointerObjectsWithImplicitPointees_ =
-      "#PointerObjectsWithImplicitPointees";
+  static constexpr const char * NumMemoryPointerObjects_ = "#MemoryPointerObjects";
+  static constexpr const char * NumMemoryPointerObjectsCanPoint_ = "#MemoryPointerObjectsCanPoint";
   static constexpr const char * NumRegisterPointerObjects_ = "#RegisterPointerObjects";
+  // A PointerObject of Register kind can represent multiple outputs in RVSDG. Sum them up.
   static constexpr const char * NumRegistersMappedToPointerObject_ =
       "#RegistersMappedToPointerObject";
 
@@ -169,12 +170,12 @@ class Andersen::Statistics final : public util::Statistics
 
   static constexpr const char * Configuration_ = "Configuration";
 
-  // Offline technique statistics
+  // ====== Offline technique statistics ======
   static constexpr const char * NumUnificationsOvs_ = "#Unifications(OVS)";
   static constexpr const char * NumConstraintsRemovedOfflineNorm_ =
       "#ConstraintsRemoved(OfflineNorm)";
 
-  // Solver statistics
+  // ====== Solver statistics ======
   static constexpr const char * NumNaiveSolverIterations_ = "#NaiveSolverIterations";
 
   static constexpr const char * WorklistPolicy_ = "WorklistPolicy";
@@ -184,7 +185,7 @@ class Andersen::Statistics final : public util::Statistics
       "#WorklistSolverWorkItemsNewPointees";
   static constexpr const char * NumTopologicalWorklistSweeps_ = "#TopologicalWorklistSweeps";
 
-  // Online technique statistics
+  // ====== Online technique statistics ======
   static constexpr const char * NumOnlineCyclesDetected_ = "#OnlineCyclesDetected";
   static constexpr const char * NumOnlineCycleUnifications_ = "#OnlineCycleUnifications";
 
@@ -196,15 +197,56 @@ class Andersen::Statistics final : public util::Statistics
 
   static constexpr const char * NumPIPExplicitPointeesRemoved_ = "#PIPExplicitPointeesRemoved";
 
-  // After solving statistics
-  static constexpr const char * NumEscapedMemoryObjects_ = "#EscapedMemoryObjects";
+  // ====== During solving points-to set statistics ======
+  // How many times a pointee has been attempted inserted into an explicit points-to set.
+  // If a set with 10 elements is unioned into another set, that counts as 10 insertion attempts.
+  static constexpr const char * NumSetInsertionAttempts_ = "#PointsToSetInsertionAttempts";
+  // How many explicit pointees have been removed from points-to sets during solving.
+  // Removal can only happen due to unification, or explicitly when using PIP
+  static constexpr const char * NumExplicitPointeesRemoved_ = "#ExplicitPointeesRemoved";
+
+  // ====== After solving statistics ======
+  // How many disjoint sets of PointerObjects exist
   static constexpr const char * NumUnificationRoots_ = "#UnificationRoots";
-  // These next measurements only count flags and pointees of unification roots
-  static constexpr const char * NumPointsToExternalFlags_ = "#PointsToExternalFlags";
-  static constexpr const char * NumPointeesEscapingFlags_ = "#PointeesEscapingFlags";
+  // How many memory objects where CanPoint() == true have escaped
+  static constexpr const char * NumCanPointsEscaped_ = "#CanPointsEscaped";
+  // How many memory objects where CanPoint() == false have escaped
+  static constexpr const char * NumCantPointsEscaped_ = "#CantPointsEscaped";
+
+  // The number of explicit pointees, counting only unification roots
   static constexpr const char * NumExplicitPointees_ = "#ExplicitPointees";
-  // If a pointee is both implicit (through PointsToExternal flag) and explicit
+  // Only unification roots may have explicit pointees, but all PointerObjects in the unification
+  // marked CanPoint effectively have those explicit pointees. Add up the number of such relations.
+  static constexpr const char * NumExplicitPointsToRelations_ = "#ExplicitPointsToRelations";
+
+  // The number of PointsToExternal flags, counting only unification roots
+  static constexpr const char * NumPointsToExternalFlags_ = "#PointsToExternalFlags";
+  // Among all PointerObjects marked CanPoint, how many are in a unification pointing to external
+  static constexpr const char * NumPointsToExternalRelations_ = "#PointsToExternalRelations";
+
+  // Among all PointerObjects marked CanPoint and NOT flagged as pointing to external,
+  // add up how many pointer-pointee relations they have.
+  static constexpr const char * NumExplicitPointsToRelationsAmongPrecise_ =
+      "#ExplicitPointsToRelationsAmongPrecise";
+
+  // The number of PointeesEscaping flags, counting only unification roots
+  static constexpr const char * NumPointeesEscapingFlags_ = "#PointeesEscapingFlags";
+  // Among all PointerObjects marked CanPoint, how many are in a unification where pointees escape.
+  static constexpr const char * NumPointeesEscapingRelations_ = "#PointeesEscapingRelations";
+
+  // The total number of pointer-pointee relations, counting both explicit and implicit.
+  // In the case of doubled up pointees, the same pointer-pointee relation is not counted twice.
+  static constexpr const char * NumPointsToRelations_ = "#PointsToRelations";
+
+  // The number of doubled up pointees, only counting unification roots
   static constexpr const char * NumDoubledUpPointees_ = "#DoubledUpPointees";
+  // The number of doubled up pointees, counting all PointerObjects marked CanPoint()
+  static constexpr const char * NumDoubledUpPointsToRelations_ = "#DoubledUpPointsToRelations";
+
+  // Number of unifications where no members have the CanPoint flag
+  static constexpr const char * NumCantPointUnifications_ = "#CantPointUnifications";
+  // In unifications where no member CanPoint, add up their explicit pointees
+  static constexpr const char * NumCantPointExplicitPointees_ = "#CantPointExplicitPointees";
 
   static constexpr const char * AnalysisTimer_ = "AnalysisTimer";
   static constexpr const char * SetAndConstraintBuildingTimer_ = "SetAndConstraintBuildingTimer";
@@ -244,12 +286,9 @@ public:
     GetTimer(SetAndConstraintBuildingTimer_).stop();
 
     AddMeasurement(NumPointerObjects_, set.NumPointerObjects());
-    AddMeasurement(
-        NumPointerObjectsWithImplicitPointees_,
-        set.NumPointerObjectsWithImplicitPointees());
-    AddMeasurement(
-        NumRegisterPointerObjects_,
-        set.NumPointerObjectsOfKind(PointerObjectKind::Register));
+    AddMeasurement(NumMemoryPointerObjects_, set.NumMemoryPointerObjects());
+    AddMeasurement(NumMemoryPointerObjectsCanPoint_, set.NumMemoryPointerObjectsCanPoint());
+    AddMeasurement(NumRegisterPointerObjects_, set.NumRegisterPointerObjects());
     AddMeasurement(NumRegistersMappedToPointerObject_, set.GetRegisterMap().size());
 
     size_t numSupersetConstraints = 0;
@@ -352,8 +391,8 @@ public:
     if (statistics.NumLazyCycleUnifications)
       AddMeasurement(NumLazyCycleUnifications_, *statistics.NumLazyCycleUnifications);
 
-    if (statistics.NumExplicitPointeesRemoved)
-      AddMeasurement(NumPIPExplicitPointeesRemoved_, *statistics.NumExplicitPointeesRemoved);
+    if (statistics.NumPipExplicitPointeesRemoved)
+      AddMeasurement(NumPIPExplicitPointeesRemoved_, *statistics.NumPipExplicitPointeesRemoved);
   }
 
   void
@@ -365,18 +404,67 @@ public:
   void
   AddStatisticsFromSolution(const PointerObjectSet & set)
   {
-    size_t numEscapedMemoryObjects = 0;
+    AddMeasurement(NumSetInsertionAttempts_, set.GetNumSetInsertionAttempts());
+    AddMeasurement(NumExplicitPointeesRemoved_, set.GetNumExplicitPointeesRemoved());
+
     size_t numUnificationRoots = 0;
-    size_t numPointsToExternalFlags = 0;
-    size_t numPointeesEscapingFlags = 0;
+
+    size_t numCanPointEscaped = 0;
+    size_t numCantPointEscaped = 0;
+
     size_t numExplicitPointees = 0;
-    size_t numDoubleUpPointees = 0;
+    size_t numExplicitPointsToRelations = 0;
+    size_t numExplicitPointeeRelationsAmongPrecise = 0;
+
+    size_t numPointsToExternalFlags = 0;
+    size_t numPointsToExternalRelations = 0;
+    size_t numPointeesEscapingFlags = 0;
+    size_t numPointeesEscapingRelations = 0;
+
+    size_t numDoubledUpPointees = 0;
+    size_t numDoubledUpPointsToRelations = 0;
+
+    std::vector<bool> unificationHasCanPoint(set.NumPointerObjects(), false);
 
     for (PointerObjectIndex i = 0; i < set.NumPointerObjects(); i++)
     {
       if (set.HasEscaped(i))
-        numEscapedMemoryObjects++;
+      {
+        if (set.CanPoint(i))
+          numCanPointEscaped++;
+        else
+          numCantPointEscaped++;
+      }
 
+      const auto & pointees = set.GetPointsToSet(i);
+
+      if (set.CanPoint(i))
+      {
+        numExplicitPointsToRelations += pointees.Size();
+        numPointeesEscapingRelations += set.HasPointeesEscaping(i);
+
+        if (set.IsPointingToExternal(i))
+        {
+          numPointsToExternalRelations++;
+          for (auto pointee : pointees.Items())
+          {
+            if (set.HasEscaped(pointee))
+              numDoubledUpPointsToRelations++;
+          }
+        }
+        else
+        {
+          // When comparing precision, the number of explicit pointees is more interesting among
+          // pointers that do not also point to external.
+          numExplicitPointeeRelationsAmongPrecise += pointees.Size();
+        }
+
+        // This unification has at least one CanPoint member
+        unificationHasCanPoint[set.GetUnificationRoot(i)] = true;
+      }
+
+      // The rest of this loop is only concerned with unification roots, as they are the only
+      // PointerObjects that actually have explicit pointees or flags
       if (!set.IsUnificationRoot(i))
         continue;
 
@@ -386,21 +474,56 @@ public:
       if (set.HasPointeesEscaping(i))
         numPointeesEscapingFlags++;
 
-      const auto & pointees = set.GetPointsToSet(i);
       numExplicitPointees += pointees.Size();
 
       // If the PointsToExternal flag is set, any explicit pointee that has escaped is doubled up
       if (set.IsPointingToExternal(i))
         for (auto pointee : pointees.Items())
           if (set.HasEscaped(pointee))
-            numDoubleUpPointees++;
+            numDoubledUpPointees++;
     }
-    AddMeasurement(NumEscapedMemoryObjects_, numEscapedMemoryObjects);
+
+    // Now find unifications where no member is marked CanPoint, as any explicit pointee is a waste
+    size_t numCantPointUnifications = 0;
+    size_t numCantPointExplicitPointees = 0;
+    for (PointerObjectIndex i = 0; i < set.NumPointerObjects(); i++)
+    {
+      if (!set.IsUnificationRoot(i))
+        continue;
+      if (unificationHasCanPoint[i])
+        continue;
+      numCantPointUnifications++;
+      numCantPointExplicitPointees += set.GetPointsToSet(i).Size();
+    }
+
     AddMeasurement(NumUnificationRoots_, numUnificationRoots);
-    AddMeasurement(NumPointsToExternalFlags_, numPointsToExternalFlags);
-    AddMeasurement(NumPointeesEscapingFlags_, numPointeesEscapingFlags);
+    AddMeasurement(NumCanPointsEscaped_, numCanPointEscaped);
+    AddMeasurement(NumCantPointsEscaped_, numCantPointEscaped);
+
     AddMeasurement(NumExplicitPointees_, numExplicitPointees);
-    AddMeasurement(NumDoubledUpPointees_, numDoubleUpPointees);
+    AddMeasurement(NumExplicitPointsToRelations_, numExplicitPointsToRelations);
+    AddMeasurement(
+        NumExplicitPointsToRelationsAmongPrecise_,
+        numExplicitPointeeRelationsAmongPrecise);
+
+    AddMeasurement(NumPointsToExternalFlags_, numPointsToExternalFlags);
+    AddMeasurement(NumPointsToExternalRelations_, numPointsToExternalRelations);
+    AddMeasurement(NumPointeesEscapingFlags_, numPointeesEscapingFlags);
+    AddMeasurement(NumPointeesEscapingRelations_, numPointeesEscapingRelations);
+
+    // Calculate the total number of pointer-pointee relations by adding up all explicit and
+    // implicit relations, and removing the doubled up relations.
+    size_t numPointsToRelations =
+        numExplicitPointsToRelations - numDoubledUpPointsToRelations
+        + numPointsToExternalRelations * (numCanPointEscaped + numCantPointEscaped);
+
+    AddMeasurement(NumPointsToRelations_, numPointsToRelations);
+
+    AddMeasurement(NumDoubledUpPointees_, numDoubledUpPointees);
+    AddMeasurement(NumDoubledUpPointsToRelations_, numDoubledUpPointsToRelations);
+
+    AddMeasurement(NumCantPointUnifications_, numCantPointUnifications);
+    AddMeasurement(NumCantPointExplicitPointees_, numCantPointExplicitPointees);
   }
 
   void
@@ -440,6 +563,9 @@ public:
     AddMeasurement(
         Label::NumPointsToGraphExternalMemorySources,
         pointsToGraph.GetExternalMemoryNode().NumSources());
+    auto [numEdges, numPointsToRelations] = pointsToGraph.NumEdges();
+    AddMeasurement(Label::NumPointsToGraphEdges, numEdges);
+    AddMeasurement(Label::NumPointsToGraphPointsToRelations, numPointsToRelations);
   }
 
   void
@@ -511,11 +637,13 @@ Andersen::AnalyzeSimpleNode(const rvsdg::simple_node & node)
 void
 Andersen::AnalyzeAlloca(const rvsdg::simple_node & node)
 {
-  JLM_ASSERT(is<alloca_op>(&node));
+  const auto allocaOp = util::AssertedCast<const alloca_op>(&node.operation());
 
   const auto & outputRegister = *node.output(0);
   const auto outputRegisterPO = Set_->CreateRegisterPointerObject(outputRegister);
-  const auto allocaPO = Set_->CreateAllocaMemoryObject(node);
+
+  const bool canPoint = IsOrContainsPointerType(*allocaOp->ValueType());
+  const auto allocaPO = Set_->CreateAllocaMemoryObject(node, canPoint);
   Constraints_->AddPointerPointeeConstraint(outputRegisterPO, allocaPO);
 }
 
@@ -526,7 +654,9 @@ Andersen::AnalyzeMalloc(const rvsdg::simple_node & node)
 
   const auto & outputRegister = *node.output(0);
   const auto outputRegisterPO = Set_->CreateRegisterPointerObject(outputRegister);
-  const auto mallocPO = Set_->CreateMallocMemoryObject(node);
+
+  // We do not know what types will be stored in the malloc, so let it track pointers
+  const auto mallocPO = Set_->CreateMallocMemoryObject(node, true);
   Constraints_->AddPointerPointeeConstraint(outputRegisterPO, mallocPO);
 }
 
@@ -863,11 +993,14 @@ Andersen::AnalyzeDelta(const delta::node & delta)
   // Get the result register from the subregion
   auto & resultRegister = *delta.result()->origin();
 
-  // Create a global memory object representing the global variable
-  const auto globalPO = Set_->CreateGlobalMemoryObject(delta);
+  // If the type of the delta can point, the analysis should track its set of possible pointees
+  bool canPoint = IsOrContainsPointerType(delta.type());
 
-  // If the subregion result is a pointer, make the global point to the same variables
-  if (IsOrContainsPointerType(resultRegister.type()))
+  // Create a global memory object representing the global variable
+  const auto globalPO = Set_->CreateGlobalMemoryObject(delta, canPoint);
+
+  // If the initializer subregion result is a pointer, make the global point to what it points to
+  if (canPoint)
   {
     const auto resultRegisterPO = Set_->GetRegisterPointerObject(resultRegister);
     Constraints_->AddConstraint(SupersetConstraint(globalPO, resultRegisterPO));
@@ -1054,12 +1187,10 @@ Andersen::AnalyzeRvsdg(const rvsdg::graph & graph)
     if (!IsOrContainsPointerType(argument.type()))
       continue;
 
-    // TODO: Mark the created ImportMemoryObject based on it being a function or a variable
-    // Functions and non-pointer typed globals can not point to other MemoryObjects,
-    // so letting them be ShouldTrackPointees() == false aids analysis.
-
     // Create a memory PointerObject representing the target of the external symbol
     // We can assume that two external symbols don't alias, clang does.
+    // Imported memory objects are always marked as CanPoint() == false, due to the fact that
+    // the analysis can't ever hope to track points-to sets of external memory with any precision.
     const auto importObjectPO = Set_->CreateImportMemoryObject(argument);
 
     // Create a register PointerObject representing the address value itself
@@ -1157,7 +1288,9 @@ Andersen::Analyze(const RvsdgModule & module, util::StatisticsCollector & statis
   statistics->StartAndersenStatistics(module.Rvsdg());
 
   // Check environment variables for debugging flags
-  const bool testAllConfigs = std::getenv(ENV_TEST_ALL_CONFIGS);
+  size_t testAllConfigsIterations = 0;
+  if (auto testAllConfigsString = std::getenv(ENV_TEST_ALL_CONFIGS))
+    testAllConfigsIterations = std::stoi(testAllConfigsString);
   const bool doubleCheck = std::getenv(ENV_DOUBLE_CHECK);
 
   const bool dumpGraphs = std::getenv(ENV_DUMP_SUBSET_GRAPH);
@@ -1167,7 +1300,7 @@ Andersen::Analyze(const RvsdgModule & module, util::StatisticsCollector & statis
 
   // If solving multiple times, make a copy of the original constraint set
   std::pair<std::unique_ptr<PointerObjectSet>, std::unique_ptr<PointerObjectConstraintSet>> copy;
-  if (testAllConfigs || doubleCheck)
+  if (testAllConfigsIterations || doubleCheck)
     copy = Constraints_->Clone();
 
   // Draw subset graph both before and after solving
@@ -1180,7 +1313,7 @@ Andersen::Analyze(const RvsdgModule & module, util::StatisticsCollector & statis
   if (dumpGraphs)
   {
     auto & graph = Constraints_->DrawSubsetGraph(writer);
-    graph.AppendToLabel("After Solving");
+    graph.AppendToLabel("After Solving with " + Config_.ToString());
     writer.OutputAllGraphs(std::cout, util::GraphOutputFormat::Dot);
   }
 
@@ -1190,23 +1323,23 @@ Andersen::Analyze(const RvsdgModule & module, util::StatisticsCollector & statis
   statisticsCollector.CollectDemandedStatistics(std::move(statistics));
 
   // Solve again if double-checking against naive is enabled
-  if (testAllConfigs || doubleCheck)
+  if (testAllConfigsIterations || doubleCheck)
   {
     if (doubleCheck)
       std::cerr << "Double checking Andersen analysis using naive solving" << std::endl;
 
-    // If double-checking, only use the naive configuration. Otherwise try all configurations
+    // If double-checking, only use the naive configuration. Otherwise, try all configurations
     std::vector<Configuration> configs;
-    if (testAllConfigs)
+    if (testAllConfigsIterations)
       configs = Configuration::GetAllConfigurations();
     else
       configs.push_back(Configuration::NaiveSolverConfiguration());
 
-    // If testing all, benchmarking is being done, so do 50 iterations of all configurations.
-    // Double-checking against Set_ only needs to be done once per configuration
-    const auto iterations = testAllConfigs ? 50 : 1;
+    // If testing all configurations, do it as many times as requested.
+    // Otherwise, do it at least once
+    const auto iterations = std::max<size_t>(testAllConfigsIterations, 1);
 
-    for (auto i = 0; i < iterations; i++)
+    for (size_t i = 0; i < iterations; i++)
     {
       for (const auto & config : configs)
       {
@@ -1296,10 +1429,6 @@ Andersen::ConstructPointsToGraphFromPointerObjectSet(
   // PointerObject's points-to set.
   auto applyPointsToSet = [&](PointsToGraph::Node & node, PointerObjectIndex index)
   {
-    // PointerObjects marked as not tracking pointees should not point to anything
-    if (!set.ShouldTrackPointees(index))
-      return;
-
     // Add all PointsToGraph nodes who should point to external to the list
     if (set.IsPointingToExternal(index))
       pointsToExternal.push_back(&node);
@@ -1336,7 +1465,9 @@ Andersen::ConstructPointsToGraphFromPointerObjectSet(
     if (memoryNodes[idx] == nullptr)
       continue; // Skip all nodes that are not MemoryNodes
 
-    applyPointsToSet(*memoryNodes[idx], idx);
+    // Add outgoing edges to nodes representing pointer values
+    if (set.CanPoint(idx))
+      applyPointsToSet(*memoryNodes[idx], idx);
 
     if (set.HasEscaped(idx))
     {
@@ -1357,6 +1488,11 @@ Andersen::ConstructPointsToGraphFromPointerObjectSet(
     source->AddEdge(pointsToGraph->GetExternalMemoryNode());
   }
   statistics.StopExternalToAllEscapedStatistics();
+
+  // We do not use the unknown node, and do not give the external node any targets
+  JLM_ASSERT(pointsToGraph->GetExternalMemoryNode().NumTargets() == 0);
+  JLM_ASSERT(pointsToGraph->GetUnknownMemoryNode().NumSources() == 0);
+  JLM_ASSERT(pointsToGraph->GetUnknownMemoryNode().NumTargets() == 0);
 
   statistics.StopPointsToGraphConstructionStatistics(*pointsToGraph);
   return pointsToGraph;

--- a/jlm/llvm/opt/alias-analyses/Andersen.hpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.hpp
@@ -227,9 +227,9 @@ public:
       config.SetSolver(Solver::Worklist);
       config.SetWorklistSolverPolicy(
           PointerObjectConstraintSet::WorklistSolverPolicy::LeastRecentlyFired);
-      config.EnableOnlineCycleDetection(true);
-      config.EnableHybridCycleDetection(false);
-      config.EnableLazyCycleDetection(false);
+      config.EnableOnlineCycleDetection(false);
+      config.EnableHybridCycleDetection(true);
+      config.EnableLazyCycleDetection(true);
       config.EnableDifferencePropagation(true);
       config.EnablePreferImplicitPointees(true);
       return config;

--- a/jlm/llvm/opt/alias-analyses/Andersen.hpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.hpp
@@ -30,6 +30,7 @@ public:
   /**
    * Environment variable that when set, triggers analyzing the program with every single
    * valid combination of Configuration flags.
+   * Must be set to a number, that determines how many times each config is used.
    */
   static inline const char * const ENV_TEST_ALL_CONFIGS = "JLM_ANDERSEN_TEST_ALL_CONFIGS";
 
@@ -226,9 +227,9 @@ public:
       config.SetSolver(Solver::Worklist);
       config.SetWorklistSolverPolicy(
           PointerObjectConstraintSet::WorklistSolverPolicy::LeastRecentlyFired);
-      config.EnableOnlineCycleDetection(false);
-      config.EnableHybridCycleDetection(true);
-      config.EnableLazyCycleDetection(true);
+      config.EnableOnlineCycleDetection(true);
+      config.EnableHybridCycleDetection(false);
+      config.EnableLazyCycleDetection(false);
       config.EnableDifferencePropagation(true);
       config.EnablePreferImplicitPointees(true);
       return config;

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
@@ -385,7 +385,6 @@ PointerObjectSet::AddToPointsToSet(PointerObjectIndex pointer, PointerObjectInde
   const auto pointerRoot = GetUnificationRoot(pointer);
 
   NumSetInsertionAttempts_++;
-
   return PointsToSets_[pointerRoot].Insert(pointee);
 }
 

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
@@ -76,7 +76,7 @@ PointerObjectSet::NumMemoryPointerObjectsCanPoint() const noexcept
   size_t count = 0;
   for (auto & pointerObject : PointerObjects_)
   {
-    count += pointerObject.Kind != PointerObjectKind::Register && pointerObject.CanPoint();
+    count += !pointerObject.IsRegister() && pointerObject.CanPoint();
   }
   return count;
 }

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
@@ -26,12 +26,12 @@ namespace jlm::llvm::aa
 static constexpr bool ENABLE_UNIFICATION = true;
 
 PointerObjectIndex
-PointerObjectSet::AddPointerObject(PointerObjectKind kind)
+PointerObjectSet::AddPointerObject(PointerObjectKind kind, bool canPoint)
 {
   JLM_ASSERT(PointerObjects_.size() < std::numeric_limits<PointerObjectIndex>::max());
   PointerObjectIndex index = PointerObjects_.size();
 
-  PointerObjects_.emplace_back(kind);
+  PointerObjects_.emplace_back(kind, canPoint);
   if constexpr (ENABLE_UNIFICATION)
   {
     PointerObjectParents_.push_back(index);
@@ -48,17 +48,6 @@ PointerObjectSet::NumPointerObjects() const noexcept
 }
 
 size_t
-PointerObjectSet::NumPointerObjectsWithImplicitPointees() const noexcept
-{
-  size_t count = 0;
-  for (auto & pointerObject : PointerObjects_)
-  {
-    count += pointerObject.CanTrackPointeesImplicitly();
-  }
-  return count;
-}
-
-size_t
 PointerObjectSet::NumPointerObjectsOfKind(PointerObjectKind kind) const noexcept
 {
   size_t count = 0;
@@ -69,11 +58,34 @@ PointerObjectSet::NumPointerObjectsOfKind(PointerObjectKind kind) const noexcept
   return count;
 }
 
+size_t
+PointerObjectSet::NumRegisterPointerObjects() const noexcept
+{
+  return NumPointerObjectsOfKind(PointerObjectKind::Register);
+}
+
+size_t
+PointerObjectSet::NumMemoryPointerObjects() const noexcept
+{
+  return NumPointerObjects() - NumRegisterPointerObjects();
+}
+
+size_t
+PointerObjectSet::NumMemoryPointerObjectsCanPoint() const noexcept
+{
+  size_t count = 0;
+  for (auto & pointerObject : PointerObjects_)
+  {
+    count += pointerObject.Kind != PointerObjectKind::Register && pointerObject.CanPoint();
+  }
+  return count;
+}
+
 PointerObjectIndex
 PointerObjectSet::CreateRegisterPointerObject(const rvsdg::output & rvsdgOutput)
 {
   JLM_ASSERT(RegisterMap_.count(&rvsdgOutput) == 0);
-  return RegisterMap_[&rvsdgOutput] = AddPointerObject(PointerObjectKind::Register);
+  return RegisterMap_[&rvsdgOutput] = AddPointerObject(PointerObjectKind::Register, true);
 }
 
 PointerObjectIndex
@@ -105,35 +117,37 @@ PointerObjectSet::MapRegisterToExistingPointerObject(
 PointerObjectIndex
 PointerObjectSet::CreateDummyRegisterPointerObject()
 {
-  return AddPointerObject(PointerObjectKind::Register);
+  return AddPointerObject(PointerObjectKind::Register, true);
 }
 
 PointerObjectIndex
-PointerObjectSet::CreateAllocaMemoryObject(const rvsdg::node & allocaNode)
+PointerObjectSet::CreateAllocaMemoryObject(const rvsdg::node & allocaNode, bool canPoint)
 {
   JLM_ASSERT(AllocaMap_.count(&allocaNode) == 0);
-  return AllocaMap_[&allocaNode] = AddPointerObject(PointerObjectKind::AllocaMemoryObject);
+  return AllocaMap_[&allocaNode] =
+             AddPointerObject(PointerObjectKind::AllocaMemoryObject, canPoint);
 }
 
 PointerObjectIndex
-PointerObjectSet::CreateMallocMemoryObject(const rvsdg::node & mallocNode)
+PointerObjectSet::CreateMallocMemoryObject(const rvsdg::node & mallocNode, bool canPoint)
 {
   JLM_ASSERT(MallocMap_.count(&mallocNode) == 0);
-  return MallocMap_[&mallocNode] = AddPointerObject(PointerObjectKind::MallocMemoryObject);
+  return MallocMap_[&mallocNode] =
+             AddPointerObject(PointerObjectKind::MallocMemoryObject, canPoint);
 }
 
 PointerObjectIndex
-PointerObjectSet::CreateGlobalMemoryObject(const delta::node & deltaNode)
+PointerObjectSet::CreateGlobalMemoryObject(const delta::node & deltaNode, bool canPoint)
 {
   JLM_ASSERT(GlobalMap_.count(&deltaNode) == 0);
-  return GlobalMap_[&deltaNode] = AddPointerObject(PointerObjectKind::GlobalMemoryObject);
+  return GlobalMap_[&deltaNode] = AddPointerObject(PointerObjectKind::GlobalMemoryObject, canPoint);
 }
 
 PointerObjectIndex
 PointerObjectSet::CreateFunctionMemoryObject(const lambda::node & lambdaNode)
 {
   JLM_ASSERT(!FunctionMap_.HasKey(&lambdaNode));
-  const auto pointerObject = AddPointerObject(PointerObjectKind::FunctionMemoryObject);
+  const auto pointerObject = AddPointerObject(PointerObjectKind::FunctionMemoryObject, false);
   FunctionMap_.Insert(&lambdaNode, pointerObject);
   return pointerObject;
 }
@@ -156,7 +170,10 @@ PointerObjectIndex
 PointerObjectSet::CreateImportMemoryObject(const GraphImport & importNode)
 {
   JLM_ASSERT(ImportMap_.count(&importNode) == 0);
-  auto importMemoryObject = AddPointerObject(PointerObjectKind::ImportMemoryObject);
+
+  // All import memory objects are marked as CanPoint() == false, as the analysis has no chance at
+  // tracking the points-to set of pointers located in separate modules
+  auto importMemoryObject = AddPointerObject(PointerObjectKind::ImportMemoryObject, false);
   ImportMap_[&importNode] = importMemoryObject;
 
   // Memory objects defined in other modules are definitely not private to this module
@@ -208,10 +225,10 @@ PointerObjectSet::GetPointerObjectKind(PointerObjectIndex index) const noexcept
 }
 
 bool
-PointerObjectSet::ShouldTrackPointees(PointerObjectIndex index) const noexcept
+PointerObjectSet::CanPoint(PointerObjectIndex index) const noexcept
 {
   JLM_ASSERT(index < NumPointerObjects());
-  return PointerObjects_[index].ShouldTrackPointees();
+  return PointerObjects_[index].CanPoint();
 }
 
 bool
@@ -339,8 +356,13 @@ PointerObjectSet::UnifyPointerObjects(PointerObjectIndex object1, PointerObjectI
   PointerObjectParents_[oldRoot] = newRoot;
 
   // Copy over all pointees, and clean the pointee set from the old root
-  PointsToSets_[newRoot].UnionWith(PointsToSets_[oldRoot]);
-  PointsToSets_[oldRoot].Clear();
+  auto & oldRootPointees = PointsToSets_[oldRoot];
+
+  NumSetInsertionAttempts_ += oldRootPointees.Size();
+  PointsToSets_[newRoot].UnionWith(oldRootPointees);
+
+  NumExplicitPointeesRemoved_ += oldRootPointees.Size();
+  oldRootPointees.Clear();
 
   return newRoot;
 }
@@ -362,6 +384,8 @@ PointerObjectSet::AddToPointsToSet(PointerObjectIndex pointer, PointerObjectInde
 
   const auto pointerRoot = GetUnificationRoot(pointer);
 
+  NumSetInsertionAttempts_++;
+
   return PointsToSets_[pointerRoot].Insert(pointee);
 }
 
@@ -381,6 +405,8 @@ PointerObjectSet::PropagateNewPointees(
 
   auto & P_super = PointsToSets_[supersetRoot];
   auto & P_sub = PointsToSets_[subsetRoot];
+
+  NumSetInsertionAttempts_ += P_sub.Size();
 
   bool modified = false;
   for (PointerObjectIndex pointee : P_sub.Items())
@@ -426,6 +452,7 @@ void
 PointerObjectSet::RemoveAllPointees(PointerObjectIndex index)
 {
   auto root = GetUnificationRoot(index);
+  NumExplicitPointeesRemoved_ += PointsToSets_[root].Size();
   PointsToSets_[root].Clear();
 }
 
@@ -483,6 +510,18 @@ PointerObjectSet::HasIdenticalSolAs(const PointerObjectSet & other) const
     }
   }
   return true;
+}
+
+size_t
+PointerObjectSet::GetNumSetInsertionAttempts() const noexcept
+{
+  return NumSetInsertionAttempts_;
+}
+
+size_t
+PointerObjectSet::GetNumExplicitPointeesRemoved() const noexcept
+{
+  return NumExplicitPointeesRemoved_;
 }
 
 // Makes P(superset) a superset of P(subset)
@@ -792,18 +831,18 @@ HandleEscapedFunction(
     markAsPointsToExternal(argumentPO.value());
   }
 
-  // All results of pointer type need to be flagged as HasEscaped
+  // All results of pointer type need to be flagged as pointees escaping
   for (auto & result : lambdaNode.fctresults())
   {
     const auto resultPO = set.TryGetRegisterPointerObject(*result.origin());
     if (!resultPO)
       continue;
 
-    // Nothing to be done if it is already marked as escaped
-    if (set.HasEscaped(resultPO.value()))
+    // Nothing to be done if it is already marked as pointees escaping
+    if (set.HasPointeesEscaping(resultPO.value()))
       continue;
 
-    // Mark the result register as escaping any pointees it may have
+    // Mark the result register as making any pointees it may have escape
     markAsPointeesEscaping(resultPO.value());
   }
 }
@@ -961,8 +1000,8 @@ CreateSubsetGraphNodeLabel(PointerObjectSet & set, PointerObjectIndex index)
     label << "#" << set.GetUnificationRoot(index);
   }
 
-  if (!set.ShouldTrackPointees(index))
-    label << "\nNOTRACK";
+  if (!set.CanPoint(index))
+    label << "\nCantPoint";
 
   return label.str();
 }
@@ -1610,7 +1649,7 @@ PointerObjectConstraintSet::RunWorklistSolver(WorklistStatistics & statistics)
     statistics.NumHybridCycleUnifications = 0;
 
   if constexpr (EnablePreferImplicitPointees)
-    statistics.NumExplicitPointeesRemoved = 0;
+    statistics.NumPipExplicitPointeesRemoved = 0;
 
   // The worklist, initialized with every unification root
   Worklist worklist;
@@ -1757,7 +1796,10 @@ PointerObjectConstraintSet::RunWorklistSolver(WorklistStatistics & statistics)
 
         // if any unification happens, the result must be added to the worklist
         bool anyUnification = false;
-        for (const auto pointee : newPointees.Items())
+
+        // Make a copy of the set, as the node itself may be unified, invalidating newPointees
+        auto unificationMembers = newPointees;
+        for (const auto pointee : unificationMembers.Items())
         {
           const auto pointeeRoot = Set_.GetUnificationRoot(pointee);
           if (pointeeRoot == refUnificationRoot)
@@ -1772,8 +1814,8 @@ PointerObjectConstraintSet::RunWorklistSolver(WorklistStatistics & statistics)
         {
           JLM_ASSERT(Set_.IsUnificationRoot(refUnificationRoot));
           worklist.PushWorkItem(refUnificationRoot);
-          // If the current node became unified due to HCD, stop the current work item visit.
-          if (Set_.GetUnificationRoot(node) == refUnificationRoot)
+          // If the node itself was unified, the new root has been added to the worklist, so exit
+          if (refUnificationRoot == Set_.GetUnificationRoot(node))
             return;
         }
       }
@@ -1840,7 +1882,7 @@ PointerObjectConstraintSet::RunWorklistSolver(WorklistStatistics & statistics)
     // If this node can track all pointees implicitly, remove its explicit nodes
     if (EnablePreferImplicitPointees && Set_.CanTrackPointeesImplicitly(node))
     {
-      *(statistics.NumExplicitPointeesRemoved) += Set_.GetPointsToSet(node).Size();
+      *(statistics.NumPipExplicitPointeesRemoved) += Set_.GetPointsToSet(node).Size();
       // This also causes newPointees to become empty
       RemoveAllPointees(node);
     }
@@ -1961,13 +2003,12 @@ PointerObjectConstraintSet::RunWorklistSolver(WorklistStatistics & statistics)
     FlushNewSupersetEdges();
   };
 
-  // The observer worklist only contains one bit of state:
-  //   "has anything been pushed since last reset?"
+  // The Workset worklist only remembers which work items have been pushed.
   // It does not provide an iteration order, so if any work item need to be revisited,
-  // we do a topological traversal over all work items instead, called a "sweep".
+  // we do a topological traversal over all work items instead, visiting ones in the Workset.
   // Performing topological sorting also detects all cycles, which are unified away.
   constexpr bool useTopologicalTraversal =
-      std::is_same_v<Worklist, util::ObserverWorklist<PointerObjectIndex>>;
+      std::is_same_v<Worklist, util::Workset<PointerObjectIndex>>;
 
   if constexpr (useTopologicalTraversal)
   {
@@ -1976,10 +2017,9 @@ PointerObjectConstraintSet::RunWorklistSolver(WorklistStatistics & statistics)
 
     statistics.NumTopologicalWorklistSweeps = 0;
 
-    while (worklist.HasPushBeenMade())
+    while (worklist.HasMoreWorkItems())
     {
       (*statistics.NumTopologicalWorklistSweeps)++;
-      worklist.ResetPush();
 
       // First perform a topological sort of the entire subset graph, with respect to simple edges
       util::FindStronglyConnectedComponents<PointerObjectIndex>(
@@ -1988,7 +2028,7 @@ PointerObjectConstraintSet::RunWorklistSolver(WorklistStatistics & statistics)
           sccIndex,
           topologicalOrder);
 
-      // Visit all nodes in topological order
+      // Visit nodes in topological order, if they are in the workset.
       // cycles will result in neighbouring nodes in the topologicalOrder sharing sccIndex
       for (size_t i = 0; i < topologicalOrder.size(); i++)
       {
@@ -2001,13 +2041,19 @@ PointerObjectConstraintSet::RunWorklistSolver(WorklistStatistics & statistics)
           {
             // This node is in a cycle with the next node, unify them
             nextNode = UnifyPointerObjects(node, nextNode);
+            // Make sure the new root is visited
+            worklist.RemoveWorkItem(node);
+            worklist.PushWorkItem(nextNode);
             continue;
           }
         }
 
-        // Otherwise handle the work item (only unification roots)
-        if (Set_.IsUnificationRoot(node))
+        // If this work item is in the workset, handle it. Repeat immediately if it gets re-added.
+        while (worklist.HasWorkItem(node))
+        {
+          worklist.RemoveWorkItem(node);
           HandleWorkItem(node);
+        }
       }
     }
   }
@@ -2060,7 +2106,7 @@ PointerObjectConstraintSet::SolveUsingWorklist(
     constexpr bool vPreferImplicitPointees = decltype(tPreferImplicitPointees)::value;
 
     if constexpr (
-        std::is_same_v<Worklist, util::ObserverWorklist<PointerObjectIndex>>
+        std::is_same_v<Worklist, util::Workset<PointerObjectIndex>>
         && (vOnlineCycleDetection || vHybridCycleDetection || vLazyCycleDetection))
     {
       JLM_UNREACHABLE("Can not enable online, hybrid or lazy cycle detection with the topo policy");
@@ -2084,11 +2130,11 @@ PointerObjectConstraintSet::SolveUsingWorklist(
   };
 
   std::variant<
-      typename util::LrfWorklist<PointerObjectIndex> *,
-      typename util::TwoPhaseLrfWorklist<PointerObjectIndex> *,
-      typename util::ObserverWorklist<PointerObjectIndex> *,
-      typename util::LifoWorklist<PointerObjectIndex> *,
-      typename util::FifoWorklist<PointerObjectIndex> *>
+      util::LrfWorklist<PointerObjectIndex> *,
+      util::TwoPhaseLrfWorklist<PointerObjectIndex> *,
+      util::Workset<PointerObjectIndex> *,
+      util::LifoWorklist<PointerObjectIndex> *,
+      util::FifoWorklist<PointerObjectIndex> *>
       policyVariant;
 
   if (policy == WorklistSolverPolicy::LeastRecentlyFired)
@@ -2096,7 +2142,7 @@ PointerObjectConstraintSet::SolveUsingWorklist(
   else if (policy == WorklistSolverPolicy::TwoPhaseLeastRecentlyFired)
     policyVariant = (util::TwoPhaseLrfWorklist<PointerObjectIndex> *)nullptr;
   else if (policy == WorklistSolverPolicy::TopologicalSort)
-    policyVariant = (util::ObserverWorklist<PointerObjectIndex> *)nullptr;
+    policyVariant = (util::Workset<PointerObjectIndex> *)nullptr;
   else if (policy == WorklistSolverPolicy::LastInFirstOut)
     policyVariant = (util::LifoWorklist<PointerObjectIndex> *)nullptr;
   else if (policy == WorklistSolverPolicy::FirstInFirstOut)

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
@@ -32,7 +32,6 @@ enum class PointerObjectKind : uint8_t
   AllocaMemoryObject,
   MallocMemoryObject,
   GlobalMemoryObject,
-  // Represents functions, they can not point to any memory objects.
   FunctionMemoryObject,
   // Represents functions and global variables imported from other modules.
   ImportMemoryObject,
@@ -59,6 +58,11 @@ class PointerObjectSet final
     // The kind of pointer object
     PointerObjectKind Kind : util::BitWidthOfEnum(PointerObjectKind::COUNT);
 
+    // If set, this pointer object may point to other pointer objects.
+    // If unset, the analysis should make no attempt at tracking what this PointerObject may target.
+    // The final PointsToGraph will not have any outgoing edges for this object.
+    const uint8_t CanPointFlag : 1;
+
     // This memory object's address is known outside the module.
     // Can only be true on memory objects.
     uint8_t HasEscaped : 1;
@@ -73,15 +77,30 @@ class PointerObjectSet final
     // This flag is implied by HasEscaped
     uint8_t PointsToExternal : 1;
 
-    explicit PointerObject(PointerObjectKind kind)
+    explicit PointerObject(PointerObjectKind kind, bool canPoint)
         : Kind(kind),
+          CanPointFlag(canPoint),
           HasEscaped(0),
           PointeesEscaping(0),
           PointsToExternal(0)
     {
       JLM_ASSERT(kind != PointerObjectKind::COUNT);
 
-      if (!ShouldTrackPointees())
+      // Ensure that certain kinds of PointerObject always CanPoint or never CanPoint
+      switch (kind)
+      {
+      case PointerObjectKind::ImportMemoryObject:
+      case PointerObjectKind::FunctionMemoryObject:
+        JLM_ASSERT(!CanPoint());
+        break;
+      case PointerObjectKind::Register:
+        JLM_ASSERT(CanPoint());
+        break;
+      default:
+        break;
+      }
+
+      if (!CanPoint())
       {
         // No attempt is made at tracking pointees, so use these flags to inform others
         PointeesEscaping = 1;
@@ -104,16 +123,13 @@ class PointerObjectSet final
 
     /**
      * Some memory objects can only be pointed to, but never themselves contain pointers.
-     * To avoid tracking their pointees, they are instead marked as both PointsToExternal and
-     * PointeesEscaping. This makes their points-to set equivalent to the set of all escaped
-     * memory objects, which means the set of explicit pointees can be empty.
      * When converting the analysis result to a PointsToGraph, these PointerObjects get no pointees.
-     * @return true if the analysis should attempt track the points-to set of this PointerObject.
+     * @return true if the analysis tracks the points-to set of this PointerObject.
      */
     [[nodiscard]] bool
-    ShouldTrackPointees() const noexcept
+    CanPoint() const noexcept
     {
-      return Kind != PointerObjectKind::FunctionMemoryObject;
+      return CanPointFlag;
     }
 
     /**
@@ -157,11 +173,18 @@ class PointerObjectSet final
 
   std::unordered_map<const GraphImport *, PointerObjectIndex> ImportMap_;
 
+  // How many items have been attempted added to explicit points-to sets
+  size_t NumSetInsertionAttempts_ = 0;
+
+  // How many pointees have been removed from points-to sets.
+  // Explicit pointees can only be removed through unification, and the remove method
+  size_t NumExplicitPointeesRemoved_ = 0;
+
   /**
    * Internal helper function for adding PointerObjects, use the Create* methods instead
    */
   [[nodiscard]] PointerObjectIndex
-  AddPointerObject(PointerObjectKind kind);
+  AddPointerObject(PointerObjectKind kind, bool canPoint);
 
   /**
    * Internal helper function for making P(superset) a superset of P(subset), with a callback.
@@ -175,20 +198,28 @@ class PointerObjectSet final
       NewPointeeFunctor & onNewPointee);
 
 public:
+  PointerObjectSet() = default;
+
   [[nodiscard]] size_t
   NumPointerObjects() const noexcept;
-
-  /**
-   * @return the number of PointerObjects where CanTrackPointeesImplicitly() is true
-   */
-  [[nodiscard]] size_t
-  NumPointerObjectsWithImplicitPointees() const noexcept;
 
   /**
    * @return the number of PointerObjects in the set matching the specified \p kind.
    */
   [[nodiscard]] size_t
   NumPointerObjectsOfKind(PointerObjectKind kind) const noexcept;
+
+  /**
+   * @return the number of PointerObjects in the set representing virtual registers
+   */
+  [[nodiscard]] size_t
+  NumRegisterPointerObjects() const noexcept;
+
+  [[nodiscard]] size_t
+  NumMemoryPointerObjects() const noexcept;
+
+  [[nodiscard]] size_t
+  NumMemoryPointerObjectsCanPoint() const noexcept;
 
   /**
    * Creates a PointerObject of Register kind and maps the rvsdg output to the new PointerObject.
@@ -238,13 +269,13 @@ public:
   CreateDummyRegisterPointerObject();
 
   [[nodiscard]] PointerObjectIndex
-  CreateAllocaMemoryObject(const rvsdg::node & allocaNode);
+  CreateAllocaMemoryObject(const rvsdg::node & allocaNode, bool canPoint);
 
   [[nodiscard]] PointerObjectIndex
-  CreateMallocMemoryObject(const rvsdg::node & mallocNode);
+  CreateMallocMemoryObject(const rvsdg::node & mallocNode, bool canPoint);
 
   [[nodiscard]] PointerObjectIndex
-  CreateGlobalMemoryObject(const delta::node & deltaNode);
+  CreateGlobalMemoryObject(const delta::node & deltaNode, bool canPoint);
 
   /**
    * Creates a PointerObject of Function kind associated with the given \p lambdaNode.
@@ -302,7 +333,7 @@ public:
    * @return true if the PointerObject with the given \p index can point, otherwise false
    */
   [[nodiscard]] bool
-  ShouldTrackPointees(PointerObjectIndex index) const noexcept;
+  CanPoint(PointerObjectIndex index) const noexcept;
 
   /**
    * @return true if the PointerObject with the given \p index is a Register
@@ -461,6 +492,21 @@ public:
    */
   [[nodiscard]] bool
   HasIdenticalSolAs(const PointerObjectSet & other) const;
+
+  /**
+   * @return the number of pointees that have been inserted, or were attempted inserted
+   * but already existed, among all points-to sets in this PointerObjectSet.
+   * Unioning a set x into another makes |x| insertion attempts.
+   */
+  [[nodiscard]] size_t
+  GetNumSetInsertionAttempts() const noexcept;
+
+  /**
+   * @return the number of pointees that have been removed from points-to sets,
+   * due to either unification, or the RemoveAllPointees() method.
+   */
+  [[nodiscard]] size_t
+  GetNumExplicitPointeesRemoved() const noexcept;
 };
 
 /**
@@ -872,7 +918,7 @@ public:
      * When Prefer Implicit Pointees is enabled, and a node's pointees can be tracked fully
      * implicitly, its set of explicit pointees is cleared.
      */
-    std::optional<size_t> NumExplicitPointeesRemoved;
+    std::optional<size_t> NumPipExplicitPointeesRemoved;
   };
 
   explicit PointerObjectConstraintSet(PointerObjectSet & set)

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
@@ -32,6 +32,7 @@ enum class PointerObjectKind : uint8_t
   AllocaMemoryObject,
   MallocMemoryObject,
   GlobalMemoryObject,
+  // Represents functions, they can not point to any memory objects.
   FunctionMemoryObject,
   // Represents functions and global variables imported from other modules.
   ImportMemoryObject,
@@ -87,18 +88,11 @@ class PointerObjectSet final
       JLM_ASSERT(kind != PointerObjectKind::COUNT);
 
       // Ensure that certain kinds of PointerObject always CanPoint or never CanPoint
-      switch (kind)
-      {
-      case PointerObjectKind::ImportMemoryObject:
-      case PointerObjectKind::FunctionMemoryObject:
+      if (kind == PointerObjectKind::FunctionMemoryObject
+          || kind == PointerObjectKind::ImportMemoryObject)
         JLM_ASSERT(!CanPoint());
-        break;
-      case PointerObjectKind::Register:
+      else if (kind == PointerObjectKind::Register)
         JLM_ASSERT(CanPoint());
-        break;
-      default:
-        break;
-      }
 
       if (!CanPoint())
       {

--- a/jlm/llvm/opt/alias-analyses/PointsToGraph.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraph.cpp
@@ -161,6 +161,38 @@ PointsToGraph::AddImportNode(std::unique_ptr<PointsToGraph::ImportNode> node)
   return *tmp;
 }
 
+std::pair<size_t, size_t>
+PointsToGraph::NumEdges() const noexcept
+{
+  size_t numEdges = 0;
+
+  auto countMemoryNodes = [&](auto iterable)
+  {
+    for (const MemoryNode & node : iterable)
+    {
+      numEdges += node.NumTargets();
+    }
+  };
+
+  countMemoryNodes(AllocaNodes());
+  countMemoryNodes(DeltaNodes());
+  countMemoryNodes(ImportNodes());
+  countMemoryNodes(LambdaNodes());
+  countMemoryNodes(MallocNodes());
+
+  numEdges += GetExternalMemoryNode().NumTargets();
+
+  // For register nodes, the number of edges and number of points-to relations is different
+  size_t numPointsToRelations = numEdges;
+  for (auto & registerNode : RegisterNodes())
+  {
+    numEdges += registerNode.NumTargets();
+    numPointsToRelations += registerNode.NumTargets() * registerNode.GetOutputs().Size();
+  }
+
+  return std::make_pair(numEdges, numPointsToRelations);
+}
+
 bool
 PointsToGraph::IsSupergraphOf(const jlm::llvm::aa::PointsToGraph & subgraph) const
 {

--- a/jlm/llvm/opt/alias-analyses/PointsToGraph.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraph.hpp
@@ -360,6 +360,18 @@ public:
   AddImportNode(std::unique_ptr<PointsToGraph::ImportNode> node);
 
   /**
+   * Gets the total number of edges in the PointsToGraph.
+   *
+   * In addition, RegisterNodes can represent multiple registers,
+   * in which case each outgoing edge represents multiple points-to relations.
+   * The total number of points-to relations is also returned.
+   *
+   * @return a pair (number of edges, number of points-to relations)
+   */
+  [[nodiscard]] std::pair<size_t, size_t>
+  NumEdges() const noexcept;
+
+  /**
    * Checks if this PointsToGraph is a supergraph of \p subgraph.
    * Every node and every edge in the subgraph needs to have corresponding nodes and edges
    * present in this graph, defined by nodes representing the same registers and memory objects.

--- a/jlm/util/Statistics.hpp
+++ b/jlm/util/Statistics.hpp
@@ -223,6 +223,10 @@ protected:
     inline static const char * NumPointsToGraphUnknownMemorySources =
         "#PointsToGraphUnknownMemorySources";
 
+    inline static const char * NumPointsToGraphEdges = "#PointsToGraphEdges";
+    inline static const char * NumPointsToGraphPointsToRelations =
+        "#PointsToGraphPointsToRelations";
+
     static inline const char * Timer = "Time";
   };
 

--- a/tests/jlm/llvm/opt/alias-analyses/TestDifferencePropagation.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestDifferencePropagation.cpp
@@ -25,10 +25,10 @@ TestTracksDifferences()
   PointerObjectSet set;
   auto r0 = set.CreateRegisterPointerObject(rvsdg.GetAllocaOutput(0));
   auto r1 = set.CreateRegisterPointerObject(rvsdg.GetAllocaOutput(1));
-  auto a0 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(0));
-  auto a1 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(1));
-  auto a2 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(2));
-  auto a3 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(3));
+  auto a0 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(0), true);
+  auto a1 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(1), true);
+  auto a2 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(2), true);
+  auto a3 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(3), true);
 
   // Let r0 -> a0 and r0 -> a3 before difference tracking even begins
   set.AddToPointsToSet(r0, a0);

--- a/tests/jlm/llvm/opt/alias-analyses/TestPointerObjectSet.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestPointerObjectSet.cpp
@@ -852,10 +852,8 @@ TestClonePointerObjectConstraintSet()
 
   // Modifying the copy doesn't affect the original
   constraintsClone->AddConstraint(LoadConstraint(register0, alloca0));
-#ifndef ANDERSEN_NO_FLAGS
   assert(constraintsClone->GetConstraints().size() == 2);
   assert(constraints.GetConstraints().size() == 1);
-#endif
 
   // Solving only affects the PointerObjectSet belonging to that constraint set
   constraints.SolveNaively();
@@ -869,9 +867,7 @@ TestClonePointerObjectConstraintSet()
 static int
 TestPointerObjectSet()
 {
-#ifndef ANDERSEN_NO_FLAGS
   TestFlagFunctions();
-#endif
   TestCreatePointerObjects();
   TestPointerObjectUnification();
   TestPointerObjectUnificationPointees();
@@ -881,13 +877,9 @@ TestPointerObjectSet()
   TestSupersetConstraint();
   TestStoreConstraintDirectly();
   TestLoadConstraintDirectly();
-#ifndef ANDERSEN_NO_FLAGS
   TestEscapedFunctionConstraint();
-#endif
   TestFunctionCallConstraint();
-#ifndef ANDERSEN_NO_FLAGS
   TestAddPointsToExternalConstraint();
-#endif
   TestAddRegisterContentEscapedConstraint();
   TestDrawSubsetGraph();
   TestPointerObjectConstraintSetSolve<false>();

--- a/tests/jlm/llvm/opt/alias-analyses/TestPointerObjectSet.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestPointerObjectSet.cpp
@@ -30,7 +30,7 @@ TestFlagFunctions()
   PointerObjectSet set;
   auto registerPO = set.CreateRegisterPointerObject(rvsdg.GetAllocaOutput());
 
-  assert(set.ShouldTrackPointees(registerPO));
+  assert(set.CanPoint(registerPO));
   assert(set.IsPointerObjectRegister(registerPO));
 
   // PointeesEscaping flag
@@ -49,11 +49,10 @@ TestFlagFunctions()
   assert(!set.MarkAsPointingToExternal(registerPO));
   assert(set.IsPointingToExternal(registerPO));
 
-  // Test that Escaped implies PointsToExternal, for memory objects
-  auto allocaPO = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode());
+  // Test that allocas can both be marked and not marked "CanPoint"
+  auto allocaPO = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(), true);
 
-  // alloca may both point
-  assert(set.ShouldTrackPointees(allocaPO));
+  assert(set.CanPoint(allocaPO));
   assert(!set.IsPointerObjectRegister(allocaPO));
 
   // Escaping means another module can write a pointer to you.
@@ -68,9 +67,9 @@ TestFlagFunctions()
   assert(!set.MarkAsPointingToExternal(allocaPO));
   assert(!set.MarkAsPointeesEscaping(allocaPO));
 
-  // The analysis should not bother tracking the pointees of lambdas
+  // lambdas are never "CanPoint"
   auto lambdaPO = set.CreateFunctionMemoryObject(rvsdg.GetLambdaNode());
-  assert(!set.ShouldTrackPointees(lambdaPO));
+  assert(!set.CanPoint(lambdaPO));
 }
 
 // Test creating pointer objects for each type of memory node
@@ -89,9 +88,9 @@ TestCreatePointerObjects()
   const auto dummy0 = set.CreateDummyRegisterPointerObject();
 
   // For PointerObjects representing MemoryObjects, there is only one Create function
-  const auto alloca0 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode());
-  const auto malloc0 = set.CreateMallocMemoryObject(rvsdg.GetMallocNode());
-  const auto delta0 = set.CreateGlobalMemoryObject(rvsdg.GetDeltaNode());
+  const auto alloca0 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(), true);
+  const auto malloc0 = set.CreateMallocMemoryObject(rvsdg.GetMallocNode(), true);
+  const auto delta0 = set.CreateGlobalMemoryObject(rvsdg.GetDeltaNode(), true);
   const auto lambda0 = set.CreateFunctionMemoryObject(rvsdg.GetLambdaNode());
   const auto import0 = set.CreateImportMemoryObject(rvsdg.GetImportOutput());
 
@@ -177,8 +176,8 @@ TestPointerObjectUnificationPointees()
 
   PointerObjectSet set;
   auto lambda0 = set.CreateFunctionMemoryObject(rvsdg.GetLambdaNode());
-  auto alloca0 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode());
-  auto delta0 = set.CreateGlobalMemoryObject(rvsdg.GetDeltaNode());
+  auto alloca0 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(), true);
+  auto delta0 = set.CreateGlobalMemoryObject(rvsdg.GetDeltaNode(), true);
 
   set.AddToPointsToSet(alloca0, lambda0);
   assert(set.GetPointsToSet(alloca0).Size() == 1);
@@ -222,7 +221,7 @@ TestAddToPointsToSet()
   rvsdg.InitializeTest();
 
   PointerObjectSet set;
-  const auto alloca0 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(0));
+  const auto alloca0 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(0), false);
   const auto reg0 = set.CreateRegisterPointerObject(rvsdg.GetAllocaOutput(0));
 
   assert(set.GetPointsToSet(reg0).Size() == 0);
@@ -245,11 +244,11 @@ TestMakePointsToSetSuperset()
   rvsdg.InitializeTest();
 
   PointerObjectSet set;
-  const auto alloca0 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(0));
+  const auto alloca0 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(0), false);
   const auto reg0 = set.CreateRegisterPointerObject(rvsdg.GetAllocaOutput(0));
-  const auto alloca1 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(1));
+  const auto alloca1 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(1), false);
   const auto reg1 = set.CreateRegisterPointerObject(rvsdg.GetAllocaOutput(1));
-  const auto alloca2 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(2));
+  const auto alloca2 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(2), false);
 
   set.AddToPointsToSet(reg0, alloca0);
   set.AddToPointsToSet(reg1, alloca1);
@@ -281,9 +280,9 @@ TestClonePointerObjectSet()
   PointerObjectSet set;
   const auto register0 = set.CreateRegisterPointerObject(rvsdg.GetAllocaOutput());
   const auto dummy0 = set.CreateDummyRegisterPointerObject();
-  const auto alloca0 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode());
-  const auto malloc0 = set.CreateMallocMemoryObject(rvsdg.GetMallocNode());
-  const auto delta0 = set.CreateGlobalMemoryObject(rvsdg.GetDeltaNode());
+  const auto alloca0 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(), false);
+  const auto malloc0 = set.CreateMallocMemoryObject(rvsdg.GetMallocNode(), true);
+  const auto delta0 = set.CreateGlobalMemoryObject(rvsdg.GetDeltaNode(), false);
   const auto lambda0 = set.CreateFunctionMemoryObject(rvsdg.GetLambdaNode());
   const auto import0 = set.CreateImportMemoryObject(rvsdg.GetImportOutput());
 
@@ -328,11 +327,11 @@ TestSupersetConstraint()
   rvsdg.InitializeTest();
 
   PointerObjectSet set;
-  const auto alloca0 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(0));
+  const auto alloca0 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(0), true);
   const auto reg0 = set.CreateRegisterPointerObject(rvsdg.GetAllocaOutput(0));
-  const auto alloca1 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(1));
+  const auto alloca1 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(1), true);
   const auto reg1 = set.CreateRegisterPointerObject(rvsdg.GetAllocaOutput(1));
-  const auto alloca2 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(2));
+  const auto alloca2 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(2), true);
   const auto reg2 = set.CreateRegisterPointerObject(rvsdg.GetAllocaOutput(2));
 
   set.AddToPointsToSet(reg0, alloca0);
@@ -386,11 +385,11 @@ TestStoreConstraintDirectly()
   rvsdg.InitializeTest();
 
   PointerObjectSet set;
-  const auto alloca0 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(0));
+  const auto alloca0 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(0), true);
   const auto reg0 = set.CreateRegisterPointerObject(rvsdg.GetAllocaOutput(0));
-  const auto alloca1 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(1));
+  const auto alloca1 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(1), true);
   const auto reg1 = set.CreateRegisterPointerObject(rvsdg.GetAllocaOutput(1));
-  const auto alloca2 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(2));
+  const auto alloca2 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(2), true);
   const auto reg2 = set.CreateRegisterPointerObject(rvsdg.GetAllocaOutput(2));
 
   set.AddToPointsToSet(reg0, alloca0);
@@ -427,11 +426,11 @@ TestLoadConstraintDirectly()
   rvsdg.InitializeTest();
 
   PointerObjectSet set;
-  const auto alloca0 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(0));
+  const auto alloca0 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(0), true);
   const auto reg0 = set.CreateRegisterPointerObject(rvsdg.GetAllocaOutput(0));
-  const auto alloca1 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(1));
+  const auto alloca1 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(1), true);
   const auto reg1 = set.CreateRegisterPointerObject(rvsdg.GetAllocaOutput(1));
-  const auto alloca2 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(2));
+  const auto alloca2 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(2), true);
   const auto reg2 = set.CreateRegisterPointerObject(rvsdg.GetAllocaOutput(2));
 
   set.AddToPointsToSet(reg0, alloca0);
@@ -506,8 +505,8 @@ TestFunctionCallConstraint()
   const auto lambdaFRegister = set.CreateRegisterPointerObject(*rvsdg.lambda_f->output());
   const auto lambdaFArgumentX = set.CreateRegisterPointerObject(*rvsdg.lambda_f->fctargument(0));
   const auto lambdaFArgumentY = set.CreateRegisterPointerObject(*rvsdg.lambda_f->fctargument(1));
-  const auto allocaX = set.CreateAllocaMemoryObject(*rvsdg.alloca_x);
-  const auto allocaY = set.CreateAllocaMemoryObject(*rvsdg.alloca_y);
+  const auto allocaX = set.CreateAllocaMemoryObject(*rvsdg.alloca_x, true);
+  const auto allocaY = set.CreateAllocaMemoryObject(*rvsdg.alloca_y, true);
   const auto allocaXRegister = set.CreateRegisterPointerObject(*rvsdg.alloca_x->output(0));
   const auto allocaYRegister = set.CreateRegisterPointerObject(*rvsdg.alloca_y->output(0));
 
@@ -537,9 +536,9 @@ TestAddPointsToExternalConstraint()
   rvsdg.InitializeTest();
 
   PointerObjectSet set;
-  const auto alloca0 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(0));
+  const auto alloca0 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(0), true);
   const auto reg0 = set.CreateRegisterPointerObject(rvsdg.GetAllocaOutput(0));
-  const auto alloca1 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(1));
+  const auto alloca1 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(1), true);
   const auto reg1 = set.CreateRegisterPointerObject(rvsdg.GetAllocaOutput(1));
 
   PointerObjectConstraintSet constraints(set);
@@ -580,9 +579,9 @@ TestAddRegisterContentEscapedConstraint()
   rvsdg.InitializeTest();
 
   PointerObjectSet set;
-  const auto alloca0 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(0));
+  const auto alloca0 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(0), false);
   const auto reg0 = set.CreateRegisterPointerObject(rvsdg.GetAllocaOutput(0));
-  const auto alloca1 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(1));
+  const auto alloca1 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(1), false);
   const auto reg1 = set.CreateRegisterPointerObject(rvsdg.GetAllocaOutput(1));
 
   PointerObjectConstraintSet constraints(set);
@@ -616,7 +615,7 @@ TestDrawSubsetGraph()
 
   // Arrange
   PointerObjectSet set;
-  const auto alloca0 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode());
+  const auto alloca0 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(), true);
   const auto allocaReg0 = set.CreateRegisterPointerObject(rvsdg.GetAllocaOutput());
 
   const auto dummy0 = set.CreateDummyRegisterPointerObject();
@@ -680,8 +679,8 @@ TestDrawSubsetGraph()
   // Check that the function contains the word "function0"
   auto & functionNode = graph.GetNode(function0);
   assert(StringContains(functionNode.GetLabel(), "function0"));
-  // Since functions don't track pointees, they should have NOTRACK
-  assert(StringContains(functionNode.GetLabel(), "NOTRACK"));
+  // Since functions don't track pointees, they should have CantPoint
+  assert(StringContains(functionNode.GetLabel(), "CantPoint"));
   // They should also both point to external, and escape all pointees
   assert(StringContains(functionNode.GetLabel(), "{+}e"));
 
@@ -711,10 +710,10 @@ TestPointerObjectConstraintSetSolve(Args... args)
   // %2 = alloca 8 (variable v2)
   // %3 = alloca 8 (variable v3)
   // %4 = alloca 8 (variable v4)
-  const auto alloca1 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(0));
-  const auto alloca2 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(1));
-  const auto alloca3 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(2));
-  const auto alloca4 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(3));
+  const auto alloca1 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(0), true);
+  const auto alloca2 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(1), true);
+  const auto alloca3 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(2), true);
+  const auto alloca4 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(3), true);
 
   // Now start building constraints based on instructions
   PointerObjectConstraintSet constraints(set);
@@ -830,7 +829,7 @@ TestClonePointerObjectConstraintSet()
 
   PointerObjectSet set;
   const auto register0 = set.CreateRegisterPointerObject(rvsdg.GetAllocaOutput());
-  const auto alloca0 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode());
+  const auto alloca0 = set.CreateAllocaMemoryObject(rvsdg.GetAllocaNode(), true);
   set.AddToPointsToSet(register0, alloca0);
 
   // Create a dummy register that will point to alloca0 after solving
@@ -844,8 +843,10 @@ TestClonePointerObjectConstraintSet()
 
   // Modifying the copy doesn't affect the original
   constraintsClone->AddConstraint(LoadConstraint(register0, alloca0));
+#ifndef ANDERSEN_NO_FLAGS
   assert(constraintsClone->GetConstraints().size() == 2);
   assert(constraints.GetConstraints().size() == 1);
+#endif
 
   // Solving only affects the PointerObjectSet belonging to that constraint set
   constraints.SolveNaively();
@@ -859,7 +860,9 @@ TestClonePointerObjectConstraintSet()
 static int
 TestPointerObjectSet()
 {
+#ifndef ANDERSEN_NO_FLAGS
   TestFlagFunctions();
+#endif
   TestCreatePointerObjects();
   TestPointerObjectUnification();
   TestPointerObjectUnificationPointees();
@@ -869,9 +872,13 @@ TestPointerObjectSet()
   TestSupersetConstraint();
   TestStoreConstraintDirectly();
   TestLoadConstraintDirectly();
+#ifndef ANDERSEN_NO_FLAGS
   TestEscapedFunctionConstraint();
+#endif
   TestFunctionCallConstraint();
+#ifndef ANDERSEN_NO_FLAGS
   TestAddPointsToExternalConstraint();
+#endif
   TestAddRegisterContentEscapedConstraint();
   TestDrawSubsetGraph();
   TestPointerObjectConstraintSetSolve<false>();

--- a/tests/jlm/util/TestWorklist.cpp
+++ b/tests/jlm/util/TestWorklist.cpp
@@ -135,22 +135,24 @@ JLM_UNIT_TEST_REGISTER(
     TestTwoPhaseLrfWorklist)
 
 static int
-TestObserverWorklist()
+TestWorkset()
 {
-  jlm::util::ObserverWorklist<size_t> wl;
-  assert(!wl.HasPushBeenMade());
-  wl.PushWorkItem(7);
-  assert(wl.HasPushBeenMade());
-  wl.ResetPush();
-  assert(!wl.HasPushBeenMade());
-  wl.ResetPush();
-  assert(!wl.HasPushBeenMade());
-  wl.PushWorkItem(7);
-  assert(wl.HasPushBeenMade());
+  jlm::util::Workset<size_t> ws;
+  assert(!ws.HasMoreWorkItems());
+  assert(!ws.HasWorkItem(7));
+  ws.PushWorkItem(7);
+  assert(ws.HasMoreWorkItems());
+  assert(ws.HasWorkItem(7));
+  ws.PushWorkItem(5);
+  assert(ws.HasWorkItem(5));
+  assert(ws.HasWorkItem(7));
+  ws.RemoveWorkItem(7);
+  assert(!ws.HasWorkItem(7));
+  assert(ws.HasWorkItem(5));
+  ws.RemoveWorkItem(5);
+  assert(!ws.HasMoreWorkItems());
 
   return 0;
 }
 
-JLM_UNIT_TEST_REGISTER(
-    "jlm/llvm/opt/alias-analyses/TestWorklist-TestObserverWorklist",
-    TestObserverWorklist)
+JLM_UNIT_TEST_REGISTER("jlm/llvm/opt/alias-analyses/TestWorklist-TestWorkset", TestWorkset)


### PR DESCRIPTION
During work on the `andersen-no-flags` branch, some other changes were made as I discovered issues or wanted more statistics:

 - There was a bug where Hybrid Cycle Detection could invalidate an iterator while using it.
 - The topological Worklist algorithm has been made slightly less terrible by actually tracking work items now, and only visiting nodes that need to be visited during the sweep. The `ObserverWorklist` is now called the `WorkSet` instead, as that name describes its new job (an unordered worklist) better. This is likely closer to what has been done by Pearce07, but it still does not make it the best worklist iteration order.
 - Make the `JLM_ANDERSEN_TEST_ALL_CONFIGS` environment variable take an integer controlling the amount of iterations each config should be used.


The bulk of this PR is related to getting more statistics:
 - Count attempts at growing points-to sets, as well as how many items are removed from points-to sets during solving (e.g due to unification or PIP).
 - Add code to the `PointsToGraph` class to count the number of edges, as well as the number of pointer-pointee relations, since `RegisterNode`s can represent multiple registers at once.
 - Add the flag `CanPoint()` to `PointerObject`s to formalize the existence of memory objects whose points-to sets we do not track (such as `int a`). This makes the statistics more useful and comparable, as well as removing potentially tons of edges in the `PointsToGraph` going out from these memory objects.
 - Add statistics for counting pointer-pointee relations to be able to say something about precision, regardless of unification.

This PR ended up being a bit larger than I wanted, let me know if you want it split up
