### PR TITLE
gamma: change API for mapping input to region argument

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/GammaConversion.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/GammaConversion.cpp
@@ -18,14 +18,14 @@ ConvertGammaNodeWithoutSpeculation(rvsdg::GammaNode & gammaNode)
 
   // create a branch for each gamma input and map the corresponding argument of each subregion to an
   // output of the branch
-  for (size_t i = 0; i < gammaNode.nentryvars(); i++)
+  for (const auto & entryvar : gammaNode.GetEntryVars())
   {
     auto branchResults =
-        hls::branch_op::create(*gammaNode.predicate()->origin(), *gammaNode.entryvar(i)->origin());
+        hls::branch_op::create(*gammaNode.predicate()->origin(), *entryvar.input->origin());
 
     for (size_t s = 0; s < gammaNode.nsubregions(); s++)
     {
-      substitutionMap.insert(gammaNode.subregion(s)->argument(i), branchResults[s]);
+      substitutionMap.insert(entryvar.branchArgument[s], branchResults[s]);
     }
   }
 
@@ -34,19 +34,19 @@ ConvertGammaNodeWithoutSpeculation(rvsdg::GammaNode & gammaNode)
     gammaNode.subregion(s)->copy(gammaNode.region(), substitutionMap, false, false);
   }
 
-  for (size_t i = 0; i < gammaNode.nexitvars(); i++)
+  for (const auto & ex : gammaNode.GetExitVars())
   {
     std::vector<rvsdg::output *> alternatives;
     for (size_t s = 0; s < gammaNode.nsubregions(); s++)
     {
-      alternatives.push_back(substitutionMap.lookup(gammaNode.subregion(s)->result(i)->origin()));
+      alternatives.push_back(substitutionMap.lookup(ex.branchResult[s]->origin()));
     }
     // create mux nodes for each gamma output
     // use mux instead of merge in case of paths with different delay - otherwise one could overtake
     // the other see https://ieeexplore.ieee.org/abstract/document/9515491
     auto mux = hls::mux_op::create(*gammaNode.predicate()->origin(), alternatives, false);
 
-    gammaNode.exitvar(i)->divert_users(mux[0]);
+    ex.output->divert_users(mux[0]);
   }
 
   remove(&gammaNode);
@@ -58,13 +58,11 @@ ConvertGammaNodeWithSpeculation(rvsdg::GammaNode & gammaNode)
   rvsdg::SubstitutionMap substitutionMap;
 
   // Map arguments to origins of inputs. Forks will automatically be created later
-  for (size_t i = 0; i < gammaNode.nentryvars(); i++)
+  for (const auto & entryvar : gammaNode.GetEntryVars())
   {
-    auto gammaInput = gammaNode.entryvar(i);
-
     for (size_t s = 0; s < gammaNode.nsubregions(); s++)
     {
-      substitutionMap.insert(gammaNode.subregion(s)->argument(i), gammaInput->origin());
+      substitutionMap.insert(entryvar.branchArgument[s], entryvar.input->origin());
     }
   }
 
@@ -73,18 +71,18 @@ ConvertGammaNodeWithSpeculation(rvsdg::GammaNode & gammaNode)
     gammaNode.subregion(s)->copy(gammaNode.region(), substitutionMap, false, false);
   }
 
-  for (size_t i = 0; i < gammaNode.nexitvars(); i++)
+  for (const auto & ex : gammaNode.GetExitVars())
   {
     std::vector<rvsdg::output *> alternatives;
     for (size_t s = 0; s < gammaNode.nsubregions(); s++)
     {
-      alternatives.push_back(substitutionMap.lookup(gammaNode.subregion(s)->result(i)->origin()));
+      alternatives.push_back(substitutionMap.lookup(ex.branchResult[s]->origin()));
     }
 
     // create discarding mux for each gamma output
     auto merge = hls::mux_op::create(*gammaNode.predicate()->origin(), alternatives, true);
 
-    gammaNode.exitvar(i)->divert_users(merge[0]);
+    ex.output->divert_users(merge[0]);
   }
 
   remove(&gammaNode);

