### PR TITLE
theta: change API for mapping loop variables

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/add-prints.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-prints.cpp
@@ -84,7 +84,7 @@ route_to_region(jlm::rvsdg::output * output, rvsdg::Region * region)
   }
   else if (auto theta = dynamic_cast<rvsdg::ThetaNode *>(region->node()))
   {
-    output = theta->add_loopvar(output)->argument();
+    output = theta->AddLoopVar(output).pre;
   }
   else if (auto lambda = dynamic_cast<llvm::lambda::node *>(region->node()))
   {

--- a/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
@@ -106,7 +106,7 @@ add_triggers(rvsdg::Region * region)
       {
         JLM_ASSERT(trigger != nullptr);
         JLM_ASSERT(get_trigger(t->subregion()) == nullptr);
-        t->add_loopvar(trigger);
+        t->AddLoopVar(trigger);
         add_triggers(t->subregion());
       }
       else if (auto gn = dynamic_cast<rvsdg::GammaNode *>(node))

--- a/jlm/hls/backend/rvsdg2rhls/mem-queue.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-queue.cpp
@@ -213,7 +213,7 @@ separate_load_edge(
       auto loop_node = jlm::util::AssertedCast<jlm::hls::loop_node>(sti->node());
       jlm::rvsdg::output * buffer;
 
-      addr_edge = loop_node->add_loopvar(addr_edge, &buffer);
+      addr_edge = loop_node->AddLoopVar(addr_edge, &buffer);
       addr_edge_user->divert_to(addr_edge);
       mem_edge = find_loop_output(sti);
       auto sti_arg = sti->arguments.first();

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -113,9 +113,9 @@ trace_call(jlm::rvsdg::input * input)
 
   auto argument = dynamic_cast<const rvsdg::RegionArgument *>(input->origin());
   const jlm::rvsdg::output * result;
-  if (auto to = dynamic_cast<const rvsdg::ThetaOutput *>(input->origin()))
+  if (auto theta = rvsdg::TryGetOwnerNode<rvsdg::ThetaNode>(*input->origin()))
   {
-    result = trace_call(to->input());
+    result = trace_call(theta->MapOutputLoopVar(*input->origin()).input);
   }
   else if (argument == nullptr)
   {

--- a/jlm/hls/ir/hls.cpp
+++ b/jlm/hls/ir/hls.cpp
@@ -66,7 +66,7 @@ ExitResult::Copy(rvsdg::output & origin, rvsdg::StructuralOutput * output)
 }
 
 rvsdg::StructuralOutput *
-loop_node::add_loopvar(jlm::rvsdg::output * origin, jlm::rvsdg::output ** buffer)
+loop_node::AddLoopVar(jlm::rvsdg::output * origin, jlm::rvsdg::output ** buffer)
 {
   auto input = rvsdg::StructuralInput::create(this, origin, origin->Type());
   auto output = rvsdg::StructuralOutput::create(this, origin->Type());

--- a/jlm/hls/ir/hls.hpp
+++ b/jlm/hls/ir/hls.hpp
@@ -787,7 +787,7 @@ public:
   add_backedge(std::shared_ptr<const jlm::rvsdg::Type> type);
 
   rvsdg::StructuralOutput *
-  add_loopvar(jlm::rvsdg::output * origin, jlm::rvsdg::output ** buffer = nullptr);
+  AddLoopVar(jlm::rvsdg::output * origin, jlm::rvsdg::output ** buffer = nullptr);
 
   jlm::rvsdg::output *
   add_loopconst(jlm::rvsdg::output * origin);

--- a/jlm/hls/opt/cne.cpp
+++ b/jlm/hls/opt/cne.cpp
@@ -183,32 +183,42 @@ congruent(jlm::rvsdg::output * o1, jlm::rvsdg::output * o2, vset & vs, cnectx & 
   if (o1->type() != o2->type())
     return false;
 
-  if (is<rvsdg::ThetaArgument>(o1) && is<rvsdg::ThetaArgument>(o2))
+  if (auto theta1 = rvsdg::TryGetRegionParentNode<rvsdg::ThetaNode>(*o1))
   {
-    JLM_ASSERT(o1->region()->node() == o2->region()->node());
-    auto a1 = static_cast<rvsdg::RegionArgument *>(o1);
-    auto a2 = static_cast<rvsdg::RegionArgument *>(o2);
-    vs.insert(a1, a2);
-    auto i1 = a1->input(), i2 = a2->input();
-    if (!congruent(a1->input()->origin(), a2->input()->origin(), vs, ctx))
-      return false;
+    if (auto theta2 = rvsdg::TryGetRegionParentNode<rvsdg::ThetaNode>(*o2))
+    {
+      JLM_ASSERT(o1->region()->node() == o2->region()->node());
+      auto loopvar1 = theta1->MapPreLoopVar(*o1);
+      auto loopvar2 = theta2->MapPreLoopVar(*o2);
+      vs.insert(o1, o2);
+      auto i1 = loopvar1.input, i2 = loopvar2.input;
+      if (!congruent(loopvar1.input->origin(), loopvar2.input->origin(), vs, ctx))
+        return false;
 
-    auto output1 = o1->region()->node()->output(i1->index());
-    auto output2 = o2->region()->node()->output(i2->index());
-    return congruent(output1, output2, vs, ctx);
+      auto output1 = o1->region()->node()->output(i1->index());
+      auto output2 = o2->region()->node()->output(i2->index());
+      return congruent(output1, output2, vs, ctx);
+    }
+  }
+
+  if (auto theta1 = rvsdg::TryGetOwnerNode<rvsdg::ThetaNode>(*o1))
+  {
+    if (auto theta2 = rvsdg::TryGetOwnerNode<rvsdg::ThetaNode>(*o2))
+    {
+      if (theta1 == theta2)
+      {
+        vs.insert(o1, o2);
+        auto loopvar1 = theta1->MapOutputLoopVar(*o1);
+        auto loopvar2 = theta2->MapOutputLoopVar(*o2);
+        auto r1 = loopvar1.post;
+        auto r2 = loopvar2.post;
+        return congruent(r1->origin(), r2->origin(), vs, ctx);
+      }
+    }
   }
 
   auto n1 = jlm::rvsdg::output::GetNode(*o1);
   auto n2 = jlm::rvsdg::output::GetNode(*o2);
-  if (is<jlm::rvsdg::ThetaOperation>(n1) && is<jlm::rvsdg::ThetaOperation>(n2) && n1 == n2)
-  {
-    auto so1 = static_cast<StructuralOutput *>(o1);
-    auto so2 = static_cast<StructuralOutput *>(o2);
-    vs.insert(o1, o2);
-    auto r1 = so1->results.first();
-    auto r2 = so2->results.first();
-    return congruent(r1->origin(), r2->origin(), vs, ctx);
-  }
 
   auto a1 = dynamic_cast<rvsdg::RegionArgument *>(o1);
   auto a2 = dynamic_cast<rvsdg::RegionArgument *>(o2);
@@ -331,10 +341,12 @@ mark_theta(const rvsdg::StructuralNode * node, cnectx & ctx)
     {
       auto input1 = theta->input(i1);
       auto input2 = theta->input(i2);
-      if (congruent(input1->argument(), input2->argument(), ctx))
+      auto loopvar1 = theta->MapInputLoopVar(*input1);
+      auto loopvar2 = theta->MapInputLoopVar(*input2);
+      if (congruent(loopvar1.pre, loopvar2.pre, ctx))
       {
-        ctx.mark(input1->argument(), input2->argument());
-        ctx.mark(input1->output(), input2->output());
+        ctx.mark(loopvar1.pre, loopvar2.pre);
+        ctx.mark(loopvar1.output, loopvar2.output);
       }
     }
   }
@@ -530,11 +542,11 @@ divert_theta(rvsdg::StructuralNode * node, cnectx & ctx)
   auto theta = static_cast<rvsdg::ThetaNode *>(node);
   auto subregion = node->subregion(0);
 
-  for (const auto & lv : *theta)
+  for (const auto & lv : theta->GetLoopVars())
   {
-    JLM_ASSERT(ctx.set(lv->argument())->size() == ctx.set(lv)->size());
-    divert_users(lv->argument(), ctx);
-    divert_users(lv, ctx);
+    JLM_ASSERT(ctx.set(lv.pre)->size() == ctx.set(lv.output)->size());
+    divert_users(lv.pre, ctx);
+    divert_users(lv.output, ctx);
   }
 
   divert(subregion, ctx);

--- a/jlm/hls/util/view.cpp
+++ b/jlm/hls/util/view.cpp
@@ -367,9 +367,10 @@ region_to_dot(rvsdg::Region * region)
     {
       dot << edge(be->argument(), be, true);
     }
-    else if (auto to = dynamic_cast<rvsdg::ThetaOutput *>(region->result(i)->output()))
+    else if (auto theta = rvsdg::TryGetOwnerNode<rvsdg::ThetaNode>(*region->result(i)->output()))
     {
-      dot << edge(to->argument(), to->result(), true);
+      auto loopvar = theta->MapOutputLoopVar(*region->result(i)->output());
+      dot << edge(loopvar.pre, loopvar.post, true);
     }
   }
 

--- a/jlm/llvm/ir/operators/lambda.cpp
+++ b/jlm/llvm/ir/operators/lambda.cpp
@@ -304,17 +304,17 @@ node::ComputeCallSummary() const
       continue;
     }
 
-    if (auto theta_input = dynamic_cast<rvsdg::ThetaInput *>(input))
+    if (auto theta = rvsdg::TryGetOwnerNode<rvsdg::ThetaNode>(*input))
     {
-      auto argument = theta_input->argument();
-      worklist.insert(worklist.end(), argument->begin(), argument->end());
+      auto loopvar = theta->MapInputLoopVar(*input);
+      worklist.insert(worklist.end(), loopvar.pre->begin(), loopvar.pre->end());
       continue;
     }
 
-    if (auto thetaResult = dynamic_cast<const rvsdg::ThetaResult *>(input))
+    if (auto theta = rvsdg::TryGetRegionParentNode<rvsdg::ThetaNode>(*input))
     {
-      auto output = thetaResult->output();
-      worklist.insert(worklist.end(), output->begin(), output->end());
+      auto loopvar = theta->MapPostLoopVar(*input);
+      worklist.insert(worklist.end(), loopvar.output->begin(), loopvar.output->end());
       continue;
     }
 

--- a/jlm/llvm/opt/InvariantValueRedirection.cpp
+++ b/jlm/llvm/opt/InvariantValueRedirection.cpp
@@ -159,15 +159,15 @@ InvariantValueRedirection::RedirectGammaOutputs(rvsdg::GammaNode & gammaNode)
 void
 InvariantValueRedirection::RedirectThetaOutputs(rvsdg::ThetaNode & thetaNode)
 {
-  for (const auto & thetaOutput : thetaNode)
+  for (const auto & loopVar : thetaNode.GetLoopVars())
   {
     // FIXME: In order to also redirect I/O state type variables, we need to know whether a loop
     // terminates.
-    if (rvsdg::is<iostatetype>(thetaOutput->type()))
+    if (rvsdg::is<iostatetype>(loopVar.input->type()))
       continue;
 
-    if (rvsdg::is_invariant(thetaOutput))
-      thetaOutput->divert_users(thetaOutput->input()->origin());
+    if (rvsdg::ThetaLoopVarIsInvariant(loopVar))
+      loopVar.output->divert_users(loopVar.input->origin());
   }
 }
 

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -1126,13 +1126,13 @@ Andersen::AnalyzeTheta(const rvsdg::ThetaNode & theta)
 {
   // Create a PointerObject for each argument in the inner region
   // And make it point to a superset of the corresponding input register
-  for (const auto thetaOutput : theta)
+  for (const auto & loopVar : theta.GetLoopVars())
   {
-    if (!IsOrContainsPointerType(thetaOutput->type()))
+    if (!IsOrContainsPointerType(loopVar.input->type()))
       continue;
 
-    auto & inputReg = *thetaOutput->input()->origin();
-    auto & innerArgumentReg = *thetaOutput->argument();
+    auto & inputReg = *loopVar.input->origin();
+    auto & innerArgumentReg = *loopVar.pre;
     const auto inputRegPO = Set_->GetRegisterPointerObject(inputReg);
     const auto innerArgumentRegPO = Set_->CreateRegisterPointerObject(innerArgumentReg);
 
@@ -1144,14 +1144,14 @@ Andersen::AnalyzeTheta(const rvsdg::ThetaNode & theta)
 
   // Iterate over loop variables again, making the inner arguments point to a superset
   // of what the corresponding result registers point to
-  for (const auto thetaOutput : theta)
+  for (const auto & loopVar : theta.GetLoopVars())
   {
-    if (!IsOrContainsPointerType(thetaOutput->type()))
+    if (!IsOrContainsPointerType(loopVar.input->type()))
       continue;
 
-    auto & innerArgumentReg = *thetaOutput->argument();
-    auto & innerResultReg = *thetaOutput->result()->origin();
-    auto & outputReg = *thetaOutput;
+    auto & innerArgumentReg = *loopVar.pre;
+    auto & innerResultReg = *loopVar.post->origin();
+    auto & outputReg = *loopVar.output;
 
     const auto innerArgumentRegPO = Set_->GetRegisterPointerObject(innerArgumentReg);
     const auto innerResultRegPO = Set_->GetRegisterPointerObject(innerResultReg);

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp
@@ -157,13 +157,13 @@ private:
   void
   EncodeTheta(rvsdg::ThetaNode & thetaNode);
 
-  std::vector<rvsdg::ThetaOutput *>
+  std::vector<rvsdg::output *>
   EncodeThetaEntry(rvsdg::ThetaNode & thetaNode);
 
   void
   EncodeThetaExit(
       rvsdg::ThetaNode & thetaNode,
-      const std::vector<rvsdg::ThetaOutput *> & thetaStateOutputs);
+      const std::vector<rvsdg::output *> & thetaStateOutputs);
 
   /**
    * Replace \p loadNode with a new copy that takes the provided \p memoryStates. All users of the

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -236,13 +236,13 @@ public:
       return jlm::util::strfmt(dbgstr, ":arg", index);
     }
 
-    if (is<rvsdg::ThetaArgument>(Output_))
+    if (rvsdg::TryGetRegionParentNode<rvsdg::ThetaNode>(*Output_))
     {
       auto dbgstr = Output_->region()->node()->GetOperation().debug_string();
       return jlm::util::strfmt(dbgstr, ":arg", index);
     }
 
-    if (is<rvsdg::ThetaOutput>(Output_))
+    if (rvsdg::TryGetOwnerNode<rvsdg::ThetaNode>(*Output_))
     {
       auto dbgstr = jlm::rvsdg::output::GetNode(*Output_)->GetOperation().debug_string();
       return jlm::util::strfmt(dbgstr, ":out", index);
@@ -1658,12 +1658,12 @@ Steensgaard::AnalyzeGamma(const rvsdg::GammaNode & node)
 void
 Steensgaard::AnalyzeTheta(const rvsdg::ThetaNode & theta)
 {
-  for (auto thetaOutput : theta)
+  for (const auto & loopVar : theta.GetLoopVars())
   {
-    if (HasOrContainsPointerType(*thetaOutput))
+    if (HasOrContainsPointerType(*loopVar.output))
     {
-      auto & originLocation = Context_->GetLocation(*thetaOutput->input()->origin());
-      auto & argumentLocation = Context_->GetOrInsertRegisterLocation(*thetaOutput->argument());
+      auto & originLocation = Context_->GetLocation(*loopVar.input->origin());
+      auto & argumentLocation = Context_->GetOrInsertRegisterLocation(*loopVar.pre);
 
       Context_->Join(argumentLocation, originLocation);
     }
@@ -1671,13 +1671,13 @@ Steensgaard::AnalyzeTheta(const rvsdg::ThetaNode & theta)
 
   AnalyzeRegion(*theta.subregion());
 
-  for (auto thetaOutput : theta)
+  for (const auto & loopVar : theta.GetLoopVars())
   {
-    if (HasOrContainsPointerType(*thetaOutput))
+    if (HasOrContainsPointerType(*loopVar.output))
     {
-      auto & originLocation = Context_->GetLocation(*thetaOutput->result()->origin());
-      auto & argumentLocation = Context_->GetLocation(*thetaOutput->argument());
-      auto & outputLocation = Context_->GetOrInsertRegisterLocation(*thetaOutput);
+      auto & originLocation = Context_->GetLocation(*loopVar.post->origin());
+      auto & argumentLocation = Context_->GetLocation(*loopVar.pre);
+      auto & outputLocation = Context_->GetOrInsertRegisterLocation(*loopVar.output);
 
       Context_->Join(originLocation, argumentLocation);
       Context_->Join(originLocation, outputLocation);

--- a/jlm/llvm/opt/inlining.cpp
+++ b/jlm/llvm/opt/inlining.cpp
@@ -78,7 +78,7 @@ route_to_region(jlm::rvsdg::output * output, rvsdg::Region * region)
   }
   else if (auto theta = dynamic_cast<rvsdg::ThetaNode *>(region->node()))
   {
-    output = theta->add_loopvar(output)->argument();
+    output = theta->AddLoopVar(output).pre;
   }
   else if (auto lambda = dynamic_cast<lambda::node *>(region->node()))
   {

--- a/jlm/llvm/opt/unroll.hpp
+++ b/jlm/llvm/opt/unroll.hpp
@@ -53,9 +53,9 @@ private:
   inline unrollinfo(
       rvsdg::Node * cmpnode,
       rvsdg::Node * armnode,
-      rvsdg::RegionArgument * idv,
-      rvsdg::RegionArgument * step,
-      rvsdg::RegionArgument * end)
+      rvsdg::output * idv,
+      rvsdg::output * step,
+      rvsdg::output * end)
       : end_(end),
         step_(step),
         cmpnode_(cmpnode),
@@ -132,7 +132,7 @@ public:
     return *static_cast<const rvsdg::SimpleOperation *>(&armnode()->GetOperation());
   }
 
-  inline rvsdg::RegionArgument *
+  inline rvsdg::output *
   idv() const noexcept
   {
     return idv_;
@@ -141,7 +141,7 @@ public:
   inline jlm::rvsdg::output *
   init() const noexcept
   {
-    return idv()->input()->origin();
+    return theta()->MapPreLoopVar(*idv()).input->origin();
   }
 
   inline const jlm::rvsdg::bitvalue_repr *
@@ -150,7 +150,7 @@ public:
     return value(init());
   }
 
-  inline rvsdg::RegionArgument *
+  inline rvsdg::output *
   step() const noexcept
   {
     return step_;
@@ -162,7 +162,7 @@ public:
     return value(step());
   }
 
-  inline rvsdg::RegionArgument *
+  inline rvsdg::output *
   end() const noexcept
   {
     return end_;
@@ -224,11 +224,11 @@ private:
     return &static_cast<const rvsdg::bitconstant_op *>(&p->GetOperation())->value();
   }
 
-  rvsdg::RegionArgument * end_;
-  rvsdg::RegionArgument * step_;
+  rvsdg::output * end_;
+  rvsdg::output * step_;
   rvsdg::Node * cmpnode_;
   rvsdg::Node * armnode_;
-  rvsdg::RegionArgument * idv_;
+  rvsdg::output * idv_;
 };
 
 /**

--- a/jlm/mlir/frontend/MlirToJlmConverter.cpp
+++ b/jlm/mlir/frontend/MlirToJlmConverter.cpp
@@ -367,7 +367,7 @@ MlirToJlmConverter::ConvertOperation(
     // Add loop vars to the theta node
     for (size_t i = 0; i < inputs.size(); i++)
     {
-      rvsdgThetaNode->add_loopvar(inputs[i]);
+      rvsdgThetaNode->AddLoopVar(inputs[i]);
     }
 
     auto regionResults = ConvertRegion(mlirThetaNode.getRegion(), *rvsdgThetaNode->subregion());

--- a/jlm/rvsdg/node.cpp
+++ b/jlm/rvsdg/node.cpp
@@ -340,14 +340,20 @@ producer(const jlm::rvsdg::output * output) noexcept
   if (auto node = output::GetNode(*output))
     return node;
 
+  if (auto theta = TryGetRegionParentNode<ThetaNode>(*output))
+  {
+    auto loopvar = theta->MapPreLoopVar(*output);
+    if (loopvar.post->origin() != output)
+    {
+      return nullptr;
+    }
+    return producer(loopvar.input->origin());
+  }
+
   JLM_ASSERT(dynamic_cast<const RegionArgument *>(output));
   auto argument = static_cast<const RegionArgument *>(output);
 
   if (!argument->input())
-    return nullptr;
-
-  if (is<ThetaOperation>(argument->region()->node())
-      && (argument->region()->result(argument->index() + 1)->origin() != argument))
     return nullptr;
 
   return producer(argument->input()->origin());

--- a/jlm/rvsdg/theta.cpp
+++ b/jlm/rvsdg/theta.cpp
@@ -24,91 +24,27 @@ ThetaOperation::copy() const
   return std::make_unique<ThetaOperation>(*this);
 }
 
+ThetaNode::~ThetaNode() noexcept = default;
+
 ThetaNode::ThetaNode(rvsdg::Region & parent)
     : StructuralNode(ThetaOperation(), &parent, 1)
 {
   auto predicate = control_false(subregion());
-  ThetaPredicateResult::Create(*predicate);
+  RegionResult::Create(*subregion(), *predicate, nullptr, ControlType::Create(2));
 }
 
-ThetaInput::~ThetaInput() noexcept
+ThetaNode::LoopVar
+ThetaNode::AddLoopVar(rvsdg::output * origin)
 {
-  if (output_)
-    output_->input_ = nullptr;
-}
-
-/* theta output */
-
-ThetaOutput::~ThetaOutput() noexcept
-{
-  if (input_)
-    input_->output_ = nullptr;
-}
-
-ThetaArgument::~ThetaArgument() noexcept = default;
-
-ThetaArgument &
-ThetaArgument::Copy(rvsdg::Region & region, StructuralInput * input)
-{
-  auto thetaInput = util::AssertedCast<ThetaInput>(input);
-  return ThetaArgument::Create(region, *thetaInput);
-}
-
-ThetaResult::~ThetaResult() noexcept = default;
-
-ThetaResult &
-ThetaResult::Copy(rvsdg::output & origin, StructuralOutput * output)
-{
-  auto thetaOutput = util::AssertedCast<ThetaOutput>(output);
-  return ThetaResult::Create(origin, *thetaOutput);
-}
-
-ThetaPredicateResult::~ThetaPredicateResult() noexcept = default;
-
-ThetaPredicateResult &
-ThetaPredicateResult::Copy(rvsdg::output & origin, StructuralOutput * output)
-{
-  JLM_ASSERT(output == nullptr);
-  return ThetaPredicateResult::Create(origin);
-}
-
-/* theta node */
-
-ThetaNode::~ThetaNode() noexcept = default;
-
-const ThetaNode::loopvar_iterator &
-ThetaNode::loopvar_iterator::operator++() noexcept
-{
-  if (output_ == nullptr)
-    return *this;
-
-  auto node = output_->node();
-  auto index = output_->index();
-  if (index == node->noutputs() - 1)
-  {
-    output_ = nullptr;
-    return *this;
-  }
-
-  index++;
-  output_ = node->output(index);
-  return *this;
-}
-
-ThetaOutput *
-ThetaNode::add_loopvar(jlm::rvsdg::output * origin)
-{
-  Node::add_input(std::make_unique<ThetaInput>(this, origin, origin->Type()));
-  Node::add_output(std::make_unique<ThetaOutput>(this, origin->Type()));
+  Node::add_input(std::make_unique<StructuralInput>(this, origin, origin->Type()));
+  Node::add_output(std::make_unique<StructuralOutput>(this, origin->Type()));
 
   auto input = ThetaNode::input(ninputs() - 1);
   auto output = ThetaNode::output(noutputs() - 1);
-  input->output_ = output;
-  output->input_ = input;
+  auto & thetaArgument = RegionArgument::Create(*subregion(), input, input->Type());
+  auto & thetaResult = RegionResult::Create(*subregion(), thetaArgument, output, output->Type());
 
-  auto & thetaArgument = ThetaArgument::Create(*subregion(), *input);
-  ThetaResult::Create(thetaArgument, *output);
-  return output;
+  return LoopVar{ input, &thetaArgument, &thetaResult, output };
 }
 
 ThetaNode *
@@ -121,10 +57,13 @@ ThetaNode::copy(rvsdg::Region * region, rvsdg::SubstitutionMap & smap) const
   auto theta = create(region);
 
   /* add loop variables */
-  for (auto olv : *this)
+  std::vector<LoopVar> oldLoopVars = GetLoopVars();
+  std::vector<LoopVar> newLoopVars;
+  for (auto olv : oldLoopVars)
   {
-    auto nlv = theta->add_loopvar(smap.lookup(olv->input()->origin()));
-    rmap.insert(olv->argument(), nlv->argument());
+    auto nlv = theta->AddLoopVar(smap.lookup(olv.input->origin()));
+    newLoopVars.push_back(nlv);
+    rmap.insert(olv.pre, nlv.pre);
   }
 
   /* copy subregion */
@@ -132,14 +71,183 @@ ThetaNode::copy(rvsdg::Region * region, rvsdg::SubstitutionMap & smap) const
   theta->set_predicate(rmap.lookup(predicate()->origin()));
 
   /* redirect loop variables */
-  for (auto olv = begin(), nlv = theta->begin(); olv != end(); olv++, nlv++)
+  for (size_t i = 0; i < oldLoopVars.size(); ++i)
   {
-    (*nlv)->result()->divert_to(rmap.lookup((*olv)->result()->origin()));
-    smap.insert(olv.output(), nlv.output());
+    newLoopVars[i].post->divert_to(rmap.lookup(oldLoopVars[i].post->origin()));
+    smap.insert(oldLoopVars[i].output, newLoopVars[i].output);
   }
 
   nf->set_mutable(true);
   return theta;
+}
+
+[[nodiscard]] ThetaNode::LoopVar
+ThetaNode::MapInputLoopVar(const rvsdg::input & input) const
+{
+  JLM_ASSERT(rvsdg::TryGetOwnerNode<ThetaNode>(input) == this);
+  auto peer = MapInputToOutputIndex(input.index());
+  return LoopVar{ const_cast<rvsdg::input *>(&input),
+                  subregion()->argument(input.index()),
+                  peer ? subregion()->result(*peer + 1) : nullptr,
+                  peer ? output(*peer) : nullptr };
+}
+
+[[nodiscard]] ThetaNode::LoopVar
+ThetaNode::MapPreLoopVar(const rvsdg::output & argument) const
+{
+  JLM_ASSERT(rvsdg::TryGetRegionParentNode<ThetaNode>(argument) == this);
+  auto peer = MapInputToOutputIndex(argument.index());
+  return LoopVar{ input(argument.index()),
+                  const_cast<rvsdg::output *>(&argument),
+                  peer ? subregion()->result(*peer + 1) : nullptr,
+                  peer ? output(*peer) : nullptr };
+}
+
+[[nodiscard]] ThetaNode::LoopVar
+ThetaNode::MapPostLoopVar(const rvsdg::input & result) const
+{
+  JLM_ASSERT(rvsdg::TryGetRegionParentNode<ThetaNode>(result) == this);
+  if (result.index() == 0)
+  {
+    // This is the loop continuation predicate.
+    // There is nothing sensible to return here.
+    throw std::logic_error("cannot map loop continuation predicate to loop variable");
+  }
+  auto peer = MapOutputToInputIndex(result.index() - 1);
+  return LoopVar{ peer ? input(*peer) : nullptr,
+                  peer ? subregion()->argument(*peer) : nullptr,
+                  const_cast<rvsdg::input *>(&result),
+                  output(result.index() - 1) };
+}
+
+[[nodiscard]] ThetaNode::LoopVar
+ThetaNode::MapOutputLoopVar(const rvsdg::output & output) const
+{
+  JLM_ASSERT(rvsdg::TryGetOwnerNode<ThetaNode>(output) == this);
+  auto peer = MapOutputToInputIndex(output.index());
+  return LoopVar{ peer ? input(*peer) : nullptr,
+                  peer ? subregion()->argument(*peer) : nullptr,
+                  subregion()->result(output.index() + 1),
+                  const_cast<rvsdg::output *>(&output) };
+}
+
+[[nodiscard]] std::vector<ThetaNode::LoopVar>
+ThetaNode::GetLoopVars() const
+{
+  std::vector<LoopVar> loopvars;
+  for (size_t input_index = 0; input_index < ninputs(); ++input_index)
+  {
+    // Check if there is a matching input/output -- if we are in
+    // the process of deleting a loop variable, inputs and outputs
+    // might be unmatched.
+    auto output_index = MapInputToOutputIndex(input_index);
+    if (output_index)
+    {
+      loopvars.push_back(LoopVar{ input(input_index),
+                                  subregion()->argument(input_index),
+                                  subregion()->result(*output_index + 1),
+                                  output(*output_index) });
+    }
+  }
+  return loopvars;
+}
+
+std::optional<std::size_t>
+ThetaNode::MapInputToOutputIndex(std::size_t index) const noexcept
+{
+  std::size_t offset = 0;
+  for (std::size_t unmatched : unmatchedInputs)
+  {
+    if (unmatched == index)
+    {
+      return std::nullopt;
+    }
+    if (unmatched < index)
+    {
+      ++offset;
+    }
+  }
+
+  index -= offset;
+  offset = 0;
+  for (std::size_t unmatched : unmatchedOutputs)
+  {
+    if (unmatched <= index)
+    {
+      ++offset;
+    }
+  }
+  return index + offset;
+}
+
+std::optional<std::size_t>
+ThetaNode::MapOutputToInputIndex(std::size_t index) const noexcept
+{
+  std::size_t offset = 0;
+  for (std::size_t unmatched : unmatchedOutputs)
+  {
+    if (unmatched == index)
+    {
+      return std::nullopt;
+    }
+    if (unmatched < index)
+    {
+      ++offset;
+    }
+  }
+
+  index -= offset;
+  offset = 0;
+  for (std::size_t unmatched : unmatchedInputs)
+  {
+    if (unmatched <= index)
+    {
+      ++offset;
+    }
+  }
+  return index + offset;
+}
+
+void
+ThetaNode::MarkInputIndexErased(std::size_t index) noexcept
+{
+  if (auto peer = MapInputToOutputIndex(index))
+  {
+    unmatchedOutputs.push_back(*peer);
+  }
+  else
+  {
+    auto i = std::remove(unmatchedInputs.begin(), unmatchedInputs.end(), index);
+    unmatchedInputs.erase(i, unmatchedInputs.end());
+  }
+  for (auto & unmatched : unmatchedInputs)
+  {
+    if (unmatched > index)
+    {
+      unmatched -= 1;
+    }
+  }
+}
+
+void
+ThetaNode::MarkOutputIndexErased(std::size_t index) noexcept
+{
+  if (auto peer = MapOutputToInputIndex(index))
+  {
+    unmatchedInputs.push_back(*peer);
+  }
+  else
+  {
+    auto i = std::remove(unmatchedOutputs.begin(), unmatchedOutputs.end(), index);
+    unmatchedOutputs.erase(i, unmatchedOutputs.end());
+  }
+  for (auto & unmatched : unmatchedOutputs)
+  {
+    if (unmatched > index)
+    {
+      unmatched -= 1;
+    }
+  }
 }
 
 }

--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -1622,29 +1622,29 @@ ThetaTest::SetupRvsdg()
 
   auto thetanode = jlm::rvsdg::ThetaNode::create(fct->subregion());
 
-  auto n = thetanode->add_loopvar(zero);
-  auto l = thetanode->add_loopvar(fct->GetFunctionArguments()[0]);
-  auto a = thetanode->add_loopvar(fct->GetFunctionArguments()[1]);
-  auto c = thetanode->add_loopvar(fct->GetFunctionArguments()[2]);
-  auto s = thetanode->add_loopvar(fct->GetFunctionArguments()[3]);
+  auto n = thetanode->AddLoopVar(zero);
+  auto l = thetanode->AddLoopVar(fct->GetFunctionArguments()[0]);
+  auto a = thetanode->AddLoopVar(fct->GetFunctionArguments()[1]);
+  auto c = thetanode->AddLoopVar(fct->GetFunctionArguments()[2]);
+  auto s = thetanode->AddLoopVar(fct->GetFunctionArguments()[3]);
 
   auto gepnode = GetElementPtrOperation::Create(
-      a->argument(),
-      { n->argument() },
+      a.pre,
+      { n.pre },
       jlm::rvsdg::bittype::Create(32),
       pointerType);
-  auto store = StoreNonVolatileNode::Create(gepnode, c->argument(), { s->argument() }, 4);
+  auto store = StoreNonVolatileNode::Create(gepnode, c.pre, { s.pre }, 4);
 
   auto one = jlm::rvsdg::create_bitconstant(thetanode->subregion(), 32, 1);
-  auto sum = jlm::rvsdg::bitadd_op::create(32, n->argument(), one);
-  auto cmp = jlm::rvsdg::bitult_op::create(32, sum, l->argument());
+  auto sum = jlm::rvsdg::bitadd_op::create(32, n.pre, one);
+  auto cmp = jlm::rvsdg::bitult_op::create(32, sum, l.pre);
   auto predicate = jlm::rvsdg::match(1, { { 1, 1 } }, 0, 2, cmp);
 
-  n->result()->divert_to(sum);
-  s->result()->divert_to(store[0]);
+  n.post->divert_to(sum);
+  s.post->divert_to(store[0]);
   thetanode->set_predicate(predicate);
 
-  fct->finalize({ s });
+  fct->finalize({ s.output });
   GraphExport::Create(*fct->output(), "f");
 
   /*

--- a/tests/jlm/hls/backend/rvsdg2rhls/DeadNodeEliminationTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/DeadNodeEliminationTests.cpp
@@ -66,8 +66,8 @@ TestDeadLoopNodeOutput()
   auto loopNode = loop_node::create(lambdaNode->subregion());
 
   jlm::rvsdg::output * buffer;
-  auto output0 = loopNode->add_loopvar(p, &buffer);
-  loopNode->add_loopvar(x);
+  auto output0 = loopNode->AddLoopVar(p, &buffer);
+  loopNode->AddLoopVar(x);
   loopNode->set_predicate(buffer);
 
   auto lambdaOutput = lambdaNode->finalize({ output0 });

--- a/tests/jlm/hls/backend/rvsdg2rhls/MemoryQueueTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/MemoryQueueTests.cpp
@@ -44,15 +44,15 @@ TestSingleLoad()
 
   // Load node
   auto functionArguments = lambda->GetFunctionArguments();
-  auto loadAddress = theta->add_loopvar(functionArguments[0]);
-  auto memoryStateArgument = theta->add_loopvar(functionArguments[1]);
+  auto loadAddress = theta->AddLoopVar(functionArguments[0]);
+  auto memoryStateArgument = theta->AddLoopVar(functionArguments[1]);
   auto loadOutput = LoadNonVolatileNode::Create(
-      loadAddress->argument(),
-      { memoryStateArgument->argument() },
+      loadAddress.pre,
+      { memoryStateArgument.pre },
       PointerType::Create(),
       32);
-  loadAddress->result()->divert_to(loadOutput[0]);
-  memoryStateArgument->result()->divert_to(loadOutput[1]);
+  loadAddress.post->divert_to(loadOutput[0]);
+  memoryStateArgument.post->divert_to(loadOutput[1]);
 
   auto lambdaOutput = lambda->finalize({ theta->output(0), theta->output(1) });
   GraphExport::Create(*lambdaOutput, "f");
@@ -122,22 +122,22 @@ TestLoadStore()
 
   // Load node
   auto functionArguments = lambda->GetFunctionArguments();
-  auto loadAddress = theta->add_loopvar(functionArguments[0]);
-  auto storeAddress = theta->add_loopvar(functionArguments[1]);
-  auto memoryStateArgument = theta->add_loopvar(functionArguments[2]);
+  auto loadAddress = theta->AddLoopVar(functionArguments[0]);
+  auto storeAddress = theta->AddLoopVar(functionArguments[1]);
+  auto memoryStateArgument = theta->AddLoopVar(functionArguments[2]);
   auto loadOutput = LoadNonVolatileNode::Create(
-      loadAddress->argument(),
-      { memoryStateArgument->argument() },
+      loadAddress.pre,
+      { memoryStateArgument.pre },
       PointerType::Create(),
       32);
   auto storeOutput = StoreNonVolatileNode::Create(
-      storeAddress->argument(),
+      storeAddress.pre,
       jlm::rvsdg::create_bitconstant(theta->subregion(), 32, 1),
       { loadOutput[1] },
       32);
 
-  loadAddress->result()->divert_to(loadOutput[0]);
-  memoryStateArgument->result()->divert_to(storeOutput[0]);
+  loadAddress.post->divert_to(loadOutput[0]);
+  memoryStateArgument.post->divert_to(storeOutput[0]);
 
   auto lambdaOutput = lambda->finalize({ theta->output(0), theta->output(2) });
   GraphExport::Create(*lambdaOutput, "f");
@@ -205,18 +205,18 @@ TestAddrQueue()
 
   // Load node
   auto functionArguments = lambda->GetFunctionArguments();
-  auto address = theta->add_loopvar(functionArguments[0]);
-  auto memoryStateArgument = theta->add_loopvar(functionArguments[1]);
+  auto address = theta->AddLoopVar(functionArguments[0]);
+  auto memoryStateArgument = theta->AddLoopVar(functionArguments[1]);
   auto loadOutput = LoadNonVolatileNode::Create(
-      address->argument(),
-      { memoryStateArgument->argument() },
+      address.pre,
+      { memoryStateArgument.pre },
       PointerType::Create(),
       32);
   auto storeOutput =
-      StoreNonVolatileNode::Create(address->argument(), loadOutput[0], { loadOutput[1] }, 32);
+      StoreNonVolatileNode::Create(address.pre, loadOutput[0], { loadOutput[1] }, 32);
 
-  address->result()->divert_to(loadOutput[0]);
-  memoryStateArgument->result()->divert_to(storeOutput[0]);
+  address.post->divert_to(loadOutput[0]);
+  memoryStateArgument.post->divert_to(storeOutput[0]);
 
   auto lambdaOutput = lambda->finalize({ theta->output(0), theta->output(1) });
   GraphExport::Create(*lambdaOutput, "f");

--- a/tests/jlm/hls/backend/rvsdg2rhls/TestFork.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/TestFork.cpp
@@ -34,11 +34,11 @@ TestFork()
   auto loop = hls::loop_node::create(lambda->subregion());
   auto subregion = loop->subregion();
   rvsdg::output * idvBuffer;
-  loop->add_loopvar(lambda->GetFunctionArguments()[0], &idvBuffer);
+  loop->AddLoopVar(lambda->GetFunctionArguments()[0], &idvBuffer);
   rvsdg::output * lvsBuffer;
-  loop->add_loopvar(lambda->GetFunctionArguments()[1], &lvsBuffer);
+  loop->AddLoopVar(lambda->GetFunctionArguments()[1], &lvsBuffer);
   rvsdg::output * lveBuffer;
-  loop->add_loopvar(lambda->GetFunctionArguments()[2], &lveBuffer);
+  loop->AddLoopVar(lambda->GetFunctionArguments()[2], &lveBuffer);
 
   auto arm = rvsdg::SimpleNode::create_normalized(subregion, add, { idvBuffer, lvsBuffer })[0];
   auto cmp = rvsdg::SimpleNode::create_normalized(subregion, ult, { arm, lveBuffer })[0];
@@ -104,7 +104,7 @@ TestConstantFork()
   auto loop = hls::loop_node::create(lambdaRegion);
   auto subregion = loop->subregion();
   rvsdg::output * idvBuffer;
-  loop->add_loopvar(lambda->GetFunctionArguments()[0], &idvBuffer);
+  loop->AddLoopVar(lambda->GetFunctionArguments()[0], &idvBuffer);
   auto bitConstant1 = rvsdg::create_bitconstant(subregion, 32, 1);
 
   auto arm = rvsdg::SimpleNode::create_normalized(subregion, add, { idvBuffer, bitConstant1 })[0];

--- a/tests/jlm/hls/backend/rvsdg2rhls/TestTheta.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/TestTheta.cpp
@@ -34,18 +34,15 @@ TestUnknownBoundaries()
 
   auto theta = jlm::rvsdg::ThetaNode::create(lambda->subregion());
   auto subregion = theta->subregion();
-  auto idv = theta->add_loopvar(lambda->GetFunctionArguments()[0]);
-  auto lvs = theta->add_loopvar(lambda->GetFunctionArguments()[1]);
-  auto lve = theta->add_loopvar(lambda->GetFunctionArguments()[2]);
+  auto idv = theta->AddLoopVar(lambda->GetFunctionArguments()[0]);
+  auto lvs = theta->AddLoopVar(lambda->GetFunctionArguments()[1]);
+  auto lve = theta->AddLoopVar(lambda->GetFunctionArguments()[2]);
 
-  auto arm = jlm::rvsdg::SimpleNode::create_normalized(
-      subregion,
-      add,
-      { idv->argument(), lvs->argument() })[0];
-  auto cmp = jlm::rvsdg::SimpleNode::create_normalized(subregion, ult, { arm, lve->argument() })[0];
+  auto arm = jlm::rvsdg::SimpleNode::create_normalized(subregion, add, { idv.pre, lvs.pre })[0];
+  auto cmp = jlm::rvsdg::SimpleNode::create_normalized(subregion, ult, { arm, lve.pre })[0];
   auto match = jlm::rvsdg::match(1, { { 1, 1 } }, 0, 2, cmp);
 
-  idv->result()->divert_to(arm);
+  idv.post->divert_to(arm);
   theta->set_predicate(match);
 
   auto f = lambda->finalize({ theta->output(0), theta->output(1), theta->output(2) });

--- a/tests/jlm/hls/backend/rvsdg2rhls/UnusedStateRemovalTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/UnusedStateRemovalTests.cpp
@@ -90,20 +90,21 @@ TestTheta()
 
   auto thetaNode = jlm::rvsdg::ThetaNode::create(&rvsdg.GetRootRegion());
 
-  auto thetaOutput0 = thetaNode->add_loopvar(p);
-  auto thetaOutput1 = thetaNode->add_loopvar(x);
-  auto thetaOutput2 = thetaNode->add_loopvar(y);
-  auto thetaOutput3 = thetaNode->add_loopvar(z);
+  auto thetaOutput0 = thetaNode->AddLoopVar(p);
+  auto thetaOutput1 = thetaNode->AddLoopVar(x);
+  auto thetaOutput2 = thetaNode->AddLoopVar(y);
+  auto thetaOutput3 = thetaNode->AddLoopVar(z);
 
-  thetaOutput2->result()->divert_to(thetaOutput3->argument());
-  thetaOutput3->result()->divert_to(thetaOutput2->argument());
-  thetaNode->set_predicate(thetaOutput0->argument());
+  thetaOutput2.post->divert_to(thetaOutput3.pre);
+  thetaOutput3.post->divert_to(thetaOutput2.pre);
+  thetaNode->set_predicate(thetaOutput0.pre);
 
-  auto result = jlm::tests::SimpleNode::Create(
-                    rvsdg.GetRootRegion(),
-                    { thetaOutput0, thetaOutput1, thetaOutput2, thetaOutput3 },
-                    { valueType })
-                    .output(0);
+  auto result =
+      jlm::tests::SimpleNode::Create(
+          rvsdg.GetRootRegion(),
+          { thetaOutput0.output, thetaOutput1.output, thetaOutput2.output, thetaOutput3.output },
+          { valueType })
+          .output(0);
 
   GraphExport::Create(*result, "f");
 

--- a/tests/jlm/hls/backend/rvsdg2rhls/test-loop-passthrough.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/test-loop-passthrough.cpp
@@ -52,7 +52,7 @@ test()
 
   auto loop = hls::loop_node::create(lambda->subregion());
 
-  auto loop_out = loop->add_loopvar(lambda->GetFunctionArguments()[1]);
+  auto loop_out = loop->AddLoopVar(lambda->GetFunctionArguments()[1]);
 
   auto f = lambda->finalize({ loop_out });
   jlm::llvm::GraphExport::Create(*f, "");

--- a/tests/jlm/llvm/opt/InvariantValueRedirectionTests.cpp
+++ b/tests/jlm/llvm/opt/InvariantValueRedirectionTests.cpp
@@ -104,20 +104,21 @@ TestTheta()
   auto l = lambdaNode->GetFunctionArguments()[2];
 
   auto thetaNode1 = jlm::rvsdg::ThetaNode::create(lambdaNode->subregion());
-  auto thetaOutput1 = thetaNode1->add_loopvar(c);
-  auto thetaOutput2 = thetaNode1->add_loopvar(x);
-  auto thetaOutput3 = thetaNode1->add_loopvar(l);
+  auto thetaVar1 = thetaNode1->AddLoopVar(c);
+  auto thetaVar2 = thetaNode1->AddLoopVar(x);
+  auto thetaVar3 = thetaNode1->AddLoopVar(l);
 
   auto thetaNode2 = jlm::rvsdg::ThetaNode::create(thetaNode1->subregion());
-  auto thetaOutput4 = thetaNode2->add_loopvar(thetaOutput1->argument());
-  thetaNode2->add_loopvar(thetaOutput2->argument());
-  auto thetaOutput5 = thetaNode2->add_loopvar(thetaOutput3->argument());
-  thetaNode2->set_predicate(thetaOutput4->argument());
+  auto thetaVar4 = thetaNode2->AddLoopVar(thetaVar1.pre);
+  thetaNode2->AddLoopVar(thetaVar2.pre);
+  auto thetaVar5 = thetaNode2->AddLoopVar(thetaVar3.pre);
+  thetaNode2->set_predicate(thetaVar4.pre);
 
-  thetaOutput3->result()->divert_to(thetaOutput5);
-  thetaNode1->set_predicate(thetaOutput1->argument());
+  thetaVar3.post->divert_to(thetaVar5.output);
+  thetaNode1->set_predicate(thetaVar1.pre);
 
-  auto lambdaOutput = lambdaNode->finalize({ thetaOutput1, thetaOutput2, thetaOutput3 });
+  auto lambdaOutput =
+      lambdaNode->finalize({ thetaVar1.output, thetaVar2.output, thetaVar3.output });
 
   GraphExport::Create(*lambdaOutput, "test");
 
@@ -127,7 +128,7 @@ TestTheta()
   // Assert
   assert(lambdaNode->GetFunctionResults()[0]->origin() == c);
   assert(lambdaNode->GetFunctionResults()[1]->origin() == x);
-  assert(lambdaNode->GetFunctionResults()[2]->origin() == thetaOutput3);
+  assert(lambdaNode->GetFunctionResults()[2]->origin() == thetaVar3.output);
 
   return 0;
 }

--- a/tests/jlm/llvm/opt/TestDeadNodeElimination.cpp
+++ b/tests/jlm/llvm/opt/TestDeadNodeElimination.cpp
@@ -130,23 +130,23 @@ TestTheta()
 
   auto theta = jlm::rvsdg::ThetaNode::create(&graph.GetRootRegion());
 
-  auto lv1 = theta->add_loopvar(x);
-  auto lv2 = theta->add_loopvar(y);
-  auto lv3 = theta->add_loopvar(z);
-  auto lv4 = theta->add_loopvar(y);
+  auto lv1 = theta->AddLoopVar(x);
+  auto lv2 = theta->AddLoopVar(y);
+  auto lv3 = theta->AddLoopVar(z);
+  auto lv4 = theta->AddLoopVar(y);
 
-  lv1->result()->divert_to(lv2->argument());
-  lv2->result()->divert_to(lv1->argument());
+  lv1.post->divert_to(lv2.pre);
+  lv2.post->divert_to(lv1.pre);
 
-  auto t = jlm::tests::create_testop(theta->subregion(), { lv3->argument() }, { vt })[0];
-  lv3->result()->divert_to(t);
-  lv4->result()->divert_to(lv2->argument());
+  auto t = jlm::tests::create_testop(theta->subregion(), { lv3.pre }, { vt })[0];
+  lv3.post->divert_to(t);
+  lv4.post->divert_to(lv2.pre);
 
   auto c = jlm::tests::create_testop(theta->subregion(), {}, { ct })[0];
   theta->set_predicate(c);
 
-  GraphExport::Create(*theta->output(0), "a");
-  GraphExport::Create(*theta->output(3), "b");
+  GraphExport::Create(*lv1.output, "a");
+  GraphExport::Create(*lv4.output, "b");
 
   //	jlm::rvsdg::view(graph.GetRootRegion(), stdout);
   RunDeadNodeElimination(rm);
@@ -173,26 +173,26 @@ TestNestedTheta()
 
   auto otheta = jlm::rvsdg::ThetaNode::create(&graph.GetRootRegion());
 
-  auto lvo1 = otheta->add_loopvar(c);
-  auto lvo2 = otheta->add_loopvar(x);
-  auto lvo3 = otheta->add_loopvar(y);
+  auto lvo1 = otheta->AddLoopVar(c);
+  auto lvo2 = otheta->AddLoopVar(x);
+  auto lvo3 = otheta->AddLoopVar(y);
 
   auto itheta = jlm::rvsdg::ThetaNode::create(otheta->subregion());
 
-  auto lvi1 = itheta->add_loopvar(lvo1->argument());
-  auto lvi2 = itheta->add_loopvar(lvo2->argument());
-  auto lvi3 = itheta->add_loopvar(lvo3->argument());
+  auto lvi1 = itheta->AddLoopVar(lvo1.pre);
+  auto lvi2 = itheta->AddLoopVar(lvo2.pre);
+  auto lvi3 = itheta->AddLoopVar(lvo3.pre);
 
-  lvi2->result()->divert_to(lvi3->argument());
+  lvi2.post->divert_to(lvi3.pre);
 
-  itheta->set_predicate(lvi1->argument());
+  itheta->set_predicate(lvi1.pre);
 
-  lvo2->result()->divert_to(itheta->output(1));
-  lvo3->result()->divert_to(itheta->output(1));
+  lvo2.post->divert_to(lvi2.output);
+  lvo3.post->divert_to(lvi2.output);
 
-  otheta->set_predicate(lvo1->argument());
+  otheta->set_predicate(lvo1.pre);
 
-  GraphExport::Create(*otheta->output(2), "y");
+  GraphExport::Create(*lvo3.output, "y");
 
   //	jlm::rvsdg::view(graph, stdout);
   RunDeadNodeElimination(rm);
@@ -219,19 +219,19 @@ TestEvolvingTheta()
 
   auto theta = jlm::rvsdg::ThetaNode::create(&graph.GetRootRegion());
 
-  auto lv0 = theta->add_loopvar(c);
-  auto lv1 = theta->add_loopvar(x1);
-  auto lv2 = theta->add_loopvar(x2);
-  auto lv3 = theta->add_loopvar(x3);
-  auto lv4 = theta->add_loopvar(x4);
+  auto lv0 = theta->AddLoopVar(c);
+  auto lv1 = theta->AddLoopVar(x1);
+  auto lv2 = theta->AddLoopVar(x2);
+  auto lv3 = theta->AddLoopVar(x3);
+  auto lv4 = theta->AddLoopVar(x4);
 
-  lv1->result()->divert_to(lv2->argument());
-  lv2->result()->divert_to(lv3->argument());
-  lv3->result()->divert_to(lv4->argument());
+  lv1.post->divert_to(lv2.pre);
+  lv2.post->divert_to(lv3.pre);
+  lv3.post->divert_to(lv4.pre);
 
-  theta->set_predicate(lv0->argument());
+  theta->set_predicate(lv0.pre);
 
-  GraphExport::Create(*lv1, "x1");
+  GraphExport::Create(*lv1.output, "x1");
 
   //	jlm::rvsdg::view(graph, stdout);
   RunDeadNodeElimination(rm);

--- a/tests/jlm/llvm/opt/alias-analyses/TestAndersen.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestAndersen.cpp
@@ -595,7 +595,7 @@ TestTheta()
 
   auto & gepOutput = ptg->GetRegisterNode(*test.gep->output(0));
 
-  auto & thetaArgument2 = ptg->GetRegisterNode(*test.theta->output(2)->argument());
+  auto & thetaArgument2 = ptg->GetRegisterNode(*test.theta->GetLoopVars()[2].pre);
   auto & thetaOutput2 = ptg->GetRegisterNode(*test.theta->output(2));
 
   assert(TargetsExactly(lambdaArgument1, { &lambda, &ptg->GetExternalMemoryNode() }));

--- a/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
@@ -1420,17 +1420,17 @@ ValidateThetaTestSteensgaardAgnostic(const jlm::tests::ThetaTest & test)
       jlm::rvsdg::output::GetNode(*test.lambda->GetFunctionResults()[0]->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambda_exit_mux, 2, 1));
 
-  auto thetaOutput =
-      jlm::util::AssertedCast<jlm::rvsdg::ThetaOutput>(lambda_exit_mux->input(0)->origin());
-  auto theta = jlm::rvsdg::output::GetNode(*thetaOutput);
+  auto thetaOutput = lambda_exit_mux->input(0)->origin();
+  auto theta = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::ThetaNode>(*thetaOutput);
   assert(theta == test.theta);
 
-  auto storeStateOutput = thetaOutput->result()->origin();
+  auto loopvar = theta->MapOutputLoopVar(*thetaOutput);
+  auto storeStateOutput = loopvar.post->origin();
   auto store = jlm::rvsdg::output::GetNode(*storeStateOutput);
   assert(is<StoreNonVolatileOperation>(*store, 4, 2));
-  assert(store->input(storeStateOutput->index() + 2)->origin() == thetaOutput->argument());
+  assert(store->input(storeStateOutput->index() + 2)->origin() == loopvar.pre);
 
-  auto lambda_entry_mux = jlm::rvsdg::output::GetNode(*thetaOutput->input()->origin());
+  auto lambda_entry_mux = jlm::rvsdg::output::GetNode(*loopvar.input->origin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambda_entry_mux, 1, 2));
 }
 
@@ -1445,17 +1445,17 @@ ValidateThetaTestSteensgaardRegionAware(const jlm::tests::ThetaTest & test)
       jlm::rvsdg::output::GetNode(*test.lambda->GetFunctionResults()[0]->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
-  auto thetaOutput =
-      jlm::util::AssertedCast<jlm::rvsdg::ThetaOutput>(lambdaExitMerge->input(0)->origin());
-  auto theta = jlm::rvsdg::output::GetNode(*thetaOutput);
+  auto thetaOutput = lambdaExitMerge->input(0)->origin();
+  auto theta = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::ThetaNode>(*thetaOutput);
   assert(theta == test.theta);
+  auto loopvar = theta->MapOutputLoopVar(*thetaOutput);
 
-  auto storeStateOutput = thetaOutput->result()->origin();
+  auto storeStateOutput = loopvar.post->origin();
   auto store = jlm::rvsdg::output::GetNode(*storeStateOutput);
   assert(is<StoreNonVolatileOperation>(*store, 4, 2));
-  assert(store->input(storeStateOutput->index() + 2)->origin() == thetaOutput->argument());
+  assert(store->input(storeStateOutput->index() + 2)->origin() == loopvar.pre);
 
-  auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*thetaOutput->input()->origin());
+  auto lambdaEntrySplit = jlm::rvsdg::output::GetNode(*loopvar.input->origin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
 }
 
@@ -1470,17 +1470,17 @@ ValidateThetaTestSteensgaardAgnosticTopDown(const jlm::tests::ThetaTest & test)
       jlm::rvsdg::output::GetNode(*test.lambda->GetFunctionResults()[0]->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambda_exit_mux, 2, 1));
 
-  auto thetaOutput =
-      jlm::util::AssertedCast<jlm::rvsdg::ThetaOutput>(lambda_exit_mux->input(0)->origin());
-  auto theta = jlm::rvsdg::output::GetNode(*thetaOutput);
+  auto thetaOutput = lambda_exit_mux->input(0)->origin();
+  auto theta = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::ThetaNode>(*thetaOutput);
   assert(theta == test.theta);
+  auto loopvar = theta->MapOutputLoopVar(*thetaOutput);
 
-  auto storeStateOutput = thetaOutput->result()->origin();
+  auto storeStateOutput = loopvar.post->origin();
   auto store = jlm::rvsdg::output::GetNode(*storeStateOutput);
   assert(is<StoreNonVolatileOperation>(*store, 4, 2));
-  assert(store->input(storeStateOutput->index() + 2)->origin() == thetaOutput->argument());
+  assert(store->input(storeStateOutput->index() + 2)->origin() == loopvar.pre);
 
-  auto lambda_entry_mux = jlm::rvsdg::output::GetNode(*thetaOutput->input()->origin());
+  auto lambda_entry_mux = jlm::rvsdg::output::GetNode(*loopvar.input->origin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(*lambda_entry_mux, 1, 2));
 }
 

--- a/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
@@ -702,7 +702,7 @@ TestTheta()
 
     auto & gepOutput = pointsToGraph.GetRegisterNode(*test.gep->output(0));
 
-    auto & thetaArgument2 = pointsToGraph.GetRegisterNode(*test.theta->output(2)->argument());
+    auto & thetaArgument2 = pointsToGraph.GetRegisterNode(*test.theta->GetLoopVars()[2].pre);
     auto & thetaOutput2 = pointsToGraph.GetRegisterNode(*test.theta->output(2));
 
     assertTargets(lambdaArgument1, { &lambda, &pointsToGraph.GetExternalMemoryNode() });

--- a/tests/jlm/llvm/opt/test-cne.cpp
+++ b/tests/jlm/llvm/opt/test-cne.cpp
@@ -148,24 +148,24 @@ test_theta()
   auto theta = jlm::rvsdg::ThetaNode::create(&graph.GetRootRegion());
   auto region = theta->subregion();
 
-  auto lv1 = theta->add_loopvar(c);
-  auto lv2 = theta->add_loopvar(x);
-  auto lv3 = theta->add_loopvar(x);
-  auto lv4 = theta->add_loopvar(x);
+  auto lv1 = theta->AddLoopVar(c);
+  auto lv2 = theta->AddLoopVar(x);
+  auto lv3 = theta->AddLoopVar(x);
+  auto lv4 = theta->AddLoopVar(x);
 
-  auto u1 = jlm::tests::create_testop(region, { lv2->argument() }, { vt })[0];
-  auto u2 = jlm::tests::create_testop(region, { lv3->argument() }, { vt })[0];
-  auto b1 = jlm::tests::create_testop(region, { lv3->argument(), lv4->argument() }, { vt })[0];
+  auto u1 = jlm::tests::create_testop(region, { lv2.pre }, { vt })[0];
+  auto u2 = jlm::tests::create_testop(region, { lv3.pre }, { vt })[0];
+  auto b1 = jlm::tests::create_testop(region, { lv3.pre, lv4.pre }, { vt })[0];
 
-  lv2->result()->divert_to(u1);
-  lv3->result()->divert_to(u2);
-  lv4->result()->divert_to(b1);
+  lv2.post->divert_to(u1);
+  lv3.post->divert_to(u2);
+  lv4.post->divert_to(b1);
 
-  theta->set_predicate(lv1->argument());
+  theta->set_predicate(lv1.pre);
 
-  GraphExport::Create(*theta->output(1), "lv2");
-  GraphExport::Create(*theta->output(2), "lv3");
-  GraphExport::Create(*theta->output(3), "lv4");
+  GraphExport::Create(*lv2.output, "lv2");
+  GraphExport::Create(*lv3.output, "lv3");
+  GraphExport::Create(*lv4.output, "lv4");
 
   //	jlm::rvsdg::view(graph.GetRootRegion(), stdout);
   jlm::llvm::cne cne;
@@ -201,29 +201,29 @@ test_theta2()
   auto theta = jlm::rvsdg::ThetaNode::create(&graph.GetRootRegion());
   auto region = theta->subregion();
 
-  auto lv1 = theta->add_loopvar(c);
-  auto lv2 = theta->add_loopvar(x);
-  auto lv3 = theta->add_loopvar(x);
+  auto lv1 = theta->AddLoopVar(c);
+  auto lv2 = theta->AddLoopVar(x);
+  auto lv3 = theta->AddLoopVar(x);
 
-  auto u1 = jlm::tests::create_testop(region, { lv2->argument() }, { vt })[0];
-  auto u2 = jlm::tests::create_testop(region, { lv3->argument() }, { vt })[0];
+  auto u1 = jlm::tests::create_testop(region, { lv2.pre }, { vt })[0];
+  auto u2 = jlm::tests::create_testop(region, { lv3.pre }, { vt })[0];
   auto b1 = jlm::tests::create_testop(region, { u2, u2 }, { vt })[0];
 
-  lv2->result()->divert_to(u1);
-  lv3->result()->divert_to(b1);
+  lv2.post->divert_to(u1);
+  lv3.post->divert_to(b1);
 
-  theta->set_predicate(lv1->argument());
+  theta->set_predicate(lv1.pre);
 
-  GraphExport::Create(*theta->output(1), "lv2");
-  GraphExport::Create(*theta->output(2), "lv3");
+  GraphExport::Create(*lv2.output, "lv2");
+  GraphExport::Create(*lv3.output, "lv3");
 
   //	jlm::rvsdg::view(graph, stdout);
   jlm::llvm::cne cne;
   cne.run(rm, statisticsCollector);
   //	jlm::rvsdg::view(graph, stdout);
 
-  assert(lv2->result()->origin() == u1);
-  assert(lv2->argument()->nusers() != 0 && lv3->argument()->nusers() != 0);
+  assert(lv2.post->origin() == u1);
+  assert(lv2.pre->nusers() != 0 && lv3.pre->nusers() != 0);
 }
 
 static inline void
@@ -245,32 +245,32 @@ test_theta3()
   auto theta1 = jlm::rvsdg::ThetaNode::create(&graph.GetRootRegion());
   auto r1 = theta1->subregion();
 
-  auto lv1 = theta1->add_loopvar(c);
-  auto lv2 = theta1->add_loopvar(x);
-  auto lv3 = theta1->add_loopvar(x);
-  auto lv4 = theta1->add_loopvar(x);
+  auto lv1 = theta1->AddLoopVar(c);
+  auto lv2 = theta1->AddLoopVar(x);
+  auto lv3 = theta1->AddLoopVar(x);
+  auto lv4 = theta1->AddLoopVar(x);
 
   auto theta2 = jlm::rvsdg::ThetaNode::create(r1);
   auto r2 = theta2->subregion();
-  auto p = theta2->add_loopvar(lv1->argument());
-  theta2->add_loopvar(lv2->argument());
-  theta2->add_loopvar(lv3->argument());
-  theta2->add_loopvar(lv4->argument());
-  theta2->set_predicate(p->argument());
+  auto p = theta2->AddLoopVar(lv1.pre);
+  auto p2 = theta2->AddLoopVar(lv2.pre);
+  auto p3 = theta2->AddLoopVar(lv3.pre);
+  auto p4 = theta2->AddLoopVar(lv4.pre);
+  theta2->set_predicate(p.pre);
 
-  auto u1 = jlm::tests::test_op::create(r1, { theta2->output(1) }, { vt });
-  auto b1 = jlm::tests::test_op::create(r1, { theta2->output(2), theta2->output(2) }, { vt });
-  auto u2 = jlm::tests::test_op::create(r1, { theta2->output(3) }, { vt });
+  auto u1 = jlm::tests::test_op::create(r1, { p2.output }, { vt });
+  auto b1 = jlm::tests::test_op::create(r1, { p3.output, p3.output }, { vt });
+  auto u2 = jlm::tests::test_op::create(r1, { p4.output }, { vt });
 
-  lv2->result()->divert_to(u1->output(0));
-  lv3->result()->divert_to(b1->output(0));
-  lv4->result()->divert_to(u1->output(0));
+  lv2.post->divert_to(u1->output(0));
+  lv3.post->divert_to(b1->output(0));
+  lv4.post->divert_to(u1->output(0));
 
-  theta1->set_predicate(lv1->argument());
+  theta1->set_predicate(lv1.pre);
 
-  GraphExport::Create(*theta1->output(1), "lv2");
-  GraphExport::Create(*theta1->output(2), "lv3");
-  GraphExport::Create(*theta1->output(3), "lv4");
+  GraphExport::Create(*lv2.output, "lv2");
+  GraphExport::Create(*lv3.output, "lv3");
+  GraphExport::Create(*lv4.output, "lv4");
 
   //	jlm::rvsdg::view(graph, stdout);
   jlm::llvm::cne cne;
@@ -305,23 +305,23 @@ test_theta4()
   auto theta = jlm::rvsdg::ThetaNode::create(&graph.GetRootRegion());
   auto region = theta->subregion();
 
-  auto lv1 = theta->add_loopvar(c);
-  auto lv2 = theta->add_loopvar(x);
-  auto lv3 = theta->add_loopvar(x);
-  auto lv4 = theta->add_loopvar(y);
-  auto lv5 = theta->add_loopvar(y);
-  auto lv6 = theta->add_loopvar(x);
-  auto lv7 = theta->add_loopvar(x);
+  auto lv1 = theta->AddLoopVar(c);
+  auto lv2 = theta->AddLoopVar(x);
+  auto lv3 = theta->AddLoopVar(x);
+  auto lv4 = theta->AddLoopVar(y);
+  auto lv5 = theta->AddLoopVar(y);
+  auto lv6 = theta->AddLoopVar(x);
+  auto lv7 = theta->AddLoopVar(x);
 
-  auto u1 = jlm::tests::test_op::create(region, { lv2->argument() }, { vt });
-  auto b1 = jlm::tests::test_op::create(region, { lv3->argument(), lv3->argument() }, { vt });
+  auto u1 = jlm::tests::test_op::create(region, { lv2.pre }, { vt });
+  auto b1 = jlm::tests::test_op::create(region, { lv3.pre, lv3.pre }, { vt });
 
-  lv2->result()->divert_to(lv4->argument());
-  lv3->result()->divert_to(lv5->argument());
-  lv4->result()->divert_to(u1->output(0));
-  lv5->result()->divert_to(b1->output(0));
+  lv2.post->divert_to(lv4.pre);
+  lv3.post->divert_to(lv5.pre);
+  lv4.post->divert_to(u1->output(0));
+  lv5.post->divert_to(b1->output(0));
 
-  theta->set_predicate(lv1->argument());
+  theta->set_predicate(lv1.pre);
 
   auto & ex1 = GraphExport::Create(*theta->output(1), "lv2");
   auto & ex2 = GraphExport::Create(*theta->output(2), "lv3");
@@ -334,8 +334,8 @@ test_theta4()
   //	jlm::rvsdg::view(graph, stdout);
 
   assert(ex1.origin() != ex2.origin());
-  assert(lv2->argument()->nusers() != 0 && lv3->argument()->nusers() != 0);
-  assert(lv6->result()->origin() == lv7->result()->origin());
+  assert(lv2.pre->nusers() != 0 && lv3.pre->nusers() != 0);
+  assert(lv6.post->origin() == lv7.post->origin());
 }
 
 static inline void
@@ -358,16 +358,16 @@ test_theta5()
   auto theta = jlm::rvsdg::ThetaNode::create(&graph.GetRootRegion());
   auto region = theta->subregion();
 
-  auto lv0 = theta->add_loopvar(c);
-  auto lv1 = theta->add_loopvar(x);
-  auto lv2 = theta->add_loopvar(x);
-  auto lv3 = theta->add_loopvar(y);
-  auto lv4 = theta->add_loopvar(y);
+  auto lv0 = theta->AddLoopVar(c);
+  auto lv1 = theta->AddLoopVar(x);
+  auto lv2 = theta->AddLoopVar(x);
+  auto lv3 = theta->AddLoopVar(y);
+  auto lv4 = theta->AddLoopVar(y);
 
-  lv1->result()->divert_to(lv3->argument());
-  lv2->result()->divert_to(lv4->argument());
+  lv1.post->divert_to(lv3.pre);
+  lv2.post->divert_to(lv4.pre);
 
-  theta->set_predicate(lv0->argument());
+  theta->set_predicate(lv0.pre);
 
   auto & ex1 = GraphExport::Create(*theta->output(1), "lv1");
   auto & ex2 = GraphExport::Create(*theta->output(2), "lv2");

--- a/tests/jlm/llvm/opt/test-inversion.cpp
+++ b/tests/jlm/llvm/opt/test-inversion.cpp
@@ -31,20 +31,20 @@ test1()
 
   auto theta = jlm::rvsdg::ThetaNode::create(&graph.GetRootRegion());
 
-  auto lvx = theta->add_loopvar(x);
-  auto lvy = theta->add_loopvar(y);
-  theta->add_loopvar(z);
+  auto lvx = theta->AddLoopVar(x);
+  auto lvy = theta->AddLoopVar(y);
+  theta->AddLoopVar(z);
 
   auto a = jlm::tests::create_testop(
       theta->subregion(),
-      { lvx->argument(), lvy->argument() },
+      { lvx.pre, lvy.pre },
       { jlm::rvsdg::bittype::Create(1) })[0];
   auto predicate = jlm::rvsdg::match(1, { { 1, 0 } }, 1, 2, a);
 
   auto gamma = jlm::rvsdg::GammaNode::create(predicate, 2);
 
-  auto evx = gamma->AddEntryVar(lvx->argument());
-  auto evy = gamma->AddEntryVar(lvy->argument());
+  auto evx = gamma->AddEntryVar(lvx.pre);
+  auto evy = gamma->AddEntryVar(lvy.pre);
 
   auto b = jlm::tests::create_testop(
       gamma->subregion(0),
@@ -57,7 +57,7 @@ test1()
 
   auto xvy = gamma->AddExitVar({ b, c });
 
-  lvy->result()->divert_to(xvy.output);
+  lvy.post->divert_to(xvy.output);
 
   theta->set_predicate(predicate);
 
@@ -87,26 +87,26 @@ test2()
 
   auto theta = jlm::rvsdg::ThetaNode::create(&graph.GetRootRegion());
 
-  auto lv1 = theta->add_loopvar(x);
+  auto lv1 = theta->AddLoopVar(x);
 
   auto n1 = jlm::tests::create_testop(
       theta->subregion(),
-      { lv1->argument() },
+      { lv1.pre },
       { jlm::rvsdg::bittype::Create(1) })[0];
-  auto n2 = jlm::tests::create_testop(theta->subregion(), { lv1->argument() }, { vt })[0];
+  auto n2 = jlm::tests::create_testop(theta->subregion(), { lv1.pre }, { vt })[0];
   auto predicate = jlm::rvsdg::match(1, { { 1, 0 } }, 1, 2, n1);
 
   auto gamma = jlm::rvsdg::GammaNode::create(predicate, 2);
 
   auto ev1 = gamma->AddEntryVar(n1);
-  auto ev2 = gamma->AddEntryVar(lv1->argument());
+  auto ev2 = gamma->AddEntryVar(lv1.pre);
   auto ev3 = gamma->AddEntryVar(n2);
 
   gamma->AddExitVar(ev1.branchArgument);
   gamma->AddExitVar(ev2.branchArgument);
   gamma->AddExitVar(ev3.branchArgument);
 
-  lv1->result()->divert_to(gamma->output(1));
+  lv1.post->divert_to(gamma->output(1));
 
   theta->set_predicate(predicate);
 

--- a/tests/jlm/llvm/opt/test-push.cpp
+++ b/tests/jlm/llvm/opt/test-push.cpp
@@ -76,23 +76,20 @@ test_theta()
 
   auto theta = jlm::rvsdg::ThetaNode::create(&graph.GetRootRegion());
 
-  auto lv1 = theta->add_loopvar(c);
-  auto lv2 = theta->add_loopvar(x);
-  auto lv3 = theta->add_loopvar(x);
-  auto lv4 = theta->add_loopvar(s);
+  auto lv1 = theta->AddLoopVar(c);
+  auto lv2 = theta->AddLoopVar(x);
+  auto lv3 = theta->AddLoopVar(x);
+  auto lv4 = theta->AddLoopVar(s);
 
   auto o1 = jlm::tests::create_testop(theta->subregion(), {}, { vt })[0];
-  auto o2 = jlm::tests::create_testop(theta->subregion(), { o1, lv3->argument() }, { vt })[0];
-  auto o3 = jlm::tests::create_testop(theta->subregion(), { lv2->argument(), o2 }, { vt })[0];
-  auto o4 = jlm::tests::create_testop(
-      theta->subregion(),
-      { lv3->argument(), lv4->argument() },
-      { st })[0];
+  auto o2 = jlm::tests::create_testop(theta->subregion(), { o1, lv3.pre }, { vt })[0];
+  auto o3 = jlm::tests::create_testop(theta->subregion(), { lv2.pre, o2 }, { vt })[0];
+  auto o4 = jlm::tests::create_testop(theta->subregion(), { lv3.pre, lv4.pre }, { st })[0];
 
-  lv2->result()->divert_to(o3);
-  lv4->result()->divert_to(o4);
+  lv2.post->divert_to(o3);
+  lv4.post->divert_to(o4);
 
-  theta->set_predicate(lv1->argument());
+  theta->set_predicate(lv1.pre);
 
   GraphExport::Create(*theta->output(0), "c");
 
@@ -121,18 +118,17 @@ test_push_theta_bottom()
 
   auto theta = jlm::rvsdg::ThetaNode::create(&graph.GetRootRegion());
 
-  auto lvc = theta->add_loopvar(c);
-  auto lva = theta->add_loopvar(a);
-  auto lvv = theta->add_loopvar(v);
-  auto lvs = theta->add_loopvar(s);
+  auto lvc = theta->AddLoopVar(c);
+  auto lva = theta->AddLoopVar(a);
+  auto lvv = theta->AddLoopVar(v);
+  auto lvs = theta->AddLoopVar(s);
 
-  auto s1 =
-      StoreNonVolatileNode::Create(lva->argument(), lvv->argument(), { lvs->argument() }, 4)[0];
+  auto s1 = StoreNonVolatileNode::Create(lva.pre, lvv.pre, { lvs.pre }, 4)[0];
 
-  lvs->result()->divert_to(s1);
-  theta->set_predicate(lvc->argument());
+  lvs.post->divert_to(s1);
+  theta->set_predicate(lvc.pre);
 
-  auto & ex = GraphExport::Create(*lvs, "s");
+  auto & ex = GraphExport::Create(*lvs.output, "s");
 
   jlm::rvsdg::view(graph, stdout);
   jlm::llvm::push_bottom(theta);

--- a/tests/jlm/mlir/backend/TestJlmToMlirConverter.cpp
+++ b/tests/jlm/mlir/backend/TestJlmToMlirConverter.cpp
@@ -634,8 +634,8 @@ TestTheta()
 
     auto predicate = jlm::rvsdg::control_constant(rvsdgThetaNode->subregion(), 2, 0);
 
-    rvsdgThetaNode->add_loopvar(entryvar1);
-    rvsdgThetaNode->add_loopvar(entryvar2);
+    rvsdgThetaNode->AddLoopVar(entryvar1);
+    rvsdgThetaNode->AddLoopVar(entryvar2);
     rvsdgThetaNode->set_predicate(predicate);
 
     // Convert the RVSDG to MLIR

--- a/tests/jlm/mlir/frontend/TestMlirToJlmConverter.cpp
+++ b/tests/jlm/mlir/frontend/TestMlirToJlmConverter.cpp
@@ -998,7 +998,7 @@ TestThetaOp()
 
       std::cout << "Checking theta node" << std::endl;
       assert(thetaNode->ninputs() == 2);
-      assert(thetaNode->nloopvars() == 2);
+      assert(thetaNode->GetLoopVars().size() == 2);
       assert(thetaNode->noutputs() == 2);
       assert(thetaNode->nsubregions() == 1);
       assert(is<jlm::rvsdg::ControlType>(thetaNode->predicate()->type()));


### PR DESCRIPTION
Provide an API to loop nodes that allows mapping the various representation pieces of a loop variable. Remove
Theta{Input|Output|Argument|Result}.