### PR TITLE
Add new node normalization interface and convert load reductions to it

### DIFF
--- a/jlm/llvm/ir/operators/Load.cpp
+++ b/jlm/llvm/ir/operators/Load.cpp
@@ -448,7 +448,7 @@ LoadStoreStateReduction::GetInstance() noexcept
   return loadStoreStateReduction;
 }
 
-LoadDuplicateStateReduction::~LoadDuplicateStateReduction() = default;
+LoadDuplicateStateReduction::~LoadDuplicateStateReduction() noexcept = default;
 
 LoadDuplicateStateReduction::LoadDuplicateStateReduction() noexcept = default;
 

--- a/jlm/llvm/ir/operators/Load.cpp
+++ b/jlm/llvm/ir/operators/Load.cpp
@@ -368,7 +368,7 @@ LoadStoreStateReduction::LoadStoreStateReduction() noexcept = default;
 bool
 LoadStoreStateReduction::IsReducibleState(
     const rvsdg::output * state,
-    const rvsdg::node * loadAlloca)
+    const rvsdg::Node * loadAlloca)
 {
   if (is<StoreNonVolatileOperation>(rvsdg::output::GetNode(*state)))
   {

--- a/jlm/llvm/ir/operators/Load.cpp
+++ b/jlm/llvm/ir/operators/Load.cpp
@@ -483,8 +483,11 @@ LoadDuplicateStateReduction::ApplyNormalization(
     }
   }
 
-  const auto loadResults =
-      LoadNonVolatileNode::Create(address, newInputStates, op.GetLoadedType(), op.GetAlignment());
+  const auto loadResults = LoadNonVolatileNode::Create(
+      address,
+      newInputStates,
+      operation.GetLoadedType(),
+      operation.GetAlignment());
 
   std::vector<rvsdg::output *> results(operands.size(), nullptr);
   results[0] = loadResults[0];

--- a/jlm/llvm/ir/operators/Load.cpp
+++ b/jlm/llvm/ir/operators/Load.cpp
@@ -262,16 +262,14 @@ LoadAllocaReduction::ApplyNormalization(
       otherStates.push_back(operands[n]);
   }
 
-  auto ld = LoadNonVolatileNode::Create(
+  auto loadResults = LoadNonVolatileNode::Create(
       operands[0],
       loadStates,
       operation.GetLoadedType(),
       operation.GetAlignment());
 
-  std::vector<rvsdg::output *> results(1, ld[0]);
-  results.insert(results.end(), std::next(ld.begin()), ld.end());
-  results.insert(results.end(), otherStates.begin(), otherStates.end());
-  return results;
+  loadResults.insert(loadResults.end(), otherStates.begin(), otherStates.end());
+  return loadResults;
 }
 
 LoadAllocaReduction &

--- a/jlm/llvm/ir/operators/Load.hpp
+++ b/jlm/llvm/ir/operators/Load.hpp
@@ -702,7 +702,7 @@ private:
   LoadStoreStateReduction() noexcept;
 
   static bool
-  IsReducibleState(const rvsdg::output * state, const rvsdg::node * loadAlloca);
+  IsReducibleState(const rvsdg::output * state, const rvsdg::Node * loadAlloca);
 };
 
 /**

--- a/jlm/llvm/ir/operators/Load.hpp
+++ b/jlm/llvm/ir/operators/Load.hpp
@@ -9,6 +9,7 @@
 #include <jlm/llvm/ir/tac.hpp>
 #include <jlm/llvm/ir/types.hpp>
 #include <jlm/rvsdg/graph.hpp>
+#include <jlm/rvsdg/NodeNormalization.hpp>
 #include <jlm/rvsdg/simple-node.hpp>
 #include <jlm/rvsdg/simple-normal-form.hpp>
 
@@ -573,6 +574,204 @@ public:
   {
     return *(new LoadNonVolatileNode(region, loadOperation, operands));
   }
+};
+
+/**
+ * sx1 = MemStateMerge si1 ... siM
+ * v sl1 = LoadNonVolatile a sx1
+ * =>
+ * v sl1 ... slM = LoadNonVolatile a si1 ... siM
+ * sx1 = MemStateMerge sl1 ... slM
+ *
+ * FIXME: The reduction can be generalized: A load node can have multiple operands from different
+ * merge nodes.
+ */
+class LoadMuxReduction final : public rvsdg::NodeNormalization<LoadNonVolatileOperation>
+{
+public:
+  ~LoadMuxReduction() noexcept override;
+
+  [[nodiscard]] bool
+  IsApplicable(const LoadNonVolatileOperation &, const std::vector<rvsdg::output *> & operands)
+      override;
+
+  std::vector<rvsdg::output *>
+  ApplyNormalization(
+      const LoadNonVolatileOperation & operation,
+      const std::vector<rvsdg::output *> & operands) override;
+
+  static LoadMuxReduction &
+  GetInstance() noexcept;
+
+private:
+  LoadMuxReduction() noexcept;
+};
+
+/**
+ * If the producer of a load's address is an alloca, then we can remove
+ * all state edges originating from other alloca operations.
+ *
+ *  a1 s1 = alloca ...
+ *  a2 s2 = alloca ...
+ *  s3 = mux_op s1
+ *  v sl1 sl2 sl3 = LoadNonVolatile a1 s1 s2 s3
+ *  =>
+ *  ...
+ *  v sl1 sl3 = LoadNonVolatile a1 s1 s3
+ */
+class LoadAllocaReduction final : public rvsdg::NodeNormalization<LoadNonVolatileOperation>
+{
+public:
+  ~LoadAllocaReduction() noexcept override;
+
+  [[nodiscard]] bool
+  IsApplicable(const LoadNonVolatileOperation &, const std::vector<rvsdg::output *> & operands)
+      override;
+
+  std::vector<rvsdg::output *>
+  ApplyNormalization(
+      const LoadNonVolatileOperation & operation,
+      const std::vector<rvsdg::output *> & operands) override;
+
+  static LoadAllocaReduction &
+  GetInstance() noexcept;
+
+private:
+  LoadAllocaReduction() noexcept;
+};
+
+/**
+ * s2 = StoreNonVolatile a v1 s1
+ * v2 s3 = LoadNonVolatile a s2
+ * ... = any_op v2
+ * =>
+ * s2 = StoreNonVolatile a v1 s1
+ * ... = any_op v1
+ */
+class LoadStoreReduction final : public rvsdg::NodeNormalization<LoadNonVolatileOperation>
+{
+public:
+  ~LoadStoreReduction() noexcept override;
+
+  [[nodiscard]] bool
+  IsApplicable(
+      const LoadNonVolatileOperation & loadOperation,
+      const std::vector<rvsdg::output *> & operands) override;
+
+  std::vector<rvsdg::output *>
+  ApplyNormalization(
+      const LoadNonVolatileOperation & operation,
+      const std::vector<rvsdg::output *> & operands) override;
+
+  static LoadStoreReduction &
+  GetInstance() noexcept;
+
+private:
+  LoadStoreReduction() noexcept;
+};
+
+/**
+ *  a1 sa1 = Alloca ...
+ *  a2 sa2 = Alloca ...
+ *  ss1 = StoreNonVolatile a1 ... sa1
+ *  ss2 = StoreNonVolatile a2 ... sa2
+ *  ... = LoadNonVolatile a1 ss1 ss2
+ *  =>
+ *  ...
+ *  ... = LoadNonVolatile a1 ss1
+ */
+class LoadStoreStateReduction final : public rvsdg::NodeNormalization<LoadNonVolatileOperation>
+{
+public:
+  ~LoadStoreStateReduction() noexcept override;
+
+  [[nodiscard]] bool
+  IsApplicable(
+      const LoadNonVolatileOperation & operation,
+      const std::vector<rvsdg::output *> & operands) override;
+
+  std::vector<rvsdg::output *>
+  ApplyNormalization(
+      const LoadNonVolatileOperation & operation,
+      const std::vector<rvsdg::output *> & operands) override;
+
+  static LoadStoreStateReduction &
+  GetInstance() noexcept;
+
+private:
+  LoadStoreStateReduction() noexcept;
+
+  static bool
+  IsReducibleState(const rvsdg::output * state, const rvsdg::node * loadAlloca);
+};
+
+/**
+ * v so1 so2 so3 = LoadNonVolatile a si1 si1 si1
+ * =>
+ * v so1 = LoadNonVolatile a si1
+ */
+class LoadDuplicateStateReduction final : public rvsdg::NodeNormalization<LoadNonVolatileOperation>
+{
+public:
+  ~LoadDuplicateStateReduction() noexcept override;
+
+  [[nodiscard]] bool
+  IsApplicable(
+      const LoadNonVolatileOperation & operation,
+      const std::vector<rvsdg::output *> & operands) override;
+
+  std::vector<rvsdg::output *>
+  ApplyNormalization(
+      const LoadNonVolatileOperation & operation,
+      const std::vector<rvsdg::output *> & operands) override;
+
+  static LoadDuplicateStateReduction &
+  GetInstance() noexcept;
+
+private:
+  LoadDuplicateStateReduction() noexcept;
+};
+
+/**
+ *  _ so1 = LoadNonVolatile _ si1
+ *  _ so2 = LoadNonVolatile _ so1
+ *  _ so3 = LoadNonVolatile _ so2
+ *  =>
+ *  _ so1 = LoadNonVolatile _ si1
+ *  _ so2 = LoadNonVolatile _ si1
+ *  _ so3 = LoadNonVolatile _ si1
+ */
+class LoadLoadStateReduction final : public rvsdg::NodeNormalization<LoadNonVolatileOperation>
+{
+public:
+  ~LoadLoadStateReduction() noexcept override;
+
+  [[nodiscard]] bool
+  IsApplicable(
+      const LoadNonVolatileOperation & operation,
+      const std::vector<rvsdg::output *> & operands) override;
+
+  std::vector<rvsdg::output *>
+  ApplyNormalization(
+      const LoadNonVolatileOperation & operation,
+      const std::vector<rvsdg::output *> & operands) override;
+
+  static LoadLoadStateReduction &
+  GetInstance() noexcept;
+
+private:
+  LoadLoadStateReduction() noexcept;
+
+  // FIXME: This function returns the corresponding state input for a state output of a load
+  // node. It should be part of a load node class.
+  static rvsdg::input &
+  GetLoadStateInput(const rvsdg::output & output);
+
+  static rvsdg::output &
+  ReduceState(
+      size_t index,
+      rvsdg::output & operand,
+      std::vector<std::vector<rvsdg::output *>> & mxStates);
 };
 
 }