--- a/jlm/hls/backend/rvsdg2rhls/UnusedStateRemoval.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/UnusedStateRemoval.cpp
@@ -132,10 +132,11 @@ RemovePassthroughArgument(const rvsdg::RegionArgument & argument)
 static void
 RemoveUnusedStatesFromGammaNode(rvsdg::GammaNode & gammaNode)
 {
-  for (int i = gammaNode.nentryvars() - 1; i >= 0; --i)
+  auto entryvars = gammaNode.GetEntryVars();
+  for (int i = entryvars.size() - 1; i >= 0; --i)
   {
     size_t resultIndex = 0;
-    auto argument = gammaNode.subregion(0)->argument(i);
+    auto argument = entryvars[i].branchArgument[0];
     if (argument->nusers() == 1)
     {
       auto result = dynamic_cast<rvsdg::RegionResult *>(*argument->begin());
@@ -154,7 +155,7 @@ RemoveUnusedStatesFromGammaNode(rvsdg::GammaNode & gammaNode)
 
     if (shouldRemove)
     {
-      auto origin = gammaNode.entryvar(i)->origin();
+      auto origin = entryvars[i].input->origin();
       gammaNode.output(resultIndex)->divert_users(origin);
 
       for (size_t r = 0; r < gammaNode.nsubregions(); r++)

--- a/jlm/hls/backend/rvsdg2rhls/add-prints.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-prints.cpp
@@ -79,7 +79,7 @@ route_to_region(jlm::rvsdg::output * output, rvsdg::Region * region)
 
   if (auto gamma = dynamic_cast<rvsdg::GammaNode *>(region->node()))
   {
-    gamma->add_entryvar(output);
+    gamma->AddEntryVar(output);
     output = region->argument(region->narguments() - 1);
   }
   else if (auto theta = dynamic_cast<rvsdg::ThetaNode *>(region->node()))

--- a/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
@@ -113,7 +113,7 @@ add_triggers(rvsdg::Region * region)
       {
         JLM_ASSERT(trigger != nullptr);
         JLM_ASSERT(get_trigger(gn->subregion(0)) == nullptr);
-        gn->add_entryvar(trigger);
+        gn->AddEntryVar(trigger);
         for (size_t i = 0; i < gn->nsubregions(); ++i)
         {
           add_triggers(gn->subregion(i));

--- a/jlm/hls/backend/rvsdg2rhls/distribute-constants.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/distribute-constants.cpp
@@ -24,6 +24,7 @@ distribute_constant(const rvsdg::SimpleOperation & op, rvsdg::simple_output * ou
     changed = false;
     for (auto user : *out)
     {
+      auto node = rvsdg::input::GetNode(*user);
       if (auto ti = dynamic_cast<rvsdg::ThetaInput *>(user))
       {
         auto arg = ti->argument();
@@ -45,24 +46,24 @@ distribute_constant(const rvsdg::SimpleOperation & op, rvsdg::simple_output * ou
           break;
         }
       }
-      if (auto gi = dynamic_cast<rvsdg::GammaInput *>(user))
+      if (auto gammaNode = dynamic_cast<rvsdg::GammaNode *>(node))
       {
-        if (gi->node()->predicate() == gi)
+        if (gammaNode->predicate() == user)
         {
           continue;
         }
-        for (int i = gi->narguments() - 1; i >= 0; --i)
+        for (auto argument : gammaNode->MapInputEntryVar(*user).branchArgument)
         {
-          if (gi->argument(i)->nusers())
+          if (argument->nusers())
           {
             auto arg_replacement = dynamic_cast<rvsdg::simple_output *>(
-                rvsdg::simple_node::create_normalized(gi->argument(i)->region(), op, {})[0]);
-            gi->argument(i)->divert_users(arg_replacement);
+                rvsdg::simple_node::create_normalized(argument->region(), op, {})[0]);
+            argument->divert_users(arg_replacement);
             distribute_constant(op, arg_replacement);
           }
-          gi->node()->subregion(i)->RemoveArgument(gi->argument(i)->index());
+          argument->region()->RemoveArgument(argument->index());
         }
-        gi->node()->RemoveInput(gi->index());
+        gammaNode->RemoveInput(user->index());
         changed = true;
         break;
       }

--- a/jlm/hls/backend/rvsdg2rhls/merge-gamma.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/merge-gamma.cpp
@@ -121,23 +121,23 @@ fix_match_inversion(rvsdg::GammaNode * old_gamma)
         auto new_gamma = rvsdg::GammaNode::create(new_match, match->nalternatives());
         rvsdg::SubstitutionMap rmap0; // subregion 0 of the new gamma - 1 of the old
         rvsdg::SubstitutionMap rmap1;
-        for (auto oev = old_gamma->begin_entryvar(); oev != old_gamma->end_entryvar(); oev++)
+        for (const auto & oev : old_gamma->GetEntryVars())
         {
-          auto nev = new_gamma->add_entryvar(oev->origin());
-          rmap0.insert(oev->argument(1), nev->argument(0));
-          rmap1.insert(oev->argument(0), nev->argument(1));
+          auto nev = new_gamma->AddEntryVar(oev.input->origin());
+          rmap0.insert(oev.branchArgument[1], nev.branchArgument[0]);
+          rmap1.insert(oev.branchArgument[0], nev.branchArgument[1]);
         }
         /* copy subregions */
         old_gamma->subregion(0)->copy(new_gamma->subregion(1), rmap1, false, false);
         old_gamma->subregion(1)->copy(new_gamma->subregion(0), rmap0, false, false);
 
-        for (auto oex = old_gamma->begin_exitvar(); oex != old_gamma->end_exitvar(); oex++)
+        for (auto oex : old_gamma->GetExitVars())
         {
           std::vector<rvsdg::output *> operands;
-          operands.push_back(rmap0.lookup(oex->result(1)->origin()));
-          operands.push_back(rmap1.lookup(oex->result(0)->origin()));
-          auto nex = new_gamma->add_exitvar(operands);
-          oex.output()->divert_users(nex);
+          operands.push_back(rmap0.lookup(oex.branchResult[1]->origin()));
+          operands.push_back(rmap1.lookup(oex.branchResult[0]->origin()));
+          auto nex = new_gamma->AddExitVar(operands).output;
+          oex.output->divert_users(nex);
         }
         remove(old_gamma);
         remove(no->node());
@@ -250,18 +250,17 @@ depends_on(jlm::rvsdg::output * output, jlm::rvsdg::node * node)
   return false;
 }
 
-rvsdg::GammaInput *
+rvsdg::GammaNode::EntryVar
 get_entryvar(jlm::rvsdg::output * origin, rvsdg::GammaNode * gamma)
 {
   for (auto user : *origin)
   {
-    auto gi = dynamic_cast<rvsdg::GammaInput *>(user);
-    if (gi && gi->node() == gamma)
+    if (rvsdg::TryGetOwnerNode<rvsdg::GammaNode>(*user) == gamma)
     {
-      return gi;
+      return gamma->MapInputEntryVar(*user);
     }
   }
-  return gamma->add_entryvar(origin);
+  return gamma->AddEntryVar(origin);
 }
 
 bool
@@ -269,48 +268,44 @@ merge_gamma(rvsdg::GammaNode * gamma)
 {
   for (auto user : *gamma->predicate()->origin())
   {
-    auto gi = dynamic_cast<rvsdg::GammaInput *>(user);
-    if (gi && gi != gamma->predicate())
+    auto other_gamma = dynamic_cast<rvsdg::GammaNode *>(rvsdg::input::GetNode(*user));
+    if (other_gamma && gamma != other_gamma)
     {
       // other gamma depending on same predicate
-      auto other_gamma = gi->node();
       JLM_ASSERT(other_gamma->nsubregions() == gamma->nsubregions());
       bool can_merge = true;
-      for (size_t i = 0; i < gamma->nentryvars(); ++i)
+      for (const auto & ev : gamma->GetEntryVars())
       {
-        auto ev = gamma->entryvar(i);
         // we only merge gammas whose inputs directly, or not at all, depend on the gamma being
         // merged into
-        can_merge &=
-            is_output_of(ev->origin(), other_gamma) || !depends_on(ev->origin(), other_gamma);
+        can_merge &= is_output_of(ev.input->origin(), other_gamma)
+                  || !depends_on(ev.input->origin(), other_gamma);
       }
-      for (size_t i = 0; i < other_gamma->nentryvars(); ++i)
+      for (const auto & oev : other_gamma->GetEntryVars())
       {
-        auto oev = other_gamma->entryvar(i);
         // prevent cycles
-        can_merge &= !depends_on(oev->origin(), gamma);
+        can_merge &= !depends_on(oev.input->origin(), gamma);
       }
       if (can_merge)
       {
         std::vector<rvsdg::SubstitutionMap> rmap(gamma->nsubregions());
         // populate argument mappings
-        for (size_t i = 0; i < gamma->nentryvars(); ++i)
+        for (const auto & ev : gamma->GetEntryVars())
         {
-          auto ev = gamma->entryvar(i);
-          if (is_output_of(ev->origin(), other_gamma))
+          if (rvsdg::TryGetOwnerNode<rvsdg::GammaNode>(*ev.input->origin()) == other_gamma)
           {
-            auto go = dynamic_cast<rvsdg::GammaOutput *>(ev->origin());
+            auto oex = other_gamma->MapOutputExitVar(*ev.input->origin());
             for (size_t j = 0; j < gamma->nsubregions(); ++j)
             {
-              rmap[j].insert(ev->argument(j), go->result(j)->origin());
+              rmap[j].insert(ev.branchArgument[j], oex.branchResult[j]->origin());
             }
           }
           else
           {
-            auto oev = get_entryvar(ev->origin(), other_gamma);
+            auto oev = get_entryvar(ev.input->origin(), other_gamma);
             for (size_t j = 0; j < gamma->nsubregions(); ++j)
             {
-              rmap[j].insert(ev->argument(j), oev->argument(j));
+              rmap[j].insert(ev.branchArgument[j], oev.branchArgument[j]);
             }
           }
         }
@@ -320,16 +315,15 @@ merge_gamma(rvsdg::GammaNode * gamma)
           gamma->subregion(j)->copy(other_gamma->subregion(j), rmap[j], false, false);
         }
         // handle exitvars
-        for (size_t i = 0; i < gamma->nexitvars(); ++i)
+        for (const auto & ex : gamma->GetExitVars())
         {
-          auto ex = gamma->exitvar(i);
           std::vector<jlm::rvsdg::output *> operands;
-          for (size_t j = 0; j < ex->nresults(); j++)
+          for (size_t j = 0; j < ex.branchResult.size(); j++)
           {
-            operands.push_back(rmap[j].lookup(ex->result(j)->origin()));
+            operands.push_back(rmap[j].lookup(ex.branchResult[j]->origin()));
           }
-          auto oex = other_gamma->add_exitvar(operands);
-          ex->divert_users(oex);
+          auto oex = other_gamma->AddExitVar(operands).output;
+          ex.output->divert_users(oex);
         }
         remove(gamma);
         return true;

--- a/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
@@ -130,11 +130,12 @@ remove_unused_state(llvm::RvsdgModule & rm)
 void
 remove_gamma_passthrough(rvsdg::GammaNode * gn)
 { // remove inputs in reverse
-  for (int i = gn->nentryvars() - 1; i >= 0; --i)
+  auto entryvars = gn->GetEntryVars();
+  for (int i = entryvars.size() - 1; i >= 0; --i)
   {
     bool can_remove = true;
     size_t res_index = 0;
-    auto arg = gn->subregion(0)->argument(i);
+    auto arg = entryvars[i].branchArgument[0];
     if (arg->nusers() == 1)
     {
       auto res = dynamic_cast<rvsdg::RegionResult *>(*arg->begin());
@@ -150,7 +151,7 @@ remove_gamma_passthrough(rvsdg::GammaNode * gn)
     }
     if (can_remove)
     {
-      auto origin = gn->entryvar(i)->origin();
+      auto origin = entryvars[i].input->origin();
       // divert users of output to origin of input
 
       gn->output(res_index)->divert_users(origin);

--- a/jlm/hls/opt/cne.cpp
+++ b/jlm/hls/opt/cne.cpp
@@ -238,12 +238,15 @@ congruent(jlm::rvsdg::output * o1, jlm::rvsdg::output * o2, vset & vs, cnectx & 
     return true;
   }
 
-  if (is<rvsdg::GammaArgument>(o1) && is<rvsdg::GammaArgument>(o2))
+  if (auto g1 = rvsdg::TryGetRegionParentNode<rvsdg::GammaNode>(*o1))
   {
-    JLM_ASSERT(o1->region()->node() == o2->region()->node());
-    auto a1 = static_cast<rvsdg::RegionArgument *>(o1);
-    auto a2 = static_cast<rvsdg::RegionArgument *>(o2);
-    return congruent(a1->input()->origin(), a2->input()->origin(), vs, ctx);
+    if (auto g2 = rvsdg::TryGetRegionParentNode<rvsdg::GammaNode>(*o2))
+    {
+      JLM_ASSERT(g1 == g2);
+      auto origin1 = g1->MapBranchArgumentEntryVar(*o1).input->origin();
+      auto origin2 = g2->MapBranchArgumentEntryVar(*o2).input->origin();
+      return congruent(origin1, origin2, vs, ctx);
+    }
   }
 
   if (jlm::rvsdg::is<SimpleOperation>(n1) && jlm::rvsdg::is<SimpleOperation>(n2)
@@ -508,10 +511,10 @@ divert_gamma(rvsdg::StructuralNode * node, cnectx & ctx)
   JLM_ASSERT(rvsdg::is<rvsdg::GammaOperation>(node));
   auto gamma = static_cast<GammaNode *>(node);
 
-  for (auto ev = gamma->begin_entryvar(); ev != gamma->end_entryvar(); ev++)
+  for (const auto & ev : gamma->GetEntryVars())
   {
-    for (size_t n = 0; n < ev->narguments(); n++)
-      divert_users(ev->argument(n), ctx);
+    for (auto input : ev.branchArgument)
+      divert_users(input, ctx);
   }
 
   for (size_t r = 0; r < node->nsubregions(); r++)

--- a/jlm/llvm/ir/operators/lambda.cpp
+++ b/jlm/llvm/ir/operators/lambda.cpp
@@ -290,16 +290,18 @@ node::ComputeCallSummary() const
       continue;
     }
 
-    if (auto gamma_input = dynamic_cast<rvsdg::GammaInput *>(input))
+    if (auto gammaNode = dynamic_cast<rvsdg::GammaNode *>(inputNode))
     {
-      for (auto & argument : *gamma_input)
-        worklist.insert(worklist.end(), argument.begin(), argument.end());
+      for (auto & argument : gammaNode->MapInputEntryVar(*input).branchArgument)
+      {
+        worklist.insert(worklist.end(), argument->begin(), argument->end());
+      }
       continue;
     }
 
-    if (auto gammaResult = dynamic_cast<const rvsdg::GammaResult *>(input))
+    if (auto gamma = rvsdg::TryGetRegionParentNode<rvsdg::GammaNode>(*input))
     {
-      auto output = gammaResult->output();
+      auto output = gamma->MapBranchResultExitVar(*input).output;
       worklist.insert(worklist.end(), output->begin(), output->end());
       continue;
     }

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -198,19 +198,19 @@ DeadNodeElimination::MarkOutput(const jlm::rvsdg::output & output)
     return;
   }
 
-  if (auto gammaOutput = dynamic_cast<const rvsdg::GammaOutput *>(&output))
+  if (auto gamma = rvsdg::TryGetOwnerNode<rvsdg::GammaNode>(output))
   {
-    MarkOutput(*gammaOutput->node()->predicate()->origin());
-    for (const auto & result : gammaOutput->results)
+    MarkOutput(*gamma->predicate()->origin());
+    for (const auto & result : gamma->MapOutputExitVar(output).branchResult)
     {
-      MarkOutput(*result.origin());
+      MarkOutput(*result->origin());
     }
     return;
   }
 
-  if (auto gammaArgument = dynamic_cast<const rvsdg::GammaArgument *>(&output))
+  if (auto gamma = rvsdg::TryGetRegionParentNode<rvsdg::GammaNode>(output))
   {
-    MarkOutput(*gammaArgument->input()->origin());
+    MarkOutput(*gamma->MapBranchArgumentEntryVar(output).input->origin());
     return;
   }
 

--- a/jlm/llvm/opt/InvariantValueRedirection.cpp
+++ b/jlm/llvm/opt/InvariantValueRedirection.cpp
@@ -140,14 +140,11 @@ InvariantValueRedirection::RedirectInSubregions(rvsdg::StructuralNode & structur
 void
 InvariantValueRedirection::RedirectGammaOutputs(rvsdg::GammaNode & gammaNode)
 {
-  for (auto it = gammaNode.begin_exitvar(); it != gammaNode.end_exitvar(); it++)
+  for (auto exitvar : gammaNode.GetExitVars())
   {
-    auto & gammaOutput = *it;
-
-    rvsdg::output * invariantOrigin = nullptr;
-    if (gammaOutput.IsInvariant(&invariantOrigin))
+    if (auto invariantOrigin = rvsdg::GetGammaInvariantOrigin(gammaNode, exitvar))
     {
-      it->divert_users(invariantOrigin);
+      exitvar.output->divert_users(*invariantOrigin);
     }
   }
 }

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -1088,16 +1088,16 @@ void
 Andersen::AnalyzeGamma(const rvsdg::GammaNode & gamma)
 {
   // Handle input variables
-  for (auto ev = gamma.begin_entryvar(); ev != gamma.end_entryvar(); ++ev)
+  for (const auto & ev : gamma.GetEntryVars())
   {
-    if (!IsOrContainsPointerType(ev->type()))
+    if (!IsOrContainsPointerType(ev.input->type()))
       continue;
 
-    auto & inputRegister = *ev->origin();
+    auto & inputRegister = *ev.input->origin();
     const auto inputRegisterPO = Set_->GetRegisterPointerObject(inputRegister);
 
-    for (auto & argument : *ev)
-      Set_->MapRegisterToExistingPointerObject(argument, inputRegisterPO);
+    for (auto & argument : ev.branchArgument)
+      Set_->MapRegisterToExistingPointerObject(*argument, inputRegisterPO);
   }
 
   // Handle subregions
@@ -1105,17 +1105,17 @@ Andersen::AnalyzeGamma(const rvsdg::GammaNode & gamma)
     AnalyzeRegion(*gamma.subregion(n));
 
   // Handle exit variables
-  for (auto ex = gamma.begin_exitvar(); ex != gamma.end_exitvar(); ++ex)
+  for (const auto & ex : gamma.GetExitVars())
   {
-    if (!IsOrContainsPointerType(ex->type()))
+    if (!IsOrContainsPointerType(ex.output->type()))
       continue;
 
-    auto & outputRegister = *ex.output();
-    const auto outputRegisterPO = Set_->CreateRegisterPointerObject(outputRegister);
+    auto & outputRegister = ex.output;
+    const auto outputRegisterPO = Set_->CreateRegisterPointerObject(*outputRegister);
 
-    for (auto & result : *ex)
+    for (auto result : ex.branchResult)
     {
-      const auto resultRegisterPO = Set_->GetRegisterPointerObject(*result.origin());
+      const auto resultRegisterPO = Set_->GetRegisterPointerObject(*result->origin());
       Constraints_->AddConstraint(SupersetConstraint(outputRegisterPO, resultRegisterPO));
     }
   }

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
@@ -858,9 +858,9 @@ MemoryStateEncoder::EncodeGammaEntry(rvsdg::GammaNode & gammaNode)
   auto memoryNodeStatePairs = stateMap.GetStates(*region, memoryNodes);
   for (auto & memoryNodeStatePair : memoryNodeStatePairs)
   {
-    auto gammaInput = gammaNode.add_entryvar(&memoryNodeStatePair->State());
-    for (auto & argument : *gammaInput)
-      stateMap.InsertState(memoryNodeStatePair->MemoryNode(), argument);
+    auto gammaInput = gammaNode.AddEntryVar(&memoryNodeStatePair->State());
+    for (auto & argument : gammaInput.branchArgument)
+      stateMap.InsertState(memoryNodeStatePair->MemoryNode(), *argument);
   }
 }
 
@@ -882,7 +882,7 @@ MemoryStateEncoder::EncodeGammaExit(rvsdg::GammaNode & gammaNode)
       states.push_back(&state);
     }
 
-    auto state = gammaNode.add_exitvar(states);
+    auto state = gammaNode.AddExitVar(states).output;
     memoryNodeStatePair->ReplaceState(*state);
   }
 }

--- a/jlm/llvm/opt/inlining.cpp
+++ b/jlm/llvm/opt/inlining.cpp
@@ -73,7 +73,7 @@ route_to_region(jlm::rvsdg::output * output, rvsdg::Region * region)
 
   if (auto gamma = dynamic_cast<rvsdg::GammaNode *>(region->node()))
   {
-    gamma->add_entryvar(output);
+    gamma->AddEntryVar(output);
     output = region->argument(region->narguments() - 1);
   }
   else if (auto theta = dynamic_cast<rvsdg::ThetaNode *>(region->node()))

--- a/jlm/llvm/opt/inversion.cpp
+++ b/jlm/llvm/opt/inversion.cpp
@@ -81,9 +81,9 @@ pullin(rvsdg::GammaNode * gamma, rvsdg::ThetaNode * theta)
   {
     if (jlm::rvsdg::output::GetNode(*lv->result()->origin()) != gamma)
     {
-      auto ev = gamma->add_entryvar(lv->result()->origin());
-      JLM_ASSERT(ev->narguments() == 2);
-      auto xv = gamma->add_exitvar({ ev->argument(0), ev->argument(1) });
+      auto ev = gamma->AddEntryVar(lv->result()->origin());
+      JLM_ASSERT(ev.branchArgument.size() == 2);
+      auto xv = gamma->AddExitVar({ ev.branchArgument[0], ev.branchArgument[1] }).output;
       lv->result()->divert_to(xv);
     }
   }
@@ -160,18 +160,18 @@ invert(rvsdg::ThetaNode * otheta)
   {
     /* setup substitution map for exit region copying */
     auto osubregion0 = ogamma->subregion(0);
-    for (auto oev = ogamma->begin_entryvar(); oev != ogamma->end_entryvar(); oev++)
+    for (const auto & oev : ogamma->GetEntryVars())
     {
-      if (auto argument = to_argument(oev->origin()))
+      if (auto argument = to_argument(oev.input->origin()))
       {
-        auto nev = ngamma->add_entryvar(argument->input()->origin());
-        r0map.insert(oev->argument(0), nev->argument(0));
+        auto nev = ngamma->AddEntryVar(argument->input()->origin());
+        r0map.insert(oev.branchArgument[0], nev.branchArgument[0]);
       }
       else
       {
-        auto substitute = smap.lookup(oev->origin());
-        auto nev = ngamma->add_entryvar(substitute);
-        r0map.insert(oev->argument(0), nev->argument(0));
+        auto substitute = smap.lookup(oev.input->origin());
+        auto nev = ngamma->AddEntryVar(substitute);
+        r0map.insert(oev.branchArgument[0], nev.branchArgument[0]);
       }
     }
 
@@ -198,24 +198,23 @@ invert(rvsdg::ThetaNode * otheta)
     std::unordered_map<jlm::rvsdg::input *, rvsdg::ThetaOutput *> nlvs;
     for (const auto & olv : *otheta)
     {
-      auto ev = ngamma->add_entryvar(olv->input()->origin());
-      auto nlv = ntheta->add_loopvar(ev->argument(1));
+      auto ev = ngamma->AddEntryVar(olv->input()->origin());
+      auto nlv = ntheta->add_loopvar(ev.branchArgument[1]);
       r1map.insert(olv->argument(), nlv->argument());
       nlvs[olv->input()] = nlv;
     }
-    for (size_t n = 1; n < ogamma->ninputs(); n++)
+    for (const auto & oev : ogamma->GetEntryVars())
     {
-      auto oev = util::AssertedCast<rvsdg::GammaInput>(ogamma->input(n));
-      if (auto argument = to_argument(oev->origin()))
+      if (auto argument = to_argument(oev.input->origin()))
       {
-        r1map.insert(oev->argument(1), nlvs[argument->input()]->argument());
+        r1map.insert(oev.branchArgument[1], nlvs[argument->input()]->argument());
       }
       else
       {
-        auto ev = ngamma->add_entryvar(smap.lookup(oev->origin()));
-        auto nlv = ntheta->add_loopvar(ev->argument(1));
-        r1map.insert(oev->argument(1), nlv->argument());
-        nlvs[oev] = nlv;
+        auto ev = ngamma->AddEntryVar(smap.lookup(oev.input->origin()));
+        auto nlv = ntheta->add_loopvar(ev.branchArgument[1]);
+        r1map.insert(oev.branchArgument[1], nlv->argument());
+        nlvs[oev.input] = nlv;
       }
     }
 
@@ -242,18 +241,17 @@ invert(rvsdg::ThetaNode * otheta)
       nlvs[olv->input()]->result()->divert_to(substitute);
       r1map.insert(olv->result()->origin(), nlvs[olv->input()]);
     }
-    for (size_t n = 1; n < ogamma->ninputs(); n++)
+    for (const auto & oev : ogamma->GetEntryVars())
     {
-      auto oev = util::AssertedCast<rvsdg::GammaInput>(ogamma->input(n));
-      if (auto argument = to_argument(oev->origin()))
+      if (auto argument = to_argument(oev.input->origin()))
       {
-        r1map.insert(oev->argument(0), nlvs[argument->input()]);
+        r1map.insert(oev.branchArgument[0], nlvs[argument->input()]);
       }
       else
       {
-        auto substitute = r1map.lookup(oev->origin());
-        nlvs[oev]->result()->divert_to(substitute);
-        r1map.insert(oev->argument(0), nlvs[oev]);
+        auto substitute = r1map.lookup(oev.input->origin());
+        nlvs[oev.input]->result()->divert_to(substitute);
+        r1map.insert(oev.branchArgument[0], nlvs[oev.input]);
       }
     }
 
@@ -276,7 +274,7 @@ invert(rvsdg::ThetaNode * otheta)
   {
     auto o0 = r0map.lookup(olv->result()->origin());
     auto o1 = r1map.lookup(olv->result()->origin());
-    auto ex = ngamma->add_exitvar({ o0, o1 });
+    auto ex = ngamma->AddExitVar({ o0, o1 }).output;
     smap.insert(olv, ex);
   }
 

--- a/jlm/llvm/opt/pull.cpp
+++ b/jlm/llvm/opt/pull.cpp
@@ -70,9 +70,9 @@ single_successor(const jlm::rvsdg::node * node)
 }
 
 static void
-remove(rvsdg::GammaInput * input)
+remove(rvsdg::input * input)
 {
-  auto gamma = input->node();
+  auto gamma = jlm::util::AssertedCast<rvsdg::GammaNode>(rvsdg::input::GetNode(*input));
 
   for (size_t n = 0; n < gamma->nsubregions(); n++)
     gamma->subregion(n)->RemoveArgument(input->index() - 1);
@@ -86,9 +86,10 @@ pullin_node(rvsdg::GammaNode * gamma, jlm::rvsdg::node * node)
   std::vector<std::vector<jlm::rvsdg::output *>> operands(gamma->nsubregions());
   for (size_t i = 0; i < node->ninputs(); i++)
   {
-    auto ev = gamma->add_entryvar(node->input(i)->origin());
-    for (size_t a = 0; a < ev->narguments(); a++)
-      operands[a].push_back(ev->argument(a));
+    auto ev = gamma->AddEntryVar(node->input(i)->origin());
+    std::size_t index = 0;
+    for (auto input : ev.branchArgument)
+      operands[index++].push_back(input);
   }
 
   /* copy node into subregions */
@@ -119,7 +120,7 @@ cleanup(rvsdg::GammaNode * gamma, jlm::rvsdg::node * node)
   for (size_t n = 0; n < node->noutputs(); n++)
   {
     while (node->output(n)->nusers() != 0)
-      remove(util::AssertedCast<rvsdg::GammaInput>(*node->output(n)->begin()));
+      remove(*node->output(n)->begin());
   }
   remove(node);
 }
@@ -128,10 +129,12 @@ void
 pullin_top(rvsdg::GammaNode * gamma)
 {
   /* FIXME: This is inefficient. We can do better. */
-  auto ev = gamma->begin_entryvar();
-  while (ev != gamma->end_entryvar())
+  auto evs = gamma->GetEntryVars();
+  size_t index = 0;
+  while (index < evs.size())
   {
-    auto node = jlm::rvsdg::output::GetNode(*ev->origin());
+    const auto & ev = evs[index];
+    auto node = jlm::rvsdg::output::GetNode(*ev.input->origin());
     auto tmp = jlm::rvsdg::output::GetNode(*gamma->predicate()->origin());
     if (node && tmp != node && single_successor(node))
     {
@@ -139,11 +142,12 @@ pullin_top(rvsdg::GammaNode * gamma)
 
       cleanup(gamma, node);
 
-      ev = gamma->begin_entryvar();
+      evs = gamma->GetEntryVars();
+      index = 0;
     }
     else
     {
-      ev++;
+      index++;
     }
   }
 }
@@ -185,8 +189,8 @@ pullin_bottom(rvsdg::GammaNode * gamma)
         }
         else
         {
-          auto ev = gamma->add_entryvar(input->origin());
-          operands.push_back(ev->argument(r));
+          auto ev = gamma->AddEntryVar(input->origin());
+          operands.push_back(ev.branchArgument[r]);
         }
       }
 
@@ -206,7 +210,7 @@ pullin_bottom(rvsdg::GammaNode * gamma)
           workset.insert(tmp);
       }
 
-      auto xv = gamma->add_exitvar(outputs[n]);
+      auto xv = gamma->AddExitVar(outputs[n]).output;
       output->divert_users(xv);
     }
   }
@@ -218,12 +222,12 @@ is_used_in_nsubregions(const rvsdg::GammaNode * gamma, const jlm::rvsdg::node * 
   JLM_ASSERT(single_successor(node));
 
   /* collect all gamma inputs */
-  std::unordered_set<const rvsdg::GammaInput *> inputs;
+  std::unordered_set<const rvsdg::input *> inputs;
   for (size_t n = 0; n < node->noutputs(); n++)
   {
     for (const auto & user : *(node->output(n)))
     {
-      inputs.insert(util::AssertedCast<const rvsdg::GammaInput>(user));
+      inputs.insert(user);
     }
   }
 
@@ -231,10 +235,10 @@ is_used_in_nsubregions(const rvsdg::GammaNode * gamma, const jlm::rvsdg::node * 
   std::unordered_set<rvsdg::Region *> subregions;
   for (const auto & input : inputs)
   {
-    for (const auto & argument : *input)
+    for (const auto & argument : gamma->MapInputEntryVar(*input).branchArgument)
     {
-      if (argument.nusers() != 0)
-        subregions.insert(argument.region());
+      if (argument->nusers() != 0)
+        subregions.insert(argument->region());
     }
   }
 
@@ -254,13 +258,15 @@ pull(rvsdg::GammaNode * gamma)
   auto prednode = jlm::rvsdg::output::GetNode(*gamma->predicate()->origin());
 
   /* FIXME: This is inefficient. We can do better. */
-  auto ev = gamma->begin_entryvar();
-  while (ev != gamma->end_entryvar())
+  auto evs = gamma->GetEntryVars();
+  size_t index = 0;
+  while (index < evs.size())
   {
-    auto node = jlm::rvsdg::output::GetNode(*ev->origin());
+    const auto & ev = evs[index];
+    auto node = jlm::rvsdg::output::GetNode(*ev.input->origin());
     if (!node || prednode == node || !single_successor(node))
     {
-      ev++;
+      index++;
       continue;
     }
 
@@ -272,11 +278,12 @@ pull(rvsdg::GammaNode * gamma)
       */
       pullin_node(gamma, node);
       cleanup(gamma, node);
-      ev = gamma->begin_entryvar();
+      evs = gamma->GetEntryVars();
+      index = 0;
     }
     else
     {
-      ev++;
+      index++;
     }
   }
 }

--- a/jlm/llvm/opt/push.cpp
+++ b/jlm/llvm/opt/push.cpp
@@ -115,9 +115,9 @@ copy_from_gamma(jlm::rvsdg::node * node, size_t r)
   auto copy = node->copy(target, operands);
   for (size_t n = 0; n < copy->noutputs(); n++)
   {
-    auto ev = gamma->add_entryvar(copy->output(n));
-    node->output(n)->divert_users(ev->argument(r));
-    arguments.push_back(ev->argument(r));
+    auto ev = gamma->AddEntryVar(copy->output(n));
+    node->output(n)->divert_users(ev.branchArgument[r]);
+    arguments.push_back(util::AssertedCast<rvsdg::RegionArgument>(ev.branchArgument[r]));
   }
 
   return arguments;

--- a/jlm/llvm/opt/unroll.cpp
+++ b/jlm/llvm/opt/unroll.cpp
@@ -405,9 +405,9 @@ unroll_unknown_theta(const unrollinfo & ui, size_t factor)
     rvsdg::SubstitutionMap rmap[2];
     for (const auto & olv : *otheta)
     {
-      auto ev = ngamma->add_entryvar(olv->input()->origin());
-      auto nlv = ntheta->add_loopvar(ev->argument(1));
-      rmap[0].insert(olv, ev->argument(0));
+      auto ev = ngamma->AddEntryVar(olv->input()->origin());
+      auto nlv = ntheta->add_loopvar(ev.branchArgument[1]);
+      rmap[0].insert(olv, ev.branchArgument[0]);
       rmap[1].insert(olv->argument(), nlv->argument());
     }
 
@@ -424,7 +424,7 @@ unroll_unknown_theta(const unrollinfo & ui, size_t factor)
 
     for (const auto & olv : *otheta)
     {
-      auto xv = ngamma->add_exitvar({ rmap[0].lookup(olv), rmap[1].lookup(olv) });
+      auto xv = ngamma->AddExitVar({ rmap[0].lookup(olv), rmap[1].lookup(olv) }).output;
       smap.insert(olv, xv);
     }
   }
@@ -438,9 +438,9 @@ unroll_unknown_theta(const unrollinfo & ui, size_t factor)
     rvsdg::SubstitutionMap rmap[2];
     for (const auto & olv : *otheta)
     {
-      auto ev = ngamma->add_entryvar(smap.lookup(olv));
-      auto nlv = ntheta->add_loopvar(ev->argument(1));
-      rmap[0].insert(olv, ev->argument(0));
+      auto ev = ngamma->AddEntryVar(smap.lookup(olv));
+      auto nlv = ntheta->add_loopvar(ev.branchArgument[1]);
+      rmap[0].insert(olv, ev.branchArgument[0]);
       rmap[1].insert(olv->argument(), nlv->argument());
     }
 
@@ -451,7 +451,7 @@ unroll_unknown_theta(const unrollinfo & ui, size_t factor)
     {
       auto origin = rmap[1].lookup((*olv)->result()->origin());
       (*nlv)->result()->divert_to(origin);
-      auto xv = ngamma->add_exitvar({ rmap[0].lookup(*olv), *nlv });
+      auto xv = ngamma->AddExitVar({ rmap[0].lookup(*olv), *nlv }).output;
       smap.insert(*olv, xv);
     }
   }

--- a/jlm/mlir/frontend/MlirToJlmConverter.cpp
+++ b/jlm/mlir/frontend/MlirToJlmConverter.cpp
@@ -335,7 +335,7 @@ MlirToJlmConverter::ConvertOperation(
     // Add inputs to the gamma node and to all it's subregions
     for (size_t i = 1; i < inputs.size(); i++)
     {
-      rvsdgGammaNode->add_entryvar(inputs[i]);
+      rvsdgGammaNode->AddEntryVar(inputs[i]);
     }
 
     ::llvm::SmallVector<::llvm::SmallVector<jlm::rvsdg::output *>> regionResults;
@@ -355,7 +355,7 @@ MlirToJlmConverter::ConvertOperation(
         JLM_ASSERT(regionResults[regionIndex].size() == regionResults[0].size());
         exitvars.push_back(regionResults[regionIndex][exitvarIndex]);
       }
-      rvsdgGammaNode->add_exitvar(exitvars);
+      rvsdgGammaNode->AddExitVar(exitvars);
     }
 
     return rvsdgGammaNode;

--- a/jlm/rvsdg/gamma.cpp
+++ b/jlm/rvsdg/gamma.cpp
@@ -29,13 +29,13 @@ perform_predicate_reduction(GammaNode * gamma)
   auto alternative = cop->value().alternative();
 
   rvsdg::SubstitutionMap smap;
-  for (auto it = gamma->begin_entryvar(); it != gamma->end_entryvar(); it++)
-    smap.insert(it->argument(alternative), it->origin());
+  for (const auto & ev : gamma->GetEntryVars())
+    smap.insert(ev.branchArgument[alternative], ev.input->origin());
 
   gamma->subregion(alternative)->copy(gamma->region(), smap, false, false);
 
-  for (auto it = gamma->begin_exitvar(); it != gamma->end_exitvar(); it++)
-    it->divert_users(smap.lookup(it->result(alternative)->origin()));
+  for (auto exitvar : gamma->GetExitVars())
+    exitvar.output->divert_users(smap.lookup(exitvar.branchResult[alternative]->origin()));
 
   remove(gamma);
 }
