### PR TITLE
lambda: revise API as well as results, arguments and outputs

### DIFF
--- a/jlm/hls/backend/rhls2firrtl/verilator-harness-hls.cpp
+++ b/jlm/hls/backend/rhls2firrtl/verilator-harness-hls.cpp
@@ -490,10 +490,10 @@ VerilatorHarnessHLS::get_text(llvm::RvsdgModule & rm)
     cpp << "    top->i_data_" << i << " = (uint64_t) a" << i << ";\n";
     register_ix++;
   }
-  for (size_t i = 0; i < ln->ncvarguments(); ++i)
+  for (const auto & ctxvar : ln->GetContextVars())
   {
     std::string name;
-    if (auto graphImport = dynamic_cast<const llvm::GraphImport *>(ln->input(i)->origin()))
+    if (auto graphImport = dynamic_cast<const llvm::GraphImport *>(ctxvar.input->origin()))
     {
       name = graphImport->Name();
     }

--- a/jlm/hls/backend/rvsdg2rhls/UnusedStateRemoval.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/UnusedStateRemoval.cpp
@@ -76,7 +76,7 @@ RemoveUnusedStatesFromLambda(llvm::lambda::node & lambdaNode)
     auto oldArgument = ctxvar.inner;
     auto origin = ctxvar.input->origin();
 
-    auto newArgument = newLambda->AddContextVar(origin).inner;
+    auto newArgument = newLambda->AddContextVar(*origin).inner;
     substitutionMap.insert(oldArgument, newArgument);
   }
 

