### PR TITLE
Fix duplicate state normalization for load nodes

### DIFF
--- a/jlm/llvm/ir/operators/Load.cpp
+++ b/jlm/llvm/ir/operators/Load.cpp
@@ -7,6 +7,7 @@
 #include <jlm/llvm/ir/operators/Load.hpp>
 #include <jlm/llvm/ir/operators/MemoryStateOperations.hpp>
 #include <jlm/llvm/ir/operators/Store.hpp>
+#include <jlm/util/HashSet.hpp>
 
 namespace jlm::llvm
 {
@@ -286,8 +287,8 @@ is_load_store_state_reducible(
 static bool
 is_multiple_origin_reducible(const std::vector<rvsdg::output *> & operands)
 {
-  std::unordered_set<rvsdg::output *> states(std::next(operands.begin()), operands.end());
-  return states.size() != operands.size() - 1;
+  const util::HashSet<rvsdg::output *> states(std::next(operands.begin()), operands.end());
+  return states.Size() != operands.size() - 1;
 }
 
 // s2 = store_op a v1 s1
@@ -453,31 +454,37 @@ perform_multiple_origin_reduction(
     const LoadNonVolatileOperation & op,
     const std::vector<rvsdg::output *> & operands)
 {
-  std::vector<rvsdg::output *> new_loadstates;
-  std::unordered_set<rvsdg::output *> seen_state;
-  std::vector<rvsdg::output *> results(operands.size(), nullptr);
+  if (operands.size() == 1)
+  {
+    // Nothing needs to be done as we do not have any states
+    return operands;
+  }
+
+  const auto address = operands[0];
+
+  std::vector<rvsdg::output *> newInputStates;
+  std::unordered_map<rvsdg::output *, size_t> stateIndexMap;
   for (size_t n = 1; n < operands.size(); n++)
   {
     auto state = operands[n];
-    if (seen_state.find(state) != seen_state.end())
-      results[n] = state;
-    else
-      new_loadstates.push_back(state);
-
-    seen_state.insert(state);
+    if (stateIndexMap.find(state) == stateIndexMap.end())
+    {
+      const size_t resultIndex = 1 + newInputStates.size(); // loaded value + states seen so far
+      newInputStates.push_back(state);
+      stateIndexMap[state] = resultIndex;
+    }
   }
 
-  auto ld = LoadNonVolatileNode::Create(
-      operands[0],
-      new_loadstates,
-      op.GetLoadedType(),
-      op.GetAlignment());
+  const auto loadResults =
+      LoadNonVolatileNode::Create(address, newInputStates, op.GetLoadedType(), op.GetAlignment());
 
-  results[0] = ld[0];
-  for (size_t n = 1, s = 1; n < results.size(); n++)
+  std::vector<rvsdg::output *> results(operands.size(), nullptr);
+  results[0] = loadResults[0];
+  for (size_t n = 1; n < operands.size(); n++)
   {
-    if (results[n] == nullptr)
-      results[n] = ld[s++];
+    auto state = operands[n];
+    JLM_ASSERT(stateIndexMap.find(state) != stateIndexMap.end());
+    results[n] = loadResults[stateIndexMap[state]];
   }
 
   return results;

--- a/jlm/llvm/ir/operators/Load.cpp
+++ b/jlm/llvm/ir/operators/Load.cpp
@@ -454,12 +454,7 @@ perform_multiple_origin_reduction(
     const LoadNonVolatileOperation & op,
     const std::vector<rvsdg::output *> & operands)
 {
-  if (operands.size() == 1)
-  {
-    // Nothing needs to be done as we do not have any states
-    return operands;
-  }
-
+  JLM_ASSERT(operands.size() > 1);
   const auto address = operands[0];
 
   std::vector<rvsdg::output *> newInputStates;

--- a/tests/jlm/llvm/ir/operators/LoadTests.cpp
+++ b/tests/jlm/llvm/ir/operators/LoadTests.cpp
@@ -46,7 +46,7 @@ JLM_UNIT_TEST_REGISTER(
     "jlm/llvm/ir/operators/LoadNonVolatileTests-OperationEquality",
     OperationEquality)
 
-static void
+static int
 TestCopy()
 {
   using namespace jlm::llvm;
@@ -74,9 +74,13 @@ TestCopy()
   auto copiedLoadNode = dynamic_cast<const LoadNonVolatileNode *>(copiedNode);
   assert(copiedLoadNode != nullptr);
   assert(loadNode->GetOperation() == copiedLoadNode->GetOperation());
+
+  return 0;
 }
 
-static void
+JLM_UNIT_TEST_REGISTER("jlm/llvm/ir/operators/LoadNonVolatileTests-Copy", TestCopy)
+
+static int
 TestLoadAllocaReduction()
 {
   using namespace jlm::llvm;
@@ -116,9 +120,15 @@ TestLoadAllocaReduction()
   assert(node->ninputs() == 3);
   assert(node->input(1)->origin() == alloca1[1]);
   assert(node->input(2)->origin() == mux[0]);
+
+  return 0;
 }
 
-static void
+JLM_UNIT_TEST_REGISTER(
+    "jlm/llvm/ir/operators/LoadNonVolatileTests-LoadAllocaReduction",
+    TestLoadAllocaReduction)
+
+static int
 TestMultipleOriginReduction()
 {
   using namespace jlm::llvm;
@@ -153,9 +163,15 @@ TestMultipleOriginReduction()
   auto node = jlm::rvsdg::output::GetNode(*ex.origin());
   assert(is<LoadNonVolatileOperation>(node));
   assert(node->ninputs() == 2);
+
+  return 0;
 }
 
-static void
+JLM_UNIT_TEST_REGISTER(
+    "jlm/llvm/ir/operators/LoadNonVolatileTests-MultipleOriginReduction",
+    TestMultipleOriginReduction)
+
+static int
 TestLoadStoreStateReduction()
 {
   using namespace jlm::llvm;
@@ -199,9 +215,15 @@ TestLoadStoreStateReduction()
   node = jlm::rvsdg::output::GetNode(*ex2.origin());
   assert(is<LoadNonVolatileOperation>(node));
   assert(node->ninputs() == 2);
+
+  return 0;
 }
 
-static void
+JLM_UNIT_TEST_REGISTER(
+    "jlm/llvm/ir/operators/LoadNonVolatileTests-LoadStoreStateReduction",
+    TestLoadStoreStateReduction)
+
+static int
 TestLoadStoreReduction()
 {
   using namespace jlm::llvm;
@@ -239,9 +261,15 @@ TestLoadStoreReduction()
   assert(graph.root()->nnodes() == 1);
   assert(x1.origin() == v);
   assert(x2.origin() == s1);
+
+  return 0;
 }
 
-static void
+JLM_UNIT_TEST_REGISTER(
+    "jlm/llvm/ir/operators/LoadNonVolatileTests-LoadStoreReduction",
+    TestLoadStoreReduction)
+
+static int
 TestLoadLoadReduction()
 {
   using namespace jlm::llvm;
@@ -298,23 +326,13 @@ TestLoadLoadReduction()
   assert(is<MemoryStateMergeOperation>(mx2) && mx2->ninputs() == 2);
   assert(mx2->input(0)->origin() == ld2[1] || mx2->input(0)->origin() == ld->output(3));
   assert(mx2->input(1)->origin() == ld2[1] || mx2->input(1)->origin() == ld->output(3));
-}
-
-static int
-TestLoad()
-{
-  TestCopy();
-
-  TestLoadAllocaReduction();
-  TestMultipleOriginReduction();
-  TestLoadStoreStateReduction();
-  TestLoadStoreReduction();
-  TestLoadLoadReduction();
 
   return 0;
 }
 
-JLM_UNIT_TEST_REGISTER("jlm/llvm/ir/operators/LoadNonVolatileTests", TestLoad)
+JLM_UNIT_TEST_REGISTER(
+    "jlm/llvm/ir/operators/LoadNonVolatileTests-LoadLoadReduction",
+    TestLoadLoadReduction)
 
 static int
 LoadVolatileOperationEquality()


### PR DESCRIPTION
This PR does the following:
1. Splits up all load tests into their own unit tests
2. Fixes the duplicate state normalization for load nodes