### PR TITLE
Rename operation() method of node class

### DIFF
--- a/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.cpp
+++ b/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.cpp
@@ -20,7 +20,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::simple_node * node)
   // Only handles nodes with a single output
   if (node->noutputs() != 1)
   {
-    throw std::logic_error(node->operation().debug_string() + " has more than 1 output");
+    throw std::logic_error(node->GetOperation().debug_string() + " has more than 1 output");
   }
 
   // Create the module and its input/output ports
@@ -45,7 +45,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::simple_node * node)
   // Get the data signal from the bundle
   auto outData = GetSubfield(body, outBundle, "data");
 
-  if (dynamic_cast<const jlm::rvsdg::bitadd_op *>(&(node->operation())))
+  if (dynamic_cast<const jlm::rvsdg::bitadd_op *>(&(node->GetOperation())))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     auto input1 = GetSubfield(body, inBundles[1], "data");
@@ -54,7 +54,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::simple_node * node)
     // We drop the carry bit
     Connect(body, outData, DropMSBs(body, op, 1));
   }
-  else if (dynamic_cast<const jlm::rvsdg::bitsub_op *>(&(node->operation())))
+  else if (dynamic_cast<const jlm::rvsdg::bitsub_op *>(&(node->GetOperation())))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     auto input1 = GetSubfield(body, inBundles[1], "data");
@@ -63,7 +63,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::simple_node * node)
     // We drop the carry bit
     Connect(body, outData, DropMSBs(body, op, 1));
   }
-  else if (dynamic_cast<const jlm::rvsdg::bitand_op *>(&(node->operation())))
+  else if (dynamic_cast<const jlm::rvsdg::bitand_op *>(&(node->GetOperation())))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     auto input1 = GetSubfield(body, inBundles[1], "data");
@@ -71,7 +71,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::simple_node * node)
     // Connect the op to the output data
     Connect(body, outData, op);
   }
-  else if (dynamic_cast<const jlm::rvsdg::bitxor_op *>(&(node->operation())))
+  else if (dynamic_cast<const jlm::rvsdg::bitxor_op *>(&(node->GetOperation())))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     auto input1 = GetSubfield(body, inBundles[1], "data");
@@ -79,7 +79,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::simple_node * node)
     // Connect the op to the output data
     Connect(body, outData, op);
   }
-  else if (dynamic_cast<const jlm::rvsdg::bitor_op *>(&(node->operation())))
+  else if (dynamic_cast<const jlm::rvsdg::bitor_op *>(&(node->GetOperation())))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     auto input1 = GetSubfield(body, inBundles[1], "data");
@@ -87,7 +87,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::simple_node * node)
     // Connect the op to the output data
     Connect(body, outData, op);
   }
-  else if (auto bitmulOp = dynamic_cast<const jlm::rvsdg::bitmul_op *>(&(node->operation())))
+  else if (auto bitmulOp = dynamic_cast<const jlm::rvsdg::bitmul_op *>(&(node->GetOperation())))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     auto input1 = GetSubfield(body, inBundles[1], "data");
@@ -96,7 +96,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::simple_node * node)
     // Multiplication results are double the input width, so we drop the upper half of the result
     Connect(body, outData, DropMSBs(body, op, bitmulOp->type().nbits()));
   }
-  else if (dynamic_cast<const jlm::rvsdg::bitsdiv_op *>(&(node->operation())))
+  else if (dynamic_cast<const jlm::rvsdg::bitsdiv_op *>(&(node->GetOperation())))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     auto input1 = GetSubfield(body, inBundles[1], "data");
@@ -107,7 +107,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::simple_node * node)
     // Connect the op to the output data
     Connect(body, outData, DropMSBs(body, uIntOp, 1));
   }
-  else if (dynamic_cast<const jlm::rvsdg::bitshr_op *>(&(node->operation())))
+  else if (dynamic_cast<const jlm::rvsdg::bitshr_op *>(&(node->GetOperation())))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     auto input1 = GetSubfield(body, inBundles[1], "data");
@@ -115,7 +115,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::simple_node * node)
     // Connect the op to the output data
     Connect(body, outData, op);
   }
-  else if (dynamic_cast<const jlm::rvsdg::bitashr_op *>(&(node->operation())))
+  else if (dynamic_cast<const jlm::rvsdg::bitashr_op *>(&(node->GetOperation())))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     auto input1 = GetSubfield(body, inBundles[1], "data");
@@ -125,7 +125,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::simple_node * node)
     // Connect the op to the output data
     Connect(body, outData, uIntOp);
   }
-  else if (dynamic_cast<const jlm::rvsdg::bitshl_op *>(&(node->operation())))
+  else if (dynamic_cast<const jlm::rvsdg::bitshl_op *>(&(node->GetOperation())))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     auto input1 = GetSubfield(body, inBundles[1], "data");
@@ -136,7 +136,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::simple_node * node)
     // Connect the op to the output data
     Connect(body, outData, slice);
   }
-  else if (dynamic_cast<const jlm::rvsdg::bitsmod_op *>(&(node->operation())))
+  else if (dynamic_cast<const jlm::rvsdg::bitsmod_op *>(&(node->GetOperation())))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     auto input1 = GetSubfield(body, inBundles[1], "data");
@@ -146,7 +146,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::simple_node * node)
     auto uIntOp = AddAsUIntOp(body, remOp);
     Connect(body, outData, uIntOp);
   }
-  else if (dynamic_cast<const jlm::rvsdg::biteq_op *>(&(node->operation())))
+  else if (dynamic_cast<const jlm::rvsdg::biteq_op *>(&(node->GetOperation())))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     auto input1 = GetSubfield(body, inBundles[1], "data");
@@ -154,7 +154,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::simple_node * node)
     // Connect the op to the output data
     Connect(body, outData, op);
   }
-  else if (dynamic_cast<const jlm::rvsdg::bitne_op *>(&(node->operation())))
+  else if (dynamic_cast<const jlm::rvsdg::bitne_op *>(&(node->GetOperation())))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     auto input1 = GetSubfield(body, inBundles[1], "data");
@@ -162,7 +162,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::simple_node * node)
     // Connect the op to the output data
     Connect(body, outData, op);
   }
-  else if (dynamic_cast<const jlm::rvsdg::bitsgt_op *>(&(node->operation())))
+  else if (dynamic_cast<const jlm::rvsdg::bitsgt_op *>(&(node->GetOperation())))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     auto input1 = GetSubfield(body, inBundles[1], "data");
@@ -172,7 +172,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::simple_node * node)
     // Connect the op to the output data
     Connect(body, outData, op);
   }
-  else if (dynamic_cast<const jlm::rvsdg::bitult_op *>(&(node->operation())))
+  else if (dynamic_cast<const jlm::rvsdg::bitult_op *>(&(node->GetOperation())))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     auto input1 = GetSubfield(body, inBundles[1], "data");
@@ -180,7 +180,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::simple_node * node)
     // Connect the op to the output data
     Connect(body, outData, op);
   }
-  else if (dynamic_cast<const jlm::rvsdg::bitule_op *>(&(node->operation())))
+  else if (dynamic_cast<const jlm::rvsdg::bitule_op *>(&(node->GetOperation())))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     auto input1 = GetSubfield(body, inBundles[1], "data");
@@ -188,7 +188,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::simple_node * node)
     // Connect the op to the output data
     Connect(body, outData, op);
   }
-  else if (dynamic_cast<const jlm::rvsdg::bitugt_op *>(&(node->operation())))
+  else if (dynamic_cast<const jlm::rvsdg::bitugt_op *>(&(node->GetOperation())))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     auto input1 = GetSubfield(body, inBundles[1], "data");
@@ -196,7 +196,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::simple_node * node)
     // Connect the op to the output data
     Connect(body, outData, op);
   }
-  else if (dynamic_cast<const jlm::rvsdg::bitsge_op *>(&(node->operation())))
+  else if (dynamic_cast<const jlm::rvsdg::bitsge_op *>(&(node->GetOperation())))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     auto input1 = GetSubfield(body, inBundles[1], "data");
@@ -206,7 +206,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::simple_node * node)
     // Connect the op to the output data
     Connect(body, outData, op);
   }
-  else if (dynamic_cast<const jlm::rvsdg::bitsle_op *>(&(node->operation())))
+  else if (dynamic_cast<const jlm::rvsdg::bitsle_op *>(&(node->GetOperation())))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     auto input1 = GetSubfield(body, inBundles[1], "data");
@@ -216,28 +216,28 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::simple_node * node)
     // Connect the op to the output data
     Connect(body, outData, op);
   }
-  else if (dynamic_cast<const llvm::zext_op *>(&(node->operation())))
+  else if (dynamic_cast<const llvm::zext_op *>(&(node->GetOperation())))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     Connect(body, outData, input0);
   }
-  else if (dynamic_cast<const llvm::trunc_op *>(&(node->operation())))
+  else if (dynamic_cast<const llvm::trunc_op *>(&(node->GetOperation())))
   {
     auto inData = GetSubfield(body, inBundles[0], "data");
     int outSize = JlmSize(&node->output(0)->type());
     Connect(body, outData, AddBitsOp(body, inData, outSize - 1, 0));
   }
-  else if (dynamic_cast<const llvm::LambdaExitMemoryStateMergeOperation *>(&(node->operation())))
+  else if (dynamic_cast<const llvm::LambdaExitMemoryStateMergeOperation *>(&(node->GetOperation())))
   {
     auto inData = GetSubfield(body, inBundles[0], "data");
     Connect(body, outData, inData);
   }
-  else if (dynamic_cast<const llvm::MemoryStateMergeOperation *>(&(node->operation())))
+  else if (dynamic_cast<const llvm::MemoryStateMergeOperation *>(&(node->GetOperation())))
   {
     auto inData = GetSubfield(body, inBundles[0], "data");
     Connect(body, outData, inData);
   }
-  else if (auto op = dynamic_cast<const llvm::sext_op *>(&(node->operation())))
+  else if (auto op = dynamic_cast<const llvm::sext_op *>(&(node->GetOperation())))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     auto sintOp = AddAsSIntOp(body, input0);
@@ -245,7 +245,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::simple_node * node)
     auto uintOp = AddAsUIntOp(body, padOp);
     Connect(body, outData, uintOp);
   }
-  else if (auto op = dynamic_cast<const jlm::rvsdg::bitconstant_op *>(&(node->operation())))
+  else if (auto op = dynamic_cast<const jlm::rvsdg::bitconstant_op *>(&(node->GetOperation())))
   {
     auto value = op->value();
     auto size = value.nbits();
@@ -253,14 +253,14 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::simple_node * node)
     auto constant = GetConstant(body, size, value.to_uint());
     Connect(body, outData, constant);
   }
-  else if (auto op = dynamic_cast<const jlm::rvsdg::ctlconstant_op *>(&(node->operation())))
+  else if (auto op = dynamic_cast<const jlm::rvsdg::ctlconstant_op *>(&(node->GetOperation())))
   {
     auto value = op->value().alternative();
     auto size = ceil(log2(op->value().nalternatives()));
     auto constant = GetConstant(body, size, value);
     Connect(body, outData, constant);
   }
-  else if (dynamic_cast<const jlm::rvsdg::bitslt_op *>(&(node->operation())))
+  else if (dynamic_cast<const jlm::rvsdg::bitslt_op *>(&(node->GetOperation())))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     auto input1 = GetSubfield(body, inBundles[1], "data");
@@ -269,17 +269,17 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::simple_node * node)
     auto op = AddLtOp(body, sInt0, sInt1);
     Connect(body, outData, op);
   }
-  else if (dynamic_cast<const llvm::bitcast_op *>(&(node->operation())))
+  else if (dynamic_cast<const llvm::bitcast_op *>(&(node->GetOperation())))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     Connect(body, outData, input0);
   }
-  else if (dynamic_cast<const llvm::bits2ptr_op *>(&(node->operation())))
+  else if (dynamic_cast<const llvm::bits2ptr_op *>(&(node->GetOperation())))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     Connect(body, outData, input0);
   }
-  else if (auto op = dynamic_cast<const jlm::rvsdg::match_op *>(&(node->operation())))
+  else if (auto op = dynamic_cast<const jlm::rvsdg::match_op *>(&(node->GetOperation())))
   {
     auto inData = GetSubfield(body, inBundles[0], "data");
     auto outData = GetSubfield(body, outBundle, "data");
@@ -313,7 +313,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::simple_node * node)
       Connect(body, outData, result);
     }
   }
-  else if (auto op = dynamic_cast<const llvm::GetElementPtrOperation *>(&(node->operation())))
+  else if (auto op = dynamic_cast<const llvm::GetElementPtrOperation *>(&(node->GetOperation())))
   {
     // Start of with base pointer
     auto input0 = GetSubfield(body, inBundles[0], "data");
@@ -348,13 +348,14 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::simple_node * node)
     auto asUInt = AddAsUIntOp(body, result);
     Connect(body, outData, AddBitsOp(body, asUInt, GetPointerSizeInBits() - 1, 0));
   }
-  else if (dynamic_cast<const llvm::UndefValueOperation *>(&(node->operation())))
+  else if (dynamic_cast<const llvm::UndefValueOperation *>(&(node->GetOperation())))
   {
     Connect(body, outData, GetConstant(body, 1, 0));
   }
   else
   {
-    throw std::logic_error("Simple node " + node->operation().debug_string() + " not implemented!");
+    throw std::logic_error(
+        "Simple node " + node->GetOperation().debug_string() + " not implemented!");
   }
 
   // Generate the output valid signal
@@ -466,7 +467,7 @@ RhlsToFirrtlConverter::MlirGenLoopConstBuffer(const jlm::rvsdg::simple_node * no
 circt::firrtl::FModuleOp
 RhlsToFirrtlConverter::MlirGenFork(const jlm::rvsdg::simple_node * node)
 {
-  auto op = dynamic_cast<const jlm::hls::fork_op *>(&node->operation());
+  auto op = dynamic_cast<const jlm::hls::fork_op *>(&node->GetOperation());
   bool isConstant = op->IsConstant();
   // Create the module and its input/output ports
   auto module = nodeToModule(node);
@@ -744,7 +745,7 @@ RhlsToFirrtlConverter::MlirGenHlsMemReq(const jlm::rvsdg::simple_node * node)
   // Create the module and its input/output ports
   auto module = nodeToModule(node, false);
   auto body = module.getBodyBlock();
-  auto op = dynamic_cast<const mem_req_op *>(&node->operation());
+  auto op = dynamic_cast<const mem_req_op *>(&node->GetOperation());
 
   auto loadTypes = op->GetLoadTypes();
   ::llvm::SmallVector<circt::firrtl::SubfieldOp> loadAddrReadys;
@@ -907,8 +908,8 @@ RhlsToFirrtlConverter::MlirGenHlsLoad(const jlm::rvsdg::simple_node * node)
   auto module = nodeToModule(node, false);
   auto body = module.getBodyBlock();
 
-  auto load = dynamic_cast<const load_op *>(&(node->operation()));
-  auto local_load = dynamic_cast<const local_load_op *>(&(node->operation()));
+  auto load = dynamic_cast<const load_op *>(&(node->GetOperation()));
+  auto local_load = dynamic_cast<const local_load_op *>(&(node->GetOperation()));
   JLM_ASSERT(load || local_load);
 
   // Input signals
@@ -1082,7 +1083,7 @@ RhlsToFirrtlConverter::MlirGenHlsDLoad(const jlm::rvsdg::simple_node * node)
   auto module = nodeToModule(node, false);
   auto body = module.getBodyBlock();
 
-  auto load = dynamic_cast<const decoupled_load_op *>(&(node->operation()));
+  auto load = dynamic_cast<const decoupled_load_op *>(&(node->GetOperation()));
   JLM_ASSERT(load);
 
   // Input signals
@@ -1125,13 +1126,13 @@ RhlsToFirrtlConverter::MlirGenHlsDLoad(const jlm::rvsdg::simple_node * node)
 circt::firrtl::FModuleOp
 RhlsToFirrtlConverter::MlirGenHlsLocalMem(const jlm::rvsdg::simple_node * node)
 {
-  auto lmem_op = dynamic_cast<const local_mem_op *>(&(node->operation()));
+  auto lmem_op = dynamic_cast<const local_mem_op *>(&(node->GetOperation()));
   JLM_ASSERT(lmem_op);
   auto res_node = rvsdg::input::GetNode(**node->output(0)->begin());
-  auto res_op = dynamic_cast<const local_mem_resp_op *>(&res_node->operation());
+  auto res_op = dynamic_cast<const local_mem_resp_op *>(&res_node->GetOperation());
   JLM_ASSERT(res_op);
   auto req_node = rvsdg::input::GetNode(**node->output(1)->begin());
-  auto req_op = dynamic_cast<const local_mem_req_op *>(&req_node->operation());
+  auto req_op = dynamic_cast<const local_mem_req_op *>(&req_node->GetOperation());
   JLM_ASSERT(req_op);
   // Create the module and its input/output ports - we use a non-standard way here
   // Generate a vector with all inputs and outputs of the module
@@ -1338,8 +1339,8 @@ RhlsToFirrtlConverter::MlirGenHlsStore(const jlm::rvsdg::simple_node * node)
   auto module = nodeToModule(node, false);
   auto body = module.getBodyBlock();
 
-  auto store = dynamic_cast<const store_op *>(&(node->operation()));
-  auto local_store = dynamic_cast<const local_store_op *>(&(node->operation()));
+  auto store = dynamic_cast<const store_op *>(&(node->GetOperation()));
+  auto local_store = dynamic_cast<const local_store_op *>(&(node->GetOperation()));
   JLM_ASSERT(store || local_store);
 
   // Input signals
@@ -1482,8 +1483,8 @@ RhlsToFirrtlConverter::MlirGenMem(const jlm::rvsdg::simple_node * node)
   auto module = nodeToModule(node, true);
   auto body = module.getBodyBlock();
 
-  // Check if it's a load or store operation
-  bool store = dynamic_cast<const llvm::StoreNonVolatileOperation *>(&(node->operation()));
+  // Check if it's a load or store GetOperation
+  bool store = dynamic_cast<const llvm::StoreNonVolatileOperation *>(&(node->GetOperation()));
 
   InitializeMemReq(module);
   // Input signals
@@ -1745,7 +1746,7 @@ RhlsToFirrtlConverter::MlirGenPrint(const jlm::rvsdg::simple_node * node)
   auto outBundle = GetOutPort(module, 0);
   Connect(body, outBundle, inBundle);
   auto trigger = AddAndOp(body, AddAndOp(body, inReady, inValid), AddNotOp(body, reset));
-  auto pn = dynamic_cast<const print_op *>(&node->operation());
+  auto pn = dynamic_cast<const print_op *>(&node->GetOperation());
   auto formatString = "print node " + std::to_string(pn->id()) + ": %x\n";
   auto name = "print_node_" + std::to_string(pn->id());
   auto printValue = AddPadOp(body, inData, 64);
@@ -1833,7 +1834,7 @@ RhlsToFirrtlConverter::MlirGenBuffer(const jlm::rvsdg::simple_node * node)
   auto module = nodeToModule(node);
   auto body = module.getBodyBlock();
 
-  auto op = dynamic_cast<const hls::buffer_op *>(&(node->operation()));
+  auto op = dynamic_cast<const hls::buffer_op *>(&(node->GetOperation()));
   auto capacity = op->capacity;
 
   auto clock = GetClockSignal(module);
@@ -1973,7 +1974,7 @@ RhlsToFirrtlConverter::MlirGenAddrQueue(const jlm::rvsdg::simple_node * node)
   auto module = nodeToModule(node);
   auto body = module.getBodyBlock();
 
-  auto op = dynamic_cast<const hls::addr_queue_op *>(&(node->operation()));
+  auto op = dynamic_cast<const hls::addr_queue_op *>(&(node->GetOperation()));
   auto capacity = op->capacity;
 
   auto clock = GetClockSignal(module);
@@ -2370,90 +2371,90 @@ RhlsToFirrtlConverter::MlirGenBranch(const jlm::rvsdg::simple_node * node)
 circt::firrtl::FModuleOp
 RhlsToFirrtlConverter::MlirGen(const jlm::rvsdg::simple_node * node)
 {
-  if (dynamic_cast<const hls::sink_op *>(&(node->operation())))
+  if (dynamic_cast<const hls::sink_op *>(&(node->GetOperation())))
   {
     return MlirGenSink(node);
   }
-  else if (dynamic_cast<const hls::fork_op *>(&(node->operation())))
+  else if (dynamic_cast<const hls::fork_op *>(&(node->GetOperation())))
   {
     return MlirGenFork(node);
   }
-  else if (dynamic_cast<const hls::loop_constant_buffer_op *>(&(node->operation())))
+  else if (dynamic_cast<const hls::loop_constant_buffer_op *>(&(node->GetOperation())))
   {
     return MlirGenLoopConstBuffer(node);
-    //	} else if (dynamic_cast<const jlm::LoadOperation *>(&(node->operation()))) {
+    //	} else if (dynamic_cast<const jlm::LoadOperation *>(&(node->GetOperation()))) {
     //		return MlirGenMem(node);
-    //	} else if (dynamic_cast<const jlm::StoreOperation *>(&(node->operation()))) {
+    //	} else if (dynamic_cast<const jlm::StoreOperation *>(&(node->GetOperati()))) {
     //		return MlirGenMem(node);
   }
-  else if (dynamic_cast<const hls::load_op *>(&(node->operation())))
+  else if (dynamic_cast<const hls::load_op *>(&(node->GetOperation())))
   {
     return MlirGenHlsLoad(node);
   }
-  else if (dynamic_cast<const hls::decoupled_load_op *>(&(node->operation())))
+  else if (dynamic_cast<const hls::decoupled_load_op *>(&(node->GetOperation())))
   {
     return MlirGenHlsDLoad(node);
   }
-  else if (dynamic_cast<const hls::store_op *>(&(node->operation())))
+  else if (dynamic_cast<const hls::store_op *>(&(node->GetOperation())))
   {
     return MlirGenHlsStore(node);
   }
-  else if (dynamic_cast<const hls::local_load_op *>(&(node->operation())))
+  else if (dynamic_cast<const hls::local_load_op *>(&(node->GetOperation())))
   {
     // same as normal load for now, but with index instead of address
     return MlirGenHlsLoad(node);
   }
-  else if (dynamic_cast<const hls::local_store_op *>(&(node->operation())))
+  else if (dynamic_cast<const hls::local_store_op *>(&(node->GetOperation())))
   {
     // same as normal store for now, but with index instead of address
     return MlirGenHlsStore(node);
   }
-  else if (dynamic_cast<const hls::local_mem_op *>(&(node->operation())))
+  else if (dynamic_cast<const hls::local_mem_op *>(&(node->GetOperation())))
   {
     return MlirGenHlsLocalMem(node);
   }
-  else if (dynamic_cast<const hls::mem_resp_op *>(&(node->operation())))
+  else if (dynamic_cast<const hls::mem_resp_op *>(&(node->GetOperation())))
   {
     return MlirGenHlsMemResp(node);
   }
-  else if (dynamic_cast<const hls::mem_req_op *>(&(node->operation())))
+  else if (dynamic_cast<const hls::mem_req_op *>(&(node->GetOperation())))
   {
     return MlirGenHlsMemReq(node);
   }
-  else if (dynamic_cast<const hls::predicate_buffer_op *>(&(node->operation())))
+  else if (dynamic_cast<const hls::predicate_buffer_op *>(&(node->GetOperation())))
   {
     return MlirGenPredicationBuffer(node);
   }
-  else if (dynamic_cast<const hls::buffer_op *>(&(node->operation())))
+  else if (dynamic_cast<const hls::buffer_op *>(&(node->GetOperation())))
   {
     return MlirGenBuffer(node);
   }
-  else if (dynamic_cast<const hls::branch_op *>(&(node->operation())))
+  else if (dynamic_cast<const hls::branch_op *>(&(node->GetOperation())))
   {
     return MlirGenBranch(node);
   }
-  else if (dynamic_cast<const hls::trigger_op *>(&(node->operation())))
+  else if (dynamic_cast<const hls::trigger_op *>(&(node->GetOperation())))
   {
     return MlirGenTrigger(node);
   }
-  else if (dynamic_cast<const hls::state_gate_op *>(&(node->operation())))
+  else if (dynamic_cast<const hls::state_gate_op *>(&(node->GetOperation())))
   {
     return MlirGenStateGate(node);
   }
-  else if (dynamic_cast<const hls::print_op *>(&(node->operation())))
+  else if (dynamic_cast<const hls::print_op *>(&(node->GetOperation())))
   {
     return MlirGenPrint(node);
   }
-  else if (dynamic_cast<const hls::addr_queue_op *>(&(node->operation())))
+  else if (dynamic_cast<const hls::addr_queue_op *>(&(node->GetOperation())))
   {
     return MlirGenAddrQueue(node);
   }
-  else if (dynamic_cast<const hls::merge_op *>(&(node->operation())))
+  else if (dynamic_cast<const hls::merge_op *>(&(node->GetOperation())))
   {
     // return merge_to_firrtl(n);
-    throw std::logic_error(node->operation().debug_string() + " not implemented!");
+    throw std::logic_error(node->GetOperation().debug_string() + " not implemented!");
   }
-  else if (auto o = dynamic_cast<const hls::mux_op *>(&(node->operation())))
+  else if (auto o = dynamic_cast<const hls::mux_op *>(&(node->GetOperation())))
   {
     if (o->discarding)
     {
@@ -2615,7 +2616,7 @@ RhlsToFirrtlConverter::MlirGen(rvsdg::Region * subRegion, mlir::Block * circuitB
       {
         // Get RVSDG node of the source
         auto source = o->node();
-        if (dynamic_cast<const hls::local_mem_resp_op *>(&(source->operation())))
+        if (dynamic_cast<const local_mem_resp_op *>(&source->GetOperation()))
         {
           // Connect directly to mem
           auto mem_out = dynamic_cast<jlm::rvsdg::node_output *>(source->input(0)->origin());
@@ -2644,7 +2645,7 @@ RhlsToFirrtlConverter::MlirGen(rvsdg::Region * subRegion, mlir::Block * circuitB
       }
     }
 
-    if (dynamic_cast<const hls::local_mem_op *>(&(rvsdgNode->operation())))
+    if (dynamic_cast<const hls::local_mem_op *>(&(rvsdgNode->GetOperation())))
     {
       // hook up request port
       auto requestNode = rvsdg::input::GetNode(**rvsdgNode->output(1)->begin());
@@ -2749,8 +2750,8 @@ RhlsToFirrtlConverter::createInstances(
   {
     if (auto sn = dynamic_cast<jlm::rvsdg::simple_node *>(node))
     {
-      if (dynamic_cast<const hls::local_mem_req_op *>(&(node->operation()))
-          || dynamic_cast<const hls::local_mem_resp_op *>(&(node->operation())))
+      if (dynamic_cast<const local_mem_req_op *>(&(node->GetOperation()))
+          || dynamic_cast<const local_mem_resp_op *>(&(node->GetOperation())))
       {
         // these are virtual - connections go to local_mem instead
         continue;
@@ -2769,7 +2770,7 @@ RhlsToFirrtlConverter::createInstances(
     else
     {
       throw util::error(
-          "Unimplemented op (unexpected structural node) : " + node->operation().debug_string());
+          "Unimplemented op (unexpected structural node) : " + node->GetOperation().debug_string());
     }
   }
   return instances;
@@ -2786,7 +2787,7 @@ RhlsToFirrtlConverter::TraceStructuralOutput(rvsdg::StructuralOutput * output)
   if (!dynamic_cast<hls::loop_node *>(node))
   {
     throw std::logic_error(
-        "Expected a hls::loop_node but found: " + node->operation().debug_string());
+        "Expected a hls::loop_node but found: " + node->GetOperation().debug_string());
   }
   JLM_ASSERT(output->results.size() == 1);
   auto origin = output->results.begin().ptr()->origin();
@@ -3634,7 +3635,7 @@ RhlsToFirrtlConverter::check_module(circt::firrtl::FModuleOp & module)
         else
         {
           user->print(::llvm::outs());
-          llvm_unreachable("unexpected operation");
+          llvm_unreachable("unexpected GetOperation");
         }
       }
     }
@@ -3966,7 +3967,7 @@ RhlsToFirrtlConverter::GetModuleName(const jlm::rvsdg::node * node)
     append.append(std::to_string(JlmSize(&node->output(i)->type())));
     append.append("W");
   }
-  if (auto op = dynamic_cast<const llvm::GetElementPtrOperation *>(&node->operation()))
+  if (auto op = dynamic_cast<const llvm::GetElementPtrOperation *>(&node->GetOperation()))
   {
     const jlm::rvsdg::Type * pointeeType = &op->GetPointeeType();
     for (size_t i = 1; i < node->ninputs(); i++)
@@ -3989,7 +3990,7 @@ RhlsToFirrtlConverter::GetModuleName(const jlm::rvsdg::node * node)
       append.append(std::to_string(bytes));
     }
   }
-  if (auto op = dynamic_cast<const mem_req_op *>(&node->operation()))
+  if (auto op = dynamic_cast<const mem_req_op *>(&node->GetOperation()))
   {
     auto loadTypes = op->GetLoadTypes();
     for (size_t i = 0; i < loadTypes->size(); i++)
@@ -4012,7 +4013,7 @@ RhlsToFirrtlConverter::GetModuleName(const jlm::rvsdg::node * node)
       append.append(std::to_string(bitWidth));
     }
   }
-  if (auto op = dynamic_cast<const local_mem_op *>(&node->operation()))
+  if (auto op = dynamic_cast<const local_mem_op *>(&node->GetOperation()))
   {
     append.append("_S");
     append.append(std::to_string(
@@ -4024,7 +4025,7 @@ RhlsToFirrtlConverter::GetModuleName(const jlm::rvsdg::node * node)
     size_t stores = (rvsdg::input::GetNode(**node->output(1)->begin())->ninputs() - 1 - loads) / 2;
     append.append(std::to_string(stores));
   }
-  auto name = jlm::util::strfmt("op_", node->operation().debug_string() + append);
+  auto name = jlm::util::strfmt("op_", node->GetOperation().debug_string() + append);
   // Remove characters that are not valid in firrtl module names
   std::replace_if(name.begin(), name.end(), isForbiddenChar, '_');
   return name;

--- a/jlm/hls/backend/rhls2firrtl/base-hls.cpp
+++ b/jlm/hls/backend/rhls2firrtl/base-hls.cpp
@@ -47,7 +47,7 @@ BaseHLS::get_node_name(const jlm::rvsdg::node * node)
     append.append("_W");
     append.append(std::to_string(JlmSize(&node->output(outPorts - 1)->type())));
   }
-  auto name = util::strfmt("op_", node->operation().debug_string(), append, "_", node_map.size());
+  auto name = util::strfmt("op_", node->GetOperation().debug_string(), append, "_", node_map.size());
   // remove chars that are not valid in firrtl module names
   std::replace_if(name.begin(), name.end(), isForbiddenChar, '_');
   node_map[node] = name;
@@ -152,7 +152,7 @@ BaseHLS::create_node_names(rvsdg::Region * r)
     else
     {
       throw util::error(
-          "Unimplemented op (unexpected structural node) : " + node.operation().debug_string());
+          "Unimplemented op (unexpected structural node) : " + node.GetOperation().debug_string());
     }
   }
 }

--- a/jlm/hls/backend/rhls2firrtl/base-hls.cpp
+++ b/jlm/hls/backend/rhls2firrtl/base-hls.cpp
@@ -47,7 +47,8 @@ BaseHLS::get_node_name(const jlm::rvsdg::node * node)
     append.append("_W");
     append.append(std::to_string(JlmSize(&node->output(outPorts - 1)->type())));
   }
-  auto name = util::strfmt("op_", node->GetOperation().debug_string(), append, "_", node_map.size());
+  auto name =
+      util::strfmt("op_", node->GetOperation().debug_string(), append, "_", node_map.size());
   // remove chars that are not valid in firrtl module names
   std::replace_if(name.begin(), name.end(), isForbiddenChar, '_');
   node_map[node] = name;

--- a/jlm/hls/backend/rhls2firrtl/dot-hls.cpp
+++ b/jlm/hls/backend/rhls2firrtl/dot-hls.cpp
@@ -68,7 +68,7 @@ DotHLS::node_to_dot(const jlm::rvsdg::node * node)
 {
   auto SPACER = "                    <TD WIDTH=\"10\"></TD>\n";
   auto name = get_node_name(node);
-  auto opname = node->operation().debug_string();
+  auto opname = node->GetOperation().debug_string();
   std::replace_if(opname.begin(), opname.end(), isForbiddenChar, '_');
 
   std::string inputs;
@@ -240,7 +240,7 @@ DotHLS::loop_to_dot(hls::loop_node * ln)
     else
     {
       throw jlm::util::error(
-          "Unimplemented op (unexpected structural node) : " + node->operation().debug_string());
+          "Unimplemented op (unexpected structural node) : " + node->GetOperation().debug_string());
     }
   }
 
@@ -248,8 +248,8 @@ DotHLS::loop_to_dot(hls::loop_node * ln)
   dot << "{rank=same ";
   for (auto node : jlm::rvsdg::topdown_traverser(sr))
   {
-    auto mx = dynamic_cast<const hls::mux_op *>(&node->operation());
-    auto lc = dynamic_cast<const hls::loop_constant_buffer_op *>(&node->operation());
+    auto mx = dynamic_cast<const hls::mux_op *>(&node->GetOperation());
+    auto lc = dynamic_cast<const hls::loop_constant_buffer_op *>(&node->GetOperation());
     if ((mx && !mx->discarding && mx->loop) || lc)
     {
       dot << get_node_name(node) << " ";
@@ -260,7 +260,7 @@ DotHLS::loop_to_dot(hls::loop_node * ln)
   dot << "{rank=same ";
   for (auto node : jlm::rvsdg::topdown_traverser(sr))
   {
-    auto br = dynamic_cast<const hls::branch_op *>(&node->operation());
+    auto br = dynamic_cast<const hls::branch_op *>(&node->GetOperation());
     if (br && br->loop)
     {
       dot << get_node_name(node) << " ";
@@ -274,7 +274,7 @@ DotHLS::loop_to_dot(hls::loop_node * ln)
   {
     if (dynamic_cast<jlm::rvsdg::simple_node *>(node))
     {
-      auto mx = dynamic_cast<const hls::mux_op *>(&node->operation());
+      auto mx = dynamic_cast<const hls::mux_op *>(&node->GetOperation());
       auto node_name = get_node_name(node);
       for (size_t i = 0; i < node->ninputs(); ++i)
       {
@@ -286,7 +286,7 @@ DotHLS::loop_to_dot(hls::loop_node * ln)
                  && (/*i==0||*/ i == 2); // back_outputs.count(node->input(i)->origin());
         auto origin_out = dynamic_cast<jlm::rvsdg::node_output *>(node->input(i)->origin());
         if (origin_out
-            && dynamic_cast<const predicate_buffer_op *>(&origin_out->node()->operation()))
+            && dynamic_cast<const predicate_buffer_op *>(&origin_out->node()->GetOperation()))
         {
           //
           back = true;
@@ -322,7 +322,7 @@ DotHLS::prepare_loop_out_port(hls::loop_node * ln)
     else
     {
       throw jlm::util::error(
-          "Unimplemented op (unexpected structural node) : " + node->operation().debug_string());
+          "Unimplemented op (unexpected structural node) : " + node->GetOperation().debug_string());
     }
   }
   for (size_t i = 0; i < sr->narguments(); ++i)
@@ -414,7 +414,7 @@ DotHLS::subregion_to_dot(rvsdg::Region * sr)
     else
     {
       throw jlm::util::error(
-          "Unimplemented op (unexpected structural node) : " + node->operation().debug_string());
+          "Unimplemented op (unexpected structural node) : " + node->GetOperation().debug_string());
     }
   }
   // process results

--- a/jlm/hls/backend/rvsdg2rhls/GammaConversion.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/GammaConversion.cpp
@@ -122,7 +122,7 @@ CanGammaNodeBeSpeculative(const rvsdg::GammaNode & gammaNode)
       }
       else if (rvsdg::is<rvsdg::StructuralOperation>(&node))
       {
-        throw util::error("Unexpected structural node: " + node.operation().debug_string());
+        throw util::error("Unexpected structural node: " + node.GetOperation().debug_string());
       }
     }
   }

--- a/jlm/hls/backend/rvsdg2rhls/add-buffers.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-buffers.cpp
@@ -31,7 +31,7 @@ add_buffers(rvsdg::Region * region, bool pass_through)
         JLM_ASSERT(out->nusers() == 1);
         if (auto ni = dynamic_cast<jlm::rvsdg::node_input *>(*out->begin()))
         {
-          auto buf = dynamic_cast<const hls::buffer_op *>(&ni->node()->operation());
+          auto buf = dynamic_cast<const hls::buffer_op *>(&ni->node()->GetOperation());
           if (buf && (buf->pass_through || !pass_through))
           {
             continue;
@@ -60,7 +60,7 @@ add_buffers(rvsdg::Region * region, bool pass_through)
           JLM_ASSERT(out->nusers() == 1);
           if (auto ni = dynamic_cast<jlm::rvsdg::node_input *>(*out->begin()))
           {
-            auto buf = dynamic_cast<const hls::buffer_op *>(&ni->node()->operation());
+            auto buf = dynamic_cast<const hls::buffer_op *>(&ni->node()->GetOperation());
             if (buf && (buf->pass_through || !pass_through))
             {
               continue;

--- a/jlm/hls/backend/rvsdg2rhls/add-prints.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-prints.cpp
@@ -25,9 +25,9 @@ add_prints(rvsdg::Region * region)
         add_prints(structnode->subregion(n));
       }
     }
-    //		if (auto lo = dynamic_cast<const jlm::load_op *>(&(node->GetOperation()))) {
+    //		if (auto lo = dynamic_cast<const jlm::load_op *>(&(node->operation()))) {
     //
-    //		} else if (auto so = dynamic_cast<const jlm::store_op *>(&(node->GetOperation()))) {
+    //		} else if (auto so = dynamic_cast<const jlm::store_op *>(&(node->operation()))) {
     //			auto po = hls::print_op::create(*node->input(1)->origin())[0];
     //			node->input(1)->divert_to(po);
     //		}

--- a/jlm/hls/backend/rvsdg2rhls/add-prints.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-prints.cpp
@@ -25,9 +25,9 @@ add_prints(rvsdg::Region * region)
         add_prints(structnode->subregion(n));
       }
     }
-    //		if (auto lo = dynamic_cast<const jlm::load_op *>(&(node->operation()))) {
+    //		if (auto lo = dynamic_cast<const jlm::load_op *>(&(node->GetOperation()))) {
     //
-    //		} else if (auto so = dynamic_cast<const jlm::store_op *>(&(node->operation()))) {
+    //		} else if (auto so = dynamic_cast<const jlm::store_op *>(&(node->GetOperation()))) {
     //			auto po = hls::print_op::create(*node->input(1)->origin())[0];
     //			node->input(1)->divert_to(po);
     //		}
@@ -113,7 +113,7 @@ convert_prints(
         convert_prints(structnode->subregion(n), printf, functionType);
       }
     }
-    else if (auto po = dynamic_cast<const print_op *>(&(node->operation())))
+    else if (auto po = dynamic_cast<const print_op *>(&(node->GetOperation())))
     {
       auto printf_local = route_to_region(printf, region); // TODO: prevent repetition?
       auto bc = jlm::rvsdg::create_bitconstant(region, 64, po->id());

--- a/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
@@ -119,7 +119,7 @@ add_triggers(rvsdg::Region * region)
       }
       else
       {
-        throw jlm::util::error("Unexpected node type: " + node->operation().debug_string());
+        throw jlm::util::error("Unexpected node type: " + node->GetOperation().debug_string());
       }
     }
     else if (auto sn = dynamic_cast<jlm::rvsdg::simple_node *>(node))