--- a/jlm/hls/backend/rvsdg2rhls/UnusedStateRemoval.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/UnusedStateRemoval.cpp
@@ -14,7 +14,7 @@ namespace jlm::hls
 {
 
 static bool
-IsPassthroughArgument(const rvsdg::RegionArgument & argument)
+IsPassthroughArgument(const rvsdg::output & argument)
 {
   if (argument.nusers() != 1)
   {
@@ -25,7 +25,7 @@ IsPassthroughArgument(const rvsdg::RegionArgument & argument)
 }
 
 static bool
-IsPassthroughResult(const rvsdg::RegionResult & result)
+IsPassthroughResult(const rvsdg::input & result)
 {
   auto argument = dynamic_cast<rvsdg::RegionArgument *>(result.origin());
   return argument != nullptr;
@@ -71,31 +71,30 @@ RemoveUnusedStatesFromLambda(llvm::lambda::node & lambdaNode)
       lambdaNode.attributes());
 
   rvsdg::SubstitutionMap substitutionMap;
-  for (size_t i = 0; i < lambdaNode.ncvarguments(); ++i)
+  for (const auto & ctxvar : lambdaNode.GetContextVars())
   {
-    auto oldArgument = lambdaNode.cvargument(i);
-    auto origin = oldArgument->input()->origin();
+    auto oldArgument = ctxvar.inner;
+    auto origin = ctxvar.input->origin();
 
-    auto newArgument = newLambda->add_ctxvar(origin);
+    auto newArgument = newLambda->AddContextVar(origin).inner;
     substitutionMap.insert(oldArgument, newArgument);
   }
 
   size_t new_i = 0;
-  for (size_t i = 0; i < lambdaNode.nfctarguments(); ++i)
+  auto newArgs = newLambda->GetFunctionArguments();
+  for (auto argument : lambdaNode.GetFunctionArguments())
   {
-    auto argument = lambdaNode.fctargument(i);
     if (!IsPassthroughArgument(*argument))
     {
-      substitutionMap.insert(argument, newLambda->fctargument(new_i));
+      substitutionMap.insert(argument, newArgs[new_i]);
       new_i++;
     }
   }
   lambdaNode.subregion()->copy(newLambda->subregion(), substitutionMap, false, false);
 
   std::vector<jlm::rvsdg::output *> newResults;
-  for (size_t i = 0; i < lambdaNode.nfctresults(); ++i)
+  for (auto result : lambdaNode.GetFunctionResults())
   {
-    auto result = lambdaNode.fctresult(i);
     if (!IsPassthroughResult(*result))
     {
       newResults.push_back(substitutionMap.lookup(result->origin()));

--- a/jlm/hls/backend/rvsdg2rhls/add-prints.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-prints.cpp
@@ -88,7 +88,7 @@ route_to_region(jlm::rvsdg::output * output, rvsdg::Region * region)
   }
   else if (auto lambda = dynamic_cast<llvm::lambda::node *>(region->node()))
   {
-    output = lambda->AddContextVar(output).inner;
+    output = lambda->AddContextVar(*output).inner;
   }
   else
   {

--- a/jlm/hls/backend/rvsdg2rhls/add-prints.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-prints.cpp
@@ -88,7 +88,7 @@ route_to_region(jlm::rvsdg::output * output, rvsdg::Region * region)
   }
   else if (auto lambda = dynamic_cast<llvm::lambda::node *>(region->node()))
   {
-    output = lambda->add_ctxvar(output);
+    output = lambda->AddContextVar(output).inner;
   }
   else
   {

--- a/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
@@ -54,7 +54,7 @@ add_lambda_argument(llvm::lambda::node * ln, std::shared_ptr<const jlm::rvsdg::T
   for (const auto & ctxvar : ln->GetContextVars())
   {
     // copy over context vars
-    smap.insert(ctxvar.inner, new_lambda->AddContextVar(ctxvar.input->origin()).inner);
+    smap.insert(ctxvar.inner, new_lambda->AddContextVar(*ctxvar.input->origin()).inner);
   }
   auto old_args = ln->GetFunctionArguments();
   auto new_args = new_lambda->GetFunctionArguments();

--- a/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
@@ -51,23 +51,25 @@ add_lambda_argument(llvm::lambda::node * ln, std::shared_ptr<const jlm::rvsdg::T
       ln->attributes());
 
   rvsdg::SubstitutionMap smap;
-  for (size_t i = 0; i < ln->ncvarguments(); ++i)
+  for (const auto & ctxvar : ln->GetContextVars())
   {
-    // copy over cvarguments
-    smap.insert(ln->cvargument(i), new_lambda->add_ctxvar(ln->cvargument(i)->input()->origin()));
+    // copy over context vars
+    smap.insert(ctxvar.inner, new_lambda->AddContextVar(ctxvar.input->origin()).inner);
   }
-  for (size_t i = 0; i < ln->nfctarguments(); ++i)
+  auto old_args = ln->GetFunctionArguments();
+  auto new_args = new_lambda->GetFunctionArguments();
+  for (size_t i = 0; i < old_args.size(); ++i)
   {
-    smap.insert(ln->fctargument(i), new_lambda->fctargument(i));
+    smap.insert(old_args[i], new_args[i]);
   }
   //	jlm::rvsdg::view(ln->subregion(), stdout);
   //	jlm::rvsdg::view(new_lambda->subregion(), stdout);
   ln->subregion()->copy(new_lambda->subregion(), smap, false, false);
 
   std::vector<jlm::rvsdg::output *> new_results;
-  for (size_t i = 0; i < ln->nfctresults(); ++i)
+  for (auto result : ln->GetFunctionResults())
   {
-    new_results.push_back(smap.lookup(ln->fctresult(i)->origin()));
+    new_results.push_back(smap.lookup(result->origin()));
   }
   auto new_out = new_lambda->finalize(new_results);
 

--- a/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
@@ -31,7 +31,7 @@ change_function_name(llvm::lambda::node * ln, const std::string & name)
   for (const auto & cv : ln->GetContextVars())
   {
     auto origin = cv.input->origin();
-    auto newcv = lambda->AddContextVar(origin);
+    auto newcv = lambda->AddContextVar(*origin);
     subregionmap.insert(cv.inner, newcv.inner);
   }
 

--- a/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
@@ -28,18 +28,20 @@ change_function_name(llvm::lambda::node * ln, const std::string & name)
 
   /* add context variables */
   rvsdg::SubstitutionMap subregionmap;
-  for (auto & cv : ln->ctxvars())
+  for (const auto & cv : ln->GetContextVars())
   {
-    auto origin = cv.origin();
-    auto newcv = lambda->add_ctxvar(origin);
-    subregionmap.insert(cv.argument(), newcv);
+    auto origin = cv.input->origin();
+    auto newcv = lambda->AddContextVar(origin);
+    subregionmap.insert(cv.inner, newcv.inner);
   }
 
   /* collect function arguments */
-  for (size_t n = 0; n < ln->nfctarguments(); n++)
+  auto args = ln->GetFunctionArguments();
+  auto new_args = lambda->GetFunctionArguments();
+  for (size_t n = 0; n < args.size(); n++)
   {
-    lambda->fctargument(n)->set_attributes(ln->fctargument(n)->attributes());
-    subregionmap.insert(ln->fctargument(n), lambda->fctargument(n));
+    lambda->SetArgumentAttributes(*new_args[n], ln->GetArgumentAttributes(*args[n]));
+    subregionmap.insert(args[n], new_args[n]);
   }
 
   /* copy subregion */
@@ -47,8 +49,8 @@ change_function_name(llvm::lambda::node * ln, const std::string & name)
 
   /* collect function results */
   std::vector<jlm::rvsdg::output *> results;
-  for (auto & result : ln->fctresults())
-    results.push_back(subregionmap.lookup(result.origin()));
+  for (auto result : ln->GetFunctionResults())
+    results.push_back(subregionmap.lookup(result->origin()));
 
   /* finalize lambda */
   lambda->finalize(results);

--- a/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
@@ -649,7 +649,7 @@ jlm::hls::MemoryConverter(jlm::llvm::RvsdgModule & rm)
   rvsdg::SubstitutionMap smap;
   for (const auto & ctxvar : lambda->GetContextVars())
   {
-    smap.insert(ctxvar.inner, newLambda->AddContextVar(ctxvar.input->origin()).inner);
+    smap.insert(ctxvar.inner, newLambda->AddContextVar(*ctxvar.input->origin()).inner);
   }
 
   auto args = lambda->GetFunctionArguments();

--- a/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
@@ -209,7 +209,7 @@ remove_lambda_passthrough(llvm::lambda::node * ln)
   for (const auto & ctxvar : ln->GetContextVars())
   {
     // copy over context vars
-    smap.insert(ctxvar.inner, new_lambda->AddContextVar(ctxvar.input->origin()).inner);
+    smap.insert(ctxvar.inner, new_lambda->AddContextVar(*ctxvar.input->origin()).inner);
   }
 
   size_t new_i = 0;

--- a/jlm/hls/backend/rvsdg2rhls/remove-unused-state.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/remove-unused-state.hpp
@@ -15,10 +15,10 @@ namespace jlm::hls
 {
 
 bool
-is_passthrough(const rvsdg::RegionArgument * arg);
+is_passthrough(const rvsdg::output * arg);
 
 bool
-is_passthrough(const rvsdg::RegionResult * res);
+is_passthrough(const rvsdg::input * res);
 
 llvm::lambda::node *
 remove_lambda_passthrough(llvm::lambda::node * ln);

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -287,18 +287,21 @@ change_linkage(llvm::lambda::node * ln, llvm::linkage link)
 
   /* add context variables */
   rvsdg::SubstitutionMap subregionmap;
-  for (auto & cv : ln->ctxvars())
+  for (const auto & cv : ln->GetContextVars())
   {
-    auto origin = cv.origin();
-    auto newcv = lambda->add_ctxvar(origin);
-    subregionmap.insert(cv.argument(), newcv);
+    auto origin = cv.input->origin();
+    auto newcv = lambda->AddContextVar(origin);
+    subregionmap.insert(cv.inner, newcv.inner);
   }
 
   /* collect function arguments */
-  for (size_t n = 0; n < ln->nfctarguments(); n++)
+  auto args = ln->GetFunctionArguments();
+  auto newArgs = lambda->GetFunctionArguments();
+  JLM_ASSERT(args.size() == newArgs.size());
+  for (size_t n = 0; n < args.size(); n++)
   {
-    lambda->fctargument(n)->set_attributes(ln->fctargument(n)->attributes());
-    subregionmap.insert(ln->fctargument(n), lambda->fctargument(n));
+    lambda->SetArgumentAttributes(*newArgs[n], ln->GetArgumentAttributes(*args[n]));
+    subregionmap.insert(args[n], newArgs[n]);
   }
 
   /* copy subregion */
@@ -306,8 +309,8 @@ change_linkage(llvm::lambda::node * ln, llvm::linkage link)
 
   /* collect function results */
   std::vector<jlm::rvsdg::output *> results;
-  for (auto & result : ln->fctresults())
-    results.push_back(subregionmap.lookup(result.origin()));
+  for (auto result : ln->GetFunctionResults())
+    results.push_back(subregionmap.lookup(result->origin()));
 
   /* finalize lambda */
   lambda->finalize(results);

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -290,7 +290,7 @@ change_linkage(llvm::lambda::node * ln, llvm::linkage link)
   for (const auto & cv : ln->GetContextVars())
   {
     auto origin = cv.input->origin();
-    auto newcv = lambda->AddContextVar(origin);
+    auto newcv = lambda->AddContextVar(*origin);
     subregionmap.insert(cv.inner, newcv.inner);
   }
 

--- a/jlm/llvm/backend/rvsdg2jlm/rvsdg2jlm.cpp
+++ b/jlm/llvm/backend/rvsdg2jlm/rvsdg2jlm.cpp
@@ -127,27 +127,27 @@ create_cfg(const lambda::node & lambda, context & ctx)
   ctx.set_cfg(cfg.get());
 
   /* add arguments */
-  size_t n = 0;
-  for (auto & fctarg : lambda.fctarguments())
+  for (auto fctarg : lambda.GetFunctionArguments())
   {
-    auto name = util::strfmt("_a", n++, "_");
-    auto argument = llvm::argument::create(name, fctarg.Type(), fctarg.attributes());
+    auto name = util::strfmt("_a", fctarg->index(), "_");
+    auto argument =
+        llvm::argument::create(name, fctarg->Type(), lambda.GetArgumentAttributes(*fctarg));
     auto v = cfg->entry()->append_argument(std::move(argument));
-    ctx.insert(&fctarg, v);
+    ctx.insert(fctarg, v);
   }
 
   /* add context variables */
-  for (auto & cv : lambda.ctxvars())
+  for (const auto & cv : lambda.GetContextVars())
   {
-    auto v = ctx.variable(cv.origin());
-    ctx.insert(cv.argument(), v);
+    auto v = ctx.variable(cv.input->origin());
+    ctx.insert(cv.inner, v);
   }
 
   convert_region(*lambda.subregion(), ctx);
 
   /* add results */
-  for (auto & result : lambda.fctresults())
-    cfg->exit()->append_result(ctx.variable(result.origin()));
+  for (auto result : lambda.GetFunctionResults())
+    cfg->exit()->append_result(ctx.variable(result->origin()));
 
   ctx.lpbb()->add_outedge(cfg->exit());
   ctx.set_lpbb(nullptr);

--- a/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
+++ b/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
@@ -614,14 +614,15 @@ Convert(
   /*
    * Add arguments
    */
-  JLM_ASSERT(entryAggregationNode.narguments() == lambdaNode.nfctarguments());
+  JLM_ASSERT(entryAggregationNode.narguments() == lambdaNode.GetFunctionArguments().size());
+  auto lambdaArgs = lambdaNode.GetFunctionArguments();
   for (size_t n = 0; n < entryAggregationNode.narguments(); n++)
   {
     auto functionNodeArgument = entryAggregationNode.argument(n);
-    auto lambdaNodeArgument = lambdaNode.fctargument(n);
+    auto lambdaNodeArgument = lambdaArgs[n];
 
     topVariableMap.insert(functionNodeArgument, lambdaNodeArgument);
-    lambdaNodeArgument->set_attributes(functionNodeArgument->attributes());
+    lambdaNode.SetArgumentAttributes(*lambdaNodeArgument, functionNodeArgument->attributes());
   }
 
   /*
@@ -631,7 +632,7 @@ Convert(
   {
     if (outerVariableMap.contains(&v))
     {
-      topVariableMap.insert(&v, lambdaNode.add_ctxvar(outerVariableMap.lookup(&v)));
+      topVariableMap.insert(&v, lambdaNode.AddContextVar(outerVariableMap.lookup(&v)).inner);
     }
     else
     {
@@ -912,7 +913,7 @@ AnnotateAggregationTree(
   return demandMap;
 }
 
-static lambda::output *
+static rvsdg::output *
 ConvertAggregationTreeToLambda(
     const aggnode & aggregationTreeRoot,
     const AnnotationMap & demandMap,

--- a/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
+++ b/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
@@ -632,7 +632,7 @@ Convert(
   {
     if (outerVariableMap.contains(&v))
     {
-      topVariableMap.insert(&v, lambdaNode.AddContextVar(outerVariableMap.lookup(&v)).inner);
+      topVariableMap.insert(&v, lambdaNode.AddContextVar(*outerVariableMap.lookup(&v)).inner);
     }
     else
     {

--- a/jlm/llvm/ir/operators/call.hpp
+++ b/jlm/llvm/ir/operators/call.hpp
@@ -172,12 +172,12 @@ public:
    *
    * @return The called function.
    */
-  [[nodiscard]] lambda::output &
+  [[nodiscard]] rvsdg::output &
   GetLambdaOutput() const noexcept
   {
     if (GetCallType() == CallType::NonRecursiveDirectCall)
     {
-      return *jlm::util::AssertedCast<lambda::output>(Output_);
+      return *Output_;
     }
 
     JLM_ASSERT(GetCallType() == CallType::RecursiveDirectCall);
@@ -187,8 +187,7 @@ public:
      * would be better if we did not use the index for retrieving the result, but instead
      * explicitly encoded it in an phi_argument.
      */
-    return *jlm::util::AssertedCast<lambda::output>(
-        argument->region()->result(argument->index())->origin());
+    return *argument->region()->result(argument->index())->origin();
   }
 
   /** \brief Returns the imported function.
@@ -219,7 +218,7 @@ public:
   }
 
   static std::unique_ptr<CallTypeClassifier>
-  CreateNonRecursiveDirectCallClassifier(lambda::output & output)
+  CreateNonRecursiveDirectCallClassifier(rvsdg::output & output)
   {
     return std::make_unique<CallTypeClassifier>(CallType::NonRecursiveDirectCall, output);
   }

--- a/jlm/llvm/ir/operators/call.hpp
+++ b/jlm/llvm/ir/operators/call.hpp
@@ -217,12 +217,31 @@ public:
     return *Output_;
   }
 
+  /**
+    \brief Classify callee as non-recursive.
+
+    \param output
+      Output representing the function called (must be a lambda).
+
+    \pre
+      The given output must belong to a lambda node.
+  */
   static std::unique_ptr<CallTypeClassifier>
   CreateNonRecursiveDirectCallClassifier(rvsdg::output & output)
   {
+    rvsdg::AssertGetOwnerNode<lambda::node>(output);
     return std::make_unique<CallTypeClassifier>(CallType::NonRecursiveDirectCall, output);
   }
 
+  /**
+    \brief Classify callee as recursive.
+
+    \param output
+      Output representing the function called (must be phi argument).
+
+    \pre
+      The given output must belong to a phi node.
+  */
   static std::unique_ptr<CallTypeClassifier>
   CreateRecursiveDirectCallClassifier(rvsdg::RegionArgument & output)
   {
@@ -230,6 +249,15 @@ public:
     return std::make_unique<CallTypeClassifier>(CallType::RecursiveDirectCall, output);
   }
 
+  /**
+    \brief Classify callee as external.
+
+    \param argument
+      Output representing the function called (must be graph argument).
+
+    \pre
+      The given output must be an argument to the root region of the graph.
+  */
   static std::unique_ptr<CallTypeClassifier>
   CreateExternalCallClassifier(rvsdg::RegionArgument & argument)
   {
@@ -237,6 +265,12 @@ public:
     return std::make_unique<CallTypeClassifier>(CallType::ExternalCall, argument);
   }
 
+  /**
+    \brief Classify callee as inderict.
+
+    \param output
+      Output representing the function called (supposed to be pointer).
+  */
   static std::unique_ptr<CallTypeClassifier>
   CreateIndirectCallClassifier(jlm::rvsdg::output & output)
   {

--- a/jlm/llvm/ir/operators/lambda.cpp
+++ b/jlm/llvm/ir/operators/lambda.cpp
@@ -41,8 +41,8 @@ operation::copy() const
 
 node::~node() = default;
 
-node::node(rvsdg::Region * parent, lambda::operation op)
-    : StructuralNode(std::move(op), parent, 1)
+node::node(rvsdg::Region & parent, lambda::operation op)
+    : StructuralNode(std::move(op), &parent, 1)
 {
   ArgumentAttributes_.resize(GetOperation().Type()->NumArguments());
 }
@@ -113,10 +113,10 @@ node::GetContextVars() const noexcept
 }
 
 node::ContextVar
-node::AddContextVar(jlm::rvsdg::output * origin)
+node::AddContextVar(jlm::rvsdg::output & origin)
 {
-  auto input = rvsdg::StructuralInput::create(this, origin, origin->Type());
-  auto argument = &rvsdg::RegionArgument::Create(*subregion(), input, origin->Type());
+  auto input = rvsdg::StructuralInput::create(this, &origin, origin.Type());
+  auto argument = &rvsdg::RegionArgument::Create(*subregion(), input, origin.Type());
   return ContextVar{ input, argument };
 }
 
@@ -170,7 +170,7 @@ node::create(
     const attributeset & attributes)
 {
   lambda::operation op(type, name, linkage, attributes);
-  auto node = new lambda::node(parent, std::move(op));
+  auto node = new lambda::node(*parent, std::move(op));
 
   for (auto & argumentType : type->Arguments())
     rvsdg::RegionArgument::Create(*node->subregion(), nullptr, argumentType);
@@ -230,7 +230,7 @@ node::copy(rvsdg::Region * region, rvsdg::SubstitutionMap & smap) const
   for (const auto & cv : GetContextVars())
   {
     auto origin = smap.lookup(cv.input->origin());
-    subregionmap.insert(cv.inner, lambda->AddContextVar(origin).inner);
+    subregionmap.insert(cv.inner, lambda->AddContextVar(*origin).inner);
   }
 
   /* collect function arguments */

--- a/jlm/llvm/ir/operators/lambda.hpp
+++ b/jlm/llvm/ir/operators/lambda.hpp
@@ -15,6 +15,7 @@
 #include <jlm/rvsdg/substitution.hpp>
 #include <jlm/util/iterator_range.hpp>
 
+#include <optional>
 #include <utility>
 
 namespace jlm::llvm
@@ -101,27 +102,22 @@ private:
   jlm::llvm::attributeset attributes_;
 };
 
-class cvargument;
-class cvinput;
-class fctargument;
-class output;
-class result;
-
 /** \brief Lambda node
  *
  * A lambda node represents a lambda expression in the RVSDG. Its creation requires the invocation
  * of two functions: \ref create() and \ref finalize(). First, a node with only the function
  * arguments is created by invoking \ref create(). The free variables of the lambda expression can
- * then be added to the lambda node using the \ref add_ctxvar() method, and the body of the lambda
- * node can be created. Finally, the lambda node can be finalized by invoking \ref finalize().
+ * then be added to the lambda node using the \ref AddContextVar() method, and the body of the
+ * lambda node can be created. Finally, the lambda node can be finalized by invoking \ref
+ * finalize().
  *
  * The following snippet illustrates the creation of lambda nodes:
  *
  * \code{.cpp}
  *   auto lambda = lambda::node::create(...);
  *   ...
- *   auto cv1 = lambda->add_ctxvar(...);
- *   auto cv2 = lambda->add_ctxvar(...);
+ *   auto cv1 = lambda->AddContextVar(...);
+ *   auto cv2 = lambda->AddContextVar(...);
  *   ...
  *   // generate lambda body
  *   ...
@@ -133,51 +129,52 @@ class node final : public rvsdg::StructuralNode
 public:
   class CallSummary;
 
-private:
-  class cviterator;
-  class cvconstiterator;
-
-  class fctargiterator;
-  class fctargconstiterator;
-
-  class fctresiterator;
-  class fctresconstiterator;
-
-  using fctargument_range = jlm::util::iterator_range<fctargiterator>;
-  using fctargument_constrange = jlm::util::iterator_range<fctargconstiterator>;
-
-  using ctxvar_range = jlm::util::iterator_range<cviterator>;
-  using ctxvar_constrange = jlm::util::iterator_range<cvconstiterator>;
-
-  using fctresult_range = jlm::util::iterator_range<fctresiterator>;
-  using fctresult_constrange = jlm::util::iterator_range<fctresconstiterator>;
-
-public:
   ~node() override;
 
 private:
-  node(rvsdg::Region * parent, lambda::operation && op)
-      : StructuralNode(op, parent, 1)
-  {}
+  node(rvsdg::Region * parent, lambda::operation op);
 
 public:
-  [[nodiscard]] fctargument_range
-  fctarguments();
+  /**
+   * \brief Bound context variable
+   *
+   * Context variables may be bound at the point of creation of a
+   * lambda abstraction. These are represented as inputs to the
+   * lambda node itself, and made accessible to the body of the
+   * lambda in the form of an initial argument to the subregion.
+   */
+  struct ContextVar
+  {
+    /**
+     * \brief Input variable bound into lambda node
+     *
+     * The input port into the lambda node that supplies the value
+     * of the context variable bound into the lambda at the
+     * time the lambda abstraction is built.
+     */
+    rvsdg::input * input;
 
-  [[nodiscard]] fctargument_constrange
-  fctarguments() const;
+    /**
+     * \brief Access to bound object in subregion.
+     *
+     * Supplies access to the value bound into the lambda abstraction
+     * from inside the region contained in the lambda node. This
+     * evaluates to the value bound into the lambda.
+     */
+    rvsdg::output * inner;
+  };
 
-  ctxvar_range
-  ctxvars();
+  [[nodiscard]] std::vector<rvsdg::output *>
+  GetFunctionArguments() const;
 
-  [[nodiscard]] ctxvar_constrange
-  ctxvars() const;
+  [[nodiscard]] std::vector<rvsdg::input *>
+  GetFunctionResults() const;
 
-  fctresult_range
-  fctresults();
+  [[nodiscard]] const jlm::llvm::attributeset &
+  GetArgumentAttributes(const rvsdg::output & argument) const noexcept;
 
-  [[nodiscard]] fctresult_constrange
-  fctresults() const;
+  void
+  SetArgumentAttributes(rvsdg::output & argument, const jlm::llvm::attributeset & attributes);
 
   [[nodiscard]] rvsdg::Region *
   subregion() const noexcept
@@ -218,43 +215,80 @@ public:
     return GetOperation().attributes();
   }
 
-  [[nodiscard]] size_t
-  ncvarguments() const noexcept
-  {
-    return ninputs();
-  }
-
-  [[nodiscard]] size_t
-  nfctarguments() const noexcept
-  {
-    return subregion()->narguments() - ninputs();
-  }
-
-  [[nodiscard]] size_t
-  nfctresults() const noexcept
-  {
-    return subregion()->nresults();
-  }
+  /**
+   * \brief Adds a context/free variable to the lambda node.
+   *
+   * \param origin
+   *   The value to be bound into the lambda node.
+   *
+   * \pre
+   *   \p origin must be from the same region as the lambda node.
+   *
+   * \return The context variable argument of the lambda abstraction.
+   */
+  ContextVar
+  AddContextVar(jlm::rvsdg::output * origin);
 
   /**
-   * Adds a context/free variable to the lambda node. The \p origin must be from the same region
-   * as the lambda node.
+   * \brief Maps input to context variable.
    *
-   * \return The context variable argument from the lambda region.
+   * \param input
+   *   Input to the lambda node.
+   *
+   * \returns
+   *   The context variable description corresponding to the input.
+   *
+   * \pre
+   *   \p input must be input to this node.
+   *
+   * Returns the context variable description corresponding
+   * to this input of the lambda node. All inputs to the lambda
+   * node are by definition bound context variables that are
+   * accessible in the subregion through the corresponding
+   * argument.
    */
-  lambda::cvargument *
-  add_ctxvar(jlm::rvsdg::output * origin);
+  [[nodiscard]] ContextVar
+  MapInputContextVar(const rvsdg::input & input) const noexcept;
+
+  /**
+   * \brief Maps bound variable reference to context variable
+   *
+   * \param output
+   *   Region argument to lambda subregion
+   *
+   * \returns
+   *   The context variable description corresponding to the argument
+   *
+   * \pre
+   *   \p output must be an argument to the subregion of this node
+   *
+   * Returns the context variable description corresponding
+   * to this bound variable reference in the lambda node region.
+   * Note that some arguments of the region are formal call arguments
+   * and do not have an associated context variable description.
+   */
+  [[nodiscard]] std::optional<ContextVar>
+  MapBinderContextVar(const rvsdg::output & output) const noexcept;
+
+  /**
+   * \brief Gets all bound context variables
+   *
+   * \returns
+   *   The context variable descriptions.
+   *
+   * Returns all context variable descriptions.
+   */
+  [[nodiscard]] std::vector<ContextVar>
+  GetContextVars() const noexcept;
 
   /**
    * Remove lambda inputs and their respective arguments.
    *
    * An input must match the condition specified by \p match and its argument must be dead.
    *
-   * @tparam F A type that supports the function call operator: bool operator(const cvinput&)
+   * @tparam F A type that supports the function call operator: bool operator(const rvsdg::input&)
    * @param match Defines the condition of the elements to remove.
    * @return The number of removed inputs.
-   *
-   * \see cvargument#IsDead()
    */
   template<typename F>
   size_t
@@ -270,7 +304,7 @@ public:
   size_t
   PruneLambdaInputs()
   {
-    auto match = [](const cvinput &)
+    auto match = [](const rvsdg::input &)
     {
       return true;
     };
@@ -278,20 +312,8 @@ public:
     return RemoveLambdaInputsWhere(match);
   }
 
-  [[nodiscard]] cvinput *
-  input(size_t n) const noexcept;
-
-  [[nodiscard]] lambda::output *
+  [[nodiscard]] rvsdg::output *
   output() const noexcept;
-
-  [[nodiscard]] lambda::fctargument *
-  fctargument(size_t n) const noexcept;
-
-  [[nodiscard]] lambda::cvargument *
-  cvargument(size_t n) const noexcept;
-
-  [[nodiscard]] lambda::result *
-  fctresult(size_t n) const noexcept;
 
   lambda::node *
   copy(rvsdg::Region * region, const std::vector<jlm::rvsdg::output *> & operands) const override;
@@ -302,13 +324,13 @@ public:
   /**
    * @return The memory state argument of the lambda subregion.
    */
-  [[nodiscard]] rvsdg::RegionArgument &
+  [[nodiscard]] rvsdg::output &
   GetMemoryStateRegionArgument() const noexcept;
 
   /**
    * @return The memory state result of the lambda subregion.
    */
-  [[nodiscard]] rvsdg::RegionResult &
+  [[nodiscard]] rvsdg::input &
   GetMemoryStateRegionResult() const noexcept;
 
   /**
@@ -338,8 +360,8 @@ public:
   /**
    * Creates a lambda node in the region \p parent with the function type \p type and name \p name.
    * After the invocation of \ref create(), the lambda node only features the function arguments.
-   * Free variables can be added to the function node using \ref add_ctxvar(). The generation of the
-   * node can be finished using the \ref finalize() method.
+   * Free variables can be added to the function node using \ref AddContextVar(). The generation of
+   * the node can be finished using the \ref finalize() method.
    *
    * \param parent The region where the lambda node is created.
    * \param type The lambda node's type.
@@ -377,7 +399,7 @@ public:
    *
    * \return The output of the lambda node.
    */
-  lambda::output *
+  rvsdg::output *
   finalize(const std::vector<jlm::rvsdg::output *> & results);
 
   /**
@@ -398,302 +420,9 @@ public:
    */
   [[nodiscard]] static bool
   IsExported(const lambda::node & lambdaNode);
-};
-
-/** \brief Lambda context variable input
- */
-class cvinput final : public rvsdg::StructuralInput
-{
-  friend ::jlm::llvm::lambda::node;
-
-public:
-  ~cvinput() override;
 
 private:
-  cvinput(lambda::node * node, jlm::rvsdg::output * origin)
-      : StructuralInput(node, origin, origin->Type())
-  {}
-
-  static cvinput *
-  create(lambda::node * node, jlm::rvsdg::output * origin)
-  {
-    auto input = std::unique_ptr<cvinput>(new cvinput(node, origin));
-    return jlm::util::AssertedCast<cvinput>(node->append_input(std::move(input)));
-  }
-
-public:
-  [[nodiscard]] cvargument *
-  argument() const noexcept;
-
-  [[nodiscard]] lambda::node *
-  node() const noexcept
-  {
-    return jlm::util::AssertedCast<lambda::node>(StructuralInput::node());
-  }
-};
-
-/** \brief Lambda context variable iterator
- */
-class node::cviterator final : public jlm::rvsdg::input::iterator<cvinput>
-{
-  friend ::jlm::llvm::lambda::node;
-
-  constexpr explicit cviterator(cvinput * input)
-      : jlm::rvsdg::input::iterator<cvinput>(input)
-  {}
-
-  [[nodiscard]] cvinput *
-  next() const override
-  {
-    auto node = value()->node();
-    auto index = value()->index();
-
-    return node->ninputs() > index + 1 ? node->input(index + 1) : nullptr;
-  }
-};
-
-/** \brief Lambda context variable const iterator
- */
-class node::cvconstiterator final : public jlm::rvsdg::input::constiterator<cvinput>
-{
-  friend ::jlm::llvm::lambda::node;
-
-  constexpr explicit cvconstiterator(const cvinput * input)
-      : jlm::rvsdg::input::constiterator<cvinput>(input)
-  {}
-
-  [[nodiscard]] const cvinput *
-  next() const override
-  {
-    auto node = value()->node();
-    auto index = value()->index();
-
-    return node->ninputs() > index + 1 ? node->input(index + 1) : nullptr;
-  }
-};
-
-/** \brief Lambda output
- */
-class output final : public rvsdg::StructuralOutput
-{
-  friend ::jlm::llvm::lambda::node;
-
-public:
-  ~output() override;
-
-  output(lambda::node * node, std::shared_ptr<const rvsdg::Type> type)
-      : StructuralOutput(node, std::move(type))
-  {}
-
-private:
-  static output *
-  create(lambda::node * node, std::shared_ptr<const rvsdg::Type> type)
-  {
-    auto output = std::make_unique<lambda::output>(node, std::move(type));
-    return jlm::util::AssertedCast<lambda::output>(node->append_output(std::move(output)));
-  }
-
-public:
-  lambda::node *
-  node() const noexcept
-  {
-    return jlm::util::AssertedCast<lambda::node>(StructuralOutput::node());
-  }
-};
-
-/** \brief Lambda function argument
- */
-class fctargument final : public rvsdg::RegionArgument
-{
-  friend ::jlm::llvm::lambda::node;
-
-public:
-  ~fctargument() override;
-
-  const jlm::llvm::attributeset &
-  attributes() const noexcept
-  {
-    return attributes_;
-  }
-
-  void
-  set_attributes(const jlm::llvm::attributeset & attributes)
-  {
-    attributes_ = attributes;
-  }
-
-  fctargument &
-  Copy(rvsdg::Region & region, rvsdg::StructuralInput * input) override;
-
-private:
-  fctargument(rvsdg::Region * region, std::shared_ptr<const jlm::rvsdg::Type> type)
-      : rvsdg::RegionArgument(region, nullptr, std::move(type))
-  {}
-
-  static fctargument *
-  create(rvsdg::Region * region, std::shared_ptr<const jlm::rvsdg::Type> type)
-  {
-    auto argument = new fctargument(region, std::move(type));
-    region->append_argument(argument);
-    return argument;
-  }
-
-  jlm::llvm::attributeset attributes_;
-};
-
-/** \brief Lambda function argument iterator
- */
-class node::fctargiterator final : public jlm::rvsdg::output::iterator<lambda::fctargument>
-{
-  friend ::jlm::llvm::lambda::node;
-
-  constexpr explicit fctargiterator(lambda::fctargument * argument)
-      : jlm::rvsdg::output::iterator<lambda::fctargument>(argument)
-  {}
-
-  [[nodiscard]] lambda::fctargument *
-  next() const override
-  {
-    auto index = value()->index();
-    auto lambda = jlm::util::AssertedCast<lambda::node>(value()->region()->node());
-
-    /*
-      This assumes that all function arguments were added to the lambda region
-      before any context variable was added.
-    */
-    return lambda->nfctarguments() > index + 1 ? lambda->fctargument(index + 1) : nullptr;
-  }
-};
-
-/** \brief Lambda function argument const iterator
- */
-class node::fctargconstiterator final
-    : public jlm::rvsdg::output::constiterator<lambda::fctargument>
-{
-  friend ::jlm::llvm::lambda::node;
-
-  constexpr explicit fctargconstiterator(const lambda::fctargument * argument)
-      : jlm::rvsdg::output::constiterator<lambda::fctargument>(argument)
-  {}
-
-  [[nodiscard]] const lambda::fctargument *
-  next() const override
-  {
-    auto index = value()->index();
-    auto lambda = jlm::util::AssertedCast<lambda::node>(value()->region()->node());
-
-    /*
-      This assumes that all function arguments were added to the lambda region
-      before any context variable was added.
-    */
-    return lambda->nfctarguments() > index + 1 ? lambda->fctargument(index + 1) : nullptr;
-  }
-};
-
-/** \brief Lambda context variable argument
- */
-class cvargument final : public rvsdg::RegionArgument
-{
-  friend ::jlm::llvm::lambda::node;
-
-public:
-  ~cvargument() override;
-
-  cvargument &
-  Copy(rvsdg::Region & region, rvsdg::StructuralInput * input) override;
-
-private:
-  cvargument(rvsdg::Region * region, cvinput * input)
-      : rvsdg::RegionArgument(region, input, input->Type())
-  {}
-
-  static cvargument *
-  create(rvsdg::Region * region, lambda::cvinput * input)
-  {
-    auto argument = new cvargument(region, input);
-    region->append_argument(argument);
-    return argument;
-  }
-
-public:
-  cvinput *
-  input() const noexcept
-  {
-    return jlm::util::AssertedCast<cvinput>(rvsdg::RegionArgument::input());
-  }
-};
-
-/** \brief Lambda result
- */
-class result final : public rvsdg::RegionResult
-{
-  friend ::jlm::llvm::lambda::node;
-
-public:
-  ~result() override;
-
-  result &
-  Copy(rvsdg::output & origin, rvsdg::StructuralOutput * output) override;
-
-private:
-  explicit result(jlm::rvsdg::output * origin)
-      : rvsdg::RegionResult(origin->region(), origin, nullptr, origin->Type())
-  {}
-
-  static result *
-  create(jlm::rvsdg::output * origin)
-  {
-    auto result = new lambda::result(origin);
-    origin->region()->append_result(result);
-    return result;
-  }
-
-public:
-  lambda::output *
-  output() const noexcept
-  {
-    return jlm::util::AssertedCast<lambda::output>(rvsdg::RegionResult::output());
-  }
-};
-
-/** \brief Lambda result iterator
- */
-class node::fctresiterator final : public jlm::rvsdg::input::iterator<lambda::result>
-{
-  friend ::jlm::llvm::lambda::node;
-
-  constexpr explicit fctresiterator(lambda::result * result)
-      : jlm::rvsdg::input::iterator<lambda::result>(result)
-  {}
-
-  [[nodiscard]] lambda::result *
-  next() const override
-  {
-    auto index = value()->index();
-    auto lambda = jlm::util::AssertedCast<lambda::node>(value()->region()->node());
-
-    return lambda->nfctresults() > index + 1 ? lambda->fctresult(index + 1) : nullptr;
-  }
-};
-
-/** \brief Lambda result const iterator
- */
-class node::fctresconstiterator final : public jlm::rvsdg::input::constiterator<lambda::result>
-{
-  friend ::jlm::llvm::lambda::node;
-
-  constexpr explicit fctresconstiterator(const lambda::result * result)
-      : jlm::rvsdg::input::constiterator<lambda::result>(result)
-  {}
-
-  [[nodiscard]] const lambda::result *
-  next() const override
-  {
-    auto index = value()->index();
-    auto lambda = jlm::util::AssertedCast<lambda::node>(value()->region()->node());
-
-    return lambda->nfctresults() > index + 1 ? lambda->fctresult(index + 1) : nullptr;
-  }
+  std::vector<jlm::llvm::attributeset> ArgumentAttributes_;
 };
 
 /**
@@ -879,10 +608,10 @@ lambda::node::RemoveLambdaInputsWhere(const F & match)
   // iterate backwards to avoid the invalidation of 'n' by RemoveInput()
   for (size_t n = ninputs() - 1; n != static_cast<size_t>(-1); n--)
   {
-    auto & lambdaInput = *input(n);
-    auto & argument = *lambdaInput.argument();
+    auto lambdaInput = input(n);
+    auto & argument = *MapInputContextVar(*lambdaInput).inner;
 
-    if (argument.IsDead() && match(lambdaInput))
+    if (argument.IsDead() && match(*lambdaInput))
     {
       subregion()->RemoveArgument(argument.index());
       RemoveInput(n);

--- a/jlm/llvm/ir/operators/lambda.hpp
+++ b/jlm/llvm/ir/operators/lambda.hpp
@@ -132,7 +132,7 @@ public:
   ~node() override;
 
 private:
-  node(rvsdg::Region * parent, lambda::operation op);
+  node(rvsdg::Region & parent, lambda::operation op);
 
 public:
   /**
@@ -227,7 +227,7 @@ public:
    * \return The context variable argument of the lambda abstraction.
    */
   ContextVar
-  AddContextVar(jlm::rvsdg::output * origin);
+  AddContextVar(jlm::rvsdg::output & origin);
 
   /**
    * \brief Maps input to context variable.

--- a/jlm/llvm/opt/InvariantValueRedirection.cpp
+++ b/jlm/llvm/opt/InvariantValueRedirection.cpp
@@ -179,21 +179,23 @@ InvariantValueRedirection::RedirectCallOutputs(CallNode & callNode)
   if (callType != CallTypeClassifier::CallType::NonRecursiveDirectCall)
     return;
 
-  auto & lambdaNode = *callTypeClassifier->GetLambdaOutput().node();
+  auto & lambdaNode =
+      rvsdg::AssertGetOwnerNode<lambda::node>(callTypeClassifier->GetLambdaOutput());
 
   // LLVM permits code where it can happen that the number and type of arguments handed in to the
   // call node do not agree with the number and type of lambda parameters, even though it is a
   // direct call. See jlm::tests::LambdaCallArgumentMismatch for an example. In this case, we cannot
   // redirect the call outputs to the call operand as the types would not align, resulting in type
   // errors.
-  if (callNode.NumArguments() != lambdaNode.nfctarguments())
+  if (callNode.NumArguments() != lambdaNode.GetFunctionArguments().size())
     return;
 
   auto memoryStateOutput = callNode.GetMemoryStateOutput();
   auto callExitSplit = CallNode::GetMemoryStateExitSplit(callNode);
   auto hasCallExitSplit = callExitSplit != nullptr;
 
-  JLM_ASSERT(callNode.noutputs() == lambdaNode.nfctresults());
+  auto results = lambdaNode.GetFunctionResults();
+  JLM_ASSERT(callNode.noutputs() == results.size());
   for (size_t n = 0; n < callNode.noutputs(); n++)
   {
     auto callOutput = callNode.output(n);
@@ -228,16 +230,21 @@ InvariantValueRedirection::RedirectCallOutputs(CallNode & callNode)
     }
     else
     {
-      auto & lambdaResult = *lambdaNode.fctresult(n);
-      if (auto lambdaFunctionArgument = dynamic_cast<lambda::fctargument *>(lambdaResult.origin()))
+      auto & lambdaResult = *results[n];
+      auto origin = lambdaResult.origin();
+      if (rvsdg::TryGetRegionParentNode<lambda::node>(*origin) == &lambdaNode)
       {
-        auto callOperand = callNode.Argument(lambdaFunctionArgument->index())->origin();
-        callOutput->divert_users(callOperand);
-      }
-      else if (dynamic_cast<lambda::cvargument *>(lambdaResult.origin()))
-      {
-        // FIXME: We would like to get this case working as well, but we need to route the origin of
-        // the respective lambda input to the subregion of the call node.
+        if (auto ctxvar = lambdaNode.MapBinderContextVar(*origin))
+        {
+          // This is a bound context variable.
+          // FIXME: We would like to get this case working as well, but we need to route the origin
+          // of the respective lambda input to the subregion of the call node.
+        }
+        else
+        {
+          auto callOperand = callNode.Argument(origin->index())->origin();
+          callOutput->divert_users(callOperand);
+        }
       }
     }
   }

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -970,22 +970,22 @@ void
 Andersen::AnalyzeLambda(const lambda::node & lambda)
 {
   // Handle context variables
-  for (auto & cv : lambda.ctxvars())
+  for (const auto & cv : lambda.GetContextVars())
   {
-    if (!IsOrContainsPointerType(cv.type()))
+    if (!IsOrContainsPointerType(cv.input->type()))
       continue;
 
-    auto & inputRegister = *cv.origin();
-    auto & argumentRegister = *cv.argument();
+    auto & inputRegister = *cv.input->origin();
+    auto & argumentRegister = *cv.inner;
     const auto inputRegisterPO = Set_->GetRegisterPointerObject(inputRegister);
     Set_->MapRegisterToExistingPointerObject(argumentRegister, inputRegisterPO);
   }
 
   // Create Register PointerObjects for each argument of pointing type in the function
-  for (auto & argument : lambda.fctarguments())
+  for (auto argument : lambda.GetFunctionArguments())
   {
-    if (IsOrContainsPointerType(argument.type()))
-      (void)Set_->CreateRegisterPointerObject(argument);
+    if (IsOrContainsPointerType(argument->type()))
+      (void)Set_->CreateRegisterPointerObject(*argument);
   }
 
   AnalyzeRegion(*lambda.subregion());

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
@@ -672,10 +672,11 @@ HandleLambdaCallParameters(
     const lambda::node & lambdaNode,
     MakeSupersetFunctor & makeSuperset)
 {
-  for (size_t n = 0; n < callNode.NumArguments() && n < lambdaNode.nfctarguments(); n++)
+  auto lambdaArgs = lambdaNode.GetFunctionArguments();
+  for (size_t n = 0; n < callNode.NumArguments() && n < lambdaArgs.size(); n++)
   {
     const auto & inputRegister = *callNode.Argument(n)->origin();
-    const auto & argumentRegister = *lambdaNode.fctargument(n);
+    const auto & argumentRegister = *lambdaArgs[n];
 
     const auto inputRegisterPO = set.TryGetRegisterPointerObject(inputRegister);
     const auto argumentRegisterPO = set.TryGetRegisterPointerObject(argumentRegister);
@@ -698,10 +699,11 @@ HandleLambdaCallReturnValues(
     const lambda::node & lambdaNode,
     MakeSupersetFunctor & makeSuperset)
 {
-  for (size_t n = 0; n < callNode.NumResults() && n < lambdaNode.nfctresults(); n++)
+  auto lambdaResults = lambdaNode.GetFunctionResults();
+  for (size_t n = 0; n < callNode.NumResults() && n < lambdaResults.size(); n++)
   {
     const auto & outputRegister = *callNode.Result(n);
-    const auto & resultRegister = *lambdaNode.fctresult(n)->origin();
+    const auto & resultRegister = *lambdaResults[n]->origin();
 
     const auto outputRegisterPO = set.TryGetRegisterPointerObject(outputRegister);
     const auto resultRegisterPO = set.TryGetRegisterPointerObject(resultRegister);
@@ -873,10 +875,10 @@ HandleEscapedFunction(
   auto & lambdaNode = set.GetLambdaNodeFromFunctionMemoryObject(lambda);
 
   // All the function's arguments need to be flagged as PointsToExternal
-  for (auto & argument : lambdaNode.fctarguments())
+  for (auto argument : lambdaNode.GetFunctionArguments())
   {
     // Argument registers that are mapped to a register pointer object should point to external
-    const auto argumentPO = set.TryGetRegisterPointerObject(argument);
+    const auto argumentPO = set.TryGetRegisterPointerObject(*argument);
     if (!argumentPO)
       continue;
 
@@ -888,9 +890,9 @@ HandleEscapedFunction(
   }
 
   // All results of pointer type need to be flagged as pointees escaping
-  for (auto & result : lambdaNode.fctresults())
+  for (auto result : lambdaNode.GetFunctionResults())
   {
-    const auto resultPO = set.TryGetRegisterPointerObject(*result.origin());
+    const auto resultPO = set.TryGetRegisterPointerObject(*result->origin());
     if (!resultPO)
       continue;
 
@@ -1207,17 +1209,19 @@ LabelFunctionsArgumentsAndReturnValues(PointerObjectSet & set, util::Graph & gra
     graph.GetNode(pointerObject).AppendToLabel(util::strfmt("function", functionIndex));
 
     // Add labels to registers corresponding to arguments and results of the function
-    for (size_t i = 0; i < function->nfctarguments(); i++)
+    auto args = function->GetFunctionArguments();
+    for (size_t i = 0; i < args.size(); i++)
     {
-      if (auto argumentRegister = set.TryGetRegisterPointerObject(*function->fctargument(i)))
+      if (auto argumentRegister = set.TryGetRegisterPointerObject(*args[i]))
       {
         const auto label = util::strfmt("function", functionIndex, " arg", i);
         graph.GetNode(*argumentRegister).AppendToLabel(label);
       }
     }
-    for (size_t i = 0; i < function->nfctresults(); i++)
+    auto results = function->GetFunctionResults();
+    for (size_t i = 0; i < results.size(); i++)
     {
-      if (auto resultRegister = set.TryGetRegisterPointerObject(*function->fctresult(i)->origin()))
+      if (auto resultRegister = set.TryGetRegisterPointerObject(*results[i]->origin()))
       {
         const auto label = util::strfmt("function", functionIndex, " res", i);
         graph.GetNode(*resultRegister).AppendToLabel(label);
@@ -1257,9 +1261,9 @@ PointerObjectConstraintSet::CreateOvsSubsetGraph()
   // Mark all function argument register nodes as not direct
   for (auto [lambda, _] : Set_.GetFunctionMap())
   {
-    for (size_t n = 0; n < lambda->nfctarguments(); n++)
+    for (auto arg : lambda->GetFunctionArguments())
     {
-      if (auto argumentPO = Set_.TryGetRegisterPointerObject(*lambda->fctargument(n)))
+      if (auto argumentPO = Set_.TryGetRegisterPointerObject(*arg))
         isDirectNode[*argumentPO] = false;
     }
   }

--- a/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.cpp
+++ b/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.cpp
@@ -377,7 +377,8 @@ public:
     if (callTypeClassifier->IsNonRecursiveDirectCall()
         || callTypeClassifier->IsRecursiveDirectCall())
     {
-      auto & lambdaNode = *callTypeClassifier->GetLambdaOutput().node();
+      auto & lambdaNode =
+          rvsdg::AssertGetOwnerNode<lambda::node>(callTypeClassifier->GetLambdaOutput());
       return GetLambdaEntryNodes(lambdaNode);
     }
     else if (callTypeClassifier->IsExternalCall())
@@ -401,7 +402,8 @@ public:
     if (callTypeClassifier->IsNonRecursiveDirectCall()
         || callTypeClassifier->IsRecursiveDirectCall())
     {
-      auto & lambdaNode = *callTypeClassifier->GetLambdaOutput().node();
+      auto & lambdaNode =
+          rvsdg::AssertGetOwnerNode<lambda::node>(callTypeClassifier->GetLambdaOutput());
       return GetLambdaExitNodes(lambdaNode);
     }
     else if (callTypeClassifier->IsExternalCall())
@@ -562,7 +564,9 @@ public:
       auto & regionUnknownMemoryNodeReferences = regionSummary.GetUnknownMemoryNodeReferences();
 
       auto callTypeClassifier = CallNode::ClassifyCall(callNode);
-      auto & lambdaRegion = *callTypeClassifier->GetLambdaOutput().node()->subregion();
+      auto & lambdaRegion =
+          *rvsdg::AssertGetOwnerNode<llvm::lambda::node>(callTypeClassifier->GetLambdaOutput())
+               .subregion();
       auto & lambdaRegionSummary = provisioning.GetRegionSummary(lambdaRegion);
       auto & lambdaRegionMemoryNodes = lambdaRegionSummary.GetMemoryNodes();
       auto & lambdaRegionUnknownMemoryNodeReferences =
@@ -947,7 +951,8 @@ RegionAwareMemoryNodeProvider::PropagateRegion(const rvsdg::Region & region)
   for (auto & callNode : regionSummary.GetNonRecursiveCalls().Items())
   {
     auto callTypeClassifier = CallNode::ClassifyCall(*callNode);
-    auto & lambdaRegion = *callTypeClassifier->GetLambdaOutput().node()->subregion();
+    auto & lambdaRegion =
+        *rvsdg::AssertGetOwnerNode<lambda::node>(callTypeClassifier->GetLambdaOutput()).subregion();
     auto & lambdaRegionSummary = Provisioning_->GetRegionSummary(lambdaRegion);
 
     RegionSummary::Propagate(regionSummary, lambdaRegionSummary);

--- a/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.cpp
+++ b/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.cpp
@@ -95,7 +95,8 @@ public:
     if (callTypeClassifier->IsNonRecursiveDirectCall()
         || callTypeClassifier->IsRecursiveDirectCall())
     {
-      auto & lambdaNode = *callTypeClassifier->GetLambdaOutput().node();
+      auto & lambdaNode =
+          rvsdg::AssertGetOwnerNode<lambda::node>(callTypeClassifier->GetLambdaOutput());
       return GetLambdaEntryNodes(lambdaNode);
     }
     else if (callTypeClassifier->IsExternalCall())
@@ -118,7 +119,8 @@ public:
     if (callTypeClassifier->IsNonRecursiveDirectCall()
         || callTypeClassifier->IsRecursiveDirectCall())
     {
-      auto & lambdaNode = *callTypeClassifier->GetLambdaOutput().node();
+      auto & lambdaNode =
+          rvsdg::AssertGetOwnerNode<lambda::node>(callTypeClassifier->GetLambdaOutput());
       return GetLambdaExitNodes(lambdaNode);
     }
     else if (callTypeClassifier->IsExternalCall())
@@ -804,7 +806,7 @@ TopDownMemoryNodeEliminator::EliminateTopDownNonRecursiveDirectCall(
   JLM_ASSERT(callTypeClassifier.IsNonRecursiveDirectCall());
 
   auto & liveNodes = Context_->GetLiveNodes(*callNode.region());
-  auto & lambdaNode = *callTypeClassifier.GetLambdaOutput().node();
+  auto & lambdaNode = rvsdg::AssertGetOwnerNode<lambda::node>(callTypeClassifier.GetLambdaOutput());
 
   Context_->AddLiveNodes(*lambdaNode.subregion(), liveNodes);
   Context_->AddLiveNodesAnnotatedLambda(lambdaNode);
@@ -818,7 +820,7 @@ TopDownMemoryNodeEliminator::EliminateTopDownRecursiveDirectCall(
   JLM_ASSERT(callTypeClassifier.IsRecursiveDirectCall());
 
   auto & liveNodes = Context_->GetLiveNodes(*callNode.region());
-  auto & lambdaNode = *callTypeClassifier.GetLambdaOutput().node();
+  auto & lambdaNode = rvsdg::AssertGetOwnerNode<lambda::node>(callTypeClassifier.GetLambdaOutput());
 
   Context_->AddLiveNodes(*lambdaNode.subregion(), liveNodes);
   Context_->AddLiveNodesAnnotatedLambda(lambdaNode);

--- a/jlm/llvm/opt/inlining.cpp
+++ b/jlm/llvm/opt/inlining.cpp
@@ -82,7 +82,7 @@ route_to_region(jlm::rvsdg::output * output, rvsdg::Region * region)
   }
   else if (auto lambda = dynamic_cast<lambda::node *>(region->node()))
   {
-    output = lambda->AddContextVar(output).inner;
+    output = lambda->AddContextVar(*output).inner;
   }
   else if (auto phi = dynamic_cast<phi::node *>(region->node()))
   {

--- a/jlm/llvm/opt/inlining.cpp
+++ b/jlm/llvm/opt/inlining.cpp
@@ -82,7 +82,7 @@ route_to_region(jlm::rvsdg::output * output, rvsdg::Region * region)
   }
   else if (auto lambda = dynamic_cast<lambda::node *>(region->node()))
   {
-    output = lambda->add_ctxvar(output);
+    output = lambda->AddContextVar(output).inner;
   }
   else if (auto phi = dynamic_cast<phi::node *>(region->node()))
   {
@@ -119,16 +119,18 @@ inlineCall(jlm::rvsdg::simple_node * call, const lambda::node * lambda)
   JLM_ASSERT(is<CallOperation>(call));
 
   auto deps = route_dependencies(lambda, call);
-  JLM_ASSERT(lambda->ncvarguments() == deps.size());
+  auto ctxvars = lambda->GetContextVars();
+  JLM_ASSERT(ctxvars.size() == deps.size());
 
   rvsdg::SubstitutionMap smap;
+  auto args = lambda->GetFunctionArguments();
   for (size_t n = 1; n < call->ninputs(); n++)
   {
-    auto argument = lambda->fctargument(n - 1);
+    auto argument = args[n - 1];
     smap.insert(argument, call->input(n)->origin());
   }
-  for (size_t n = 0; n < lambda->ncvarguments(); n++)
-    smap.insert(lambda->cvargument(n), deps[n]);
+  for (size_t n = 0; n < ctxvars.size(); n++)
+    smap.insert(ctxvars[n].inner, deps[n]);
 
   lambda->subregion()->copy(call->region(), smap, false, false);
 

--- a/jlm/mlir/backend/JlmToMlirConverter.cpp
+++ b/jlm/mlir/backend/JlmToMlirConverter.cpp
@@ -389,15 +389,15 @@ JlmToMlirConverter::ConvertSimpleNode(
 JlmToMlirConverter::ConvertLambda(const llvm::lambda::node & lambdaNode, ::mlir::Block & block)
 {
   ::llvm::SmallVector<::mlir::Type> arguments;
-  for (size_t i = 0; i < lambdaNode.nfctarguments(); ++i)
+  for (auto arg : lambdaNode.GetFunctionArguments())
   {
-    arguments.push_back(ConvertType(lambdaNode.fctargument(i)->type()));
+    arguments.push_back(ConvertType(arg->type()));
   }
 
   ::llvm::SmallVector<::mlir::Type> results;
-  for (size_t i = 0; i < lambdaNode.nfctresults(); ++i)
+  for (auto res : lambdaNode.GetFunctionResults())
   {
-    results.push_back(ConvertType(lambdaNode.fctresult(i)->type()));
+    results.push_back(ConvertType(res->type()));
   }
 
   ::llvm::SmallVector<::mlir::Type> lambdaRef;

--- a/scripts/run-hls-test.sh
+++ b/scripts/run-hls-test.sh
@@ -3,7 +3,7 @@ set -eu
 
 # URL to the benchmark git repository and the commit to be used
 GIT_REPOSITORY=https://github.com/phate/hls-test-suite.git
-GIT_COMMIT=d0bb58feb2432aefbc65364e10fded264c024fd8
+GIT_COMMIT=99d309be2a9aa8d565c2ece493dc33a447ad166d
 
 # Get the absolute path to this script and set default JLM paths
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
@@ -60,7 +60,7 @@ done
 # Check if verilator exists
 if ! command -v verilator &> /dev/null
 then
-	echo "No verilator in ${PATH}" 
+	echo "No verilator in ${PATH}"
 	echo "Consider installing the verilator package for your Linux distro."
 	exit 1
 fi

--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -403,7 +403,7 @@ Bits2PtrTest::SetupRvsdg()
     auto iOStateArgument = lambda->GetFunctionArguments()[1];
     auto memoryStateArgument = lambda->GetFunctionArguments()[2];
 
-    auto cvbits2ptr = lambda->AddContextVar(b2p).inner;
+    auto cvbits2ptr = lambda->AddContextVar(*b2p).inner;
 
     auto & call = CallNode::CreateNode(
         cvbits2ptr,
@@ -565,8 +565,8 @@ CallTest1::SetupRvsdg()
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto cvf = lambda->AddContextVar(f->output()).inner;
-    auto cvg = lambda->AddContextVar(g->output()).inner;
+    auto cvf = lambda->AddContextVar(*f->output()).inner;
+    auto cvg = lambda->AddContextVar(*g->output()).inner;
 
     auto size = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
 
@@ -703,8 +703,8 @@ CallTest2::SetupRvsdg()
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto create_cv = lambda->AddContextVar(lambdaCreate->output()).inner;
-    auto destroy_cv = lambda->AddContextVar(lambdaDestroy->output()).inner;
+    auto create_cv = lambda->AddContextVar(*lambdaCreate->output()).inner;
+    auto destroy_cv = lambda->AddContextVar(*lambdaDestroy->output()).inner;
 
     auto six = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 6);
     auto seven = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 7);
@@ -823,9 +823,9 @@ IndirectCallTest1::SetupRvsdg()
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto fctindcall_cv = lambda->AddContextVar(fctindcall).inner;
-    auto fctfour_cv = lambda->AddContextVar(fctfour).inner;
-    auto fctthree_cv = lambda->AddContextVar(fctthree).inner;
+    auto fctindcall_cv = lambda->AddContextVar(*fctindcall).inner;
+    auto fctfour_cv = lambda->AddContextVar(*fctfour).inner;
+    auto fctthree_cv = lambda->AddContextVar(*fctthree).inner;
 
     auto & call_four = CallNode::CreateNode(
         fctindcall_cv,
@@ -966,8 +966,8 @@ IndirectCallTest2::SetupRvsdg()
     auto iOStateArgument = lambda->GetFunctionArguments()[1];
     auto memoryStateArgument = lambda->GetFunctionArguments()[2];
 
-    auto functionICv = lambda->AddContextVar(&functionI).inner;
-    auto argumentFunctionCv = lambda->AddContextVar(&argumentFunction).inner;
+    auto functionICv = lambda->AddContextVar(functionI).inner;
+    auto argumentFunctionCv = lambda->AddContextVar(argumentFunction).inner;
 
     auto five = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, n);
     auto storeNode =
@@ -997,10 +997,10 @@ IndirectCallTest2::SetupRvsdg()
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto functionXCv = lambda->AddContextVar(&functionX).inner;
-    auto functionYCv = lambda->AddContextVar(&functionY).inner;
-    auto globalG1Cv = lambda->AddContextVar(&globalG1).inner;
-    auto globalG2Cv = lambda->AddContextVar(&globalG2).inner;
+    auto functionXCv = lambda->AddContextVar(functionX).inner;
+    auto functionYCv = lambda->AddContextVar(functionY).inner;
+    auto globalG1Cv = lambda->AddContextVar(globalG1).inner;
+    auto globalG2Cv = lambda->AddContextVar(globalG2).inner;
 
     auto constantSize = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
 
@@ -1064,7 +1064,7 @@ IndirectCallTest2::SetupRvsdg()
     auto pzMerge = MemoryStateMergeOperation::Create(
         std::vector<jlm::rvsdg::output *>{ pzAlloca[1], memoryStateArgument });
 
-    auto functionXCv = lambda->AddContextVar(&functionX).inner;
+    auto functionXCv = lambda->AddContextVar(functionX).inner;
 
     auto & callX = CallNode::CreateNode(
         functionXCv,
@@ -1163,7 +1163,7 @@ ExternalCallTest1::SetupRvsdg()
     auto iOStateArgument = lambda->GetFunctionArguments()[2];
     auto memoryStateArgument = lambda->GetFunctionArguments()[3];
 
-    auto functionGCv = lambda->AddContextVar(functionG).inner;
+    auto functionGCv = lambda->AddContextVar(*functionG).inner;
 
     auto size = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
 
@@ -1251,9 +1251,9 @@ ExternalCallTest2::SetupRvsdg()
   LambdaG_ = lambda::node::create(rvsdg.root(), lambdaGType, "g", linkage::external_linkage);
   auto iOStateArgument = LambdaG_->GetFunctionArguments()[0];
   auto memoryStateArgument = LambdaG_->GetFunctionArguments()[1];
-  auto llvmLifetimeStartArgument = LambdaG_->AddContextVar(llvmLifetimeStart).inner;
-  auto llvmLifetimeEndArgument = LambdaG_->AddContextVar(llvmLifetimeEnd).inner;
-  auto lambdaFArgument = LambdaG_->AddContextVar(ExternalFArgument_).inner;
+  auto llvmLifetimeStartArgument = LambdaG_->AddContextVar(*llvmLifetimeStart).inner;
+  auto llvmLifetimeEndArgument = LambdaG_->AddContextVar(*llvmLifetimeEnd).inner;
+  auto lambdaFArgument = LambdaG_->AddContextVar(*ExternalFArgument_).inner;
 
   auto twentyFour = jlm::rvsdg::create_bitconstant(LambdaG_->subregion(), 64, 24);
 
@@ -1490,7 +1490,7 @@ GammaTest2::SetupRvsdg()
         lambda::node::create(rvsdg->root(), functionType, functionName, linkage::external_linkage);
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
-    auto lambdaFArgument = lambda->AddContextVar(&lambdaF).inner;
+    auto lambdaFArgument = lambda->AddContextVar(lambdaF).inner;
 
     auto size = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
 
@@ -1672,8 +1672,8 @@ DeltaTest1::SetupRvsdg()
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto cvf = lambda->AddContextVar(f).inner;
-    auto cvg = lambda->AddContextVar(g).inner;
+    auto cvf = lambda->AddContextVar(*f).inner;
+    auto cvg = lambda->AddContextVar(*g).inner;
 
     auto five = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 5);
     auto st = StoreNonVolatileNode::Create(cvf, five, { memoryStateArgument }, 4);
@@ -1760,7 +1760,7 @@ DeltaTest2::SetupRvsdg()
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto cvd1 = lambda->AddContextVar(d1).inner;
+    auto cvd1 = lambda->AddContextVar(*d1).inner;
     auto b2 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 2);
     auto st = StoreNonVolatileNode::Create(cvd1, b2, { memoryStateArgument }, 4);
 
@@ -1780,9 +1780,9 @@ DeltaTest2::SetupRvsdg()
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto cvd1 = lambda->AddContextVar(d1).inner;
-    auto cvd2 = lambda->AddContextVar(d2).inner;
-    auto cvf1 = lambda->AddContextVar(f1).inner;
+    auto cvd1 = lambda->AddContextVar(*d1).inner;
+    auto cvd2 = lambda->AddContextVar(*d2).inner;
+    auto cvf1 = lambda->AddContextVar(*f1).inner;
 
     auto b5 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 5);
     auto b42 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 42);
@@ -1865,8 +1865,8 @@ DeltaTest3::SetupRvsdg()
     auto lambda = lambda::node::create(graph->root(), functionType, "f", linkage::external_linkage);
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
-    auto g1CtxVar = lambda->AddContextVar(&g1).inner;
-    auto g2CtxVar = lambda->AddContextVar(&g2).inner;
+    auto g1CtxVar = lambda->AddContextVar(g1).inner;
+    auto g2CtxVar = lambda->AddContextVar(g2).inner;
 
     auto loadResults =
         LoadNonVolatileNode::Create(g2CtxVar, { memoryStateArgument }, PointerType::Create(), 8);
@@ -1893,7 +1893,7 @@ DeltaTest3::SetupRvsdg()
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto lambdaFArgument = lambda->AddContextVar(&lambdaF).inner;
+    auto lambdaFArgument = lambda->AddContextVar(lambdaF).inner;
 
     auto & call = CallNode::CreateNode(
         lambdaFArgument,
@@ -1949,7 +1949,7 @@ ImportTest::SetupRvsdg()
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto cvd1 = lambda->AddContextVar(d1).inner;
+    auto cvd1 = lambda->AddContextVar(*d1).inner;
 
     auto b5 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 5);
     auto st = StoreNonVolatileNode::Create(cvd1, b5, { memoryStateArgument }, 4);
@@ -1970,9 +1970,9 @@ ImportTest::SetupRvsdg()
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto cvd1 = lambda->AddContextVar(d1).inner;
-    auto cvd2 = lambda->AddContextVar(d2).inner;
-    auto cvf1 = lambda->AddContextVar(f1).inner;
+    auto cvd1 = lambda->AddContextVar(*d1).inner;
+    auto cvd2 = lambda->AddContextVar(*d2).inner;
+    auto cvf1 = lambda->AddContextVar(*f1).inner;
     auto b2 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 2);
     auto b21 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 21);
     auto st = StoreNonVolatileNode::Create(cvd1, b2, { memoryStateArgument }, 4);
@@ -2049,7 +2049,7 @@ PhiTest1::SetupRvsdg()
     auto pointerArgument = lambda->GetFunctionArguments()[1];
     auto iOStateArgument = lambda->GetFunctionArguments()[2];
     auto memoryStateArgument = lambda->GetFunctionArguments()[3];
-    auto ctxVarFib = lambda->AddContextVar(fibrv->argument()).inner;
+    auto ctxVarFib = lambda->AddContextVar(*fibrv->argument()).inner;
 
     auto two = jlm::rvsdg::create_bitconstant(lambda->subregion(), 64, 2);
     auto bitult = jlm::rvsdg::bitult_op::create(64, valueArgument, two);
@@ -2138,7 +2138,7 @@ PhiTest1::SetupRvsdg()
         lambda::node::create(graph->root(), functionType, "test", linkage::external_linkage);
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
-    auto fibcv = lambda->AddContextVar(phiNode->output(0)).inner;
+    auto fibcv = lambda->AddContextVar(*phiNode->output(0)).inner;
 
     auto ten = jlm::rvsdg::create_bitconstant(lambda->subregion(), 64, 10);
     auto allocaResults = alloca_op::create(at, ten, 16);
@@ -2250,8 +2250,8 @@ PhiTest2::SetupRvsdg()
     auto iOStateArgument = lambda->GetFunctionArguments()[1];
     auto memoryStateArgument = lambda->GetFunctionArguments()[2];
 
-    auto functionBCv = lambda->AddContextVar(&functionB).inner;
-    auto functionDCv = lambda->AddContextVar(&functionD).inner;
+    auto functionBCv = lambda->AddContextVar(functionB).inner;
+    auto functionDCv = lambda->AddContextVar(functionD).inner;
 
     auto one = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 1);
     auto storeNode = StoreNonVolatileNode::Create(pointerArgument, one, { memoryStateArgument }, 4);
@@ -2294,9 +2294,9 @@ PhiTest2::SetupRvsdg()
     auto iOStateArgument = lambda->GetFunctionArguments()[1];
     auto memoryStateArgument = lambda->GetFunctionArguments()[2];
 
-    auto functionICv = lambda->AddContextVar(&functionI).inner;
-    auto functionCCv = lambda->AddContextVar(&functionC).inner;
-    auto functionEightCv = lambda->AddContextVar(&functionEight).inner;
+    auto functionICv = lambda->AddContextVar(functionI).inner;
+    auto functionCCv = lambda->AddContextVar(functionC).inner;
+    auto functionEightCv = lambda->AddContextVar(functionEight).inner;
 
     auto two = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 2);
     auto storeNode = StoreNonVolatileNode::Create(pointerArgument, two, { memoryStateArgument }, 4);
@@ -2336,7 +2336,7 @@ PhiTest2::SetupRvsdg()
     auto iOStateArgument = lambda->GetFunctionArguments()[1];
     auto memoryStateArgument = lambda->GetFunctionArguments()[2];
 
-    auto functionACv = lambda->AddContextVar(&functionA).inner;
+    auto functionACv = lambda->AddContextVar(functionA).inner;
 
     auto three = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 3);
     auto storeNode = StoreNonVolatileNode::Create(xArgument, three, { memoryStateArgument }, 4);
@@ -2375,7 +2375,7 @@ PhiTest2::SetupRvsdg()
     auto iOStateArgument = lambda->GetFunctionArguments()[1];
     auto memoryStateArgument = lambda->GetFunctionArguments()[2];
 
-    auto functionACv = lambda->AddContextVar(&functionA).inner;
+    auto functionACv = lambda->AddContextVar(functionA).inner;
 
     auto four = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
     auto storeNode = StoreNonVolatileNode::Create(xArgument, four, { memoryStateArgument }, 4);
@@ -2458,7 +2458,7 @@ PhiTest2::SetupRvsdg()
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto functionACv = lambda->AddContextVar(&functionA).inner;
+    auto functionACv = lambda->AddContextVar(functionA).inner;
 
     auto four = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
     auto pTestAlloca = alloca_op::create(jlm::rvsdg::bittype::Create(32), four, 4);
@@ -2695,7 +2695,7 @@ EscapedMemoryTest1::SetupRvsdg()
     auto iOStateArgument = lambda->GetFunctionArguments()[1];
     auto memoryStateArgument = lambda->GetFunctionArguments()[2];
 
-    auto contextVariableB = lambda->AddContextVar(&deltaB).inner;
+    auto contextVariableB = lambda->AddContextVar(deltaB).inner;
 
     auto loadResults1 =
         LoadNonVolatileNode::Create(pointerArgument, { memoryStateArgument }, pointerType, 4);
@@ -2827,7 +2827,7 @@ EscapedMemoryTest2::SetupRvsdg()
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto externalFunction1 = lambda->AddContextVar(externalFunction1Argument).inner;
+    auto externalFunction1 = lambda->AddContextVar(*externalFunction1Argument).inner;
 
     auto eight = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 8);
 
@@ -2863,7 +2863,7 @@ EscapedMemoryTest2::SetupRvsdg()
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto externalFunction2 = lambda->AddContextVar(externalFunction2Argument).inner;
+    auto externalFunction2 = lambda->AddContextVar(*externalFunction2Argument).inner;
 
     auto & call = CallNode::CreateNode(
         externalFunction2,
@@ -2976,7 +2976,7 @@ EscapedMemoryTest3::SetupRvsdg()
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto externalFunction = lambda->AddContextVar(externalFunctionArgument).inner;
+    auto externalFunction = lambda->AddContextVar(*externalFunctionArgument).inner;
 
     auto & call = CallNode::CreateNode(
         externalFunction,
@@ -3084,7 +3084,7 @@ MemcpyTest::SetupRvsdg()
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto globalArrayArgument = lambda->AddContextVar(&globalArray).inner;
+    auto globalArrayArgument = lambda->AddContextVar(globalArray).inner;
 
     auto zero = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 0);
     auto two = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 2);
@@ -3121,9 +3121,9 @@ MemcpyTest::SetupRvsdg()
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto localArrayArgument = lambda->AddContextVar(&localArray).inner;
-    auto globalArrayArgument = lambda->AddContextVar(&globalArray).inner;
-    auto functionFArgument = lambda->AddContextVar(&lambdaF).inner;
+    auto localArrayArgument = lambda->AddContextVar(localArray).inner;
+    auto globalArrayArgument = lambda->AddContextVar(globalArray).inner;
+    auto functionFArgument = lambda->AddContextVar(lambdaF).inner;
 
     auto bcLocalArray = bitcast_op::create(localArrayArgument, PointerType::Create());
     auto bcGlobalArray = bitcast_op::create(globalArrayArgument, PointerType::Create());
@@ -3235,7 +3235,7 @@ MemcpyTest2::SetupRvsdg()
     auto iOStateArgument = lambda->GetFunctionArguments()[2];
     auto memoryStateArgument = lambda->GetFunctionArguments()[3];
 
-    auto functionFArgument = lambda->AddContextVar(&functionF).inner;
+    auto functionFArgument = lambda->AddContextVar(functionF).inner;
 
     auto c0 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 0);
 
@@ -3374,7 +3374,7 @@ LinkedListTest::SetupRvsdg()
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto myListArgument = lambda->AddContextVar(&myList).inner;
+    auto myListArgument = lambda->AddContextVar(myList).inner;
 
     auto zero = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 0);
     auto size = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
@@ -3450,8 +3450,8 @@ AllMemoryNodesTest::SetupRvsdg()
   // Start of function "f"
   Lambda_ = lambda::node::create(graph->root(), fcttype, "f", linkage::external_linkage);
   auto entryMemoryState = Lambda_->GetFunctionArguments()[0];
-  auto deltaContextVar = Lambda_->AddContextVar(Delta_->output()).inner;
-  auto importContextVar = Lambda_->AddContextVar(Import_).inner;
+  auto deltaContextVar = Lambda_->AddContextVar(*Delta_->output()).inner;
+  auto importContextVar = Lambda_->AddContextVar(*Import_).inner;
 
   // Create alloca node
   auto allocaSize = jlm::rvsdg::create_bitconstant(Lambda_->subregion(), 32, 1);
@@ -3600,7 +3600,7 @@ EscapingLocalFunctionTest::SetupRvsdg()
       StoreNonVolatileNode::Create(allocaOutputs[0], LocalFuncParam_, { mergedMemoryState }, 4);
 
   // Bring in deltaOuput as a context variable
-  const auto deltaOutputCtxVar = LocalFunc_->AddContextVar(deltaOutput).inner;
+  const auto deltaOutputCtxVar = LocalFunc_->AddContextVar(*deltaOutput).inner;
 
   // Return &global
   LocalFunc_->finalize({ deltaOutputCtxVar, storeOutputs[0] });
@@ -3613,7 +3613,7 @@ EscapingLocalFunctionTest::SetupRvsdg()
       "exportedFunc",
       linkage::external_linkage);
 
-  const auto localFuncCtxVar = ExportedFunc_->AddContextVar(LocalFuncRegister_).inner;
+  const auto localFuncCtxVar = ExportedFunc_->AddContextVar(*LocalFuncRegister_).inner;
 
   // Return &localFunc, pass memory state directly through
   ExportedFunc_->finalize({ localFuncCtxVar, ExportedFunc_->GetFunctionArguments()[0] });
@@ -3702,7 +3702,7 @@ LambdaCallArgumentMismatch::SetupRvsdg()
         lambda::node::create(rvsdg.root(), functionTypeMain, "main", linkage::external_linkage);
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
-    auto lambdaGArgument = lambda->AddContextVar(&lambdaG).inner;
+    auto lambdaGArgument = lambda->AddContextVar(lambdaG).inner;
 
     auto one = rvsdg::create_bitconstant(lambda->subregion(), 32, 1);
     auto six = rvsdg::create_bitconstant(lambda->subregion(), 32, 6);
@@ -3774,7 +3774,7 @@ VariadicFunctionTest1::SetupRvsdg()
     auto iArgument = LambdaF_->GetFunctionArguments()[0];
     auto iOStateArgument = LambdaF_->GetFunctionArguments()[1];
     auto memoryStateArgument = LambdaF_->GetFunctionArguments()[2];
-    auto lambdaHArgument = LambdaF_->AddContextVar(ImportH_).inner;
+    auto lambdaHArgument = LambdaF_->AddContextVar(*ImportH_).inner;
 
     auto one = jlm::rvsdg::create_bitconstant(LambdaF_->subregion(), 32, 1);
     auto three = jlm::rvsdg::create_bitconstant(LambdaF_->subregion(), 32, 3);
@@ -3800,7 +3800,7 @@ VariadicFunctionTest1::SetupRvsdg()
     LambdaG_ = lambda::node::create(rvsdg.root(), lambdaGType, "g", linkage::external_linkage);
     auto iOStateArgument = LambdaG_->GetFunctionArguments()[0];
     auto memoryStateArgument = LambdaG_->GetFunctionArguments()[1];
-    auto lambdaFArgument = LambdaG_->AddContextVar(LambdaF_->output()).inner;
+    auto lambdaFArgument = LambdaG_->AddContextVar(*LambdaF_->output()).inner;
 
     auto one = jlm::rvsdg::create_bitconstant(LambdaG_->subregion(), 32, 1);
     auto five = jlm::rvsdg::create_bitconstant(LambdaG_->subregion(), 32, 5);
@@ -3885,10 +3885,10 @@ VariadicFunctionTest2::SetupRvsdg()
         lambda::node::create(rvsdg.root(), lambdaFstType, "fst", linkage::internal_linkage);
     auto iOStateArgument = LambdaFst_->GetFunctionArguments()[2];
     auto memoryStateArgument = LambdaFst_->GetFunctionArguments()[3];
-    auto llvmLifetimeStartArgument = LambdaFst_->AddContextVar(llvmLifetimeStart).inner;
-    auto llvmLifetimeEndArgument = LambdaFst_->AddContextVar(llvmLifetimeEnd).inner;
-    auto llvmVaStartArgument = LambdaFst_->AddContextVar(llvmVaStart).inner;
-    auto llvmVaEndArgument = LambdaFst_->AddContextVar(llvmVaEnd).inner;
+    auto llvmLifetimeStartArgument = LambdaFst_->AddContextVar(*llvmLifetimeStart).inner;
+    auto llvmLifetimeEndArgument = LambdaFst_->AddContextVar(*llvmLifetimeEnd).inner;
+    auto llvmVaStartArgument = LambdaFst_->AddContextVar(*llvmVaStart).inner;
+    auto llvmVaEndArgument = LambdaFst_->AddContextVar(*llvmVaEnd).inner;
 
     auto one = jlm::rvsdg::create_bitconstant(LambdaFst_->subregion(), 32, 1);
     auto twentyFour = jlm::rvsdg::create_bitconstant(LambdaFst_->subregion(), 64, 24);
@@ -3997,7 +3997,7 @@ VariadicFunctionTest2::SetupRvsdg()
     LambdaG_ = lambda::node::create(rvsdg.root(), lambdaGType, "g", linkage::external_linkage);
     auto iOStateArgument = LambdaG_->GetFunctionArguments()[0];
     auto memoryStateArgument = LambdaG_->GetFunctionArguments()[1];
-    auto lambdaFstArgument = LambdaG_->AddContextVar(LambdaFst_->output()).inner;
+    auto lambdaFstArgument = LambdaG_->AddContextVar(*LambdaFst_->output()).inner;
 
     auto zero = jlm::rvsdg::create_bitconstant(LambdaG_->subregion(), 32, 0);
     auto one = jlm::rvsdg::create_bitconstant(LambdaG_->subregion(), 32, 1);

--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -31,7 +31,8 @@ StoreTest1::SetupRvsdg()
   auto b = alloca_op::create(pointerType, csize, 4);
   auto a = alloca_op::create(pointerType, csize, 4);
 
-  auto merge_d = MemoryStateMergeOperation::Create({ d[1], fct->fctargument(0) });
+  auto merge_d = MemoryStateMergeOperation::Create(
+      std::vector<jlm::rvsdg::output *>{ d[1], fct->GetFunctionArguments()[0] });
   auto merge_c =
       MemoryStateMergeOperation::Create(std::vector<jlm::rvsdg::output *>({ c[1], merge_d }));
   auto merge_b =
@@ -85,7 +86,8 @@ StoreTest2::SetupRvsdg()
   auto y = alloca_op::create(pointerType, csize, 4);
   auto p = alloca_op::create(pointerType, csize, 4);
 
-  auto merge_a = MemoryStateMergeOperation::Create({ a[1], fct->fctargument(0) });
+  auto merge_a = MemoryStateMergeOperation::Create(
+      std::vector<jlm::rvsdg::output *>{ a[1], fct->GetFunctionArguments()[0] });
   auto merge_b =
       MemoryStateMergeOperation::Create(std::vector<jlm::rvsdg::output *>({ b[1], merge_a }));
   auto merge_x =
@@ -138,8 +140,11 @@ LoadTest1::SetupRvsdg()
 
   auto fct = lambda::node::create(graph->root(), fcttype, "f", linkage::external_linkage);
 
-  auto ld1 =
-      LoadNonVolatileNode::Create(fct->fctargument(0), { fct->fctargument(1) }, pointerType, 4);
+  auto ld1 = LoadNonVolatileNode::Create(
+      fct->GetFunctionArguments()[0],
+      { fct->GetFunctionArguments()[1] },
+      pointerType,
+      4);
   auto ld2 = LoadNonVolatileNode::Create(ld1[0], { ld1[1] }, jlm::rvsdg::bittype::Create(32), 4);
 
   fct->finalize(ld2);
@@ -181,7 +186,8 @@ LoadTest2::SetupRvsdg()
   auto y = alloca_op::create(pointerType, csize, 4);
   auto p = alloca_op::create(pointerType, csize, 4);
 
-  auto merge_a = MemoryStateMergeOperation::Create({ a[1], fct->fctargument(0) });
+  auto merge_a = MemoryStateMergeOperation::Create(
+      std::vector<jlm::rvsdg::output *>{ a[1], fct->GetFunctionArguments()[0] });
   auto merge_b =
       MemoryStateMergeOperation::Create(std::vector<jlm::rvsdg::output *>({ b[1], merge_a }));
   auto merge_x =
@@ -243,7 +249,7 @@ LoadFromUndefTest::SetupRvsdg()
   auto undefValue = UndefValueOperation::Create(*Lambda_->subregion(), pointerType);
   auto loadResults = LoadNonVolatileNode::Create(
       undefValue,
-      { Lambda_->fctargument(0) },
+      { Lambda_->GetFunctionArguments()[0] },
       jlm::rvsdg::bittype::Create(32),
       4);
 
@@ -284,16 +290,22 @@ GetElementPtrTest::SetupRvsdg()
   auto zero = jlm::rvsdg::create_bitconstant(fct->subregion(), 32, 0);
   auto one = jlm::rvsdg::create_bitconstant(fct->subregion(), 32, 1);
 
-  auto gepx =
-      GetElementPtrOperation::Create(fct->fctargument(0), { zero, zero }, structType, pointerType);
+  auto gepx = GetElementPtrOperation::Create(
+      fct->GetFunctionArguments()[0],
+      { zero, zero },
+      structType,
+      pointerType);
   auto ldx = LoadNonVolatileNode::Create(
       gepx,
-      { fct->fctargument(1) },
+      { fct->GetFunctionArguments()[1] },
       jlm::rvsdg::bittype::Create(32),
       4);
 
-  auto gepy =
-      GetElementPtrOperation::Create(fct->fctargument(0), { zero, one }, structType, pointerType);
+  auto gepy = GetElementPtrOperation::Create(
+      fct->GetFunctionArguments()[0],
+      { zero, one },
+      structType,
+      pointerType);
   auto ldy = LoadNonVolatileNode::Create(gepy, { ldx[1] }, jlm::rvsdg::bittype::Create(32), 4);
 
   auto sum = jlm::rvsdg::bitadd_op::create(32, ldx[0], ldy[0]);
@@ -329,7 +341,7 @@ BitCastTest::SetupRvsdg()
 
   auto fct = lambda::node::create(graph->root(), fcttype, "f", linkage::external_linkage);
 
-  auto cast = bitcast_op::create(fct->fctargument(0), pointerType);
+  auto cast = bitcast_op::create(fct->GetFunctionArguments()[0], pointerType);
 
   fct->finalize({ cast });
 
@@ -366,9 +378,9 @@ Bits2PtrTest::SetupRvsdg()
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, "bit2ptr", linkage::external_linkage);
-    auto valueArgument = lambda->fctargument(0);
-    auto iOStateArgument = lambda->fctargument(1);
-    auto memoryStateArgument = lambda->fctargument(2);
+    auto valueArgument = lambda->GetFunctionArguments()[0];
+    auto iOStateArgument = lambda->GetFunctionArguments()[1];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[2];
 
     auto cast = bits2ptr_op::create(valueArgument, pt);
 
@@ -377,7 +389,7 @@ Bits2PtrTest::SetupRvsdg()
     return std::make_tuple(lambda, jlm::rvsdg::output::GetNode(*cast));
   };
 
-  auto setupTestFunction = [&](lambda::output * b2p)
+  auto setupTestFunction = [&](rvsdg::output * b2p)
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
@@ -387,15 +399,15 @@ Bits2PtrTest::SetupRvsdg()
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, "test", linkage::external_linkage);
-    auto valueArgument = lambda->fctargument(0);
-    auto iOStateArgument = lambda->fctargument(1);
-    auto memoryStateArgument = lambda->fctargument(2);
+    auto valueArgument = lambda->GetFunctionArguments()[0];
+    auto iOStateArgument = lambda->GetFunctionArguments()[1];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[2];
 
-    auto cvbits2ptr = lambda->add_ctxvar(b2p);
+    auto cvbits2ptr = lambda->AddContextVar(b2p).inner;
 
     auto & call = CallNode::CreateNode(
         cvbits2ptr,
-        b2p->node()->Type(),
+        rvsdg::AssertGetOwnerNode<lambda::node>(*b2p).Type(),
         { valueArgument, iOStateArgument, memoryStateArgument });
 
     lambda->finalize({ call.GetIoStateOutput(), call.GetMemoryStateOutput() });
@@ -440,9 +452,9 @@ ConstantPointerNullTest::SetupRvsdg()
   auto constantPointerNullResult =
       ConstantPointerNullOperation::Create(fct->subregion(), pointerType);
   auto st = StoreNonVolatileNode::Create(
-      fct->fctargument(0),
+      fct->GetFunctionArguments()[0],
       constantPointerNullResult,
-      { fct->fctargument(1) },
+      { fct->GetFunctionArguments()[1] },
       4);
 
   fct->finalize({ st[0] });
@@ -482,10 +494,10 @@ CallTest1::SetupRvsdg()
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
     auto lambda = lambda::node::create(graph->root(), functionType, "f", linkage::external_linkage);
-    auto pointerArgument1 = lambda->fctargument(0);
-    auto pointerArgument2 = lambda->fctargument(1);
-    auto iOStateArgument = lambda->fctargument(2);
-    auto memoryStateArgument = lambda->fctargument(3);
+    auto pointerArgument1 = lambda->GetFunctionArguments()[0];
+    auto pointerArgument2 = lambda->GetFunctionArguments()[1];
+    auto iOStateArgument = lambda->GetFunctionArguments()[2];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[3];
 
     auto ld1 = LoadNonVolatileNode::Create(
         pointerArgument1,
@@ -518,10 +530,10 @@ CallTest1::SetupRvsdg()
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
     auto lambda = lambda::node::create(graph->root(), functionType, "g", linkage::external_linkage);
-    auto pointerArgument1 = lambda->fctargument(0);
-    auto pointerArgument2 = lambda->fctargument(1);
-    auto iOStateArgument = lambda->fctargument(2);
-    auto memoryStateArgument = lambda->fctargument(3);
+    auto pointerArgument1 = lambda->GetFunctionArguments()[0];
+    auto pointerArgument2 = lambda->GetFunctionArguments()[1];
+    auto iOStateArgument = lambda->GetFunctionArguments()[2];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[3];
 
     auto ld1 = LoadNonVolatileNode::Create(
         pointerArgument1,
@@ -550,11 +562,11 @@ CallTest1::SetupRvsdg()
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
     auto lambda = lambda::node::create(graph->root(), functionType, "h", linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto cvf = lambda->add_ctxvar(f->output());
-    auto cvg = lambda->add_ctxvar(g->output());
+    auto cvf = lambda->AddContextVar(f->output()).inner;
+    auto cvg = lambda->AddContextVar(g->output()).inner;
 
     auto size = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
 
@@ -636,9 +648,9 @@ CallTest2::SetupRvsdg()
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, "create", linkage::external_linkage);
-    auto valueArgument = lambda->fctargument(0);
-    auto iOStateArgument = lambda->fctargument(1);
-    auto memoryStateArgument = lambda->fctargument(2);
+    auto valueArgument = lambda->GetFunctionArguments()[0];
+    auto iOStateArgument = lambda->GetFunctionArguments()[1];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[2];
 
     auto four = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
     auto prod = jlm::rvsdg::bitmul_op::create(32, valueArgument, four);
@@ -665,9 +677,9 @@ CallTest2::SetupRvsdg()
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, "destroy", linkage::external_linkage);
-    auto pointerArgument = lambda->fctargument(0);
-    auto iOStateArgument = lambda->fctargument(1);
-    auto memoryStateArgument = lambda->fctargument(2);
+    auto pointerArgument = lambda->GetFunctionArguments()[0];
+    auto iOStateArgument = lambda->GetFunctionArguments()[1];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[2];
 
     auto cast = bitcast_op::create(pointerArgument, pointerType);
     auto freeResults = FreeOperation::Create(cast, { memoryStateArgument }, iOStateArgument);
@@ -688,11 +700,11 @@ CallTest2::SetupRvsdg()
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, "test", linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto create_cv = lambda->add_ctxvar(lambdaCreate->output());
-    auto destroy_cv = lambda->add_ctxvar(lambdaDestroy->output());
+    auto create_cv = lambda->AddContextVar(lambdaCreate->output()).inner;
+    auto destroy_cv = lambda->AddContextVar(lambdaDestroy->output()).inner;
 
     auto six = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 6);
     auto seven = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 7);
@@ -767,8 +779,8 @@ IndirectCallTest1::SetupRvsdg()
   {
     auto lambda =
         lambda::node::create(graph->root(), constantFunctionType, name, linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
     auto constant = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, n);
 
@@ -785,9 +797,9 @@ IndirectCallTest1::SetupRvsdg()
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, "indcall", linkage::external_linkage);
-    auto pointerArgument = lambda->fctargument(0);
-    auto iOStateArgument = lambda->fctargument(1);
-    auto memoryStateArgument = lambda->fctargument(2);
+    auto pointerArgument = lambda->GetFunctionArguments()[0];
+    auto iOStateArgument = lambda->GetFunctionArguments()[1];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[2];
 
     auto & call = CallNode::CreateNode(
         pointerArgument,
@@ -800,7 +812,7 @@ IndirectCallTest1::SetupRvsdg()
   };
 
   auto SetupTestFunction =
-      [&](lambda::output * fctindcall, lambda::output * fctthree, lambda::output * fctfour)
+      [&](rvsdg::output * fctindcall, rvsdg::output * fctthree, rvsdg::output * fctfour)
   {
     auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
@@ -808,20 +820,20 @@ IndirectCallTest1::SetupRvsdg()
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, "test", linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto fctindcall_cv = lambda->add_ctxvar(fctindcall);
-    auto fctfour_cv = lambda->add_ctxvar(fctfour);
-    auto fctthree_cv = lambda->add_ctxvar(fctthree);
+    auto fctindcall_cv = lambda->AddContextVar(fctindcall).inner;
+    auto fctfour_cv = lambda->AddContextVar(fctfour).inner;
+    auto fctthree_cv = lambda->AddContextVar(fctthree).inner;
 
     auto & call_four = CallNode::CreateNode(
         fctindcall_cv,
-        fctindcall->node()->Type(),
+        rvsdg::AssertGetOwnerNode<lambda::node>(*fctindcall).Type(),
         { fctfour_cv, iOStateArgument, memoryStateArgument });
     auto & call_three = CallNode::CreateNode(
         fctindcall_cv,
-        fctindcall->node()->Type(),
+        rvsdg::AssertGetOwnerNode<lambda::node>(*fctindcall).Type(),
         { fctthree_cv, call_four.GetIoStateOutput(), call_four.GetMemoryStateOutput() });
 
     auto add = jlm::rvsdg::bitadd_op::create(32, call_four.Result(0), call_three.Result(0));
@@ -842,10 +854,10 @@ IndirectCallTest1::SetupRvsdg()
   /*
    * Assign
    */
-  this->LambdaThree_ = fctthree->node();
-  this->LambdaFour_ = fctfour->node();
-  this->LambdaIndcall_ = fctindcall->node();
-  this->LambdaTest_ = fcttest->node();
+  this->LambdaThree_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*fctthree);
+  this->LambdaFour_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*fctfour);
+  this->LambdaIndcall_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*fctindcall);
+  this->LambdaTest_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*fcttest);
 
   this->CallIndcall_ = callIndirectFunction;
   this->CallThree_ = callFunctionThree;
@@ -906,8 +918,8 @@ IndirectCallTest2::SetupRvsdg()
   {
     auto lambda =
         lambda::node::create(graph->root(), constantFunctionType, name, linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
     auto constant = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, n);
 
@@ -923,9 +935,9 @@ IndirectCallTest2::SetupRvsdg()
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
     auto lambda = lambda::node::create(graph->root(), functionType, "i", linkage::external_linkage);
-    auto pointerArgument = lambda->fctargument(0);
-    auto iOStateArgument = lambda->fctargument(1);
-    auto memoryStateArgument = lambda->fctargument(2);
+    auto pointerArgument = lambda->GetFunctionArguments()[0];
+    auto iOStateArgument = lambda->GetFunctionArguments()[1];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[2];
 
     auto & call = CallNode::CreateNode(
         pointerArgument,
@@ -939,8 +951,8 @@ IndirectCallTest2::SetupRvsdg()
 
   auto SetupIndirectCallFunction = [&](ssize_t n,
                                        const std::string & name,
-                                       lambda::output & functionI,
-                                       lambda::output & argumentFunction)
+                                       rvsdg::output & functionI,
+                                       rvsdg::output & argumentFunction)
   {
     auto pointerType = PointerType::Create();
 
@@ -950,12 +962,12 @@ IndirectCallTest2::SetupRvsdg()
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, name, linkage::external_linkage);
-    auto pointerArgument = lambda->fctargument(0);
-    auto iOStateArgument = lambda->fctargument(1);
-    auto memoryStateArgument = lambda->fctargument(2);
+    auto pointerArgument = lambda->GetFunctionArguments()[0];
+    auto iOStateArgument = lambda->GetFunctionArguments()[1];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[2];
 
-    auto functionICv = lambda->add_ctxvar(&functionI);
-    auto argumentFunctionCv = lambda->add_ctxvar(&argumentFunction);
+    auto functionICv = lambda->AddContextVar(&functionI).inner;
+    auto argumentFunctionCv = lambda->AddContextVar(&argumentFunction).inner;
 
     auto five = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, n);
     auto storeNode =
@@ -963,7 +975,7 @@ IndirectCallTest2::SetupRvsdg()
 
     auto & call = CallNode::CreateNode(
         functionICv,
-        functionI.node()->Type(),
+        rvsdg::AssertGetOwnerNode<lambda::node>(functionI).Type(),
         { argumentFunctionCv, iOStateArgument, storeNode[0] });
 
     auto lambdaOutput = lambda->finalize(call.Results());
@@ -971,8 +983,8 @@ IndirectCallTest2::SetupRvsdg()
     return std::make_tuple(lambdaOutput, &call);
   };
 
