### PR TITLE
Make small fixes to scripts + update commit hashes of CIRCT and hls-test-suite

### DIFF
--- a/.github/actions/BuildCirct/action.yml
+++ b/.github/actions/BuildCirct/action.yml
@@ -30,8 +30,7 @@ runs:
       run: |
         ./scripts/build-circt.sh \
           --build-path ${{ github.workspace }}/build-circt \
-          --install-path ${{ github.workspace }}/build-circt/circt \
-          --llvm-lit-path ~/.local/bin/lit
+          --install-path ${{ github.workspace }}/build-circt/circt
       shell: bash
 
     - name: "Save CIRCT to the cache"

--- a/.github/actions/InstallPackages/action.yml
+++ b/.github/actions/InstallPackages/action.yml
@@ -72,7 +72,6 @@ runs:
       run: |
         sudo apt-get install llvm-${{inputs.llvm-version}}-dev
         pip install "lit~=${{inputs.llvm-version}}.0"
-        echo "$(python -m site --user-base)/bin" >> $GITHUB_PATH
       shell: bash
 
     - name: "Install clang package"

--- a/.github/actions/InstallPackages/action.yml
+++ b/.github/actions/InstallPackages/action.yml
@@ -72,6 +72,7 @@ runs:
       run: |
         sudo apt-get install llvm-${{inputs.llvm-version}}-dev
         pip install "lit~=${{inputs.llvm-version}}.0"
+        pip show lit
       shell: bash
 
     - name: "Install clang package"

--- a/.github/actions/InstallPackages/action.yml
+++ b/.github/actions/InstallPackages/action.yml
@@ -72,7 +72,7 @@ runs:
       run: |
         sudo apt-get install llvm-${{inputs.llvm-version}}-dev
         pip install "lit~=${{inputs.llvm-version}}.0"
-        pip show lit
+        echo "$(python -m site --user-base)/bin" >> $GITHUB_PATH
       shell: bash
 
     - name: "Install clang package"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Regionalized Value State Dependence Graph (RVSDG) as intermediate representation
 ## Dependencies
 * Clang/LLVM 18
 * Doxygen 1.9.1
+* `lit` 18
 
 ### HLS dependencies
 * MLIR 18
@@ -24,7 +25,7 @@ Regionalized Value State Dependence Graph (RVSDG) as intermediate representation
 make all
 ```
 
-This presumes that the reight version of llvm-config can be found in $PATH.
+This presumes that the right version of llvm-config can be found in $PATH.
 If that is not the case, you may need to explicitly configure it:
 
 ```

--- a/scripts/build-circt.sh
+++ b/scripts/build-circt.sh
@@ -68,7 +68,7 @@ while [[ "$#" -ge 1 ]] ; do
 	esac
 done
 
-if [ ! -z "$LLVM_LIT_PATH" ]; then
+if [ z "$LLVM_LIT_PATH" ]; then
   echo "error: --llvm-lit-path could not be found automatically" >&2
   exit 1
 fi

--- a/scripts/build-circt.sh
+++ b/scripts/build-circt.sh
@@ -68,7 +68,7 @@ while [[ "$#" -ge 1 ]] ; do
 	esac
 done
 
-if [ z "$LLVM_LIT_PATH" ]; then
+if [ -z "$LLVM_LIT_PATH" ]; then
   echo "error: --llvm-lit-path could not be found automatically" >&2
   exit 1
 fi

--- a/scripts/build-circt.sh
+++ b/scripts/build-circt.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 set -eu
 
-GIT_COMMIT=2dc8240d91a0f993d616b152aa4d7520156862fe
+GIT_REPOSITORY=https://github.com/EECS-NTNU/circt.git
+GIT_COMMIT=c3c436b321db83dfabc9065e552a5da2f4694faa
 
 # Get the absolute path to this script and set default build and install paths
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 JLM_ROOT_DIR="$(realpath "${SCRIPT_DIR}/..")"
 CIRCT_BUILD=${JLM_ROOT_DIR}/build-circt
 CIRCT_INSTALL=${JLM_ROOT_DIR}/usr
