### PR TITLE
Fetch hls-test repo if already cloned

### DIFF
--- a/scripts/run-hls-test.sh
+++ b/scripts/run-hls-test.sh
@@ -68,6 +68,8 @@ fi
 if [ ! -d "$BENCHMARK_DIR" ] ;
 then
 	git clone ${GIT_REPOSITORY} ${BENCHMARK_DIR}
+else
+	git -C ${BENCHMARK_DIR} fetch origin
 fi
 
 export PATH=${JLM_BIN_DIR}:${PATH}


### PR DESCRIPTION
If the git repository already existed, then updates of the run-hls-test.sh script could cause the git hash to not exist as the repo never got updated.