### PR TITLE
Cancel GitHub workflow if another commit is made to the same PR

### DIFF
--- a/.github/workflows/CheckHeaders.yml
+++ b/.github/workflows/CheckHeaders.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   CheckHeaders:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ClangFormat.yml
+++ b/.github/workflows/ClangFormat.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   CheckFormat:
     runs-on: ubuntu-22.04

--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   GenerateDocumentation:
     runs-on: ubuntu-22.04

--- a/.github/workflows/hls.yml
+++ b/.github/workflows/hls.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   hls-test-suite:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Adds the `cancel-in-progress: true` option to our GitHub workflows, which triggers if another commit is made to the same PR. I my experience, we only care about the latest commit, which makes it wasteful to finish the old workflow when a new commit is added.

The exact code used in the PR is taken from [here](https://turso.tech/blog/simple-trick-to-save-environment-and-money-when-using-github-actions).