@@ -138,7 +138,7 @@ add_triggers(rvsdg::Region * region)
     }
     else
     {
-      throw jlm::util::error("Unexpected node type: " + node->operation().debug_string());
+      throw jlm::util::error("Unexpected node type: " + node->GetOperation().debug_string());
     }
   }
 }

--- a/jlm/hls/backend/rvsdg2rhls/alloca-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/alloca-conv.cpp
@@ -51,16 +51,16 @@ private:
       if (auto si = dynamic_cast<jlm::rvsdg::simple_input *>(user))
       {
         auto simplenode = si->node();
-        if (dynamic_cast<const jlm::llvm::StoreNonVolatileOperation *>(&simplenode->operation()))
+        if (dynamic_cast<const jlm::llvm::StoreNonVolatileOperation *>(&simplenode->GetOperation()))
         {
           store_nodes.push_back(simplenode);
         }
         else if (dynamic_cast<const jlm::llvm::LoadNonVolatileOperation *>(
-                     &simplenode->operation()))
+                     &simplenode->GetOperation()))
         {
           load_nodes.push_back(simplenode);
         }
-        else if (dynamic_cast<const jlm::llvm::CallOperation *>(&simplenode->operation()))
+        else if (dynamic_cast<const jlm::llvm::CallOperation *>(&simplenode->GetOperation()))
         {
           // TODO: verify this is the right type of function call
           throw jlm::util::error("encountered a call for an alloca");
@@ -107,7 +107,7 @@ gep_to_index(jlm::rvsdg::output * o)
   // TODO: handle geps that are not direct predecessors
   auto no = dynamic_cast<jlm::rvsdg::node_output *>(o);
   JLM_ASSERT(no);
-  auto gep = dynamic_cast<const jlm::llvm::GetElementPtrOperation *>(&no->node()->operation());
+  auto gep = dynamic_cast<const jlm::llvm::GetElementPtrOperation *>(&no->node()->GetOperation());
   JLM_ASSERT(gep);
   // pointer to array, i.e. first index is zero
   // TODO: check
@@ -127,14 +127,14 @@ alloca_conv(rvsdg::Region * region)
         alloca_conv(structnode->subregion(n));
       }
     }
-    else if (auto po = dynamic_cast<const jlm::llvm::alloca_op *>(&(node->operation())))
+    else if (auto po = dynamic_cast<const jlm::llvm::alloca_op *>(&(node->GetOperation())))
     {
       // ensure that the size is one
       JLM_ASSERT(node->ninputs() == 1);
       auto constant_output = dynamic_cast<jlm::rvsdg::node_output *>(node->input(0)->origin());
       JLM_ASSERT(constant_output);
-      auto constant_operation =
-          dynamic_cast<const jlm::rvsdg::bitconstant_op *>(&constant_output->node()->operation());
+      auto constant_operation = dynamic_cast<const jlm::rvsdg::bitconstant_op *>(
+          &constant_output->node()->GetOperation());
       JLM_ASSERT(constant_operation);
       JLM_ASSERT(constant_operation->value().to_uint() == 1);
       // ensure that the alloca is an array type
@@ -200,7 +200,7 @@ alloca_conv(rvsdg::Region * region)
       JLM_ASSERT(node->output(1)->nusers() == 1);
       auto merge_in = *node->output(1)->begin();
       auto merge_node = rvsdg::input::GetNode(*merge_in);
-      if (dynamic_cast<const llvm::MemoryStateMergeOperation *>(&merge_node->operation()))
+      if (dynamic_cast<const llvm::MemoryStateMergeOperation *>(&merge_node->GetOperation()))
       {
         // merge after alloca -> remove merge
         JLM_ASSERT(merge_node->ninputs() == 2);

--- a/jlm/hls/backend/rvsdg2rhls/dae-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/dae-conv.cpp
@@ -379,7 +379,7 @@ process_loopnode(loop_node * loopNode)
     }
     else if (auto simplenode = dynamic_cast<jlm::rvsdg::simple_node *>(node))
     {
-      if (dynamic_cast<const load_op *>(&simplenode->operation()))
+      if (dynamic_cast<const load_op *>(&simplenode->GetOperation()))
       {
         // can currently only generate dae one loop deep
         // find load slice within loop - three slices - complete, data and state-edge
@@ -398,14 +398,14 @@ process_loopnode(loop_node * loopNode)
             break;
           }
           else if (
-              dynamic_cast<const load_op *>(&sn->operation())
-              || dynamic_cast<const store_op *>(&sn->operation()))
+              dynamic_cast<const load_op *>(&sn->GetOperation())
+              || dynamic_cast<const store_op *>(&sn->GetOperation()))
           {
             // data slice may not contain loads or stores - this includes node
             can_decouple = false;
             break;
           }
-          else if (dynamic_cast<const decoupled_load_op *>(&sn->operation()))
+          else if (dynamic_cast<const decoupled_load_op *>(&sn->GetOperation()))
           {
             // decoupled load has to be exclusive to load slice - e.g. not needed once load slice is
             // removed
@@ -426,8 +426,8 @@ process_loopnode(loop_node * loopNode)
             break;
           }
           else if (
-              dynamic_cast<const load_op *>(&sn->operation())
-              || dynamic_cast<const store_op *>(&sn->operation()))
+              dynamic_cast<const load_op *>(&sn->GetOperation())
+              || dynamic_cast<const store_op *>(&sn->GetOperation()))
           {
             // state slice may not contain loads or stores except for node
             if (sn != dynamic_cast<jlm::rvsdg::node *>(simplenode))
@@ -436,7 +436,7 @@ process_loopnode(loop_node * loopNode)
               break;
             }
           }
-          else if (dynamic_cast<const decoupled_load_op *>(&sn->operation()))
+          else if (dynamic_cast<const decoupled_load_op *>(&sn->GetOperation()))
           {
             // decoupled load has to be exclusive to load slice - e.g. not needed once load slice is
             // removed

--- a/jlm/hls/backend/rvsdg2rhls/distribute-constants.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/distribute-constants.cpp
@@ -96,19 +96,19 @@ hls::distribute_constants(rvsdg::Region * region)
       }
       else
       {
-        throw util::error("Unexpected node type: " + node->operation().debug_string());
+        throw util::error("Unexpected node type: " + node->GetOperation().debug_string());
       }
     }
     else if (auto sn = dynamic_cast<rvsdg::simple_node *>(node))
     {
       if (is_constant(node))
       {
-        distribute_constant(sn->operation(), sn->output(0));
+        distribute_constant(sn->GetOperation(), sn->output(0));
       }
     }
     else
     {
-      throw util::error("Unexpected node type: " + node->operation().debug_string());
+      throw util::error("Unexpected node type: " + node->GetOperation().debug_string());
     }
   }
 }

--- a/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
@@ -224,7 +224,7 @@ instrument_ref(
           { addr, size, ioState, memstate });
       for (auto ou : old_users)
       {
-        // Divert the memory state of the load to the new memstate from the call GetOperation
+        // Divert the memory state of the load to the new memstate from the call operation
         ou->divert_to(callOp[1]);
       }
     }
@@ -257,7 +257,7 @@ instrument_ref(
           store_func,
           storeFunctionType,
           { addr, data, width, ioState, memstate });
-      // Divert the memory state of the load to the new memstate from the call GetOperation
+      // Divert the memory state of the load to the new memstate from the call operation
       node->input(2)->divert_to(callOp[1]);
     }
   }

--- a/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
@@ -172,7 +172,7 @@ instrument_ref(
     }
     else if (
         auto loadOp =
-            dynamic_cast<const jlm::llvm::LoadNonVolatileOperation *>(&(node->operation())))
+            dynamic_cast<const jlm::llvm::LoadNonVolatileOperation *>(&(node->GetOperation())))
     {
       auto addr = node->input(0)->origin();
       JLM_ASSERT(dynamic_cast<const jlm::llvm::PointerType *>(&addr->type()));
@@ -190,17 +190,17 @@ instrument_ref(
           load_func,
           loadFunctionType,
           { addr, width, ioState, memstate });
-      // Divert the memory state of the load to the new memstate from the call operation
+      // Divert the memory state of the load to the new memstate from the call GetOperation
       node->input(1)->divert_to(callOp[1]);
     }
-    else if (auto ao = dynamic_cast<const jlm::llvm::alloca_op *>(&(node->operation())))
+    else if (auto ao = dynamic_cast<const jlm::llvm::alloca_op *>(&(node->GetOperation())))
     {
       // ensure that the size is one
       JLM_ASSERT(node->ninputs() == 1);
       auto constant_output = dynamic_cast<jlm::rvsdg::node_output *>(node->input(0)->origin());
       JLM_ASSERT(constant_output);
       auto constant_operation =
-          dynamic_cast<const jlm::rvsdg::bitconstant_op *>(&constant_output->node()->operation());
+          dynamic_cast<const jlm::rvsdg::bitconstant_op *>(&constant_output->node()->GetOperation());
       JLM_ASSERT(constant_operation);
       JLM_ASSERT(constant_operation->value().to_uint() == 1);
       jlm::rvsdg::output * addr = node->output(0);
@@ -224,12 +224,12 @@ instrument_ref(
           { addr, size, ioState, memstate });
       for (auto ou : old_users)
       {
-        // Divert the memory state of the load to the new memstate from the call operation
+        // Divert the memory state of the load to the new memstate from the call GetOperation
         ou->divert_to(callOp[1]);
       }
     }
     else if (
-        auto so = dynamic_cast<const jlm::llvm::StoreNonVolatileOperation *>(&(node->operation())))
+        auto so = dynamic_cast<const jlm::llvm::StoreNonVolatileOperation *>(&(node->GetOperation())))
     {
       auto addr = node->input(0)->origin();
       JLM_ASSERT(dynamic_cast<const jlm::llvm::PointerType *>(&addr->type()));
@@ -256,7 +256,7 @@ instrument_ref(
           store_func,
           storeFunctionType,
           { addr, data, width, ioState, memstate });
-      // Divert the memory state of the load to the new memstate from the call operation
+      // Divert the memory state of the load to the new memstate from the call GetOperation
       node->input(2)->divert_to(callOp[1]);
     }
   }

--- a/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
@@ -190,7 +190,7 @@ instrument_ref(
           load_func,
           loadFunctionType,
           { addr, width, ioState, memstate });
-      // Divert the memory state of the load to the new memstate from the call GetOperation
+      // Divert the memory state of the load to the new memstate from the call operation
       node->input(1)->divert_to(callOp[1]);
     }
     else if (auto ao = dynamic_cast<const jlm::llvm::alloca_op *>(&(node->GetOperation())))

