### PR TITLE
Introduce accessor and convenience API for node type matching

### DIFF
--- a/jlm/rvsdg/node.hpp
+++ b/jlm/rvsdg/node.hpp
@@ -12,6 +12,7 @@
 #include <stdint.h>
 #include <unordered_set>
 #include <utility>
+#include <variant>
 
 #include <jlm/rvsdg/operation.hpp>
 #include <jlm/util/common.hpp>
@@ -100,6 +101,9 @@ public:
    */
   [[nodiscard]] static rvsdg::node *
   GetNode(const rvsdg::input & input) noexcept;
+
+  [[nodiscard]] virtual std::variant<node *, Region *>
+  GetOwner() const noexcept = 0;
 
   template<class T>
   class iterator
@@ -374,6 +378,9 @@ public:
   virtual std::string
   debug_string() const;
 
+  [[nodiscard]] virtual std::variant<node *, Region *>
+  GetOwner() const noexcept = 0;
+
   /**
    * Retrieve the associated node from \p output if \p output is derived from
    * jlm::rvsdg::node_output.
@@ -585,6 +592,9 @@ public:
     return node_;
   }
 
+  [[nodiscard]] std::variant<rvsdg::node *, Region *>
+  GetOwner() const noexcept override;
+
 private:
   jlm::rvsdg::node * node_;
 };
@@ -608,6 +618,9 @@ public:
     auto no = dynamic_cast<const node_output *>(output);
     return no != nullptr ? no->node() : nullptr;
   }
+
+  [[nodiscard]] std::variant<rvsdg::node *, Region *>
+  GetOwner() const noexcept override;
 
 private:
   jlm::rvsdg::node * node_;
@@ -877,6 +890,164 @@ private:
   std::vector<std::unique_ptr<node_input>> inputs_;
   std::vector<std::unique_ptr<node_output>> outputs_;
 };
+
+/**
+ * \brief Checks if this is an input to a node of specified type.
+ *
+ * \tparam NodeType
+ *   The node type to be matched against.
+ *
+ * \param input
+ *   Input to be checked.
+ *
+ * \returns
+ *   Owning node of requested type or nullptr.
+ *
+ * Checks if the specified input belongs to a node of requested type.
+ * If this is the case, returns a pointer to the node of matched type.
+ * If this is not the case (because either this as a region exit
+ * result or its owning node is not of the requested type), returns
+ * nullptr.
+ *
+ * See \ref def_use_inspection.
+ */
+template<typename NodeType>
+inline NodeType *
+TryGetOwnerNode(const rvsdg::input & input) noexcept
+{
+  auto owner = input.GetOwner();
+  if (auto node = std::get_if<rvsdg::node *>(&owner))
+  {
+    return dynamic_cast<NodeType *>(*node);
+  }
+  else
+  {
+    return nullptr;
+  }
+}
+
+/**
+ * \brief Checks if this is an output to a node of specified type.
+ *
+ * \tparam NodeType
+ *   The node type to be matched against.
+ *
+ * \param output
+ *   Output to be checked.
+ *
+ * \returns
+ *   Owning node of requested type or nullptr.
+ *
+ * Checks if the specified output belongs to a node of requested type.
+ * If this is the case, returns a pointer to the node of matched type.
+ * If this is not the case (because either this as a region entry
+ * argument or its owning node is not of the requested type), returns
+ * nullptr.
+ *
+ * See \ref def_use_inspection.
+ */
+template<typename NodeType>
+inline NodeType *
+TryGetOwnerNode(const rvsdg::output & output) noexcept
+{
+  auto owner = output.GetOwner();
+  if (auto node = std::get_if<rvsdg::node *>(&owner))
+  {
+    return dynamic_cast<NodeType *>(*node);
+  }
+  else
+  {
+    return nullptr;
+  }
+}
+
+/**
+ * \brief Asserts that this is an input to a node of specified type.
+ *
+ * \tparam NodeType
+ *   The node type to be matched against.
+ *
+ * \param input
+ *   Input to be checked.
+ *
+ * \returns
+ *   Owning node of requested type.
+ *
+ * Checks if the specified input belongs to a node of requested type.
+ * If this is the case, returns a reference to the node of matched type,
+ * otherwise throws std::logic_error.
+ *
+ * See \ref def_use_inspection.
+ */
+template<typename NodeType>
+inline NodeType &
+AssertGetOwnerNode(const rvsdg::input & input)
+{
+  auto node = TryGetOwnerNode<NodeType>(input);
+  if (!node)
+  {
+    throw std::logic_error(std::string("expected node of type ") + typeid(NodeType).name());
+  }
+  return *node;
+}
+
+/**
+ * \brief Asserts that this is an output of a node of specified type.
+ *
+ * \tparam NodeType
+ *   The node type to be matched against.
+ *
+ * \param output
+ *   Output to be checked.
+ *
+ * \returns
+ *   Owning node of requested type.
+ *
+ * Checks if the specified output belongs to a node of requested type.
+ * If this is the case, returns a reference to the node of matched type,
+ * otherwise throws std::logic_error.
+ *
+ * See \ref def_use_inspection.
+ */
+template<typename NodeType>
+inline NodeType &
+AssertGetOwnerNode(const rvsdg::output & output)
+{
+  auto node = TryGetOwnerNode<NodeType>(output);
+  if (!node)
+  {
+    throw std::logic_error(std::string("expected node of type ") + typeid(NodeType).name());
+  }
+  return *node;
+}
+
+inline Region *
+TryGetOwnerRegion(const rvsdg::input & input) noexcept
+{
+  auto owner = input.GetOwner();
+  if (auto region = std::get_if<Region *>(&owner))
+  {
+    return *region;
+  }
+  else
+  {
+    return nullptr;
+  }
+}
+
+inline Region *
+TryGetOwnerRegion(const rvsdg::output & output) noexcept
+{
+  auto owner = output.GetOwner();
+  if (auto region = std::get_if<Region *>(&owner))
+  {
+    return *region;
+  }
+  else
+  {
+    return nullptr;
+  }
+}
 
 static inline std::vector<jlm::rvsdg::output *>
 operands(const jlm::rvsdg::node * node)

--- a/jlm/rvsdg/region.cpp
+++ b/jlm/rvsdg/region.cpp
@@ -43,6 +43,12 @@ RegionArgument::RegionArgument(
   }
 }
 
+[[nodiscard]] std::variant<node *, Region *>
+RegionArgument::GetOwner() const noexcept
+{
+  return region();
+}
+
 RegionResult::~RegionResult() noexcept
 {
   on_input_destroy(this);
@@ -71,6 +77,12 @@ RegionResult::RegionResult(
 
     output->results.push_back(this);
   }
+}
+
+[[nodiscard]] std::variant<node *, Region *>
+RegionResult::GetOwner() const noexcept
+{
+  return region();
 }
 
 Region::~Region() noexcept


### PR DESCRIPTION
Introduce input::GetOwner and output::GetOwner as the canonical and type-generic way to determine what "kind" an output/input is (either output/input to a node or region argument/result).

Introduce TryGetOwnerNode and TryGetRegionParentNode as convenience API to easily match different node kinds.