-  auto SetupTestFunction = [&](lambda::output & functionX,
-                               lambda::output & functionY,
+  auto SetupTestFunction = [&](rvsdg::output & functionX,
+                               rvsdg::output & functionY,
                                delta::output & globalG1,
                                delta::output & globalG2)
   {
@@ -982,31 +994,32 @@ IndirectCallTest2::SetupRvsdg()
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, "test", linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto functionXCv = lambda->add_ctxvar(&functionX);
-    auto functionYCv = lambda->add_ctxvar(&functionY);
-    auto globalG1Cv = lambda->add_ctxvar(&globalG1);
-    auto globalG2Cv = lambda->add_ctxvar(&globalG2);
+    auto functionXCv = lambda->AddContextVar(&functionX).inner;
+    auto functionYCv = lambda->AddContextVar(&functionY).inner;
+    auto globalG1Cv = lambda->AddContextVar(&globalG1).inner;
+    auto globalG2Cv = lambda->AddContextVar(&globalG2).inner;
 
     auto constantSize = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
 
     auto pxAlloca = alloca_op::create(jlm::rvsdg::bittype::Create(32), constantSize, 4);
     auto pyAlloca = alloca_op::create(jlm::rvsdg::bittype::Create(32), constantSize, 4);
 
-    auto pxMerge = MemoryStateMergeOperation::Create({ pxAlloca[1], memoryStateArgument });
+    auto pxMerge = MemoryStateMergeOperation::Create(
+        std::vector<jlm::rvsdg::output *>{ pxAlloca[1], memoryStateArgument });
     auto pyMerge = MemoryStateMergeOperation::Create(
         std::vector<jlm::rvsdg::output *>({ pyAlloca[1], pxMerge }));
 
     auto & callX = CallNode::CreateNode(
         functionXCv,
-        functionX.node()->Type(),
+        rvsdg::AssertGetOwnerNode<lambda::node>(functionX).Type(),
         { pxAlloca[0], iOStateArgument, pyMerge });
 
     auto & callY = CallNode::CreateNode(
         functionYCv,
-        functionY.node()->Type(),
+        rvsdg::AssertGetOwnerNode<lambda::node>(functionY).Type(),
         { pyAlloca[0], callX.GetIoStateOutput(), callX.GetMemoryStateOutput() });
 
     auto loadG1 = LoadNonVolatileNode::Create(
@@ -1034,7 +1047,7 @@ IndirectCallTest2::SetupRvsdg()
             jlm::rvsdg::output::GetNode(*pyAlloca[0])));
   };
 
-  auto SetupTest2Function = [&](lambda::output & functionX)
+  auto SetupTest2Function = [&](rvsdg::output & functionX)
   {
     auto functionType = FunctionType::Create(
         { iostatetype::Create(), MemoryStateType::Create() },
@@ -1042,19 +1055,20 @@ IndirectCallTest2::SetupRvsdg()
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, "test2", linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
     auto constantSize = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
 
     auto pzAlloca = alloca_op::create(jlm::rvsdg::bittype::Create(32), constantSize, 4);
-    auto pzMerge = MemoryStateMergeOperation::Create({ pzAlloca[1], memoryStateArgument });
+    auto pzMerge = MemoryStateMergeOperation::Create(
+        std::vector<jlm::rvsdg::output *>{ pzAlloca[1], memoryStateArgument });
 
-    auto functionXCv = lambda->add_ctxvar(&functionX);
+    auto functionXCv = lambda->AddContextVar(&functionX).inner;
 
     auto & callX = CallNode::CreateNode(
         functionXCv,
-        functionX.node()->Type(),
+        rvsdg::AssertGetOwnerNode<lambda::node>(functionX).Type(),
         { pzAlloca[0], iOStateArgument, pzMerge });
 
     auto lambdaOutput = lambda->finalize(callX.Results());
@@ -1083,13 +1097,13 @@ IndirectCallTest2::SetupRvsdg()
    */
   this->DeltaG1_ = deltaG1->node();
   this->DeltaG2_ = deltaG2->node();
-  this->LambdaThree_ = lambdaThree->node();
-  this->LambdaFour_ = lambdaFour->node();
-  this->LambdaI_ = lambdaI->node();
-  this->LambdaX_ = lambdaX->node();
-  this->LambdaY_ = lambdaY->node();
-  this->LambdaTest_ = lambdaTest->node();
-  this->LambdaTest2_ = lambdaTest2->node();
+  this->LambdaThree_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaThree);
+  this->LambdaFour_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaFour);
+  this->LambdaI_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaI);
+  this->LambdaX_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaX);
+  this->LambdaY_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaY);
+  this->LambdaTest_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaTest);
+  this->LambdaTest2_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaTest2);
 
   this->IndirectCall_ = indirectCall;
   this->CallIWithThree_ = callIWithThree;
@@ -1144,19 +1158,20 @@ ExternalCallTest1::SetupRvsdg()
         { PointerType::Create(), iostatetype::Create(), MemoryStateType::Create() });
 
     auto lambda = lambda::node::create(rvsdg->root(), functionType, "f", linkage::external_linkage);
-    auto pathArgument = lambda->fctargument(0);
-    auto modeArgument = lambda->fctargument(1);
-    auto iOStateArgument = lambda->fctargument(2);
-    auto memoryStateArgument = lambda->fctargument(3);
+    auto pathArgument = lambda->GetFunctionArguments()[0];
+    auto modeArgument = lambda->GetFunctionArguments()[1];
+    auto iOStateArgument = lambda->GetFunctionArguments()[2];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[3];
 
-    auto functionGCv = lambda->add_ctxvar(functionG);
+    auto functionGCv = lambda->AddContextVar(functionG).inner;
 
     auto size = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
 
     auto allocaPath = alloca_op::create(pointerType, size, 4);
     auto allocaMode = alloca_op::create(pointerType, size, 4);
 
-    auto mergePath = MemoryStateMergeOperation::Create({ allocaPath[1], memoryStateArgument });
+    auto mergePath = MemoryStateMergeOperation::Create(
+        std::vector<jlm::rvsdg::output *>{ allocaPath[1], memoryStateArgument });
     auto mergeMode = MemoryStateMergeOperation::Create(
         std::vector<jlm::rvsdg::output *>({ allocaMode[1], mergePath }));
 
@@ -1234,16 +1249,17 @@ ExternalCallTest2::SetupRvsdg()
 
   // Setup function g()
   LambdaG_ = lambda::node::create(rvsdg.root(), lambdaGType, "g", linkage::external_linkage);
-  auto iOStateArgument = LambdaG_->fctargument(0);
-  auto memoryStateArgument = LambdaG_->fctargument(1);
-  auto llvmLifetimeStartArgument = LambdaG_->add_ctxvar(llvmLifetimeStart);
-  auto llvmLifetimeEndArgument = LambdaG_->add_ctxvar(llvmLifetimeEnd);
-  auto lambdaFArgument = LambdaG_->add_ctxvar(ExternalFArgument_);
+  auto iOStateArgument = LambdaG_->GetFunctionArguments()[0];
+  auto memoryStateArgument = LambdaG_->GetFunctionArguments()[1];
+  auto llvmLifetimeStartArgument = LambdaG_->AddContextVar(llvmLifetimeStart).inner;
+  auto llvmLifetimeEndArgument = LambdaG_->AddContextVar(llvmLifetimeEnd).inner;
+  auto lambdaFArgument = LambdaG_->AddContextVar(ExternalFArgument_).inner;
 
   auto twentyFour = jlm::rvsdg::create_bitconstant(LambdaG_->subregion(), 64, 24);
 
   auto allocaResults = alloca_op::create(structType, twentyFour, 16);
-  auto memoryState = MemoryStateMergeOperation::Create({ allocaResults[1], memoryStateArgument });
+  auto memoryState = MemoryStateMergeOperation::Create(
+      std::vector<jlm::rvsdg::output *>{ allocaResults[1], memoryStateArgument });
 
   auto & callLLvmLifetimeStart = CallNode::CreateNode(
       llvmLifetimeStartArgument,
@@ -1316,21 +1332,21 @@ GammaTest::SetupRvsdg()
   auto fct = lambda::node::create(graph->root(), fcttype, "f", linkage::external_linkage);
 
   auto zero = jlm::rvsdg::create_bitconstant(fct->subregion(), 32, 0);
-  auto biteq = jlm::rvsdg::biteq_op::create(32, fct->fctargument(0), zero);
+  auto biteq = jlm::rvsdg::biteq_op::create(32, fct->GetFunctionArguments()[0], zero);
   auto predicate = jlm::rvsdg::match(1, { { 0, 1 } }, 0, 2, biteq);
 
   auto gammanode = jlm::rvsdg::GammaNode::create(predicate, 2);
-  auto p1ev = gammanode->add_entryvar(fct->fctargument(1));
-  auto p2ev = gammanode->add_entryvar(fct->fctargument(2));
-  auto p3ev = gammanode->add_entryvar(fct->fctargument(3));
-  auto p4ev = gammanode->add_entryvar(fct->fctargument(4));
+  auto p1ev = gammanode->add_entryvar(fct->GetFunctionArguments()[1]);
+  auto p2ev = gammanode->add_entryvar(fct->GetFunctionArguments()[2]);
+  auto p3ev = gammanode->add_entryvar(fct->GetFunctionArguments()[3]);
+  auto p4ev = gammanode->add_entryvar(fct->GetFunctionArguments()[4]);
 
   auto tmp1 = gammanode->add_exitvar({ p1ev->argument(0), p3ev->argument(1) });
   auto tmp2 = gammanode->add_exitvar({ p2ev->argument(0), p4ev->argument(1) });
 
   auto ld1 = LoadNonVolatileNode::Create(
       tmp1,
-      { fct->fctargument(5) },
+      { fct->GetFunctionArguments()[5] },
       jlm::rvsdg::bittype::Create(32),
       4);
   auto ld2 = LoadNonVolatileNode::Create(tmp2, { ld1[1] }, jlm::rvsdg::bittype::Create(32), 4);
@@ -1417,18 +1433,18 @@ GammaTest2::SetupRvsdg()
         { rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
     auto lambda = lambda::node::create(rvsdg->root(), functionType, "f", linkage::external_linkage);
-    auto cArgument = lambda->fctargument(0);
-    auto xArgument = lambda->fctargument(1);
-    auto yArgument = lambda->fctargument(2);
-    auto iOStateArgument = lambda->fctargument(3);
-    auto memoryStateArgument = lambda->fctargument(4);
+    auto cArgument = lambda->GetFunctionArguments()[0];
+    auto xArgument = lambda->GetFunctionArguments()[1];
+    auto yArgument = lambda->GetFunctionArguments()[2];
+    auto iOStateArgument = lambda->GetFunctionArguments()[3];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[4];
 
     auto size = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
 
     auto allocaZResults = alloca_op::create(pointerType, size, 4);
 
-    auto memoryState =
-        MemoryStateMergeOperation::Create({ allocaZResults[1], memoryStateArgument });
+    auto memoryState = MemoryStateMergeOperation::Create(
+        std::vector<jlm::rvsdg::output *>{ allocaZResults[1], memoryStateArgument });
 
     auto nullPointer = ConstantPointerNullOperation::Create(lambda->subregion(), pointerType);
     auto storeZResults =
@@ -1457,7 +1473,7 @@ GammaTest2::SetupRvsdg()
         rvsdg::output::GetNode(*allocaZResults[0]));
   };
 
-  auto SetupLambdaGH = [&](lambda::output & lambdaF,
+  auto SetupLambdaGH = [&](rvsdg::output & lambdaF,
                            int64_t cValue,
                            int64_t xValue,
                            int64_t yValue,
@@ -1472,17 +1488,17 @@ GammaTest2::SetupRvsdg()
 
     auto lambda =
         lambda::node::create(rvsdg->root(), functionType, functionName, linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
-    auto lambdaFArgument = lambda->add_ctxvar(&lambdaF);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
+    auto lambdaFArgument = lambda->AddContextVar(&lambdaF).inner;
 
     auto size = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
 
     auto allocaXResults = alloca_op::create(rvsdg::bittype::Create(32), size, 4);
     auto allocaYResults = alloca_op::create(pointerType, size, 4);
 
-    auto memoryState =
-        MemoryStateMergeOperation::Create({ allocaXResults[1], memoryStateArgument });
+    auto memoryState = MemoryStateMergeOperation::Create(
+        std::vector<jlm::rvsdg::output *>{ allocaXResults[1], memoryStateArgument });
     memoryState = MemoryStateMergeOperation::Create(
         std::vector<jlm::rvsdg::output *>({ allocaYResults[1], memoryState }));
 
@@ -1498,7 +1514,7 @@ GammaTest2::SetupRvsdg()
 
     auto & call = CallNode::CreateNode(
         lambdaFArgument,
-        lambdaF.node()->Type(),
+        rvsdg::AssertGetOwnerNode<lambda::node>(lambdaF).Type(),
         { predicate, allocaXResults[0], allocaYResults[0], iOStateArgument, storeYResults[0] });
 
     lambda->finalize(call.Results());
@@ -1516,9 +1532,9 @@ GammaTest2::SetupRvsdg()
   auto [lambdaH, callFromH, allocaXFromH, allocaYFromH] = SetupLambdaGH(*lambdaF, 1, 3, 4, "h");
 
   // Assign nodes
-  this->LambdaF_ = lambdaF->node();
-  this->LambdaG_ = lambdaG->node();
-  this->LambdaH_ = lambdaH->node();
+  this->LambdaF_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaF);
+  this->LambdaG_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaG);
+  this->LambdaH_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaH);
 
   this->Gamma_ = gammaNode;
 
@@ -1561,10 +1577,10 @@ ThetaTest::SetupRvsdg()
   auto thetanode = jlm::rvsdg::ThetaNode::create(fct->subregion());
 
   auto n = thetanode->add_loopvar(zero);
-  auto l = thetanode->add_loopvar(fct->fctargument(0));
-  auto a = thetanode->add_loopvar(fct->fctargument(1));
-  auto c = thetanode->add_loopvar(fct->fctargument(2));
-  auto s = thetanode->add_loopvar(fct->fctargument(3));
+  auto l = thetanode->add_loopvar(fct->GetFunctionArguments()[0]);
+  auto a = thetanode->add_loopvar(fct->GetFunctionArguments()[1]);
+  auto c = thetanode->add_loopvar(fct->GetFunctionArguments()[2]);
+  auto s = thetanode->add_loopvar(fct->GetFunctionArguments()[3]);
 
   auto gepnode = GetElementPtrOperation::Create(
       a->argument(),
@@ -1631,9 +1647,9 @@ DeltaTest1::SetupRvsdg()
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
     auto lambda = lambda::node::create(graph->root(), functionType, "g", linkage::external_linkage);
-    auto pointerArgument = lambda->fctargument(0);
-    auto iOStateArgument = lambda->fctargument(1);
-    auto memoryStateArgument = lambda->fctargument(2);
+    auto pointerArgument = lambda->GetFunctionArguments()[0];
+    auto iOStateArgument = lambda->GetFunctionArguments()[1];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[2];
 
     auto ld = LoadNonVolatileNode::Create(
         pointerArgument,
@@ -1644,7 +1660,7 @@ DeltaTest1::SetupRvsdg()
     return lambda->finalize({ ld[0], iOStateArgument, ld[1] });
   };
 
-  auto SetupFunctionH = [&](delta::output * f, lambda::output * g)
+  auto SetupFunctionH = [&](delta::output * f, rvsdg::output * g)
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
@@ -1653,15 +1669,18 @@ DeltaTest1::SetupRvsdg()
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
     auto lambda = lambda::node::create(graph->root(), functionType, "h", linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto cvf = lambda->add_ctxvar(f);
-    auto cvg = lambda->add_ctxvar(g);
+    auto cvf = lambda->AddContextVar(f).inner;
+    auto cvg = lambda->AddContextVar(g).inner;
 
     auto five = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 5);
     auto st = StoreNonVolatileNode::Create(cvf, five, { memoryStateArgument }, 4);
-    auto & callG = CallNode::CreateNode(cvg, g->node()->Type(), { cvf, iOStateArgument, st[0] });
+    auto & callG = CallNode::CreateNode(
+        cvg,
+        rvsdg::AssertGetOwnerNode<lambda::node>(*g).Type(),
+        { cvf, iOStateArgument, st[0] });
 
     auto lambdaOutput = lambda->finalize(callG.Results());
     GraphExport::Create(*lambda->output(), "h");
@@ -1676,8 +1695,8 @@ DeltaTest1::SetupRvsdg()
   /*
    * Assign nodes
    */
-  this->lambda_g = g->node();
-  this->lambda_h = h->node();
+  this->lambda_g = &rvsdg::AssertGetOwnerNode<lambda::node>(*g);
+  this->lambda_h = &rvsdg::AssertGetOwnerNode<lambda::node>(*h);
 
   this->delta_f = f->node();
 
@@ -1738,17 +1757,17 @@ DeltaTest2::SetupRvsdg()
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, "f1", linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto cvd1 = lambda->add_ctxvar(d1);
+    auto cvd1 = lambda->AddContextVar(d1).inner;
     auto b2 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 2);
     auto st = StoreNonVolatileNode::Create(cvd1, b2, { memoryStateArgument }, 4);
 
     return lambda->finalize({ iOStateArgument, st[0] });
   };
 
-  auto SetupF2 = [&](lambda::output * f1, delta::output * d1, delta::output * d2)
+  auto SetupF2 = [&](rvsdg::output * f1, delta::output * d1, delta::output * d2)
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
@@ -1758,17 +1777,20 @@ DeltaTest2::SetupRvsdg()
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, "f2", linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto cvd1 = lambda->add_ctxvar(d1);
-    auto cvd2 = lambda->add_ctxvar(d2);
-    auto cvf1 = lambda->add_ctxvar(f1);
+    auto cvd1 = lambda->AddContextVar(d1).inner;
+    auto cvd2 = lambda->AddContextVar(d2).inner;
+    auto cvf1 = lambda->AddContextVar(f1).inner;
 
     auto b5 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 5);
     auto b42 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 42);
     auto st = StoreNonVolatileNode::Create(cvd1, b5, { memoryStateArgument }, 4);
-    auto & call = CallNode::CreateNode(cvf1, f1->node()->Type(), { iOStateArgument, st[0] });
+    auto & call = CallNode::CreateNode(
+        cvf1,
+        rvsdg::AssertGetOwnerNode<lambda::node>(*f1).Type(),
+        { iOStateArgument, st[0] });
     st = StoreNonVolatileNode::Create(cvd2, b42, { call.GetMemoryStateOutput() }, 4);
 
     auto lambdaOutput = lambda->finalize(call.Results());
@@ -1783,8 +1805,8 @@ DeltaTest2::SetupRvsdg()
   auto [f2, callF1] = SetupF2(f1, d1, d2);
 
   // Assign nodes
