### PR TITLE
[AndersenAgnostic] add flags for soundly handling pointer smuggling through loads and stores of scalar values

### DIFF
--- a/jlm/llvm/opt/RvsdgTreePrinter.cpp
+++ b/jlm/llvm/opt/RvsdgTreePrinter.cpp
@@ -8,6 +8,7 @@
 #include <jlm/rvsdg/structural-node.hpp>
 #include <jlm/util/Statistics.hpp>
 
+#include <algorithm>
 #include <fstream>
 
 namespace jlm::llvm

--- a/jlm/llvm/opt/alias-analyses/Andersen.hpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.hpp
@@ -35,6 +35,13 @@ public:
   static inline const char * const ENV_TEST_ALL_CONFIGS = "JLM_ANDERSEN_TEST_ALL_CONFIGS";
 
   /**
+   * Alternative to testing all configs, this environment variable specifies exactly which config to
+   * use. It must be an index into the Configuration::GetAllConfigurations() vector.
+   * Should likely not be combined with ENV_TEST_ALL_CONFIGS or ENV_DOUBLE_CHECK
+   */
+  static inline const char * const ENV_USE_EXACT_CONFIG = "JLM_ANDERSEN_USE_EXACT_CONFIG";
+
+  /**
    * Environment variable that will trigger double checking of the analysis.
    * If ENV_TEST_ALL_CONFIGS is set, the output is double checked against them all.
    * Otherwise, the output is double checked only against the default naive solver.


### PR DESCRIPTION
Adds flags for soundly handling any potential pointer smuggling through loading or storing pointers as scalars

Also includes some small changes:
 - Add counts of the different types of PointerObject to the statistics
 - Add `#include <algorithm>` to a file because I needed that to compile it.
 - Fix bug where OnlineCD would never be combined with DP or PIP.
 - Add environment variable option for using a specific config.