--- a/jlm/llvm/ir/operators/Load.hpp
+++ b/jlm/llvm/ir/operators/Load.hpp
@@ -591,6 +591,16 @@ class LoadMuxReduction final : public rvsdg::NodeNormalization<LoadNonVolatileOp
 public:
   ~LoadMuxReduction() noexcept override;
 
+  LoadMuxReduction(const LoadMuxReduction &) = delete;
+
+  LoadMuxReduction(LoadMuxReduction &&) = delete;
+
+  LoadMuxReduction &
+  operator=(const LoadMuxReduction &) = delete;
+
+  LoadMuxReduction &
+  operator=(LoadMuxReduction &&) = delete;
+
   [[nodiscard]] bool
   IsApplicable(const LoadNonVolatileOperation &, const std::vector<rvsdg::output *> & operands)
       override;
@@ -624,6 +634,16 @@ class LoadAllocaReduction final : public rvsdg::NodeNormalization<LoadNonVolatil
 public:
   ~LoadAllocaReduction() noexcept override;
 
+  LoadAllocaReduction(const LoadAllocaReduction &) = delete;
+
+  LoadAllocaReduction(LoadAllocaReduction &&) = delete;
+
+  LoadAllocaReduction &
+  operator=(const LoadAllocaReduction &) = delete;
+
+  LoadAllocaReduction &
+  operator=(LoadAllocaReduction &&) = delete;
+
   [[nodiscard]] bool
   IsApplicable(const LoadNonVolatileOperation &, const std::vector<rvsdg::output *> & operands)
       override;