@@ -44,24 +44,25 @@ static bool
 perform_invariant_reduction(GammaNode * gamma)
 {
   bool was_normalized = true;
-  for (auto it = gamma->begin_exitvar(); it != gamma->end_exitvar(); it++)
+  for (auto exitvar : gamma->GetExitVars())
   {
-    auto argument = dynamic_cast<const rvsdg::RegionArgument *>(it->result(0)->origin());
+    auto argument = dynamic_cast<const rvsdg::RegionArgument *>(exitvar.branchResult[0]->origin());
     if (!argument)
       continue;
 
     size_t n;
     auto input = argument->input();
-    for (n = 1; n < it->nresults(); n++)
+    for (n = 1; n < exitvar.branchResult.size(); n++)
     {
-      auto argument = dynamic_cast<const rvsdg::RegionArgument *>(it->result(n)->origin());
+      auto argument =
+          dynamic_cast<const rvsdg::RegionArgument *>(exitvar.branchResult[n]->origin());
       if (!argument && argument->input() != input)
         break;
     }
 
-    if (n == it->nresults())
+    if (n == exitvar.branchResult.size())
     {
-      it->divert_users(argument->input()->origin());
+      exitvar.output->divert_users(argument->input()->origin());
       was_normalized = false;
     }
   }
@@ -69,7 +70,7 @@ perform_invariant_reduction(GammaNode * gamma)
   return was_normalized;
 }
 