-LLVM_LIT_PATH=`which lit`
+LLVM_LIT_PATH=`command -v lit || true`
 
 LLVM_VERSION=18
 LLVM_CONFIG_BIN=llvm-config-${LLVM_VERSION}
@@ -60,12 +61,17 @@ while [[ "$#" -ge 1 ]] ; do
 			commit >&1
 			exit 0
 			;;
-		--help)
+		--help|*)
 			usage >&2
 			exit 1
 			;;
 	esac
 done
+
+if [ ! -z "$LLVM_LIT_PATH" ]; then
+  echo "error: --llvm-lit-path could not be found automatically" >&2
+  exit 1
+fi
 
 LLVM_BINDIR=$(${LLVM_CONFIG_BIN} --bindir)
 LLVM_CMAKEDIR=$(${LLVM_CONFIG_BIN} --cmakedir)
@@ -75,7 +81,7 @@ CIRCT_BUILD_DIR=${CIRCT_BUILD}/build
 
 if [ ! -d "$CIRCT_GIT_DIR" ] ;
 then
-	git clone https://github.com/EECS-NTNU/circt.git ${CIRCT_GIT_DIR}
+	git clone ${GIT_REPOSITORY} ${CIRCT_GIT_DIR}
 fi
 git -C ${CIRCT_GIT_DIR} checkout ${GIT_COMMIT}
 cmake -G Ninja \

--- a/scripts/build-mlir.sh
+++ b/scripts/build-mlir.sh
@@ -52,7 +52,7 @@ while [[ "$#" -ge 1 ]] ; do
 			commit >&1
 			exit 0
 			;;
-		--help)
+		--help|*)
 			usage >&2
 			exit 1
 			;;

--- a/scripts/run-hls-test.sh
+++ b/scripts/run-hls-test.sh
@@ -3,11 +3,11 @@ set -eu
 
 # URL to the benchmark git repository and the commit to be used
 GIT_REPOSITORY=https://github.com/phate/hls-test-suite.git
-GIT_COMMIT=99d309be2a9aa8d565c2ece493dc33a447ad166d
+GIT_COMMIT=c81fc559afa3cca66efc908b0a932d81f9c90d49
 
 # Get the absolute path to this script and set default JLM paths
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
-JLM_ROOT_DIR=${SCRIPT_DIR}/..
+JLM_ROOT_DIR="$(realpath "${SCRIPT_DIR}/..")"
 JLM_BIN_DIR=${JLM_ROOT_DIR}/build
 
 # Set default path for where the benchmark will be cloned and make target for running it
@@ -50,7 +50,7 @@ while [[ "$#" -ge 1 ]] ; do
 			commit >&2
 			exit 1
 			;;
-		--help)
+		--help|*)
 			usage >&2
 			exit 1
 			;;

--- a/scripts/run-llvm-test-suite.sh
+++ b/scripts/run-llvm-test-suite.sh
@@ -47,7 +47,7 @@ while [[ "$#" -ge 1 ]] ; do
 			commit >&2
 			exit 1
 			;;
-		--help)
+		--help|*)
 			usage >&2
 			exit 1
 			;;

--- a/scripts/run-polybench.sh
+++ b/scripts/run-polybench.sh
@@ -40,7 +40,7 @@ while [[ "$#" -ge 1 ]] ; do
 			commit >&2
 			exit 1
 			;;
-		--help)
+		--help|*)
 			usage >&2
 			exit 1
 			;;


### PR DESCRIPTION
The updated hashes give us a smaller CIRCT build, and cleaner output from the hls-test-suite, plus disables the problem test `test_memory_5`.

The other fixes include:
 - avoid crashing if `lit` is not found immediately (it can be supplied using the option instead)
 - avoid looping indefinitely when seeing unknown options
 - make the scripts a little more consistent