-  this->lambda_f1 = f1->node();
-  this->lambda_f2 = f2->node();
+  this->lambda_f1 = &rvsdg::AssertGetOwnerNode<lambda::node>(*f1);
+  this->lambda_f2 = &rvsdg::AssertGetOwnerNode<lambda::node>(*f2);
 
   this->delta_d1 = d1->node();
   this->delta_d2 = d2->node();
@@ -1841,10 +1863,10 @@ DeltaTest3::SetupRvsdg()
         { jlm::rvsdg::bittype::Create(16), iostatetype::Create(), MemoryStateType::Create() });
 
     auto lambda = lambda::node::create(graph->root(), functionType, "f", linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
-    auto g1CtxVar = lambda->add_ctxvar(&g1);
-    auto g2CtxVar = lambda->add_ctxvar(&g2);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
+    auto g1CtxVar = lambda->AddContextVar(&g1).inner;
+    auto g2CtxVar = lambda->AddContextVar(&g2).inner;
 
     auto loadResults =
         LoadNonVolatileNode::Create(g2CtxVar, { memoryStateArgument }, PointerType::Create(), 8);
@@ -1858,7 +1880,7 @@ DeltaTest3::SetupRvsdg()
     return lambda->finalize({ truncResult, iOStateArgument, loadResults[1] });
   };
 
-  auto SetupTest = [&](lambda::output & lambdaF)
+  auto SetupTest = [&](rvsdg::output & lambdaF)
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
@@ -1868,14 +1890,14 @@ DeltaTest3::SetupRvsdg()
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, "test", linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto lambdaFArgument = lambda->add_ctxvar(&lambdaF);
+    auto lambdaFArgument = lambda->AddContextVar(&lambdaF).inner;
 
     auto & call = CallNode::CreateNode(
         lambdaFArgument,
-        lambdaF.node()->Type(),
+        rvsdg::AssertGetOwnerNode<lambda::node>(lambdaF).Type(),
         { iOStateArgument, memoryStateArgument });
 
     auto lambdaOutput = lambda->finalize({ call.GetIoStateOutput(), call.GetMemoryStateOutput() });
@@ -1892,8 +1914,8 @@ DeltaTest3::SetupRvsdg()
   /*
    * Assign nodes
    */
-  this->LambdaF_ = f->node();
-  this->LambdaTest_ = test->node();
+  this->LambdaF_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*f);
+  this->LambdaTest_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*test);
 
   this->DeltaG1_ = g1->node();
   this->DeltaG2_ = g2->node();
@@ -1924,10 +1946,10 @@ ImportTest::SetupRvsdg()
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, "f1", linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto cvd1 = lambda->add_ctxvar(d1);
+    auto cvd1 = lambda->AddContextVar(d1).inner;
 
     auto b5 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 5);
     auto st = StoreNonVolatileNode::Create(cvd1, b5, { memoryStateArgument }, 4);
@@ -1935,7 +1957,7 @@ ImportTest::SetupRvsdg()
     return lambda->finalize({ iOStateArgument, st[0] });
   };
 
-  auto SetupF2 = [&](lambda::output * f1, jlm::rvsdg::output * d1, jlm::rvsdg::output * d2)
+  auto SetupF2 = [&](rvsdg::output * f1, jlm::rvsdg::output * d1, jlm::rvsdg::output * d2)
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
@@ -1945,16 +1967,19 @@ ImportTest::SetupRvsdg()
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, "f2", linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto cvd1 = lambda->add_ctxvar(d1);
-    auto cvd2 = lambda->add_ctxvar(d2);
-    auto cvf1 = lambda->add_ctxvar(f1);
+    auto cvd1 = lambda->AddContextVar(d1).inner;
+    auto cvd2 = lambda->AddContextVar(d2).inner;
+    auto cvf1 = lambda->AddContextVar(f1).inner;
     auto b2 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 2);
     auto b21 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 21);
     auto st = StoreNonVolatileNode::Create(cvd1, b2, { memoryStateArgument }, 4);
-    auto & call = CallNode::CreateNode(cvf1, f1->node()->Type(), { iOStateArgument, st[0] });
+    auto & call = CallNode::CreateNode(
+        cvf1,
+        rvsdg::AssertGetOwnerNode<lambda::node>(*f1).Type(),
+        { iOStateArgument, st[0] });
     st = StoreNonVolatileNode::Create(cvd2, b21, { call.GetMemoryStateOutput() }, 4);
 
     auto lambdaOutput = lambda->finalize(call.Results());
@@ -1978,8 +2003,8 @@ ImportTest::SetupRvsdg()
   auto [f2, callF1] = SetupF2(f1, d1, d2);
 
   // Assign nodes
-  this->lambda_f1 = f1->node();
-  this->lambda_f2 = f2->node();
+  this->lambda_f1 = &rvsdg::AssertGetOwnerNode<lambda::node>(*f1);
+  this->lambda_f2 = &rvsdg::AssertGetOwnerNode<lambda::node>(*f2);
 
   this->CallF1_ = callF1;
 
@@ -2020,11 +2045,11 @@ PhiTest1::SetupRvsdg()
 
     auto lambda =
         lambda::node::create(pb.subregion(), fibFunctionType, "fib", linkage::external_linkage);
-    auto valueArgument = lambda->fctargument(0);
-    auto pointerArgument = lambda->fctargument(1);
-    auto iOStateArgument = lambda->fctargument(2);
-    auto memoryStateArgument = lambda->fctargument(3);
-    auto ctxVarFib = lambda->add_ctxvar(fibrv->argument());
+    auto valueArgument = lambda->GetFunctionArguments()[0];
+    auto pointerArgument = lambda->GetFunctionArguments()[1];
+    auto iOStateArgument = lambda->GetFunctionArguments()[2];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[3];
+    auto ctxVarFib = lambda->AddContextVar(fibrv->argument()).inner;
 
     auto two = jlm::rvsdg::create_bitconstant(lambda->subregion(), 64, 2);
     auto bitult = jlm::rvsdg::bitult_op::create(64, valueArgument, two);
@@ -2111,13 +2136,14 @@ PhiTest1::SetupRvsdg()
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, "test", linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
-    auto fibcv = lambda->add_ctxvar(phiNode->output(0));
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
+    auto fibcv = lambda->AddContextVar(phiNode->output(0)).inner;
 
     auto ten = jlm::rvsdg::create_bitconstant(lambda->subregion(), 64, 10);
     auto allocaResults = alloca_op::create(at, ten, 16);
-    auto state = MemoryStateMergeOperation::Create({ allocaResults[1], memoryStateArgument });
+    auto state = MemoryStateMergeOperation::Create(
+        std::vector<jlm::rvsdg::output *>{ allocaResults[1], memoryStateArgument });
 
     auto zero = jlm::rvsdg::create_bitconstant(lambda->subregion(), 64, 0);
     auto gep = GetElementPtrOperation::Create(allocaResults[0], { zero, zero }, at, pbit64);
@@ -2135,8 +2161,8 @@ PhiTest1::SetupRvsdg()
   auto [testfct, callFib, alloca] = SetupTestFunction(phiNode);
 
   // Assign nodes
-  this->lambda_fib = fibfct->node();
-  this->lambda_test = testfct->node();
+  this->lambda_fib = &rvsdg::AssertGetOwnerNode<lambda::node>(*fibfct);
+  this->lambda_test = &rvsdg::AssertGetOwnerNode<lambda::node>(*testfct);
 
   this->gamma = gammaNode;
   this->phi = phiNode;
@@ -2190,8 +2216,8 @@ PhiTest2::SetupRvsdg()
         constantFunctionType,
         "eight",
         linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
     auto constant = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 8);
 
@@ -2202,9 +2228,9 @@ PhiTest2::SetupRvsdg()
   {
     auto lambda =
         lambda::node::create(graph->root(), functionIType, "i", linkage::external_linkage);
-    auto pointerArgument = lambda->fctargument(0);
-    auto iOStateArgument = lambda->fctargument(1);
-    auto memoryStateArgument = lambda->fctargument(2);
+    auto pointerArgument = lambda->GetFunctionArguments()[0];
+    auto iOStateArgument = lambda->GetFunctionArguments()[1];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[2];
 
     auto & call = CallNode::CreateNode(
         pointerArgument,
@@ -2220,12 +2246,12 @@ PhiTest2::SetupRvsdg()
       [&](jlm::rvsdg::Region & region, phi::rvargument & functionB, phi::rvargument & functionD)
   {
     auto lambda = lambda::node::create(&region, recFunctionType, "a", linkage::external_linkage);
-    auto pointerArgument = lambda->fctargument(0);
-    auto iOStateArgument = lambda->fctargument(1);
-    auto memoryStateArgument = lambda->fctargument(2);
+    auto pointerArgument = lambda->GetFunctionArguments()[0];
+    auto iOStateArgument = lambda->GetFunctionArguments()[1];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[2];
 
-    auto functionBCv = lambda->add_ctxvar(&functionB);
-    auto functionDCv = lambda->add_ctxvar(&functionD);
+    auto functionBCv = lambda->AddContextVar(&functionB).inner;
+    auto functionDCv = lambda->AddContextVar(&functionD).inner;
 
     auto one = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 1);
     auto storeNode = StoreNonVolatileNode::Create(pointerArgument, one, { memoryStateArgument }, 4);
@@ -2264,13 +2290,13 @@ PhiTest2::SetupRvsdg()
                     phi::cvargument & functionEight)
   {
     auto lambda = lambda::node::create(&region, recFunctionType, "b", linkage::external_linkage);
-    auto pointerArgument = lambda->fctargument(0);
-    auto iOStateArgument = lambda->fctargument(1);
-    auto memoryStateArgument = lambda->fctargument(2);
+    auto pointerArgument = lambda->GetFunctionArguments()[0];
+    auto iOStateArgument = lambda->GetFunctionArguments()[1];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[2];
 
-    auto functionICv = lambda->add_ctxvar(&functionI);
-    auto functionCCv = lambda->add_ctxvar(&functionC);
-    auto functionEightCv = lambda->add_ctxvar(&functionEight);
+    auto functionICv = lambda->AddContextVar(&functionI).inner;
+    auto functionCCv = lambda->AddContextVar(&functionC).inner;
+    auto functionEightCv = lambda->AddContextVar(&functionEight).inner;
 
     auto two = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 2);
     auto storeNode = StoreNonVolatileNode::Create(pointerArgument, two, { memoryStateArgument }, 4);
@@ -2306,11 +2332,11 @@ PhiTest2::SetupRvsdg()
   auto SetupC = [&](jlm::rvsdg::Region & region, phi::rvargument & functionA)
   {
     auto lambda = lambda::node::create(&region, recFunctionType, "c", linkage::external_linkage);
-    auto xArgument = lambda->fctargument(0);
-    auto iOStateArgument = lambda->fctargument(1);
-    auto memoryStateArgument = lambda->fctargument(2);
+    auto xArgument = lambda->GetFunctionArguments()[0];
+    auto iOStateArgument = lambda->GetFunctionArguments()[1];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[2];
 
-    auto functionACv = lambda->add_ctxvar(&functionA);
+    auto functionACv = lambda->AddContextVar(&functionA).inner;
 
     auto three = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 3);
     auto storeNode = StoreNonVolatileNode::Create(xArgument, three, { memoryStateArgument }, 4);
@@ -2345,11 +2371,11 @@ PhiTest2::SetupRvsdg()
   auto SetupD = [&](jlm::rvsdg::Region & region, phi::rvargument & functionA)
   {
     auto lambda = lambda::node::create(&region, recFunctionType, "d", linkage::external_linkage);
-    auto xArgument = lambda->fctargument(0);
-    auto iOStateArgument = lambda->fctargument(1);
-    auto memoryStateArgument = lambda->fctargument(2);
+    auto xArgument = lambda->GetFunctionArguments()[0];
+    auto iOStateArgument = lambda->GetFunctionArguments()[1];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[2];
 
-    auto functionACv = lambda->add_ctxvar(&functionA);
+    auto functionACv = lambda->AddContextVar(&functionA).inner;
 
     auto four = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
     auto storeNode = StoreNonVolatileNode::Create(xArgument, four, { memoryStateArgument }, 4);
@@ -2372,7 +2398,7 @@ PhiTest2::SetupRvsdg()
             jlm::rvsdg::output::GetNode(*pdAlloca[0])));
   };
 
-  auto SetupPhi = [&](lambda::output & lambdaEight, lambda::output & lambdaI)
+  auto SetupPhi = [&](rvsdg::output & lambdaEight, rvsdg::output & lambdaI)
   {
     jlm::llvm::phi::builder phiBuilder;
     phiBuilder.begin(graph->root());
@@ -2429,10 +2455,10 @@ PhiTest2::SetupRvsdg()
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, "test", linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto functionACv = lambda->add_ctxvar(&functionA);
+    auto functionACv = lambda->AddContextVar(&functionA).inner;
 
     auto four = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
     auto pTestAlloca = alloca_op::create(jlm::rvsdg::bittype::Create(32), four, 4);
@@ -2478,17 +2504,13 @@ PhiTest2::SetupRvsdg()
   /*
    * Assign nodes
    */
-  this->LambdaEight_ = lambdaEight->node();
-  this->LambdaI_ = lambdaI->node();
-  this->LambdaA_ = jlm::util::AssertedCast<lambda::node>(
-      jlm::rvsdg::output::GetNode(*lambdaA->result()->origin()));
-  this->LambdaB_ = jlm::util::AssertedCast<lambda::node>(
-      jlm::rvsdg::output::GetNode(*lambdaB->result()->origin()));
-  this->LambdaC_ = jlm::util::AssertedCast<lambda::node>(
-      jlm::rvsdg::output::GetNode(*lambdaC->result()->origin()));
-  this->LambdaD_ = jlm::util::AssertedCast<lambda::node>(
-      jlm::rvsdg::output::GetNode(*lambdaD->result()->origin()));
-  this->LambdaTest_ = lambdaTest->node();
+  this->LambdaEight_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaEight);
+  this->LambdaI_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaI);
+  this->LambdaA_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaA->result()->origin());
+  this->LambdaB_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaB->result()->origin());
+  this->LambdaC_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaC->result()->origin());
+  this->LambdaD_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaD->result()->origin());
+  this->LambdaTest_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaTest);
 
   this->CallAFromTest_ = callAFromTest;
   this->CallAFromC_ = callAFromC;
@@ -2574,9 +2596,9 @@ ExternalMemoryTest::SetupRvsdg()
    * Setup function f.
    */
   LambdaF = lambda::node::create(graph->root(), ft, "f", linkage::external_linkage);
-  auto x = LambdaF->fctargument(0);
-  auto y = LambdaF->fctargument(1);
-  auto state = LambdaF->fctargument(2);
+  auto x = LambdaF->GetFunctionArguments()[0];
+  auto y = LambdaF->GetFunctionArguments()[1];
+  auto state = LambdaF->GetFunctionArguments()[2];
 
   auto one = jlm::rvsdg::create_bitconstant(LambdaF->subregion(), 32, 1);
   auto two = jlm::rvsdg::create_bitconstant(LambdaF->subregion(), 32, 2);
@@ -2669,11 +2691,11 @@ EscapedMemoryTest1::SetupRvsdg()
 
     auto lambda =
         lambda::node::create(rvsdg->root(), functionType, "test", linkage::external_linkage);
-    auto pointerArgument = lambda->fctargument(0);
-    auto iOStateArgument = lambda->fctargument(1);
-    auto memoryStateArgument = lambda->fctargument(2);
+    auto pointerArgument = lambda->GetFunctionArguments()[0];
+    auto iOStateArgument = lambda->GetFunctionArguments()[1];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[2];
 
-    auto contextVariableB = lambda->add_ctxvar(&deltaB);
+    auto contextVariableB = lambda->AddContextVar(&deltaB).inner;
 
     auto loadResults1 =
         LoadNonVolatileNode::Create(pointerArgument, { memoryStateArgument }, pointerType, 4);
@@ -2706,7 +2728,7 @@ EscapedMemoryTest1::SetupRvsdg()
   /*
    * Assign nodes
    */
-  this->LambdaTest = lambdaTest->node();
+  this->LambdaTest = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaTest);
 
   this->DeltaA = deltaA->node();
   this->DeltaB = deltaB->node();
@@ -2773,8 +2795,8 @@ EscapedMemoryTest2::SetupRvsdg()
         functionType,
         "ReturnAddress",
         linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
     auto eight = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 8);
 
@@ -2802,10 +2824,10 @@ EscapedMemoryTest2::SetupRvsdg()
         functionType,
         "CallExternalFunction1",
         linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto externalFunction1 = lambda->add_ctxvar(externalFunction1Argument);
+    auto externalFunction1 = lambda->AddContextVar(externalFunction1Argument).inner;
 
     auto eight = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 8);
 
@@ -2838,10 +2860,10 @@ EscapedMemoryTest2::SetupRvsdg()
         functionType,
         "CallExternalFunction2",
         linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto externalFunction2 = lambda->add_ctxvar(externalFunction2Argument);
+    auto externalFunction2 = lambda->AddContextVar(externalFunction2Argument).inner;
 
     auto & call = CallNode::CreateNode(
         externalFunction2,
@@ -2877,9 +2899,9 @@ EscapedMemoryTest2::SetupRvsdg()
   /*
    * Assign nodes
    */
-  this->ReturnAddressFunction = returnAddressFunction->node();
-  this->CallExternalFunction1 = callExternalFunction1->node();
-  this->CallExternalFunction2 = callExternalFunction2->node();
+  this->ReturnAddressFunction = &rvsdg::AssertGetOwnerNode<lambda::node>(*returnAddressFunction);
+  this->CallExternalFunction1 = &rvsdg::AssertGetOwnerNode<lambda::node>(*callExternalFunction1);
+  this->CallExternalFunction2 = &rvsdg::AssertGetOwnerNode<lambda::node>(*callExternalFunction2);
 
   this->ExternalFunction1Call = externalFunction1Call;
   this->ExternalFunction2Call = externalFunction2Call;
@@ -2951,10 +2973,10 @@ EscapedMemoryTest3::SetupRvsdg()
 
     auto lambda =
         lambda::node::create(rvsdg->root(), functionType, "test", linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto externalFunction = lambda->add_ctxvar(externalFunctionArgument);
+    auto externalFunction = lambda->AddContextVar(externalFunctionArgument).inner;
 
     auto & call = CallNode::CreateNode(
         externalFunction,
@@ -2984,7 +3006,7 @@ EscapedMemoryTest3::SetupRvsdg()
   auto [lambdaTest, callExternalFunction, loadNode] = SetupTestFunction(importExternalFunction);
 
   // Assign nodes
-  this->LambdaTest = lambdaTest->node();
+  this->LambdaTest = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaTest);
   this->DeltaGlobal = deltaGlobal->node();
   this->ImportExternalFunction = importExternalFunction;
   this->CallExternalFunction = callExternalFunction;
@@ -3059,10 +3081,10 @@ MemcpyTest::SetupRvsdg()
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
     auto lambda = lambda::node::create(rvsdg->root(), functionType, "f", linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto globalArrayArgument = lambda->add_ctxvar(&globalArray);
+    auto globalArrayArgument = lambda->AddContextVar(&globalArray).inner;
 
     auto zero = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 0);
     auto two = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 2);
@@ -3087,7 +3109,7 @@ MemcpyTest::SetupRvsdg()
   };
 
   auto SetupFunctionG =
-      [&](delta::output & localArray, delta::output & globalArray, lambda::output & lambdaF)
+      [&](delta::output & localArray, delta::output & globalArray, rvsdg::output & lambdaF)
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
@@ -3096,12 +3118,12 @@ MemcpyTest::SetupRvsdg()
         { jlm::rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
     auto lambda = lambda::node::create(rvsdg->root(), functionType, "g", linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto localArrayArgument = lambda->add_ctxvar(&localArray);
-    auto globalArrayArgument = lambda->add_ctxvar(&globalArray);
-    auto functionFArgument = lambda->add_ctxvar(&lambdaF);
+    auto localArrayArgument = lambda->AddContextVar(&localArray).inner;
+    auto globalArrayArgument = lambda->AddContextVar(&globalArray).inner;
+    auto functionFArgument = lambda->AddContextVar(&lambdaF).inner;
 
     auto bcLocalArray = bitcast_op::create(localArrayArgument, PointerType::Create());
     auto bcGlobalArray = bitcast_op::create(globalArrayArgument, PointerType::Create());
@@ -3116,7 +3138,7 @@ MemcpyTest::SetupRvsdg()
 
     auto & call = CallNode::CreateNode(
         functionFArgument,
-        lambdaF.node()->Type(),
+        rvsdg::AssertGetOwnerNode<lambda::node>(lambdaF).Type(),
         { iOStateArgument, memcpyResults[0] });
 
     auto lambdaOutput = lambda->finalize(call.Results());
@@ -3134,8 +3156,8 @@ MemcpyTest::SetupRvsdg()
   /*
    * Assign nodes
    */
-  this->LambdaF_ = lambdaF->node();
-  this->LambdaG_ = lambdaG->node();
+  this->LambdaF_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaF);
+  this->LambdaG_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaG);
   this->LocalArray_ = localArray->node();
   this->GlobalArray_ = globalArray->node();
   this->CallF_ = callF;
@@ -3173,10 +3195,10 @@ MemcpyTest2::SetupRvsdg()
         { iostatetype::Create(), MemoryStateType::Create() });
 
     auto lambda = lambda::node::create(rvsdg->root(), functionType, "g", linkage::internal_linkage);
-    auto s1Argument = lambda->fctargument(0);
-    auto s2Argument = lambda->fctargument(1);
-    auto iOStateArgument = lambda->fctargument(2);
-    auto memoryStateArgument = lambda->fctargument(3);
+    auto s1Argument = lambda->GetFunctionArguments()[0];
+    auto s2Argument = lambda->GetFunctionArguments()[1];
+    auto iOStateArgument = lambda->GetFunctionArguments()[2];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[3];
 
     auto c0 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 0);
     auto c128 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 64, 128);
@@ -3196,7 +3218,7 @@ MemcpyTest2::SetupRvsdg()
     return std::make_tuple(lambdaOutput, jlm::rvsdg::output::GetNode(*memcpyResults[0]));
   };
 
-  auto SetupFunctionF = [&](lambda::output & functionF)
+  auto SetupFunctionF = [&](rvsdg::output & functionF)
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
@@ -3208,12 +3230,12 @@ MemcpyTest2::SetupRvsdg()
         { iostatetype::Create(), MemoryStateType::Create() });
 
     auto lambda = lambda::node::create(rvsdg->root(), functionType, "f", linkage::external_linkage);
-    auto s1Argument = lambda->fctargument(0);
-    auto s2Argument = lambda->fctargument(1);
-    auto iOStateArgument = lambda->fctargument(2);
-    auto memoryStateArgument = lambda->fctargument(3);
+    auto s1Argument = lambda->GetFunctionArguments()[0];
+    auto s2Argument = lambda->GetFunctionArguments()[1];
+    auto iOStateArgument = lambda->GetFunctionArguments()[2];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[3];
 
-    auto functionFArgument = lambda->add_ctxvar(&functionF);
+    auto functionFArgument = lambda->AddContextVar(&functionF).inner;
 
     auto c0 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 0);
 
@@ -3225,7 +3247,7 @@ MemcpyTest2::SetupRvsdg()
 
     auto & call = CallNode::CreateNode(
         functionFArgument,
-        functionF.node()->Type(),
+        rvsdg::AssertGetOwnerNode<lambda::node>(functionF).Type(),
         { ldS1[0], ldS2[0], iOStateArgument, ldS2[1] });
 
     auto lambdaOutput = lambda->finalize(call.Results());
@@ -3238,8 +3260,8 @@ MemcpyTest2::SetupRvsdg()
   auto [lambdaG, memcpyNode] = SetupFunctionG();
   auto [lambdaF, callG] = SetupFunctionF(*lambdaG);
 
-  this->LambdaF_ = lambdaF->node();
-  this->LambdaG_ = lambdaG->node();
+  this->LambdaF_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaF);
+  this->LambdaG_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaG);
   this->CallG_ = callG;
   this->Memcpy_ = memcpyNode;
 
@@ -3269,9 +3291,9 @@ MemcpyTest3::SetupRvsdg()
       { iostatetype::Create(), MemoryStateType::Create() });
 
   Lambda_ = lambda::node::create(rvsdg->root(), functionType, "f", linkage::internal_linkage);
-  auto pArgument = Lambda_->fctargument(0);
-  auto iOStateArgument = Lambda_->fctargument(1);
-  auto memoryStateArgument = Lambda_->fctargument(2);
+  auto pArgument = Lambda_->GetFunctionArguments()[0];
+  auto iOStateArgument = Lambda_->GetFunctionArguments()[1];
+  auto memoryStateArgument = Lambda_->GetFunctionArguments()[2];
 
   auto eight = jlm::rvsdg::create_bitconstant(Lambda_->subregion(), 64, 8);
   auto zero = jlm::rvsdg::create_bitconstant(Lambda_->subregion(), 32, 0);
@@ -3279,7 +3301,8 @@ MemcpyTest3::SetupRvsdg()
   auto three = jlm::rvsdg::create_bitconstant(Lambda_->subregion(), 64, 3);
 
   auto allocaResults = alloca_op::create(structType, eight, 8);
-  auto memoryState = MemoryStateMergeOperation::Create({ allocaResults[1], memoryStateArgument });
+  auto memoryState = MemoryStateMergeOperation::Create(
+      std::vector<jlm::rvsdg::output *>{ allocaResults[1], memoryStateArgument });
 
   auto memcpyResults =
       MemCpyNonVolatileOperation::create(allocaResults[0], pArgument, eight, { memoryState });
@@ -3348,16 +3371,17 @@ LinkedListTest::SetupRvsdg()
 
     auto lambda =
         lambda::node::create(rvsdg.root(), functionType, "next", linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
-    auto myListArgument = lambda->add_ctxvar(&myList);
+    auto myListArgument = lambda->AddContextVar(&myList).inner;
 
     auto zero = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 0);
     auto size = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
 
     auto alloca = alloca_op::create(pointerType, size, 4);
-    auto mergedMemoryState = MemoryStateMergeOperation::Create({ alloca[1], memoryStateArgument });
+    auto mergedMemoryState = MemoryStateMergeOperation::Create(
+        std::vector<jlm::rvsdg::output *>{ alloca[1], memoryStateArgument });
 
     auto load1 = LoadNonVolatileNode::Create(myListArgument, { mergedMemoryState }, pointerType, 4);
     auto store1 = StoreNonVolatileNode::Create(alloca[0], load1[0], { load1[1] }, 4);
@@ -3383,7 +3407,7 @@ LinkedListTest::SetupRvsdg()
    * Assign nodes
    */
   this->DeltaMyList_ = deltaMyList->node();
-  this->LambdaNext_ = lambdaNext->node();
+  this->LambdaNext_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaNext);
   this->Alloca_ = alloca;
 
   return rvsdgModule;
@@ -3425,9 +3449,9 @@ AllMemoryNodesTest::SetupRvsdg()
 
   // Start of function "f"
   Lambda_ = lambda::node::create(graph->root(), fcttype, "f", linkage::external_linkage);
-  auto entryMemoryState = Lambda_->fctargument(0);
-  auto deltaContextVar = Lambda_->add_ctxvar(Delta_->output());
-  auto importContextVar = Lambda_->add_ctxvar(Import_);
+  auto entryMemoryState = Lambda_->GetFunctionArguments()[0];
+  auto deltaContextVar = Lambda_->AddContextVar(Delta_->output()).inner;
+  auto importContextVar = Lambda_->AddContextVar(Import_).inner;
 
   // Create alloca node
   auto allocaSize = jlm::rvsdg::create_bitconstant(Lambda_->subregion(), 32, 1);
@@ -3505,7 +3529,7 @@ NAllocaNodesTest::SetupRvsdg()
 
   auto allocaSize = jlm::rvsdg::create_bitconstant(Function_->subregion(), 32, 1);
 
-  jlm::rvsdg::output * latestMemoryState = Function_->fctargument(0);
+  jlm::rvsdg::output * latestMemoryState = Function_->GetFunctionArguments()[0];
 
   for (size_t i = 0; i < NumAllocaNodes_; i++)
   {
@@ -3561,7 +3585,7 @@ EscapingLocalFunctionTest::SetupRvsdg()
       "localFunction",
       linkage::internal_linkage);
 
-  LocalFuncParam_ = LocalFunc_->fctargument(0);
+  LocalFuncParam_ = LocalFunc_->GetFunctionArguments()[0];
 
   const auto allocaSize = rvsdg::create_bitconstant(LocalFunc_->subregion(), 32, 1);
   const auto allocaOutputs = alloca_op::create(uint32Type, allocaSize, 4);
@@ -3569,14 +3593,14 @@ EscapingLocalFunctionTest::SetupRvsdg()
 
   // Merge function's input Memory State and alloca node's memory state
   rvsdg::output * mergedMemoryState = MemoryStateMergeOperation::Create(
-      std::vector<rvsdg::output *>{ LocalFunc_->fctargument(1), allocaOutputs[1] });
+      std::vector<rvsdg::output *>{ LocalFunc_->GetFunctionArguments()[1], allocaOutputs[1] });
 
   // Store the function parameter into the alloca node
   auto storeOutputs =
       StoreNonVolatileNode::Create(allocaOutputs[0], LocalFuncParam_, { mergedMemoryState }, 4);
 
   // Bring in deltaOuput as a context variable
-  const auto deltaOutputCtxVar = LocalFunc_->add_ctxvar(deltaOutput);
+  const auto deltaOutputCtxVar = LocalFunc_->AddContextVar(deltaOutput).inner;
 
   // Return &global
   LocalFunc_->finalize({ deltaOutputCtxVar, storeOutputs[0] });
@@ -3589,10 +3613,10 @@ EscapingLocalFunctionTest::SetupRvsdg()
       "exportedFunc",
       linkage::external_linkage);
 
-  const auto localFuncCtxVar = ExportedFunc_->add_ctxvar(LocalFuncRegister_);
+  const auto localFuncCtxVar = ExportedFunc_->AddContextVar(LocalFuncRegister_).inner;
 
   // Return &localFunc, pass memory state directly through
-  ExportedFunc_->finalize({ localFuncCtxVar, ExportedFunc_->fctargument(0) });
+  ExportedFunc_->finalize({ localFuncCtxVar, ExportedFunc_->GetFunctionArguments()[0] });
 
   GraphExport::Create(*ExportedFunc_->output(), "exportedFunc");
 
@@ -3616,8 +3640,8 @@ FreeNullTest::SetupRvsdg()
 
   LambdaMain_ =
       lambda::node::create(graph->root(), functionType, "main", linkage::external_linkage);
-  auto iOStateArgument = LambdaMain_->fctargument(0);
-  auto memoryStateArgument = LambdaMain_->fctargument(1);
+  auto iOStateArgument = LambdaMain_->GetFunctionArguments()[0];
+  auto memoryStateArgument = LambdaMain_->GetFunctionArguments()[1];
 
   auto constantPointerNullResult =
       ConstantPointerNullOperation::Create(LambdaMain_->subregion(), PointerType::Create());
@@ -3650,15 +3674,15 @@ LambdaCallArgumentMismatch::SetupRvsdg()
         { rvsdg::bittype::Create(32), iostatetype::Create(), MemoryStateType::Create() });
 
     auto lambda = lambda::node::create(rvsdg.root(), functionType, "g", linkage::internal_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
     auto five = rvsdg::create_bitconstant(lambda->subregion(), 32, 5);
 
     return lambda->finalize({ five, iOStateArgument, memoryStateArgument });
   };
 
-  auto setupLambdaMain = [&](lambda::output & lambdaG)
+  auto setupLambdaMain = [&](rvsdg::output & lambdaG)
   {
     auto pointerType = PointerType::Create();
     auto iOStateType = iostatetype::Create();
@@ -3676,9 +3700,9 @@ LambdaCallArgumentMismatch::SetupRvsdg()
 
     auto lambda =
         lambda::node::create(rvsdg.root(), functionTypeMain, "main", linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
-    auto lambdaGArgument = lambda->add_ctxvar(&lambdaG);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
+    auto lambdaGArgument = lambda->AddContextVar(&lambdaG).inner;
 
     auto one = rvsdg::create_bitconstant(lambda->subregion(), 32, 1);
     auto six = rvsdg::create_bitconstant(lambda->subregion(), 32, 6);
@@ -3707,9 +3731,9 @@ LambdaCallArgumentMismatch::SetupRvsdg()
     return std::make_tuple(lambdaOutput, &call);
   };
 
-  LambdaG_ = setupLambdaG()->node();
+  LambdaG_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*setupLambdaG());
   auto [lambdaMainOutput, call] = setupLambdaMain(*LambdaG_->output());
-  LambdaMain_ = lambdaMainOutput->node();
+  LambdaMain_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaMainOutput);
   Call_ = call;
 
   return rvsdgModule;