-static std::unordered_set<StructuralOutput *>
+static std::unordered_set<jlm::rvsdg::output *>
 is_control_constant_reducible(GammaNode * gamma)
 {
   /* check gamma predicate */
@@ -87,16 +88,16 @@ is_control_constant_reducible(GammaNode * gamma)
     return {};
 
   /* check for constants */
-  std::unordered_set<StructuralOutput *> outputs;
-  for (auto it = gamma->begin_exitvar(); it != gamma->end_exitvar(); it++)
+  std::unordered_set<jlm::rvsdg::output *> outputs;
+  for (const auto & exitvar : gamma->GetExitVars())
   {
-    if (!is_ctltype(it->type()))
+    if (!is_ctltype(exitvar.output->type()))
       continue;
 
     size_t n;
-    for (n = 0; n < it->nresults(); n++)
+    for (n = 0; n < exitvar.branchResult.size(); n++)
     {
-      auto node = output::GetNode(*it->result(n)->origin());
+      auto node = output::GetNode(*exitvar.branchResult[n]->origin());
       if (!is<ctlconstant_op>(node))
         break;
 
@@ -104,18 +105,18 @@ is_control_constant_reducible(GammaNode * gamma)
       if (op->value().nalternatives() != 2)
         break;
     }
-    if (n == it->nresults())
-      outputs.insert(it.output());
+    if (n == exitvar.branchResult.size())
+      outputs.insert(exitvar.output);
   }
 
   return outputs;
 }
 
 static void
-perform_control_constant_reduction(std::unordered_set<StructuralOutput *> & outputs)
+perform_control_constant_reduction(std::unordered_set<jlm::rvsdg::output *> & outputs)
 {
-  auto gamma = static_cast<GammaNode *>((*outputs.begin())->node());
-  auto origin = static_cast<node_output *>(gamma->predicate()->origin());
+  auto & gamma = rvsdg::AssertGetOwnerNode<GammaNode>(**outputs.begin());
+  auto origin = static_cast<node_output *>(gamma.predicate()->origin());
   auto match = origin->node();
   auto & match_op = to_match_op(match->GetOperation());
 
@@ -123,17 +124,17 @@ perform_control_constant_reduction(std::unordered_set<StructuralOutput *> & outp
   for (const auto & pair : match_op)
     map[pair.second] = pair.first;
 
-  for (auto xv = gamma->begin_exitvar(); xv != gamma->end_exitvar(); xv++)
+  for (const auto & xv : gamma.GetExitVars())
   {
-    if (outputs.find(xv.output()) == outputs.end())
+    if (outputs.find(xv.output) == outputs.end())
       continue;
 
     size_t defalt = 0;
     size_t nalternatives = 0;
     std::unordered_map<uint64_t, uint64_t> new_mapping;
-    for (size_t n = 0; n < xv->nresults(); n++)
+    for (size_t n = 0; n < xv.branchResult.size(); n++)
     {
-      auto origin = static_cast<node_output *>(xv->result(n)->origin());
+      auto origin = static_cast<node_output *>(xv.branchResult[n]->origin());
       auto & value = to_ctlconstant_op(origin->node()->GetOperation()).value();
       nalternatives = value.nalternatives();
       if (map.find(n) != map.end())
@@ -144,7 +145,7 @@ perform_control_constant_reduction(std::unordered_set<StructuralOutput *> & outp
 
     auto origin = match->input(0)->origin();
     auto m = jlm::rvsdg::match(match_op.nbits(), new_mapping, defalt, nalternatives, origin);
-    xv->divert_users(m);
+    xv.output->divert_users(m);
   }
 }
 
@@ -265,79 +266,132 @@ GammaOperation::operator==(const operation & other) const noexcept
   return op && op->nalternatives_ == nalternatives_;
 }
 
-/* gamma input */
-
-GammaInput::~GammaInput() noexcept = default;
-
-/* gamma output */
-
-GammaOutput::~GammaOutput() noexcept = default;
-
-bool
-GammaOutput::IsInvariant(rvsdg::output ** invariantOrigin) const noexcept
-{
-  auto argument = dynamic_cast<const rvsdg::RegionArgument *>(result(0)->origin());
-  if (!argument)
-  {
-    return false;
-  }
-
-  size_t n;
-  auto origin = argument->input()->origin();
-  for (n = 1; n < nresults(); n++)
-  {
-    argument = dynamic_cast<const rvsdg::RegionArgument *>(result(n)->origin());
-    if (argument == nullptr || argument->input()->origin() != origin)
-      break;
-  }
-
-  auto isInvariant = (n == nresults());
-  if (isInvariant && invariantOrigin != nullptr)
-  {
-    *invariantOrigin = origin;
-  }
-
-  return isInvariant;
-}
-
 /* gamma node */
 
 GammaNode::~GammaNode() noexcept = default;
 
-const GammaNode::entryvar_iterator &
-GammaNode::entryvar_iterator::operator++() noexcept
+GammaNode::GammaNode(rvsdg::output * predicate, size_t nalternatives)
+    : StructuralNode(GammaOperation(nalternatives), predicate->region(), nalternatives)
 {
-  if (input_ == nullptr)
-    return *this;
-
-  auto node = input_->node();
-  auto index = input_->index();
-  if (index == node->ninputs() - 1)
-  {
-    input_ = nullptr;
-    return *this;
-  }
-
-  input_ = static_cast<GammaInput *>(node->input(++index));
-  return *this;
+  node::add_input(std::unique_ptr<node_input>(
+      new rvsdg::StructuralInput(this, predicate, ControlType::Create(nalternatives))));
 }
 
-const GammaNode::exitvar_iterator &
-GammaNode::exitvar_iterator::operator++() noexcept
+GammaNode::EntryVar
+GammaNode::AddEntryVar(rvsdg::output * origin)
 {
-  if (output_ == nullptr)
-    return *this;
+  auto gammaInput = new StructuralInput(this, origin, origin->Type());
+  node::add_input(std::unique_ptr<node_input>(gammaInput));
 
-  auto node = output_->node();
-  auto index = output_->index();
-  if (index == node->nexitvars() - 1)
+  EntryVar ev;
+  ev.input = gammaInput;
+
+  for (size_t n = 0; n < nsubregions(); n++)
   {
-    output_ = nullptr;
-    return *this;
+    ev.branchArgument.push_back(
+        &RegionArgument::Create(*subregion(n), gammaInput, gammaInput->Type()));
   }
 
-  output_ = node->exitvar(++index);
-  return *this;
+  return ev;
+}
+
+GammaNode::EntryVar
+GammaNode::GetEntryVar(std::size_t index) const
+{
+  JLM_ASSERT(index <= ninputs() - 1);
+  EntryVar ev;
+  ev.input = input(index + 1);
+  for (size_t n = 0; n < nsubregions(); ++n)
+  {
+    ev.branchArgument.push_back(subregion(n)->argument(index));
+  }
+  return ev;
+}
+
+std::vector<GammaNode::EntryVar>
+GammaNode::GetEntryVars() const
+{
+  std::vector<GammaNode::EntryVar> vars;
+  for (size_t n = 0; n < ninputs() - 1; ++n)
+  {
+    vars.push_back(GetEntryVar(n));
+  }
+  return vars;
+}
+
+GammaNode::EntryVar
+GammaNode::MapInputEntryVar(const rvsdg::input & input) const
+{
+  JLM_ASSERT(rvsdg::TryGetOwnerNode<GammaNode>(input) == this);
+  JLM_ASSERT(input.index() != 0);
+  return GetEntryVar(input.index() - 1);
+}
+
+GammaNode::EntryVar
+GammaNode::MapBranchArgumentEntryVar(const rvsdg::output & output) const
+{
+  JLM_ASSERT(rvsdg::TryGetRegionParentNode<GammaNode>(output) == this);
+  return GetEntryVar(output.index());
+}
+
+GammaNode::ExitVar
+GammaNode::AddExitVar(std::vector<jlm::rvsdg::output *> values)
+{
+  if (values.size() != nsubregions())
+    throw jlm::util::error("Incorrect number of values.");
+
+  const auto & type = values[0]->Type();
+  auto output = static_cast<rvsdg::StructuralOutput *>(
+      node::add_output(std::make_unique<rvsdg::StructuralOutput>(this, type)));
+
+  std::vector<rvsdg::input *> branchResults;
+  for (size_t n = 0; n < nsubregions(); n++)
+  {
+    branchResults.push_back(
+        &rvsdg::RegionResult::Create(*subregion(n), *values[n], output, output->Type()));
+  }
+
+  return ExitVar{ std::move(branchResults), std::move(output) };
+}
+
+std::vector<GammaNode::ExitVar>
+GammaNode::GetExitVars() const
+{
+  std::vector<GammaNode::ExitVar> vars;
+  for (size_t n = 0; n < noutputs(); ++n)
+  {
+    std::vector<rvsdg::input *> branchResults;
+    for (size_t k = 0; k < nsubregions(); ++k)
+    {
+      branchResults.push_back(subregion(k)->result(n));
+    }
+    vars.push_back(ExitVar{ std::move(branchResults), output(n) });
+  }
+  return vars;
+}
+
+GammaNode::ExitVar
+GammaNode::MapOutputExitVar(const rvsdg::output & output) const
+{
+  JLM_ASSERT(TryGetOwnerNode<GammaNode>(output) == this);
+  std::vector<rvsdg::input *> branchResults;
+  for (size_t k = 0; k < nsubregions(); ++k)
+  {
+    branchResults.push_back(subregion(k)->result(output.index()));
+  }
+  return ExitVar{ std::move(branchResults), node::output(output.index()) };
+}
+
+GammaNode::ExitVar
+GammaNode::MapBranchResultExitVar(const rvsdg::input & input) const
+{
+  JLM_ASSERT(TryGetRegionParentNode<GammaNode>(input) == this);
+  std::vector<rvsdg::input *> branchResults;
+  for (size_t k = 0; k < nsubregions(); ++k)
+  {
+    branchResults.push_back(subregion(k)->result(input.index()));
+  }
+  return ExitVar{ std::move(branchResults), node::output(input.index()) };
 }
 
 GammaNode *
@@ -347,11 +401,11 @@ GammaNode::copy(rvsdg::Region * region, SubstitutionMap & smap) const
 
   /* add entry variables to new gamma */
   std::vector<SubstitutionMap> rmap(nsubregions());
-  for (auto oev = begin_entryvar(); oev != end_entryvar(); oev++)
+  for (const auto & oev : GetEntryVars())
   {
-    auto nev = gamma->add_entryvar(smap.lookup(oev->origin()));
-    for (size_t n = 0; n < nev->narguments(); n++)
-      rmap[n].insert(oev->argument(n), nev->argument(n));
+    auto nev = gamma->AddEntryVar(smap.lookup(oev.input->origin()));
+    for (size_t n = 0; n < nsubregions(); n++)
+      rmap[n].insert(oev.branchArgument[n], nev.branchArgument[n]);
   }
 
   /* copy subregions */
@@ -359,34 +413,52 @@ GammaNode::copy(rvsdg::Region * region, SubstitutionMap & smap) const
     subregion(r)->copy(gamma->subregion(r), rmap[r], false, false);
 
   /* add exit variables to new gamma */
-  for (auto oex = begin_exitvar(); oex != end_exitvar(); oex++)
+  for (const auto & oex : GetExitVars())
   {
     std::vector<jlm::rvsdg::output *> operands;
-    for (size_t n = 0; n < oex->nresults(); n++)
-      operands.push_back(rmap[n].lookup(oex->result(n)->origin()));
-    auto nex = gamma->add_exitvar(operands);
-    smap.insert(oex.output(), nex);
+    for (size_t n = 0; n < oex.branchResult.size(); n++)
+      operands.push_back(rmap[n].lookup(oex.branchResult[n]->origin()));
+    auto nex = gamma->AddExitVar(std::move(operands));
+    smap.insert(oex.output, nex.output);
   }
 
   return gamma;
 }
 
-GammaArgument::~GammaArgument() noexcept = default;
-
-GammaArgument &
-GammaArgument::Copy(rvsdg::Region & region, StructuralInput * input)
+std::optional<rvsdg::output *>
+GetGammaInvariantOrigin(const GammaNode & gamma, const GammaNode::ExitVar & exitvar)
 {
-  auto gammaInput = util::AssertedCast<GammaInput>(input);
-  return Create(region, *gammaInput);
-}
+  // For any region result, check if it directly maps to a
+  // gamma entry variable, and returns the origin of its
+  // corresponding value (the def site preceding the gamma node).
+  auto GetExternalOriginOf = [&gamma](rvsdg::input * use) -> std::optional<rvsdg::output *>
+  {
+    // Test whether origin of this is a region entry argument of
+    // this gamma node.
+    auto def = use->origin();
+    if (rvsdg::TryGetRegionParentNode<GammaNode>(*def) != &gamma)
+    {
+      return std::nullopt;
+    }
+    return gamma.MapBranchArgumentEntryVar(*def).input->origin();
+  };
 
-GammaResult::~GammaResult() noexcept = default;
+  auto firstOrigin = GetExternalOriginOf(exitvar.branchResult[0]);
+  if (!firstOrigin)
+  {
+    return std::nullopt;
+  }
 
-GammaResult &
-GammaResult::Copy(rvsdg::output & origin, StructuralOutput * output)
-{
-  auto gammaOutput = util::AssertedCast<GammaOutput>(output);
-  return GammaResult::Create(*origin.region(), origin, *gammaOutput);
+  for (size_t n = 1; n < exitvar.branchResult.size(); ++n)
+  {
+    auto currentOrigin = GetExternalOriginOf(exitvar.branchResult[n]);
+    if (!currentOrigin || *firstOrigin != *currentOrigin)
+    {
+      return std::nullopt;
+    }
+  }
+
+  return firstOrigin;
 }
 
 }