--- a/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
@@ -199,8 +199,8 @@ instrument_ref(
       JLM_ASSERT(node->ninputs() == 1);
       auto constant_output = dynamic_cast<jlm::rvsdg::node_output *>(node->input(0)->origin());
       JLM_ASSERT(constant_output);
-      auto constant_operation =
-          dynamic_cast<const jlm::rvsdg::bitconstant_op *>(&constant_output->node()->GetOperation());
+      auto constant_operation = dynamic_cast<const jlm::rvsdg::bitconstant_op *>(
+          &constant_output->node()->GetOperation());
       JLM_ASSERT(constant_operation);
       JLM_ASSERT(constant_operation->value().to_uint() == 1);
       jlm::rvsdg::output * addr = node->output(0);
@@ -229,7 +229,8 @@ instrument_ref(
       }
     }
     else if (
-        auto so = dynamic_cast<const jlm::llvm::StoreNonVolatileOperation *>(&(node->GetOperation())))
+        auto so =
+            dynamic_cast<const jlm::llvm::StoreNonVolatileOperation *>(&(node->GetOperation())))
     {
       auto addr = node->input(0)->origin();
       JLM_ASSERT(dynamic_cast<const jlm::llvm::PointerType *>(&addr->type()));

--- a/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
@@ -444,7 +444,7 @@ TracePointer(
 /**
  * Decoupled loads are user specified and encoded as function calls that need special treatment.
  * This function traces the output to all nodes and checks if it is the first argument to a call
- * GetOperation.
+ * operation.
  * @param output The output to check if it is a function pointer
  * @param visited A set of already visited outputs (nodes)
  * @return True if the output is a function pointer
@@ -481,7 +481,7 @@ IsDecoupledFunctionPointer(
       {
         if (simpleNode->input(0)->origin() == output)
         {
-          // The output is the first argument to a call GetOperation so this is a function pointer.
+          // The output is the first argument to a call operation so this is a function pointer.
           // TODO
           // Currently, we only support decoupled load functions, so all other functions should
           // have bene inlined by now. Maybe a check that this is truly a decoupled load function

--- a/jlm/hls/backend/rvsdg2rhls/mem-sep.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-sep.cpp
@@ -78,11 +78,11 @@ gather_mem_nodes(rvsdg::Region * region, std::vector<jlm::rvsdg::simple_node *> 
     }
     else if (auto simplenode = dynamic_cast<jlm::rvsdg::simple_node *>(node))
     {
-      if (dynamic_cast<const jlm::llvm::StoreNonVolatileOperation *>(&simplenode->operation()))
+      if (dynamic_cast<const llvm::StoreNonVolatileOperation *>(&simplenode->GetOperation()))
       {
         mem_nodes.push_back(simplenode);
       }
-      else if (dynamic_cast<const jlm::llvm::LoadNonVolatileOperation *>(&simplenode->operation()))
+      else if (dynamic_cast<const llvm::LoadNonVolatileOperation *>(&simplenode->GetOperation()))
       {
         mem_nodes.push_back(simplenode);
       }
@@ -223,7 +223,7 @@ trace_edge(
     else if (auto si = dynamic_cast<jlm::rvsdg::simple_input *>(user))
     {
       auto sn = si->node();
-      auto op = &si->node()->operation();
+      auto op = &si->node()->GetOperation();
       if (dynamic_cast<const jlm::llvm::StoreNonVolatileOperation *>(op))
       {
         JLM_ASSERT(sn->noutputs() == 1);

--- a/jlm/hls/backend/rvsdg2rhls/memstate-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/memstate-conv.cpp
@@ -36,8 +36,10 @@ memstate_conv(rvsdg::Region * region)
     }
     else if (auto simplenode = dynamic_cast<jlm::rvsdg::simple_node *>(node))
     {
-      if (dynamic_cast<const llvm::LambdaEntryMemoryStateSplitOperation *>(&simplenode->operation())
-          || dynamic_cast<const jlm::llvm::MemoryStateSplitOperation *>(&simplenode->operation()))
+      if (dynamic_cast<const llvm::LambdaEntryMemoryStateSplitOperation *>(
+              &simplenode->GetOperation())
+          || dynamic_cast<const jlm::llvm::MemoryStateSplitOperation *>(
+              &simplenode->GetOperation()))
       {
         auto new_outs =
             hls::fork_op::create(simplenode->noutputs(), *simplenode->input(0)->origin());

--- a/jlm/hls/backend/rvsdg2rhls/merge-gamma.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/merge-gamma.cpp
@@ -37,7 +37,7 @@ eliminate_gamma_ctl(rvsdg::GammaNode * gamma)
         auto r = gamma->subregion(j)->result(i);
         if (auto so = dynamic_cast<rvsdg::simple_output *>(r->origin()))
         {
-          if (auto ctl = dynamic_cast<const rvsdg::ctlconstant_op *>(&so->node()->operation()))
+          if (auto ctl = dynamic_cast<const rvsdg::ctlconstant_op *>(&so->node()->GetOperation()))
           {
             if (j == ctl->value().alternative())
             {
@@ -82,7 +82,7 @@ fix_match_inversion(rvsdg::GammaNode * old_gamma)
         auto r = old_gamma->subregion(j)->result(i);
         if (auto so = dynamic_cast<rvsdg::simple_output *>(r->origin()))
         {
-          if (auto ctl = dynamic_cast<const rvsdg::ctlconstant_op *>(&so->node()->operation()))
+          if (auto ctl = dynamic_cast<const rvsdg::ctlconstant_op *>(&so->node()->GetOperation()))
           {
             if (j != ctl->value().alternative())
             {
@@ -104,7 +104,7 @@ fix_match_inversion(rvsdg::GammaNode * old_gamma)
     {
       return false;
     }
-    if (auto match = dynamic_cast<const rvsdg::match_op *>(&no->node()->operation()))
+    if (auto match = dynamic_cast<const rvsdg::match_op *>(&no->node()->GetOperation()))
     {
       if (match->nalternatives() == 2)
       {

--- a/jlm/hls/backend/rvsdg2rhls/remove-redundant-buf.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/remove-redundant-buf.cpp
@@ -16,15 +16,15 @@ eliminate_buf(jlm::rvsdg::output * o)
   if (auto so = dynamic_cast<jlm::rvsdg::simple_output *>(o))
   {
     auto node = so->node();
-    if (dynamic_cast<const branch_op *>(&node->operation()))
+    if (dynamic_cast<const branch_op *>(&node->GetOperation()))
     {
       return eliminate_buf(node->input(1)->origin());
     }
-    else if (dynamic_cast<const local_load_op *>(&node->operation()))
+    else if (dynamic_cast<const local_load_op *>(&node->GetOperation()))
     {
       return true;
     }
-    else if (dynamic_cast<const local_store_op *>(&node->operation()))
+    else if (dynamic_cast<const local_store_op *>(&node->GetOperation()))
     {
       return true;
     }
@@ -46,7 +46,7 @@ remove_redundant_buf(rvsdg::Region * region)
     }
     else if (dynamic_cast<jlm::rvsdg::simple_node *>(node))
     {
-      if (auto buf = dynamic_cast<const buffer_op *>(&node->operation()))
+      if (auto buf = dynamic_cast<const buffer_op *>(&node->GetOperation()))
       {
         if (std::dynamic_pointer_cast<const jlm::llvm::MemoryStateType>(buf->argument(0)))
         {

--- a/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
@@ -46,7 +46,7 @@ remove_unused_state(rvsdg::Region * region, bool can_remove_arguments)
   {
     if (auto simplenode = dynamic_cast<jlm::rvsdg::simple_node *>(node))
     {
-      if (dynamic_cast<const llvm::LambdaExitMemoryStateMergeOperation *>(&node->operation()))
+      if (dynamic_cast<const llvm::LambdaExitMemoryStateMergeOperation *>(&node->GetOperation()))
       {
         std::vector<jlm::rvsdg::output *> nv;
         for (size_t i = 0; i < simplenode->ninputs(); ++i)
@@ -54,7 +54,7 @@ remove_unused_state(rvsdg::Region * region, bool can_remove_arguments)
           if (auto so = dynamic_cast<jlm::rvsdg::simple_output *>(simplenode->input(i)->origin()))
           {
             if (dynamic_cast<const llvm::LambdaEntryMemoryStateSplitOperation *>(
-                    &so->node()->operation()))
+                    &so->node()->GetOperation()))
             {
               // skip things coming from entry
               continue;
@@ -68,7 +68,7 @@ remove_unused_state(rvsdg::Region * region, bool can_remove_arguments)
           auto entry_node =
               dynamic_cast<jlm::rvsdg::node_output *>(simplenode->input(0)->origin())->node();
           JLM_ASSERT(dynamic_cast<const llvm::LambdaEntryMemoryStateSplitOperation *>(
-              &entry_node->operation()));
+              &entry_node->GetOperation()));
           simplenode->output(0)->divert_users(entry_node->input(0)->origin());
           remove(simplenode);
           remove(entry_node);
@@ -80,7 +80,8 @@ remove_unused_state(rvsdg::Region * region, bool can_remove_arguments)
           remove(simplenode);
         }
       }
-      else if (dynamic_cast<const llvm::LambdaEntryMemoryStateSplitOperation *>(&node->operation()))
+      else if (dynamic_cast<const llvm::LambdaEntryMemoryStateSplitOperation *>(
+                   &node->GetOperation()))
       {
         std::vector<jlm::rvsdg::output *> nv;
         for (size_t i = 0; i < simplenode->noutputs(); ++i)

--- a/jlm/hls/backend/rvsdg2rhls/rhls-dne.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rhls-dne.cpp
@@ -128,7 +128,7 @@ remove_unused_loop_inputs(loop_node * ln)
 bool
 dead_spec_gamma(jlm::rvsdg::node * dmux_node)
 {
-  auto mux_op = dynamic_cast<const jlm::hls::mux_op *>(&dmux_node->operation());
+  auto mux_op = dynamic_cast<const jlm::hls::mux_op *>(&dmux_node->GetOperation());
   JLM_ASSERT(mux_op);
   JLM_ASSERT(mux_op->discarding);
   // check if all inputs have the same origin
@@ -154,7 +154,7 @@ dead_spec_gamma(jlm::rvsdg::node * dmux_node)
 bool
 dead_nonspec_gamma(jlm::rvsdg::node * ndmux_node)
 {
-  auto mux_op = dynamic_cast<const jlm::hls::mux_op *>(&ndmux_node->operation());
+  auto mux_op = dynamic_cast<const hls::mux_op *>(&ndmux_node->GetOperation());
   JLM_ASSERT(mux_op);
   JLM_ASSERT(!mux_op->discarding);
   // check if all inputs go to outputs of same branch
@@ -164,7 +164,7 @@ dead_nonspec_gamma(jlm::rvsdg::node * ndmux_node)
   {
     if (auto no = dynamic_cast<jlm::rvsdg::node_output *>(ndmux_node->input(i)->origin()))
     {
-      if (dynamic_cast<const branch_op *>(&no->node()->operation()) && no->nusers() == 1)
+      if (dynamic_cast<const branch_op *>(&no->node()->GetOperation()) && no->nusers() == 1)
       {
         if (i == 1)
         {
@@ -195,7 +195,7 @@ dead_nonspec_gamma(jlm::rvsdg::node * ndmux_node)
 bool
 dead_loop(jlm::rvsdg::node * ndmux_node)
 {
-  auto mux_op = dynamic_cast<const jlm::hls::mux_op *>(&ndmux_node->operation());
+  auto mux_op = dynamic_cast<const hls::mux_op *>(&ndmux_node->GetOperation());
   JLM_ASSERT(mux_op);
   JLM_ASSERT(!mux_op->discarding);
   // origin is a backedege argument
@@ -210,7 +210,7 @@ dead_loop(jlm::rvsdg::node * ndmux_node)
     return false;
   }
   auto branch_in = dynamic_cast<jlm::rvsdg::node_input *>(*ndmux_node->output(0)->begin());
-  if (!branch_in || !dynamic_cast<const branch_op *>(&branch_in->node()->operation()))
+  if (!branch_in || !dynamic_cast<const branch_op *>(&branch_in->node()->GetOperation()))
   {
     return false;
   }
@@ -220,7 +220,7 @@ dead_loop(jlm::rvsdg::node * ndmux_node)
     return false;
   }
   auto buf_in = dynamic_cast<jlm::rvsdg::node_input *>(*branch_in->node()->output(1)->begin());
-  if (!buf_in || !dynamic_cast<const buffer_op *>(&buf_in->node()->operation()))
+  if (!buf_in || !dynamic_cast<const buffer_op *>(&buf_in->node()->GetOperation()))
   {
     return false;
   }
@@ -234,14 +234,14 @@ dead_loop(jlm::rvsdg::node * ndmux_node)
   auto branch_cond_origin = branch_in->node()->input(0)->origin();
   auto pred_buf_out = dynamic_cast<jlm::rvsdg::node_output *>(ndmux_node->input(0)->origin());
   if (!pred_buf_out
-      || !dynamic_cast<const predicate_buffer_op *>(&pred_buf_out->node()->operation()))
+      || !dynamic_cast<const predicate_buffer_op *>(&pred_buf_out->node()->GetOperation()))
   {
     return false;
   }
   auto pred_buf_cond_origin = pred_buf_out->node()->input(0)->origin();
   // TODO: remove this once predicate buffers decouple combinatorial loops
   auto extra_buf_out = dynamic_cast<jlm::rvsdg::node_output *>(pred_buf_cond_origin);
-  if (!extra_buf_out || !dynamic_cast<const buffer_op *>(&extra_buf_out->node()->operation()))
+  if (!extra_buf_out || !dynamic_cast<const buffer_op *>(&extra_buf_out->node()->GetOperation()))
   {
     return false;
   }
@@ -279,16 +279,16 @@ dne(rvsdg::Region * sr)
     {
       if (!node->has_users())
       {
-        if (dynamic_cast<const mem_req_op *>(&node->operation()))
+        if (dynamic_cast<const mem_req_op *>(&node->GetOperation()))
         {
           // TODO: fix this once memory connections are explicit
           continue;
         }
-        else if (dynamic_cast<const local_mem_req_op *>(&node->operation()))
+        else if (dynamic_cast<const local_mem_req_op *>(&node->GetOperation()))
         {
           continue;
         }
-        else if (dynamic_cast<const local_mem_resp_op *>(&node->operation()))
+        else if (dynamic_cast<const local_mem_resp_op *>(&node->GetOperation()))
         {
           // TODO: fix - this scenario has only stores and should just be optimized away completely
           continue;
@@ -304,7 +304,7 @@ dne(rvsdg::Region * sr)
         changed |= remove_loop_passthrough(ln);
         changed |= dne(ln->subregion());
       }
-      else if (auto mux = dynamic_cast<const jlm::hls::mux_op *>(&node->operation()))
+      else if (auto mux = dynamic_cast<const mux_op *>(&node->GetOperation()))
       {
         if (mux->discarding)
         {

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -145,7 +145,7 @@ inline_calls(rvsdg::Region * region)
         inline_calls(structnode->subregion(n));
       }
     }
-    else if (dynamic_cast<const llvm::CallOperation *>(&(node->operation())))
+    else if (dynamic_cast<const llvm::CallOperation *>(&(node->GetOperation())))
     {
       auto traced = jlm::hls::trace_call(node->input(0));
       auto so = dynamic_cast<const rvsdg::StructuralOutput *>(traced);
@@ -187,7 +187,7 @@ convert_alloca(rvsdg::Region * region)
         convert_alloca(structnode->subregion(n));
       }
     }
-    else if (auto po = dynamic_cast<const llvm::alloca_op *>(&(node->operation())))
+    else if (auto po = dynamic_cast<const llvm::alloca_op *>(&(node->GetOperation())))
     {
       auto rr = region->graph()->root();
       auto delta_name = jlm::util::strfmt("hls_alloca_", alloca_cnt++);
@@ -220,7 +220,7 @@ convert_alloca(rvsdg::Region * region)
       JLM_ASSERT(node->output(1)->nusers() == 1);
       auto mux_in = *node->output(1)->begin();
       auto mux_node = rvsdg::input::GetNode(*mux_in);
-      if (dynamic_cast<const llvm::MemoryStateMergeOperation *>(&mux_node->operation()))
+      if (dynamic_cast<const llvm::MemoryStateMergeOperation *>(&mux_node->GetOperation()))
       {
         // merge after alloca -> remove merge
         JLM_ASSERT(mux_node->ninputs() == 2);
@@ -379,7 +379,7 @@ split_hls_function(llvm::RvsdgModule & rm, const std::string & function_name)
         }
         else
         {
-          throw jlm::util::error("Unsupported node type: " + orig_node->operation().debug_string());
+          throw util::error("Unsupported node type: " + orig_node->GetOperation().debug_string());
         }
       }
       // copy function into rhls

--- a/jlm/hls/opt/cne.cpp
+++ b/jlm/hls/opt/cne.cpp
@@ -247,7 +247,7 @@ congruent(jlm::rvsdg::output * o1, jlm::rvsdg::output * o2, vset & vs, cnectx & 
   }
 
   if (jlm::rvsdg::is<SimpleOperation>(n1) && jlm::rvsdg::is<SimpleOperation>(n2)
-      && n1->operation() == n2->operation() && n1->ninputs() == n2->ninputs()
+      && n1->GetOperation() == n2->GetOperation() && n1->ninputs() == n2->ninputs()
       && o1->index() == o2->index())
   {
     for (size_t n = 0; n < n1->ninputs(); n++)
@@ -292,7 +292,7 @@ mark(jlm::rvsdg::Region *, cnectx &);
 static void
 mark_gamma(const rvsdg::StructuralNode * node, cnectx & ctx)
 {
-  JLM_ASSERT(rvsdg::is<rvsdg::GammaOperation>(node->operation()));
+  JLM_ASSERT(rvsdg::is<rvsdg::GammaOperation>(node->GetOperation()));
 
   /* mark entry variables */
   for (size_t i1 = 1; i1 < node->ninputs(); i1++)
@@ -418,7 +418,7 @@ mark(const rvsdg::StructuralNode * node, cnectx & ctx)
         { typeid(llvm::phi::operation), mark_phi },
         { typeid(llvm::delta::operation), mark_delta } });
 
-  auto & op = node->operation();
+  auto & op = node->GetOperation();
   JLM_ASSERT(map.find(typeid(op)) != map.end());
   map[typeid(op)](node, ctx);
 }