@@ -3747,10 +3771,10 @@ VariadicFunctionTest1::SetupRvsdg()
   // Setup f()
   {
     LambdaF_ = lambda::node::create(rvsdg.root(), lambdaFType, "f", linkage::internal_linkage);
-    auto iArgument = LambdaF_->fctargument(0);
-    auto iOStateArgument = LambdaF_->fctargument(1);
-    auto memoryStateArgument = LambdaF_->fctargument(2);
-    auto lambdaHArgument = LambdaF_->add_ctxvar(ImportH_);
+    auto iArgument = LambdaF_->GetFunctionArguments()[0];
+    auto iOStateArgument = LambdaF_->GetFunctionArguments()[1];
+    auto memoryStateArgument = LambdaF_->GetFunctionArguments()[2];
+    auto lambdaHArgument = LambdaF_->AddContextVar(ImportH_).inner;
 
     auto one = jlm::rvsdg::create_bitconstant(LambdaF_->subregion(), 32, 1);
     auto three = jlm::rvsdg::create_bitconstant(LambdaF_->subregion(), 32, 3);
@@ -3774,15 +3798,16 @@ VariadicFunctionTest1::SetupRvsdg()
   // Setup g()
   {
     LambdaG_ = lambda::node::create(rvsdg.root(), lambdaGType, "g", linkage::external_linkage);
-    auto iOStateArgument = LambdaG_->fctargument(0);
-    auto memoryStateArgument = LambdaG_->fctargument(1);
-    auto lambdaFArgument = LambdaG_->add_ctxvar(LambdaF_->output());
+    auto iOStateArgument = LambdaG_->GetFunctionArguments()[0];
+    auto memoryStateArgument = LambdaG_->GetFunctionArguments()[1];
+    auto lambdaFArgument = LambdaG_->AddContextVar(LambdaF_->output()).inner;
 
     auto one = jlm::rvsdg::create_bitconstant(LambdaG_->subregion(), 32, 1);
     auto five = jlm::rvsdg::create_bitconstant(LambdaG_->subregion(), 32, 5);
 
     auto allocaResults = alloca_op::create(jlm::rvsdg::bittype::Create(32), one, 4);
-    auto merge = MemoryStateMergeOperation::Create({ allocaResults[1], memoryStateArgument });
+    auto merge = MemoryStateMergeOperation::Create(
+        std::vector<jlm::rvsdg::output *>{ allocaResults[1], memoryStateArgument });
     AllocaNode_ = rvsdg::output::GetNode(*allocaResults[0]);
 
     auto storeResults = StoreNonVolatileNode::Create(allocaResults[0], five, { merge }, 4);
@@ -3858,19 +3883,20 @@ VariadicFunctionTest2::SetupRvsdg()
   {
     LambdaFst_ =
         lambda::node::create(rvsdg.root(), lambdaFstType, "fst", linkage::internal_linkage);
-    auto iOStateArgument = LambdaFst_->fctargument(2);
-    auto memoryStateArgument = LambdaFst_->fctargument(3);
-    auto llvmLifetimeStartArgument = LambdaFst_->add_ctxvar(llvmLifetimeStart);
-    auto llvmLifetimeEndArgument = LambdaFst_->add_ctxvar(llvmLifetimeEnd);
-    auto llvmVaStartArgument = LambdaFst_->add_ctxvar(llvmVaStart);
-    auto llvmVaEndArgument = LambdaFst_->add_ctxvar(llvmVaEnd);
+    auto iOStateArgument = LambdaFst_->GetFunctionArguments()[2];
+    auto memoryStateArgument = LambdaFst_->GetFunctionArguments()[3];
+    auto llvmLifetimeStartArgument = LambdaFst_->AddContextVar(llvmLifetimeStart).inner;
+    auto llvmLifetimeEndArgument = LambdaFst_->AddContextVar(llvmLifetimeEnd).inner;
+    auto llvmVaStartArgument = LambdaFst_->AddContextVar(llvmVaStart).inner;
+    auto llvmVaEndArgument = LambdaFst_->AddContextVar(llvmVaEnd).inner;
 
     auto one = jlm::rvsdg::create_bitconstant(LambdaFst_->subregion(), 32, 1);
     auto twentyFour = jlm::rvsdg::create_bitconstant(LambdaFst_->subregion(), 64, 24);
     auto fortyOne = jlm::rvsdg::create_bitconstant(LambdaFst_->subregion(), 32, 41);
 
     auto allocaResults = alloca_op::create(arrayType, one, 16);
-    auto memoryState = MemoryStateMergeOperation::Create({ allocaResults[1], memoryStateArgument });
+    auto memoryState = MemoryStateMergeOperation::Create(
+        std::vector<jlm::rvsdg::output *>{ allocaResults[1], memoryStateArgument });
     AllocaNode_ = rvsdg::output::GetNode(*allocaResults[0]);
 
     auto & callLLvmLifetimeStart = CallNode::CreateNode(
@@ -3969,9 +3995,9 @@ VariadicFunctionTest2::SetupRvsdg()
   // Setup function g()
   {
     LambdaG_ = lambda::node::create(rvsdg.root(), lambdaGType, "g", linkage::external_linkage);
-    auto iOStateArgument = LambdaG_->fctargument(0);
-    auto memoryStateArgument = LambdaG_->fctargument(1);
-    auto lambdaFstArgument = LambdaG_->add_ctxvar(LambdaFst_->output());
+    auto iOStateArgument = LambdaG_->GetFunctionArguments()[0];
+    auto memoryStateArgument = LambdaG_->GetFunctionArguments()[1];
+    auto lambdaFstArgument = LambdaG_->AddContextVar(LambdaFst_->output()).inner;
 
     auto zero = jlm::rvsdg::create_bitconstant(LambdaG_->subregion(), 32, 0);
     auto one = jlm::rvsdg::create_bitconstant(LambdaG_->subregion(), 32, 1);

--- a/tests/TestRvsdgs.hpp
+++ b/tests/TestRvsdgs.hpp
@@ -2122,7 +2122,7 @@ public:
     return *Lambda_;
   }
 
-  [[nodiscard]] const jlm::llvm::lambda::output &
+  [[nodiscard]] const rvsdg::output &
   GetLambdaOutput() const noexcept
   {
     JLM_ASSERT(Lambda_);
@@ -2279,7 +2279,7 @@ public:
     return *LocalFuncRegister_;
   }
 
-  [[nodiscard]] const jlm::rvsdg::RegionArgument &
+  [[nodiscard]] const jlm::rvsdg::output &
   GetLocalFunctionParam() const noexcept
   {
     JLM_ASSERT(LocalFuncParam_);
@@ -2306,7 +2306,7 @@ private:
 
   jlm::llvm::delta::node * Global_ = {};
   jlm::llvm::lambda::node * LocalFunc_ = {};
-  jlm::rvsdg::RegionArgument * LocalFuncParam_ = {};
+  jlm::rvsdg::output * LocalFuncParam_ = {};
   jlm::rvsdg::output * LocalFuncRegister_ = {};
   jlm::rvsdg::node * LocalFuncParamAllocaNode_ = {};
   jlm::llvm::lambda::node * ExportedFunc_ = {};

--- a/tests/jlm/hls/backend/rvsdg2rhls/DeadNodeEliminationTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/DeadNodeEliminationTests.cpp
@@ -31,7 +31,7 @@ TestDeadLoopNode()
 
   loop_node::create(lambdaNode->subregion());
 
-  lambdaNode->finalize({ lambdaNode->fctargument(1) });
+  lambdaNode->finalize({ lambdaNode->GetFunctionArguments()[1] });
 
   // Act
   EliminateDeadNodes(rvsdgModule);
@@ -60,8 +60,8 @@ TestDeadLoopNodeOutput()
       "f",
       jlm::llvm::linkage::external_linkage);
 
-  auto p = lambdaNode->fctargument(0);
-  auto x = lambdaNode->fctargument(1);
+  auto p = lambdaNode->GetFunctionArguments()[0];
+  auto x = lambdaNode->GetFunctionArguments()[1];
 
   auto loopNode = loop_node::create(lambdaNode->subregion());
 

--- a/tests/jlm/hls/backend/rvsdg2rhls/MemoryConverterTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/MemoryConverterTests.cpp
@@ -41,16 +41,16 @@ TestTraceArgument()
       linkage::external_linkage);
 
   // Load followed by store
-  auto loadAddress = lambda->fctargument(0);
-  auto memoryStateArgument = lambda->fctargument(3);
+  auto loadAddress = lambda->GetFunctionArguments()[0];
+  auto memoryStateArgument = lambda->GetFunctionArguments()[3];
   auto loadOutput = LoadNonVolatileNode::Create(
       loadAddress,
       { memoryStateArgument },
       jlm::llvm::PointerType::Create(),
       32);
 
-  auto storeAddress = lambda->fctargument(1);
-  auto storeData = lambda->fctargument(2);
+  auto storeAddress = lambda->GetFunctionArguments()[1];
+  auto storeData = lambda->GetFunctionArguments()[2];
   auto storeOutput = StoreNonVolatileNode::Create(storeAddress, storeData, { loadOutput[1] }, 32);
 
   auto lambdaOutput = lambda->finalize({ storeOutput[0] });
@@ -98,8 +98,8 @@ TestLoad()
       linkage::external_linkage);
 
   // Single load
-  auto loadAddress = lambda->fctargument(0);
-  auto memoryStateArgument = lambda->fctargument(1);
+  auto loadAddress = lambda->GetFunctionArguments()[0];
+  auto memoryStateArgument = lambda->GetFunctionArguments()[1];
   auto loadOutput = LoadNonVolatileNode::Create(
       loadAddress,
       { memoryStateArgument },
@@ -182,9 +182,9 @@ TestLoadStore()
       linkage::external_linkage);
 
   // Load followed by store
-  auto loadAddress = lambda->fctargument(0);
-  auto storeData = lambda->fctargument(1);
-  auto memoryStateArgument = lambda->fctargument(2);
+  auto loadAddress = lambda->GetFunctionArguments()[0];
+  auto storeData = lambda->GetFunctionArguments()[1];
+  auto memoryStateArgument = lambda->GetFunctionArguments()[2];
   auto loadOutput = LoadNonVolatileNode::Create(
       loadAddress,
       { memoryStateArgument },
@@ -274,9 +274,9 @@ TestThetaLoad()
   auto theta = jlm::rvsdg::ThetaNode::create(lambda->subregion());
   auto thetaRegion = theta->subregion();
   // Predicate
-  auto idv = theta->add_loopvar(lambda->fctargument(0));
-  auto lvs = theta->add_loopvar(lambda->fctargument(1));
-  auto lve = theta->add_loopvar(lambda->fctargument(2));
+  auto idv = theta->add_loopvar(lambda->GetFunctionArguments()[0]);
+  auto lvs = theta->add_loopvar(lambda->GetFunctionArguments()[1]);
+  auto lve = theta->add_loopvar(lambda->GetFunctionArguments()[2]);
   jlm::rvsdg::bitult_op ult(32);
   jlm::rvsdg::bitsgt_op sgt(32);
   jlm::rvsdg::bitadd_op add(32);
@@ -292,8 +292,8 @@ TestThetaLoad()
   theta->set_predicate(match);
 
   // Load node
-  auto loadAddress = theta->add_loopvar(lambda->fctargument(3));
-  auto memoryStateArgument = theta->add_loopvar(lambda->fctargument(4));
+  auto loadAddress = theta->add_loopvar(lambda->GetFunctionArguments()[3]);
+  auto memoryStateArgument = theta->add_loopvar(lambda->GetFunctionArguments()[4]);
   auto loadOutput = LoadNonVolatileNode::Create(
       loadAddress->argument(),
       { memoryStateArgument->argument() },

--- a/tests/jlm/hls/backend/rvsdg2rhls/TestFork.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/TestFork.cpp
@@ -33,11 +33,11 @@ TestFork()
   auto loop = hls::loop_node::create(lambda->subregion());
   auto subregion = loop->subregion();
   rvsdg::output * idvBuffer;
-  loop->add_loopvar(lambda->fctargument(0), &idvBuffer);
+  loop->add_loopvar(lambda->GetFunctionArguments()[0], &idvBuffer);
   rvsdg::output * lvsBuffer;
-  loop->add_loopvar(lambda->fctargument(1), &lvsBuffer);
+  loop->add_loopvar(lambda->GetFunctionArguments()[1], &lvsBuffer);
   rvsdg::output * lveBuffer;
-  loop->add_loopvar(lambda->fctargument(2), &lveBuffer);
+  loop->add_loopvar(lambda->GetFunctionArguments()[2], &lveBuffer);
 
   auto arm = rvsdg::simple_node::create_normalized(subregion, add, { idvBuffer, lvsBuffer })[0];
   auto cmp = rvsdg::simple_node::create_normalized(subregion, ult, { arm, lveBuffer })[0];
@@ -102,7 +102,7 @@ TestConstantFork()
   auto loop = hls::loop_node::create(lambdaRegion);
   auto subregion = loop->subregion();
   rvsdg::output * idvBuffer;
-  loop->add_loopvar(lambda->fctargument(0), &idvBuffer);
+  loop->add_loopvar(lambda->GetFunctionArguments()[0], &idvBuffer);
   auto bitConstant1 = rvsdg::create_bitconstant(subregion, 32, 1);
 
   auto arm = rvsdg::simple_node::create_normalized(subregion, add, { idvBuffer, bitConstant1 })[0];

--- a/tests/jlm/hls/backend/rvsdg2rhls/TestGamma.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/TestGamma.cpp
@@ -28,10 +28,10 @@ TestWithMatch()
 
   auto lambda = lambda::node::create(rm.Rvsdg().root(), ft, "f", linkage::external_linkage);
 
-  auto match = jlm::rvsdg::match(1, { { 0, 0 } }, 1, 2, lambda->fctargument(0));
+  auto match = jlm::rvsdg::match(1, { { 0, 0 } }, 1, 2, lambda->GetFunctionArguments()[0]);
   auto gamma = jlm::rvsdg::GammaNode::create(match, 2);
-  auto ev1 = gamma->add_entryvar(lambda->fctargument(1));
-  auto ev2 = gamma->add_entryvar(lambda->fctargument(2));
+  auto ev1 = gamma->add_entryvar(lambda->GetFunctionArguments()[1]);
+  auto ev2 = gamma->add_entryvar(lambda->GetFunctionArguments()[2]);
   auto ex = gamma->add_exitvar({ ev1->argument(0), ev2->argument(1) });
 
   auto f = lambda->finalize({ ex });
@@ -65,9 +65,9 @@ TestWithoutMatch()
 
   auto lambda = lambda::node::create(rm.Rvsdg().root(), ft, "f", linkage::external_linkage);
 
-  auto gamma = jlm::rvsdg::GammaNode::create(lambda->fctargument(0), 2);
-  auto ev1 = gamma->add_entryvar(lambda->fctargument(1));
-  auto ev2 = gamma->add_entryvar(lambda->fctargument(2));
+  auto gamma = jlm::rvsdg::GammaNode::create(lambda->GetFunctionArguments()[0], 2);
+  auto ev1 = gamma->add_entryvar(lambda->GetFunctionArguments()[1]);
+  auto ev2 = gamma->add_entryvar(lambda->GetFunctionArguments()[2]);
   auto ex = gamma->add_exitvar({ ev1->argument(0), ev2->argument(1) });
 
   auto f = lambda->finalize({ ex });

--- a/tests/jlm/hls/backend/rvsdg2rhls/TestTheta.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/TestTheta.cpp
@@ -32,9 +32,9 @@ TestUnknownBoundaries()
 
   auto theta = jlm::rvsdg::ThetaNode::create(lambda->subregion());
   auto subregion = theta->subregion();
-  auto idv = theta->add_loopvar(lambda->fctargument(0));
-  auto lvs = theta->add_loopvar(lambda->fctargument(1));
-  auto lve = theta->add_loopvar(lambda->fctargument(2));
+  auto idv = theta->add_loopvar(lambda->GetFunctionArguments()[0]);
+  auto lvs = theta->add_loopvar(lambda->GetFunctionArguments()[1]);
+  auto lve = theta->add_loopvar(lambda->GetFunctionArguments()[2]);
 
   auto arm = jlm::rvsdg::simple_node::create_normalized(
       subregion,

--- a/tests/jlm/hls/backend/rvsdg2rhls/UnusedStateRemovalTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/UnusedStateRemovalTests.cpp
@@ -140,8 +140,8 @@ TestLambda()
       lambda::node::create(rvsdg.root(), functionType, "f", linkage::external_linkage);
   auto argument0 = lambdaNode->GetFunctionArguments()[0];
   auto argument1 = lambdaNode->GetFunctionArguments()[1];
-  auto argument2 = lambdaNode->AddContextVar(x).inner;
-  auto argument3 = lambdaNode->AddContextVar(x).inner;
+  auto argument2 = lambdaNode->AddContextVar(*x).inner;
+  auto argument3 = lambdaNode->AddContextVar(*x).inner;
 
   auto result1 =
       jlm::tests::SimpleNode::Create(*lambdaNode->subregion(), { argument1 }, { valueType })

--- a/tests/jlm/hls/backend/rvsdg2rhls/UnusedStateRemovalTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/UnusedStateRemovalTests.cpp
@@ -138,10 +138,10 @@ TestLambda()
 
   auto lambdaNode =
       lambda::node::create(rvsdg.root(), functionType, "f", linkage::external_linkage);
-  auto argument0 = lambdaNode->fctargument(0);
-  auto argument1 = lambdaNode->fctargument(1);
-  auto argument2 = lambdaNode->add_ctxvar(x);
-  auto argument3 = lambdaNode->add_ctxvar(x);
+  auto argument0 = lambdaNode->GetFunctionArguments()[0];
+  auto argument1 = lambdaNode->GetFunctionArguments()[1];
+  auto argument2 = lambdaNode->AddContextVar(x).inner;
+  auto argument3 = lambdaNode->AddContextVar(x).inner;
 
   auto result1 =
       jlm::tests::SimpleNode::Create(*lambdaNode->subregion(), { argument1 }, { valueType })

--- a/tests/jlm/hls/backend/rvsdg2rhls/test-loop-passthrough.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/test-loop-passthrough.cpp
@@ -52,7 +52,7 @@ test()
 
   auto loop = hls::loop_node::create(lambda->subregion());
 
-  auto loop_out = loop->add_loopvar(lambda->fctargument(1));
+  auto loop_out = loop->add_loopvar(lambda->GetFunctionArguments()[1]);
 
   auto f = lambda->finalize({ loop_out });
   jlm::llvm::GraphExport::Create(*f, "");
@@ -66,7 +66,7 @@ test()
   stringToFile(dhls2.run(rm), "/tmp/jlm_hls_test_after.dot");
 
   // The whole loop gets eliminated, leading to a direct connection
-  assert(lambda->fctresult(0)->origin() == lambda->fctargument(1));
+  assert(lambda->GetFunctionResults()[0]->origin() == lambda->GetFunctionArguments()[1]);
 
   return 0;
 }

--- a/tests/jlm/llvm/backend/llvm/r2j/GammaTests.cpp
+++ b/tests/jlm/llvm/backend/llvm/r2j/GammaTests.cpp
@@ -38,10 +38,10 @@ GammaWithMatch()
       "lambdaOutput",
       linkage::external_linkage);
 
-  auto match = jlm::rvsdg::match(1, { { 0, 0 } }, 1, 2, lambdaNode->fctargument(0));
+  auto match = jlm::rvsdg::match(1, { { 0, 0 } }, 1, 2, lambdaNode->GetFunctionArguments()[0]);
   auto gamma = jlm::rvsdg::GammaNode::create(match, 2);
-  auto gammaInput1 = gamma->add_entryvar(lambdaNode->fctargument(1));
-  auto gammaInput2 = gamma->add_entryvar(lambdaNode->fctargument(2));
+  auto gammaInput1 = gamma->add_entryvar(lambdaNode->GetFunctionArguments()[1]);
+  auto gammaInput2 = gamma->add_entryvar(lambdaNode->GetFunctionArguments()[2]);
   auto gammaOutput = gamma->add_exitvar({ gammaInput1->argument(0), gammaInput2->argument(1) });
 
   auto lambdaOutput = lambdaNode->finalize({ gammaOutput });
@@ -92,9 +92,9 @@ GammaWithoutMatch()
       "lambdaOutput",
       linkage::external_linkage);
 
-  auto gammaNode = jlm::rvsdg::GammaNode::create(lambdaNode->fctargument(0), 2);
-  auto gammaInput1 = gammaNode->add_entryvar(lambdaNode->fctargument(1));
-  auto gammaInput2 = gammaNode->add_entryvar(lambdaNode->fctargument(2));
+  auto gammaNode = jlm::rvsdg::GammaNode::create(lambdaNode->GetFunctionArguments()[0], 2);
+  auto gammaInput1 = gammaNode->add_entryvar(lambdaNode->GetFunctionArguments()[1]);
+  auto gammaInput2 = gammaNode->add_entryvar(lambdaNode->GetFunctionArguments()[2]);
   auto gammaOutput = gammaNode->add_exitvar({ gammaInput1->argument(0), gammaInput2->argument(1) });
 
   auto lambdaOutput = lambdaNode->finalize({ gammaOutput });
@@ -146,11 +146,12 @@ EmptyGammaWithThreeSubregions()
       "lambdaOutput",
       linkage::external_linkage);
 
-  auto match = jlm::rvsdg::match(32, { { 0, 0 }, { 1, 1 } }, 2, 3, lambdaNode->fctargument(0));
+  auto match =
+      jlm::rvsdg::match(32, { { 0, 0 }, { 1, 1 } }, 2, 3, lambdaNode->GetFunctionArguments()[0]);
 
   auto gammaNode = jlm::rvsdg::GammaNode::create(match, 3);
-  auto gammaInput1 = gammaNode->add_entryvar(lambdaNode->fctargument(1));
-  auto gammaInput2 = gammaNode->add_entryvar(lambdaNode->fctargument(2));
+  auto gammaInput1 = gammaNode->add_entryvar(lambdaNode->GetFunctionArguments()[1]);
+  auto gammaInput2 = gammaNode->add_entryvar(lambdaNode->GetFunctionArguments()[2]);
   auto gammaOutput = gammaNode->add_exitvar(
       { gammaInput1->argument(0), gammaInput1->argument(1), gammaInput2->argument(2) });
 
@@ -198,9 +199,9 @@ PartialEmptyGamma()
       "lambdaOutput",
       linkage::external_linkage);
 
-  auto match = jlm::rvsdg::match(1, { { 0, 0 } }, 1, 2, lambdaNode->fctargument(0));
+  auto match = jlm::rvsdg::match(1, { { 0, 0 } }, 1, 2, lambdaNode->GetFunctionArguments()[0]);
   auto gammaNode = jlm::rvsdg::GammaNode::create(match, 2);
-  auto gammaInput = gammaNode->add_entryvar(lambdaNode->fctargument(1));
+  auto gammaInput = gammaNode->add_entryvar(lambdaNode->GetFunctionArguments()[1]);
   auto output = jlm::tests::create_testop(
       gammaNode->subregion(1),
       { gammaInput->argument(1) },

--- a/tests/jlm/llvm/ir/operators/TestCall.cpp
+++ b/tests/jlm/llvm/ir/operators/TestCall.cpp
@@ -118,14 +118,18 @@ TestCallTypeClassifierIndirectCall()
   auto SetupFunction = [&]()
   {
     auto lambda = lambda::node::create(graph->root(), fcttype2, "fct", linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(1);
-    auto memoryStateArgument = lambda->fctargument(2);
+    auto iOStateArgument = lambda->GetFunctionArguments()[1];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[2];
 
     auto one = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 1);
 
     auto alloca = alloca_op::create(PointerType::Create(), one, 8);
 
-    auto store = StoreNonVolatileNode::Create(alloca[0], lambda->fctargument(0), { alloca[1] }, 8);
+    auto store = StoreNonVolatileNode::Create(
+        alloca[0],
+        lambda->GetFunctionArguments()[0],
+        { alloca[1] },
+        8);
 
     auto load = LoadNonVolatileNode::Create(alloca[0], store, PointerType::Create(), 8);
 
@@ -175,8 +179,8 @@ TestCallTypeClassifierNonRecursiveDirectCall()
   {
     auto lambda =
         lambda::node::create(graph->root(), functionTypeG, "g", linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
     auto constant = jlm::tests::test_op::create(lambda->subregion(), {}, { vt });
 
@@ -186,9 +190,9 @@ TestCallTypeClassifierNonRecursiveDirectCall()
     return lambdaOutput;
   };
 
-  auto SetupFunctionF = [&](lambda::output * g)
+  auto SetupFunctionF = [&](jlm::rvsdg::output * g)
   {
-    auto SetupOuterTheta = [](jlm::rvsdg::Region * region, jlm::rvsdg::RegionArgument * functionG)
+    auto SetupOuterTheta = [](jlm::rvsdg::Region * region, jlm::rvsdg::output * functionG)
     {
       auto outerTheta = jlm::rvsdg::ThetaNode::create(region);
       auto otf = outerTheta->add_loopvar(functionG);
@@ -216,9 +220,9 @@ TestCallTypeClassifierNonRecursiveDirectCall()
         { vt, iostatetype::Create(), MemoryStateType::Create() });
 
     auto lambda = lambda::node::create(graph->root(), functionType, "f", linkage::external_linkage);
-    auto functionGArgument = lambda->add_ctxvar(g);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto functionGArgument = lambda->AddContextVar(g).inner;
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
     auto functionG = SetupOuterTheta(lambda->subregion(), functionGArgument);
 
@@ -271,18 +275,18 @@ TestCallTypeClassifierNonRecursiveDirectCallTheta()
   {
     auto lambda =
         lambda::node::create(graph->root(), functionTypeG, "g", linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
     auto c1 = jlm::tests::test_op::create(lambda->subregion(), {}, { vt });
 
     return lambda->finalize({ c1->output(0), iOStateArgument, memoryStateArgument });
   };
 
-  auto SetupFunctionF = [&](lambda::output * g)
+  auto SetupFunctionF = [&](jlm::rvsdg::output * g)
   {
     auto SetupOuterTheta = [&](jlm::rvsdg::Region * region,
-                               jlm::rvsdg::RegionArgument * g,
+                               jlm::rvsdg::output * g,
                                jlm::rvsdg::output * value,
                                jlm::rvsdg::output * iOState,
                                jlm::rvsdg::output * memoryState)
@@ -329,9 +333,9 @@ TestCallTypeClassifierNonRecursiveDirectCallTheta()
         { vt, iostatetype::Create(), MemoryStateType::Create() });
 
     auto lambda = lambda::node::create(graph->root(), functionType, "f", linkage::external_linkage);
-    auto functionG = lambda->add_ctxvar(g);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto functionG = lambda->AddContextVar(g).inner;
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
     auto value = jlm::tests::test_op::create(lambda->subregion(), {}, { vt })->output(0);
 
@@ -392,11 +396,11 @@ TestCallTypeClassifierRecursiveDirectCall()
 
     auto lambda =
         lambda::node::create(pb.subregion(), functionType, "fib", linkage::external_linkage);
-    auto valueArgument = lambda->fctargument(0);
-    auto pointerArgument = lambda->fctargument(1);
-    auto iOStateArgument = lambda->fctargument(2);
-    auto memoryStateArgument = lambda->fctargument(3);
-    auto ctxVarFib = lambda->add_ctxvar(fibrv->argument());
+    auto valueArgument = lambda->GetFunctionArguments()[0];
+    auto pointerArgument = lambda->GetFunctionArguments()[1];
+    auto iOStateArgument = lambda->GetFunctionArguments()[2];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[3];
+    auto ctxVarFib = lambda->AddContextVar(fibrv->argument()).inner;
 
     auto two = jlm::rvsdg::create_bitconstant(lambda->subregion(), 64, 2);
     auto bitult = jlm::rvsdg::bitult_op::create(64, valueArgument, two);

--- a/tests/jlm/llvm/ir/operators/TestCall.cpp
+++ b/tests/jlm/llvm/ir/operators/TestCall.cpp
@@ -220,7 +220,7 @@ TestCallTypeClassifierNonRecursiveDirectCall()
         { vt, iostatetype::Create(), MemoryStateType::Create() });
 
     auto lambda = lambda::node::create(graph->root(), functionType, "f", linkage::external_linkage);
-    auto functionGArgument = lambda->AddContextVar(g).inner;
+    auto functionGArgument = lambda->AddContextVar(*g).inner;
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -333,7 +333,7 @@ TestCallTypeClassifierNonRecursiveDirectCallTheta()
         { vt, iostatetype::Create(), MemoryStateType::Create() });
 
     auto lambda = lambda::node::create(graph->root(), functionType, "f", linkage::external_linkage);
-    auto functionG = lambda->AddContextVar(g).inner;
+    auto functionG = lambda->AddContextVar(*g).inner;
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -400,7 +400,7 @@ TestCallTypeClassifierRecursiveDirectCall()
     auto pointerArgument = lambda->GetFunctionArguments()[1];
     auto iOStateArgument = lambda->GetFunctionArguments()[2];
     auto memoryStateArgument = lambda->GetFunctionArguments()[3];
-    auto ctxVarFib = lambda->AddContextVar(fibrv->argument()).inner;
+    auto ctxVarFib = lambda->AddContextVar(*fibrv->argument()).inner;
 
     auto two = jlm::rvsdg::create_bitconstant(lambda->subregion(), 64, 2);
     auto bitult = jlm::rvsdg::bitult_op::create(64, valueArgument, two);

--- a/tests/jlm/llvm/ir/operators/TestLambda.cpp
+++ b/tests/jlm/llvm/ir/operators/TestLambda.cpp
@@ -27,13 +27,14 @@ TestArgumentIterators()
         functionType,
         "f",
         linkage::external_linkage);
-    lambda->finalize({ lambda->fctargument(0) });
+    lambda->finalize({ lambda->GetFunctionArguments()[0] });
 
-    std::vector<jlm::rvsdg::RegionArgument *> functionArguments;
-    for (auto & argument : lambda->fctarguments())
-      functionArguments.push_back(&argument);
+    std::vector<const jlm::rvsdg::output *> functionArguments;
+    for (auto argument : lambda->GetFunctionArguments())
+      functionArguments.push_back(argument);
 
-    assert(functionArguments.size() == 1 && functionArguments[0] == lambda->fctargument(0));
+    assert(
+        functionArguments.size() == 1 && functionArguments[0] == lambda->GetFunctionArguments()[0]);
   }
 
   {
@@ -49,7 +50,7 @@ TestArgumentIterators()
 
     lambda->finalize({ nullaryNode });
 
-    assert(lambda->nfctarguments() == 0);
+    assert(lambda->GetFunctionArguments().empty());
   }
 
   {
@@ -63,18 +64,18 @@ TestArgumentIterators()
         "f",
         linkage::external_linkage);
 
-    auto cv = lambda->add_ctxvar(rvsdgImport);
+    auto cv = lambda->AddContextVar(rvsdgImport).inner;
 
-    lambda->finalize({ lambda->fctargument(0), cv });
+    lambda->finalize({ lambda->GetFunctionArguments()[0], cv });
 
-    std::vector<jlm::rvsdg::RegionArgument *> functionArguments;
-    for (auto & argument : lambda->fctarguments())
-      functionArguments.push_back(&argument);
+    std::vector<const jlm::rvsdg::output *> functionArguments;
+    for (auto argument : lambda->GetFunctionArguments())
+      functionArguments.push_back(argument);
 
     assert(functionArguments.size() == 3);
-    assert(functionArguments[0] == lambda->fctargument(0));
-    assert(functionArguments[1] == lambda->fctargument(1));
-    assert(functionArguments[2] == lambda->fctargument(2));
+    assert(functionArguments[0] == lambda->GetFunctionArguments()[0]);
+    assert(functionArguments[1] == lambda->GetFunctionArguments()[1]);
+    assert(functionArguments[2] == lambda->GetFunctionArguments()[2]);
   }
 }
 
@@ -126,13 +127,13 @@ TestRemoveLambdaInputsWhere()
   auto lambdaNode =
       lambda::node::create(rvsdg.root(), functionType, "f", linkage::external_linkage);
 
-  auto lambdaInput0 = lambdaNode->add_ctxvar(x)->input();
-  auto lambdaInput1 = lambdaNode->add_ctxvar(x)->input();
-  lambdaNode->add_ctxvar(x)->input();
+  auto lambdaBinder0 = lambdaNode->AddContextVar(x);
+  auto lambdaBinder1 = lambdaNode->AddContextVar(x);
+  lambdaNode->AddContextVar(x);
 
   auto result = jlm::tests::SimpleNode::Create(
                     *lambdaNode->subregion(),
-                    { lambdaInput1->argument() },
+                    { lambdaBinder1.inner },
                     { valueType })
                     .output(0);
 
@@ -141,38 +142,38 @@ TestRemoveLambdaInputsWhere()
   // Act & Assert
   // Try to remove lambdaInput1 even though it is used
   auto numRemovedInputs = lambdaNode->RemoveLambdaInputsWhere(
-      [&](const lambda::cvinput & input)
+      [&](const jlm::rvsdg::input & input)
       {
-        return input.index() == lambdaInput1->index();
+        return input.index() == lambdaBinder1.input->index();
       });
   assert(numRemovedInputs == 0);
   assert(lambdaNode->ninputs() == 3);
-  assert(lambdaNode->ncvarguments() == 3);
+  assert(lambdaNode->GetContextVars().size() == 3);
 
   // Remove lambdaInput2
   numRemovedInputs = lambdaNode->RemoveLambdaInputsWhere(
-      [&](const lambda::cvinput & input)
+      [&](const jlm::rvsdg::input & input)
       {
         return input.index() == 2;
       });
   assert(numRemovedInputs == 1);
   assert(lambdaNode->ninputs() == 2);
-  assert(lambdaNode->ncvarguments() == 2);
-  assert(lambdaNode->input(0) == lambdaInput0);
-  assert(lambdaNode->input(1) == lambdaInput1);
+  assert(lambdaNode->GetContextVars().size() == 2);
+  assert(lambdaNode->input(0) == lambdaBinder0.input);
+  assert(lambdaNode->input(1) == lambdaBinder1.input);
 
   // Remove lambdaInput0
   numRemovedInputs = lambdaNode->RemoveLambdaInputsWhere(
-      [&](const lambda::cvinput & input)
+      [&](const jlm::rvsdg::input & input)
       {
         return input.index() == 0;
       });
   assert(numRemovedInputs == 1);
   assert(lambdaNode->ninputs() == 1);