--- a/tests/jlm/hls/backend/rvsdg2rhls/TestGamma.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/TestGamma.cpp
@@ -30,11 +30,11 @@ TestWithMatch()
 
   auto match = jlm::rvsdg::match(1, { { 0, 0 } }, 1, 2, lambda->GetFunctionArguments()[0]);
   auto gamma = jlm::rvsdg::GammaNode::create(match, 2);
-  auto ev1 = gamma->add_entryvar(lambda->GetFunctionArguments()[1]);
-  auto ev2 = gamma->add_entryvar(lambda->GetFunctionArguments()[2]);
-  auto ex = gamma->add_exitvar({ ev1->argument(0), ev2->argument(1) });
+  auto ev1 = gamma->AddEntryVar(lambda->GetFunctionArguments()[1]);
+  auto ev2 = gamma->AddEntryVar(lambda->GetFunctionArguments()[2]);
+  auto ex = gamma->AddExitVar({ ev1.branchArgument[0], ev2.branchArgument[1] });
 
-  auto f = lambda->finalize({ ex });
+  auto f = lambda->finalize({ ex.output });
   jlm::llvm::GraphExport::Create(*f, "");
 
   jlm::rvsdg::view(rm.Rvsdg(), stdout);
@@ -66,11 +66,11 @@ TestWithoutMatch()
   auto lambda = lambda::node::create(rm.Rvsdg().root(), ft, "f", linkage::external_linkage);
 
   auto gamma = jlm::rvsdg::GammaNode::create(lambda->GetFunctionArguments()[0], 2);
-  auto ev1 = gamma->add_entryvar(lambda->GetFunctionArguments()[1]);
-  auto ev2 = gamma->add_entryvar(lambda->GetFunctionArguments()[2]);
-  auto ex = gamma->add_exitvar({ ev1->argument(0), ev2->argument(1) });
+  auto ev1 = gamma->AddEntryVar(lambda->GetFunctionArguments()[1]);
+  auto ev2 = gamma->AddEntryVar(lambda->GetFunctionArguments()[2]);
+  auto ex = gamma->AddExitVar({ ev1.branchArgument[0], ev2.branchArgument[1] });
 
-  auto f = lambda->finalize({ ex });
+  auto f = lambda->finalize({ ex.output });
   jlm::llvm::GraphExport::Create(*f, "");
 
   jlm::rvsdg::view(rm.Rvsdg(), stdout);

--- a/tests/jlm/hls/backend/rvsdg2rhls/UnusedStateRemovalTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/UnusedStateRemovalTests.cpp
@@ -32,30 +32,29 @@ TestGamma()
 
   auto gammaNode = jlm::rvsdg::GammaNode::create(p, 2);
 
-  auto gammaInput1 = gammaNode->add_entryvar(x);
-  auto gammaInput2 = gammaNode->add_entryvar(y);
-  auto gammaInput3 = gammaNode->add_entryvar(z);
-  auto gammaInput4 = gammaNode->add_entryvar(x);
-  auto gammaInput5 = gammaNode->add_entryvar(x);
-  auto gammaInput6 = gammaNode->add_entryvar(x);
-  auto gammaInput7 = gammaNode->add_entryvar(x);
+  auto gammaInput1 = gammaNode->AddEntryVar(x);
+  auto gammaInput2 = gammaNode->AddEntryVar(y);
+  auto gammaInput3 = gammaNode->AddEntryVar(z);
+  auto gammaInput4 = gammaNode->AddEntryVar(x);
+  auto gammaInput5 = gammaNode->AddEntryVar(x);
+  auto gammaInput6 = gammaNode->AddEntryVar(x);
+  auto gammaInput7 = gammaNode->AddEntryVar(x);
 
-  auto gammaOutput1 =
-      gammaNode->add_exitvar({ gammaInput1->argument(0), gammaInput1->argument(1) });
+  auto gammaOutput1 = gammaNode->AddExitVar(gammaInput1.branchArgument);
   auto gammaOutput2 =
-      gammaNode->add_exitvar({ gammaInput2->argument(0), gammaInput3->argument(1) });
+      gammaNode->AddExitVar({ gammaInput2.branchArgument[0], gammaInput3.branchArgument[1] });
   auto gammaOutput3 =
-      gammaNode->add_exitvar({ gammaInput4->argument(0), gammaInput5->argument(1) });
+      gammaNode->AddExitVar({ gammaInput4.branchArgument[0], gammaInput5.branchArgument[1] });
   auto gammaOutput4 =
-      gammaNode->add_exitvar({ gammaInput6->argument(0), gammaInput6->argument(1) });
+      gammaNode->AddExitVar({ gammaInput6.branchArgument[0], gammaInput6.branchArgument[1] });
   auto gammaOutput5 =
-      gammaNode->add_exitvar({ gammaInput6->argument(0), gammaInput7->argument(1) });
+      gammaNode->AddExitVar({ gammaInput6.branchArgument[0], gammaInput7.branchArgument[1] });
 
-  GraphExport::Create(*gammaOutput1, "");
-  GraphExport::Create(*gammaOutput2, "");
-  GraphExport::Create(*gammaOutput3, "");
-  GraphExport::Create(*gammaOutput4, "");
-  GraphExport::Create(*gammaOutput5, "");
+  GraphExport::Create(*gammaOutput1.output, "");
+  GraphExport::Create(*gammaOutput2.output, "");
+  GraphExport::Create(*gammaOutput3.output, "");
+  GraphExport::Create(*gammaOutput4.output, "");
+  GraphExport::Create(*gammaOutput5.output, "");
 
   // Act
   jlm::hls::RemoveUnusedStates(*rvsdgModule);
@@ -63,8 +62,8 @@ TestGamma()
   // Assert
   assert(gammaNode->ninputs() == 7);  // gammaInput1 was removed
   assert(gammaNode->noutputs() == 4); // gammaOutput1 was removed
-  assert(gammaInput2->index() == 1);
-  assert(gammaOutput2->index() == 0);
+  assert(gammaInput2.input->index() == 1);
+  assert(gammaOutput2.output->index() == 0);
   // FIXME: The transformation is way too conservative here. The only input and output it removes
   // are gammaInput1 and gammaOutput1, respectively. However, it could also remove gammaOutput3,
   // gammaOutput4, and gammaOutput5 as they are all invariant. This in turn would also render some

--- a/tests/jlm/llvm/backend/llvm/r2j/GammaTests.cpp
+++ b/tests/jlm/llvm/backend/llvm/r2j/GammaTests.cpp
@@ -40,11 +40,12 @@ GammaWithMatch()
 
   auto match = jlm::rvsdg::match(1, { { 0, 0 } }, 1, 2, lambdaNode->GetFunctionArguments()[0]);
   auto gamma = jlm::rvsdg::GammaNode::create(match, 2);
-  auto gammaInput1 = gamma->add_entryvar(lambdaNode->GetFunctionArguments()[1]);
-  auto gammaInput2 = gamma->add_entryvar(lambdaNode->GetFunctionArguments()[2]);
-  auto gammaOutput = gamma->add_exitvar({ gammaInput1->argument(0), gammaInput2->argument(1) });
+  auto gammaInput1 = gamma->AddEntryVar(lambdaNode->GetFunctionArguments()[1]);
+  auto gammaInput2 = gamma->AddEntryVar(lambdaNode->GetFunctionArguments()[2]);
+  auto gammaOutput =
+      gamma->AddExitVar({ gammaInput1.branchArgument[0], gammaInput2.branchArgument[1] });
 
-  auto lambdaOutput = lambdaNode->finalize({ gammaOutput });
+  auto lambdaOutput = lambdaNode->finalize({ gammaOutput.output });
   jlm::llvm::GraphExport::Create(*lambdaOutput, "");
 
   view(rvsdgModule.Rvsdg(), stdout);
@@ -93,11 +94,12 @@ GammaWithoutMatch()
       linkage::external_linkage);
 
   auto gammaNode = jlm::rvsdg::GammaNode::create(lambdaNode->GetFunctionArguments()[0], 2);
-  auto gammaInput1 = gammaNode->add_entryvar(lambdaNode->GetFunctionArguments()[1]);
-  auto gammaInput2 = gammaNode->add_entryvar(lambdaNode->GetFunctionArguments()[2]);
-  auto gammaOutput = gammaNode->add_exitvar({ gammaInput1->argument(0), gammaInput2->argument(1) });
+  auto gammaInput1 = gammaNode->AddEntryVar(lambdaNode->GetFunctionArguments()[1]);
+  auto gammaInput2 = gammaNode->AddEntryVar(lambdaNode->GetFunctionArguments()[2]);
+  auto gammaOutput =
+      gammaNode->AddExitVar({ gammaInput1.branchArgument[0], gammaInput2.branchArgument[1] });
 
-  auto lambdaOutput = lambdaNode->finalize({ gammaOutput });
+  auto lambdaOutput = lambdaNode->finalize({ gammaOutput.output });
   jlm::llvm::GraphExport::Create(*lambdaOutput, "");
 
   jlm::rvsdg::view(rvsdgModule.Rvsdg(), stdout);
@@ -150,12 +152,13 @@ EmptyGammaWithThreeSubregions()
       jlm::rvsdg::match(32, { { 0, 0 }, { 1, 1 } }, 2, 3, lambdaNode->GetFunctionArguments()[0]);
 
   auto gammaNode = jlm::rvsdg::GammaNode::create(match, 3);
-  auto gammaInput1 = gammaNode->add_entryvar(lambdaNode->GetFunctionArguments()[1]);
-  auto gammaInput2 = gammaNode->add_entryvar(lambdaNode->GetFunctionArguments()[2]);
-  auto gammaOutput = gammaNode->add_exitvar(
-      { gammaInput1->argument(0), gammaInput1->argument(1), gammaInput2->argument(2) });
+  auto gammaInput1 = gammaNode->AddEntryVar(lambdaNode->GetFunctionArguments()[1]);
+  auto gammaInput2 = gammaNode->AddEntryVar(lambdaNode->GetFunctionArguments()[2]);
+  auto gammaOutput = gammaNode->AddExitVar({ gammaInput1.branchArgument[0],
+                                             gammaInput1.branchArgument[1],
+                                             gammaInput2.branchArgument[2] });
 
-  auto lambdaOutput = lambdaNode->finalize({ gammaOutput });
+  auto lambdaOutput = lambdaNode->finalize({ gammaOutput.output });
   jlm::llvm::GraphExport::Create(*lambdaOutput, "");
 
   jlm::rvsdg::view(rvsdgModule.Rvsdg(), stdout);
