### PR TITLE
Updated caching for CI CIRCT build

### DIFF
--- a/.github/actions/BuildCirct/action.yml
+++ b/.github/actions/BuildCirct/action.yml
@@ -26,7 +26,7 @@ runs:
         key: ${{ runner.os }}-circt-${{ steps.get-circt-hash.outputs.hash }}
 
     - name: "Build CIRCT if we didn't hit in the cache"
-      if: steps.cache-circt.outputs.cache-hit != 'true'
+      if: steps.restore-cache-circt.outputs.cache-hit != 'true'
       run: |
         ./scripts/build-circt.sh \
           --build-path ${{ github.workspace }}/build-circt \

--- a/.github/actions/BuildCirct/action.yml
+++ b/.github/actions/BuildCirct/action.yml
@@ -4,6 +4,13 @@ description: "Builds CIRCT, which is used for the HLS backend"
 runs:
   using: "composite"
   steps:
+    - name: "Install LLVM, Clang, MLIR, and Ninja"
+      uses: ./.github/actions/InstallPackages
+      with:
+        install-llvm: true
+        install-mlir: true
+        install-ninja: true
+
     - name: "Get the commit used for building CIRCT and use it as the cache key"
       id: get-circt-hash
       run: |
@@ -18,13 +25,6 @@ runs:
           ${{ github.workspace }}/build-circt/circt
         key: ${{ runner.os }}-circt-${{ steps.get-circt-hash.outputs.hash }}
 
-    - name: "Install LLVM, Clang, MLIR, and Ninja"
-      uses: ./.github/actions/InstallPackages
-      with:
-        install-llvm: true
-        install-mlir: true
-        install-ninja: true
-
     - name: "Build CIRCT if we didn't hit in the cache"
       if: steps.cache-circt.outputs.cache-hit != 'true'
       run: |
@@ -35,10 +35,9 @@ runs:
       shell: bash
 
     - name: "Save CIRCT to the cache"
-      if: steps.cache-circt.outputs.cache-hit != 'true'
       id: save-cache-circt
       uses: actions/cache/save@v4
       with:
         path: |
           ${{ github.workspace }}/build-circt/circt
-        key: ${{ runner.os }}-circt-${{ steps.get-circt-hash.outputs.hash }}
+        key: ${{ steps.restore-cache-circt.outputs.cache-primary-key }}

--- a/.github/actions/BuildCirct/action.yml
+++ b/.github/actions/BuildCirct/action.yml
@@ -36,7 +36,6 @@ runs:
 
     - name: "Save CIRCT to the cache"
       if: steps.cache-circt.outputs.cache-hit != 'true'
-      run: |
       id: save-cache-circt
       uses: actions/cache/save@v4
       with:

--- a/.github/actions/BuildCirct/action.yml
+++ b/.github/actions/BuildCirct/action.yml
@@ -35,6 +35,7 @@ runs:
       shell: bash
 
     - name: "Save CIRCT to the cache"
+      if: steps.restore-cache-circt.outputs.cache-hit != 'true'
       id: save-cache-circt
       uses: actions/cache/save@v4
       with:

--- a/.github/actions/BuildCirct/action.yml
+++ b/.github/actions/BuildCirct/action.yml
@@ -13,7 +13,7 @@ runs:
       shell: bash
 
     - name: "Try to fetch CIRCT from the cache"
-      id: cache-circt
+      id: restore-cache-circt
       uses: actions/cache/restore@v4
       with:
         path: |
@@ -37,7 +37,7 @@ runs:
       shell: bash
 
     - name: "Save CIRCT to the cache"
-      id: cache-circt
+      id: save-cache-circt
       uses: actions/cache/save@v4
       with:
         path: |

--- a/.github/actions/BuildCirct/action.yml
+++ b/.github/actions/BuildCirct/action.yml
@@ -4,6 +4,8 @@ description: "Builds CIRCT, which is used for the HLS backend"
 runs:
   using: "composite"
   steps:
+    - uses: actions/checkout@v4
+
     - name: "Get the commit used for building CIRCT and use it as the cache key"
       id: get-circt-hash
       run: |
@@ -12,9 +14,8 @@ runs:
 
     - name: "Try to fetch CIRCT from the cache"
       id: cache-circt
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
-        save-always: true
         path: |
           ${{ github.workspace }}/build-circt/circt
         key: ${{ runner.os }}-circt-${{ steps.get-circt-hash.outputs.hash }}
@@ -34,3 +35,11 @@ runs:
           --install-path ${{ github.workspace }}/build-circt/circt \
           --llvm-lit-path ~/.local/bin/lit
       shell: bash
+
+    - name: "Save CIRCT to the cache"
+      id: cache-circt
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          ${{ github.workspace }}/build-circt/circt
+        key: ${{ runner.os }}-circt-${{ steps.get-circt-hash.outputs.hash }}

--- a/.github/actions/BuildCirct/action.yml
+++ b/.github/actions/BuildCirct/action.yml
@@ -4,8 +4,6 @@ description: "Builds CIRCT, which is used for the HLS backend"
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
-
     - name: "Get the commit used for building CIRCT and use it as the cache key"
       id: get-circt-hash
       run: |
@@ -37,6 +35,8 @@ runs:
       shell: bash
 
     - name: "Save CIRCT to the cache"
+      if: steps.cache-circt.outputs.cache-hit != 'true'
+      run: |
       id: save-cache-circt
       uses: actions/cache/save@v4
       with:


### PR DESCRIPTION
The 'save-always: true' option is deprecated.
This version should have the advantage that even if the CI fails at a later step, the build should have already been saved and not require to be rebuilt when a fix is pushed.