-  assert(lambdaNode->ncvarguments() == 1);
-  assert(lambdaNode->input(0) == lambdaInput1);
-  assert(lambdaInput1->index() == 0);
-  assert(lambdaInput1->argument()->index() == 0);
+  assert(lambdaNode->GetContextVars().size() == 1);
+  assert(lambdaNode->input(0) == lambdaBinder1.input);
+  assert(lambdaBinder1.input->index() == 0);
+  assert(lambdaBinder1.inner->index() == 0);
 }
 
 /**
@@ -195,13 +196,13 @@ TestPruneLambdaInputs()
   auto lambdaNode =
       lambda::node::create(rvsdg.root(), functionType, "f", linkage::external_linkage);
 
-  lambdaNode->add_ctxvar(x)->input();
-  auto lambdaInput1 = lambdaNode->add_ctxvar(x)->input();
-  lambdaNode->add_ctxvar(x)->input();
+  lambdaNode->AddContextVar(x);
+  auto lambdaInput1 = lambdaNode->AddContextVar(x);
+  lambdaNode->AddContextVar(x);
 
   auto result = jlm::tests::SimpleNode::Create(
                     *lambdaNode->subregion(),
-                    { lambdaInput1->argument() },
+                    { lambdaInput1.inner },
                     { valueType })
                     .output(0);
 
@@ -213,11 +214,11 @@ TestPruneLambdaInputs()
   // Assert
   assert(numRemovedInputs == 2);
   assert(lambdaNode->ninputs() == 1);
-  assert(lambdaNode->ncvarguments() == 1);
-  assert(lambdaNode->input(0) == lambdaInput1);
-  assert(lambdaNode->cvargument(0) == lambdaInput1->argument());
-  assert(lambdaInput1->index() == 0);
-  assert(lambdaInput1->argument()->index() == 0);
+  assert(lambdaNode->GetContextVars().size() == 1);
+  assert(lambdaNode->input(0) == lambdaInput1.input);
+  assert(lambdaNode->GetContextVars()[0].inner == lambdaInput1.inner);
+  assert(lambdaInput1.input->index() == 0);
+  assert(lambdaInput1.inner->index() == 0);
 }
 
 static void
@@ -310,24 +311,24 @@ TestCallSummaryComputationDirectCalls()
         functionType,
         "x",
         jlm::llvm::linkage::external_linkage);
-    auto iOStateArgument = lambdaNode->fctargument(0);
-    auto memoryStateArgument = lambdaNode->fctargument(1);
+    auto iOStateArgument = lambdaNode->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambdaNode->GetFunctionArguments()[1];
 
     auto result = tests::create_testop(lambdaNode->subregion(), {}, { vt })[0];
 
     return lambdaNode->finalize({ result, iOStateArgument, memoryStateArgument });
   };
 
-  auto SetupLambdaY = [&](jlm::llvm::lambda::output & lambdaX)
+  auto SetupLambdaY = [&](rvsdg::output & lambdaX)
   {
     auto lambdaNode = jlm::llvm::lambda::node::create(
         rvsdg.root(),
         functionType,
         "y",
         jlm::llvm::linkage::external_linkage);
-    auto iOStateArgument = lambdaNode->fctargument(0);
-    auto memoryStateArgument = lambdaNode->fctargument(1);
-    auto lambdaXCv = lambdaNode->add_ctxvar(&lambdaX);
+    auto iOStateArgument = lambdaNode->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambdaNode->GetFunctionArguments()[1];
+    auto lambdaXCv = lambdaNode->AddContextVar(&lambdaX).inner;
 
     auto callResults = jlm::llvm::CallNode::Create(
         lambdaXCv,
@@ -340,17 +341,17 @@ TestCallSummaryComputationDirectCalls()
     return lambdaOutput;
   };
 
-  auto SetupLambdaZ = [&](jlm::llvm::lambda::output & lambdaX, jlm::llvm::lambda::output & lambdaY)
+  auto SetupLambdaZ = [&](rvsdg::output & lambdaX, rvsdg::output & lambdaY)
   {
     auto lambdaNode = jlm::llvm::lambda::node::create(
         rvsdg.root(),
         functionType,
         "y",
         jlm::llvm::linkage::external_linkage);
-    auto iOStateArgument = lambdaNode->fctargument(0);
-    auto memoryStateArgument = lambdaNode->fctargument(1);
-    auto lambdaXCv = lambdaNode->add_ctxvar(&lambdaX);
-    auto lambdaYCv = lambdaNode->add_ctxvar(&lambdaY);
+    auto iOStateArgument = lambdaNode->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambdaNode->GetFunctionArguments()[1];
+    auto lambdaXCv = lambdaNode->AddContextVar(&lambdaX).inner;
+    auto lambdaYCv = lambdaNode->AddContextVar(&lambdaY).inner;
 
     auto callXResults = jlm::llvm::CallNode::Create(
         lambdaXCv,
@@ -375,9 +376,12 @@ TestCallSummaryComputationDirectCalls()
   auto lambdaZ = SetupLambdaZ(*lambdaX, *lambdaY);
 
   // Act
-  auto lambdaXCallSummary = lambdaX->node()->ComputeCallSummary();
-  auto lambdaYCallSummary = lambdaY->node()->ComputeCallSummary();
-  auto lambdaZCallSummary = lambdaZ->node()->ComputeCallSummary();
+  auto lambdaXCallSummary =
+      rvsdg::AssertGetOwnerNode<jlm::llvm::lambda::node>(*lambdaX).ComputeCallSummary();
+  auto lambdaYCallSummary =
+      rvsdg::AssertGetOwnerNode<jlm::llvm::lambda::node>(*lambdaY).ComputeCallSummary();
+  auto lambdaZCallSummary =
+      rvsdg::AssertGetOwnerNode<jlm::llvm::lambda::node>(*lambdaZ).ComputeCallSummary();
 
   // Assert
   assert(lambdaXCallSummary->HasOnlyDirectCalls());
@@ -459,7 +463,7 @@ TestCallSummaryComputationFunctionPointerInDelta()
 
   auto lambdaNode =
       lambda::node::create(rvsdg->root(), functionType, "f", linkage::external_linkage);
-  lambdaNode->finalize({ lambdaNode->fctargument(0) });
+  lambdaNode->finalize({ lambdaNode->GetFunctionArguments()[0] });
 
   auto deltaNode = delta::node::Create(
       rvsdg->root(),
@@ -499,11 +503,11 @@ TestCallSummaryComputationLambdaResult()
 
   auto lambdaNodeG =
       lambda::node::create(rvsdg.root(), functionTypeG, "g", linkage::external_linkage);
-  auto lambdaOutputG = lambdaNodeG->finalize({ lambdaNodeG->fctargument(0) });
+  auto lambdaOutputG = lambdaNodeG->finalize({ lambdaNodeG->GetFunctionArguments()[0] });
 
   auto lambdaNodeF =
       lambda::node::create(rvsdg.root(), functionTypeF, "f", linkage::external_linkage);
-  auto lambdaGArgument = lambdaNodeF->add_ctxvar(lambdaOutputG);
+  auto lambdaGArgument = lambdaNodeF->AddContextVar(lambdaOutputG).inner;
   auto lambdaOutputF = lambdaNodeF->finalize({ lambdaGArgument });
 
   GraphExport::Create(*lambdaOutputF, "f");

--- a/tests/jlm/llvm/ir/operators/TestLambda.cpp
+++ b/tests/jlm/llvm/ir/operators/TestLambda.cpp
@@ -64,7 +64,7 @@ TestArgumentIterators()
         "f",
         linkage::external_linkage);
 
-    auto cv = lambda->AddContextVar(rvsdgImport).inner;
+    auto cv = lambda->AddContextVar(*rvsdgImport).inner;
 
     lambda->finalize({ lambda->GetFunctionArguments()[0], cv });
 
@@ -127,9 +127,9 @@ TestRemoveLambdaInputsWhere()
   auto lambdaNode =
       lambda::node::create(rvsdg.root(), functionType, "f", linkage::external_linkage);
 
-  auto lambdaBinder0 = lambdaNode->AddContextVar(x);
-  auto lambdaBinder1 = lambdaNode->AddContextVar(x);
-  lambdaNode->AddContextVar(x);
+  auto lambdaBinder0 = lambdaNode->AddContextVar(*x);
+  auto lambdaBinder1 = lambdaNode->AddContextVar(*x);
+  lambdaNode->AddContextVar(*x);
 
   auto result = jlm::tests::SimpleNode::Create(
                     *lambdaNode->subregion(),
@@ -196,9 +196,9 @@ TestPruneLambdaInputs()
   auto lambdaNode =
       lambda::node::create(rvsdg.root(), functionType, "f", linkage::external_linkage);
 
-  lambdaNode->AddContextVar(x);
-  auto lambdaInput1 = lambdaNode->AddContextVar(x);
-  lambdaNode->AddContextVar(x);
+  lambdaNode->AddContextVar(*x);
+  auto lambdaInput1 = lambdaNode->AddContextVar(*x);
+  lambdaNode->AddContextVar(*x);
 
   auto result = jlm::tests::SimpleNode::Create(
                     *lambdaNode->subregion(),
@@ -328,7 +328,7 @@ TestCallSummaryComputationDirectCalls()
         jlm::llvm::linkage::external_linkage);
     auto iOStateArgument = lambdaNode->GetFunctionArguments()[0];
     auto memoryStateArgument = lambdaNode->GetFunctionArguments()[1];
-    auto lambdaXCv = lambdaNode->AddContextVar(&lambdaX).inner;
+    auto lambdaXCv = lambdaNode->AddContextVar(lambdaX).inner;
 
     auto callResults = jlm::llvm::CallNode::Create(
         lambdaXCv,
@@ -350,8 +350,8 @@ TestCallSummaryComputationDirectCalls()
         jlm::llvm::linkage::external_linkage);
     auto iOStateArgument = lambdaNode->GetFunctionArguments()[0];
     auto memoryStateArgument = lambdaNode->GetFunctionArguments()[1];
-    auto lambdaXCv = lambdaNode->AddContextVar(&lambdaX).inner;
-    auto lambdaYCv = lambdaNode->AddContextVar(&lambdaY).inner;
+    auto lambdaXCv = lambdaNode->AddContextVar(lambdaX).inner;
+    auto lambdaYCv = lambdaNode->AddContextVar(lambdaY).inner;
 
     auto callXResults = jlm::llvm::CallNode::Create(
         lambdaXCv,
@@ -507,7 +507,7 @@ TestCallSummaryComputationLambdaResult()
 
   auto lambdaNodeF =
       lambda::node::create(rvsdg.root(), functionTypeF, "f", linkage::external_linkage);
-  auto lambdaGArgument = lambdaNodeF->AddContextVar(lambdaOutputG).inner;
+  auto lambdaGArgument = lambdaNodeF->AddContextVar(*lambdaOutputG).inner;
   auto lambdaOutputF = lambdaNodeF->finalize({ lambdaGArgument });
 
   GraphExport::Create(*lambdaOutputF, "f");

--- a/tests/jlm/llvm/ir/operators/TestPhi.cpp
+++ b/tests/jlm/llvm/ir/operators/TestPhi.cpp
@@ -41,7 +41,7 @@ TestPhiCreation()
   auto SetupF2 = [&](jlm::rvsdg::Region * region, jlm::rvsdg::RegionArgument * f2)
   {
     auto lambda = lambda::node::create(region, f1type, "f2", linkage::external_linkage);
-    auto ctxVarF2 = lambda->AddContextVar(f2).inner;
+    auto ctxVarF2 = lambda->AddContextVar(*f2).inner;
     auto valueArgument = lambda->GetFunctionArguments()[0];
     auto iOStateArgument = lambda->GetFunctionArguments()[1];
     auto memoryStateArgument = lambda->GetFunctionArguments()[2];

--- a/tests/jlm/llvm/ir/operators/TestPhi.cpp
+++ b/tests/jlm/llvm/ir/operators/TestPhi.cpp
@@ -32,8 +32,8 @@ TestPhiCreation()
   auto SetupEmptyLambda = [&](jlm::rvsdg::Region * region, const std::string & name)
   {
     auto lambda = lambda::node::create(region, f0type, name, linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(1);
-    auto memoryStateArgument = lambda->fctargument(2);
+    auto iOStateArgument = lambda->GetFunctionArguments()[1];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[2];
 
     return lambda->finalize({ iOStateArgument, memoryStateArgument });
   };
@@ -41,10 +41,10 @@ TestPhiCreation()
   auto SetupF2 = [&](jlm::rvsdg::Region * region, jlm::rvsdg::RegionArgument * f2)
   {
     auto lambda = lambda::node::create(region, f1type, "f2", linkage::external_linkage);
-    auto ctxVarF2 = lambda->add_ctxvar(f2);
-    auto valueArgument = lambda->fctargument(0);
-    auto iOStateArgument = lambda->fctargument(1);
-    auto memoryStateArgument = lambda->fctargument(2);
+    auto ctxVarF2 = lambda->AddContextVar(f2).inner;
+    auto valueArgument = lambda->GetFunctionArguments()[0];
+    auto iOStateArgument = lambda->GetFunctionArguments()[1];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[2];
 
     auto callResults =
         CallNode::Create(ctxVarF2, f1type, { valueArgument, iOStateArgument, memoryStateArgument });

--- a/tests/jlm/llvm/opt/InvariantValueRedirectionTests.cpp
+++ b/tests/jlm/llvm/opt/InvariantValueRedirectionTests.cpp
@@ -46,9 +46,9 @@ TestGamma()
   auto lambdaNode =
       lambda::node::create(rvsdg.root(), functionType, "test", linkage::external_linkage);
 
-  auto c = lambdaNode->fctargument(0);
-  auto x = lambdaNode->fctargument(1);
-  auto y = lambdaNode->fctargument(2);
+  auto c = lambdaNode->GetFunctionArguments()[0];
+  auto x = lambdaNode->GetFunctionArguments()[1];
+  auto y = lambdaNode->GetFunctionArguments()[2];
 
   auto gammaNode1 = jlm::rvsdg::GammaNode::create(c, 2);
   auto gammaInput1 = gammaNode1->add_entryvar(c);
@@ -72,8 +72,8 @@ TestGamma()
   RunInvariantValueRedirection(*rvsdgModule);
 
   // Assert
-  assert(lambdaNode->fctresult(0)->origin() == x);
-  assert(lambdaNode->fctresult(1)->origin() == y);
+  assert(lambdaNode->GetFunctionResults()[0]->origin() == x);
+  assert(lambdaNode->GetFunctionResults()[1]->origin() == y);
 
   return 0;
 }
@@ -99,9 +99,9 @@ TestTheta()
   auto lambdaNode =
       lambda::node::create(rvsdg.root(), functionType, "test", linkage::external_linkage);
 
-  auto c = lambdaNode->fctargument(0);
-  auto x = lambdaNode->fctargument(1);
-  auto l = lambdaNode->fctargument(2);
+  auto c = lambdaNode->GetFunctionArguments()[0];
+  auto x = lambdaNode->GetFunctionArguments()[1];
+  auto l = lambdaNode->GetFunctionArguments()[2];
 
   auto thetaNode1 = jlm::rvsdg::ThetaNode::create(lambdaNode->subregion());
   auto thetaOutput1 = thetaNode1->add_loopvar(c);
@@ -125,9 +125,9 @@ TestTheta()
   RunInvariantValueRedirection(*rvsdgModule);
 
   // Assert
-  assert(lambdaNode->fctresult(0)->origin() == c);
-  assert(lambdaNode->fctresult(1)->origin() == x);
-  assert(lambdaNode->fctresult(2)->origin() == thetaOutput3);
+  assert(lambdaNode->GetFunctionResults()[0]->origin() == c);
+  assert(lambdaNode->GetFunctionResults()[1]->origin() == x);
+  assert(lambdaNode->GetFunctionResults()[2]->origin() == thetaOutput3);
 
   return 0;
 }
@@ -151,16 +151,16 @@ TestCall()
   auto rvsdgModule = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto & rvsdg = rvsdgModule->Rvsdg();
 
-  lambda::output * lambdaOutputTest1;
+  jlm::rvsdg::output * lambdaOutputTest1;
   {
     auto lambdaNode =
         lambda::node::create(rvsdg.root(), functionTypeTest1, "test1", linkage::external_linkage);
 
-    auto controlArgument = lambdaNode->fctargument(0);
-    auto xArgument = lambdaNode->fctargument(1);
-    auto yArgument = lambdaNode->fctargument(2);
-    auto ioStateArgument = lambdaNode->fctargument(3);
-    auto memoryStateArgument = lambdaNode->fctargument(4);
+    auto controlArgument = lambdaNode->GetFunctionArguments()[0];
+    auto xArgument = lambdaNode->GetFunctionArguments()[1];
+    auto yArgument = lambdaNode->GetFunctionArguments()[2];
+    auto ioStateArgument = lambdaNode->GetFunctionArguments()[3];
+    auto memoryStateArgument = lambdaNode->GetFunctionArguments()[4];
 
     auto gammaNode = jlm::rvsdg::GammaNode::create(controlArgument, 2);
     auto gammaInputX = gammaNode->add_entryvar(xArgument);
@@ -180,7 +180,7 @@ TestCall()
         { gammaOutputX, gammaOutputY, gammaOutputIOState, gammaOutputMemoryState });
   }
 
-  lambda::output * lambdaOutputTest2;
+  jlm::rvsdg::output * lambdaOutputTest2;
   {
     auto functionType = FunctionType::Create(
         { valueType, valueType, ioStateType, memoryStateType },
@@ -188,11 +188,11 @@ TestCall()
 
     auto lambdaNode =
         lambda::node::create(rvsdg.root(), functionType, "test2", linkage::external_linkage);
-    auto xArgument = lambdaNode->fctargument(0);
-    auto yArgument = lambdaNode->fctargument(1);
-    auto ioStateArgument = lambdaNode->fctargument(2);
-    auto memoryStateArgument = lambdaNode->fctargument(3);
-    auto lambdaArgumentTest1 = lambdaNode->add_ctxvar(lambdaOutputTest1);
+    auto xArgument = lambdaNode->GetFunctionArguments()[0];
+    auto yArgument = lambdaNode->GetFunctionArguments()[1];
+    auto ioStateArgument = lambdaNode->GetFunctionArguments()[2];
+    auto memoryStateArgument = lambdaNode->GetFunctionArguments()[3];
+    auto lambdaArgumentTest1 = lambdaNode->AddContextVar(lambdaOutputTest1).inner;
 
     auto controlResult = jlm::rvsdg::control_constant(lambdaNode->subregion(), 2, 0);
 
@@ -209,12 +209,12 @@ TestCall()
   RunInvariantValueRedirection(*rvsdgModule);
 
   // Assert
-  auto lambdaNode = lambdaOutputTest2->node();
-  assert(lambdaNode->nfctresults() == 4);
-  assert(lambdaNode->fctresult(0)->origin() == lambdaNode->fctargument(1));
-  assert(lambdaNode->fctresult(1)->origin() == lambdaNode->fctargument(0));
-  assert(lambdaNode->fctresult(2)->origin() == lambdaNode->fctargument(2));
-  assert(lambdaNode->fctresult(3)->origin() == lambdaNode->fctargument(3));
+  auto & lambdaNode = jlm::rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaOutputTest2);
+  assert(lambdaNode.GetFunctionResults().size() == 4);
+  assert(lambdaNode.GetFunctionResults()[0]->origin() == lambdaNode.GetFunctionArguments()[1]);
+  assert(lambdaNode.GetFunctionResults()[1]->origin() == lambdaNode.GetFunctionArguments()[0]);
+  assert(lambdaNode.GetFunctionResults()[2]->origin() == lambdaNode.GetFunctionArguments()[2]);
+  assert(lambdaNode.GetFunctionResults()[3]->origin() == lambdaNode.GetFunctionArguments()[3]);
 
   return 0;
 }
@@ -238,15 +238,15 @@ TestCallWithMemoryStateNodes()
   auto rvsdgModule = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto & rvsdg = rvsdgModule->Rvsdg();
 
-  lambda::output * lambdaOutputTest1;
+  jlm::rvsdg::output * lambdaOutputTest1;
   {
     auto lambdaNode =
         lambda::node::create(rvsdg.root(), functionTypeTest1, "test1", linkage::external_linkage);
 
-    auto controlArgument = lambdaNode->fctargument(0);
-    auto xArgument = lambdaNode->fctargument(1);
-    auto ioStateArgument = lambdaNode->fctargument(2);
-    auto memoryStateArgument = lambdaNode->fctargument(3);
+    auto controlArgument = lambdaNode->GetFunctionArguments()[0];
+    auto xArgument = lambdaNode->GetFunctionArguments()[1];
+    auto ioStateArgument = lambdaNode->GetFunctionArguments()[2];
+    auto memoryStateArgument = lambdaNode->GetFunctionArguments()[3];
 
     auto lambdaEntrySplitResults =
         LambdaEntryMemoryStateSplitOperation::Create(*memoryStateArgument, 2);
@@ -272,7 +272,7 @@ TestCallWithMemoryStateNodes()
         lambdaNode->finalize({ gammaOutputX, ioStateArgument, &lambdaExitMergeResult });
   }
 
-  lambda::output * lambdaOutputTest2;
+  jlm::rvsdg::output * lambdaOutputTest2;
   {
     auto functionType = FunctionType::Create(
         { valueType, ioStateType, memoryStateType },
@@ -280,10 +280,10 @@ TestCallWithMemoryStateNodes()
 
     auto lambdaNode =
         lambda::node::create(rvsdg.root(), functionType, "test2", linkage::external_linkage);
-    auto xArgument = lambdaNode->fctargument(0);
-    auto ioStateArgument = lambdaNode->fctargument(1);
-    auto memoryStateArgument = lambdaNode->fctargument(2);
-    auto lambdaArgumentTest1 = lambdaNode->add_ctxvar(lambdaOutputTest1);
+    auto xArgument = lambdaNode->GetFunctionArguments()[0];
+    auto ioStateArgument = lambdaNode->GetFunctionArguments()[1];
+    auto memoryStateArgument = lambdaNode->GetFunctionArguments()[2];
+    auto lambdaArgumentTest1 = lambdaNode->AddContextVar(lambdaOutputTest1).inner;
 
     auto lambdaEntrySplitResults =
         LambdaEntryMemoryStateSplitOperation::Create(*memoryStateArgument, 2);
@@ -314,13 +314,13 @@ TestCallWithMemoryStateNodes()
   RunInvariantValueRedirection(*rvsdgModule);
 
   // Assert
-  auto lambdaNode = lambdaOutputTest2->node();
-  assert(lambdaNode->nfctresults() == 3);
-  assert(lambdaNode->fctresult(0)->origin() == lambdaNode->fctargument(0));
-  assert(lambdaNode->fctresult(1)->origin() == lambdaNode->fctargument(1));
+  auto & lambdaNode = jlm::rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaOutputTest2);
+  assert(lambdaNode.GetFunctionResults().size() == 3);
+  assert(lambdaNode.GetFunctionResults()[0]->origin() == lambdaNode.GetFunctionArguments()[0]);
+  assert(lambdaNode.GetFunctionResults()[1]->origin() == lambdaNode.GetFunctionArguments()[1]);
 
-  auto lambdaEntrySplit = lambda::node::GetMemoryStateEntrySplit(*lambdaNode);
-  auto lambdaExitMerge = lambda::node::GetMemoryStateExitMerge(*lambdaNode);
+  auto lambdaEntrySplit = lambda::node::GetMemoryStateEntrySplit(lambdaNode);
+  auto lambdaExitMerge = lambda::node::GetMemoryStateExitMerge(lambdaNode);
 
   assert(lambdaEntrySplit->noutputs() == 2);
   assert(lambdaExitMerge->ninputs() == 2);
@@ -347,11 +347,11 @@ TestLambdaCallArgumentMismatch()
   auto & callNode = test.GetCall();
   auto & lambdaNode = test.GetLambdaMain();
 
-  assert(lambdaNode.nfctresults() == 3);
-  assert(lambdaNode.nfctresults() == callNode.NumResults());
-  assert(lambdaNode.fctresult(0)->origin() == callNode.Result(0));
-  assert(lambdaNode.fctresult(1)->origin() == callNode.Result(1));
-  assert(lambdaNode.fctresult(2)->origin() == callNode.Result(2));
+  assert(lambdaNode.GetFunctionResults().size() == 3);
+  assert(lambdaNode.GetFunctionResults().size() == callNode.NumResults());
+  assert(lambdaNode.GetFunctionResults()[0]->origin() == callNode.Result(0));
+  assert(lambdaNode.GetFunctionResults()[1]->origin() == callNode.Result(1));
+  assert(lambdaNode.GetFunctionResults()[2]->origin() == callNode.Result(2));
 
   return 0;
 }

--- a/tests/jlm/llvm/opt/InvariantValueRedirectionTests.cpp
+++ b/tests/jlm/llvm/opt/InvariantValueRedirectionTests.cpp
@@ -192,7 +192,7 @@ TestCall()
     auto yArgument = lambdaNode->GetFunctionArguments()[1];
     auto ioStateArgument = lambdaNode->GetFunctionArguments()[2];
     auto memoryStateArgument = lambdaNode->GetFunctionArguments()[3];
-    auto lambdaArgumentTest1 = lambdaNode->AddContextVar(lambdaOutputTest1).inner;
+    auto lambdaArgumentTest1 = lambdaNode->AddContextVar(*lambdaOutputTest1).inner;
 
     auto controlResult = jlm::rvsdg::control_constant(lambdaNode->subregion(), 2, 0);
 
@@ -283,7 +283,7 @@ TestCallWithMemoryStateNodes()
     auto xArgument = lambdaNode->GetFunctionArguments()[0];
     auto ioStateArgument = lambdaNode->GetFunctionArguments()[1];
     auto memoryStateArgument = lambdaNode->GetFunctionArguments()[2];
-    auto lambdaArgumentTest1 = lambdaNode->AddContextVar(lambdaOutputTest1).inner;
+    auto lambdaArgumentTest1 = lambdaNode->AddContextVar(*lambdaOutputTest1).inner;
 
     auto lambdaEntrySplitResults =
         LambdaEntryMemoryStateSplitOperation::Create(*memoryStateArgument, 2);

--- a/tests/jlm/llvm/opt/RvsdgTreePrinterTests.cpp
+++ b/tests/jlm/llvm/opt/RvsdgTreePrinterTests.cpp
@@ -39,7 +39,7 @@ PrintRvsdgTree()
       functionType,
       "f",
       linkage::external_linkage);
-  auto lambdaOutput = lambda->finalize({ lambda->fctargument(0) });
+  auto lambdaOutput = lambda->finalize({ lambda->GetFunctionArguments()[0] });
   jlm::tests::GraphExport::Create(*lambdaOutput, "f");
 
   auto tempDirectory = std::filesystem::temp_directory_path();

--- a/tests/jlm/llvm/opt/TestDeadNodeElimination.cpp
+++ b/tests/jlm/llvm/opt/TestDeadNodeElimination.cpp
@@ -258,8 +258,8 @@ TestLambda()
       "f",
       linkage::external_linkage);
 
-  auto cv1 = lambda->AddContextVar(x).inner;
-  auto cv2 = lambda->AddContextVar(y).inner;
+  auto cv1 = lambda->AddContextVar(*x).inner;
+  auto cv2 = lambda->AddContextVar(*y).inner;
   jlm::tests::create_testop(
       lambda->subregion(),
       { lambda->GetFunctionArguments()[0], cv1 },
@@ -296,8 +296,8 @@ TestPhi()
       [&](jlm::rvsdg::Region & region, phi::rvoutput & rv2, jlm::rvsdg::RegionArgument & dx)
   {
     auto lambda1 = lambda::node::create(&region, functionType, "f1", linkage::external_linkage);
-    auto f2Argument = lambda1->AddContextVar(rv2.argument()).inner;
-    auto xArgument = lambda1->AddContextVar(&dx).inner;
+    auto f2Argument = lambda1->AddContextVar(*rv2.argument()).inner;
+    auto xArgument = lambda1->AddContextVar(dx).inner;
 
     auto result = jlm::tests::SimpleNode::Create(
                       *lambda1->subregion(),
@@ -312,8 +312,8 @@ TestPhi()
       [&](jlm::rvsdg::Region & region, phi::rvoutput & rv1, jlm::rvsdg::RegionArgument & dy)
   {
     auto lambda2 = lambda::node::create(&region, functionType, "f2", linkage::external_linkage);
-    auto f1Argument = lambda2->AddContextVar(rv1.argument()).inner;
-    lambda2->AddContextVar(&dy);
+    auto f1Argument = lambda2->AddContextVar(*rv1.argument()).inner;
+    lambda2->AddContextVar(dy);
 
     auto result = jlm::tests::SimpleNode::Create(
                       *lambda2->subregion(),
@@ -327,7 +327,7 @@ TestPhi()
   auto setupF3 = [&](jlm::rvsdg::Region & region, jlm::rvsdg::RegionArgument & dz)
   {
     auto lambda3 = lambda::node::create(&region, functionType, "f3", linkage::external_linkage);
-    auto zArgument = lambda3->AddContextVar(&dz).inner;
+    auto zArgument = lambda3->AddContextVar(dz).inner;
 
     auto result = jlm::tests::SimpleNode::Create(
                       *lambda3->subregion(),

--- a/tests/jlm/llvm/opt/TestDeadNodeElimination.cpp
+++ b/tests/jlm/llvm/opt/TestDeadNodeElimination.cpp
@@ -258,11 +258,14 @@ TestLambda()
       "f",
       linkage::external_linkage);
 
-  auto cv1 = lambda->add_ctxvar(x);
-  auto cv2 = lambda->add_ctxvar(y);
-  jlm::tests::create_testop(lambda->subregion(), { lambda->fctargument(0), cv1 }, { vt });
+  auto cv1 = lambda->AddContextVar(x).inner;
+  auto cv2 = lambda->AddContextVar(y).inner;
+  jlm::tests::create_testop(
+      lambda->subregion(),
+      { lambda->GetFunctionArguments()[0], cv1 },
+      { vt });
 
-  auto output = lambda->finalize({ lambda->fctargument(0), cv2 });
+  auto output = lambda->finalize({ lambda->GetFunctionArguments()[0], cv2 });
 
   GraphExport::Create(*output, "f");
 
@@ -293,12 +296,12 @@ TestPhi()
       [&](jlm::rvsdg::Region & region, phi::rvoutput & rv2, jlm::rvsdg::RegionArgument & dx)
   {
     auto lambda1 = lambda::node::create(&region, functionType, "f1", linkage::external_linkage);
-    auto f2Argument = lambda1->add_ctxvar(rv2.argument());
-    auto xArgument = lambda1->add_ctxvar(&dx);
+    auto f2Argument = lambda1->AddContextVar(rv2.argument()).inner;
+    auto xArgument = lambda1->AddContextVar(&dx).inner;
 
     auto result = jlm::tests::SimpleNode::Create(
                       *lambda1->subregion(),
-                      { lambda1->fctargument(0), f2Argument, xArgument },
+                      { lambda1->GetFunctionArguments()[0], f2Argument, xArgument },
                       { valueType })
                       .output(0);
 
@@ -309,12 +312,12 @@ TestPhi()
       [&](jlm::rvsdg::Region & region, phi::rvoutput & rv1, jlm::rvsdg::RegionArgument & dy)
   {
     auto lambda2 = lambda::node::create(&region, functionType, "f2", linkage::external_linkage);
-    auto f1Argument = lambda2->add_ctxvar(rv1.argument());
-    lambda2->add_ctxvar(&dy);
+    auto f1Argument = lambda2->AddContextVar(rv1.argument()).inner;
+    lambda2->AddContextVar(&dy);
 
     auto result = jlm::tests::SimpleNode::Create(
                       *lambda2->subregion(),
-                      { lambda2->fctargument(0), f1Argument },
+                      { lambda2->GetFunctionArguments()[0], f1Argument },
                       { valueType })
                       .output(0);
 
@@ -324,11 +327,11 @@ TestPhi()
   auto setupF3 = [&](jlm::rvsdg::Region & region, jlm::rvsdg::RegionArgument & dz)
   {
     auto lambda3 = lambda::node::create(&region, functionType, "f3", linkage::external_linkage);
-    auto zArgument = lambda3->add_ctxvar(&dz);
+    auto zArgument = lambda3->AddContextVar(&dz).inner;
 
     auto result = jlm::tests::SimpleNode::Create(
                       *lambda3->subregion(),
-                      { lambda3->fctargument(0), zArgument },
+                      { lambda3->GetFunctionArguments()[0], zArgument },
                       { valueType })
                       .output(0);
 
@@ -338,7 +341,7 @@ TestPhi()
   auto setupF4 = [&](jlm::rvsdg::Region & region)
   {
     auto lambda = lambda::node::create(&region, functionType, "f4", linkage::external_linkage);
-    return lambda->finalize({ lambda->fctargument(0) });
+    return lambda->finalize({ lambda->GetFunctionArguments()[0] });
   };
 
   phi::builder phiBuilder;

--- a/tests/jlm/llvm/opt/alias-analyses/TestAndersen.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestAndersen.cpp
@@ -161,7 +161,7 @@ TestLoad1()
 
   auto & lambda = ptg->GetLambdaNode(*test.lambda);
   auto & lambdaOutput = ptg->GetRegisterNode(*test.lambda->output());
-  auto & lambdaArgument0 = ptg->GetRegisterNode(*test.lambda->fctargument(0));
+  auto & lambdaArgument0 = ptg->GetRegisterNode(*test.lambda->GetFunctionArguments()[0]);
 
   assert(TargetsExactly(loadResult, { &lambda, &ptg->GetExternalMemoryNode() }));
 
@@ -267,7 +267,7 @@ TestBitCast()
 
   auto & lambda = ptg->GetLambdaNode(*test.lambda);
   auto & lambdaOut = ptg->GetRegisterNode(*test.lambda->output());
-  auto & lambdaArg = ptg->GetRegisterNode(*test.lambda->fctargument(0));
+  auto & lambdaArg = ptg->GetRegisterNode(*test.lambda->GetFunctionArguments()[0]);
   auto & bitCast = ptg->GetRegisterNode(*test.bitCast->output(0));
 
   assert(TargetsExactly(lambdaOut, { &lambda }));
@@ -291,7 +291,7 @@ TestConstantPointerNull()
 
   auto & lambda = ptg->GetLambdaNode(*test.lambda);
   auto & lambdaOut = ptg->GetRegisterNode(*test.lambda->output());
-  auto & lambdaArg = ptg->GetRegisterNode(*test.lambda->fctargument(0));
+  auto & lambdaArg = ptg->GetRegisterNode(*test.lambda->GetFunctionArguments()[0]);
 
   auto & constantPointerNull = ptg->GetRegisterNode(*test.constantPointerNullNode->output(0));
 
@@ -357,14 +357,14 @@ TestCall1()
   auto & plambda_g = ptg->GetRegisterNode(*test.lambda_g->output());
   auto & plambda_h = ptg->GetRegisterNode(*test.lambda_h->output());
 
-  auto & lambda_f_arg0 = ptg->GetRegisterNode(*test.lambda_f->fctargument(0));
-  auto & lambda_f_arg1 = ptg->GetRegisterNode(*test.lambda_f->fctargument(1));
+  auto & lambda_f_arg0 = ptg->GetRegisterNode(*test.lambda_f->GetFunctionArguments()[0]);
+  auto & lambda_f_arg1 = ptg->GetRegisterNode(*test.lambda_f->GetFunctionArguments()[1]);
 
-  auto & lambda_g_arg0 = ptg->GetRegisterNode(*test.lambda_g->fctargument(0));
-  auto & lambda_g_arg1 = ptg->GetRegisterNode(*test.lambda_g->fctargument(1));
+  auto & lambda_g_arg0 = ptg->GetRegisterNode(*test.lambda_g->GetFunctionArguments()[0]);
+  auto & lambda_g_arg1 = ptg->GetRegisterNode(*test.lambda_g->GetFunctionArguments()[1]);
 
-  auto & lambda_h_cv0 = ptg->GetRegisterNode(*test.lambda_h->cvargument(0));
-  auto & lambda_h_cv1 = ptg->GetRegisterNode(*test.lambda_h->cvargument(1));
+  auto & lambda_h_cv0 = ptg->GetRegisterNode(*test.lambda_h->GetContextVars()[0].inner);
+  auto & lambda_h_cv1 = ptg->GetRegisterNode(*test.lambda_h->GetContextVars()[1].inner);
 
   assert(TargetsExactly(palloca_x, { &alloca_x }));
   assert(TargetsExactly(palloca_y, { &alloca_y }));
@@ -405,12 +405,12 @@ TestCall2()
 
   auto & lambda_destroy = ptg->GetLambdaNode(*test.lambda_destroy);
   auto & lambda_destroy_out = ptg->GetRegisterNode(*test.lambda_destroy->output());
-  auto & lambda_destroy_arg = ptg->GetRegisterNode(*test.lambda_destroy->fctargument(0));
+  auto & lambda_destroy_arg = ptg->GetRegisterNode(*test.lambda_destroy->GetFunctionArguments()[0]);
 
   auto & lambda_test = ptg->GetLambdaNode(*test.lambda_test);
   auto & lambda_test_out = ptg->GetRegisterNode(*test.lambda_test->output());
-  auto & lambda_test_cv1 = ptg->GetRegisterNode(*test.lambda_test->cvargument(0));
-  auto & lambda_test_cv2 = ptg->GetRegisterNode(*test.lambda_test->cvargument(1));
+  auto & lambda_test_cv1 = ptg->GetRegisterNode(*test.lambda_test->GetContextVars()[0].inner);
+  auto & lambda_test_cv2 = ptg->GetRegisterNode(*test.lambda_test->GetContextVars()[1].inner);
 
   auto & call_create1_out = ptg->GetRegisterNode(*test.CallCreate1().output(0));
   auto & call_create2_out = ptg->GetRegisterNode(*test.CallCreate2().output(0));
@@ -456,13 +456,14 @@ TestIndirectCall1()
 
   auto & lambda_indcall = ptg->GetLambdaNode(test.GetLambdaIndcall());
   auto & lambda_indcall_out = ptg->GetRegisterNode(*test.GetLambdaIndcall().output());
-  auto & lambda_indcall_arg = ptg->GetRegisterNode(*test.GetLambdaIndcall().fctargument(0));
+  auto & lambda_indcall_arg =
+      ptg->GetRegisterNode(*test.GetLambdaIndcall().GetFunctionArguments()[0]);
 
   auto & lambda_test = ptg->GetLambdaNode(test.GetLambdaTest());
   auto & lambda_test_out = ptg->GetRegisterNode(*test.GetLambdaTest().output());
-  auto & lambda_test_cv0 = ptg->GetRegisterNode(*test.GetLambdaTest().cvargument(0));
-  auto & lambda_test_cv1 = ptg->GetRegisterNode(*test.GetLambdaTest().cvargument(1));
-  auto & lambda_test_cv2 = ptg->GetRegisterNode(*test.GetLambdaTest().cvargument(2));
+  auto & lambda_test_cv0 = ptg->GetRegisterNode(*test.GetLambdaTest().GetContextVars()[0].inner);
+  auto & lambda_test_cv1 = ptg->GetRegisterNode(*test.GetLambdaTest().GetContextVars()[1].inner);
+  auto & lambda_test_cv2 = ptg->GetRegisterNode(*test.GetLambdaTest().GetContextVars()[2].inner);
 
   assert(TargetsExactly(lambda_three_out, { &lambda_three }));
 
@@ -522,8 +523,8 @@ TestExternalCall1()
   assert(ptg->NumMappedRegisters() == 10);
 
   auto & lambdaF = ptg->GetLambdaNode(test.LambdaF());
-  auto & lambdaFArgument0 = ptg->GetRegisterNode(*test.LambdaF().fctargument(0));
-  auto & lambdaFArgument1 = ptg->GetRegisterNode(*test.LambdaF().fctargument(1));
+  auto & lambdaFArgument0 = ptg->GetRegisterNode(*test.LambdaF().GetFunctionArguments()[0]);
+  auto & lambdaFArgument1 = ptg->GetRegisterNode(*test.LambdaF().GetFunctionArguments()[1]);
   auto & importG = ptg->GetImportNode(test.ExternalGArgument());
 
   auto & callResult = ptg->GetRegisterNode(*test.CallG().Result(0));
@@ -553,7 +554,7 @@ TestGamma()
 
   for (size_t n = 1; n < 5; n++)
   {
-    auto & lambdaArgument = ptg->GetRegisterNode(*test.lambda->fctargument(n));
+    auto & lambdaArgument = ptg->GetRegisterNode(*test.lambda->GetFunctionArguments()[n]);
     assert(TargetsExactly(lambdaArgument, { &lambda, &ptg->GetExternalMemoryNode() }));
   }
 
@@ -588,7 +589,7 @@ TestTheta()
   assert(ptg->NumMappedRegisters() == 5);
 
   auto & lambda = ptg->GetLambdaNode(*test.lambda);
-  auto & lambdaArgument1 = ptg->GetRegisterNode(*test.lambda->fctargument(1));
+  auto & lambdaArgument1 = ptg->GetRegisterNode(*test.lambda->GetFunctionArguments()[1]);
   auto & lambdaOutput = ptg->GetRegisterNode(*test.lambda->output());
 
   auto & gepOutput = ptg->GetRegisterNode(*test.gep->output(0));
@@ -625,12 +626,12 @@ TestDelta1()
 
   auto & lambda_g = ptg->GetLambdaNode(*test.lambda_g);
   auto & plambda_g = ptg->GetRegisterNode(*test.lambda_g->output());
-  auto & lambda_g_arg0 = ptg->GetRegisterNode(*test.lambda_g->fctargument(0));
+  auto & lambda_g_arg0 = ptg->GetRegisterNode(*test.lambda_g->GetFunctionArguments()[0]);
 
   auto & lambda_h = ptg->GetLambdaNode(*test.lambda_h);
   auto & plambda_h = ptg->GetRegisterNode(*test.lambda_h->output());
-  auto & lambda_h_cv0 = ptg->GetRegisterNode(*test.lambda_h->cvargument(0));
-  auto & lambda_h_cv1 = ptg->GetRegisterNode(*test.lambda_h->cvargument(1));
+  auto & lambda_h_cv0 = ptg->GetRegisterNode(*test.lambda_h->GetContextVars()[0].inner);
+  auto & lambda_h_cv1 = ptg->GetRegisterNode(*test.lambda_h->GetContextVars()[1].inner);
 
   assert(TargetsExactly(pdelta_f, { &delta_f }));
 
@@ -666,13 +667,13 @@ TestDelta2()
 
   auto & lambda_f1 = ptg->GetLambdaNode(*test.lambda_f1);
   auto & lambda_f1_out = ptg->GetRegisterNode(*test.lambda_f1->output());
-  auto & lambda_f1_cvd1 = ptg->GetRegisterNode(*test.lambda_f1->cvargument(0));
+  auto & lambda_f1_cvd1 = ptg->GetRegisterNode(*test.lambda_f1->GetContextVars()[0].inner);
 
   auto & lambda_f2 = ptg->GetLambdaNode(*test.lambda_f2);
   auto & lambda_f2_out = ptg->GetRegisterNode(*test.lambda_f2->output());
-  auto & lambda_f2_cvd1 = ptg->GetRegisterNode(*test.lambda_f2->cvargument(0));
-  auto & lambda_f2_cvd2 = ptg->GetRegisterNode(*test.lambda_f2->cvargument(1));
-  auto & lambda_f2_cvf1 = ptg->GetRegisterNode(*test.lambda_f2->cvargument(2));
+  auto & lambda_f2_cvd1 = ptg->GetRegisterNode(*test.lambda_f2->GetContextVars()[0].inner);
+  auto & lambda_f2_cvd2 = ptg->GetRegisterNode(*test.lambda_f2->GetContextVars()[1].inner);
+  auto & lambda_f2_cvf1 = ptg->GetRegisterNode(*test.lambda_f2->GetContextVars()[2].inner);
 
   assert(TargetsExactly(delta_d1_out, { &delta_d1 }));
   assert(TargetsExactly(delta_d2_out, { &delta_d2 }));
@@ -709,13 +710,13 @@ TestImports()
 
   auto & lambda_f1 = ptg->GetLambdaNode(*test.lambda_f1);
   auto & lambda_f1_out = ptg->GetRegisterNode(*test.lambda_f1->output());
-  auto & lambda_f1_cvd1 = ptg->GetRegisterNode(*test.lambda_f1->cvargument(0));
+  auto & lambda_f1_cvd1 = ptg->GetRegisterNode(*test.lambda_f1->GetContextVars()[0].inner);
 
   auto & lambda_f2 = ptg->GetLambdaNode(*test.lambda_f2);
   auto & lambda_f2_out = ptg->GetRegisterNode(*test.lambda_f2->output());
-  auto & lambda_f2_cvd1 = ptg->GetRegisterNode(*test.lambda_f2->cvargument(0));
-  auto & lambda_f2_cvd2 = ptg->GetRegisterNode(*test.lambda_f2->cvargument(1));
-  auto & lambda_f2_cvf1 = ptg->GetRegisterNode(*test.lambda_f2->cvargument(2));
+  auto & lambda_f2_cvd1 = ptg->GetRegisterNode(*test.lambda_f2->GetContextVars()[0].inner);
+  auto & lambda_f2_cvd2 = ptg->GetRegisterNode(*test.lambda_f2->GetContextVars()[1].inner);
+  auto & lambda_f2_cvf1 = ptg->GetRegisterNode(*test.lambda_f2->GetContextVars()[2].inner);
 
   assert(TargetsExactly(import_d1, { &d1 }));
   assert(TargetsExactly(import_d2, { &d2 }));
@@ -746,7 +747,7 @@ TestPhi1()
 
   auto & lambda_fib = ptg->GetLambdaNode(*test.lambda_fib);
   auto & lambda_fib_out = ptg->GetRegisterNode(*test.lambda_fib->output());
-  auto & lambda_fib_arg1 = ptg->GetRegisterNode(*test.lambda_fib->fctargument(1));
+  auto & lambda_fib_arg1 = ptg->GetRegisterNode(*test.lambda_fib->GetFunctionArguments()[1]);
 
   auto & lambda_test = ptg->GetLambdaNode(*test.lambda_test);
   auto & lambda_test_out = ptg->GetRegisterNode(*test.lambda_test->output());
@@ -789,8 +790,8 @@ TestExternalMemory()
   assert(ptg->NumMappedRegisters() == 3);
 
   auto & lambdaF = ptg->GetLambdaNode(*test.LambdaF);
-  auto & lambdaFArgument0 = ptg->GetRegisterNode(*test.LambdaF->fctargument(0));
-  auto & lambdaFArgument1 = ptg->GetRegisterNode(*test.LambdaF->fctargument(1));
+  auto & lambdaFArgument0 = ptg->GetRegisterNode(*test.LambdaF->GetFunctionArguments()[0]);
+  auto & lambdaFArgument1 = ptg->GetRegisterNode(*test.LambdaF->GetFunctionArguments()[1]);
 
   assert(TargetsExactly(lambdaFArgument0, { &lambdaF, &ptg->GetExternalMemoryNode() }));
   assert(TargetsExactly(lambdaFArgument1, { &lambdaF, &ptg->GetExternalMemoryNode() }));
@@ -813,8 +814,8 @@ TestEscapedMemory1()
   assert(ptg->NumLambdaNodes() == 1);
   assert(ptg->NumMappedRegisters() == 10);
 
-  auto & lambdaTestArgument0 = ptg->GetRegisterNode(*test.LambdaTest->fctargument(0));
-  auto & lambdaTestCv0 = ptg->GetRegisterNode(*test.LambdaTest->cvargument(0));
+  auto & lambdaTestArgument0 = ptg->GetRegisterNode(*test.LambdaTest->GetFunctionArguments()[0]);
+  auto & lambdaTestCv0 = ptg->GetRegisterNode(*test.LambdaTest->GetContextVars()[0].inner);
   auto & loadNode1Output = ptg->GetRegisterNode(*test.LoadNode1->output(0));
 
   auto deltaA = &ptg->GetDeltaNode(*test.DeltaA);

--- a/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
@@ -79,7 +79,8 @@ ValidateStoreTest1SteensgaardAgnostic(const jlm::tests::StoreTest1 & test)
 
   assert(test.lambda->subregion()->nnodes() == 10);
 
-  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
+  auto lambdaExitMerge =
+      jlm::rvsdg::output::GetNode(*test.lambda->GetFunctionResults()[0]->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 6, 1));
 
   assert(test.alloca_d->output(1)->nusers() == 1);
@@ -112,7 +113,8 @@ ValidateStoreTest1SteensgaardRegionAware(const jlm::tests::StoreTest1 & test)
 
   assert(test.lambda->subregion()->nnodes() == 9);
 
-  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
+  auto lambdaExitMerge =
+      jlm::rvsdg::output::GetNode(*test.lambda->GetFunctionResults()[0]->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 4, 1));
 
   assert(test.alloca_d->output(1)->nusers() == 1);
@@ -145,7 +147,8 @@ ValidateStoreTest1SteensgaardAgnosticTopDown(const jlm::tests::StoreTest1 & test
 
   assert(test.lambda->subregion()->nnodes() == 2);
 
-  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
+  auto lambdaExitMerge =
+      jlm::rvsdg::output::GetNode(*test.lambda->GetFunctionResults()[0]->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
   auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
@@ -160,7 +163,8 @@ ValidateStoreTest2SteensgaardAgnostic(const jlm::tests::StoreTest2 & test)
 
   assert(test.lambda->subregion()->nnodes() == 12);
 
-  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
+  auto lambdaExitMerge =
+      jlm::rvsdg::output::GetNode(*test.lambda->GetFunctionResults()[0]->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 7, 1));
 
   assert(test.alloca_a->output(1)->nusers() == 1);
@@ -200,7 +204,8 @@ ValidateStoreTest2SteensgaardRegionAware(const jlm::tests::StoreTest2 & test)
 
   assert(test.lambda->subregion()->nnodes() == 11);
 
-  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
+  auto lambdaExitMerge =
+      jlm::rvsdg::output::GetNode(*test.lambda->GetFunctionResults()[0]->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
 
   assert(test.alloca_a->output(1)->nusers() == 1);
@@ -240,7 +245,8 @@ ValidateStoreTest2SteensgaardAgnosticTopDown(const jlm::tests::StoreTest2 & test
 
   assert(test.lambda->subregion()->nnodes() == 2);
 
-  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
+  auto lambdaExitMerge =
+      jlm::rvsdg::output::GetNode(*test.lambda->GetFunctionResults()[0]->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
   auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
@@ -255,20 +261,22 @@ ValidateLoadTest1SteensgaardAgnostic(const jlm::tests::LoadTest1 & test)
 
   assert(test.lambda->subregion()->nnodes() == 4);
 
-  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(1)->origin());
+  auto lambdaExitMerge =
+      jlm::rvsdg::output::GetNode(*test.lambda->GetFunctionResults()[1]->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
-  auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda->fctargument(1)->begin());
+  auto lambdaEntrySplit =
+      jlm::rvsdg::input::GetNode(**test.lambda->GetFunctionArguments()[1]->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 
-  auto loadA = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
+  auto loadA = jlm::rvsdg::output::GetNode(*test.lambda->GetFunctionResults()[0]->origin());
   auto loadX = jlm::rvsdg::output::GetNode(*loadA->input(0)->origin());
 
   assert(is<LoadNonVolatileOperation>(*loadA, 3, 3));
   assert(jlm::rvsdg::output::GetNode(*loadA->input(1)->origin()) == loadX);
 
   assert(is<LoadNonVolatileOperation>(*loadX, 3, 3));
-  assert(loadX->input(0)->origin() == test.lambda->fctargument(0));
+  assert(loadX->input(0)->origin() == test.lambda->GetFunctionArguments()[0]);
   assert(jlm::rvsdg::output::GetNode(*loadX->input(1)->origin()) == lambdaEntrySplit);
 }
 
@@ -279,20 +287,22 @@ ValidateLoadTest1SteensgaardRegionAware(const jlm::tests::LoadTest1 & test)
 
   assert(test.lambda->subregion()->nnodes() == 4);
 
-  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(1)->origin());
+  auto lambdaExitMerge =
+      jlm::rvsdg::output::GetNode(*test.lambda->GetFunctionResults()[1]->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
-  auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda->fctargument(1)->begin());
+  auto lambdaEntrySplit =
+      jlm::rvsdg::input::GetNode(**test.lambda->GetFunctionArguments()[1]->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 
-  auto loadA = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
+  auto loadA = jlm::rvsdg::output::GetNode(*test.lambda->GetFunctionResults()[0]->origin());
   auto loadX = jlm::rvsdg::output::GetNode(*loadA->input(0)->origin());
 
   assert(is<LoadNonVolatileOperation>(*loadA, 3, 3));
   assert(jlm::rvsdg::output::GetNode(*loadA->input(1)->origin()) == loadX);
 
   assert(is<LoadNonVolatileOperation>(*loadX, 3, 3));
-  assert(loadX->input(0)->origin() == test.lambda->fctargument(0));
+  assert(loadX->input(0)->origin() == test.lambda->GetFunctionArguments()[0]);
   assert(jlm::rvsdg::output::GetNode(*loadX->input(1)->origin()) == lambdaEntrySplit);
 }
 
@@ -303,20 +313,22 @@ ValidateLoadTest1SteensgaardAgnosticTopDown(const jlm::tests::LoadTest1 & test)
 
   assert(test.lambda->subregion()->nnodes() == 4);
 
-  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(1)->origin());
+  auto lambdaExitMerge =
+      jlm::rvsdg::output::GetNode(*test.lambda->GetFunctionResults()[1]->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
-  auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda->fctargument(1)->begin());
+  auto lambdaEntrySplit =
+      jlm::rvsdg::input::GetNode(**test.lambda->GetFunctionArguments()[1]->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 
-  auto loadA = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
+  auto loadA = jlm::rvsdg::output::GetNode(*test.lambda->GetFunctionResults()[0]->origin());
   auto loadX = jlm::rvsdg::output::GetNode(*loadA->input(0)->origin());
 
   assert(is<LoadNonVolatileOperation>(*loadA, 3, 3));
   assert(jlm::rvsdg::output::GetNode(*loadA->input(1)->origin()) == loadX);
 
   assert(is<LoadNonVolatileOperation>(*loadX, 3, 3));
-  assert(loadX->input(0)->origin() == test.lambda->fctargument(0));
+  assert(loadX->input(0)->origin() == test.lambda->GetFunctionArguments()[0]);
   assert(jlm::rvsdg::output::GetNode(*loadX->input(1)->origin()) == lambdaEntrySplit);
 }
 
@@ -327,7 +339,8 @@ ValidateLoadTest2SteensgaardAgnostic(const jlm::tests::LoadTest2 & test)
 
   assert(test.lambda->subregion()->nnodes() == 14);
 
-  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
+  auto lambdaExitMerge =
+      jlm::rvsdg::output::GetNode(*test.lambda->GetFunctionResults()[0]->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 7, 1));
 
   assert(test.alloca_a->output(1)->nusers() == 1);
@@ -377,7 +390,8 @@ ValidateLoadTest2SteensgaardRegionAware(const jlm::tests::LoadTest2 & test)
 
   assert(test.lambda->subregion()->nnodes() == 13);
 
-  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
+  auto lambdaExitMerge =
+      jlm::rvsdg::output::GetNode(*test.lambda->GetFunctionResults()[0]->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
 
   assert(test.alloca_a->output(1)->nusers() == 1);
@@ -424,7 +438,8 @@ ValidateLoadTest2SteensgaardAgnosticTopDown(const jlm::tests::LoadTest2 & test)
 
   assert(test.lambda->subregion()->nnodes() == 2);
 
-  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
+  auto lambdaExitMerge =
+      jlm::rvsdg::output::GetNode(*test.lambda->GetFunctionResults()[0]->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
   auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
@@ -439,13 +454,15 @@ ValidateLoadFromUndefSteensgaardAgnostic(const jlm::tests::LoadFromUndefTest & t
 
   assert(test.Lambda().subregion()->nnodes() == 4);
 
-  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.Lambda().fctresult(1)->origin());
+  auto lambdaExitMerge =
+      jlm::rvsdg::output::GetNode(*test.Lambda().GetFunctionResults()[1]->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
-  auto load = jlm::rvsdg::output::GetNode(*test.Lambda().fctresult(0)->origin());
+  auto load = jlm::rvsdg::output::GetNode(*test.Lambda().GetFunctionResults()[0]->origin());
   assert(is<LoadNonVolatileOperation>(*load, 1, 1));
 
-  auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.Lambda().fctargument(0)->begin());
+  auto lambdaEntrySplit =
+      jlm::rvsdg::input::GetNode(**test.Lambda().GetFunctionArguments()[0]->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 }
 
@@ -456,10 +473,11 @@ ValidateLoadFromUndefSteensgaardRegionAware(const jlm::tests::LoadFromUndefTest 
 
   assert(test.Lambda().subregion()->nnodes() == 3);
 
-  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.Lambda().fctresult(1)->origin());
+  auto lambdaExitMerge =
+      jlm::rvsdg::output::GetNode(*test.Lambda().GetFunctionResults()[1]->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 0, 1));
 
-  auto load = jlm::rvsdg::output::GetNode(*test.Lambda().fctresult(0)->origin());
+  auto load = jlm::rvsdg::output::GetNode(*test.Lambda().GetFunctionResults()[0]->origin());
   assert(is<LoadNonVolatileOperation>(*load, 1, 1));
 }
 
@@ -470,13 +488,15 @@ ValidateLoadFromUndefSteensgaardAgnosticTopDown(const jlm::tests::LoadFromUndefT
 
   assert(test.Lambda().subregion()->nnodes() == 4);
 
-  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.Lambda().fctresult(1)->origin());
+  auto lambdaExitMerge =
+      jlm::rvsdg::output::GetNode(*test.Lambda().GetFunctionResults()[1]->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
-  auto load = jlm::rvsdg::output::GetNode(*test.Lambda().fctresult(0)->origin());
+  auto load = jlm::rvsdg::output::GetNode(*test.Lambda().GetFunctionResults()[0]->origin());
   assert(is<LoadNonVolatileOperation>(*load, 1, 1));
 
-  auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.Lambda().fctargument(0)->begin());
+  auto lambdaEntrySplit =
+      jlm::rvsdg::input::GetNode(**test.Lambda().GetFunctionArguments()[0]->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 }
 
@@ -487,10 +507,12 @@ ValidateCallTest1SteensgaardAgnostic(const jlm::tests::CallTest1 & test)
 
   /* validate f */
   {
-    auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_f->fctargument(3)->begin());
-    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda_f->fctresult(2)->origin());
-    auto loadX = jlm::rvsdg::input::GetNode(**test.lambda_f->fctargument(0)->begin());
-    auto loadY = jlm::rvsdg::input::GetNode(**test.lambda_f->fctargument(1)->begin());
+    auto lambdaEntrySplit =
+        jlm::rvsdg::input::GetNode(**test.lambda_f->GetFunctionArguments()[3]->begin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::output::GetNode(*test.lambda_f->GetFunctionResults()[2]->origin());
+    auto loadX = jlm::rvsdg::input::GetNode(**test.lambda_f->GetFunctionArguments()[0]->begin());
+    auto loadY = jlm::rvsdg::input::GetNode(**test.lambda_f->GetFunctionArguments()[1]->begin());
 
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 7, 1));
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 7));
@@ -504,10 +526,12 @@ ValidateCallTest1SteensgaardAgnostic(const jlm::tests::CallTest1 & test)
 
   /* validate g */
   {
-    auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(3)->begin());
-    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda_g->fctresult(2)->origin());
-    auto loadX = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(0)->begin());
-    auto loadY = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(1)->begin());
+    auto lambdaEntrySplit =
+        jlm::rvsdg::input::GetNode(**test.lambda_g->GetFunctionArguments()[3]->begin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::output::GetNode(*test.lambda_g->GetFunctionResults()[2]->origin());
+    auto loadX = jlm::rvsdg::input::GetNode(**test.lambda_g->GetFunctionArguments()[0]->begin());
+    auto loadY = jlm::rvsdg::input::GetNode(**test.lambda_g->GetFunctionArguments()[1]->begin());
 
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 7, 1));
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 7));
@@ -542,10 +566,12 @@ ValidateCallTest1SteensgaardRegionAware(const jlm::tests::CallTest1 & test)
 
   /* validate f */
   {
-    auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_f->fctargument(3)->begin());
-    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda_f->fctresult(2)->origin());
-    auto loadX = jlm::rvsdg::input::GetNode(**test.lambda_f->fctargument(0)->begin());
-    auto loadY = jlm::rvsdg::input::GetNode(**test.lambda_f->fctargument(1)->begin());
+    auto lambdaEntrySplit =
+        jlm::rvsdg::input::GetNode(**test.lambda_f->GetFunctionArguments()[3]->begin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::output::GetNode(*test.lambda_f->GetFunctionResults()[2]->origin());
+    auto loadX = jlm::rvsdg::input::GetNode(**test.lambda_f->GetFunctionArguments()[0]->begin());
+    auto loadY = jlm::rvsdg::input::GetNode(**test.lambda_f->GetFunctionArguments()[1]->begin());
 
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
@@ -559,10 +585,12 @@ ValidateCallTest1SteensgaardRegionAware(const jlm::tests::CallTest1 & test)
 
   /* validate g */
   {
-    auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(3)->begin());
-    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda_g->fctresult(2)->origin());
-    auto loadX = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(0)->begin());
-    auto loadY = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(1)->begin());
+    auto lambdaEntrySplit =
+        jlm::rvsdg::input::GetNode(**test.lambda_g->GetFunctionArguments()[3]->begin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::output::GetNode(*test.lambda_g->GetFunctionResults()[2]->origin());
+    auto loadX = jlm::rvsdg::input::GetNode(**test.lambda_g->GetFunctionArguments()[0]->begin());
+    auto loadY = jlm::rvsdg::input::GetNode(**test.lambda_g->GetFunctionArguments()[1]->begin());
 
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 1, 1));
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 1));
@@ -597,10 +625,12 @@ ValidateCallTest1SteensgaardAgnosticTopDown(const jlm::tests::CallTest1 & test)
 
   // validate function f
   {
-    auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_f->fctargument(3)->begin());
-    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda_f->fctresult(2)->origin());
-    auto loadX = jlm::rvsdg::input::GetNode(**test.lambda_f->fctargument(0)->begin());
-    auto loadY = jlm::rvsdg::input::GetNode(**test.lambda_f->fctargument(1)->begin());
+    auto lambdaEntrySplit =
+        jlm::rvsdg::input::GetNode(**test.lambda_f->GetFunctionArguments()[3]->begin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::output::GetNode(*test.lambda_f->GetFunctionResults()[2]->origin());
+    auto loadX = jlm::rvsdg::input::GetNode(**test.lambda_f->GetFunctionArguments()[0]->begin());
+    auto loadY = jlm::rvsdg::input::GetNode(**test.lambda_f->GetFunctionArguments()[1]->begin());
 
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 7, 1));
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 7));
@@ -614,10 +644,12 @@ ValidateCallTest1SteensgaardAgnosticTopDown(const jlm::tests::CallTest1 & test)
 
   // validate function g
   {
-    auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(3)->begin());
-    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda_g->fctresult(2)->origin());
-    auto loadX = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(0)->begin());
-    auto loadY = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(1)->begin());
+    auto lambdaEntrySplit =
+        jlm::rvsdg::input::GetNode(**test.lambda_g->GetFunctionArguments()[3]->begin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::output::GetNode(*test.lambda_g->GetFunctionResults()[2]->origin());
+    auto loadX = jlm::rvsdg::input::GetNode(**test.lambda_g->GetFunctionArguments()[0]->begin());
+    auto loadY = jlm::rvsdg::input::GetNode(**test.lambda_g->GetFunctionArguments()[1]->begin());
 
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 7, 1));
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 7));
@@ -753,7 +785,7 @@ ValidateIndirectCallTest1SteensgaardAgnostic(const jlm::tests::IndirectCallTest1
     assert(test.GetLambdaIndcall().subregion()->nnodes() == 5);
 
     auto lambda_exit_mux =
-        jlm::rvsdg::output::GetNode(*test.GetLambdaIndcall().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaIndcall().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambda_exit_mux, 5, 1));
 
     auto call_exit_mux = jlm::rvsdg::output::GetNode(*lambda_exit_mux->input(0)->origin());