@@ -201,14 +204,14 @@ PartialEmptyGamma()
 
   auto match = jlm::rvsdg::match(1, { { 0, 0 } }, 1, 2, lambdaNode->GetFunctionArguments()[0]);
   auto gammaNode = jlm::rvsdg::GammaNode::create(match, 2);
-  auto gammaInput = gammaNode->add_entryvar(lambdaNode->GetFunctionArguments()[1]);
+  auto gammaInput = gammaNode->AddEntryVar(lambdaNode->GetFunctionArguments()[1]);
   auto output = jlm::tests::create_testop(
       gammaNode->subregion(1),
-      { gammaInput->argument(1) },
+      { gammaInput.branchArgument[1] },
       { valueType })[0];
-  auto gammaOutput = gammaNode->add_exitvar({ gammaInput->argument(0), output });
+  auto gammaOutput = gammaNode->AddExitVar({ gammaInput.branchArgument[0], output });
 
-  auto lambdaOutput = lambdaNode->finalize({ gammaOutput });
+  auto lambdaOutput = lambdaNode->finalize({ gammaOutput.output });
 
   jlm::llvm::GraphExport::Create(*lambdaOutput, "");
 

--- a/tests/jlm/llvm/ir/operators/TestCall.cpp
+++ b/tests/jlm/llvm/ir/operators/TestCall.cpp
@@ -202,10 +202,10 @@ TestCallTypeClassifierNonRecursiveDirectCall()
 
       auto predicate = jlm::rvsdg::control_false(innerTheta->subregion());
       auto gamma = jlm::rvsdg::GammaNode::create(predicate, 2);
-      auto ev = gamma->add_entryvar(itf->argument());
-      auto xv = gamma->add_exitvar({ ev->argument(0), ev->argument(1) });
+      auto ev = gamma->AddEntryVar(itf->argument());
+      auto xv = gamma->AddExitVar(ev.branchArgument);
 
-      itf->result()->divert_to(xv);
+      itf->result()->divert_to(xv.output);
       otf->result()->divert_to(itf);
 
       return otf;
@@ -407,29 +407,32 @@ TestCallTypeClassifierRecursiveDirectCall()
     auto predicate = jlm::rvsdg::match(1, { { 0, 1 } }, 0, 2, bitult);
 
     auto gammaNode = jlm::rvsdg::GammaNode::create(predicate, 2);
-    auto nev = gammaNode->add_entryvar(valueArgument);
-    auto resultev = gammaNode->add_entryvar(pointerArgument);
-    auto fibev = gammaNode->add_entryvar(ctxVarFib);
-    auto gIIoState = gammaNode->add_entryvar(iOStateArgument);
-    auto gIMemoryState = gammaNode->add_entryvar(memoryStateArgument);
+    auto nev = gammaNode->AddEntryVar(valueArgument);
+    auto resultev = gammaNode->AddEntryVar(pointerArgument);
+    auto fibev = gammaNode->AddEntryVar(ctxVarFib);
+    auto gIIoState = gammaNode->AddEntryVar(iOStateArgument);
+    auto gIMemoryState = gammaNode->AddEntryVar(memoryStateArgument);
 
     /* gamma subregion 0 */
     auto one = jlm::rvsdg::create_bitconstant(gammaNode->subregion(0), 64, 1);
-    auto nm1 = jlm::rvsdg::bitsub_op::create(64, nev->argument(0), one);
+    auto nm1 = jlm::rvsdg::bitsub_op::create(64, nev.branchArgument[0], one);
     auto callfibm1Results = CallNode::Create(
-        fibev->argument(0),
+        fibev.branchArgument[0],
         functionType,
-        { nm1, resultev->argument(0), gIIoState->argument(0), gIMemoryState->argument(0) });
+        { nm1,
+          resultev.branchArgument[0],
+          gIIoState.branchArgument[0],
+          gIMemoryState.branchArgument[0] });
 
     two = jlm::rvsdg::create_bitconstant(gammaNode->subregion(0), 64, 2);
-    auto nm2 = jlm::rvsdg::bitsub_op::create(64, nev->argument(0), two);
+    auto nm2 = jlm::rvsdg::bitsub_op::create(64, nev.branchArgument[0], two);
     auto callfibm2Results = CallNode::Create(
-        fibev->argument(0),
+        fibev.branchArgument[0],
         functionType,
-        { nm2, resultev->argument(0), callfibm1Results[0], callfibm1Results[1] });
+        { nm2, resultev.branchArgument[0], callfibm1Results[0], callfibm1Results[1] });
 
     auto gepnm1 = GetElementPtrOperation::Create(
-        resultev->argument(0),
+        resultev.branchArgument[0],
         { nm1 },
         jlm::rvsdg::bittype::Create(64),
         pbit64);
@@ -440,7 +443,7 @@ TestCallTypeClassifierRecursiveDirectCall()
         8);
 
     auto gepnm2 = GetElementPtrOperation::Create(
-        resultev->argument(0),
+        resultev.branchArgument[0],
         { nm2 },
         jlm::rvsdg::bittype::Create(64),
         pbit64);
@@ -452,18 +455,18 @@ TestCallTypeClassifierRecursiveDirectCall()
     /* gamma subregion 1 */
     /* Nothing needs to be done */
 
-    auto sumex = gammaNode->add_exitvar({ sum, nev->argument(1) });
-    auto gOIoState = gammaNode->add_exitvar({ callfibm2Results[0], gIIoState->argument(1) });
-    auto gOMemoryState = gammaNode->add_exitvar({ ldnm2[1], gIMemoryState->argument(1) });
+    auto sumex = gammaNode->AddExitVar({ sum, nev.branchArgument[1] });
+    auto gOIoState = gammaNode->AddExitVar({ callfibm2Results[0], gIIoState.branchArgument[1] });
+    auto gOMemoryState = gammaNode->AddExitVar({ ldnm2[1], gIMemoryState.branchArgument[1] });
 
     auto gepn = GetElementPtrOperation::Create(
         pointerArgument,
         { valueArgument },
         jlm::rvsdg::bittype::Create(64),
         pbit64);
-    auto store = StoreNonVolatileNode::Create(gepn, sumex, { gOMemoryState }, 8);
+    auto store = StoreNonVolatileNode::Create(gepn, sumex.output, { gOMemoryState.output }, 8);
 
-    auto lambdaOutput = lambda->finalize({ gOIoState, store[0] });
+    auto lambdaOutput = lambda->finalize({ gOIoState.output, store[0] });
 
     fibrv->result()->divert_to(lambdaOutput);
     pb.end();

--- a/tests/jlm/llvm/opt/TestDeadNodeElimination.cpp
+++ b/tests/jlm/llvm/opt/TestDeadNodeElimination.cpp
@@ -60,15 +60,15 @@ TestGamma()
   auto y = &jlm::tests::GraphImport::Create(graph, vt, "y");
 
   auto gamma = jlm::rvsdg::GammaNode::create(c, 2);
-  auto ev1 = gamma->add_entryvar(x);
-  auto ev2 = gamma->add_entryvar(y);
-  auto ev3 = gamma->add_entryvar(x);
+  auto ev1 = gamma->AddEntryVar(x);
+  auto ev2 = gamma->AddEntryVar(y);
+  auto ev3 = gamma->AddEntryVar(x);
 
-  auto t = jlm::tests::create_testop(gamma->subregion(1), { ev2->argument(1) }, { vt })[0];
+  auto t = jlm::tests::create_testop(gamma->subregion(1), { ev2.branchArgument[1] }, { vt })[0];
 
-  gamma->add_exitvar({ ev1->argument(0), ev1->argument(1) });
-  gamma->add_exitvar({ ev2->argument(0), t });
-  gamma->add_exitvar({ ev3->argument(0), ev1->argument(1) });
+  gamma->AddExitVar(ev1.branchArgument);
+  gamma->AddExitVar({ ev2.branchArgument[0], t });
+  gamma->AddExitVar({ ev3.branchArgument[0], ev1.branchArgument[1] });
 
   GraphExport::Create(*gamma->output(0), "z");
   GraphExport::Create(*gamma->output(2), "w");
@@ -98,12 +98,12 @@ TestGamma2()
   auto x = &jlm::tests::GraphImport::Create(graph, vt, "x");
 
   auto gamma = jlm::rvsdg::GammaNode::create(c, 2);
-  gamma->add_entryvar(x);
+  gamma->AddEntryVar(x);
 
   auto n1 = jlm::tests::create_testop(gamma->subregion(0), {}, { vt })[0];
   auto n2 = jlm::tests::create_testop(gamma->subregion(1), {}, { vt })[0];
 
-  gamma->add_exitvar({ n1, n2 });
+  gamma->AddExitVar({ n1, n2 });
 
   GraphExport::Create(*gamma->output(0), "x");
 