@@ -652,6 +672,16 @@ class LoadStoreReduction final : public rvsdg::NodeNormalization<LoadNonVolatile
 {
 public:
   ~LoadStoreReduction() noexcept override;
+
+  LoadStoreReduction(const LoadStoreReduction &) = delete;
+
+  LoadStoreReduction(LoadStoreReduction &&) = delete;
+
+  LoadStoreReduction &
+  operator=(const LoadStoreReduction &) = delete;
+
+  LoadStoreReduction &
+  operator=(LoadStoreReduction &&) = delete;
 
   [[nodiscard]] bool
   IsApplicable(
@@ -685,6 +715,16 @@ class LoadStoreStateReduction final : public rvsdg::NodeNormalization<LoadNonVol
 public:
   ~LoadStoreStateReduction() noexcept override;
 
+  LoadStoreStateReduction(const LoadStoreStateReduction &) = delete;
+
+  LoadStoreStateReduction(LoadStoreStateReduction &&) = delete;
+
+  LoadStoreStateReduction &
+  operator=(const LoadStoreStateReduction &) = delete;
+
+  LoadStoreStateReduction &
+  operator=(LoadStoreStateReduction &&) = delete;
+
   [[nodiscard]] bool
   IsApplicable(
       const LoadNonVolatileOperation & operation,
@@ -714,6 +754,16 @@ class LoadDuplicateStateReduction final : public rvsdg::NodeNormalization<LoadNo
 {
 public:
   ~LoadDuplicateStateReduction() noexcept override;
+
+  LoadDuplicateStateReduction(const LoadDuplicateStateReduction &) = delete;
+
+  LoadDuplicateStateReduction(LoadDuplicateStateReduction &&) = delete;
+
+  LoadDuplicateStateReduction &
+  operator=(const LoadDuplicateStateReduction &) = delete;
+
+  LoadDuplicateStateReduction &
+  operator=(LoadDuplicateStateReduction &&) = delete;
 
   [[nodiscard]] bool
   IsApplicable(
@@ -745,6 +795,16 @@ class LoadLoadStateReduction final : public rvsdg::NodeNormalization<LoadNonVola
 {
 public:
   ~LoadLoadStateReduction() noexcept override;
+
+  LoadLoadStateReduction(const LoadLoadStateReduction &) = delete;
+
+  LoadLoadStateReduction(LoadLoadStateReduction &&) = delete;
+
+  LoadLoadStateReduction &
+  operator=(const LoadLoadStateReduction &) = delete;
+
+  LoadLoadStateReduction &
+  operator=(LoadLoadStateReduction &&) = delete;
 
   [[nodiscard]] bool
   IsApplicable(

--- a/jlm/rvsdg/Makefile.sub
+++ b/jlm/rvsdg/Makefile.sub
@@ -61,6 +61,7 @@ librvsdg_HEADERS = \
 	jlm/rvsdg/bitstring.hpp \
 	jlm/rvsdg/node.hpp \
 	jlm/rvsdg/node-normal-form.hpp \
+	jlm/rvsdg/NodeNormalization.hpp \
 	jlm/rvsdg/nullary.hpp \
 	jlm/rvsdg/structural-node.hpp \
 	jlm/rvsdg/control.hpp \

--- a/jlm/rvsdg/NodeNormalization.hpp
+++ b/jlm/rvsdg/NodeNormalization.hpp
@@ -62,7 +62,7 @@ public:
    * @param operation The operation for which to normalize the operands.
    * @param operands The operands corresponding to the operation.
    *
-   * @return The normalized operands.
+   * @return The normalized result values.
    */
   virtual std::vector<output *>
   ApplyNormalization(const TOperation & operation, const std::vector<output *> & operands) = 0;

--- a/jlm/rvsdg/NodeNormalization.hpp
+++ b/jlm/rvsdg/NodeNormalization.hpp
@@ -33,16 +33,6 @@ public:
 
   NodeNormalization() = default;
 
-  NodeNormalization(const NodeNormalization &) = delete;
-
-  NodeNormalization(NodeNormalization &&) = delete;
-
-  NodeNormalization &
-  operator=(const NodeNormalization &) = delete;
-
-  NodeNormalization &
-  operator=(NodeNormalization &&) = delete;
-
   /**
    * Determines whether the operands can be normalized.
    *

--- a/jlm/rvsdg/NodeNormalization.hpp
+++ b/jlm/rvsdg/NodeNormalization.hpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#ifndef JLM_RVSDG_NODENORMALIZATION_HPP
+#define JLM_RVSDG_NODENORMALIZATION_HPP
+
+#include <vector>
+
+namespace jlm::rvsdg
+{
+
+class node;
+class output;
+
+/**
+ * \brief Normalizes the operands of an operation.
+ *
+ * The usage expectation is that IsApplicable() is invoked to determine whether operands can be
+ * normalized BEFORE ApplyNormalization() is invoked.
+ *
+ * @tparam TOperation The operation for which to normalize the operands.
+ */
+template<class TOperation>
+class NodeNormalization
+{
+  static_assert(
+      std::is_base_of<operation, TOperation>::value,
+      "Template parameter TOperation must be derived from jlm::rvsdg::operation.");
+
+public:
+  virtual ~NodeNormalization() noexcept = default;
+
+  NodeNormalization() = default;
+
+  NodeNormalization(const NodeNormalization &) = delete;
+
+  NodeNormalization(NodeNormalization &&) = delete;
+
+  NodeNormalization &
+  operator=(const NodeNormalization &) = delete;
+
+  NodeNormalization &
+  operator=(NodeNormalization &&) = delete;
+
+  /**
+   * Determines whether the operands can be normalized.
+   *
+   * \note While the method can modify internal state, it is expected to be re-entrant.
+   *
+   * @param operation The operation for which to normalize the operands.
+   * @param operands The operands corresponding to the operation.
+   *
+   * @return True, if the operands can be normalized, otherwise false.
+   */
+  virtual bool
+  IsApplicable(const TOperation & operation, const std::vector<output *> & operands) = 0;
+
+  /**
+   * \brief Performs the normalization of the operands.
+   *
+   * @param operation The operation for which to normalize the operands.
+   * @param operands The operands corresponding to the operation.
+   *
+   * @return The normalized operands.
+   */
+  virtual std::vector<output *>
+  ApplyNormalization(const TOperation & operation, const std::vector<output *> & operands) = 0;
+};
+
+}
+
+#endif

--- a/jlm/rvsdg/NodeNormalization.hpp
+++ b/jlm/rvsdg/NodeNormalization.hpp
@@ -11,7 +11,6 @@
 namespace jlm::rvsdg
 {
 
-class node;
 class output;
 
 /**
@@ -26,7 +25,7 @@ template<class TOperation>
 class NodeNormalization
 {
   static_assert(
-      std::is_base_of<operation, TOperation>::value,
+      std::is_base_of<Operation, TOperation>::value,
       "Template parameter TOperation must be derived from jlm::rvsdg::operation.");
 
 public:


### PR DESCRIPTION
This PR is a series of PRs to remove the old node normalization interface that is intertwined in the RVSDG library. This PR does the following:

1. Adds a new and simple node normalization interface for optimizing the operands of a node. This enables to create individual instances of normalizations and therefore pass them around, and/or configure optimization by simply providing these instances instead of utilizing the flags of the old interface.
2. Converts the load reductions to this new interface