@@ -774,7 +806,7 @@ ValidateIndirectCallTest1SteensgaardAgnostic(const jlm::tests::IndirectCallTest1
     assert(test.GetLambdaTest().subregion()->nnodes() == 9);
 
     auto lambda_exit_mux =
-        jlm::rvsdg::output::GetNode(*test.GetLambdaTest().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaTest().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambda_exit_mux, 5, 1));
 
     auto call_exit_mux = jlm::rvsdg::output::GetNode(*lambda_exit_mux->input(0)->origin());
@@ -810,7 +842,7 @@ ValidateIndirectCallTest1SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(test.GetLambdaIndcall().subregion()->nnodes() == 5);
 
     auto lambdaExitMerge =
-        jlm::rvsdg::output::GetNode(*test.GetLambdaIndcall().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaIndcall().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 1, 1));
 
     auto callExitSplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
@@ -831,7 +863,7 @@ ValidateIndirectCallTest1SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(test.GetLambdaTest().subregion()->nnodes() == 9);
 
     auto lambdaExitMerge =
-        jlm::rvsdg::output::GetNode(*test.GetLambdaTest().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaTest().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 1, 1));
 
     auto callExitSplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
@@ -867,7 +899,7 @@ ValidateIndirectCallTest1SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(test.GetLambdaIndcall().subregion()->nnodes() == 5);
 
     auto lambda_exit_mux =
-        jlm::rvsdg::output::GetNode(*test.GetLambdaIndcall().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaIndcall().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambda_exit_mux, 5, 1));
 
     auto call_exit_mux = jlm::rvsdg::output::GetNode(*lambda_exit_mux->input(0)->origin());
@@ -888,7 +920,7 @@ ValidateIndirectCallTest1SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(test.GetLambdaTest().subregion()->nnodes() == 9);
 
     auto lambda_exit_mux =
-        jlm::rvsdg::output::GetNode(*test.GetLambdaTest().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaTest().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambda_exit_mux, 5, 1));
 
     auto call_exit_mux = jlm::rvsdg::output::GetNode(*lambda_exit_mux->input(0)->origin());
@@ -924,11 +956,11 @@ ValidateIndirectCallTest2SteensgaardAgnostic(const jlm::tests::IndirectCallTest2
     assert(test.GetLambdaThree().subregion()->nnodes() == 3);
 
     auto lambdaExitMerge =
-        jlm::rvsdg::output::GetNode(*test.GetLambdaThree().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaThree().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 13, 1));
 
     auto lambdaEntrySplit =
-        jlm::rvsdg::input::GetNode(**test.GetLambdaThree().fctargument(1)->begin());
+        jlm::rvsdg::input::GetNode(**test.GetLambdaThree().GetFunctionArguments()[1]->begin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 13));
   }
 
@@ -937,11 +969,11 @@ ValidateIndirectCallTest2SteensgaardAgnostic(const jlm::tests::IndirectCallTest2
     assert(test.GetLambdaFour().subregion()->nnodes() == 3);
 
     auto lambdaExitMerge =
-        jlm::rvsdg::output::GetNode(*test.GetLambdaFour().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaFour().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 13, 1));
 
     auto lambdaEntrySplit =
-        jlm::rvsdg::input::GetNode(**test.GetLambdaFour().fctargument(1)->begin());
+        jlm::rvsdg::input::GetNode(**test.GetLambdaFour().GetFunctionArguments()[1]->begin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 13));
   }
 
@@ -949,7 +981,8 @@ ValidateIndirectCallTest2SteensgaardAgnostic(const jlm::tests::IndirectCallTest2
   {
     assert(test.GetLambdaI().subregion()->nnodes() == 5);
 
-    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.GetLambdaI().fctresult(2)->origin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::output::GetNode(*test.GetLambdaI().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 13, 1));
 
     auto callExitSplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
@@ -973,7 +1006,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(test.GetLambdaThree().subregion()->nnodes() == 2);
 
     auto lambdaExitMerge =
-        jlm::rvsdg::output::GetNode(*test.GetLambdaThree().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaThree().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 0, 1));
   }
 
@@ -982,7 +1015,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(test.GetLambdaFour().subregion()->nnodes() == 2);
 
     auto lambdaExitMerge =
-        jlm::rvsdg::output::GetNode(*test.GetLambdaFour().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaFour().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 0, 1));
   }
 
@@ -990,7 +1023,8 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
   {
     assert(test.GetLambdaI().subregion()->nnodes() == 5);
 
-    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.GetLambdaI().fctresult(2)->origin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::output::GetNode(*test.GetLambdaI().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 6, 1));
 
     auto callExitSplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
@@ -1007,7 +1041,8 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
   {
     assert(test.GetLambdaX().subregion()->nnodes() == 7);
 
-    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.GetLambdaX().fctresult(2)->origin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::output::GetNode(*test.GetLambdaX().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 6, 1));
 
     auto callExitSplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
@@ -1043,7 +1078,8 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
   {
     assert(test.GetLambdaY().subregion()->nnodes() == 7);
 
-    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.GetLambdaY().fctresult(2)->origin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::output::GetNode(*test.GetLambdaY().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 6, 1));
 
     auto callExitSplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
@@ -1080,17 +1116,19 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(test.GetLambdaTest().subregion()->nnodes() == 16);
 
     auto lambdaExitMerge =
-        jlm::rvsdg::output::GetNode(*test.GetLambdaTest().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaTest().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 6, 1));
 
-    auto loadG1 = jlm::rvsdg::input::GetNode(**test.GetLambdaTest().cvargument(2)->begin());
+    auto loadG1 =
+        jlm::rvsdg::input::GetNode(**test.GetLambdaTest().GetContextVars()[2].inner->begin());
     assert(is<LoadNonVolatileOperation>(*loadG1, 2, 2));
 
-    auto loadG2 = jlm::rvsdg::input::GetNode(**test.GetLambdaTest().cvargument(3)->begin());
+    auto loadG2 =
+        jlm::rvsdg::input::GetNode(**test.GetLambdaTest().GetContextVars()[3].inner->begin());
     assert(is<LoadNonVolatileOperation>(*loadG2, 2, 2));
 
     auto lambdaEntrySplit =
-        jlm::rvsdg::input::GetNode(**test.GetLambdaTest().fctargument(1)->begin());
+        jlm::rvsdg::input::GetNode(**test.GetLambdaTest().GetFunctionArguments()[1]->begin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 6));
   }
 
@@ -1099,11 +1137,11 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
     assert(test.GetLambdaTest2().subregion()->nnodes() == 7);
 
     auto lambdaExitMerge =
-        jlm::rvsdg::output::GetNode(*test.GetLambdaTest2().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaTest2().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 6, 1));
 
     auto lambdaEntrySplit =
-        jlm::rvsdg::input::GetNode(**test.GetLambdaTest().fctargument(1)->begin());
+        jlm::rvsdg::input::GetNode(**test.GetLambdaTest().GetFunctionArguments()[1]->begin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 6));
   }
 }
@@ -1118,11 +1156,11 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(test.GetLambdaThree().subregion()->nnodes() == 3);
 
     auto lambdaExitMerge =
-        jlm::rvsdg::output::GetNode(*test.GetLambdaThree().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaThree().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 13, 1));
 
     auto lambdaEntrySplit =
-        jlm::rvsdg::input::GetNode(**test.GetLambdaThree().fctargument(1)->begin());
+        jlm::rvsdg::input::GetNode(**test.GetLambdaThree().GetFunctionArguments()[1]->begin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 13));
   }
 
@@ -1131,11 +1169,11 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(test.GetLambdaFour().subregion()->nnodes() == 3);
 
     auto lambdaExitMerge =
-        jlm::rvsdg::output::GetNode(*test.GetLambdaFour().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaFour().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 13, 1));
 
     auto lambdaEntrySplit =
-        jlm::rvsdg::input::GetNode(**test.GetLambdaFour().fctargument(1)->begin());
+        jlm::rvsdg::input::GetNode(**test.GetLambdaFour().GetFunctionArguments()[1]->begin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 13));
   }
 
@@ -1143,7 +1181,8 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
   {
     assert(test.GetLambdaI().subregion()->nnodes() == 5);
 
-    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.GetLambdaI().fctresult(2)->origin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::output::GetNode(*test.GetLambdaI().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 13, 1));
 
     auto callExitSplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
@@ -1160,7 +1199,8 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
   {
     assert(test.GetLambdaX().subregion()->nnodes() == 7);
 
-    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.GetLambdaX().fctresult(2)->origin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::output::GetNode(*test.GetLambdaX().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 13, 1));
 
     auto callExitSplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
@@ -1196,7 +1236,8 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
   {
     assert(test.GetLambdaY().subregion()->nnodes() == 8);
 
-    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.GetLambdaY().fctresult(2)->origin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::output::GetNode(*test.GetLambdaY().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 12, 1));
 
     auto callExitSplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
@@ -1240,10 +1281,11 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(test.GetLambdaTest().subregion()->nnodes() == 17);
 
     auto lambdaExitMerge =
-        jlm::rvsdg::output::GetNode(*test.GetLambdaTest().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaTest().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 10, 1));
 
-    auto loadG1 = jlm::rvsdg::input::GetNode(**test.GetLambdaTest().cvargument(2)->begin());
+    auto loadG1 =
+        jlm::rvsdg::input::GetNode(**test.GetLambdaTest().GetContextVars()[2].inner->begin());
     assert(is<LoadNonVolatileOperation>(*loadG1, 2, 2));
 
     auto callXEntryMerge = jlm::rvsdg::output::GetNode(*test.GetTestCallX().input(3)->origin());
@@ -1265,11 +1307,12 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(undefNode->output(0)->nusers() == 1);
     assert(jlm::rvsdg::input::GetNode(**undefNode->output(0)->begin()) == callXEntryMerge);
 
-    auto loadG2 = jlm::rvsdg::input::GetNode(**test.GetLambdaTest().cvargument(3)->begin());
+    auto loadG2 =
+        jlm::rvsdg::input::GetNode(**test.GetLambdaTest().GetContextVars()[3].inner->begin());
     assert(is<LoadNonVolatileOperation>(*loadG2, 2, 2));
 
     auto lambdaEntrySplit =
-        jlm::rvsdg::input::GetNode(**test.GetLambdaTest().fctargument(1)->begin());
+        jlm::rvsdg::input::GetNode(**test.GetLambdaTest().GetFunctionArguments()[1]->begin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 10));
   }
 
@@ -1278,7 +1321,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     assert(test.GetLambdaTest2().subregion()->nnodes() == 8);
 
     auto lambdaExitMerge =
-        jlm::rvsdg::output::GetNode(*test.GetLambdaTest2().fctresult(2)->origin());
+        jlm::rvsdg::output::GetNode(*test.GetLambdaTest2().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 10, 1));
 
     auto callXEntryMerge = jlm::rvsdg::output::GetNode(*test.GetTest2CallX().input(3)->origin());
@@ -1304,7 +1347,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
     }
 
     auto lambdaEntrySplit =
-        jlm::rvsdg::input::GetNode(**test.GetLambdaTest2().fctargument(1)->begin());
+        jlm::rvsdg::input::GetNode(**test.GetLambdaTest2().GetFunctionArguments()[1]->begin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 10));
   }
 }
@@ -1314,7 +1357,8 @@ ValidateGammaTestSteensgaardAgnostic(const jlm::tests::GammaTest & test)
 {
   using namespace jlm::llvm;
 
-  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(1)->origin());
+  auto lambdaExitMerge =
+      jlm::rvsdg::output::GetNode(*test.lambda->GetFunctionResults()[1]->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
   auto loadTmp2 = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
@@ -1332,7 +1376,8 @@ ValidateGammaTestSteensgaardRegionAware(const jlm::tests::GammaTest & test)
 {
   using namespace jlm::llvm;
 
-  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(1)->origin());
+  auto lambdaExitMerge =
+      jlm::rvsdg::output::GetNode(*test.lambda->GetFunctionResults()[1]->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
   auto loadTmp2 = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
@@ -1350,7 +1395,8 @@ ValidateGammaTestSteensgaardAgnosticTopDown(const jlm::tests::GammaTest & test)
 {
   using namespace jlm::llvm;
 
-  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(1)->origin());
+  auto lambdaExitMerge =
+      jlm::rvsdg::output::GetNode(*test.lambda->GetFunctionResults()[1]->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
   auto loadTmp2 = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
@@ -1370,7 +1416,8 @@ ValidateThetaTestSteensgaardAgnostic(const jlm::tests::ThetaTest & test)
 
   assert(test.lambda->subregion()->nnodes() == 4);
 
-  auto lambda_exit_mux = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
+  auto lambda_exit_mux =
+      jlm::rvsdg::output::GetNode(*test.lambda->GetFunctionResults()[0]->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambda_exit_mux, 2, 1));
 
   auto thetaOutput =
@@ -1394,7 +1441,8 @@ ValidateThetaTestSteensgaardRegionAware(const jlm::tests::ThetaTest & test)
 
   assert(test.lambda->subregion()->nnodes() == 4);
 
-  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
+  auto lambdaExitMerge =
+      jlm::rvsdg::output::GetNode(*test.lambda->GetFunctionResults()[0]->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
   auto thetaOutput =
@@ -1418,7 +1466,8 @@ ValidateThetaTestSteensgaardAgnosticTopDown(const jlm::tests::ThetaTest & test)
 
   assert(test.lambda->subregion()->nnodes() == 4);
 
-  auto lambda_exit_mux = jlm::rvsdg::output::GetNode(*test.lambda->fctresult(0)->origin());
+  auto lambda_exit_mux =
+      jlm::rvsdg::output::GetNode(*test.lambda->GetFunctionResults()[0]->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambda_exit_mux, 2, 1));
 
   auto thetaOutput =
@@ -1442,7 +1491,8 @@ ValidateDeltaTest1SteensgaardAgnostic(const jlm::tests::DeltaTest1 & test)
 
   assert(test.lambda_h->subregion()->nnodes() == 7);
 
-  auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_h->fctargument(1)->begin());
+  auto lambdaEntrySplit =
+      jlm::rvsdg::input::GetNode(**test.lambda_h->GetFunctionArguments()[1]->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 4));
 
   auto storeF = jlm::rvsdg::input::GetNode(**test.constantFive->output(0)->begin());
@@ -1451,7 +1501,7 @@ ValidateDeltaTest1SteensgaardAgnostic(const jlm::tests::DeltaTest1 & test)
 
   auto deltaStateIndex = storeF->input(2)->origin()->index();
 
-  auto loadF = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(0)->begin());
+  auto loadF = jlm::rvsdg::input::GetNode(**test.lambda_g->GetFunctionArguments()[0]->begin());
   assert(is<LoadNonVolatileOperation>(*loadF, 2, 2));
   assert(loadF->input(1)->origin()->index() == deltaStateIndex);
 }
@@ -1463,7 +1513,8 @@ ValidateDeltaTest1SteensgaardRegionAware(const jlm::tests::DeltaTest1 & test)
 
   assert(test.lambda_h->subregion()->nnodes() == 7);
 
-  auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_h->fctargument(1)->begin());
+  auto lambdaEntrySplit =
+      jlm::rvsdg::input::GetNode(**test.lambda_h->GetFunctionArguments()[1]->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 1));
 
   auto storeF = jlm::rvsdg::input::GetNode(**test.constantFive->output(0)->begin());
@@ -1472,7 +1523,7 @@ ValidateDeltaTest1SteensgaardRegionAware(const jlm::tests::DeltaTest1 & test)
 
   auto deltaStateIndex = storeF->input(2)->origin()->index();
 
-  auto loadF = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(0)->begin());
+  auto loadF = jlm::rvsdg::input::GetNode(**test.lambda_g->GetFunctionArguments()[0]->begin());
   assert(is<LoadNonVolatileOperation>(*loadF, 2, 2));
   assert(loadF->input(1)->origin()->index() == deltaStateIndex);
 }
@@ -1484,14 +1535,15 @@ ValidateDeltaTest1SteensgaardAgnosticTopDown(const jlm::tests::DeltaTest1 & test
 
   assert(test.lambda_h->subregion()->nnodes() == 7);
 
-  auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_h->fctargument(1)->begin());
+  auto lambdaEntrySplit =
+      jlm::rvsdg::input::GetNode(**test.lambda_h->GetFunctionArguments()[1]->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 4));
 
   auto storeF = jlm::rvsdg::input::GetNode(**test.constantFive->output(0)->begin());
   assert(is<StoreNonVolatileOperation>(*storeF, 3, 1));
   assert(jlm::rvsdg::output::GetNode(*storeF->input(2)->origin()) == lambdaEntrySplit);
 
-  auto loadF = jlm::rvsdg::input::GetNode(**test.lambda_g->fctargument(0)->begin());
+  auto loadF = jlm::rvsdg::input::GetNode(**test.lambda_g->GetFunctionArguments()[0]->begin());
   assert(is<LoadNonVolatileOperation>(*loadF, 2, 2));
 }
 
@@ -1502,21 +1554,25 @@ ValidateDeltaTest2SteensgaardAgnostic(const jlm::tests::DeltaTest2 & test)
 
   assert(test.lambda_f2->subregion()->nnodes() == 9);
 
-  auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_f2->fctargument(1)->begin());
+  auto lambdaEntrySplit =
+      jlm::rvsdg::input::GetNode(**test.lambda_f2->GetFunctionArguments()[1]->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
 
-  auto storeD1InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(0)->begin());
+  auto storeD1InF2 =
+      jlm::rvsdg::input::GetNode(**test.lambda_f2->GetContextVars()[0].inner->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
   assert(jlm::rvsdg::output::GetNode(*storeD1InF2->input(2)->origin()) == lambdaEntrySplit);
 
   auto d1StateIndex = storeD1InF2->input(2)->origin()->index();
 
-  auto storeD1InF1 = jlm::rvsdg::input::GetNode(**test.lambda_f1->cvargument(0)->begin());
+  auto storeD1InF1 =
+      jlm::rvsdg::input::GetNode(**test.lambda_f1->GetContextVars()[0].inner->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF1, 3, 1));
 
   assert(d1StateIndex == storeD1InF1->input(2)->origin()->index());
 
-  auto storeD2InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(1)->begin());
+  auto storeD2InF2 =
+      jlm::rvsdg::input::GetNode(**test.lambda_f2->GetContextVars()[1].inner->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
 
   assert(d1StateIndex != storeD2InF2->input(2)->origin()->index());
@@ -1531,7 +1587,8 @@ ValidateDeltaTest2SteensgaardRegionAware(const jlm::tests::DeltaTest2 & test)
   {
     assert(test.lambda_f1->subregion()->nnodes() == 4);
 
-    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda_f1->fctresult(1)->origin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::output::GetNode(*test.lambda_f1->GetFunctionResults()[1]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 1, 1));
 
     auto storeNode = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
@@ -1545,14 +1602,15 @@ ValidateDeltaTest2SteensgaardRegionAware(const jlm::tests::DeltaTest2 & test)
   {
     assert(test.lambda_f2->subregion()->nnodes() == 9);
 
-    auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_f2->fctargument(1)->begin());
+    auto lambdaEntrySplit =
+        jlm::rvsdg::input::GetNode(**test.lambda_f2->GetFunctionArguments()[1]->begin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 
-    auto storeD1 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(0)->begin());
+    auto storeD1 = jlm::rvsdg::input::GetNode(**test.lambda_f2->GetContextVars()[0].inner->begin());
     assert(is<StoreNonVolatileOperation>(*storeD1, 3, 1));
     assert(jlm::rvsdg::output::GetNode(*storeD1->input(2)->origin()) == lambdaEntrySplit);
 
-    auto storeD2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(1)->begin());
+    auto storeD2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->GetContextVars()[1].inner->begin());
     assert(is<StoreNonVolatileOperation>(*storeD2, 3, 1));
     assert(jlm::rvsdg::output::GetNode(*storeD2->input(2)->origin()) == lambdaEntrySplit);
 
@@ -1577,19 +1635,23 @@ ValidateDeltaTest2SteensgaardAgnosticTopDown(const jlm::tests::DeltaTest2 & test
 
   assert(test.lambda_f2->subregion()->nnodes() == 9);
 
-  auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_f2->fctargument(1)->begin());
+  auto lambdaEntrySplit =
+      jlm::rvsdg::input::GetNode(**test.lambda_f2->GetFunctionArguments()[1]->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
 
-  auto storeD1InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(0)->begin());
+  auto storeD1InF2 =
+      jlm::rvsdg::input::GetNode(**test.lambda_f2->GetContextVars()[0].inner->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
   assert(jlm::rvsdg::output::GetNode(*storeD1InF2->input(2)->origin()) == lambdaEntrySplit);
 
   auto d1StateIndex = storeD1InF2->input(2)->origin()->index();
 
-  auto storeD1InF1 = jlm::rvsdg::input::GetNode(**test.lambda_f1->cvargument(0)->begin());
+  auto storeD1InF1 =
+      jlm::rvsdg::input::GetNode(**test.lambda_f1->GetContextVars()[0].inner->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF1, 3, 1));
 