--- a/tests/jlm/llvm/opt/alias-analyses/TestAndersen.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestAndersen.cpp
@@ -560,8 +560,9 @@ TestGamma()
 
   for (size_t n = 0; n < 4; n++)
   {
-    auto & argument0 = ptg->GetRegisterNode(*test.gamma->entryvar(n)->argument(0));
-    auto & argument1 = ptg->GetRegisterNode(*test.gamma->entryvar(n)->argument(1));
+    auto entryvar = test.gamma->GetEntryVar(n);
+    auto & argument0 = ptg->GetRegisterNode(*entryvar.branchArgument[0]);
+    auto & argument1 = ptg->GetRegisterNode(*entryvar.branchArgument[1]);
 
     assert(TargetsExactly(argument0, { &lambda, &ptg->GetExternalMemoryNode() }));
     assert(TargetsExactly(argument1, { &lambda, &ptg->GetExternalMemoryNode() }));
@@ -569,7 +570,7 @@ TestGamma()
 
   for (size_t n = 0; n < 4; n++)
   {
-    auto & gammaOutput = ptg->GetRegisterNode(*test.gamma->exitvar(0));
+    auto & gammaOutput = ptg->GetRegisterNode(*test.gamma->GetExitVars()[0].output);
     assert(TargetsExactly(gammaOutput, { &lambda, &ptg->GetExternalMemoryNode() }));
   }
 

--- a/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
@@ -1919,8 +1919,8 @@ ValidatePhiTestSteensgaardAgnostic(const jlm::tests::PhiTest1 & test)
 
   auto gammaStateIndex = store->input(2)->origin()->index();
 
-  auto load1 =
-      jlm::rvsdg::output::GetNode(*test.gamma->exitvar(gammaStateIndex)->result(0)->origin());
+  auto load1 = jlm::rvsdg::output::GetNode(
+      *test.gamma->GetExitVars()[gammaStateIndex].branchResult[0]->origin());
   assert(is<LoadNonVolatileOperation>(*load1, 2, 2));
 
   auto load2 = jlm::rvsdg::output::GetNode(*load1->input(1)->origin());
@@ -1948,8 +1948,8 @@ ValidatePhiTestSteensgaardRegionAware(const jlm::tests::PhiTest1 & test)
 
   auto gammaStateIndex = store->input(2)->origin()->index();
 
-  auto load1 =
-      jlm::rvsdg::output::GetNode(*test.gamma->exitvar(gammaStateIndex)->result(0)->origin());
+  auto load1 = jlm::rvsdg::output::GetNode(
+      *test.gamma->GetExitVars()[gammaStateIndex].branchResult[0]->origin());
   assert(is<LoadNonVolatileOperation>(*load1, 2, 2));
 
   auto load2 = jlm::rvsdg::output::GetNode(*load1->input(1)->origin());
@@ -1991,8 +1991,8 @@ ValidatePhiTestSteensgaardAgnosticTopDown(const jlm::tests::PhiTest1 & test)
 
   auto gammaStateIndex = storeNode->input(2)->origin()->index();
 
-  auto load1 =
-      jlm::rvsdg::output::GetNode(*test.gamma->exitvar(gammaStateIndex)->result(0)->origin());
+  auto load1 = jlm::rvsdg::output::GetNode(
+      *test.gamma->GetExitVars()[gammaStateIndex].branchResult[0]->origin());
   assert(is<LoadNonVolatileOperation>(*load1, 2, 2));
 
   auto load2 = jlm::rvsdg::output::GetNode(*load1->input(1)->origin());

--- a/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
@@ -660,8 +660,9 @@ TestGamma()
 
     for (size_t n = 0; n < 4; n++)
     {
-      auto & argument0 = pointsToGraph.GetRegisterNode(*test.gamma->entryvar(n)->argument(0));
-      auto & argument1 = pointsToGraph.GetRegisterNode(*test.gamma->entryvar(n)->argument(1));
+      auto entryvar = test.gamma->GetEntryVar(n);
+      auto & argument0 = pointsToGraph.GetRegisterNode(*entryvar.branchArgument[0]);
+      auto & argument1 = pointsToGraph.GetRegisterNode(*entryvar.branchArgument[1]);
 
       assertTargets(argument0, { &lambda, &pointsToGraph.GetExternalMemoryNode() });
       assertTargets(argument1, { &lambda, &pointsToGraph.GetExternalMemoryNode() });
@@ -669,7 +670,7 @@ TestGamma()
 
     for (size_t n = 0; n < 4; n++)
     {
-      auto & gammaOutput = pointsToGraph.GetRegisterNode(*test.gamma->exitvar(0));
+      auto & gammaOutput = pointsToGraph.GetRegisterNode(*test.gamma->GetExitVars()[0].output);
       assertTargets(gammaOutput, { &lambda, &pointsToGraph.GetExternalMemoryNode() });
     }
 

--- a/tests/jlm/llvm/opt/test-cne.cpp
+++ b/tests/jlm/llvm/opt/test-cne.cpp
@@ -86,23 +86,23 @@ test_gamma()
 
   auto gamma = jlm::rvsdg::GammaNode::create(c, 2);
 
-  auto ev1 = gamma->add_entryvar(u1);
-  auto ev2 = gamma->add_entryvar(u2);
-  auto ev3 = gamma->add_entryvar(y);
-  auto ev4 = gamma->add_entryvar(z);
-  auto ev5 = gamma->add_entryvar(z);
+  auto ev1 = gamma->AddEntryVar(u1);
+  auto ev2 = gamma->AddEntryVar(u2);
+  auto ev3 = gamma->AddEntryVar(y);
+  auto ev4 = gamma->AddEntryVar(z);
+  auto ev5 = gamma->AddEntryVar(z);
 
   auto n1 = jlm::tests::create_testop(gamma->subregion(0), {}, { vt })[0];
   auto n2 = jlm::tests::create_testop(gamma->subregion(0), {}, { vt })[0];
   auto n3 = jlm::tests::create_testop(gamma->subregion(0), {}, { vt })[0];
 
-  gamma->add_exitvar({ ev1->argument(0), ev2->argument(1) });
-  gamma->add_exitvar({ ev2->argument(0), ev2->argument(1) });
-  gamma->add_exitvar({ ev3->argument(0), ev3->argument(1) });
-  gamma->add_exitvar({ n1, ev3->argument(1) });
-  gamma->add_exitvar({ n2, ev3->argument(1) });
-  gamma->add_exitvar({ n3, ev3->argument(1) });
-  gamma->add_exitvar({ ev5->argument(0), ev4->argument(1) });
+  gamma->AddExitVar({ ev1.branchArgument[0], ev1.branchArgument[1] });
+  gamma->AddExitVar({ ev2.branchArgument[0], ev2.branchArgument[1] });
+  gamma->AddExitVar({ ev3.branchArgument[0], ev3.branchArgument[1] });
+  gamma->AddExitVar({ n1, ev3.branchArgument[1] });
+  gamma->AddExitVar({ n2, ev3.branchArgument[1] });
+  gamma->AddExitVar({ n3, ev3.branchArgument[1] });
+  gamma->AddExitVar({ ev5.branchArgument[0], ev4.branchArgument[1] });
 
   GraphExport::Create(*gamma->output(0), "x1");
   GraphExport::Create(*gamma->output(1), "x2");

--- a/tests/jlm/llvm/opt/test-inlining.cpp
+++ b/tests/jlm/llvm/opt/test-inlining.cpp
@@ -70,25 +70,27 @@ test1()
     auto memoryStateArgument = lambda->GetFunctionArguments()[3];
 
     auto gamma = jlm::rvsdg::GammaNode::create(controlArgument, 2);
-    auto gammaInputF1 = gamma->add_entryvar(d);
-    auto gammaInputValue = gamma->add_entryvar(valueArgument);
-    auto gammaInputIoState = gamma->add_entryvar(iOStateArgument);
-    auto gammaInputMemoryState = gamma->add_entryvar(memoryStateArgument);
+    auto gammaInputF1 = gamma->AddEntryVar(d);
+    auto gammaInputValue = gamma->AddEntryVar(valueArgument);
+    auto gammaInputIoState = gamma->AddEntryVar(iOStateArgument);
+    auto gammaInputMemoryState = gamma->AddEntryVar(memoryStateArgument);
 
     auto callResults = CallNode::Create(
-        gammaInputF1->argument(0),
+        gammaInputF1.branchArgument[0],
         jlm::rvsdg::AssertGetOwnerNode<lambda::node>(*f1).Type(),
-        { gammaInputValue->argument(0),
-          gammaInputIoState->argument(0),
-          gammaInputMemoryState->argument(0) });
+        { gammaInputValue.branchArgument[0],
+          gammaInputIoState.branchArgument[0],
+          gammaInputMemoryState.branchArgument[0] });
 
-    auto gammaOutputValue = gamma->add_exitvar({ callResults[0], gammaInputValue->argument(1) });
+    auto gammaOutputValue =
+        gamma->AddExitVar({ callResults[0], gammaInputValue.branchArgument[1] });
     auto gammaOutputIoState =
-        gamma->add_exitvar({ callResults[1], gammaInputIoState->argument(1) });
+        gamma->AddExitVar({ callResults[1], gammaInputIoState.branchArgument[1] });
     auto gammaOutputMemoryState =
-        gamma->add_exitvar({ callResults[2], gammaInputMemoryState->argument(1) });
+        gamma->AddExitVar({ callResults[2], gammaInputMemoryState.branchArgument[1] });
 
-    return lambda->finalize({ gammaOutputValue, gammaOutputIoState, gammaOutputMemoryState });
+    return lambda->finalize(
+        { gammaOutputValue.output, gammaOutputIoState.output, gammaOutputMemoryState.output });
   };
 
   auto f1 = SetupF1();

--- a/tests/jlm/llvm/opt/test-inversion.cpp
+++ b/tests/jlm/llvm/opt/test-inversion.cpp
@@ -43,21 +43,21 @@ test1()
 
   auto gamma = jlm::rvsdg::GammaNode::create(predicate, 2);
 
-  auto evx = gamma->add_entryvar(lvx->argument());
-  auto evy = gamma->add_entryvar(lvy->argument());
+  auto evx = gamma->AddEntryVar(lvx->argument());
+  auto evy = gamma->AddEntryVar(lvy->argument());
 
   auto b = jlm::tests::create_testop(
       gamma->subregion(0),
-      { evx->argument(0), evy->argument(0) },
+      { evx.branchArgument[0], evy.branchArgument[0] },
       { vt })[0];
   auto c = jlm::tests::create_testop(
       gamma->subregion(1),
-      { evx->argument(1), evy->argument(1) },
+      { evx.branchArgument[1], evy.branchArgument[1] },
       { vt })[0];
 
-  auto xvy = gamma->add_exitvar({ b, c });
+  auto xvy = gamma->AddExitVar({ b, c });
 
-  lvy->result()->divert_to(xvy);
+  lvy->result()->divert_to(xvy.output);
 
   theta->set_predicate(predicate);
 
@@ -98,13 +98,13 @@ test2()
 
   auto gamma = jlm::rvsdg::GammaNode::create(predicate, 2);
 
-  auto ev1 = gamma->add_entryvar(n1);
-  auto ev2 = gamma->add_entryvar(lv1->argument());
-  auto ev3 = gamma->add_entryvar(n2);
+  auto ev1 = gamma->AddEntryVar(n1);
+  auto ev2 = gamma->AddEntryVar(lv1->argument());
+  auto ev3 = gamma->AddEntryVar(n2);
 
-  gamma->add_exitvar({ ev1->argument(0), ev1->argument(1) });
-  gamma->add_exitvar({ ev2->argument(0), ev2->argument(1) });
-  gamma->add_exitvar({ ev3->argument(0), ev3->argument(1) });
+  gamma->AddExitVar(ev1.branchArgument);
+  gamma->AddExitVar(ev2.branchArgument);
+  gamma->AddExitVar(ev3.branchArgument);
 
   lv1->result()->divert_to(gamma->output(1));
 

--- a/tests/jlm/llvm/opt/test-pull.cpp
+++ b/tests/jlm/llvm/opt/test-pull.cpp
@@ -41,9 +41,9 @@ test_pullin_top()
 
   auto gamma = jlm::rvsdg::GammaNode::create(n4, 2);
 
-  gamma->add_entryvar(n4);
-  auto ev = gamma->add_entryvar(n5);
-  gamma->add_exitvar({ ev->argument(0), ev->argument(1) });
+  gamma->AddEntryVar(n4);
+  auto ev = gamma->AddEntryVar(n5);
+  gamma->AddExitVar(ev.branchArgument);
 
   GraphExport::Create(*gamma->output(0), "x");
   GraphExport::Create(*n2, "y");
@@ -68,8 +68,8 @@ test_pullin_bottom()
 
   auto gamma = jlm::rvsdg::GammaNode::create(c, 2);
 
-  auto ev = gamma->add_entryvar(x);
-  gamma->add_exitvar({ ev->argument(0), ev->argument(1) });
+  auto ev = gamma->AddEntryVar(x);
+  gamma->AddExitVar(ev.branchArgument);
 
   auto b1 = jlm::tests::create_testop(graph.root(), { gamma->output(0), x }, { vt })[0];
   auto b2 = jlm::tests::create_testop(graph.root(), { gamma->output(0), b1 }, { vt })[0];
@@ -99,21 +99,21 @@ test_pull()
 
   /* outer gamma */
   auto gamma1 = jlm::rvsdg::GammaNode::create(p, 2);
-  auto ev1 = gamma1->add_entryvar(p);
-  auto ev2 = gamma1->add_entryvar(croot);
+  auto ev1 = gamma1->AddEntryVar(p);
+  auto ev2 = gamma1->AddEntryVar(croot);
 
   auto cg1 = jlm::tests::create_testop(gamma1->subregion(0), {}, { vt })[0];
 
   /* inner gamma */
-  auto gamma2 = jlm::rvsdg::GammaNode::create(ev1->argument(1), 2);
-  auto ev3 = gamma2->add_entryvar(ev2->argument(1));
+  auto gamma2 = jlm::rvsdg::GammaNode::create(ev1.branchArgument[1], 2);
+  auto ev3 = gamma2->AddEntryVar(ev2.branchArgument[1]);
   auto cg2 = jlm::tests::create_testop(gamma2->subregion(0), {}, { vt })[0];
-  auto un = jlm::tests::create_testop(gamma2->subregion(1), { ev3->argument(1) }, { vt })[0];
-  auto g2xv = gamma2->add_exitvar({ cg2, un });
+  auto un = jlm::tests::create_testop(gamma2->subregion(1), { ev3.branchArgument[1] }, { vt })[0];
+  auto g2xv = gamma2->AddExitVar({ cg2, un });
 
-  auto g1xv = gamma1->add_exitvar({ cg1, g2xv });
+  auto g1xv = gamma1->AddExitVar({ cg1, g2xv.output });
 
-  GraphExport::Create(*g1xv, "");
+  GraphExport::Create(*g1xv.output, "");
 
   jlm::rvsdg::view(graph, stdout);
   jlm::llvm::pullin pullin;

--- a/tests/jlm/llvm/opt/test-push.cpp
+++ b/tests/jlm/llvm/opt/test-push.cpp
@@ -35,14 +35,16 @@ test_gamma()
   auto s = &jlm::tests::GraphImport::Create(graph, st, "s");
 
   auto gamma = jlm::rvsdg::GammaNode::create(c, 2);
-  auto evx = gamma->add_entryvar(x);
-  auto evs = gamma->add_entryvar(s);
+  auto evx = gamma->AddEntryVar(x);
+  auto evs = gamma->AddEntryVar(s);
 
   auto null = jlm::tests::create_testop(gamma->subregion(0), {}, { vt })[0];
-  auto bin = jlm::tests::create_testop(gamma->subregion(0), { null, evx->argument(0) }, { vt })[0];
-  auto state = jlm::tests::create_testop(gamma->subregion(0), { bin, evs->argument(0) }, { st })[0];
+  auto bin =
+      jlm::tests::create_testop(gamma->subregion(0), { null, evx.branchArgument[0] }, { vt })[0];
+  auto state =
+      jlm::tests::create_testop(gamma->subregion(0), { bin, evs.branchArgument[0] }, { st })[0];
 
-  gamma->add_exitvar({ state, evs->argument(1) });
+  gamma->AddExitVar({ state, evs.branchArgument[1] });
 
   GraphExport::Create(*gamma->output(0), "x");
 

--- a/tests/jlm/mlir/backend/TestJlmToMlirConverter.cpp
+++ b/tests/jlm/mlir/backend/TestJlmToMlirConverter.cpp
@@ -509,8 +509,8 @@ TestGamma()
         3             // nalternatives
     );
 
-    rvsdgGammaNode->add_entryvar(entryvar1);
-    rvsdgGammaNode->add_entryvar(entryvar2);
+    rvsdgGammaNode->AddEntryVar(entryvar1);
+    rvsdgGammaNode->AddEntryVar(entryvar2);
 
     std::vector<jlm::rvsdg::output *> exitvars1;
     std::vector<jlm::rvsdg::output *> exitvars2;
@@ -521,8 +521,8 @@ TestGamma()
           jlm::rvsdg::create_bitconstant(rvsdgGammaNode->subregion(i), 32, 10 * (i + 1)));
     }
 
-    rvsdgGammaNode->add_exitvar(exitvars1);
-    rvsdgGammaNode->add_exitvar(exitvars2);
+    rvsdgGammaNode->AddExitVar(exitvars1);
+    rvsdgGammaNode->AddExitVar(exitvars2);
 
     // Convert the RVSDG to MLIR
     std::cout << "Convert to MLIR" << std::endl;

--- a/tests/jlm/rvsdg/test-gamma.cpp
+++ b/tests/jlm/rvsdg/test-gamma.cpp
@@ -26,10 +26,10 @@ test_gamma(void)
   auto pred = match(2, { { 0, 0 }, { 1, 1 } }, 2, 3, cmp);
 
   auto gamma = GammaNode::create(pred, 3);
