### PR TITLE
Add new normalization interface and convert load reductions to it

### DIFF
--- a/jlm/llvm/ir/operators/Load.cpp
+++ b/jlm/llvm/ir/operators/Load.cpp
@@ -670,6 +670,72 @@ load_normal_form::normalized_create(
   return simple_normal_form::normalized_create(region, op, operands);
 }
 
+std::optional<std::vector<rvsdg::output *>>
+NormalizeLoadMux(
+    const LoadNonVolatileOperation & operation,
+    const std::vector<rvsdg::output *> & operands)
+{
+  if (is_load_mux_reducible(operands))
+    return perform_load_mux_reduction(operation, operands);
+
+  return std::nullopt;
+}
+
+std::optional<std::vector<rvsdg::output *>>
+NormalizeLoadStore(
+    const LoadNonVolatileOperation & operation,
+    const std::vector<rvsdg::output *> & operands)
+{
+  if (is_load_store_reducible(operation, operands))
+    return perform_load_store_reduction(operation, operands);
+
+  return std::nullopt;
+}
+
+std::optional<std::vector<rvsdg::output *>>
+NormalizeLoadAlloca(
+    const LoadNonVolatileOperation & operation,
+    const std::vector<rvsdg::output *> & operands)
+{
+  if (is_load_alloca_reducible(operands))
+    return perform_load_alloca_reduction(operation, operands);
+
+  return std::nullopt;
+}
+
+std::optional<std::vector<rvsdg::output *>>
+NormalizeLoadStoreState(
+    const LoadNonVolatileOperation & operation,
+    const std::vector<rvsdg::output *> & operands)
+{
+  if (is_load_store_state_reducible(operation, operands))
+    return perform_load_store_state_reduction(operation, operands);
+
+  return std::nullopt;
+}
+
+std::optional<std::vector<rvsdg::output *>>
+NormalizeLoadDuplicateState(
+    const LoadNonVolatileOperation & operation,
+    const std::vector<rvsdg::output *> & operands)
+{
+  if (is_multiple_origin_reducible(operands))
+    return perform_multiple_origin_reduction(operation, operands);
+
+  return std::nullopt;
+}
+
+std::optional<std::vector<rvsdg::output *>>
+NormalizeLoadLoadState(
+    const LoadNonVolatileOperation & operation,
+    const std::vector<rvsdg::output *> & operands)
+{
+  if (is_load_load_state_reducible(operands))
+    return perform_load_load_state_reduction(operation, operands);
+
+  return std::nullopt;
+}
+
 }
 
 namespace

--- a/jlm/llvm/ir/operators/Load.hpp
+++ b/jlm/llvm/ir/operators/Load.hpp
@@ -12,6 +12,8 @@
 #include <jlm/rvsdg/simple-node.hpp>
 #include <jlm/rvsdg/simple-normal-form.hpp>
 
+#include <optional>
+
 namespace jlm::llvm
 {
 
@@ -574,6 +576,134 @@ public:
     return *(new LoadNonVolatileNode(region, loadOperation, operands));
   }
 };