-  auto storeD2InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(1)->begin());
+  auto storeD2InF2 =
+      jlm::rvsdg::input::GetNode(**test.lambda_f2->GetContextVars()[1].inner->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
 
   assert(d1StateIndex != storeD2InF2->input(2)->origin()->index());
@@ -1604,10 +1666,11 @@ ValidateDeltaTest3SteensgaardAgnostic(const jlm::tests::DeltaTest3 & test)
   {
     assert(test.LambdaF().subregion()->nnodes() == 6);
 
-    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.LambdaF().fctresult(2)->origin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::output::GetNode(*test.LambdaF().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
 
-    auto truncNode = jlm::rvsdg::output::GetNode(*test.LambdaF().fctresult(0)->origin());
+    auto truncNode = jlm::rvsdg::output::GetNode(*test.LambdaF().GetFunctionResults()[0]->origin());
     assert(is<trunc_op>(*truncNode, 1, 1));
 
     auto loadG1Node = jlm::rvsdg::output::GetNode(*truncNode->input(0)->origin());
@@ -1646,10 +1709,11 @@ ValidateDeltaTest3SteensgaardRegionAware(const jlm::tests::DeltaTest3 & test)
   {
     assert(test.LambdaF().subregion()->nnodes() == 6);
 
-    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.LambdaF().fctresult(2)->origin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::output::GetNode(*test.LambdaF().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
-    auto truncNode = jlm::rvsdg::output::GetNode(*test.LambdaF().fctresult(0)->origin());
+    auto truncNode = jlm::rvsdg::output::GetNode(*test.LambdaF().GetFunctionResults()[0]->origin());
     assert(is<trunc_op>(*truncNode, 1, 1));
 
     auto loadG1Node = jlm::rvsdg::output::GetNode(*truncNode->input(0)->origin());
@@ -1688,10 +1752,11 @@ ValidateDeltaTest3SteensgaardAgnosticTopDown(const jlm::tests::DeltaTest3 & test
   {
     assert(test.LambdaF().subregion()->nnodes() == 6);
 
-    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.LambdaF().fctresult(2)->origin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::output::GetNode(*test.LambdaF().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
 
-    auto truncNode = jlm::rvsdg::output::GetNode(*test.LambdaF().fctresult(0)->origin());
+    auto truncNode = jlm::rvsdg::output::GetNode(*test.LambdaF().GetFunctionResults()[0]->origin());
     assert(is<trunc_op>(*truncNode, 1, 1));
 
     auto loadG1Node = jlm::rvsdg::output::GetNode(*truncNode->input(0)->origin());
@@ -1728,21 +1793,25 @@ ValidateImportTestSteensgaardAgnostic(const jlm::tests::ImportTest & test)
 
   assert(test.lambda_f2->subregion()->nnodes() == 9);
 
-  auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_f2->fctargument(1)->begin());
+  auto lambdaEntrySplit =
+      jlm::rvsdg::input::GetNode(**test.lambda_f2->GetFunctionArguments()[1]->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
 
-  auto storeD1InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(0)->begin());
+  auto storeD1InF2 =
+      jlm::rvsdg::input::GetNode(**test.lambda_f2->GetContextVars()[0].inner->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
   assert(jlm::rvsdg::output::GetNode(*storeD1InF2->input(2)->origin()) == lambdaEntrySplit);
 
   auto d1StateIndex = storeD1InF2->input(2)->origin()->index();
 
-  auto storeD1InF1 = jlm::rvsdg::input::GetNode(**test.lambda_f1->cvargument(0)->begin());
+  auto storeD1InF1 =
+      jlm::rvsdg::input::GetNode(**test.lambda_f1->GetContextVars()[0].inner->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF1, 3, 1));
 
   assert(d1StateIndex == storeD1InF1->input(2)->origin()->index());
 
-  auto storeD2InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(1)->begin());
+  auto storeD2InF2 =
+      jlm::rvsdg::input::GetNode(**test.lambda_f2->GetContextVars()[1].inner->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
 
   assert(d1StateIndex != storeD2InF2->input(2)->origin()->index());
@@ -1757,7 +1826,8 @@ ValidateImportTestSteensgaardRegionAware(const jlm::tests::ImportTest & test)
   {
     assert(test.lambda_f1->subregion()->nnodes() == 4);
 
-    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda_f1->fctresult(1)->origin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::output::GetNode(*test.lambda_f1->GetFunctionResults()[1]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 1, 1));
 
     auto storeNode = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
@@ -1771,14 +1841,15 @@ ValidateImportTestSteensgaardRegionAware(const jlm::tests::ImportTest & test)
   {
     assert(test.lambda_f2->subregion()->nnodes() == 9);
 
-    auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_f2->fctargument(1)->begin());
+    auto lambdaEntrySplit =
+        jlm::rvsdg::input::GetNode(**test.lambda_f2->GetFunctionArguments()[1]->begin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 
-    auto storeD1 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(0)->begin());
+    auto storeD1 = jlm::rvsdg::input::GetNode(**test.lambda_f2->GetContextVars()[0].inner->begin());
     assert(is<StoreNonVolatileOperation>(*storeD1, 3, 1));
     assert(jlm::rvsdg::output::GetNode(*storeD1->input(2)->origin()) == lambdaEntrySplit);
 
-    auto storeD2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(1)->begin());
+    auto storeD2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->GetContextVars()[1].inner->begin());
     assert(is<StoreNonVolatileOperation>(*storeD2, 3, 1));
     assert(jlm::rvsdg::output::GetNode(*storeD2->input(2)->origin()) == lambdaEntrySplit);
 
@@ -1803,23 +1874,27 @@ ValidateImportTestSteensgaardAgnosticTopDown(const jlm::tests::ImportTest & test
 
   assert(test.lambda_f2->subregion()->nnodes() == 9);
 
-  auto lambdaEntrySplit = jlm::rvsdg::input::GetNode(**test.lambda_f2->fctargument(1)->begin());
+  auto lambdaEntrySplit =
+      jlm::rvsdg::input::GetNode(**test.lambda_f2->GetFunctionArguments()[1]->begin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
 
-  auto storeD1InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(0)->begin());
+  auto storeD1InF2 =
+      jlm::rvsdg::input::GetNode(**test.lambda_f2->GetContextVars()[0].inner->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
   assert(jlm::rvsdg::output::GetNode(*storeD1InF2->input(2)->origin()) == lambdaEntrySplit);
 
   assert(storeD1InF2->output(0)->nusers() == 1);
   auto d1StateIndexEntry = (*storeD1InF2->output(0)->begin())->index();
 
-  auto storeD1InF1 = jlm::rvsdg::input::GetNode(**test.lambda_f1->cvargument(0)->begin());
+  auto storeD1InF1 =
+      jlm::rvsdg::input::GetNode(**test.lambda_f1->GetContextVars()[0].inner->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF1, 3, 1));
   assert(d1StateIndexEntry == storeD1InF1->input(2)->origin()->index());
   assert(storeD1InF1->output(0)->nusers() == 1);
   auto d1StateIndexExit = (*storeD1InF1->output(0)->begin())->index();
 
-  auto storeD2InF2 = jlm::rvsdg::input::GetNode(**test.lambda_f2->cvargument(1)->begin());
+  auto storeD2InF2 =
+      jlm::rvsdg::input::GetNode(**test.lambda_f2->GetContextVars()[1].inner->begin());
   assert(is<StoreNonVolatileOperation>(*storeD1InF2, 3, 1));
 
   assert(d1StateIndexExit != storeD2InF2->input(2)->origin()->index());
@@ -1832,7 +1907,8 @@ ValidatePhiTestSteensgaardAgnostic(const jlm::tests::PhiTest1 & test)
 
   auto arrayStateIndex = (*test.alloca->output(1)->begin())->index();
 
-  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda_fib->fctresult(1)->origin());
+  auto lambdaExitMerge =
+      jlm::rvsdg::output::GetNode(*test.lambda_fib->GetFunctionResults()[1]->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 4, 1));
 
   auto store = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(arrayStateIndex)->origin());
@@ -1860,7 +1936,8 @@ ValidatePhiTestSteensgaardRegionAware(const jlm::tests::PhiTest1 & test)
 
   auto arrayStateIndex = (*test.alloca->output(1)->begin())->index();
 
-  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda_fib->fctresult(1)->origin());
+  auto lambdaExitMerge =
+      jlm::rvsdg::output::GetNode(*test.lambda_fib->GetFunctionResults()[1]->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 1, 1));
 
   auto store = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(arrayStateIndex)->origin());
@@ -1886,7 +1963,8 @@ ValidatePhiTestSteensgaardAgnosticTopDown(const jlm::tests::PhiTest1 & test)
 {
   using namespace jlm::llvm;
 
-  auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.lambda_fib->fctresult(1)->origin());
+  auto lambdaExitMerge =
+      jlm::rvsdg::output::GetNode(*test.lambda_fib->GetFunctionResults()[1]->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 4, 1));
 
   const StoreNonVolatileNode * storeNode = nullptr;
@@ -1930,10 +2008,11 @@ ValidateMemcpySteensgaardAgnostic(const jlm::tests::MemcpyTest & test)
    * Validate function f
    */
   {
-    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.LambdaF().fctresult(2)->origin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::output::GetNode(*test.LambdaF().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
 
-    auto load = jlm::rvsdg::output::GetNode(*test.LambdaF().fctresult(0)->origin());
+    auto load = jlm::rvsdg::output::GetNode(*test.LambdaF().GetFunctionResults()[0]->origin());
     assert(is<LoadNonVolatileOperation>(*load, 3, 3));
 
     auto store = jlm::rvsdg::output::GetNode(*load->input(1)->origin());
@@ -1947,7 +2026,8 @@ ValidateMemcpySteensgaardAgnostic(const jlm::tests::MemcpyTest & test)
    * Validate function g
    */
   {
-    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.LambdaG().fctresult(2)->origin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::output::GetNode(*test.LambdaG().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
 
     auto callExitSplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
@@ -1983,10 +2063,11 @@ ValidateMemcpySteensgaardRegionAware(const jlm::tests::MemcpyTest & test)
    * Validate function f
    */
   {
-    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.LambdaF().fctresult(2)->origin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::output::GetNode(*test.LambdaF().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
-    auto load = jlm::rvsdg::output::GetNode(*test.LambdaF().fctresult(0)->origin());
+    auto load = jlm::rvsdg::output::GetNode(*test.LambdaF().GetFunctionResults()[0]->origin());
     assert(is<LoadNonVolatileOperation>(*load, 3, 3));
 
     auto store = jlm::rvsdg::output::GetNode(*load->input(1)->origin());
@@ -2000,7 +2081,7 @@ ValidateMemcpySteensgaardRegionAware(const jlm::tests::MemcpyTest & test)
    * Validate function g
    */
   {
-    auto callNode = jlm::rvsdg::input::GetNode(**test.LambdaG().cvargument(2)->begin());
+    auto callNode = jlm::rvsdg::input::GetNode(**test.LambdaG().GetContextVars()[2].inner->begin());
     assert(is<CallOperation>(*callNode, 3, 3));
 
     auto callEntryMerge = jlm::rvsdg::output::GetNode(*callNode->input(2)->origin());
@@ -2028,10 +2109,11 @@ ValidateMemcpyTestSteensgaardAgnosticTopDown(const jlm::tests::MemcpyTest & test
 
   // Validate function f
   {
-    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.LambdaF().fctresult(2)->origin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::output::GetNode(*test.LambdaF().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
 
-    auto load = jlm::rvsdg::output::GetNode(*test.LambdaF().fctresult(0)->origin());
+    auto load = jlm::rvsdg::output::GetNode(*test.LambdaF().GetFunctionResults()[0]->origin());
     assert(is<LoadNonVolatileOperation>(*load, 3, 3));
 
     auto store = jlm::rvsdg::output::GetNode(*load->input(1)->origin());
@@ -2043,7 +2125,8 @@ ValidateMemcpyTestSteensgaardAgnosticTopDown(const jlm::tests::MemcpyTest & test
 
   // Validate function g
   {
-    auto lambdaExitMerge = jlm::rvsdg::output::GetNode(*test.LambdaG().fctresult(2)->origin());
+    auto lambdaExitMerge =
+        jlm::rvsdg::output::GetNode(*test.LambdaG().GetFunctionResults()[2]->origin());
     assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 5, 1));
 
     auto callExitSplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());
@@ -2080,7 +2163,7 @@ ValidateFreeNullTestSteensgaardAgnostic(const jlm::tests::FreeNullTest & test)
       jlm::rvsdg::output::GetNode(*test.LambdaMain().GetMemoryStateRegionResult().origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
-  auto free = jlm::rvsdg::output::GetNode(*test.LambdaMain().fctresult(0)->origin());
+  auto free = jlm::rvsdg::output::GetNode(*test.LambdaMain().GetFunctionResults()[0]->origin());
   assert(is<FreeOperation>(*free, 2, 1));
 
   auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*lambdaExitMerge->input(0)->origin());

--- a/tests/jlm/llvm/opt/alias-analyses/TestPointerObjectSet.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestPointerObjectSet.cpp
@@ -472,7 +472,7 @@ TestEscapedFunctionConstraint()
   const auto & localFunction = rvsdg.GetLocalFunction();
   const auto & localFunctionRegister = rvsdg.GetLocalFunctionRegister();
   const auto & exportedFunction = rvsdg.GetExportedFunction();
-  const auto & exportedFunctionReturn = *exportedFunction.fctresult(0)->origin();
+  const auto & exportedFunctionReturn = *exportedFunction.GetFunctionResults()[0]->origin();
 
   PointerObjectSet set;
   const auto localFunctionPO = set.CreateFunctionMemoryObject(localFunction);
@@ -632,8 +632,10 @@ TestFunctionCallConstraint()
   PointerObjectSet set;
   const auto lambdaF = set.CreateFunctionMemoryObject(*rvsdg.lambda_f);
   const auto lambdaFRegister = set.CreateRegisterPointerObject(*rvsdg.lambda_f->output());
-  const auto lambdaFArgumentX = set.CreateRegisterPointerObject(*rvsdg.lambda_f->fctargument(0));
-  const auto lambdaFArgumentY = set.CreateRegisterPointerObject(*rvsdg.lambda_f->fctargument(1));
+  const auto lambdaFArgumentX =
+      set.CreateRegisterPointerObject(*rvsdg.lambda_f->GetFunctionArguments()[0]);
+  const auto lambdaFArgumentY =
+      set.CreateRegisterPointerObject(*rvsdg.lambda_f->GetFunctionArguments()[1]);
   const auto allocaX = set.CreateAllocaMemoryObject(*rvsdg.alloca_x, true);
   const auto allocaY = set.CreateAllocaMemoryObject(*rvsdg.alloca_y, true);
   const auto allocaXRegister = set.CreateRegisterPointerObject(*rvsdg.alloca_x->output(0));

--- a/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
@@ -153,7 +153,7 @@ TestLoad1()
 
     auto & lambda = pointsToGraph.GetLambdaNode(*test.lambda);
     auto & lambdaOutput = pointsToGraph.GetRegisterNode(*test.lambda->output());
-    auto & lambdaArgument0 = pointsToGraph.GetRegisterNode(*test.lambda->fctargument(0));
+    auto & lambdaArgument0 = pointsToGraph.GetRegisterNode(*test.lambda->GetFunctionArguments()[0]);
 
     assertTargets(loadResult, { &lambda, &pointsToGraph.GetExternalMemoryNode() });
 
@@ -284,7 +284,7 @@ TestBitCast()
 
     auto & lambda = pointsToGraph.GetLambdaNode(*test.lambda);
     auto & lambdaOut = pointsToGraph.GetRegisterNode(*test.lambda->output());
-    auto & lambdaArg = pointsToGraph.GetRegisterNode(*test.lambda->fctargument(0));
+    auto & lambdaArg = pointsToGraph.GetRegisterNode(*test.lambda->GetFunctionArguments()[0]);
 
     auto & bitCast = pointsToGraph.GetRegisterNode(*test.bitCast->output(0));
 
@@ -316,7 +316,7 @@ TestConstantPointerNull()
 
     auto & lambda = pointsToGraph.GetLambdaNode(*test.lambda);
     auto & lambdaOut = pointsToGraph.GetRegisterNode(*test.lambda->output());
-    auto & lambdaArg = pointsToGraph.GetRegisterNode(*test.lambda->fctargument(0));
+    auto & lambdaArg = pointsToGraph.GetRegisterNode(*test.lambda->GetFunctionArguments()[0]);
     auto & externalMemoryNode = pointsToGraph.GetExternalMemoryNode();
 
     auto & constantPointerNull =
@@ -402,14 +402,14 @@ TestCall1()
     auto & plambda_g = ptg.GetRegisterNode(*test.lambda_g->output());
     auto & plambda_h = ptg.GetRegisterNode(*test.lambda_h->output());
 
-    auto & lambda_f_arg0 = ptg.GetRegisterNode(*test.lambda_f->fctargument(0));
-    auto & lambda_f_arg1 = ptg.GetRegisterNode(*test.lambda_f->fctargument(1));
+    auto & lambda_f_arg0 = ptg.GetRegisterNode(*test.lambda_f->GetFunctionArguments()[0]);
+    auto & lambda_f_arg1 = ptg.GetRegisterNode(*test.lambda_f->GetFunctionArguments()[1]);
 
-    auto & lambda_g_arg0 = ptg.GetRegisterNode(*test.lambda_g->fctargument(0));
-    auto & lambda_g_arg1 = ptg.GetRegisterNode(*test.lambda_g->fctargument(1));
+    auto & lambda_g_arg0 = ptg.GetRegisterNode(*test.lambda_g->GetFunctionArguments()[0]);
+    auto & lambda_g_arg1 = ptg.GetRegisterNode(*test.lambda_g->GetFunctionArguments()[1]);
 
-    auto & lambda_h_cv0 = ptg.GetRegisterNode(*test.lambda_h->cvargument(0));
-    auto & lambda_h_cv1 = ptg.GetRegisterNode(*test.lambda_h->cvargument(1));
+    auto & lambda_h_cv0 = ptg.GetRegisterNode(*test.lambda_h->GetContextVars()[0].inner);
+    auto & lambda_h_cv1 = ptg.GetRegisterNode(*test.lambda_h->GetContextVars()[1].inner);
 
     assertTargets(palloca_x, { &alloca_x });
     assertTargets(palloca_y, { &alloca_y });
@@ -457,12 +457,13 @@ TestCall2()
 
     auto & lambda_destroy = ptg.GetLambdaNode(*test.lambda_destroy);
     auto & lambda_destroy_out = ptg.GetRegisterNode(*test.lambda_destroy->output());
-    auto & lambda_destroy_arg = ptg.GetRegisterNode(*test.lambda_destroy->fctargument(0));
+    auto & lambda_destroy_arg =
+        ptg.GetRegisterNode(*test.lambda_destroy->GetFunctionArguments()[0]);
 
     auto & lambda_test = ptg.GetLambdaNode(*test.lambda_test);
     auto & lambda_test_out = ptg.GetRegisterNode(*test.lambda_test->output());
-    auto & lambda_test_cv1 = ptg.GetRegisterNode(*test.lambda_test->cvargument(0));
-    auto & lambda_test_cv2 = ptg.GetRegisterNode(*test.lambda_test->cvargument(1));
+    auto & lambda_test_cv1 = ptg.GetRegisterNode(*test.lambda_test->GetContextVars()[0].inner);
+    auto & lambda_test_cv2 = ptg.GetRegisterNode(*test.lambda_test->GetContextVars()[1].inner);
 
     auto & call_create1_out = ptg.GetRegisterNode(*test.CallCreate1().output(0));
     auto & call_create2_out = ptg.GetRegisterNode(*test.CallCreate2().output(0));
@@ -515,13 +516,14 @@ TestIndirectCall()
 
     auto & lambda_indcall = ptg.GetLambdaNode(test.GetLambdaIndcall());
     auto & lambda_indcall_out = ptg.GetRegisterNode(*test.GetLambdaIndcall().output());
-    auto & lambda_indcall_arg = ptg.GetRegisterNode(*test.GetLambdaIndcall().fctargument(0));
+    auto & lambda_indcall_arg =
+        ptg.GetRegisterNode(*test.GetLambdaIndcall().GetFunctionArguments()[0]);
 
     auto & lambda_test = ptg.GetLambdaNode(test.GetLambdaTest());
     auto & lambda_test_out = ptg.GetRegisterNode(*test.GetLambdaTest().output());
-    auto & lambda_test_cv0 = ptg.GetRegisterNode(*test.GetLambdaTest().cvargument(0));
-    auto & lambda_test_cv1 = ptg.GetRegisterNode(*test.GetLambdaTest().cvargument(1));
-    auto & lambda_test_cv2 = ptg.GetRegisterNode(*test.GetLambdaTest().cvargument(2));
+    auto & lambda_test_cv0 = ptg.GetRegisterNode(*test.GetLambdaTest().GetContextVars()[0].inner);
+    auto & lambda_test_cv1 = ptg.GetRegisterNode(*test.GetLambdaTest().GetContextVars()[1].inner);
+    auto & lambda_test_cv2 = ptg.GetRegisterNode(*test.GetLambdaTest().GetContextVars()[2].inner);
 
     assertTargets(lambda_three_out, { &lambda_three, &lambda_four });
 
@@ -591,8 +593,10 @@ TestExternalCall1()
     assert(pointsToGraph.NumRegisterNodes() == 7);
 
     auto & lambdaF = pointsToGraph.GetLambdaNode(test.LambdaF());
-    auto & lambdaFArgument0 = pointsToGraph.GetRegisterNode(*test.LambdaF().fctargument(0));
-    auto & lambdaFArgument1 = pointsToGraph.GetRegisterNode(*test.LambdaF().fctargument(1));
+    auto & lambdaFArgument0 =
+        pointsToGraph.GetRegisterNode(*test.LambdaF().GetFunctionArguments()[0]);
+    auto & lambdaFArgument1 =
+        pointsToGraph.GetRegisterNode(*test.LambdaF().GetFunctionArguments()[1]);
 
     auto & callResult = pointsToGraph.GetRegisterNode(*test.CallG().Result(0));
 
@@ -649,7 +653,8 @@ TestGamma()
 
     for (size_t n = 1; n < 5; n++)
     {
-      auto & lambdaArgument = pointsToGraph.GetRegisterNode(*test.lambda->fctargument(n));
+      auto & lambdaArgument =
+          pointsToGraph.GetRegisterNode(*test.lambda->GetFunctionArguments()[n]);
       assertTargets(lambdaArgument, { &lambda, &pointsToGraph.GetExternalMemoryNode() });
     }
 
@@ -691,7 +696,7 @@ TestTheta()
     assert(pointsToGraph.NumRegisterNodes() == 2);
 
     auto & lambda = pointsToGraph.GetLambdaNode(*test.lambda);
-    auto & lambdaArgument1 = pointsToGraph.GetRegisterNode(*test.lambda->fctargument(1));
+    auto & lambdaArgument1 = pointsToGraph.GetRegisterNode(*test.lambda->GetFunctionArguments()[1]);
     auto & lambdaOutput = pointsToGraph.GetRegisterNode(*test.lambda->output());
 
     auto & gepOutput = pointsToGraph.GetRegisterNode(*test.gep->output(0));
@@ -735,12 +740,12 @@ TestDelta1()
 
     auto & lambda_g = ptg.GetLambdaNode(*test.lambda_g);
     auto & plambda_g = ptg.GetRegisterNode(*test.lambda_g->output());
-    auto & lambda_g_arg0 = ptg.GetRegisterNode(*test.lambda_g->fctargument(0));
+    auto & lambda_g_arg0 = ptg.GetRegisterNode(*test.lambda_g->GetFunctionArguments()[0]);
 
     auto & lambda_h = ptg.GetLambdaNode(*test.lambda_h);
     auto & plambda_h = ptg.GetRegisterNode(*test.lambda_h->output());
-    auto & lambda_h_cv0 = ptg.GetRegisterNode(*test.lambda_h->cvargument(0));
-    auto & lambda_h_cv1 = ptg.GetRegisterNode(*test.lambda_h->cvargument(1));
+    auto & lambda_h_cv0 = ptg.GetRegisterNode(*test.lambda_h->GetContextVars()[0].inner);
+    auto & lambda_h_cv1 = ptg.GetRegisterNode(*test.lambda_h->GetContextVars()[1].inner);
 
     assertTargets(pdelta_f, { &delta_f });
 
@@ -783,13 +788,13 @@ TestDelta2()
 
     auto & lambda_f1 = ptg.GetLambdaNode(*test.lambda_f1);
     auto & lambda_f1_out = ptg.GetRegisterNode(*test.lambda_f1->output());
-    auto & lambda_f1_cvd1 = ptg.GetRegisterNode(*test.lambda_f1->cvargument(0));
+    auto & lambda_f1_cvd1 = ptg.GetRegisterNode(*test.lambda_f1->GetContextVars()[0].inner);
 
     auto & lambda_f2 = ptg.GetLambdaNode(*test.lambda_f2);
     auto & lambda_f2_out = ptg.GetRegisterNode(*test.lambda_f2->output());
-    auto & lambda_f2_cvd1 = ptg.GetRegisterNode(*test.lambda_f2->cvargument(0));
-    auto & lambda_f2_cvd2 = ptg.GetRegisterNode(*test.lambda_f2->cvargument(1));
-    auto & lambda_f2_cvf1 = ptg.GetRegisterNode(*test.lambda_f2->cvargument(2));
+    auto & lambda_f2_cvd1 = ptg.GetRegisterNode(*test.lambda_f2->GetContextVars()[0].inner);
+    auto & lambda_f2_cvd2 = ptg.GetRegisterNode(*test.lambda_f2->GetContextVars()[1].inner);
+    auto & lambda_f2_cvf1 = ptg.GetRegisterNode(*test.lambda_f2->GetContextVars()[2].inner);
 
     assertTargets(delta_d1_out, { &delta_d1 });
     assertTargets(delta_d2_out, { &delta_d2 });
@@ -833,13 +838,13 @@ TestImports()
 
     auto & lambda_f1 = ptg.GetLambdaNode(*test.lambda_f1);
     auto & lambda_f1_out = ptg.GetRegisterNode(*test.lambda_f1->output());
-    auto & lambda_f1_cvd1 = ptg.GetRegisterNode(*test.lambda_f1->cvargument(0));
+    auto & lambda_f1_cvd1 = ptg.GetRegisterNode(*test.lambda_f1->GetContextVars()[0].inner);
 
     auto & lambda_f2 = ptg.GetLambdaNode(*test.lambda_f2);
     auto & lambda_f2_out = ptg.GetRegisterNode(*test.lambda_f2->output());
-    auto & lambda_f2_cvd1 = ptg.GetRegisterNode(*test.lambda_f2->cvargument(0));
-    auto & lambda_f2_cvd2 = ptg.GetRegisterNode(*test.lambda_f2->cvargument(1));
-    auto & lambda_f2_cvf1 = ptg.GetRegisterNode(*test.lambda_f2->cvargument(2));
+    auto & lambda_f2_cvd1 = ptg.GetRegisterNode(*test.lambda_f2->GetContextVars()[0].inner);
+    auto & lambda_f2_cvd2 = ptg.GetRegisterNode(*test.lambda_f2->GetContextVars()[1].inner);
+    auto & lambda_f2_cvf1 = ptg.GetRegisterNode(*test.lambda_f2->GetContextVars()[2].inner);
 
     assertTargets(import_d1, { &d1 });
     assertTargets(import_d2, { &d2 });
@@ -877,7 +882,7 @@ TestPhi1()
 
     auto & lambda_fib = ptg.GetLambdaNode(*test.lambda_fib);
     auto & lambda_fib_out = ptg.GetRegisterNode(*test.lambda_fib->output());
-    auto & lambda_fib_arg1 = ptg.GetRegisterNode(*test.lambda_fib->fctargument(1));
+    auto & lambda_fib_arg1 = ptg.GetRegisterNode(*test.lambda_fib->GetFunctionArguments()[1]);
 
     auto & lambda_test = ptg.GetLambdaNode(*test.lambda_test);
     auto & lambda_test_out = ptg.GetRegisterNode(*test.lambda_test->output());
@@ -927,8 +932,10 @@ TestExternalMemory()
     assert(pointsToGraph.NumRegisterNodes() == 3);
 
     auto & lambdaF = pointsToGraph.GetLambdaNode(*test.LambdaF);
-    auto & lambdaFArgument0 = pointsToGraph.GetRegisterNode(*test.LambdaF->fctargument(0));
-    auto & lambdaFArgument1 = pointsToGraph.GetRegisterNode(*test.LambdaF->fctargument(1));
+    auto & lambdaFArgument0 =
+        pointsToGraph.GetRegisterNode(*test.LambdaF->GetFunctionArguments()[0]);
+    auto & lambdaFArgument1 =
+        pointsToGraph.GetRegisterNode(*test.LambdaF->GetFunctionArguments()[1]);
 
     assertTargets(lambdaFArgument0, { &lambdaF, &pointsToGraph.GetExternalMemoryNode() });
     assertTargets(lambdaFArgument1, { &lambdaF, &pointsToGraph.GetExternalMemoryNode() });
@@ -956,8 +963,10 @@ TestEscapedMemory1()
     assert(pointsToGraph.NumLambdaNodes() == 1);
     assert(pointsToGraph.NumRegisterNodes() == 7);
 
-    auto & lambdaTestArgument0 = pointsToGraph.GetRegisterNode(*test.LambdaTest->fctargument(0));
-    auto & lambdaTestCv0 = pointsToGraph.GetRegisterNode(*test.LambdaTest->cvargument(0));
+    auto & lambdaTestArgument0 =
+        pointsToGraph.GetRegisterNode(*test.LambdaTest->GetFunctionArguments()[0]);
+    auto & lambdaTestCv0 =
+        pointsToGraph.GetRegisterNode(*test.LambdaTest->GetContextVars()[0].inner);
     auto & loadNode1Output = pointsToGraph.GetRegisterNode(*test.LoadNode1->output(0));
 
     auto deltaA = &pointsToGraph.GetDeltaNode(*test.DeltaA);
@@ -1129,11 +1138,15 @@ TestMemcpy2()
   assert(pointsToGraph->NumLambdaNodes() == 2);
 
   auto & lambdaFNode = pointsToGraph->GetLambdaNode(test.LambdaF());
-  auto & lambdaFArgument0 = pointsToGraph->GetRegisterNode(*test.LambdaF().fctargument(0));
-  auto & lambdaFArgument1 = pointsToGraph->GetRegisterNode(*test.LambdaF().fctargument(1));
+  auto & lambdaFArgument0 =
+      pointsToGraph->GetRegisterNode(*test.LambdaF().GetFunctionArguments()[0]);
+  auto & lambdaFArgument1 =
+      pointsToGraph->GetRegisterNode(*test.LambdaF().GetFunctionArguments()[1]);
 
-  auto & lambdaGArgument0 = pointsToGraph->GetRegisterNode(*test.LambdaG().fctargument(0));
-  auto & lambdaGArgument1 = pointsToGraph->GetRegisterNode(*test.LambdaG().fctargument(1));
+  auto & lambdaGArgument0 =
+      pointsToGraph->GetRegisterNode(*test.LambdaG().GetFunctionArguments()[0]);
+  auto & lambdaGArgument1 =
+      pointsToGraph->GetRegisterNode(*test.LambdaG().GetFunctionArguments()[1]);
 
   auto & memcpyOperand0 = pointsToGraph->GetRegisterNode(*test.Memcpy().input(0)->origin());
   auto & memcpyOperand1 = pointsToGraph->GetRegisterNode(*test.Memcpy().input(1)->origin());
@@ -1168,7 +1181,7 @@ TestMemcpy3()
   assert(pointsToGraph->NumAllocaNodes() == 1);
 
   auto & lambdaNode = pointsToGraph->GetLambdaNode(test.Lambda());
-  auto & lambdaArgument0 = pointsToGraph->GetRegisterNode(*test.Lambda().fctargument(0));
+  auto & lambdaArgument0 = pointsToGraph->GetRegisterNode(*test.Lambda().GetFunctionArguments()[0]);
 
   auto & allocaNode = pointsToGraph->GetAllocaNode(test.Alloca());
 

--- a/tests/jlm/llvm/opt/test-cne.cpp
+++ b/tests/jlm/llvm/opt/test-cne.cpp
@@ -402,8 +402,8 @@ test_lambda()
 
   auto lambda = lambda::node::create(graph.root(), ft, "f", linkage::external_linkage);
 
-  auto d1 = lambda->AddContextVar(x).inner;
-  auto d2 = lambda->AddContextVar(x).inner;
+  auto d1 = lambda->AddContextVar(*x).inner;
+  auto d2 = lambda->AddContextVar(*x).inner;
 
   auto b1 = jlm::tests::create_testop(lambda->subregion(), { d1, d2 }, { vt })[0];
 
@@ -446,11 +446,11 @@ test_phi()
   auto r2 = pb.add_recvar(PointerType::Create());
 
   auto lambda1 = lambda::node::create(region, ft, "f", linkage::external_linkage);
-  auto cv1 = lambda1->AddContextVar(d1).inner;
+  auto cv1 = lambda1->AddContextVar(*d1).inner;
   auto f1 = lambda1->finalize({ cv1 });
 
   auto lambda2 = lambda::node::create(region, ft, "f", linkage::external_linkage);
-  auto cv2 = lambda2->AddContextVar(d2).inner;
+  auto cv2 = lambda2->AddContextVar(*d2).inner;
   auto f2 = lambda2->finalize({ cv2 });
 
   r1->set_rvorigin(f1);

--- a/tests/jlm/llvm/opt/test-cne.cpp
+++ b/tests/jlm/llvm/opt/test-cne.cpp
@@ -402,8 +402,8 @@ test_lambda()
 
   auto lambda = lambda::node::create(graph.root(), ft, "f", linkage::external_linkage);
 
-  auto d1 = lambda->add_ctxvar(x);
-  auto d2 = lambda->add_ctxvar(x);
+  auto d1 = lambda->AddContextVar(x).inner;
+  auto d2 = lambda->AddContextVar(x).inner;
 
   auto b1 = jlm::tests::create_testop(lambda->subregion(), { d1, d2 }, { vt })[0];
 
@@ -446,11 +446,11 @@ test_phi()
   auto r2 = pb.add_recvar(PointerType::Create());
 
   auto lambda1 = lambda::node::create(region, ft, "f", linkage::external_linkage);
-  auto cv1 = lambda1->add_ctxvar(d1);
+  auto cv1 = lambda1->AddContextVar(d1).inner;
   auto f1 = lambda1->finalize({ cv1 });
 
   auto lambda2 = lambda::node::create(region, ft, "f", linkage::external_linkage);
-  auto cv2 = lambda2->add_ctxvar(d2);
+  auto cv2 = lambda2->AddContextVar(d2).inner;
   auto f2 = lambda2->finalize({ cv2 });
 
   r1->set_rvorigin(f1);
@@ -466,7 +466,9 @@ test_phi()
   cne.run(rm, statisticsCollector);
   //	jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(f1->node()->input(0)->origin() == f2->node()->input(0)->origin());
+  assert(
+      jlm::rvsdg::AssertGetOwnerNode<lambda::node>(*f1).input(0)->origin()
+      == jlm::rvsdg::AssertGetOwnerNode<lambda::node>(*f2).input(0)->origin());
 }
 
 static int

--- a/tests/jlm/llvm/opt/test-inlining.cpp
+++ b/tests/jlm/llvm/opt/test-inlining.cpp
@@ -38,7 +38,7 @@ test1()
         { vt, iostatetype::Create(), MemoryStateType::Create() });
 
     auto lambda = lambda::node::create(graph.root(), functionType, "f1", linkage::external_linkage);
-    lambda->AddContextVar(i);
+    lambda->AddContextVar(*i);
 
     auto t = jlm::tests::test_op::create(
         lambda->subregion(),
@@ -63,7 +63,7 @@ test1()
         { vt, iostatetype::Create(), MemoryStateType::Create() });
 
     auto lambda = lambda::node::create(graph.root(), functionType, "f1", linkage::external_linkage);
-    auto d = lambda->AddContextVar(f1).inner;
+    auto d = lambda->AddContextVar(*f1).inner;
     auto controlArgument = lambda->GetFunctionArguments()[0];
     auto valueArgument = lambda->GetFunctionArguments()[1];
     auto iOStateArgument = lambda->GetFunctionArguments()[2];
@@ -146,8 +146,8 @@ test2()
         { iostatetype::Create(), MemoryStateType::Create() });
 
     auto lambda = lambda::node::create(graph.root(), functionType, "f2", linkage::external_linkage);
-    auto cvi = lambda->AddContextVar(i).inner;
-    auto cvf1 = lambda->AddContextVar(f1).inner;
+    auto cvi = lambda->AddContextVar(*i).inner;
+    auto cvf1 = lambda->AddContextVar(*f1).inner;
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 

--- a/tests/jlm/llvm/opt/test-inlining.cpp
+++ b/tests/jlm/llvm/opt/test-inlining.cpp
@@ -38,14 +38,18 @@ test1()
         { vt, iostatetype::Create(), MemoryStateType::Create() });
 
     auto lambda = lambda::node::create(graph.root(), functionType, "f1", linkage::external_linkage);
-    lambda->add_ctxvar(i);
+    lambda->AddContextVar(i);
 
-    auto t = jlm::tests::test_op::create(lambda->subregion(), { lambda->fctargument(0) }, { vt });
+    auto t = jlm::tests::test_op::create(
+        lambda->subregion(),
+        { lambda->GetFunctionArguments()[0] },
+        { vt });
 
-    return lambda->finalize({ t->output(0), lambda->fctargument(1), lambda->fctargument(2) });
+    return lambda->finalize(
+        { t->output(0), lambda->GetFunctionArguments()[1], lambda->GetFunctionArguments()[2] });
   };
 
-  auto SetupF2 = [&](lambda::output * f1)
+  auto SetupF2 = [&](jlm::rvsdg::output * f1)
   {
     auto vt = jlm::tests::valuetype::Create();
     auto iOStateType = iostatetype::Create();
@@ -59,11 +63,11 @@ test1()
         { vt, iostatetype::Create(), MemoryStateType::Create() });
 
     auto lambda = lambda::node::create(graph.root(), functionType, "f1", linkage::external_linkage);
-    auto d = lambda->add_ctxvar(f1);
-    auto controlArgument = lambda->fctargument(0);
-    auto valueArgument = lambda->fctargument(1);
-    auto iOStateArgument = lambda->fctargument(2);
-    auto memoryStateArgument = lambda->fctargument(3);
+    auto d = lambda->AddContextVar(f1).inner;
+    auto controlArgument = lambda->GetFunctionArguments()[0];
+    auto valueArgument = lambda->GetFunctionArguments()[1];
+    auto iOStateArgument = lambda->GetFunctionArguments()[2];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[3];
 
     auto gamma = jlm::rvsdg::GammaNode::create(controlArgument, 2);
     auto gammaInputF1 = gamma->add_entryvar(d);
@@ -73,7 +77,7 @@ test1()
 
     auto callResults = CallNode::Create(
         gammaInputF1->argument(0),
-        f1->node()->Type(),
+        jlm::rvsdg::AssertGetOwnerNode<lambda::node>(*f1).Type(),
         { gammaInputValue->argument(0),
           gammaInputIoState->argument(0),
           gammaInputMemoryState->argument(0) });
@@ -129,10 +133,11 @@ test2()
   auto SetupF1 = [&](const std::shared_ptr<const FunctionType> & functionType)
   {
     auto lambda = lambda::node::create(graph.root(), functionType, "f1", linkage::external_linkage);
-    return lambda->finalize({ lambda->fctargument(1), lambda->fctargument(2) });
+    return lambda->finalize(
+        { lambda->GetFunctionArguments()[1], lambda->GetFunctionArguments()[2] });
   };
 
-  auto SetupF2 = [&](lambda::output * f1)
+  auto SetupF2 = [&](jlm::rvsdg::output * f1)
   {
     auto iOStateType = iostatetype::Create();
     auto memoryStateType = MemoryStateType::Create();
@@ -141,10 +146,10 @@ test2()
         { iostatetype::Create(), MemoryStateType::Create() });
 
     auto lambda = lambda::node::create(graph.root(), functionType, "f2", linkage::external_linkage);
-    auto cvi = lambda->add_ctxvar(i);
-    auto cvf1 = lambda->add_ctxvar(f1);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto cvi = lambda->AddContextVar(i).inner;
+    auto cvf1 = lambda->AddContextVar(f1).inner;
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
     auto callResults =
         CallNode::Create(cvi, functionType2, { cvf1, iOStateArgument, memoryStateArgument });
@@ -166,7 +171,8 @@ test2()
 
   // Assert
   // Function f1 should not have been inlined.
-  assert(is<CallOperation>(jlm::rvsdg::output::GetNode(*f2->node()->fctresult(0)->origin())));
+  assert(is<CallOperation>(jlm::rvsdg::output::GetNode(
+      *jlm::rvsdg::AssertGetOwnerNode<lambda::node>(*f2).GetFunctionResults()[0]->origin())));
 }
 
 static int

--- a/tests/jlm/mlir/backend/TestJlmToMlirConverter.cpp
+++ b/tests/jlm/mlir/backend/TestJlmToMlirConverter.cpp
@@ -33,8 +33,8 @@ TestLambda()
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, "test", linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
     auto constant = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
 
@@ -152,8 +152,8 @@ TestAddOperation()
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, "test", linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
     // Create add operation
     std::cout << "Add Operation" << std::endl;
@@ -253,8 +253,8 @@ TestComZeroExt()
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, "test", linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
     // Create add operation
     std::cout << "Add Operation" << std::endl;
@@ -399,8 +399,8 @@ TestMatch()
 
     auto lambda =
         lambda::node::create(graph->root(), functionType, "test", linkage::external_linkage);
-    auto iOStateArgument = lambda->fctargument(0);
-    auto memoryStateArgument = lambda->fctargument(1);
+    auto iOStateArgument = lambda->GetFunctionArguments()[0];
+    auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
     // Create a match operation
     std::cout << "Match Operation" << std::endl;


### PR DESCRIPTION
Remove all auxiliary input/output/argument/result classes for lambda. Provide new API for mapping pieces to context variables. Change all dispatch to be based on checking for "lambda node" instead of subclassed inputs/outputs.

This leads to:
- making the lambda abstraction a generic rvsdg concept
- removing all needs to implement subclasses of argument, result, input and output
- dispatching purely based on node kind