-  auto ev0 = gamma->add_entryvar(v0);
-  auto ev1 = gamma->add_entryvar(v1);
-  auto ev2 = gamma->add_entryvar(v2);
-  gamma->add_exitvar({ ev0->argument(0), ev1->argument(1), ev2->argument(2) });
+  auto ev0 = gamma->AddEntryVar(v0);
+  auto ev1 = gamma->AddEntryVar(v1);
+  auto ev2 = gamma->AddEntryVar(v2);
+  gamma->AddExitVar({ ev0.branchArgument[0], ev1.branchArgument[1], ev2.branchArgument[2] });
 
   jlm::tests::GraphExport::Create(*gamma->output(0), "dummy");
 
@@ -44,8 +44,8 @@ test_gamma(void)
   /* test entry and exit variable iterators */
 
   auto gamma3 = GammaNode::create(v3, 2);
-  assert(gamma3->begin_entryvar() == gamma3->end_entryvar());
-  assert(gamma3->begin_exitvar() == gamma3->end_exitvar());
+  assert(gamma3->GetEntryVars().empty());
+  assert(gamma3->GetExitVars().empty());
 }
 
 static void
@@ -65,10 +65,10 @@ test_predicate_reduction(void)
   auto pred = jlm::rvsdg::control_constant(graph.root(), 3, 1);
 
   auto gamma = GammaNode::create(pred, 3);
-  auto ev0 = gamma->add_entryvar(v0);
-  auto ev1 = gamma->add_entryvar(v1);
-  auto ev2 = gamma->add_entryvar(v2);
-  gamma->add_exitvar({ ev0->argument(0), ev1->argument(1), ev2->argument(2) });
+  auto ev0 = gamma->AddEntryVar(v0);
+  auto ev1 = gamma->AddEntryVar(v1);
+  auto ev2 = gamma->AddEntryVar(v2);
+  gamma->AddExitVar({ ev0.branchArgument[0], ev1.branchArgument[1], ev2.branchArgument[2] });
 
   auto & r = jlm::tests::GraphExport::Create(*gamma->output(0), "");
 
@@ -94,8 +94,8 @@ test_invariant_reduction(void)
   auto v = &jlm::tests::GraphImport::Create(graph, vtype, "");
 
   auto gamma = GammaNode::create(pred, 2);
-  auto ev = gamma->add_entryvar(v);
-  gamma->add_exitvar({ ev->argument(0), ev->argument(1) });
+  auto ev = gamma->AddEntryVar(v);
+  gamma->AddExitVar(ev.branchArgument);
 
   auto & r = jlm::tests::GraphExport::Create(*gamma->output(0), "");
 
@@ -127,11 +127,11 @@ test_control_constant_reduction()
   auto n0 = jlm::rvsdg::control_constant(gamma->subregion(0), 3, 0);
   auto n1 = jlm::rvsdg::control_constant(gamma->subregion(1), 3, 1);
 
-  auto xv1 = gamma->add_exitvar({ t, f });
-  auto xv2 = gamma->add_exitvar({ n0, n1 });
+  auto xv1 = gamma->AddExitVar({ t, f });
+  auto xv2 = gamma->AddExitVar({ n0, n1 });
 
-  auto & ex1 = jlm::tests::GraphExport::Create(*xv1, "");
-  auto & ex2 = jlm::tests::GraphExport::Create(*xv2, "");
+  auto & ex1 = jlm::tests::GraphExport::Create(*xv1.output, "");
+  auto & ex2 = jlm::tests::GraphExport::Create(*xv2.output, "");
 
   jlm::rvsdg::view(graph.root(), stdout);
   graph.normalize();
@@ -164,9 +164,9 @@ test_control_constant_reduction2()
   auto t3 = jlm::rvsdg::control_true(gamma->subregion(2));
   auto f = jlm::rvsdg::control_false(gamma->subregion(3));
 
-  auto xv = gamma->add_exitvar({ t1, t2, t3, f });
+  auto xv = gamma->AddExitVar({ t1, t2, t3, f });
 
-  auto & ex = jlm::tests::GraphExport::Create(*xv, "");
+  auto & ex = jlm::tests::GraphExport::Create(*xv.output, "");
 
   jlm::rvsdg::view(graph.root(), stdout);
   graph.normalize();
@@ -193,49 +193,45 @@ TestRemoveGammaOutputsWhere()
   auto v3 = &jlm::tests::GraphImport::Create(rvsdg, vt, "");
 
   auto gammaNode = GammaNode::create(predicate, 2);
-  auto gammaInput0 = gammaNode->add_entryvar(v0);
-  auto gammaInput1 = gammaNode->add_entryvar(v1);
-  auto gammaInput2 = gammaNode->add_entryvar(v2);
-  auto gammaInput3 = gammaNode->add_entryvar(v3);
+  auto gammaInput0 = gammaNode->AddEntryVar(v0);
+  auto gammaInput1 = gammaNode->AddEntryVar(v1);
+  auto gammaInput2 = gammaNode->AddEntryVar(v2);
+  auto gammaInput3 = gammaNode->AddEntryVar(v3);
 
-  auto gammaOutput0 =
-      gammaNode->add_exitvar({ gammaInput0->argument(0), gammaInput0->argument(1) });
-  auto gammaOutput1 =
-      gammaNode->add_exitvar({ gammaInput1->argument(0), gammaInput1->argument(1) });
-  auto gammaOutput2 =
-      gammaNode->add_exitvar({ gammaInput2->argument(0), gammaInput2->argument(1) });
-  auto gammaOutput3 =
-      gammaNode->add_exitvar({ gammaInput3->argument(0), gammaInput3->argument(1) });
+  auto gammaOutput0 = gammaNode->AddExitVar(gammaInput0.branchArgument);
+  auto gammaOutput1 = gammaNode->AddExitVar(gammaInput1.branchArgument);
+  auto gammaOutput2 = gammaNode->AddExitVar(gammaInput2.branchArgument);
+  auto gammaOutput3 = gammaNode->AddExitVar(gammaInput3.branchArgument);
 
-  jlm::tests::GraphExport::Create(*gammaOutput0, "");
-  jlm::tests::GraphExport::Create(*gammaOutput2, "");
+  jlm::tests::GraphExport::Create(*gammaOutput0.output, "");
+  jlm::tests::GraphExport::Create(*gammaOutput2.output, "");
 
   // Act & Assert
   assert(gammaNode->noutputs() == 4);
 
   // Remove gammaOutput1
   gammaNode->RemoveGammaOutputsWhere(
-      [&](const GammaOutput & output)
+      [&](const jlm::rvsdg::output & output)
       {
-        return output.index() == gammaOutput1->index();
+        return output.index() == gammaOutput1.output->index();
       });
   assert(gammaNode->noutputs() == 3);
   assert(gammaNode->subregion(0)->nresults() == 3);
   assert(gammaNode->subregion(1)->nresults() == 3);
-  assert(gammaOutput2->index() == 1);
-  assert(gammaOutput3->index() == 2);
+  assert(gammaOutput2.output->index() == 1);
+  assert(gammaOutput3.output->index() == 2);
 
   // Try to remove gammaOutput2. This should result in no change as gammaOutput2 still has users.
   gammaNode->RemoveGammaOutputsWhere(
-      [&](const GammaOutput & output)
+      [&](const jlm::rvsdg::output & output)
       {
-        return output.index() == gammaOutput2->index();
+        return output.index() == gammaOutput2.output->index();
       });
   assert(gammaNode->noutputs() == 3);
   assert(gammaNode->subregion(0)->nresults() == 3);
   assert(gammaNode->subregion(1)->nresults() == 3);
-  assert(gammaOutput2->index() == 1);
-  assert(gammaOutput3->index() == 2);
+  assert(gammaOutput2.output->index() == 1);
+  assert(gammaOutput3.output->index() == 2);
 }
 
 static void
@@ -255,20 +251,18 @@ TestPruneOutputs()
   auto v3 = &jlm::tests::GraphImport::Create(rvsdg, vt, "");
 
   auto gammaNode = GammaNode::create(predicate, 2);
-  auto gammaInput0 = gammaNode->add_entryvar(v0);
-  auto gammaInput1 = gammaNode->add_entryvar(v1);
-  auto gammaInput2 = gammaNode->add_entryvar(v2);
-  auto gammaInput3 = gammaNode->add_entryvar(v3);
+  auto gammaInput0 = gammaNode->AddEntryVar(v0);
+  auto gammaInput1 = gammaNode->AddEntryVar(v1);
+  auto gammaInput2 = gammaNode->AddEntryVar(v2);
+  auto gammaInput3 = gammaNode->AddEntryVar(v3);
 
-  auto gammaOutput0 =
-      gammaNode->add_exitvar({ gammaInput0->argument(0), gammaInput0->argument(1) });
-  gammaNode->add_exitvar({ gammaInput1->argument(0), gammaInput1->argument(1) });
-  auto gammaOutput2 =
-      gammaNode->add_exitvar({ gammaInput2->argument(0), gammaInput2->argument(1) });
-  gammaNode->add_exitvar({ gammaInput3->argument(0), gammaInput3->argument(1) });
+  auto gammaOutput0 = gammaNode->AddExitVar(gammaInput0.branchArgument);
+  gammaNode->AddExitVar(gammaInput1.branchArgument);
+  auto gammaOutput2 = gammaNode->AddExitVar(gammaInput2.branchArgument);
+  gammaNode->AddExitVar(gammaInput3.branchArgument);
 
-  jlm::tests::GraphExport::Create(*gammaOutput0, "");
-  jlm::tests::GraphExport::Create(*gammaOutput2, "");
+  jlm::tests::GraphExport::Create(*gammaOutput0.output, "");
+  jlm::tests::GraphExport::Create(*gammaOutput2.output, "");
 
   // Act
   gammaNode->PruneOutputs();
@@ -278,13 +272,11 @@ TestPruneOutputs()
   assert(gammaNode->subregion(0)->nresults() == 2);
   assert(gammaNode->subregion(1)->nresults() == 2);
 
-  assert(gammaOutput0->index() == 0);
-  assert(gammaNode->subregion(0)->result(0)->output() == gammaOutput0);
-  assert(gammaNode->subregion(1)->result(0)->output() == gammaOutput0);
+  assert(gammaOutput0.output->index() == 0);
+  assert(gammaNode->GetExitVars()[0].output == gammaOutput0.output);
 
-  assert(gammaOutput2->index() == 1);
-  assert(gammaNode->subregion(0)->result(1)->output() == gammaOutput2);
-  assert(gammaNode->subregion(1)->result(1)->output() == gammaOutput2);
+  assert(gammaOutput2.output->index() == 1);
+  assert(gammaNode->GetExitVars()[1].output == gammaOutput2.output);
 }
 
 static void
@@ -302,30 +294,26 @@ TestIsInvariant()
   auto v1 = &jlm::tests::GraphImport::Create(rvsdg, vt, "");
 
   auto gammaNode = GammaNode::create(predicate, 2);
-  auto gammaInput0 = gammaNode->add_entryvar(v0);
-  auto gammaInput1 = gammaNode->add_entryvar(v1);
-  auto gammaInput2 = gammaNode->add_entryvar(v1);
+  auto gammaInput0 = gammaNode->AddEntryVar(v0);
+  auto gammaInput1 = gammaNode->AddEntryVar(v1);
+  auto gammaInput2 = gammaNode->AddEntryVar(v1);
 
-  auto gammaOutput0 =
-      gammaNode->add_exitvar({ gammaInput0->argument(0), gammaInput0->argument(1) });
+  auto gammaOutput0 = gammaNode->AddExitVar(gammaInput0.branchArgument);
   auto gammaOutput1 =
-      gammaNode->add_exitvar({ gammaInput1->argument(0), gammaInput2->argument(1) });
+      gammaNode->AddExitVar({ gammaInput1.branchArgument[0], gammaInput2.branchArgument[1] });
   auto gammaOutput2 =
-      gammaNode->add_exitvar({ gammaInput0->argument(0), gammaInput2->argument(1) });
+      gammaNode->AddExitVar({ gammaInput0.branchArgument[0], gammaInput2.branchArgument[1] });
 
   // Act & Assert
-  assert(gammaOutput0->IsInvariant());
-  output * invariantOrigin = nullptr;
-  gammaOutput0->IsInvariant(&invariantOrigin);
-  assert(invariantOrigin == v0);
+  std::optional<jlm::rvsdg::output *> invariantOrigin;
+  invariantOrigin = jlm::rvsdg::GetGammaInvariantOrigin(*gammaNode, gammaOutput0);
+  assert(invariantOrigin && *invariantOrigin == v0);
 
-  assert(gammaOutput1->IsInvariant(&invariantOrigin));
-  assert(invariantOrigin == v1);
+  invariantOrigin = jlm::rvsdg::GetGammaInvariantOrigin(*gammaNode, gammaOutput1);
+  assert(invariantOrigin && *invariantOrigin == v1);
 
-  invariantOrigin = nullptr;
-  assert(!gammaOutput2->IsInvariant(&invariantOrigin));
-  // invariantOrigin should not have been touched as gammaOutput2 is not invariant
-  assert(invariantOrigin == nullptr);
+  invariantOrigin = jlm::rvsdg::GetGammaInvariantOrigin(*gammaNode, gammaOutput2);
+  assert(!invariantOrigin);
 }
 
 static int


### PR DESCRIPTION
Remove the GammaInput class and the way it is used to map an input to the corresponding argument inside the lambda region. Replace this with an API function attached to the node instead.