+
+/**
+ * \brief Swaps a memory state merge operation and a load operation.
+ *
+ * sx1 = MemStateMerge si1 ... siM
+ * v sl1 = load_op a sx1
+ * =>
+ * v sl1 ... slM = load_op a si1 ... siM
+ * sx1 = MemStateMerge sl1 ... slM
+ *
+ * FIXME: The reduction can be generalized: A load node can have multiple operands from different
+ * merge nodes.
+ *
+ * @return If the normalization could be applied, then the results of the load operation after
+ * the transformation. Otherwise, std::nullopt.
+ */
+std::optional<std::vector<rvsdg::output *>>
+NormalizeLoadMux(
+    const LoadNonVolatileOperation & operation,
+    const std::vector<rvsdg::output *> & operands);
+
+/**
+ * \brief If the producer of a load's address is an alloca operation, then we can remove all
+ * state edges originating from other alloca operations.
+ *
+ * a1 s1 = alloca_op ...
+ * a2 s2 = alloca_op ...
+ * s3 = mux_op s1
+ * v sl1 sl2 sl3 = load_op a1 s1 s2 s3
+ * =>
+ * ...
+ * v sl1 sl3 = load_op a1 s1 s3
+ *
+ * @param operation The load operation on which the transformation is performed.
+ * @param operands The operands of the load node.
+ *
+ * @return If the normalization could be applied, then the results of the load operation after
+ * the transformation. Otherwise, std::nullopt.
+ */
+std::optional<std::vector<rvsdg::output *>>
+NormalizeLoadAlloca(
+    const LoadNonVolatileOperation & operation,
+    const std::vector<rvsdg::output *> & operands);
+
+/**
+ * \brief Forwards the value from a store operation.
+ *
+ * s2 = store_op a v1 s1
+ * v2 s3 = load_op a s2
+ * ... = any_op v2
+ * =>
+ * s2 = store_op a v1 s1
+ * ... = any_op v1
+ *
+ * @param operation The load operation on which the transformation is performed.
+ * @param operands The operands of the load node.
+ *
+ * @return If the normalization could be applied, then the results of the load operation after
+ * the transformation. Otherwise, std::nullopt.
+ */
+std::optional<std::vector<rvsdg::output *>>
+NormalizeLoadStore(
+    const LoadNonVolatileOperation & operation,
+    const std::vector<rvsdg::output *> & operands);
+
+/**
+ * \brief If the producer of a load's address is an alloca operation, then we can remove all
+ * state edges originating from other alloca operations coming through store operations.
+ *
+ * a1 sa1 = alloca_op ...
+ * a2 sa2 = alloca_op ...
+ * ss1 = store_op a1 ... sa1
+ * ss2 = store_op a2 ... sa2
+ * ... = load_op a1 ss1 ss2
+ * =>
+ * ...
+ * ... = load_op a1 ss1
+ *
+ * @param operation The load operation on which the transformation is performed.
+ * @param operands The operands of the load node.
+ *
+ * @return If the normalization could be applied, then the results of the load operation after
+ * the transformation. Otherwise, std::nullopt.
+ */
+std::optional<std::vector<rvsdg::output *>>
+NormalizeLoadStoreState(
+    const LoadNonVolatileOperation & operation,
+    const std::vector<rvsdg::output *> & operands);
+
+/**
+ * \brief Remove duplicated state operands
+ *
+ * v so1 so2 so3 = load_op a si1 si1 si1
+ * =>
+ * v so1 = load_op a si1
+ *
+ * @param operation The load operation on which the transformation is performed.
+ * @param operands The operands of the load node.
+ *
+ * @return If the normalization could be applied, then the results of the load operation after
+ * the transformation. Otherwise, std::nullopt.
+ */
+std::optional<std::vector<rvsdg::output *>>
+NormalizeLoadDuplicateState(
+    const LoadNonVolatileOperation & operation,
+    const std::vector<rvsdg::output *> & operands);
+
+/**
+ * \brief Avoid sequentialization of load operations.
+ *
+ * _ so1 = load_op _ si1
+ * _ so2 = load_op _ so1
+ * _ so3 = load_op _ so2
+ * =>
+ * _ so1 = load_op _ si1
+ * _ so2 = load_op _ si1
+ * _ so3 = load_op _ si1
+ *
+ * @param operation The load operation on which the transformation is performed.
+ * @param operands The operands of the load node.
+ *
+ * @return If the normalization could be applied, then the results of the load operation after
+ * the transformation. Otherwise, std::nullopt.
+ */
+std::optional<std::vector<rvsdg::output *>>
+NormalizeLoadLoadState(
+    const LoadNonVolatileOperation & operation,
+    const std::vector<rvsdg::output *> & operands);
 
 }
 

--- a/jlm/rvsdg/Makefile.sub
+++ b/jlm/rvsdg/Makefile.sub
@@ -61,6 +61,7 @@ librvsdg_HEADERS = \
 	jlm/rvsdg/bitstring.hpp \
 	jlm/rvsdg/node.hpp \
 	jlm/rvsdg/node-normal-form.hpp \
+	jlm/rvsdg/NodeNormalization.hpp \
 	jlm/rvsdg/nullary.hpp \
 	jlm/rvsdg/structural-node.hpp \
 	jlm/rvsdg/control.hpp \

--- a/jlm/rvsdg/NodeNormalization.hpp
+++ b/jlm/rvsdg/NodeNormalization.hpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#ifndef JLM_RVSDG_NODENORMALIZATION_HPP
+#define JLM_RVSDG_NODENORMALIZATION_HPP
+
+#include <jlm/rvsdg/node.hpp>
+#include <jlm/rvsdg/region.hpp>
+#include <jlm/util/common.hpp>
+
+#include <functional>
+#include <optional>
+#include <vector>
+
+namespace jlm::rvsdg
+{
+
+class output;
+
+template<class TOperation>
+using NodeNormalization = std::function<
+    std::optional<std::vector<output *>>(const TOperation &, const std::vector<output *> &)>;
+
+template<class TOperation>
+std::optional<std::vector<output *>>
+NormalizeSequence(
+    const std::vector<NodeNormalization<TOperation>> & nodeNormalizations,
+    const TOperation & operation,
+    const std::vector<output *> & operands)
+{
+  for (auto & nodeNormalization : nodeNormalizations)
+  {
+    if (auto results = nodeNormalization(operation, operands))
+    {
+      return results;
+    }
+  }
+
+  return std::nullopt;
+}
+
+template<class TOperation>
+bool
+ReduceNode(const NodeNormalization<TOperation> & nodeNormalization, Node & node)
+{
+  auto operation = util::AssertedCast<const TOperation>(&node.GetOperation());
+  auto operands = rvsdg::operands(&node);
+
+  if (auto results = nodeNormalization(*operation, operands))
+  {
+    divert_users(&node, *results);
+    remove(&node);
+    return true;
+  }
+
+  return false;
+}
+
+}
+
+#endif


### PR DESCRIPTION
This PR is the first in a series of PRs to remove the old node normalization interface that is intertwined in the RVSDG library. This PR does the following:

1. Adds a new and simple node normalization interface for optimizing the operands of a node. This enables to create individual instances of normalizations and therefore pass them around, and/or configure optimization by simply providing these instances instead of utilizing the flags of the old interface.
2. Converts the load reductions to this new interface
3. Utilizes these new reductions in load tests