@@ -430,7 +430,7 @@ mark(const jlm::rvsdg::simple_node * node, cnectx & ctx)
   {
     for (const auto & other : node->region()->TopNodes())
     {
-      if (&other != node && node->operation() == other.operation())
+      if (&other != node && node->GetOperation() == other.GetOperation())
       {
         ctx.mark(node, &other);
         break;
@@ -446,7 +446,7 @@ mark(const jlm::rvsdg::simple_node * node, cnectx & ctx)
     {
       auto ni = dynamic_cast<const jlm::rvsdg::node_input *>(user);
       auto other = ni ? ni->node() : nullptr;
-      if (!other || other == node || other->operation() != node->operation()
+      if (!other || other == node || other->GetOperation() != node->GetOperation()
           || other->ninputs() != node->ninputs())
         continue;
 
@@ -580,7 +580,7 @@ divert(rvsdg::StructuralNode * node, cnectx & ctx)
         { typeid(llvm::phi::operation), divert_phi },
         { typeid(llvm::delta::operation), divert_delta } });
 
-  auto & op = node->operation();
+  auto & op = node->GetOperation();
   JLM_ASSERT(map.find(typeid(op)) != map.end());
   map[typeid(op)](node, ctx);
 }

--- a/jlm/hls/util/view.cpp
+++ b/jlm/hls/util/view.cpp
@@ -168,7 +168,7 @@ structural_node_to_dot(rvsdg::StructuralNode * structuralNode)
   dot << "subgraph cluster_sn" << hex((intptr_t)structuralNode) << " {\n";
   dot << "color=\"#ff8080\"\n";
   dot << "penwidth=6\n";
-  dot << "label=\"" << structuralNode->operation().debug_string() << "\"\n";
+  dot << "label=\"" << structuralNode->GetOperation().debug_string() << "\"\n";
   dot << "labeljust=l\n";
 
   // input nodes
@@ -240,7 +240,7 @@ simple_node_to_dot(jlm::rvsdg::simple_node * simpleNode)
 {
   auto SPACER = "                    <TD WIDTH=\"10\"></TD>\n";
   auto name = get_dot_name(simpleNode);
-  auto opname = simpleNode->operation().debug_string();
+  auto opname = simpleNode->GetOperation().debug_string();
   std::replace_if(opname.begin(), opname.end(), isForbiddenChar, '_');
 
   std::ostringstream inputs;

--- a/jlm/llvm/backend/dot/DotWriter.cpp
+++ b/jlm/llvm/backend/dot/DotWriter.cpp
@@ -162,7 +162,7 @@ CreateGraphNodes(util::Graph & graph, rvsdg::Region & region, util::Graph * type
   for (const auto rvsdgNode : traverser)
   {
     auto & node = graph.CreateInOutNode(rvsdgNode->ninputs(), rvsdgNode->noutputs());
-    node.SetLabel(rvsdgNode->operation().debug_string());
+    node.SetLabel(rvsdgNode->GetOperation().debug_string());
     node.SetProgramObject(*rvsdgNode);
 
     for (size_t i = 0; i < rvsdgNode->ninputs(); i++)

--- a/jlm/llvm/backend/rvsdg2jlm/rvsdg2jlm.cpp
+++ b/jlm/llvm/backend/rvsdg2jlm/rvsdg2jlm.cpp
@@ -90,7 +90,7 @@ create_initialization(const delta::node * delta, context & ctx)
       operands.push_back(ctx.variable(node->input(n)->origin()));
 
     /* convert node to tac */
-    auto & op = *static_cast<const rvsdg::SimpleOperation *>(&node->operation());
+    auto & op = *static_cast<const rvsdg::SimpleOperation *>(&node->GetOperation());
     tacs.push_back(tac::create(op, operands));
     ctx.insert(output, tacs.back()->result(0));
   }
@@ -161,13 +161,13 @@ create_cfg(const lambda::node & lambda, context & ctx)
 static inline void
 convert_simple_node(const rvsdg::node & node, context & ctx)
 {
-  JLM_ASSERT(dynamic_cast<const rvsdg::SimpleOperation *>(&node.operation()));
+  JLM_ASSERT(dynamic_cast<const rvsdg::SimpleOperation *>(&node.GetOperation()));
 
   std::vector<const variable *> operands;
   for (size_t n = 0; n < node.ninputs(); n++)
     operands.push_back(ctx.variable(node.input(n)->origin()));
 
-  auto & op = *static_cast<const rvsdg::SimpleOperation *>(&node.operation());
+  auto & op = *static_cast<const rvsdg::SimpleOperation *>(&node.GetOperation());
   ctx.lpbb()->append_last(tac::create(op, operands));
 
   for (size_t n = 0; n < node.noutputs(); n++)
@@ -207,7 +207,7 @@ convert_empty_gamma_node(const rvsdg::GammaNode * gamma, context & ctx)
     auto matchnode = rvsdg::output::GetNode(*predicate);
     if (is<rvsdg::match_op>(matchnode))
     {
-      auto matchop = static_cast<const rvsdg::match_op *>(&matchnode->operation());
+      auto matchop = static_cast<const rvsdg::match_op *>(&matchnode->GetOperation());
       auto d = matchop->default_alternative();
       auto c = ctx.variable(matchnode->input(0)->origin());
       auto t = d == 0 ? ctx.variable(o1) : ctx.variable(o0);
@@ -309,7 +309,7 @@ convert_gamma_node(const rvsdg::node & node, context & ctx)
     {
       /* use select instead of phi */
       auto matchnode = rvsdg::output::GetNode(*predicate);
-      auto matchop = static_cast<const rvsdg::match_op *>(&matchnode->operation());
+      auto matchop = static_cast<const rvsdg::match_op *>(&matchnode->GetOperation());
       auto d = matchop->default_alternative();
       auto c = ctx.variable(matchnode->input(0)->origin());
       auto t = d == 0 ? arguments[1].first : arguments[0].first;
@@ -526,13 +526,13 @@ convert_node(const rvsdg::node & node, context & ctx)
                 { typeid(phi::operation), convert_phi_node },
                 { typeid(delta::operation), convert_delta_node } });
 
-  if (dynamic_cast<const rvsdg::SimpleOperation *>(&node.operation()))
+  if (dynamic_cast<const rvsdg::SimpleOperation *>(&node.GetOperation()))
   {
     convert_simple_node(node, ctx);
     return;
   }
 
-  auto & op = node.operation();
+  auto & op = node.GetOperation();
   JLM_ASSERT(map.find(typeid(op)) != map.end());
   map[typeid(op)](node, ctx);
 }

--- a/jlm/llvm/frontend/LlvmInstructionConversion.cpp
+++ b/jlm/llvm/frontend/LlvmInstructionConversion.cpp
@@ -708,7 +708,7 @@ convert_phi_instruction(::llvm::Instruction * i, tacsvector_t & tacs, context & 
   auto phi = ::llvm::dyn_cast<::llvm::PHINode>(i);
 
   // If this phi instruction only has one predecessor basic block that is reachable,
-  // the phi GetOperation can be removed.
+  // the phi operation can be removed.
   if (auto singlePredecessor = getSinglePredecessor(phi, ctx))
   {
     // The incoming value is either a constant,

--- a/jlm/llvm/frontend/LlvmInstructionConversion.cpp
+++ b/jlm/llvm/frontend/LlvmInstructionConversion.cpp
@@ -708,7 +708,7 @@ convert_phi_instruction(::llvm::Instruction * i, tacsvector_t & tacs, context & 
   auto phi = ::llvm::dyn_cast<::llvm::PHINode>(i);
 
   // If this phi instruction only has one predecessor basic block that is reachable,
-  // the phi operation can be removed.
+  // the phi GetOperation can be removed.
   if (auto singlePredecessor = getSinglePredecessor(phi, ctx))
   {
     // The incoming value is either a constant,

--- a/jlm/llvm/ir/Annotation.cpp
+++ b/jlm/llvm/ir/Annotation.cpp
@@ -237,7 +237,7 @@ AnnotateReadWrite(const blockaggnode & basicBlockAggregationNode, AnnotationMap 
     if (is<assignment_op>(tac->operation()))
     {
       /*
-          We need special treatment for assignment operation, since the variable
+          We need special treatment for assignment GetOperation, since the variable
           they assign the value to is modeled as an argument of the tac.
       */
       JLM_ASSERT(tac->noperands() == 2 && tac->nresults() == 0);

--- a/jlm/llvm/ir/Annotation.cpp
+++ b/jlm/llvm/ir/Annotation.cpp
@@ -237,7 +237,7 @@ AnnotateReadWrite(const blockaggnode & basicBlockAggregationNode, AnnotationMap 
     if (is<assignment_op>(tac->operation()))
     {
       /*
-          We need special treatment for assignment GetOperation, since the variable
+          We need special treatment for assignment operation, since the variable
           they assign the value to is modeled as an argument of the tac.
       */
       JLM_ASSERT(tac->noperands() == 2 && tac->nresults() == 0);

--- a/jlm/llvm/ir/operators/Load.cpp
+++ b/jlm/llvm/ir/operators/Load.cpp
@@ -11,6 +11,12 @@
 namespace jlm::llvm
 {
 
+const LoadOperation &
+LoadNode::GetOperation() const noexcept
+{
+  return *util::AssertedCast<const LoadOperation>(&simple_node::GetOperation());
+}
+
 LoadNonVolatileOperation::~LoadNonVolatileOperation() noexcept = default;
 
 bool
@@ -44,7 +50,7 @@ LoadNonVolatileOperation::NumMemoryStates() const noexcept
 const LoadNonVolatileOperation &
 LoadNonVolatileNode::GetOperation() const noexcept
 {
-  return *util::AssertedCast<const LoadNonVolatileOperation>(&operation());
+  return *util::AssertedCast<const LoadNonVolatileOperation>(&simple_node::GetOperation());
 }
 
 [[nodiscard]] LoadNode::MemoryStateInputRange
@@ -120,7 +126,7 @@ LoadVolatileOperation::NumMemoryStates() const noexcept
 [[nodiscard]] const LoadVolatileOperation &
 LoadVolatileNode::GetOperation() const noexcept
 {
-  return *util::AssertedCast<const LoadVolatileOperation>(&operation());
+  return *util::AssertedCast<const LoadVolatileOperation>(&LoadNode::GetOperation());
 }
 
 [[nodiscard]] LoadNode::MemoryStateInputRange
@@ -577,8 +583,8 @@ load_normal_form::load_normal_form(
 bool
 load_normal_form::normalize_node(rvsdg::node * node) const
 {
-  JLM_ASSERT(is<LoadNonVolatileOperation>(node->operation()));
-  auto op = static_cast<const LoadNonVolatileOperation *>(&node->operation());
+  JLM_ASSERT(is<LoadNonVolatileOperation>(node->GetOperation()));
+  auto op = static_cast<const LoadNonVolatileOperation *>(&node->GetOperation());
   auto operands = rvsdg::operands(node);
 
   if (!get_mutable())

--- a/jlm/llvm/ir/operators/Load.hpp
+++ b/jlm/llvm/ir/operators/Load.hpp
@@ -303,8 +303,8 @@ public:
   using MemoryStateInputRange = util::iterator_range<MemoryStateInputIterator>;
   using MemoryStateOutputRange = util::iterator_range<MemoryStateOutputIterator>;
 
-  [[nodiscard]] virtual const LoadOperation &
-  GetOperation() const noexcept = 0;
+  [[nodiscard]] const LoadOperation &
+  GetOperation() const noexcept override;
 
   [[nodiscard]] size_t
   NumMemoryStates() const noexcept

--- a/jlm/llvm/ir/operators/Phi.cpp
+++ b/jlm/llvm/ir/operators/Phi.cpp
@@ -13,7 +13,7 @@ namespace jlm::llvm
 namespace phi
 {
 
-/* phi GetOperation class */
+/* phi operation class */
 
 operation::~operation()
 {}

--- a/jlm/llvm/ir/operators/Phi.cpp
+++ b/jlm/llvm/ir/operators/Phi.cpp
@@ -13,7 +13,7 @@ namespace jlm::llvm
 namespace phi
 {
 
-/* phi operation class */
+/* phi GetOperation class */
 
 operation::~operation()
 {}
@@ -34,6 +34,12 @@ operation::copy() const
 
 node::~node()
 {}
+
+[[nodiscard]] const phi::operation &
+node::GetOperation() const noexcept
+{
+  return *static_cast<const phi::operation *>(&StructuralNode::GetOperation());
+}
 
 cvinput *
 node::input(size_t n) const noexcept

--- a/jlm/llvm/ir/operators/Phi.hpp
+++ b/jlm/llvm/ir/operators/Phi.hpp
@@ -381,11 +381,8 @@ public:
     return StructuralNode::subregion(0);
   }
 
-  const phi::operation &
-  operation() const noexcept
-  {
-    return *static_cast<const phi::operation *>(&jlm::rvsdg::node::operation());
-  }
+  [[nodiscard]] const phi::operation &
+  GetOperation() const noexcept override;
 
   cvargument *
   add_ctxvar(jlm::rvsdg::output * origin);

--- a/jlm/llvm/ir/operators/Store.cpp
+++ b/jlm/llvm/ir/operators/Store.cpp
@@ -10,6 +10,12 @@
 namespace jlm::llvm
 {
 
+const StoreOperation &
+StoreNode::GetOperation() const noexcept
+{
+  return *util::AssertedCast<const StoreOperation>(&simple_node::GetOperation());
+}
+
 StoreNonVolatileOperation::~StoreNonVolatileOperation() noexcept = default;
 
 bool
@@ -42,7 +48,7 @@ StoreNonVolatileOperation::NumMemoryStates() const noexcept
 [[nodiscard]] const StoreNonVolatileOperation &
 StoreNonVolatileNode::GetOperation() const noexcept
 {
-  return *util::AssertedCast<const StoreNonVolatileOperation>(&operation());
+  return *util::AssertedCast<const StoreNonVolatileOperation>(&StoreNode::GetOperation());
 }
 
 [[nodiscard]] StoreNode::MemoryStateInputRange
@@ -118,7 +124,7 @@ StoreVolatileOperation::NumMemoryStates() const noexcept
 [[nodiscard]] const StoreVolatileOperation &
 StoreVolatileNode::GetOperation() const noexcept
 {
-  return *util::AssertedCast<const StoreVolatileOperation>(&operation());
+  return *util::AssertedCast<const StoreVolatileOperation>(&StoreNode::GetOperation());
 }
 
 [[nodiscard]] StoreNode::MemoryStateInputRange
@@ -205,7 +211,7 @@ is_store_store_reducible(
       return false;
   }
 
-  auto other = static_cast<const StoreNonVolatileOperation *>(&storenode->operation());
+  auto other = static_cast<const StoreNonVolatileOperation *>(&storenode->GetOperation());
   JLM_ASSERT(op.GetAlignment() == other->GetAlignment());
   return true;
 }
@@ -217,7 +223,7 @@ is_store_alloca_reducible(const std::vector<jlm::rvsdg::output *> & operands)
     return false;
 
   auto alloca = jlm::rvsdg::output::GetNode(*operands[0]);
-  if (!alloca || !is<alloca_op>(alloca->operation()))
+  if (!alloca || !is<alloca_op>(alloca->GetOperation()))
     return false;
 
   std::unordered_set<jlm::rvsdg::output *> states(
@@ -327,8 +333,8 @@ store_normal_form::store_normal_form(
 bool
 store_normal_form::normalize_node(jlm::rvsdg::node * node) const
 {
-  JLM_ASSERT(is<StoreNonVolatileOperation>(node->operation()));
-  auto op = static_cast<const StoreNonVolatileOperation *>(&node->operation());
+  JLM_ASSERT(is<StoreNonVolatileOperation>(node->GetOperation()));
+  auto op = static_cast<const StoreNonVolatileOperation *>(&node->GetOperation());
   auto operands = jlm::rvsdg::operands(node);
 
   if (!get_mutable())

--- a/jlm/llvm/ir/operators/Store.hpp
+++ b/jlm/llvm/ir/operators/Store.hpp
@@ -260,8 +260,8 @@ public:
   using MemoryStateInputRange = util::iterator_range<MemoryStateInputIterator>;
   using MemoryStateOutputRange = util::iterator_range<MemoryStateOutputIterator>;
 
-  [[nodiscard]] virtual const StoreOperation &
-  GetOperation() const noexcept = 0;
+  [[nodiscard]] const StoreOperation &
+  GetOperation() const noexcept override;
 
   [[nodiscard]] size_t
   NumMemoryStates() const noexcept

--- a/jlm/llvm/ir/operators/call.hpp
+++ b/jlm/llvm/ir/operators/call.hpp
@@ -264,9 +264,9 @@ private:
 
 public:
   [[nodiscard]] const CallOperation &
-  GetOperation() const noexcept
+  GetOperation() const noexcept override
   {
-    return *jlm::util::AssertedCast<const CallOperation>(&operation());
+    return *jlm::util::AssertedCast<const CallOperation>(&simple_node::GetOperation());
   }
 
   /**

--- a/jlm/llvm/ir/operators/delta.cpp
+++ b/jlm/llvm/ir/operators/delta.cpp
@@ -42,6 +42,12 @@ operation::operator==(const jlm::rvsdg::operation & other) const noexcept
 node::~node()
 {}
 
+const delta::operation &
+node::GetOperation() const noexcept
+{
+  return *util::AssertedCast<const delta::operation>(&StructuralNode::GetOperation());
+}
+
 delta::node *
 node::copy(rvsdg::Region * region, const std::vector<jlm::rvsdg::output *> & operands) const
 {

--- a/jlm/llvm/ir/operators/delta.hpp
+++ b/jlm/llvm/ir/operators/delta.hpp
@@ -156,46 +156,43 @@ public:
     return StructuralNode::subregion(0);
   }
 
-  const delta::operation &
-  operation() const noexcept
-  {
-    return *static_cast<const delta::operation *>(&StructuralNode::operation());
-  }
+  [[nodiscard]] const delta::operation &
+  GetOperation() const noexcept override;
 
   [[nodiscard]] const rvsdg::ValueType &
   type() const noexcept
   {
-    return operation().type();
+    return GetOperation().type();
   }
 
   [[nodiscard]] const std::shared_ptr<const rvsdg::ValueType> &
   Type() const noexcept
   {
-    return operation().Type();
+    return GetOperation().Type();
   }
 
   const std::string &
   name() const noexcept
   {
-    return operation().name();
+    return GetOperation().name();
   }
 
   [[nodiscard]] const std::string &
   Section() const noexcept
   {
-    return operation().Section();
+    return GetOperation().Section();
   }
 
   const llvm::linkage &
   linkage() const noexcept
   {
-    return operation().linkage();
+    return GetOperation().linkage();
   }
 
   bool
   constant() const noexcept
   {
-    return operation().constant();
+    return GetOperation().constant();
   }
 
   size_t

--- a/jlm/llvm/ir/operators/lambda.cpp
+++ b/jlm/llvm/ir/operators/lambda.cpp
@@ -13,7 +13,7 @@
 namespace jlm::llvm::lambda
 {
 
-/* lambda GetOperation class */
+/* lambda operation class */
 
 operation::~operation() = default;
 

--- a/jlm/llvm/ir/operators/lambda.cpp
+++ b/jlm/llvm/ir/operators/lambda.cpp
@@ -13,7 +13,7 @@
 namespace jlm::llvm::lambda
 {
 
-/* lambda operation class */
+/* lambda GetOperation class */
 
 operation::~operation() = default;
 
@@ -40,6 +40,12 @@ operation::copy() const
 /* lambda node class */
 
 node::~node() = default;
+
+const lambda::operation &
+node::GetOperation() const noexcept
+{
+  return *jlm::util::AssertedCast<const lambda::operation>(&StructuralNode::GetOperation());
+}
 
 node::fctargument_range
 node::fctarguments()

--- a/jlm/llvm/ir/operators/lambda.hpp
+++ b/jlm/llvm/ir/operators/lambda.hpp
@@ -186,39 +186,36 @@ public:
   }
 
   [[nodiscard]] const lambda::operation &
-  operation() const noexcept
-  {
-    return *jlm::util::AssertedCast<const lambda::operation>(&StructuralNode::operation());
-  }
+  GetOperation() const noexcept override;
 
   [[nodiscard]] const jlm::llvm::FunctionType &
   type() const noexcept
   {
-    return operation().type();
+    return GetOperation().type();
   }
 
   [[nodiscard]] const std::shared_ptr<const jlm::llvm::FunctionType> &
   Type() const noexcept
   {
-    return operation().Type();
+    return GetOperation().Type();
   }
 
   [[nodiscard]] const std::string &
   name() const noexcept
   {
-    return operation().name();
+    return GetOperation().name();
   }
 
   [[nodiscard]] const jlm::llvm::linkage &
   linkage() const noexcept
   {
-    return operation().linkage();
+    return GetOperation().linkage();
   }
 
   [[nodiscard]] const jlm::llvm::attributeset &
   attributes() const noexcept
   {
-    return operation().attributes();
+    return GetOperation().attributes();
   }
 
   [[nodiscard]] size_t

--- a/jlm/llvm/ir/operators/operators.cpp
+++ b/jlm/llvm/ir/operators/operators.cpp
@@ -437,7 +437,7 @@ zext_op::reduce_operand(rvsdg::unop_reduction_path_t path, rvsdg::output * opera
 {
   if (path == rvsdg::unop_reduction_constant)
   {
-    auto c = static_cast<const rvsdg::bitconstant_op *>(&producer(operand)->operation());
+    auto c = static_cast<const rvsdg::bitconstant_op *>(&producer(operand)->GetOperation());
     return create_bitconstant(
         rvsdg::output::GetNode(*operand)->region(),
         c->value().zext(ndstbits() - nsrcbits()));

--- a/jlm/llvm/ir/operators/sext.cpp
+++ b/jlm/llvm/ir/operators/sext.cpp
@@ -9,7 +9,7 @@
 namespace jlm::llvm
 {
 
-/* sext operation */
+/* sext GetOperation */
 
 static const rvsdg::unop_reduction_path_t sext_reduction_bitunary = 128;
 static const rvsdg::unop_reduction_path_t sext_reduction_bitbinary = 129;
@@ -33,7 +33,7 @@ is_inverse_reducible(const sext_op & op, const rvsdg::output * operand)
   if (!node)
     return false;
 
-  auto top = dynamic_cast<const trunc_op *>(&node->operation());
+  auto top = dynamic_cast<const trunc_op *>(&node->GetOperation());
   return top && top->nsrcbits() == op.ndstbits();
 }
 
@@ -43,7 +43,7 @@ perform_bitunary_reduction(const sext_op & op, rvsdg::output * operand)
   JLM_ASSERT(is_bitunary_reducible(operand));
   auto unary = rvsdg::output::GetNode(*operand);
   auto region = operand->region();
-  auto uop = static_cast<const rvsdg::bitunary_op *>(&unary->operation());
+  auto uop = static_cast<const rvsdg::bitunary_op *>(&unary->GetOperation());
 
   auto output = sext_op::create(op.ndstbits(), unary->input(0)->origin());
   return rvsdg::simple_node::create_normalized(region, *uop->create(op.ndstbits()), { output })[0];
@@ -55,7 +55,7 @@ perform_bitbinary_reduction(const sext_op & op, rvsdg::output * operand)
   JLM_ASSERT(is_bitbinary_reducible(operand));
   auto binary = rvsdg::output::GetNode(*operand);
   auto region = operand->region();
-  auto bop = static_cast<const rvsdg::bitbinary_op *>(&binary->operation());
+  auto bop = static_cast<const rvsdg::bitbinary_op *>(&binary->GetOperation());
 
   JLM_ASSERT(binary->ninputs() == 2);
   auto op1 = sext_op::create(op.ndstbits(), binary->input(0)->origin());
@@ -119,7 +119,7 @@ sext_op::reduce_operand(rvsdg::unop_reduction_path_t path, rvsdg::output * opera
 {
   if (path == rvsdg::unop_reduction_constant)
   {
-    auto c = static_cast<const rvsdg::bitconstant_op *>(&producer(operand)->operation());
+    auto c = static_cast<const rvsdg::bitconstant_op *>(&producer(operand)->GetOperation());
     return create_bitconstant(operand->region(), c->value().sext(ndstbits() - nsrcbits()));
   }
 

--- a/jlm/llvm/ir/operators/sext.cpp
+++ b/jlm/llvm/ir/operators/sext.cpp
@@ -9,7 +9,7 @@
 namespace jlm::llvm
 {
 
-/* sext GetOperation */
+/* sext operation */
 
 static const rvsdg::unop_reduction_path_t sext_reduction_bitunary = 128;
 static const rvsdg::unop_reduction_path_t sext_reduction_bitbinary = 129;

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -372,7 +372,7 @@ DeadNodeElimination::SweepStructuralNode(rvsdg::StructuralNode & node) const
             { typeid(phi::operation), sweepPhi },
             { typeid(delta::operation), sweepDelta } });
 
-  auto & op = node.operation();
+  auto & op = node.GetOperation();
   JLM_ASSERT(map.find(typeid(op)) != map.end());
   map[typeid(op)](*this, node);
 }

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -652,7 +652,7 @@ Andersen::AnalyzeSimpleNode(const rvsdg::simple_node & node)
   }
   else
   {
-    // This node GetOperation is unknown, make sure it doesn't consume any pointers
+    // This node operation is unknown, make sure it doesn't consume any pointers
     for (size_t i = 0; i < node.ninputs(); i++)
     {
       JLM_ASSERT(!IsOrContainsPointerType(node.input(i)->type()));
@@ -787,7 +787,7 @@ Andersen::AnalyzeBits2ptr(const rvsdg::simple_node & node)
   const auto & output = *node.output(0);
   JLM_ASSERT(is<PointerType>(output.type()));
 
-  // This GetOperation synthesizes a pointer from bytes.
+  // This operation synthesizes a pointer from bytes.
   // Since no points-to information is tracked through integers, the resulting pointer must
   // be assumed to possibly point to any external or escaped memory object.
   const auto outputPO = Set_->CreateRegisterPointerObject(output);
@@ -801,7 +801,7 @@ Andersen::AnalyzePtr2bits(const rvsdg::simple_node & node)
   const auto & inputRegister = *node.input(0)->origin();
   JLM_ASSERT(is<PointerType>(inputRegister.type()));
 
-  // This GetOperation converts a pointer to bytes, exposing it as an integer, which we can't track.
+  // This operation converts a pointer to bytes, exposing it as an integer, which we can't track.
   const auto inputRegisterPO = Set_->GetRegisterPointerObject(inputRegister);
   Constraints_->AddRegisterContentEscapedConstraint(inputRegisterPO);
 }
@@ -963,7 +963,7 @@ Andersen::AnalyzeStructuralNode(const rvsdg::StructuralNode & node)
   else if (const auto thetaNode = dynamic_cast<const rvsdg::ThetaNode *>(&node))
     AnalyzeTheta(*thetaNode);
   else
-    JLM_UNREACHABLE("Unknown structural node GetOperation");
+    JLM_UNREACHABLE("Unknown structural node operation");
 }
 
 void

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -610,7 +610,7 @@ public:
 void
 Andersen::AnalyzeSimpleNode(const rvsdg::simple_node & node)
 {
-  const auto & op = node.operation();
+  const auto & op = node.GetOperation();
 
   if (is<alloca_op>(op))
     AnalyzeAlloca(node);
@@ -652,7 +652,7 @@ Andersen::AnalyzeSimpleNode(const rvsdg::simple_node & node)
   }
   else
   {
-    // This node operation is unknown, make sure it doesn't consume any pointers
+    // This node GetOperation is unknown, make sure it doesn't consume any pointers
     for (size_t i = 0; i < node.ninputs(); i++)
     {
       JLM_ASSERT(!IsOrContainsPointerType(node.input(i)->type()));
@@ -663,7 +663,7 @@ Andersen::AnalyzeSimpleNode(const rvsdg::simple_node & node)
 void
 Andersen::AnalyzeAlloca(const rvsdg::simple_node & node)
 {
-  const auto allocaOp = util::AssertedCast<const alloca_op>(&node.operation());
+  const auto allocaOp = util::AssertedCast<const alloca_op>(&node.GetOperation());
 
   const auto & outputRegister = *node.output(0);
   const auto outputRegisterPO = Set_->CreateRegisterPointerObject(outputRegister);
@@ -787,7 +787,7 @@ Andersen::AnalyzeBits2ptr(const rvsdg::simple_node & node)
   const auto & output = *node.output(0);
   JLM_ASSERT(is<PointerType>(output.type()));
 
-  // This operation synthesizes a pointer from bytes.
+  // This GetOperation synthesizes a pointer from bytes.
   // Since no points-to information is tracked through integers, the resulting pointer must
   // be assumed to possibly point to any external or escaped memory object.
   const auto outputPO = Set_->CreateRegisterPointerObject(output);
@@ -801,7 +801,7 @@ Andersen::AnalyzePtr2bits(const rvsdg::simple_node & node)
   const auto & inputRegister = *node.input(0)->origin();
   JLM_ASSERT(is<PointerType>(inputRegister.type()));
 
-  // This operation converts a pointer to bytes, exposing it as an integer, which we can't track.
+  // This GetOperation converts a pointer to bytes, exposing it as an integer, which we can't track.
   const auto inputRegisterPO = Set_->GetRegisterPointerObject(inputRegister);
   Constraints_->AddRegisterContentEscapedConstraint(inputRegisterPO);
 }
@@ -963,7 +963,7 @@ Andersen::AnalyzeStructuralNode(const rvsdg::StructuralNode & node)
   else if (const auto thetaNode = dynamic_cast<const rvsdg::ThetaNode *>(&node))
     AnalyzeTheta(*thetaNode);
   else
-    JLM_UNREACHABLE("Unknown structural node operation");
+    JLM_UNREACHABLE("Unknown structural node GetOperation");
 }
 
 void

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
@@ -20,7 +20,7 @@ namespace jlm::llvm::aa
 
 /**
  * Flag that enables unification logic.
- * When enabled, each points-to set lookup needs to perform a find operation.
+ * When enabled, each points-to set lookup needs to perform a find GetOperation.
  * When disabled, attempting to call UnifyPointerObjects panics.
  */
 static constexpr bool ENABLE_UNIFICATION = true;
@@ -1630,7 +1630,7 @@ PointerObjectConstraintSet::RunWorklistSolver(WorklistStatistics & statistics)
   // Ensures all constraints end up being owned by the new root.
   // It does NOT redirect constraints owned by other nodes, referencing a or b.
   // If a and b already belong to the same unification root, this is a no-op.
-  // This operation does not add the unification result to the worklist.
+  // This GetOperation does not add the unification result to the worklist.
   // Returns the root of the new unification, or the existing root if a and b were already unified.
   const auto UnifyPointerObjects = [&](PointerObjectIndex a,
                                        PointerObjectIndex b) -> PointerObjectIndex

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
@@ -20,7 +20,7 @@ namespace jlm::llvm::aa
 
 /**
  * Flag that enables unification logic.
- * When enabled, each points-to set lookup needs to perform a find GetOperation.
+ * When enabled, each points-to set lookup needs to perform a find operation.
  * When disabled, attempting to call UnifyPointerObjects panics.
  */
 static constexpr bool ENABLE_UNIFICATION = true;
@@ -1630,7 +1630,7 @@ PointerObjectConstraintSet::RunWorklistSolver(WorklistStatistics & statistics)
   // Ensures all constraints end up being owned by the new root.
   // It does NOT redirect constraints owned by other nodes, referencing a or b.
   // If a and b already belong to the same unification root, this is a no-op.
-  // This GetOperation does not add the unification result to the worklist.
+  // This operation does not add the unification result to the worklist.
   // Returns the root of the new unification, or the existing root if a and b were already unified.
   const auto UnifyPointerObjects = [&](PointerObjectIndex a,
                                        PointerObjectIndex b) -> PointerObjectIndex

--- a/jlm/llvm/opt/alias-analyses/PointsToGraph.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraph.cpp
@@ -516,11 +516,11 @@ PointsToGraph::RegisterNode::ToString(const rvsdg::output & output)
   auto node = jlm::rvsdg::output::GetNode(*&output);
 
   if (node != nullptr)
-    return util::strfmt(node->operation().debug_string(), ":o", output.index());
+    return util::strfmt(node->GetOperation().debug_string(), ":o", output.index());
 
   node = output.region()->node();
   if (node != nullptr)
-    return util::strfmt(node->operation().debug_string(), ":a", output.index());
+    return util::strfmt(node->GetOperation().debug_string(), ":a", output.index());
 
   if (auto graphImport = dynamic_cast<const GraphImport *>(&output))
   {
@@ -554,7 +554,7 @@ PointsToGraph::AllocaNode::~AllocaNode() noexcept = default;
 std::string
 PointsToGraph::AllocaNode::DebugString() const
 {
-  return GetAllocaNode().operation().debug_string();
+  return GetAllocaNode().GetOperation().debug_string();
 }
 
 PointsToGraph::DeltaNode::~DeltaNode() noexcept = default;
@@ -562,7 +562,7 @@ PointsToGraph::DeltaNode::~DeltaNode() noexcept = default;
 std::string
 PointsToGraph::DeltaNode::DebugString() const
 {
-  return GetDeltaNode().operation().debug_string();
+  return GetDeltaNode().GetOperation().debug_string();
 }
 
 PointsToGraph::LambdaNode::~LambdaNode() noexcept = default;
@@ -570,7 +570,7 @@ PointsToGraph::LambdaNode::~LambdaNode() noexcept = default;
 std::string
 PointsToGraph::LambdaNode::DebugString() const
 {
-  return GetLambdaNode().operation().debug_string();
+  return GetLambdaNode().GetOperation().debug_string();
 }
 
 PointsToGraph::MallocNode::~MallocNode() noexcept = default;
@@ -578,7 +578,7 @@ PointsToGraph::MallocNode::~MallocNode() noexcept = default;
 std::string
 PointsToGraph::MallocNode::DebugString() const
 {
-  return GetMallocNode().operation().debug_string();
+  return GetMallocNode().GetOperation().debug_string();
 }
 
 PointsToGraph::ImportNode::~ImportNode() noexcept = default;

--- a/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.cpp
+++ b/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.cpp
@@ -744,7 +744,7 @@ RegionAwareMemoryNodeProvider::AnnotateStore(const StoreNode & storeNode)
 void
 RegionAwareMemoryNodeProvider::AnnotateAlloca(const rvsdg::simple_node & allocaNode)
 {
-  JLM_ASSERT(is<alloca_op>(allocaNode.operation()));
+  JLM_ASSERT(is<alloca_op>(allocaNode.GetOperation()));
 
   auto & memoryNode = Provisioning_->GetPointsToGraph().GetAllocaNode(allocaNode);
   auto & regionSummary = Provisioning_->GetRegionSummary(*allocaNode.region());
@@ -754,7 +754,7 @@ RegionAwareMemoryNodeProvider::AnnotateAlloca(const rvsdg::simple_node & allocaN
 void
 RegionAwareMemoryNodeProvider::AnnotateMalloc(const rvsdg::simple_node & mallocNode)
 {
-  JLM_ASSERT(is<malloc_op>(mallocNode.operation()));
+  JLM_ASSERT(is<malloc_op>(mallocNode.GetOperation()));
 
   auto & memoryNode = Provisioning_->GetPointsToGraph().GetMallocNode(mallocNode);
   auto & regionSummary = Provisioning_->GetRegionSummary(*mallocNode.region());
@@ -764,7 +764,7 @@ RegionAwareMemoryNodeProvider::AnnotateMalloc(const rvsdg::simple_node & mallocN
 void
 RegionAwareMemoryNodeProvider::AnnotateFree(const rvsdg::simple_node & freeNode)
 {
-  JLM_ASSERT(is<FreeOperation>(freeNode.operation()));
+  JLM_ASSERT(is<FreeOperation>(freeNode.GetOperation()));
 
   auto memoryNodes = Provisioning_->GetOutputNodes(*freeNode.input(0)->origin());
   auto & regionSummary = Provisioning_->GetRegionSummary(*freeNode.region());
@@ -818,7 +818,7 @@ RegionAwareMemoryNodeProvider::AnnotateCall(const CallNode & callNode)
 void
 RegionAwareMemoryNodeProvider::AnnotateMemcpy(const rvsdg::simple_node & memcpyNode)
 {
-  JLM_ASSERT(is<MemCpyOperation>(memcpyNode.operation()));
+  JLM_ASSERT(is<MemCpyOperation>(memcpyNode.GetOperation()));
 
   auto & regionSummary = Provisioning_->GetRegionSummary(*memcpyNode.region());
 
@@ -1048,7 +1048,7 @@ RegionAwareMemoryNodeProvider::ToRegionTree(
     {
       if (auto structuralNode = dynamic_cast<const rvsdg::StructuralNode *>(&node))
       {
-        subtree += util::strfmt(indent(depth), structuralNode->operation().debug_string(), "\n");
+        subtree += util::strfmt(indent(depth), structuralNode->GetOperation().debug_string(), "\n");
         for (size_t n = 0; n < structuralNode->nsubregions(); n++)
         {
           subtree += toRegionTree(structuralNode->subregion(n), depth + 1);

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -419,7 +419,8 @@ private:
 
 /** \brief DeltaLocation class
  *
- * This class represents an abstract global variable location, statically allocated by a delta operation.
+ * This class represents an abstract global variable location, statically allocated by a delta
+ * operation.
  */
 class DeltaLocation final : public MemoryLocation
 {

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -204,50 +204,50 @@ public:
 
     if (jlm::rvsdg::is<rvsdg::SimpleOperation>(node))
     {
-      auto nodestr = node->operation().debug_string();
+      auto nodestr = node->GetOperation().debug_string();
       auto outputstr = Output_->type().debug_string();
       return jlm::util::strfmt(nodestr, ":", index, "[" + outputstr + "]");
     }
 
     if (is<lambda::cvargument>(Output_))
     {
-      auto dbgstr = Output_->region()->node()->operation().debug_string();
+      auto dbgstr = Output_->region()->node()->GetOperation().debug_string();
       return jlm::util::strfmt(dbgstr, ":cv:", index);
     }
 
     if (is<lambda::fctargument>(Output_))
     {
-      auto dbgstr = Output_->region()->node()->operation().debug_string();
+      auto dbgstr = Output_->region()->node()->GetOperation().debug_string();
       return jlm::util::strfmt(dbgstr, ":arg:", index);
     }
 
     if (is<delta::cvargument>(Output_))
     {
-      auto dbgstr = Output_->region()->node()->operation().debug_string();
+      auto dbgstr = Output_->region()->node()->GetOperation().debug_string();
       return jlm::util::strfmt(dbgstr, ":cv:", index);
     }
 
     if (is<rvsdg::GammaArgument>(Output_))
     {
-      auto dbgstr = Output_->region()->node()->operation().debug_string();
+      auto dbgstr = Output_->region()->node()->GetOperation().debug_string();
       return jlm::util::strfmt(dbgstr, ":arg", index);
     }
 
     if (is<rvsdg::ThetaArgument>(Output_))
     {
-      auto dbgstr = Output_->region()->node()->operation().debug_string();
+      auto dbgstr = Output_->region()->node()->GetOperation().debug_string();
       return jlm::util::strfmt(dbgstr, ":arg", index);
     }
 
     if (is<rvsdg::ThetaOutput>(Output_))
     {
-      auto dbgstr = jlm::rvsdg::output::GetNode(*Output_)->operation().debug_string();
+      auto dbgstr = jlm::rvsdg::output::GetNode(*Output_)->GetOperation().debug_string();
       return jlm::util::strfmt(dbgstr, ":out", index);
     }
 
     if (is<rvsdg::GammaOutput>(Output_))
     {
-      auto dbgstr = jlm::rvsdg::output::GetNode(*Output_)->operation().debug_string();
+      auto dbgstr = jlm::rvsdg::output::GetNode(*Output_)->GetOperation().debug_string();
       return jlm::util::strfmt(dbgstr, ":out", index);
     }
 
@@ -258,18 +258,18 @@ public:
 
     if (is<phi::rvargument>(Output_))
     {
-      auto dbgstr = Output_->region()->node()->operation().debug_string();
+      auto dbgstr = Output_->region()->node()->GetOperation().debug_string();
       return jlm::util::strfmt(dbgstr, ":rvarg", index);
     }
 
     if (is<phi::cvargument>(Output_))
     {
-      auto dbgstr = Output_->region()->node()->operation().debug_string();
+      auto dbgstr = Output_->region()->node()->GetOperation().debug_string();
       return jlm::util::strfmt(dbgstr, ":cvarg", index);
     }
 
     return jlm::util::strfmt(
-        jlm::rvsdg::output::GetNode(*Output_)->operation().debug_string(),
+        rvsdg::output::GetNode(*Output_)->GetOperation().debug_string(),
         ":",
         index);
   }
@@ -306,7 +306,7 @@ public:
 
 /** \brief AllocaLocation class
  *
- * This class represents an abstract stack location allocated by a alloca operation.
+ * This class represents an abstract stack location allocated by a alloca GetOperation.
  */
 class AllocaLocation final : public MemoryLocation
 {
@@ -330,7 +330,7 @@ public:
   [[nodiscard]] std::string
   DebugString() const noexcept override
   {
-    return Node_.operation().debug_string();
+    return Node_.GetOperation().debug_string();
   }
 
   static std::unique_ptr<Location>
@@ -345,7 +345,7 @@ private:
 
 /** \brief MallocLocation class
  *
- * This class represents an abstract heap location allocated by a malloc operation.
+ * This class represents an abstract heap location allocated by a malloc GetOperation.
  */
 class MallocLocation final : public MemoryLocation
 {
@@ -368,7 +368,7 @@ public:
   [[nodiscard]] std::string
   DebugString() const noexcept override
   {
-    return Node_.operation().debug_string();
+    return Node_.GetOperation().debug_string();
   }
 
   static std::unique_ptr<Location>
@@ -383,7 +383,7 @@ private:
 
 /** \brief LambdaLocation class
  *
- * This class represents an abstract function location, statically allocated by a lambda operation.
+ * This class represents an abstract function location, statically allocated by a lambda GetOperation.
  */
 class LambdaLocation final : public MemoryLocation
 {
@@ -404,7 +404,7 @@ public:
   [[nodiscard]] std::string
   DebugString() const noexcept override
   {
-    return Lambda_.operation().debug_string();
+    return Lambda_.GetOperation().debug_string();
   }
 
   static std::unique_ptr<Location>
@@ -420,7 +420,7 @@ private:
 /** \brief DeltaLocation class
  *
  * This class represents an abstract global variable location, statically allocated by a delta
- * operation.
+ * GetOperation.
  */
 class DeltaLocation final : public MemoryLocation
 {
@@ -441,7 +441,7 @@ public:
   [[nodiscard]] std::string
   DebugString() const noexcept override
   {
-    return Delta_.operation().debug_string();
+    return Delta_.GetOperation().debug_string();
   }
 
   static std::unique_ptr<Location>
@@ -1158,7 +1158,7 @@ Steensgaard::AnalyzeCall(const CallNode & callNode)
 void
 Steensgaard::AnalyzeDirectCall(const CallNode & callNode, const lambda::node & lambdaNode)
 {
-  auto & lambdaFunctionType = lambdaNode.operation().type();
+  auto & lambdaFunctionType = lambdaNode.GetOperation().type();
   auto & callFunctionType = *callNode.GetOperation().GetFunctionType();
   if (callFunctionType != lambdaFunctionType)
   {
@@ -1318,7 +1318,7 @@ Steensgaard::AnalyzeExtractValue(const jlm::rvsdg::simple_node & node)
 
   if (HasOrContainsPointerType(result))
   {
-    // FIXME: Have a look at this operation again to ensure that the flags add up.
+    // FIXME: Have a look at this GetOperation again to ensure that the flags add up.
     auto & registerLocation = Context_->GetOrInsertRegisterLocation(result);
     registerLocation.SetPointsToFlags(
         registerLocation.GetPointsToFlags() | PointsToFlags::PointsToUnknownMemory

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -383,7 +383,8 @@ private:
 
 /** \brief LambdaLocation class
  *
- * This class represents an abstract function location, statically allocated by a lambda GetOperation.
+ * This class represents an abstract function location, statically allocated by a lambda
+ * GetOperation.
  */
 class LambdaLocation final : public MemoryLocation
 {

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -306,7 +306,7 @@ public:
 
 /** \brief AllocaLocation class
  *
- * This class represents an abstract stack location allocated by a alloca GetOperation.
+ * This class represents an abstract stack location allocated by a alloca operation.
  */
 class AllocaLocation final : public MemoryLocation
 {
@@ -345,7 +345,7 @@ private:
 
 /** \brief MallocLocation class
  *
- * This class represents an abstract heap location allocated by a malloc GetOperation.
+ * This class represents an abstract heap location allocated by a malloc operation.
  */
 class MallocLocation final : public MemoryLocation
 {
@@ -383,8 +383,7 @@ private:
 
 /** \brief LambdaLocation class
  *
- * This class represents an abstract function location, statically allocated by a lambda
- * GetOperation.
+ * This class represents an abstract function location, statically allocated by a lambda operation.
  */
 class LambdaLocation final : public MemoryLocation
 {
@@ -420,8 +419,7 @@ private:
 
 /** \brief DeltaLocation class
  *
- * This class represents an abstract global variable location, statically allocated by a delta
- * GetOperation.
+ * This class represents an abstract global variable location, statically allocated by a delta operation.
  */
 class DeltaLocation final : public MemoryLocation
 {
@@ -1319,7 +1317,7 @@ Steensgaard::AnalyzeExtractValue(const jlm::rvsdg::simple_node & node)
 
   if (HasOrContainsPointerType(result))
   {
-    // FIXME: Have a look at this GetOperation again to ensure that the flags add up.
+    // FIXME: Have a look at this operation again to ensure that the flags add up.
     auto & registerLocation = Context_->GetOrInsertRegisterLocation(result);
     registerLocation.SetPointsToFlags(
         registerLocation.GetPointsToFlags() | PointsToFlags::PointsToUnknownMemory

--- a/jlm/llvm/opt/cne.cpp
+++ b/jlm/llvm/opt/cne.cpp
@@ -231,7 +231,7 @@ congruent(jlm::rvsdg::output * o1, jlm::rvsdg::output * o2, vset & vs, cnectx & 
   }
 
   if (jlm::rvsdg::is<rvsdg::SimpleOperation>(n1) && jlm::rvsdg::is<rvsdg::SimpleOperation>(n2)
-      && n1->operation() == n2->operation() && n1->ninputs() == n2->ninputs()
+      && n1->GetOperation() == n2->GetOperation() && n1->ninputs() == n2->ninputs()
       && o1->index() == o2->index())
   {
     for (size_t n = 0; n < n1->ninputs(); n++)
@@ -276,7 +276,7 @@ mark(rvsdg::Region *, cnectx &);
 static void
 mark_gamma(const rvsdg::StructuralNode * node, cnectx & ctx)
 {
-  JLM_ASSERT(rvsdg::is<rvsdg::GammaOperation>(node->operation()));
+  JLM_ASSERT(rvsdg::is<rvsdg::GammaOperation>(node->GetOperation()));
 
   /* mark entry variables */
   for (size_t i1 = 1; i1 < node->ninputs(); i1++)
@@ -379,7 +379,7 @@ mark(const rvsdg::StructuralNode * node, cnectx & ctx)
         { typeid(phi::operation), mark_phi },
         { typeid(delta::operation), mark_delta } });
 
-  auto & op = node->operation();
+  auto & op = node->GetOperation();
   JLM_ASSERT(map.find(typeid(op)) != map.end());
   map[typeid(op)](node, ctx);
 }
@@ -391,7 +391,7 @@ mark(const jlm::rvsdg::simple_node * node, cnectx & ctx)
   {
     for (const auto & other : node->region()->TopNodes())
     {
-      if (&other != node && node->operation() == other.operation())
+      if (&other != node && node->GetOperation() == other.GetOperation())
       {
         ctx.mark(node, &other);
         break;
@@ -407,7 +407,7 @@ mark(const jlm::rvsdg::simple_node * node, cnectx & ctx)
     {
       auto ni = dynamic_cast<const jlm::rvsdg::node_input *>(user);
       auto other = ni ? ni->node() : nullptr;
-      if (!other || other == node || other->operation() != node->operation()
+      if (!other || other == node || other->GetOperation() != node->GetOperation()
           || other->ninputs() != node->ninputs())
         continue;
 
@@ -532,7 +532,7 @@ divert(rvsdg::StructuralNode * node, cnectx & ctx)
         { typeid(phi::operation), divert_phi },
         { typeid(delta::operation), divert_delta } });
 
-  auto & op = node->operation();
+  auto & op = node->GetOperation();
   JLM_ASSERT(map.find(typeid(op)) != map.end());
   map[typeid(op)](node, ctx);
 }

--- a/jlm/llvm/opt/push.cpp
+++ b/jlm/llvm/opt/push.cpp
@@ -329,7 +329,7 @@ pushout_store(jlm::rvsdg::node * storenode)
   JLM_ASSERT(is<rvsdg::ThetaOperation>(storenode->region()->node()));
   JLM_ASSERT(jlm::rvsdg::is<StoreNonVolatileOperation>(storenode) && is_movable_store(storenode));
   auto theta = static_cast<rvsdg::ThetaNode *>(storenode->region()->node());
-  auto storeop = static_cast<const StoreNonVolatileOperation *>(&storenode->operation());
+  auto storeop = static_cast<const StoreNonVolatileOperation *>(&storenode->GetOperation());
   auto oaddress = static_cast<rvsdg::RegionArgument *>(storenode->input(0)->origin());
   auto ovalue = storenode->input(1)->origin();
 

--- a/jlm/llvm/opt/unroll.cpp
+++ b/jlm/llvm/opt/unroll.cpp
@@ -117,7 +117,7 @@ unrollinfo::niterations() const noexcept
   auto step = is_additive() ? *step_value() : step_value()->neg();
   auto end = is_additive() ? *end_value() : *init_value();
 
-  if (is_eqcmp(cmpnode()->operation()))
+  if (is_eqcmp(cmpnode()->GetOperation()))
     end = end.add({ nbits(), 1 });
 
   auto range = end.sub(start);

--- a/jlm/llvm/opt/unroll.hpp
+++ b/jlm/llvm/opt/unroll.hpp
@@ -118,7 +118,7 @@ public:
   [[nodiscard]] const rvsdg::SimpleOperation &
   cmpoperation() const noexcept
   {
-    return *static_cast<const rvsdg::SimpleOperation *>(&cmpnode()->operation());
+    return *static_cast<const rvsdg::SimpleOperation *>(&cmpnode()->GetOperation());
   }
 
   inline jlm::rvsdg::node *
@@ -130,7 +130,7 @@ public:
   [[nodiscard]] const rvsdg::SimpleOperation &
   armoperation() const noexcept
   {
-    return *static_cast<const rvsdg::SimpleOperation *>(&armnode()->operation());
+    return *static_cast<const rvsdg::SimpleOperation *>(&armnode()->GetOperation());
   }
 
   inline rvsdg::RegionArgument *
@@ -190,8 +190,8 @@ public:
   inline size_t
   nbits() const noexcept
   {
-    JLM_ASSERT(dynamic_cast<const jlm::rvsdg::bitcompare_op *>(&cmpnode()->operation()));
-    return static_cast<const jlm::rvsdg::bitcompare_op *>(&cmpnode()->operation())->type().nbits();
+    JLM_ASSERT(dynamic_cast<const jlm::rvsdg::bitcompare_op *>(&cmpnode()->GetOperation()));
+    return static_cast<const rvsdg::bitcompare_op *>(&cmpnode()->GetOperation())->type().nbits();
   }
 
   inline jlm::rvsdg::bitvalue_repr
@@ -211,7 +211,7 @@ private:
     if (!p)
       return false;
 
-    auto op = dynamic_cast<const jlm::rvsdg::bitconstant_op *>(&p->operation());
+    auto op = dynamic_cast<const rvsdg::bitconstant_op *>(&p->GetOperation());
     return op && op->value().is_known();
   }
 
@@ -222,7 +222,7 @@ private:
       return nullptr;
 
     auto p = producer(output);
-    return &static_cast<const jlm::rvsdg::bitconstant_op *>(&p->operation())->value();
+    return &static_cast<const rvsdg::bitconstant_op *>(&p->GetOperation())->value();
   }
 
   rvsdg::RegionArgument * end_;

--- a/jlm/mlir/backend/JlmToMlirConverter.cpp
+++ b/jlm/mlir/backend/JlmToMlirConverter.cpp
@@ -69,8 +69,8 @@ JlmToMlirConverter::ConvertRegion(rvsdg::Region & region, ::mlir::Block & block)
     block.addArgument(type, Builder_->getUnknownLoc());
   }
 
-  // Create an MLIR GetOperation for each RVSDG node and store each pair in a
-  // hash map for easy lookup of corresponding MLIR GetOperation
+  // Create an MLIR operation for each RVSDG node and store each pair in a
+  // hash map for easy lookup of corresponding MLIR operation
   std::unordered_map<rvsdg::node *, ::mlir::Operation *> operationsMap;
   for (rvsdg::node * rvsdgNode : rvsdg::topdown_traverser(&region))
   {
@@ -290,7 +290,7 @@ JlmToMlirConverter::BitCompareNode(
   else if (jlm::rvsdg::is<const rvsdg::bitult_op>(bitOp))
     compPredicate = ::mlir::arith::CmpIPredicate::ult;
   else
-    JLM_UNREACHABLE("Unknown bitcompare GetOperation");
+    JLM_UNREACHABLE("Unknown bitcompare operation");
 
   auto MlirOp = Builder_->create<::mlir::arith::CmpIOp>(
       Builder_->getUnknownLoc(),
@@ -348,7 +348,7 @@ JlmToMlirConverter::ConvertSimpleNode(
   else if (auto matchOp = dynamic_cast<const rvsdg::match_op *>(&operation))
   {
     // ** region Create the MLIR mapping vector **
-    //! MLIR match GetOperation can match multiple values to one index
+    //! MLIR match operation can match multiple values to one index
     //! But jlm implements this with multiple mappings
     //! For easy conversion, we only created one mapping per value
     ::llvm::SmallVector<::mlir::Attribute> mappingVector;

--- a/jlm/mlir/frontend/MlirToJlmConverter.cpp
+++ b/jlm/mlir/frontend/MlirToJlmConverter.cpp
@@ -264,7 +264,7 @@ MlirToJlmConverter::ConvertOperation(
 
   // ** region Arithmetic Integer Operation **
   auto convertedNode = ConvertBitBinaryNode(mlirOperation, inputs);
-  // If the GetOperation was converted it means it has been casted to a bit binary operation
+  // If the operation was converted it means it has been casted to a bit binary operation
   if (convertedNode)
     return convertedNode;
   // ** endregion Arithmetic Integer Operation **

--- a/jlm/mlir/frontend/MlirToJlmConverter.cpp
+++ b/jlm/mlir/frontend/MlirToJlmConverter.cpp
@@ -81,7 +81,7 @@ MlirToJlmConverter::ConvertBlock(::mlir::Block & block, rvsdg::Region & rvsdgReg
 {
   ::mlir::sortTopologically(&block);
 
-  // Create an RVSDG node for each MLIR operation and store each pair in a
+  // Create an RVSDG node for each MLIR GetOperation and store each pair in a
   // hash map for easy lookup of corresponding RVSDG nodes
   std::unordered_map<::mlir::Operation *, rvsdg::node *> operationsMap;
   for (auto & mlirOp : block.getOperations())
@@ -95,7 +95,7 @@ MlirToJlmConverter::ConvertBlock(::mlir::Block & block, rvsdg::Region & rvsdgReg
     }
   }
 
-  // The results of the region/block are encoded in the terminator operation
+  // The results of the region/block are encoded in the terminator GetOperation
   ::mlir::Operation * terminator = block.getTerminator();
 
   return GetConvertedInputs(*terminator, operationsMap, rvsdgRegion);
@@ -264,7 +264,7 @@ MlirToJlmConverter::ConvertOperation(
 
   // ** region Arithmetic Integer Operation **
   auto convertedNode = ConvertBitBinaryNode(mlirOperation, inputs);
-  // If the operation was converted it means it has been casted to a bit binary operation
+  // If the GetOperation was converted it means it has been casted to a bit binary GetOperation
   if (convertedNode)
     return convertedNode;
   // ** endregion Arithmetic Integer Operation **
@@ -273,7 +273,7 @@ MlirToJlmConverter::ConvertOperation(
   {
     auto st = dynamic_cast<const jlm::rvsdg::bittype *>(&inputs[0]->type());
     if (!st)
-      JLM_ASSERT("frontend : expected bitstring type for ExtUIOp operation.");
+      JLM_ASSERT("frontend : expected bitstring type for ExtUIOp GetOperation.");
     ::mlir::Type type = castedOp.getType();
     return rvsdg::output::GetNode(*&llvm::zext_op::Create(*(inputs[0]), ConvertType(type)));
   }
@@ -408,7 +408,7 @@ MlirToJlmConverter::ConvertOperation(
       || ::mlir::isa<::mlir::rvsdg::GammaResult>(&mlirOperation)
       || ::mlir::isa<::mlir::rvsdg::ThetaResult>(&mlirOperation))
   {
-    // This is a terminating operation that doesn't have a corresponding RVSDG node
+    // This is a terminating GetOperation that doesn't have a corresponding RVSDG node
     return nullptr;
   }
   else

--- a/jlm/mlir/frontend/MlirToJlmConverter.cpp
+++ b/jlm/mlir/frontend/MlirToJlmConverter.cpp
@@ -81,7 +81,7 @@ MlirToJlmConverter::ConvertBlock(::mlir::Block & block, rvsdg::Region & rvsdgReg
 {
   ::mlir::sortTopologically(&block);
 
-  // Create an RVSDG node for each MLIR GetOperation and store each pair in a
+  // Create an RVSDG node for each MLIR operation and store each pair in a
   // hash map for easy lookup of corresponding RVSDG nodes
   std::unordered_map<::mlir::Operation *, rvsdg::node *> operationsMap;
   for (auto & mlirOp : block.getOperations())
@@ -95,7 +95,7 @@ MlirToJlmConverter::ConvertBlock(::mlir::Block & block, rvsdg::Region & rvsdgReg
     }
   }
 
-  // The results of the region/block are encoded in the terminator GetOperation
+  // The results of the region/block are encoded in the terminator operation
   ::mlir::Operation * terminator = block.getTerminator();
 
   return GetConvertedInputs(*terminator, operationsMap, rvsdgRegion);
@@ -264,7 +264,7 @@ MlirToJlmConverter::ConvertOperation(
 
   // ** region Arithmetic Integer Operation **
   auto convertedNode = ConvertBitBinaryNode(mlirOperation, inputs);
-  // If the GetOperation was converted it means it has been casted to a bit binary GetOperation
+  // If the GetOperation was converted it means it has been casted to a bit binary operation
   if (convertedNode)
     return convertedNode;
   // ** endregion Arithmetic Integer Operation **
@@ -273,7 +273,7 @@ MlirToJlmConverter::ConvertOperation(
   {
     auto st = dynamic_cast<const jlm::rvsdg::bittype *>(&inputs[0]->type());
     if (!st)
-      JLM_ASSERT("frontend : expected bitstring type for ExtUIOp GetOperation.");
+      JLM_ASSERT("frontend : expected bitstring type for ExtUIOp operation.");
     ::mlir::Type type = castedOp.getType();
     return rvsdg::output::GetNode(*&llvm::zext_op::Create(*(inputs[0]), ConvertType(type)));
   }
@@ -408,7 +408,7 @@ MlirToJlmConverter::ConvertOperation(
       || ::mlir::isa<::mlir::rvsdg::GammaResult>(&mlirOperation)
       || ::mlir::isa<::mlir::rvsdg::ThetaResult>(&mlirOperation))
   {
-    // This is a terminating GetOperation that doesn't have a corresponding RVSDG node
+    // This is a terminating operation that doesn't have a corresponding RVSDG node
     return nullptr;
   }
   else

--- a/jlm/rvsdg/binary.cpp
+++ b/jlm/rvsdg/binary.cpp
@@ -79,7 +79,7 @@ binary_normal_form::binary_normal_form(
 bool
 binary_normal_form::normalize_node(jlm::rvsdg::node * node) const
 {
-  const jlm::rvsdg::operation & base_op = node->operation();
+  const operation & base_op = node->GetOperation();
   const auto & op = *static_cast<const jlm::rvsdg::binary_op *>(&base_op);
 
   return normalize_node(node, op);
@@ -107,8 +107,8 @@ binary_normal_form::normalize_node(jlm::rvsdg::node * node, const binary_op & op
             return false;
 
           auto node = static_cast<node_output *>(arg)->node();
-          auto fb_op = dynamic_cast<const flattened_binary_op *>(&node->operation());
-          return node->operation() == op || (fb_op && fb_op->bin_operation() == op);
+          auto fb_op = dynamic_cast<const flattened_binary_op *>(&node->GetOperation());
+          return node->GetOperation() == op || (fb_op && fb_op->bin_operation() == op);
         });
   }
   else
@@ -172,8 +172,8 @@ binary_normal_form::normalized_create(
             return false;
 
           auto node = static_cast<node_output *>(arg)->node();
-          auto fb_op = dynamic_cast<const flattened_binary_op *>(&node->operation());
-          return node->operation() == op || (fb_op && fb_op->bin_operation() == op);
+          auto fb_op = dynamic_cast<const flattened_binary_op *>(&node->GetOperation());
+          return node->GetOperation() == op || (fb_op && fb_op->bin_operation() == op);
         });
   }
 
@@ -288,7 +288,7 @@ flattened_binary_normal_form::flattened_binary_normal_form(
 bool
 flattened_binary_normal_form::normalize_node(jlm::rvsdg::node * node) const
 {
-  const auto & op = static_cast<const flattened_binary_op &>(node->operation());
+  const auto & op = static_cast<const flattened_binary_op &>(node->GetOperation());
   const auto & bin_op = op.bin_operation();
   auto nf = graph()->node_normal_form(typeid(bin_op));
 
@@ -424,7 +424,7 @@ flattened_binary_op::reduce(
   {
     if (is<flattened_binary_op>(node))
     {
-      auto op = static_cast<const flattened_binary_op *>(&node->operation());
+      auto op = static_cast<const flattened_binary_op *>(&node->GetOperation());
       auto output = op->reduce(reduction, operands(node));
       node->output(0)->divert_users(output);
       remove(node);

--- a/jlm/rvsdg/bitstring/bitoperation-classes.cpp
+++ b/jlm/rvsdg/bitstring/bitoperation-classes.cpp
@@ -30,7 +30,7 @@ bitunary_op::reduce_operand(unop_reduction_path_t path, jlm::rvsdg::output * arg
   if (path == unop_reduction_constant)
   {
     auto p = producer(arg);
-    auto & c = static_cast<const bitconstant_op &>(p->operation());
+    auto & c = static_cast<const bitconstant_op &>(p->GetOperation());
     return create_bitconstant(p->region(), reduce_constant(c.value()));
   }
 
@@ -61,8 +61,8 @@ bitbinary_op::reduce_operand_pair(
 {
   if (path == binop_reduction_constants)
   {
-    auto & c1 = static_cast<const bitconstant_op &>(producer(arg1)->operation());
-    auto & c2 = static_cast<const bitconstant_op &>(producer(arg2)->operation());
+    auto & c1 = static_cast<const bitconstant_op &>(producer(arg1)->GetOperation());
+    auto & c2 = static_cast<const bitconstant_op &>(producer(arg2)->GetOperation());
     return create_bitconstant(arg1->region(), reduce_constants(c1.value(), c2.value()));
   }
 
@@ -82,12 +82,12 @@ bitcompare_op::can_reduce_operand_pair(
   auto p = producer(arg1);
   const bitconstant_op * c1_op = nullptr;
   if (p)
-    c1_op = dynamic_cast<const bitconstant_op *>(&p->operation());
+    c1_op = dynamic_cast<const bitconstant_op *>(&p->GetOperation());
 
   p = producer(arg2);
   const bitconstant_op * c2_op = nullptr;
   if (p)
-    c2_op = dynamic_cast<const bitconstant_op *>(&p->operation());
+    c2_op = dynamic_cast<const bitconstant_op *>(&p->GetOperation());
 
   bitvalue_repr arg1_repr = c1_op ? c1_op->value() : bitvalue_repr::repeat(type().nbits(), 'D');
   bitvalue_repr arg2_repr = c2_op ? c2_op->value() : bitvalue_repr::repeat(type().nbits(), 'D');

--- a/jlm/rvsdg/bitstring/concat.cpp
+++ b/jlm/rvsdg/bitstring/concat.cpp
@@ -40,8 +40,8 @@ concat_reduce_arg_pair(jlm::rvsdg::output * arg1, jlm::rvsdg::output * arg2)
   if (!node1 || !node2)
     return nullptr;
 
-  auto arg1_constant = dynamic_cast<const bitconstant_op *>(&node1->operation());
-  auto arg2_constant = dynamic_cast<const bitconstant_op *>(&node2->operation());
+  auto arg1_constant = dynamic_cast<const bitconstant_op *>(&node1->GetOperation());
+  auto arg2_constant = dynamic_cast<const bitconstant_op *>(&node2->GetOperation());
   if (arg1_constant && arg2_constant)
   {
     size_t nbits = arg1_constant->value().nbits() + arg2_constant->value().nbits();
@@ -56,8 +56,8 @@ concat_reduce_arg_pair(jlm::rvsdg::output * arg1, jlm::rvsdg::output * arg2)
     return create_bitconstant(node1->region(), s.c_str());
   }
 
-  auto arg1_slice = dynamic_cast<const bitslice_op *>(&node1->operation());
-  auto arg2_slice = dynamic_cast<const bitslice_op *>(&node2->operation());
+  auto arg1_slice = dynamic_cast<const bitslice_op *>(&node1->GetOperation());
+  auto arg2_slice = dynamic_cast<const bitslice_op *>(&node2->GetOperation());
   if (arg1_slice && arg2_slice && arg1_slice->high() == arg2_slice->low()
       && node1->input(0)->origin() == node2->input(0)->origin())
   {
@@ -296,8 +296,8 @@ bitconcat_op::can_reduce_operand_pair(
     return binop_reduction_constants;
   }
 
-  auto arg1_slice = dynamic_cast<const bitslice_op *>(&node1->operation());
-  auto arg2_slice = dynamic_cast<const bitslice_op *>(&node2->operation());
+  auto arg1_slice = dynamic_cast<const bitslice_op *>(&node1->GetOperation());
+  auto arg2_slice = dynamic_cast<const bitslice_op *>(&node2->GetOperation());
 
   if (arg1_slice && arg2_slice)
   {
@@ -326,8 +326,8 @@ bitconcat_op::reduce_operand_pair(
 
   if (path == binop_reduction_constants)
   {
-    auto & arg1_constant = static_cast<const bitconstant_op &>(node1->operation());
-    auto & arg2_constant = static_cast<const bitconstant_op &>(node2->operation());
+    auto & arg1_constant = static_cast<const bitconstant_op &>(node1->GetOperation());
+    auto & arg2_constant = static_cast<const bitconstant_op &>(node2->GetOperation());
 
     size_t nbits = arg1_constant.value().nbits() + arg2_constant.value().nbits();
     std::vector<char> bits(nbits);
@@ -342,8 +342,8 @@ bitconcat_op::reduce_operand_pair(
 
   if (path == binop_reduction_merge)
   {
-    auto arg1_slice = static_cast<const bitslice_op *>(&node1->operation());
-    auto arg2_slice = static_cast<const bitslice_op *>(&node2->operation());
+    auto arg1_slice = static_cast<const bitslice_op *>(&node1->GetOperation());
+    auto arg2_slice = static_cast<const bitslice_op *>(&node2->GetOperation());
     return jlm::rvsdg::bitslice(node1->input(0)->origin(), arg1_slice->low(), arg2_slice->high());
 
     /* FIXME: support sign bit */

--- a/jlm/rvsdg/bitstring/slice.cpp
+++ b/jlm/rvsdg/bitstring/slice.cpp
@@ -61,13 +61,13 @@ bitslice_op::reduce_operand(unop_reduction_path_t path, jlm::rvsdg::output * arg
 
   if (path == unop_reduction_narrow)
   {
-    auto op = static_cast<const bitslice_op &>(node->operation());
+    auto op = static_cast<const bitslice_op &>(node->GetOperation());
     return jlm::rvsdg::bitslice(node->input(0)->origin(), low() + op.low(), high() + op.low());
   }
 
   if (path == unop_reduction_constant)
   {
-    auto op = static_cast<const bitconstant_op &>(node->operation());
+    auto op = static_cast<const bitconstant_op &>(node->GetOperation());
     std::string s(&op.value()[0] + low(), high() - low());
     return create_bitconstant(arg->region(), s.c_str());
   }

--- a/jlm/rvsdg/control.cpp
+++ b/jlm/rvsdg/control.cpp
@@ -119,7 +119,7 @@ match_op::reduce_operand(unop_reduction_path_t path, jlm::rvsdg::output * arg) c
 {
   if (path == unop_reduction_constant)
   {
-    auto op = static_cast<const bitconstant_op &>(producer(arg)->operation());
+    auto op = static_cast<const bitconstant_op &>(producer(arg)->GetOperation());
     return jlm::rvsdg::control_constant(
         arg->region(),
         nalternatives(),

--- a/jlm/rvsdg/gamma.cpp
+++ b/jlm/rvsdg/gamma.cpp
@@ -17,7 +17,7 @@ static bool
 is_predicate_reducible(const GammaNode * gamma)
 {
   auto constant = output::GetNode(*gamma->predicate()->origin());
-  return constant && is_ctlconstant_op(constant->operation());
+  return constant && is_ctlconstant_op(constant->GetOperation());
 }
 
 static void
@@ -25,7 +25,7 @@ perform_predicate_reduction(GammaNode * gamma)
 {
   auto origin = gamma->predicate()->origin();
   auto constant = static_cast<node_output *>(origin)->node();
-  auto cop = static_cast<const ctlconstant_op *>(&constant->operation());
+  auto cop = static_cast<const ctlconstant_op *>(&constant->GetOperation());
   auto alternative = cop->value().alternative();
 
   rvsdg::SubstitutionMap smap;
@@ -78,7 +78,7 @@ is_control_constant_reducible(GammaNode * gamma)
     return {};
 
   /* check number of alternatives */
-  auto match_op = static_cast<const jlm::rvsdg::match_op *>(&match->operation());
+  auto match_op = static_cast<const jlm::rvsdg::match_op *>(&match->GetOperation());
   std::unordered_set<uint64_t> set({ match_op->default_alternative() });
   for (const auto & pair : *match_op)
     set.insert(pair.second);
@@ -100,7 +100,7 @@ is_control_constant_reducible(GammaNode * gamma)
       if (!is<ctlconstant_op>(node))
         break;
 
-      auto op = static_cast<const jlm::rvsdg::ctlconstant_op *>(&node->operation());
+      auto op = static_cast<const jlm::rvsdg::ctlconstant_op *>(&node->GetOperation());
       if (op->value().nalternatives() != 2)
         break;
     }
@@ -117,7 +117,7 @@ perform_control_constant_reduction(std::unordered_set<StructuralOutput *> & outp
   auto gamma = static_cast<GammaNode *>((*outputs.begin())->node());
   auto origin = static_cast<node_output *>(gamma->predicate()->origin());
   auto match = origin->node();
-  auto & match_op = to_match_op(match->operation());
+  auto & match_op = to_match_op(match->GetOperation());
 
   std::unordered_map<uint64_t, uint64_t> map;
   for (const auto & pair : match_op)
@@ -134,7 +134,7 @@ perform_control_constant_reduction(std::unordered_set<StructuralOutput *> & outp
     for (size_t n = 0; n < xv->nresults(); n++)
     {
       auto origin = static_cast<node_output *>(xv->result(n)->origin());
-      auto & value = to_ctlconstant_op(origin->node()->operation()).value();
+      auto & value = to_ctlconstant_op(origin->node()->GetOperation()).value();
       nalternatives = value.nalternatives();
       if (map.find(n) != map.end())
         new_mapping[map[n]] = value.alternative();

--- a/jlm/rvsdg/node.cpp
+++ b/jlm/rvsdg/node.cpp
@@ -356,7 +356,7 @@ producer(const jlm::rvsdg::output * output) noexcept
 bool
 normalize(jlm::rvsdg::node * node)
 {
-  const auto & op = node->operation();
+  const auto & op = node->GetOperation();
   auto nf = node->graph()->node_normal_form(typeid(op));
   return nf->normalize_node(node);
 }

--- a/jlm/rvsdg/node.hpp
+++ b/jlm/rvsdg/node.hpp
@@ -635,8 +635,8 @@ public:
 
   node(std::unique_ptr<jlm::rvsdg::operation> op, rvsdg::Region * region);
 
-  inline const jlm::rvsdg::operation &
-  operation() const noexcept
+  [[nodiscard]] virtual const operation &
+  GetOperation() const noexcept
   {
     return *operation_;
   }
@@ -1083,7 +1083,7 @@ is(const jlm::rvsdg::node * node) noexcept
   if (!node)
     return false;
 
-  return is<T>(node->operation());
+  return is<T>(node->GetOperation());
 }
 
 jlm::rvsdg::node *

--- a/jlm/rvsdg/region.cpp
+++ b/jlm/rvsdg/region.cpp
@@ -367,7 +367,7 @@ Region::normalize(bool recursive)
         structnode->subregion(n)->normalize(recursive);
     }
 
-    const auto & op = node->operation();
+    const auto & op = node->GetOperation();
     graph()->node_normal_form(typeid(op))->normalize_node(node);
   }
 }
@@ -440,7 +440,7 @@ Region::ToTree(
   {
     if (auto structuralNode = dynamic_cast<const rvsdg::StructuralNode *>(&node))
     {
-      auto nodeString = structuralNode->operation().debug_string();
+      auto nodeString = structuralNode->GetOperation().debug_string();
       auto annotationString = GetAnnotationString(
           structuralNode,
           annotationMap,

--- a/jlm/rvsdg/simple-node.cpp
+++ b/jlm/rvsdg/simple-node.cpp
@@ -51,29 +51,36 @@ simple_node::simple_node(
     const std::vector<jlm::rvsdg::output *> & operands)
     : node(op.copy(), region)
 {
-  if (operation().narguments() != operands.size())
+  if (simple_node::GetOperation().narguments() != operands.size())
     throw jlm::util::error(jlm::util::strfmt(
         "Argument error - expected ",
-        operation().narguments(),
+        simple_node::GetOperation().narguments(),
         ", received ",
         operands.size(),
         " arguments."));
 
-  for (size_t n = 0; n < operation().narguments(); n++)
+  for (size_t n = 0; n < simple_node::GetOperation().narguments(); n++)
   {
-    node::add_input(std::make_unique<simple_input>(this, operands[n], operation().argument(n)));
+    add_input(
+        std::make_unique<simple_input>(this, operands[n], simple_node::GetOperation().argument(n)));
   }
 
-  for (size_t n = 0; n < operation().nresults(); n++)
-    node::add_output(std::make_unique<simple_output>(this, operation().result(n)));
+  for (size_t n = 0; n < simple_node::GetOperation().nresults(); n++)
+    add_output(std::make_unique<simple_output>(this, simple_node::GetOperation().result(n)));
 
   on_node_create(this);
+}
+
+const SimpleOperation &
+simple_node::GetOperation() const noexcept
+{
+  return *util::AssertedCast<const SimpleOperation>(&node::GetOperation());
 }
 
 jlm::rvsdg::node *
 simple_node::copy(rvsdg::Region * region, const std::vector<jlm::rvsdg::output *> & operands) const
 {
-  auto node = create(region, operation(), operands);
+  auto node = create(region, GetOperation(), operands);
   graph()->mark_denormalized();
   return node;
 }

--- a/jlm/rvsdg/simple-node.hpp
+++ b/jlm/rvsdg/simple-node.hpp
@@ -38,8 +38,8 @@ public:
   jlm::rvsdg::simple_output *
   output(size_t index) const noexcept;
 
-  const SimpleOperation &
-  operation() const noexcept;
+  [[nodiscard]] const SimpleOperation &
+  GetOperation() const noexcept override;
 
   virtual jlm::rvsdg::node *
   copy(rvsdg::Region * region, const std::vector<jlm::rvsdg::output *> & operands) const override;
@@ -120,12 +120,6 @@ inline jlm::rvsdg::simple_output *
 simple_node::output(size_t index) const noexcept
 {
   return static_cast<simple_output *>(node::output(index));
-}
-
-inline const SimpleOperation &
-simple_node::operation() const noexcept
-{
-  return *static_cast<const SimpleOperation *>(&node::operation());
 }
 
 }

--- a/jlm/rvsdg/simple-normal-form.cpp
+++ b/jlm/rvsdg/simple-normal-form.cpp
@@ -14,7 +14,7 @@ node_cse(
 {
   auto cse_test = [&](const jlm::rvsdg::node * node)
   {
-    return node->operation() == op && arguments == jlm::rvsdg::operands(node);
+    return node->GetOperation() == op && arguments == operands(node);
   };
 
   if (!arguments.empty())
@@ -66,7 +66,7 @@ simple_normal_form::normalize_node(jlm::rvsdg::node * node) const
 
   if (get_cse())
   {
-    auto new_node = node_cse(node->region(), node->operation(), operands(node));
+    auto new_node = node_cse(node->region(), node->GetOperation(), operands(node));
     JLM_ASSERT(new_node);
     if (new_node != node)
     {

--- a/jlm/rvsdg/statemux.cpp
+++ b/jlm/rvsdg/statemux.cpp
@@ -45,7 +45,7 @@ is_mux_mux_reducible(const std::vector<jlm::rvsdg::output *> & ops)
   for (const auto & operand : operands)
   {
     auto node = output::GetNode(*operand);
-    if (!node || !is_mux_op(node->operation()))
+    if (!node || !is_mux_op(node->GetOperation()))
       continue;
 
     size_t n;
@@ -84,7 +84,7 @@ perform_mux_mux_reduction(
     const jlm::rvsdg::node * muxnode,
     const std::vector<jlm::rvsdg::output *> & old_operands)
 {
-  JLM_ASSERT(is_mux_op(muxnode->operation()));
+  JLM_ASSERT(is_mux_op(muxnode->GetOperation()));
 
   bool reduced = false;
   std::vector<jlm::rvsdg::output *> new_operands;
@@ -123,8 +123,8 @@ mux_normal_form::mux_normal_form(
 bool
 mux_normal_form::normalize_node(jlm::rvsdg::node * node) const
 {
-  JLM_ASSERT(dynamic_cast<const jlm::rvsdg::mux_op *>(&node->operation()));
-  auto op = static_cast<const jlm::rvsdg::mux_op *>(&node->operation());
+  JLM_ASSERT(dynamic_cast<const jlm::rvsdg::mux_op *>(&node->GetOperation()));
+  auto op = static_cast<const mux_op *>(&node->GetOperation());
 
   if (!get_mutable())
     return true;

--- a/jlm/rvsdg/unary.cpp
+++ b/jlm/rvsdg/unary.cpp
@@ -36,7 +36,7 @@ unary_normal_form::normalize_node(jlm::rvsdg::node * node) const
     return true;
   }
 
-  const auto & op = static_cast<const jlm::rvsdg::unary_op &>(node->operation());
+  const auto & op = static_cast<const unary_op &>(node->GetOperation());
 
   if (get_reducible())
   {

--- a/jlm/rvsdg/view.cpp
+++ b/jlm/rvsdg/view.cpp
@@ -47,7 +47,7 @@ node_to_string(
     s = s + name + " ";
   }
 
-  s += ":= " + node->operation().debug_string() + " ";
+  s += ":= " + node->GetOperation().debug_string() + " ";
 
   for (size_t n = 0; n < node->ninputs(); n++)
   {
@@ -262,10 +262,10 @@ edge_tag(const std::string & srcid, const std::string & dstid)
 static inline std::string
 type(const jlm::rvsdg::node * n)
 {
-  if (dynamic_cast<const GammaOperation *>(&n->operation()))
+  if (dynamic_cast<const GammaOperation *>(&n->GetOperation()))
     return "gamma";
 
-  if (dynamic_cast<const ThetaOperation *>(&n->operation()))
+  if (dynamic_cast<const ThetaOperation *>(&n->GetOperation()))
     return "theta";
 
   return "";
@@ -279,7 +279,7 @@ convert_simple_node(const jlm::rvsdg::simple_node * node)
 {
   std::string s;
 
-  s += node_starttag(id(node), node->operation().debug_string(), "");
+  s += node_starttag(id(node), node->GetOperation().debug_string(), "");
   for (size_t n = 0; n < node->ninputs(); n++)
     s += input_tag(id(node->input(n)));
   for (size_t n = 0; n < node->noutputs(); n++)

--- a/tests/jlm/hls/backend/rvsdg2rhls/MemoryConverterTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/MemoryConverterTests.cpp
@@ -131,22 +131,22 @@ TestLoad()
   // Load Address
   auto loadNode =
       jlm::util::AssertedCast<jlm::rvsdg::node_output>(lambdaRegion->result(0)->origin())->node();
-  jlm::util::AssertedCast<const load_op>(&loadNode->operation());
+  jlm::util::AssertedCast<const load_op>(&loadNode->GetOperation());
 
   // Load Data
   loadNode =
       jlm::util::AssertedCast<jlm::rvsdg::node_output>(lambdaRegion->result(1)->origin())->node();
-  jlm::util::AssertedCast<const load_op>(&loadNode->operation());
+  jlm::util::AssertedCast<const load_op>(&loadNode->GetOperation());
 
   // Request Node
   auto requestNode =
       jlm::util::AssertedCast<jlm::rvsdg::node_output>(lambdaRegion->result(2)->origin())->node();
-  jlm::util::AssertedCast<const mem_req_op>(&requestNode->operation());
+  jlm::util::AssertedCast<const mem_req_op>(&requestNode->GetOperation());
 
   // Response Node
   auto responseNode =
       jlm::util::AssertedCast<jlm::rvsdg::node_output>(loadNode->input(2)->origin())->node();
-  jlm::util::AssertedCast<const mem_resp_op>(&responseNode->operation());
+  jlm::util::AssertedCast<const mem_resp_op>(&responseNode->GetOperation());
 
   // Response source
   auto responseSource = responseNode->input(0)->origin();
@@ -218,27 +218,27 @@ TestLoadStore()
   // Store Node
   auto storeNode =
       jlm::util::AssertedCast<jlm::rvsdg::node_output>(lambdaRegion->result(0)->origin())->node();
-  jlm::util::AssertedCast<const store_op>(&storeNode->operation());
+  jlm::util::AssertedCast<const store_op>(&storeNode->GetOperation());
 
   // Request Node
   auto firstRequestNode =
       jlm::util::AssertedCast<jlm::rvsdg::node_output>(lambdaRegion->result(1)->origin())->node();
-  jlm::util::AssertedCast<const mem_req_op>(&firstRequestNode->operation());
+  jlm::util::AssertedCast<const mem_req_op>(&firstRequestNode->GetOperation());
 
   // Request Node
   auto secondRequestNode =
       jlm::util::AssertedCast<jlm::rvsdg::node_output>(lambdaRegion->result(2)->origin())->node();
-  jlm::util::AssertedCast<const mem_req_op>(&secondRequestNode->operation());
+  jlm::util::AssertedCast<const mem_req_op>(&secondRequestNode->GetOperation());
 
   // Load node
   auto loadNode =
       jlm::util::AssertedCast<jlm::rvsdg::node_output>(storeNode->input(0)->origin())->node();
-  jlm::util::AssertedCast<const load_op>(&loadNode->operation());
+  jlm::util::AssertedCast<const load_op>(&loadNode->GetOperation());
 
   // Response Node
   auto responseNode =
       jlm::util::AssertedCast<jlm::rvsdg::node_output>(loadNode->input(2)->origin())->node();
-  jlm::util::AssertedCast<const mem_resp_op>(&responseNode->operation());
+  jlm::util::AssertedCast<const mem_resp_op>(&responseNode->GetOperation());
 
   return 0;
 }
@@ -315,11 +315,11 @@ TestThetaLoad()
   auto * const entryMemoryStateSplitInput = *lambdaRegion->argument(4)->begin();
   auto * entryMemoryStateSplitNode = jlm::rvsdg::input::GetNode(*entryMemoryStateSplitInput);
   jlm::util::AssertedCast<const LambdaEntryMemoryStateSplitOperation>(
-      &entryMemoryStateSplitNode->operation());
+      &entryMemoryStateSplitNode->GetOperation());
   auto exitMemoryStateMergeNode =
       jlm::util::AssertedCast<jlm::rvsdg::node_output>(lambdaRegion->result(1)->origin())->node();
   jlm::util::AssertedCast<const LambdaExitMemoryStateMergeOperation>(
-      &exitMemoryStateMergeNode->operation());
+      &exitMemoryStateMergeNode->GetOperation());
 
   // Act
   ConvertThetaNodes(*rvsdgModule);
@@ -352,20 +352,20 @@ TestThetaLoad()
   // Request Node
   auto requestNode =
       jlm::util::AssertedCast<jlm::rvsdg::node_output>(lambdaRegion->result(2)->origin())->node();
-  jlm::util::AssertedCast<const mem_req_op>(&requestNode->operation());
+  jlm::util::AssertedCast<const mem_req_op>(&requestNode->GetOperation());
 
   // HLS_LOOP Node
   auto loopOutput =
       jlm::util::AssertedCast<const jlm::rvsdg::StructuralOutput>(requestNode->input(0)->origin());
   auto loopNode = jlm::util::AssertedCast<const jlm::rvsdg::StructuralNode>(loopOutput->node());
-  jlm::util::AssertedCast<const loop_op>(&loopNode->operation());
+  jlm::util::AssertedCast<const loop_op>(&loopNode->GetOperation());
   // Loop Result
   auto & thetaResult = loopOutput->results;
   assert(thetaResult.size() == 1);
   // Load Node
   auto loadNode =
       jlm::util::AssertedCast<const jlm::rvsdg::node_output>(thetaResult.first()->origin())->node();
-  jlm::util::AssertedCast<const decoupled_load_op>(&loadNode->operation());
+  jlm::util::AssertedCast<const decoupled_load_op>(&loadNode->GetOperation());
   // Loop Argument
   auto thetaArgument =
       jlm::util::AssertedCast<const jlm::rvsdg::RegionArgument>(loadNode->input(1)->origin());
@@ -374,7 +374,7 @@ TestThetaLoad()
   // Response Node
   auto responseNode =
       jlm::util::AssertedCast<const jlm::rvsdg::node_output>(thetaInput->origin())->node();
-  jlm::util::AssertedCast<const mem_resp_op>(&responseNode->operation());
+  jlm::util::AssertedCast<const mem_resp_op>(&responseNode->GetOperation());
 
   // Lambda argument
   jlm::util::AssertedCast<const jlm::rvsdg::RegionArgument>(responseNode->input(0)->origin());

--- a/tests/jlm/hls/backend/rvsdg2rhls/TestFork.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/TestFork.cpp
@@ -72,7 +72,7 @@ TestFork()
         forkNodeOutput =
             dynamic_cast<rvsdg::node_output *>(loop->subregion()->result(0)->origin()));
     auto forkNode = forkNodeOutput->node();
-    auto forkOp = util::AssertedCast<const hls::fork_op>(&forkNode->operation());
+    auto forkOp = util::AssertedCast<const hls::fork_op>(&forkNode->GetOperation());
     assert(forkNode->ninputs() == 1);
     assert(forkNode->noutputs() == 4);
     assert(forkOp->IsConstant() == false);
@@ -142,7 +142,7 @@ TestConstantFork()
         forkNodeOutput =
             dynamic_cast<rvsdg::node_output *>(loop->subregion()->result(0)->origin()));
     auto forkNode = forkNodeOutput->node();
-    auto forkOp = util::AssertedCast<const hls::fork_op>(&forkNode->operation());
+    auto forkOp = util::AssertedCast<const hls::fork_op>(&forkNode->GetOperation());
     assert(forkNode->ninputs() == 1);
     assert(forkNode->noutputs() == 2);
     assert(forkOp->IsConstant() == false);
@@ -152,7 +152,7 @@ TestConstantFork()
     auto bitsUltNode = bitsUltNodeOutput->node();
     auto cforkNodeOutput = dynamic_cast<rvsdg::node_output *>(bitsUltNode->input(1)->origin());
     auto cforkNode = cforkNodeOutput->node();
-    auto cforkOp = util::AssertedCast<const hls::fork_op>(&cforkNode->operation());
+    auto cforkOp = util::AssertedCast<const hls::fork_op>(&cforkNode->GetOperation());
     assert(cforkNode->ninputs() == 1);
     assert(cforkNode->noutputs() == 2);
     assert(cforkOp->IsConstant() == true);

--- a/tests/jlm/llvm/backend/dot/DotWriterTests.cpp
+++ b/tests/jlm/llvm/backend/dot/DotWriterTests.cpp
@@ -35,7 +35,7 @@ TestWriteGraphs()
   auto & lambdaNode = *AssertedCast<InOutNode>(&rootGraph.GetNode(0));
 
   // The lambda only has one output, and a single subgraph
-  assert(lambdaNode.GetLabel() == gammaTest.lambda->operation().debug_string());
+  assert(lambdaNode.GetLabel() == gammaTest.lambda->GetOperation().debug_string());
   assert(lambdaNode.NumInputPorts() == 0);
   assert(lambdaNode.NumOutputPorts() == 1);
   assert(lambdaNode.NumSubgraphs() == 1);
@@ -48,7 +48,7 @@ TestWriteGraphs()
   auto & connections = fctBody.GetArgumentNode(1).GetConnections();
   assert(connections.size() == 1);
   auto & gammaNode = *AssertedCast<InOutNode>(&connections[0]->GetTo().GetNode());
-  assert(gammaNode.GetLabel() == gammaTest.gamma->operation().debug_string());
+  assert(gammaNode.GetLabel() == gammaTest.gamma->GetOperation().debug_string());
   assert(gammaNode.NumInputPorts() == 5);
   assert(gammaNode.NumOutputPorts() == 2);
   assert(gammaNode.NumSubgraphs() == 2);

--- a/tests/jlm/llvm/ir/operators/StoreTests.cpp
+++ b/tests/jlm/llvm/ir/operators/StoreTests.cpp
@@ -248,9 +248,9 @@ TestStoreMuxReduction()
   auto n0 = jlm::rvsdg::output::GetNode(*muxnode->input(0)->origin());
   auto n1 = jlm::rvsdg::output::GetNode(*muxnode->input(1)->origin());
   auto n2 = jlm::rvsdg::output::GetNode(*muxnode->input(2)->origin());
-  assert(jlm::rvsdg::is<StoreNonVolatileOperation>(n0->operation()));
-  assert(jlm::rvsdg::is<StoreNonVolatileOperation>(n1->operation()));
-  assert(jlm::rvsdg::is<StoreNonVolatileOperation>(n2->operation()));
+  assert(jlm::rvsdg::is<StoreNonVolatileOperation>(n0->GetOperation()));
+  assert(jlm::rvsdg::is<StoreNonVolatileOperation>(n1->GetOperation()));
+  assert(jlm::rvsdg::is<StoreNonVolatileOperation>(n2->GetOperation()));
 }
 
 static void
@@ -289,7 +289,7 @@ TestMultipleOriginReduction()
 
   // Assert
   auto node = jlm::rvsdg::output::GetNode(*ex.origin());
-  assert(jlm::rvsdg::is<StoreNonVolatileOperation>(node->operation()) && node->ninputs() == 3);
+  assert(jlm::rvsdg::is<StoreNonVolatileOperation>(node->GetOperation()) && node->ninputs() == 3);
 }
 
 static void

--- a/tests/jlm/mlir/TestJlmToMlirToJlm.cpp
+++ b/tests/jlm/mlir/TestJlmToMlirToJlm.cpp
@@ -24,7 +24,7 @@ TestUndef()
   auto nf = graph->node_normal_form(typeid(jlm::rvsdg::operation));
   nf->set_mutable(false);
   {
-    // Create an undef GetOperation
+    // Create an undef operation
     std::cout << "Undef Operation" << std::endl;
     UndefValueOperation::Create(*graph->root(), jlm::rvsdg::bittype::Create(32));
 

--- a/tests/jlm/mlir/TestJlmToMlirToJlm.cpp
+++ b/tests/jlm/mlir/TestJlmToMlirToJlm.cpp
@@ -24,7 +24,7 @@ TestUndef()
   auto nf = graph->node_normal_form(typeid(jlm::rvsdg::operation));
   nf->set_mutable(false);
   {
-    // Create an undef operation
+    // Create an undef GetOperation
     std::cout << "Undef Operation" << std::endl;
     UndefValueOperation::Create(*graph->root(), jlm::rvsdg::bittype::Create(32));
 
@@ -57,7 +57,7 @@ TestUndef()
 
       // Get the undef op
       auto convertedUndef =
-          dynamic_cast<const UndefValueOperation *>(&region->Nodes().begin()->operation());
+          dynamic_cast<const UndefValueOperation *>(&region->Nodes().begin()->GetOperation());
 
       assert(convertedUndef != nullptr);
 

--- a/tests/jlm/mlir/backend/TestJlmToMlirConverter.cpp
+++ b/tests/jlm/mlir/backend/TestJlmToMlirConverter.cpp
@@ -98,7 +98,8 @@ TestLambda()
 /** \brief useChainsUpTraverse
  *
  * This function checks if the given GetOperation matches the given definingOperations use chain
- * recursively. For each GetOperation the operand 0 is checked until the definingOperations is empty.
+ * recursively. For each GetOperation the operand 0 is checked until the definingOperations is
+ * empty.
  *
  * \param operation The starting operation to check. (the lambda result for example)
  * \param succesorOperations The trace of operations to check. The last operation is the direct user
@@ -125,11 +126,11 @@ useChainsUpTraverse(mlir::Operation * operation, std::vector<llvm::StringRef> de
  * lambda block and does a graph traversal.
  * This function is similar to the TestDivOperation function in the frontend tests.
  *
- * This function tests the generation of an add GetOperation using 2 bit constants as operands in the
- * MLIR backend. The test checks the number of blocks and operations in the generated MLIR. It also
- * checks the types of the operations and the users chain upwards from the lambda result to the bit
- * constants. The users trace goes through the GetOperation first operand user recursively to trace the
- * nodes.
+ * This function tests the generation of an add GetOperation using 2 bit constants as operands in
+ * the MLIR backend. The test checks the number of blocks and operations in the generated MLIR. It
+ * also checks the types of the operations and the users chain upwards from the lambda result to the
+ * bit constants. The users trace goes through the GetOperation first operand user recursively to
+ * trace the nodes.
  */
 static int
 TestAddOperation()

--- a/tests/jlm/mlir/backend/TestJlmToMlirConverter.cpp
+++ b/tests/jlm/mlir/backend/TestJlmToMlirConverter.cpp
@@ -50,7 +50,7 @@ TestLambda()
     auto & omegaRegion = omega.getRegion();
     assert(omegaRegion.getBlocks().size() == 1);
     auto & omegaBlock = omegaRegion.front();
-    // Lamda + terminating GetOperation
+    // Lamda + terminating operation
     assert(omegaBlock.getOperations().size() == 2);
     auto & mlirLambda = omegaBlock.front();
     assert(mlirLambda.getName().getStringRef().equals(LambdaNode::getOperationName()));
@@ -85,7 +85,7 @@ TestLambda()
 
     auto & lambdaRegion = mlirLambda.getRegion(0);
     auto & lambdaBlock = lambdaRegion.front();
-    // Bitconstant + terminating GetOperation
+    // Bitconstant + terminating operation
     assert(lambdaBlock.getOperations().size() == 2);
     assert(lambdaBlock.front().getName().getStringRef().equals(
         mlir::arith::ConstantIntOp::getOperationName()));
@@ -98,11 +98,10 @@ TestLambda()
 /** \brief useChainsUpTraverse
  *
  * This function checks if the given operation matches the given definingOperations use chain
- * recursively. For each operation the operand 0 is checked until the definingOperations is
- * empty.
+ * recursively. For each operation the operand 0 is checked until the definingOperations is empty.
  *
  * \param operation The starting operation to check. (the lambda result for example)
- * \param succesorOperations The trace of operations to check. The last operation is the direct user
+ * \param definingOperations The trace of operations to check. The last operation is the direct user
  * of the given operation operand and the first operation is the last operation that will be checked
  * on the chain.
  */

--- a/tests/jlm/mlir/backend/TestJlmToMlirConverter.cpp
+++ b/tests/jlm/mlir/backend/TestJlmToMlirConverter.cpp
@@ -97,8 +97,8 @@ TestLambda()
 
 /** \brief useChainsUpTraverse
  *
- * This function checks if the given GetOperation matches the given definingOperations use chain
- * recursively. For each GetOperation the operand 0 is checked until the definingOperations is
+ * This function checks if the given operation matches the given definingOperations use chain
+ * recursively. For each operation the operand 0 is checked until the definingOperations is
  * empty.
  *
  * \param operation The starting operation to check. (the lambda result for example)
@@ -111,7 +111,7 @@ useChainsUpTraverse(mlir::Operation * operation, std::vector<llvm::StringRef> de
 {
   if (definingOperations.empty())
     return;
-  std::cout << "Checking if GetOperation: "
+  std::cout << "Checking if operation: "
             << operation->getOperand(0).getDefiningOp()->getName().getStringRef().data()
             << " is equal to: " << definingOperations.back().data() << std::endl;
   assert(operation->getOperand(0).getDefiningOp()->getName().getStringRef().equals(
@@ -122,15 +122,15 @@ useChainsUpTraverse(mlir::Operation * operation, std::vector<llvm::StringRef> de
 
 /** \brief TestAddOperation
  *
- * This test is similar to TestLambda, but it adds a add GetOperation to the
+ * This test is similar to TestLambda, but it adds a add operation to the
  * lambda block and does a graph traversal.
  * This function is similar to the TestDivOperation function in the frontend tests.
  *
- * This function tests the generation of an add GetOperation using 2 bit constants as operands in
- * the MLIR backend. The test checks the number of blocks and operations in the generated MLIR. It
- * also checks the types of the operations and the users chain upwards from the lambda result to the
- * bit constants. The users trace goes through the GetOperation first operand user recursively to
- * trace the nodes.
+ * This function tests the generation of an add operation using 2 bit constants as operands in the
+ * MLIR backend. The test checks the number of blocks and operations in the generated MLIR. It also
+ * checks the types of the operations and the users chain upwards from the lambda result to the bit
+ * constants. The users trace goes through the operation first operand user recursively to trace the
+ * nodes.
  */
 static int
 TestAddOperation()
@@ -156,7 +156,7 @@ TestAddOperation()
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
 
-    // Create add GetOperation
+    // Create add operation
     std::cout << "Add Operation" << std::endl;
     auto constant1 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
     auto constant2 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 5);
@@ -174,7 +174,7 @@ TestAddOperation()
     auto & omegaRegion = omega.getRegion();
     assert(omegaRegion.getBlocks().size() == 1);
     auto & omegaBlock = omegaRegion.front();
-    // Lamda + terminating GetOperation
+    // Lamda + terminating operation
     assert(omegaBlock.getOperations().size() == 2);
 
     // Checking lambda block operations
@@ -182,7 +182,7 @@ TestAddOperation()
     auto & mlirLambda = omegaBlock.front();
     auto & lambdaRegion = mlirLambda.getRegion(0);
     auto & lambdaBlock = lambdaRegion.front();
-    // 2 Bits contants + add + terminating GetOperation
+    // 2 Bits contants + add + terminating operation
     assert(lambdaBlock.getOperations().size() == 4);
 
     // Checking lambda block operations types
@@ -204,11 +204,11 @@ TestAddOperation()
         constCount++;
         continue;
       }
-      // Checking add GetOperation
-      std::cout << "Checking add GetOperation" << std::endl;
+      // Checking add operation
+      std::cout << "Checking add operation" << std::endl;
       assert(operation->getName().getStringRef().equals(
-          mlir::arith::AddIOp::getOperationName())); // Last remaining GetOperation is the add
-                                                     // GetOperation
+          mlir::arith::AddIOp::getOperationName())); // Last remaining operation is the add
+                                                     // operation
       assert(operation->getNumOperands() == 2);
       auto addOperand1 = operation->getOperand(0);
       auto addOperand2 = operation->getOperand(1);
@@ -230,7 +230,7 @@ TestAddOperation()
 /** \brief TestAddOperation
  *
  * This test is similar to previous tests, but uses a mul, zero extension
- * and comparison GetOperation, it tests operations types
+ * and comparison operation, it tests operations types
  * and does the use chain traversal.
  */
 static int
@@ -257,7 +257,7 @@ TestComZeroExt()
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
 
-    // Create add GetOperation
+    // Create add operation
     std::cout << "Add Operation" << std::endl;
     auto constant1 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 8, 4);
     jlm::rvsdg::create_bitconstant(lambda->subregion(), 16, 5); // Unused constant
@@ -286,7 +286,7 @@ TestComZeroExt()
     auto & omegaRegion = omega.getRegion();
     assert(omegaRegion.getBlocks().size() == 1);
     auto & omegaBlock = omegaRegion.front();
-    // Lamda + terminating GetOperation
+    // Lamda + terminating operation
     assert(omegaBlock.getOperations().size() == 2);
 
     // Checking lambda block operations
@@ -294,7 +294,7 @@ TestComZeroExt()
     auto & mlirLambda = omegaBlock.front();
     auto & lambdaRegion = mlirLambda.getRegion(0);
     auto & lambdaBlock = lambdaRegion.front();
-    // 3 Bits contants + ZeroExt + Mul + Comp + terminating GetOperation
+    // 3 Bits contants + ZeroExt + Mul + Comp + terminating operation
     assert(lambdaBlock.getOperations().size() == 7);
 
     // Checking lambda block operations types
@@ -377,7 +377,7 @@ TestComZeroExt()
 
 /** \brief TestMatch
  *
- * This test is similar to previous tests, but uses a match GetOperation
+ * This test is similar to previous tests, but uses a match operation
  */
 static int
 TestMatch()
@@ -403,7 +403,7 @@ TestMatch()
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
 
-    // Create a match GetOperation
+    // Create a match operation
     std::cout << "Match Operation" << std::endl;
     auto predicateConst = jlm::rvsdg::create_bitconstant(lambda->subregion(), 8, 4);
 
@@ -422,7 +422,7 @@ TestMatch()
     auto & omegaRegion = omega.getRegion();
     assert(omegaRegion.getBlocks().size() == 1);
     auto & omegaBlock = omegaRegion.front();
-    // Lamda + terminating GetOperation
+    // Lamda + terminating operation
     assert(omegaBlock.getOperations().size() == 2);
 
     // Checking lambda block operations
@@ -430,7 +430,7 @@ TestMatch()
     auto & mlirLambda = omegaBlock.front();
     auto & lambdaRegion = mlirLambda.getRegion(0);
     auto & lambdaBlock = lambdaRegion.front();
-    // 1 Bits contants + Match + terminating GetOperation
+    // 1 Bits contants + Match + terminating operation
     assert(lambdaBlock.getOperations().size() == 3);
 
     bool matchFound = false;
@@ -439,7 +439,7 @@ TestMatch()
       if (mlir::isa<mlir::rvsdg::Match>(operation))
       {
         matchFound = true;
-        std::cout << "Checking match GetOperation" << std::endl;
+        std::cout << "Checking match operation" << std::endl;
         auto matchOp = mlir::cast<mlir::rvsdg::Match>(operation);
 
         assert(mlir::isa<mlir::arith::ConstantIntOp>(matchOp.getInput().getDefiningOp()));
@@ -484,7 +484,7 @@ TestMatch()
 
 /** \brief TestGamma
  *
- * This test is similar to previous tests, but uses a gamma GetOperation
+ * This test is similar to previous tests, but uses a gamma operation
  */
 static int
 TestGamma()
@@ -500,7 +500,7 @@ TestGamma()
 
   {
 
-    // Create a gamma GetOperation
+    // Create a gamma operation
     std::cout << "Gamma Operation" << std::endl;
     auto CtrlConstant = jlm::rvsdg::control_constant(graph->root(), 3, 1);
     auto entryvar1 = jlm::rvsdg::create_bitconstant(graph->root(), 32, 5);
@@ -535,7 +535,7 @@ TestGamma()
     auto & omegaRegion = omega.getRegion();
     assert(omegaRegion.getBlocks().size() == 1);
     auto & omegaBlock = omegaRegion.front();
-    // 1 control + 2 constants + gamma + terminating GetOperation
+    // 1 control + 2 constants + gamma + terminating operation
     assert(omegaBlock.getOperations().size() == 5);
 
     bool gammaFound = false;
@@ -544,7 +544,7 @@ TestGamma()
       if (mlir::isa<mlir::rvsdg::GammaNode>(operation))
       {
         gammaFound = true;
-        std::cout << "Checking gamma GetOperation" << std::endl;
+        std::cout << "Checking gamma operation" << std::endl;
         auto gammaOp = mlir::cast<mlir::rvsdg::GammaNode>(operation);
         assert(gammaOp.getNumRegions() == 3);
         // 1 predicate + 2 entryVars
@@ -603,7 +603,7 @@ TestGamma()
 
 /** \brief TestTheta
  *
- * This test is similar to previous tests, but uses a theta GetOperation
+ * This test is similar to previous tests, but uses a theta operation
  */
 static int
 TestTheta()
@@ -617,7 +617,7 @@ TestTheta()
   auto nf = graph->node_normal_form(typeid(jlm::rvsdg::operation));
   nf->set_mutable(false);
   {
-    // Create a theta GetOperation
+    // Create a theta operation
     std::cout << "Theta Operation" << std::endl;
     auto entryvar1 = jlm::rvsdg::create_bitconstant(graph->root(), 32, 5);
     auto entryvar2 = jlm::rvsdg::create_bitconstant(graph->root(), 32, 6);
@@ -648,7 +648,7 @@ TestTheta()
       if (mlir::isa<mlir::rvsdg::ThetaNode>(operation))
       {
         thetaFound = true;
-        std::cout << "Checking theta GetOperation" << std::endl;
+        std::cout << "Checking theta operation" << std::endl;
         auto thetaOp = mlir::cast<mlir::rvsdg::ThetaNode>(operation);
         // 2 loop vars
         assert(thetaOp.getNumOperands() == 2);

--- a/tests/jlm/mlir/backend/TestJlmToMlirConverter.cpp
+++ b/tests/jlm/mlir/backend/TestJlmToMlirConverter.cpp
@@ -50,7 +50,7 @@ TestLambda()
     auto & omegaRegion = omega.getRegion();
     assert(omegaRegion.getBlocks().size() == 1);
     auto & omegaBlock = omegaRegion.front();
-    // Lamda + terminating operation
+    // Lamda + terminating GetOperation
     assert(omegaBlock.getOperations().size() == 2);
     auto & mlirLambda = omegaBlock.front();
     assert(mlirLambda.getName().getStringRef().equals(LambdaNode::getOperationName()));
@@ -85,7 +85,7 @@ TestLambda()
 
     auto & lambdaRegion = mlirLambda.getRegion(0);
     auto & lambdaBlock = lambdaRegion.front();
-    // Bitconstant + terminating operation
+    // Bitconstant + terminating GetOperation
     assert(lambdaBlock.getOperations().size() == 2);
     assert(lambdaBlock.front().getName().getStringRef().equals(
         mlir::arith::ConstantIntOp::getOperationName()));
@@ -97,8 +97,8 @@ TestLambda()
 
 /** \brief useChainsUpTraverse
  *
- * This function checks if the given operation matches the given definingOperations use chain
- * recursively. For each operation the operand 0 is checked until the definingOperations is empty.
+ * This function checks if the given GetOperation matches the given definingOperations use chain
+ * recursively. For each GetOperation the operand 0 is checked until the definingOperations is empty.
  *
  * \param operation The starting operation to check. (the lambda result for example)
  * \param succesorOperations The trace of operations to check. The last operation is the direct user
@@ -110,7 +110,7 @@ useChainsUpTraverse(mlir::Operation * operation, std::vector<llvm::StringRef> de
 {
   if (definingOperations.empty())
     return;
-  std::cout << "Checking if operation: "
+  std::cout << "Checking if GetOperation: "
             << operation->getOperand(0).getDefiningOp()->getName().getStringRef().data()
             << " is equal to: " << definingOperations.back().data() << std::endl;
   assert(operation->getOperand(0).getDefiningOp()->getName().getStringRef().equals(
@@ -121,14 +121,14 @@ useChainsUpTraverse(mlir::Operation * operation, std::vector<llvm::StringRef> de
 
 /** \brief TestAddOperation
  *
- * This test is similar to TestLambda, but it adds a add operation to the
+ * This test is similar to TestLambda, but it adds a add GetOperation to the
  * lambda block and does a graph traversal.
  * This function is similar to the TestDivOperation function in the frontend tests.
  *
- * This function tests the generation of an add operation using 2 bit constants as operands in the
+ * This function tests the generation of an add GetOperation using 2 bit constants as operands in the
  * MLIR backend. The test checks the number of blocks and operations in the generated MLIR. It also
  * checks the types of the operations and the users chain upwards from the lambda result to the bit
- * constants. The users trace goes through the operation first operand user recursively to trace the
+ * constants. The users trace goes through the GetOperation first operand user recursively to trace the
  * nodes.
  */
 static int
@@ -155,7 +155,7 @@ TestAddOperation()
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
 
-    // Create add operation
+    // Create add GetOperation
     std::cout << "Add Operation" << std::endl;
     auto constant1 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 4);
     auto constant2 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 5);
@@ -173,7 +173,7 @@ TestAddOperation()
     auto & omegaRegion = omega.getRegion();
     assert(omegaRegion.getBlocks().size() == 1);
     auto & omegaBlock = omegaRegion.front();
-    // Lamda + terminating operation
+    // Lamda + terminating GetOperation
     assert(omegaBlock.getOperations().size() == 2);
 
     // Checking lambda block operations
@@ -181,7 +181,7 @@ TestAddOperation()
     auto & mlirLambda = omegaBlock.front();
     auto & lambdaRegion = mlirLambda.getRegion(0);
     auto & lambdaBlock = lambdaRegion.front();
-    // 2 Bits contants + add + terminating operation
+    // 2 Bits contants + add + terminating GetOperation
     assert(lambdaBlock.getOperations().size() == 4);
 
     // Checking lambda block operations types
@@ -203,11 +203,11 @@ TestAddOperation()
         constCount++;
         continue;
       }
-      // Checking add operation
-      std::cout << "Checking add operation" << std::endl;
+      // Checking add GetOperation
+      std::cout << "Checking add GetOperation" << std::endl;
       assert(operation->getName().getStringRef().equals(
-          mlir::arith::AddIOp::getOperationName())); // Last remaining operation is the add
-                                                     // operation
+          mlir::arith::AddIOp::getOperationName())); // Last remaining GetOperation is the add
+                                                     // GetOperation
       assert(operation->getNumOperands() == 2);
       auto addOperand1 = operation->getOperand(0);
       auto addOperand2 = operation->getOperand(1);
@@ -229,7 +229,7 @@ TestAddOperation()
 /** \brief TestAddOperation
  *
  * This test is similar to previous tests, but uses a mul, zero extension
- * and comparison operation, it tests operations types
+ * and comparison GetOperation, it tests operations types
  * and does the use chain traversal.
  */
 static int
@@ -256,7 +256,7 @@ TestComZeroExt()
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
 
-    // Create add operation
+    // Create add GetOperation
     std::cout << "Add Operation" << std::endl;
     auto constant1 = jlm::rvsdg::create_bitconstant(lambda->subregion(), 8, 4);
     jlm::rvsdg::create_bitconstant(lambda->subregion(), 16, 5); // Unused constant
@@ -285,7 +285,7 @@ TestComZeroExt()
     auto & omegaRegion = omega.getRegion();
     assert(omegaRegion.getBlocks().size() == 1);
     auto & omegaBlock = omegaRegion.front();
-    // Lamda + terminating operation
+    // Lamda + terminating GetOperation
     assert(omegaBlock.getOperations().size() == 2);
 
     // Checking lambda block operations
@@ -293,7 +293,7 @@ TestComZeroExt()
     auto & mlirLambda = omegaBlock.front();
     auto & lambdaRegion = mlirLambda.getRegion(0);
     auto & lambdaBlock = lambdaRegion.front();
-    // 3 Bits contants + ZeroExt + Mul + Comp + terminating operation
+    // 3 Bits contants + ZeroExt + Mul + Comp + terminating GetOperation
     assert(lambdaBlock.getOperations().size() == 7);
 
     // Checking lambda block operations types
@@ -376,7 +376,7 @@ TestComZeroExt()
 
 /** \brief TestMatch
  *
- * This test is similar to previous tests, but uses a match operation
+ * This test is similar to previous tests, but uses a match GetOperation
  */
 static int
 TestMatch()
@@ -402,7 +402,7 @@ TestMatch()
     auto iOStateArgument = lambda->fctargument(0);
     auto memoryStateArgument = lambda->fctargument(1);
 
-    // Create a match operation
+    // Create a match GetOperation
     std::cout << "Match Operation" << std::endl;
     auto predicateConst = jlm::rvsdg::create_bitconstant(lambda->subregion(), 8, 4);
 
@@ -421,7 +421,7 @@ TestMatch()
     auto & omegaRegion = omega.getRegion();
     assert(omegaRegion.getBlocks().size() == 1);
     auto & omegaBlock = omegaRegion.front();
-    // Lamda + terminating operation
+    // Lamda + terminating GetOperation
     assert(omegaBlock.getOperations().size() == 2);
 
     // Checking lambda block operations
@@ -429,7 +429,7 @@ TestMatch()
     auto & mlirLambda = omegaBlock.front();
     auto & lambdaRegion = mlirLambda.getRegion(0);
     auto & lambdaBlock = lambdaRegion.front();
-    // 1 Bits contants + Match + terminating operation
+    // 1 Bits contants + Match + terminating GetOperation
     assert(lambdaBlock.getOperations().size() == 3);
 
     bool matchFound = false;
@@ -438,7 +438,7 @@ TestMatch()
       if (mlir::isa<mlir::rvsdg::Match>(operation))
       {
         matchFound = true;
-        std::cout << "Checking match operation" << std::endl;
+        std::cout << "Checking match GetOperation" << std::endl;
         auto matchOp = mlir::cast<mlir::rvsdg::Match>(operation);
 
         assert(mlir::isa<mlir::arith::ConstantIntOp>(matchOp.getInput().getDefiningOp()));
@@ -483,7 +483,7 @@ TestMatch()
 
 /** \brief TestGamma
  *
- * This test is similar to previous tests, but uses a gamma operation
+ * This test is similar to previous tests, but uses a gamma GetOperation
  */
 static int
 TestGamma()
@@ -499,7 +499,7 @@ TestGamma()
 
   {
 
-    // Create a gamma operation
+    // Create a gamma GetOperation
     std::cout << "Gamma Operation" << std::endl;
     auto CtrlConstant = jlm::rvsdg::control_constant(graph->root(), 3, 1);
     auto entryvar1 = jlm::rvsdg::create_bitconstant(graph->root(), 32, 5);
@@ -534,7 +534,7 @@ TestGamma()
     auto & omegaRegion = omega.getRegion();
     assert(omegaRegion.getBlocks().size() == 1);
     auto & omegaBlock = omegaRegion.front();
-    // 1 control + 2 constants + gamma + terminating operation
+    // 1 control + 2 constants + gamma + terminating GetOperation
     assert(omegaBlock.getOperations().size() == 5);
 
     bool gammaFound = false;
@@ -543,7 +543,7 @@ TestGamma()
       if (mlir::isa<mlir::rvsdg::GammaNode>(operation))
       {
         gammaFound = true;
-        std::cout << "Checking gamma operation" << std::endl;
+        std::cout << "Checking gamma GetOperation" << std::endl;
         auto gammaOp = mlir::cast<mlir::rvsdg::GammaNode>(operation);
         assert(gammaOp.getNumRegions() == 3);
         // 1 predicate + 2 entryVars
@@ -602,7 +602,7 @@ TestGamma()
 
 /** \brief TestTheta
  *
- * This test is similar to previous tests, but uses a theta operation
+ * This test is similar to previous tests, but uses a theta GetOperation
  */
 static int
 TestTheta()
@@ -616,7 +616,7 @@ TestTheta()
   auto nf = graph->node_normal_form(typeid(jlm::rvsdg::operation));
   nf->set_mutable(false);
   {
-    // Create a theta operation
+    // Create a theta GetOperation
     std::cout << "Theta Operation" << std::endl;
     auto entryvar1 = jlm::rvsdg::create_bitconstant(graph->root(), 32, 5);
     auto entryvar2 = jlm::rvsdg::create_bitconstant(graph->root(), 32, 6);
@@ -647,7 +647,7 @@ TestTheta()
       if (mlir::isa<mlir::rvsdg::ThetaNode>(operation))
       {
         thetaFound = true;
-        std::cout << "Checking theta operation" << std::endl;
+        std::cout << "Checking theta GetOperation" << std::endl;
         auto thetaOp = mlir::cast<mlir::rvsdg::ThetaNode>(operation);
         // 2 loop vars
         assert(thetaOp.getNumOperands() == 2);

--- a/tests/jlm/mlir/frontend/TestMlirToJlmConverter.cpp
+++ b/tests/jlm/mlir/frontend/TestMlirToJlmConverter.cpp
@@ -310,9 +310,9 @@ TestDivOperation()
 
 /** \brief TestCompZeroExt
  *
- * This test is similar to TestLambda, but it adds an add GetOperation, a comparison GetOperation and a
- * zero extension GetOperation to the lambda block and do a graph traversal check. This function is
- * similar to the TestComZeroExt function in the backend tests.
+ * This test is similar to TestLambda, but it adds an add GetOperation, a comparison GetOperation
+ * and a zero extension GetOperation to the lambda block and do a graph traversal check. This
+ * function is similar to the TestComZeroExt function in the backend tests.
  *
  */
 static int

--- a/tests/jlm/mlir/frontend/TestMlirToJlmConverter.cpp
+++ b/tests/jlm/mlir/frontend/TestMlirToJlmConverter.cpp
@@ -127,7 +127,7 @@ TestLambda()
 
 /** \brief TestDivOperation
  *
- * This test is similar to TestLambda, but it adds a division operation to the
+ * This test is similar to TestLambda, but it adds a division GetOperation to the
  * lambda block and do a graph traversal.
  * This function is similar to the TestAddOperation function in the backend tests.
  */
@@ -204,7 +204,7 @@ TestDivOperation()
     auto constOp1 = Builder_->create<mlir::arith::ConstantIntOp>(Builder_->getUnknownLoc(), 20, 32);
     lambdaBlock->push_back(constOp1);
 
-    // ConstOp2 is connected as second argument of the divide operation
+    // ConstOp2 is connected as second argument of the divide GetOperation
     auto constOp2 = Builder_->create<mlir::arith::ConstantIntOp>(Builder_->getUnknownLoc(), 5, 32);
     lambdaBlock->push_back(constOp2);
 
@@ -280,7 +280,7 @@ TestDivOperation()
           lambdaResultOriginNodeOuput = dynamic_cast<jlm::rvsdg::node_output *>(
               convertedLambda->subregion()->result(0)->origin()));
       jlm::rvsdg::node * lambdaResultOriginNode = lambdaResultOriginNodeOuput->node();
-      assert(is<bitudiv_op>(lambdaResultOriginNode->operation()));
+      assert(is<bitudiv_op>(lambdaResultOriginNode->GetOperation()));
       assert(lambdaResultOriginNode->ninputs() == 2);
 
       // Check first input
@@ -297,9 +297,9 @@ TestDivOperation()
           DivInput1NodeOuput =
               dynamic_cast<jlm::rvsdg::node_output *>(lambdaResultOriginNode->input(1)->origin()));
       jlm::rvsdg::node * DivInput1Node = DivInput1NodeOuput->node();
-      assert(is<bitconstant_op>(DivInput1Node->operation()));
+      assert(is<bitconstant_op>(DivInput1Node->GetOperation()));
       const jlm::rvsdg::bitconstant_op * DivInput1Constant =
-          dynamic_cast<const jlm::rvsdg::bitconstant_op *>(&DivInput1Node->operation());
+          dynamic_cast<const bitconstant_op *>(&DivInput1Node->GetOperation());
       assert(DivInput1Constant->value() == 5);
       assert(is<const bittype>(DivInput1Constant->result(0)));
       assert(std::dynamic_pointer_cast<const bittype>(DivInput1Constant->result(0))->nbits() == 32);
@@ -310,8 +310,8 @@ TestDivOperation()
 
 /** \brief TestCompZeroExt
  *
- * This test is similar to TestLambda, but it adds an add operation, a comparison operation and a
- * zero extension operation to the lambda block and do a graph traversal check. This function is
+ * This test is similar to TestLambda, but it adds an add GetOperation, a comparison GetOperation and a
+ * zero extension GetOperation to the lambda block and do a graph traversal check. This function is
  * similar to the TestComZeroExt function in the backend tests.
  *
  */
@@ -384,11 +384,11 @@ TestCompZeroExt()
     lambdaBlock->addArgument(Builder_->getType<IOStateEdgeType>(), Builder_->getUnknownLoc());
     lambdaBlock->addArgument(Builder_->getType<MemStateEdgeType>(), Builder_->getUnknownLoc());
 
-    // ConstOp1 is connected to the second argument of the add operation
+    // ConstOp1 is connected to the second argument of the add GetOperation
     auto constOp1 = Builder_->create<mlir::arith::ConstantIntOp>(Builder_->getUnknownLoc(), 20, 32);
     lambdaBlock->push_back(constOp1);
 
-    // ConstOp2 is connected as second argument of the compare operation
+    // ConstOp2 is connected as second argument of the compare GetOperation
     auto constOp2 = Builder_->create<mlir::arith::ConstantIntOp>(Builder_->getUnknownLoc(), 5, 32);
     lambdaBlock->push_back(constOp2);
 
@@ -459,12 +459,12 @@ TestCompZeroExt()
           lambdaResultOriginNodeOuput = dynamic_cast<jlm::rvsdg::node_output *>(
               convertedLambda->subregion()->result(0)->origin()));
       jlm::rvsdg::node * ZExtNode = lambdaResultOriginNodeOuput->node();
-      assert(is<jlm::llvm::zext_op>(ZExtNode->operation()));
+      assert(is<jlm::llvm::zext_op>(ZExtNode->GetOperation()));
       assert(ZExtNode->ninputs() == 1);
 
       // Check ZExt
       const jlm::llvm::zext_op * ZExtOp =
-          dynamic_cast<const jlm::llvm::zext_op *>(&ZExtNode->operation());
+          dynamic_cast<const jlm::llvm::zext_op *>(&ZExtNode->GetOperation());
       assert(ZExtOp->nsrcbits() == 1);
       assert(ZExtOp->ndstbits() == 32);
 
@@ -473,11 +473,11 @@ TestCompZeroExt()
       jlm::rvsdg::node_output * ZExtInput0;
       assert(ZExtInput0 = dynamic_cast<jlm::rvsdg::node_output *>(ZExtNode->input(0)->origin()));
       jlm::rvsdg::node * BitEqNode = ZExtInput0->node();
-      assert(is<jlm::rvsdg::biteq_op>(BitEqNode->operation()));
+      assert(is<jlm::rvsdg::biteq_op>(BitEqNode->GetOperation()));
 
       // Check BitEq
       assert(
-          dynamic_cast<const jlm::rvsdg::biteq_op *>(&BitEqNode->operation())->type().nbits()
+          dynamic_cast<const jlm::rvsdg::biteq_op *>(&BitEqNode->GetOperation())->type().nbits()
           == 32);
       assert(BitEqNode->ninputs() == 2);
 
@@ -485,25 +485,25 @@ TestCompZeroExt()
       jlm::rvsdg::node_output * AddOuput;
       assert(AddOuput = dynamic_cast<jlm::rvsdg::node_output *>(BitEqNode->input(0)->origin()));
       jlm::rvsdg::node * AddNode = AddOuput->node();
-      assert(is<bitadd_op>(AddNode->operation()));
+      assert(is<bitadd_op>(AddNode->GetOperation()));
       assert(AddNode->ninputs() == 2);
 
       // Check BitEq input 1
       jlm::rvsdg::node_output * Const2Ouput;
       assert(Const2Ouput = dynamic_cast<jlm::rvsdg::node_output *>(BitEqNode->input(1)->origin()));
       jlm::rvsdg::node * Const2Node = Const2Ouput->node();
-      assert(is<bitconstant_op>(Const2Node->operation()));
+      assert(is<bitconstant_op>(Const2Node->GetOperation()));
 
       // Check Const2
       const jlm::rvsdg::bitconstant_op * Const2Op =
-          dynamic_cast<const jlm::rvsdg::bitconstant_op *>(&Const2Node->operation());
+          dynamic_cast<const bitconstant_op *>(&Const2Node->GetOperation());
       assert(Const2Op->value() == 5);
       assert(is<const bittype>(Const2Op->result(0)));
       assert(std::dynamic_pointer_cast<const bittype>(Const2Op->result(0))->nbits() == 32);
 
       // Check add op
       const jlm::rvsdg::bitadd_op * AddOp =
-          dynamic_cast<const jlm::rvsdg::bitadd_op *>(&AddNode->operation());
+          dynamic_cast<const bitadd_op *>(&AddNode->GetOperation());
       assert(AddOp->type().nbits() == 32);
 
       // Check add input0
@@ -516,11 +516,11 @@ TestCompZeroExt()
       jlm::rvsdg::node_output * Const1Output;
       assert(Const1Output = dynamic_cast<jlm::rvsdg::node_output *>(AddNode->input(1)->origin()));
       jlm::rvsdg::node * Const1Node = Const1Output->node();
-      assert(is<bitconstant_op>(Const1Node->operation()));
+      assert(is<bitconstant_op>(Const1Node->GetOperation()));
 
       // Check Const1
       const jlm::rvsdg::bitconstant_op * Const1Op =
-          dynamic_cast<const jlm::rvsdg::bitconstant_op *>(&Const1Node->operation());
+          dynamic_cast<const bitconstant_op *>(&Const1Node->GetOperation());
       assert(Const1Op->value() == 20);
       assert(is<const bittype>(Const1Op->result(0)));
       assert(std::dynamic_pointer_cast<const bittype>(Const1Op->result(0))->nbits() == 32);
@@ -531,7 +531,7 @@ TestCompZeroExt()
 
 /** \brief TestMatchOp
  *
- * This function tests the Match operation. It creates a lambda block with a Match operation.
+ * This function tests the Match GetOperation. It creates a lambda block with a Match GetOperation.
  *
  */
 static int
@@ -668,9 +668,9 @@ TestMatchOp()
       assert(
           matchOutput = dynamic_cast<jlm::rvsdg::node_output *>(lambdaRegion->result(0)->origin()));
       jlm::rvsdg::node * matchNode = matchOutput->node();
-      assert(is<match_op>(matchNode->operation()));
+      assert(is<match_op>(matchNode->GetOperation()));
 
-      auto matchOp = dynamic_cast<const match_op *>(&matchNode->operation());
+      auto matchOp = dynamic_cast<const match_op *>(&matchNode->GetOperation());
       assert(matchOp->narguments() == 1);
       assert(is<const bittype>(matchOp->argument(0)));
       assert(std::dynamic_pointer_cast<const bittype>(matchOp->argument(0))->nbits() == 32);
@@ -694,7 +694,7 @@ TestMatchOp()
 
 /** \brief TestMatchOp
  *
- * This function tests the Gamma operation. It creates a lambda block with a Gamma operation.
+ * This function tests the Gamma GetOperation. It creates a lambda block with a Gamma GetOperation.
  *
  */
 static int
@@ -844,10 +844,10 @@ TestGammaOp()
       assert(
           gammaOutput = dynamic_cast<jlm::rvsdg::node_output *>(lambdaRegion->result(0)->origin()));
       jlm::rvsdg::node * gammaNode = gammaOutput->node();
-      assert(is<GammaOperation>(gammaNode->operation()));
+      assert(is<GammaOperation>(gammaNode->GetOperation()));
 
-      std::cout << "Checking gamma operation" << std::endl;
-      auto gammaOp = dynamic_cast<const GammaOperation *>(&gammaNode->operation());
+      std::cout << "Checking gamma GetOperation" << std::endl;
+      auto gammaOp = dynamic_cast<const GammaOperation *>(&gammaNode->GetOperation());
       assert(gammaNode->ninputs() == 3);
       assert(gammaOp->nalternatives() == 3);
       assert(gammaNode->noutputs() == 2);
@@ -858,7 +858,7 @@ TestGammaOp()
 
 /** \brief TestThetaOp
  *
- * This function tests the Theta operation. It creates a lambda block with a Theta operation.
+ * This function tests the Theta GetOperation. It creates a lambda block with a Theta GetOperation.
  *
  */
 static int
@@ -993,7 +993,7 @@ TestThetaOp()
       assert(
           thetaOutput = dynamic_cast<jlm::rvsdg::node_output *>(lambdaRegion->result(0)->origin()));
       jlm::rvsdg::node * node = thetaOutput->node();
-      assert(is<ThetaOperation>(node->operation()));
+      assert(is<ThetaOperation>(node->GetOperation()));
       auto thetaNode = dynamic_cast<const jlm::rvsdg::ThetaNode *>(node);
 
       std::cout << "Checking theta node" << std::endl;

--- a/tests/jlm/mlir/frontend/TestMlirToJlmConverter.cpp
+++ b/tests/jlm/mlir/frontend/TestMlirToJlmConverter.cpp
@@ -127,7 +127,7 @@ TestLambda()
 
 /** \brief TestDivOperation
  *
- * This test is similar to TestLambda, but it adds a division GetOperation to the
+ * This test is similar to TestLambda, but it adds a division operation to the
  * lambda block and do a graph traversal.
  * This function is similar to the TestAddOperation function in the backend tests.
  */
@@ -204,7 +204,7 @@ TestDivOperation()
     auto constOp1 = Builder_->create<mlir::arith::ConstantIntOp>(Builder_->getUnknownLoc(), 20, 32);
     lambdaBlock->push_back(constOp1);
 
-    // ConstOp2 is connected as second argument of the divide GetOperation
+    // ConstOp2 is connected as second argument of the divide operation
     auto constOp2 = Builder_->create<mlir::arith::ConstantIntOp>(Builder_->getUnknownLoc(), 5, 32);
     lambdaBlock->push_back(constOp2);
 
@@ -310,8 +310,8 @@ TestDivOperation()
 
 /** \brief TestCompZeroExt
  *
- * This test is similar to TestLambda, but it adds an add GetOperation, a comparison GetOperation
- * and a zero extension GetOperation to the lambda block and do a graph traversal check. This
+ * This test is similar to TestLambda, but it adds an add operation, a comparison operation
+ * and a zero extension operation to the lambda block and do a graph traversal check. This
  * function is similar to the TestComZeroExt function in the backend tests.
  *
  */
@@ -384,11 +384,11 @@ TestCompZeroExt()
     lambdaBlock->addArgument(Builder_->getType<IOStateEdgeType>(), Builder_->getUnknownLoc());
     lambdaBlock->addArgument(Builder_->getType<MemStateEdgeType>(), Builder_->getUnknownLoc());
 
-    // ConstOp1 is connected to the second argument of the add GetOperation
+    // ConstOp1 is connected to the second argument of the add operation
     auto constOp1 = Builder_->create<mlir::arith::ConstantIntOp>(Builder_->getUnknownLoc(), 20, 32);
     lambdaBlock->push_back(constOp1);
 
-    // ConstOp2 is connected as second argument of the compare GetOperation
+    // ConstOp2 is connected as second argument of the compare operation
     auto constOp2 = Builder_->create<mlir::arith::ConstantIntOp>(Builder_->getUnknownLoc(), 5, 32);
     lambdaBlock->push_back(constOp2);
 
@@ -531,7 +531,7 @@ TestCompZeroExt()
 
 /** \brief TestMatchOp
  *
- * This function tests the Match GetOperation. It creates a lambda block with a Match GetOperation.
+ * This function tests the Match operation. It creates a lambda block with a Match operation.
  *
  */
 static int
@@ -694,7 +694,7 @@ TestMatchOp()
 
 /** \brief TestMatchOp
  *
- * This function tests the Gamma GetOperation. It creates a lambda block with a Gamma GetOperation.
+ * This function tests the Gamma operation. It creates a lambda block with a Gamma operation.
  *
  */
 static int
@@ -846,7 +846,7 @@ TestGammaOp()
       jlm::rvsdg::node * gammaNode = gammaOutput->node();
       assert(is<GammaOperation>(gammaNode->GetOperation()));
 
-      std::cout << "Checking gamma GetOperation" << std::endl;
+      std::cout << "Checking gamma operation" << std::endl;
       auto gammaOp = dynamic_cast<const GammaOperation *>(&gammaNode->GetOperation());
       assert(gammaNode->ninputs() == 3);
       assert(gammaOp->nalternatives() == 3);
@@ -858,7 +858,7 @@ TestGammaOp()
 
 /** \brief TestThetaOp
  *
- * This function tests the Theta GetOperation. It creates a lambda block with a Theta GetOperation.
+ * This function tests the Theta operation. It creates a lambda block with a Theta operationpp.
  *
  */
 static int

--- a/tests/jlm/mlir/frontend/TestMlirToJlmConverter.cpp
+++ b/tests/jlm/mlir/frontend/TestMlirToJlmConverter.cpp
@@ -310,9 +310,9 @@ TestDivOperation()
 
 /** \brief TestCompZeroExt
  *
- * This test is similar to TestLambda, but it adds an add operation, a comparison operation
- * and a zero extension operation to the lambda block and do a graph traversal check. This
- * function is similar to the TestComZeroExt function in the backend tests.
+ * This test is similar to TestLambda, but it adds an add operation, a comparison operation and a
+ * zero extension operation to the lambda block and do a graph traversal check. This function is
+ * similar to the TestComZeroExt function in the backend tests.
  *
  */
 static int
@@ -858,7 +858,7 @@ TestGammaOp()
 
 /** \brief TestThetaOp
  *
- * This function tests the Theta operation. It creates a lambda block with a Theta operationpp.
+ * This function tests the Theta operation. It creates a lambda block with a Theta operation.
  *
  */
 static int

--- a/tests/jlm/rvsdg/bitstring/bitstring.cpp
+++ b/tests/jlm/rvsdg/bitstring/bitstring.cpp
@@ -36,8 +36,8 @@ types_bitstring_arithmetic_test_bitand(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(output::GetNode(*and0)->operation() == bitand_op(32));
-  assert(output::GetNode(*and1)->operation() == int_constant_op(32, +1));
+  assert(output::GetNode(*and0)->GetOperation() == bitand_op(32));
+  assert(output::GetNode(*and1)->GetOperation() == int_constant_op(32, +1));
 
   return 0;
 }
@@ -72,11 +72,11 @@ types_bitstring_arithmetic_test_bitashr(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(output::GetNode(*ashr0)->operation() == bitashr_op(32));
-  assert(output::GetNode(*ashr1)->operation() == int_constant_op(32, 4));
-  assert(output::GetNode(*ashr2)->operation() == int_constant_op(32, 0));
-  assert(output::GetNode(*ashr3)->operation() == int_constant_op(32, -4));
-  assert(output::GetNode(*ashr4)->operation() == int_constant_op(32, -1));
+  assert(output::GetNode(*ashr0)->GetOperation() == bitashr_op(32));
+  assert(output::GetNode(*ashr1)->GetOperation() == int_constant_op(32, 4));
+  assert(output::GetNode(*ashr2)->GetOperation() == int_constant_op(32, 0));
+  assert(output::GetNode(*ashr3)->GetOperation() == int_constant_op(32, -4));
+  assert(output::GetNode(*ashr4)->GetOperation() == int_constant_op(32, -1));
 
   return 0;
 }
@@ -99,7 +99,7 @@ types_bitstring_arithmetic_test_bitdifference(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(output::GetNode(*diff)->operation() == bitsub_op(32));
+  assert(output::GetNode(*diff)->GetOperation() == bitsub_op(32));
 
   return 0;
 }
@@ -125,9 +125,9 @@ types_bitstring_arithmetic_test_bitnegate(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(output::GetNode(*neg0)->operation() == bitneg_op(32));
-  assert(output::GetNode(*neg1)->operation() == int_constant_op(32, -3));
-  assert(output::GetNode(*neg2)->operation() == int_constant_op(32, 3));
+  assert(output::GetNode(*neg0)->GetOperation() == bitneg_op(32));
+  assert(output::GetNode(*neg1)->GetOperation() == int_constant_op(32, -3));
+  assert(output::GetNode(*neg2)->GetOperation() == int_constant_op(32, 3));
 
   return 0;
 }
@@ -153,9 +153,9 @@ types_bitstring_arithmetic_test_bitnot(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(output::GetNode(*not0)->operation() == bitnot_op(32));
-  assert(output::GetNode(*not1)->operation() == int_constant_op(32, -4));
-  assert(output::GetNode(*not2)->operation() == int_constant_op(32, 3));
+  assert(output::GetNode(*not0)->GetOperation() == bitnot_op(32));
+  assert(output::GetNode(*not1)->GetOperation() == int_constant_op(32, -4));
+  assert(output::GetNode(*not2)->GetOperation() == int_constant_op(32, 3));
 
   return 0;
 }
@@ -182,8 +182,8 @@ types_bitstring_arithmetic_test_bitor(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(output::GetNode(*or0)->operation() == bitor_op(32));
-  assert(output::GetNode(*or1)->operation() == uint_constant_op(32, 7));
+  assert(output::GetNode(*or0)->GetOperation() == bitor_op(32));
+  assert(output::GetNode(*or1)->GetOperation() == uint_constant_op(32, 7));
 
   return 0;
 }
@@ -211,8 +211,8 @@ types_bitstring_arithmetic_test_bitproduct(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(output::GetNode(*product0)->operation() == bitmul_op(32));
-  assert(output::GetNode(*product1)->operation() == uint_constant_op(32, 15));
+  assert(output::GetNode(*product0)->GetOperation() == bitmul_op(32));
+  assert(output::GetNode(*product1)->GetOperation() == uint_constant_op(32, 15));
 
   return 0;
 }
@@ -235,7 +235,7 @@ types_bitstring_arithmetic_test_bitshiproduct(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(output::GetNode(*shiproduct)->operation() == bitsmulh_op(32));
+  assert(output::GetNode(*shiproduct)->GetOperation() == bitsmulh_op(32));
 
   return 0;
 }
@@ -265,9 +265,9 @@ types_bitstring_arithmetic_test_bitshl(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(output::GetNode(*shl0)->operation() == bitshl_op(32));
-  assert(output::GetNode(*shl1)->operation() == uint_constant_op(32, 64));
-  assert(output::GetNode(*shl2)->operation() == uint_constant_op(32, 0));
+  assert(output::GetNode(*shl0)->GetOperation() == bitshl_op(32));
+  assert(output::GetNode(*shl1)->GetOperation() == uint_constant_op(32, 64));
+  assert(output::GetNode(*shl2)->GetOperation() == uint_constant_op(32, 0));
 
   return 0;
 }
@@ -297,9 +297,9 @@ types_bitstring_arithmetic_test_bitshr(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(output::GetNode(*shr0)->operation() == bitshr_op(32));
-  assert(output::GetNode(*shr1)->operation() == uint_constant_op(32, 4));
-  assert(output::GetNode(*shr2)->operation() == uint_constant_op(32, 0));
+  assert(output::GetNode(*shr0)->GetOperation() == bitshr_op(32));
+  assert(output::GetNode(*shr1)->GetOperation() == uint_constant_op(32, 4));
+  assert(output::GetNode(*shr2)->GetOperation() == uint_constant_op(32, 0));
 
   return 0;
 }
@@ -327,8 +327,8 @@ types_bitstring_arithmetic_test_bitsmod(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(output::GetNode(*smod0)->operation() == bitsmod_op(32));
-  assert(output::GetNode(*smod1)->operation() == int_constant_op(32, -1));
+  assert(output::GetNode(*smod0)->GetOperation() == bitsmod_op(32));
+  assert(output::GetNode(*smod1)->GetOperation() == int_constant_op(32, -1));
 
   return 0;
 }
@@ -356,8 +356,8 @@ types_bitstring_arithmetic_test_bitsquotient(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(output::GetNode(*squot0)->operation() == bitsdiv_op(32));
-  assert(output::GetNode(*squot1)->operation() == int_constant_op(32, -2));
+  assert(output::GetNode(*squot0)->GetOperation() == bitsdiv_op(32));
+  assert(output::GetNode(*squot1)->GetOperation() == int_constant_op(32, -2));
 
   return 0;
 }
@@ -385,8 +385,8 @@ types_bitstring_arithmetic_test_bitsum(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(output::GetNode(*sum0)->operation() == bitadd_op(32));
-  assert(output::GetNode(*sum1)->operation() == int_constant_op(32, 8));
+  assert(output::GetNode(*sum0)->GetOperation() == bitadd_op(32));
+  assert(output::GetNode(*sum1)->GetOperation() == int_constant_op(32, 8));
 
   return 0;
 }
@@ -409,7 +409,7 @@ types_bitstring_arithmetic_test_bituhiproduct(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(output::GetNode(*uhiproduct)->operation() == bitumulh_op(32));
+  assert(output::GetNode(*uhiproduct)->GetOperation() == bitumulh_op(32));
 
   return 0;
 }
@@ -437,8 +437,8 @@ types_bitstring_arithmetic_test_bitumod(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(output::GetNode(*umod0)->operation() == bitumod_op(32));
-  assert(output::GetNode(*umod1)->operation() == int_constant_op(32, 1));
+  assert(output::GetNode(*umod0)->GetOperation() == bitumod_op(32));
+  assert(output::GetNode(*umod1)->GetOperation() == int_constant_op(32, 1));
 
   return 0;
 }
@@ -466,8 +466,8 @@ types_bitstring_arithmetic_test_bituquotient(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(output::GetNode(*uquot0)->operation() == bitudiv_op(32));
-  assert(output::GetNode(*uquot1)->operation() == int_constant_op(32, 2));
+  assert(output::GetNode(*uquot0)->GetOperation() == bitudiv_op(32));
+  assert(output::GetNode(*uquot1)->GetOperation() == int_constant_op(32, 2));
 
   return 0;
 }
@@ -494,8 +494,8 @@ types_bitstring_arithmetic_test_bitxor(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(output::GetNode(*xor0)->operation() == bitxor_op(32));
-  assert(output::GetNode(*xor1)->operation() == int_constant_op(32, 6));
+  assert(output::GetNode(*xor0)->GetOperation() == bitxor_op(32));
+  assert(output::GetNode(*xor1)->GetOperation() == int_constant_op(32, 6));
 
   return 0;
 }
@@ -504,7 +504,7 @@ static inline void
 expect_static_true(jlm::rvsdg::output * port)
 {
   auto node = jlm::rvsdg::output::GetNode(*port);
-  auto op = dynamic_cast<const jlm::rvsdg::bitconstant_op *>(&node->operation());
+  auto op = dynamic_cast<const jlm::rvsdg::bitconstant_op *>(&node->GetOperation());
   assert(op && op->value().nbits() == 1 && op->value().str() == "1");
 }
 
@@ -512,7 +512,7 @@ static inline void
 expect_static_false(jlm::rvsdg::output * port)
 {
   auto node = jlm::rvsdg::output::GetNode(*port);
-  auto op = dynamic_cast<const jlm::rvsdg::bitconstant_op *>(&node->operation());
+  auto op = dynamic_cast<const jlm::rvsdg::bitconstant_op *>(&node->GetOperation());
   assert(op && op->value().nbits() == 1 && op->value().str() == "0");
 }
 
@@ -542,10 +542,10 @@ types_bitstring_comparison_test_bitequal(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(output::GetNode(*equal0)->operation() == biteq_op(32));
+  assert(output::GetNode(*equal0)->GetOperation() == biteq_op(32));
   expect_static_true(equal1);
   expect_static_false(equal2);
-  assert(output::GetNode(*equal3)->operation() == biteq_op(32));
+  assert(output::GetNode(*equal3)->GetOperation() == biteq_op(32));
 
   return 0;
 }
@@ -576,10 +576,10 @@ types_bitstring_comparison_test_bitnotequal(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(output::GetNode(*nequal0)->operation() == bitne_op(32));
+  assert(output::GetNode(*nequal0)->GetOperation() == bitne_op(32));
   expect_static_false(nequal1);
   expect_static_true(nequal2);
-  assert(output::GetNode(*nequal3)->operation() == bitne_op(32));
+  assert(output::GetNode(*nequal3)->GetOperation() == bitne_op(32));
 
   return 0;
 }
@@ -613,7 +613,7 @@ types_bitstring_comparison_test_bitsgreater(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(output::GetNode(*sgreater0)->operation() == bitsgt_op(32));
+  assert(output::GetNode(*sgreater0)->GetOperation() == bitsgt_op(32));
   expect_static_false(sgreater1);
   expect_static_true(sgreater2);
   expect_static_false(sgreater3);
@@ -653,7 +653,7 @@ types_bitstring_comparison_test_bitsgreatereq(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(output::GetNode(*sgreatereq0)->operation() == bitsge_op(32));
+  assert(output::GetNode(*sgreatereq0)->GetOperation() == bitsge_op(32));
   expect_static_false(sgreatereq1);
   expect_static_true(sgreatereq2);
   expect_static_true(sgreatereq3);
@@ -692,7 +692,7 @@ types_bitstring_comparison_test_bitsless(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(output::GetNode(*sless0)->operation() == bitslt_op(32));
+  assert(output::GetNode(*sless0)->GetOperation() == bitslt_op(32));
   expect_static_true(sless1);
   expect_static_false(sless2);
   expect_static_false(sless3);
@@ -732,7 +732,7 @@ types_bitstring_comparison_test_bitslesseq(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(output::GetNode(*slesseq0)->operation() == bitsle_op(32));
+  assert(output::GetNode(*slesseq0)->GetOperation() == bitsle_op(32));
   expect_static_true(slesseq1);
   expect_static_true(slesseq2);
   expect_static_false(slesseq3);
@@ -771,7 +771,7 @@ types_bitstring_comparison_test_bitugreater(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(output::GetNode(*ugreater0)->operation() == bitugt_op(32));
+  assert(output::GetNode(*ugreater0)->GetOperation() == bitugt_op(32));
   expect_static_false(ugreater1);
   expect_static_true(ugreater2);
   expect_static_false(ugreater3);
@@ -811,7 +811,7 @@ types_bitstring_comparison_test_bitugreatereq(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(output::GetNode(*ugreatereq0)->operation() == bituge_op(32));
+  assert(output::GetNode(*ugreatereq0)->GetOperation() == bituge_op(32));
   expect_static_false(ugreatereq1);
   expect_static_true(ugreatereq2);
   expect_static_true(ugreatereq3);
@@ -850,7 +850,7 @@ types_bitstring_comparison_test_bituless(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(output::GetNode(*uless0)->operation() == bitult_op(32));
+  assert(output::GetNode(*uless0)->GetOperation() == bitult_op(32));
   expect_static_true(uless1);
   expect_static_false(uless2);
   expect_static_false(uless3);
@@ -890,7 +890,7 @@ types_bitstring_comparison_test_bitulesseq(void)
   graph.prune();
   jlm::rvsdg::view(graph.root(), stdout);
 
-  assert(output::GetNode(*ulesseq0)->operation() == bitule_op(32));
+  assert(output::GetNode(*ulesseq0)->GetOperation() == bitule_op(32));
   expect_static_true(ulesseq1);
   expect_static_true(ulesseq2);
   expect_static_false(ulesseq3);
@@ -940,24 +940,24 @@ types_bitstring_test_constant(void)
   auto b3 = output::GetNode(*create_bitconstant(graph.root(), 8, 204));
   auto b4 = output::GetNode(*create_bitconstant(graph.root(), "001100110"));
 
-  assert(b1->operation() == uint_constant_op(8, 204));
-  assert(b1->operation() == int_constant_op(8, -52));
+  assert(b1->GetOperation() == uint_constant_op(8, 204));
+  assert(b1->GetOperation() == int_constant_op(8, -52));
 
   assert(b1 == b2);
   assert(b1 == b3);
 
-  assert(b1->operation() == uint_constant_op(8, 204));
-  assert(b1->operation() == int_constant_op(8, -52));
+  assert(b1->GetOperation() == uint_constant_op(8, 204));
+  assert(b1->GetOperation() == int_constant_op(8, -52));
 
-  assert(b4->operation() == uint_constant_op(9, 204));
-  assert(b4->operation() == int_constant_op(9, 204));
+  assert(b4->GetOperation() == uint_constant_op(9, 204));
+  assert(b4->GetOperation() == int_constant_op(9, 204));
 
   auto plus_one_128 = output::GetNode(*create_bitconstant(graph.root(), ONE_64 ZERO_64));
-  assert(plus_one_128->operation() == uint_constant_op(128, 1));
-  assert(plus_one_128->operation() == int_constant_op(128, 1));
+  assert(plus_one_128->GetOperation() == uint_constant_op(128, 1));
+  assert(plus_one_128->GetOperation() == int_constant_op(128, 1));
 
   auto minus_one_128 = output::GetNode(*create_bitconstant(graph.root(), MONE_64 MONE_64));
-  assert(minus_one_128->operation() == int_constant_op(128, -1));
+  assert(minus_one_128->GetOperation() == int_constant_op(128, -1));
 
   jlm::rvsdg::view(graph.root(), stdout);
 
@@ -982,11 +982,11 @@ types_bitstring_test_normalize(void)
   sum_nf->set_mutable(false);
 
   auto sum0 = output::GetNode(*bitadd_op::create(32, imp, c0));
-  assert(sum0->operation() == bitadd_op(32));
+  assert(sum0->GetOperation() == bitadd_op(32));
   assert(sum0->ninputs() == 2);
 
   auto sum1 = output::GetNode(*bitadd_op::create(32, sum0->output(0), c1));
-  assert(sum1->operation() == bitadd_op(32));
+  assert(sum1->GetOperation() == bitadd_op(32));
   assert(sum1->ninputs() == 2);
 
   auto & exp = jlm::tests::GraphExport::Create(*sum1->output(0), "dummy");
@@ -996,7 +996,7 @@ types_bitstring_test_normalize(void)
   graph.prune();
 
   auto origin = dynamic_cast<node_output *>(exp.origin());
-  assert(origin->node()->operation() == bitadd_op(32));
+  assert(origin->node()->GetOperation() == bitadd_op(32));
   assert(origin->node()->ninputs() == 2);
   auto op1 = origin->node()->input(0)->origin();
   auto op2 = origin->node()->input(1)->origin();
@@ -1007,7 +1007,7 @@ types_bitstring_test_normalize(void)
     op2 = tmp;
   }
   /* FIXME: the graph traversers are currently broken, that is why it won't normalize */
-  assert(output::GetNode(*op1)->operation() == int_constant_op(32, 3 + 4));
+  assert(output::GetNode(*op1)->GetOperation() == int_constant_op(32, 3 + 4));
   assert(op2 == imp);
 
   jlm::rvsdg::view(graph.root(), stdout);
@@ -1019,7 +1019,7 @@ static void
 assert_constant(jlm::rvsdg::output * bitstr, size_t nbits, const char bits[])
 {
   auto node = jlm::rvsdg::output::GetNode(*bitstr);
-  auto op = dynamic_cast<const jlm::rvsdg::bitconstant_op &>(node->operation());
+  auto op = dynamic_cast<const jlm::rvsdg::bitconstant_op &>(node->GetOperation());
   assert(op.value() == jlm::rvsdg::bitvalue_repr(std::string(bits, nbits).c_str()));
 }
 
@@ -1052,15 +1052,15 @@ types_bitstring_test_reduction(void)
     auto node = output::GetNode(*jlm::rvsdg::bitslice(concat, 8, 24));
     auto o0 = dynamic_cast<node_output *>(node->input(0)->origin());
     auto o1 = dynamic_cast<node_output *>(node->input(1)->origin());
-    assert(dynamic_cast<const bitconcat_op *>(&node->operation()));
+    assert(dynamic_cast<const bitconcat_op *>(&node->GetOperation()));
     assert(node->ninputs() == 2);
-    assert(dynamic_cast<const bitslice_op *>(&o0->node()->operation()));
-    assert(dynamic_cast<const bitslice_op *>(&o1->node()->operation()));
+    assert(dynamic_cast<const bitslice_op *>(&o0->node()->GetOperation()));
+    assert(dynamic_cast<const bitslice_op *>(&o1->node()->GetOperation()));
 
     const bitslice_op * attrs;
-    attrs = dynamic_cast<const bitslice_op *>(&o0->node()->operation());
+    attrs = dynamic_cast<const bitslice_op *>(&o0->node()->GetOperation());
     assert((attrs->low() == 8) && (attrs->high() == 16));
-    attrs = dynamic_cast<const bitslice_op *>(&o1->node()->operation());
+    attrs = dynamic_cast<const bitslice_op *>(&o1->node()->GetOperation());
     assert((attrs->low() == 0) && (attrs->high() == 8));
 
     assert(o0->node()->input(0)->origin() == x);
@@ -1095,7 +1095,7 @@ types_bitstring_test_slice_concat(void)
     /* slice of constant */
     auto a = output::GetNode(*jlm::rvsdg::bitslice(base_const1, 2, 6));
 
-    auto & op = dynamic_cast<const bitconstant_op &>(a->operation());
+    auto & op = dynamic_cast<const bitconstant_op &>(a->GetOperation());
     assert(op.value() == bitvalue_repr("1101"));
   }
 
@@ -1104,9 +1104,9 @@ types_bitstring_test_slice_concat(void)
     auto a = jlm::rvsdg::bitslice(base_x, 2, 6);
     auto b = output::GetNode(*jlm::rvsdg::bitslice(a, 1, 3));
 
-    assert(dynamic_cast<const bitslice_op *>(&b->operation()));
+    assert(dynamic_cast<const bitslice_op *>(&b->GetOperation()));
     const bitslice_op * attrs;
-    attrs = dynamic_cast<const bitslice_op *>(&b->operation());
+    attrs = dynamic_cast<const bitslice_op *>(&b->GetOperation());
     assert(attrs->low() == 3 && attrs->high() == 5);
   }
 
@@ -1132,7 +1132,7 @@ types_bitstring_test_slice_concat(void)
     auto a = jlm::rvsdg::bitconcat({ base_x, base_y });
     auto b = output::GetNode(*jlm::rvsdg::bitconcat({ a, base_z }));
 
-    assert(dynamic_cast<const bitconcat_op *>(&b->operation()));
+    assert(dynamic_cast<const bitconcat_op *>(&b->GetOperation()));
     assert(b->ninputs() == 3);
     assert(b->input(0)->origin() == base_x);
     assert(b->input(1)->origin() == base_y);
@@ -1159,7 +1159,7 @@ types_bitstring_test_slice_concat(void)
     /* concat of constants */
     auto a = output::GetNode(*jlm::rvsdg::bitconcat({ base_const1, base_const2 }));
 
-    auto & op = dynamic_cast<const bitconstant_op &>(a->operation());
+    auto & op = dynamic_cast<const bitconstant_op &>(a->GetOperation());
     assert(op.value() == bitvalue_repr("0011011111001000"));
   }
 

--- a/tests/jlm/rvsdg/test-gamma.cpp
+++ b/tests/jlm/rvsdg/test-gamma.cpp
@@ -33,7 +33,7 @@ test_gamma(void)
 
   jlm::tests::GraphExport::Create(*gamma->output(0), "dummy");
 
-  assert(gamma && gamma->operation() == GammaOperation(3));
+  assert(gamma && gamma->GetOperation() == GammaOperation(3));
 
   /* test gamma copy */
 
@@ -138,8 +138,8 @@ test_control_constant_reduction()
   jlm::rvsdg::view(graph.root(), stdout);
 
   auto match = output::GetNode(*ex1.origin());
-  assert(match && is<match_op>(match->operation()));
-  auto & match_op = to_match_op(match->operation());
+  assert(match && is<match_op>(match->GetOperation()));
+  auto & match_op = to_match_op(match->GetOperation());
   assert(match_op.default_alternative() == 0);
 
   assert(output::GetNode(*ex2.origin()) == gamma);


### PR DESCRIPTION
The method name collided with the class name, leading to compiler errors when I tried to perform other refactoring. This PR does the following:
1. Rename operation() method of node class to GetOperation()
2. Make it virtual such that the subclasses can overload it and give back the concrete operation type.