### PR TITLE
Add clang-tidy support to CI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,8 @@
+---
+Checks: '-*,
+  modernize-deprecated-headers,
+  '
+
+WarningsAsErrors: '
+  modernize-deprecated-headers,
+  '

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,5 +4,5 @@ Checks: '-*,
   '
 
 WarningsAsErrors: '
-  modernize-deprecated-headers,
+#  modernize-deprecated-headers,
   '

--- a/.github/actions/InstallPackages/action.yml
+++ b/.github/actions/InstallPackages/action.yml
@@ -27,6 +27,11 @@ inputs:
     default: "false"
     required: false
 
+  install-clang-tidy:
+    description: "Install clang-tidy package. Default is 'false'."
+    default: "false"
+    required: false
+
   install-ninja:
     description: "Install ninja package. Default is 'false'."
     default: "false"
@@ -93,6 +98,11 @@ runs:
     - name: "Install clang-format package"
       if: ${{inputs.install-clang-format == 'true'}}
       run: sudo apt-get install clang-format-${{inputs.llvm-version}}
+      shell: bash
+
+    - name: "Install clang-tidy package"
+      if: ${{inputs.install-clang-tidy == 'true'}}
+      run: sudo apt-get install clang-tidy-${{inputs.llvm-version}}
       shell: bash
 
     - name: "Install ninja package"

--- a/.github/actions/InstallPackages/action.yml
+++ b/.github/actions/InstallPackages/action.yml
@@ -59,7 +59,8 @@ runs:
       if: ${{inputs.install-llvm == 'true'
         || inputs.install-clang == 'true'
         || inputs.install-mlir == 'true'
-        || inputs.install-clang-format == 'true'}}
+        || inputs.install-clang-format == 'true'
+        || inputs.install-clang-tidy == 'true'}}
       run: |
         export HAS_LLVM_REPOSITORY=$(find /etc/apt/ -name *.list | xargs cat | grep llvm-toolchain-jammy-${{inputs.llvm-version}})
         if [[ -z $HAS_LLVM_REPOSITORY ]]; then

--- a/.github/workflows/ClangTidy.yml
+++ b/.github/workflows/ClangTidy.yml
@@ -26,7 +26,7 @@ jobs:
         uses: ./.github/actions/BuildMlirDialect
 
       - name: "Configure jlm with HLS and MLIR enabled"
-        run: ./configure.sh --enable-mlir --enable-hls
+        run: ./configure.sh --enable-mlir=${{ github.workspace }}/lib/mlir-rvsdg --enable-hls=${{ github.workspace }}/build-circt/circt
 
       - name: "Run clang tidy"
         run: make tidy

--- a/.github/workflows/ClangTidy.yml
+++ b/.github/workflows/ClangTidy.yml
@@ -25,5 +25,8 @@ jobs:
       - name: "Install MLIR dialect dependencies"
         uses: ./.github/actions/BuildMlirDialect
 
+      - name: "Configure jlm with HLS and MLIR enabled"
+        run: ./configure.sh --enable-mlir --enable-hls
+
       - name: "Run clang tidy"
         run: make tidy

--- a/.github/workflows/ClangTidy.yml
+++ b/.github/workflows/ClangTidy.yml
@@ -1,0 +1,24 @@
+name: ClangTidy
+
+on:
+  pull_request:
+    branches: [ master ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  CheckTidy:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Install clang tidy"
+        uses: ./.github/actions/InstallPackages
+        with:
+          install-llvm: true # Needed to configure jlm
+          install-clang-tidy: true
+      - name: "Configure jlm with HLS and MLIR enabled"
+        run: ./configure.sh --enable-mlir --enable-hls
+      - name: "Run clang tidy"
+        run: make tidy

--- a/.github/workflows/ClangTidy.yml
+++ b/.github/workflows/ClangTidy.yml
@@ -13,9 +13,16 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+
+      - name: "Install clang tidy"
+        uses: ./.github/actions/InstallPackages
+        with:
+          install-clang-tidy: true
+
       # We need to build jlm to create jlm/tooling/CommandPaths.hpp. If that file is not present,
       # then clang-tidy will produce an error.
       - name: "Build jlm"
         uses: ./.github/actions/BuildJlm
+
       - name: "Run clang tidy"
         run: make tidy

--- a/.github/workflows/ClangTidy.yml
+++ b/.github/workflows/ClangTidy.yml
@@ -13,20 +13,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-
-      - name: "Install clang tidy"
-        uses: ./.github/actions/InstallPackages
-        with:
-          install-clang-tidy: true
-
-      - name: "Install HLS dialect dependencies"
-        uses: ./.github/actions/BuildCirct
-
-      - name: "Install MLIR dialect dependencies"
-        uses: ./.github/actions/BuildMlirDialect
-
-      - name: "Configure jlm with HLS and MLIR enabled"
-        run: ./configure.sh --enable-mlir=${{ github.workspace }}/lib/mlir-rvsdg --enable-hls=${{ github.workspace }}/build-circt/circt
-
+      # We need to build jlm to create jlm/tooling/CommandPaths.hpp. If that file is not present,
+      # then clang-tidy will produce an error.
+      - name: "Build jlm"
+        uses: ./.github/actions/BuildJlm
       - name: "Run clang tidy"
         run: make tidy

--- a/.github/workflows/ClangTidy.yml
+++ b/.github/workflows/ClangTidy.yml
@@ -19,10 +19,11 @@ jobs:
         with:
           install-clang-tidy: true
 
-      # We need to build jlm to create jlm/tooling/CommandPaths.hpp. If that file is not present,
-      # then clang-tidy will produce an error.
-      - name: "Build jlm"
-        uses: ./.github/actions/BuildJlm
+      - name: "Install HLS dialect dependencies"
+        uses: ./.github/actions/BuildCirct
+
+      - name: "Install MLIR dialect dependencies"
+        uses: ./.github/actions/BuildMlirDialect
 
       - name: "Run clang tidy"
         run: make tidy

--- a/.github/workflows/ClangTidy.yml
+++ b/.github/workflows/ClangTidy.yml
@@ -20,11 +20,9 @@ jobs:
           install-clang-tidy: true
 
       - name: "Install HLS dialect dependencies"
-        if: ${{inputs.enable-hls == 'true'}}
         uses: ./.github/actions/BuildCirct
 
       - name: "Install MLIR dialect dependencies"
-        if: ${{inputs.enable-mlir == 'true'}}
         uses: ./.github/actions/BuildMlirDialect
 
       - name: "Configure jlm with HLS and MLIR enabled"

--- a/.github/workflows/ClangTidy.yml
+++ b/.github/workflows/ClangTidy.yml
@@ -13,13 +13,22 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+
       - name: "Install clang tidy"
         uses: ./.github/actions/InstallPackages
         with:
-          install-llvm: true # Needed to configure jlm
-          install-mlir: true # Needed for MLIR headers
           install-clang-tidy: true
+
+      - name: "Install HLS dialect dependencies"
+        if: ${{inputs.enable-hls == 'true'}}
+        uses: ./.github/actions/BuildCirct
+
+      - name: "Install MLIR dialect dependencies"
+        if: ${{inputs.enable-mlir == 'true'}}
+        uses: ./.github/actions/BuildMlirDialect
+
       - name: "Configure jlm with HLS and MLIR enabled"
         run: ./configure.sh --enable-mlir --enable-hls
+
       - name: "Run clang tidy"
         run: make tidy

--- a/.github/workflows/ClangTidy.yml
+++ b/.github/workflows/ClangTidy.yml
@@ -17,6 +17,7 @@ jobs:
         uses: ./.github/actions/InstallPackages
         with:
           install-llvm: true # Needed to configure jlm
+          install-mlir: true # Needed for MLIR headers
           install-clang-tidy: true
       - name: "Configure jlm with HLS and MLIR enabled"
         run: ./configure.sh --enable-mlir --enable-hls

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -188,4 +188,4 @@ format-dry-run:
 # Clang tidy rules
 
 tidy:
-	clang-tidy --config-file=.clang-tidy /home/reissman/Documents/jlm/jlm/rvsdg/bitstring/concat.cpp -- $(CXXFLAGS) $(CPPFLAGS)
+	clang-tidy-$(LLVM_VERSION) --config-file=.clang-tidy $(HEADERS) -- $(CXXFLAGS) $(CPPFLAGS)

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -188,4 +188,4 @@ format-dry-run:
 # Clang tidy rules
 
 tidy:
-	clang-tidy --config-file=.clang-tidy $(SOURCES) $(HEADERS) -- $(CXXFLAGS) $(CPPFLAGS)
+	clang-tidy --config-file=.clang-tidy /home/reissman/Documents/jlm/jlm/rvsdg/bitstring/concat.cpp -- $(CXXFLAGS) $(CPPFLAGS)

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -183,3 +183,9 @@ format:
 
 format-dry-run:
 	clang-format-$(LLVM_VERSION) --dry-run --Werror --style="file:.clang-format" --verbose -i $(SOURCES) $(HEADERS)
+
+#################################################################################
+# Clang tidy rules
+
+tidy:
+	clang-tidy --config-file=.clang-tidy $(SOURCES) $(HEADERS) -- $(CXXFLAGS) $(CPPFLAGS)

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -187,5 +187,5 @@ format-dry-run:
 #################################################################################
 # Clang tidy rules
 
-tidy:
-	clang-tidy-$(LLVM_VERSION) --config-file=.clang-tidy $(HEADERS) $(SOURCES) -- $(CXXFLAGS) $(CPPFLAGS)
+tidy: $(COMMANDPATHSFILE)
+	clang-tidy-$(LLVM_VERSION) --config-file=.clang-tidy $(HEADERS) $(SOURCES) -- $(CXXFLAGS) $(CPPFLAGS) -I$(BUILD_OUT_PREFIX)

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -188,4 +188,4 @@ format-dry-run:
 # Clang tidy rules
 
 tidy:
-	clang-tidy-$(LLVM_VERSION) --config-file=.clang-tidy $(HEADERS) -- $(CXXFLAGS) $(CPPFLAGS)
+	clang-tidy-$(LLVM_VERSION) --config-file=.clang-tidy $(HEADERS) $(SOURCES) -- $(CXXFLAGS) $(CPPFLAGS)

--- a/jlm/llvm/backend/jlm2llvm/instruction.hpp
+++ b/jlm/llvm/backend/jlm2llvm/instruction.hpp
@@ -6,6 +6,8 @@
 #ifndef JLM_LLVM_BACKEND_JLM2LLVM_INSTRUCTION_HPP
 #define JLM_LLVM_BACKEND_JLM2LLVM_INSTRUCTION_HPP
 
+#include <jlm/llvm/ir/tac.hpp>
+
 namespace llvm
 {
 
@@ -16,6 +18,7 @@ class Constant;
 namespace jlm::llvm
 {
 
+class cfg_node;
 class tac;
 
 namespace jlm2llvm

--- a/jlm/llvm/frontend/LlvmInstructionConversion.hpp
+++ b/jlm/llvm/frontend/LlvmInstructionConversion.hpp
@@ -6,6 +6,8 @@
 #ifndef JLM_LLVM_FRONTEND_LLVMINSTRUCTIONCONVERSION_HPP
 #define JLM_LLVM_FRONTEND_LLVMINSTRUCTIONCONVERSION_HPP
 
+#include <jlm/llvm/ir/tac.hpp>
+
 namespace llvm
 {
 class Constant;

--- a/jlm/llvm/opt/InvariantValueRedirection.hpp
+++ b/jlm/llvm/opt/InvariantValueRedirection.hpp
@@ -11,12 +11,16 @@
 namespace jlm::rvsdg
 {
 class GammaNode;
+class Graph;
+class Region;
+class StructuralNode;
 class ThetaNode;
 }
 
 namespace jlm::llvm
 {
 
+class CallNode;
 class RvsdgModule;
 
 /** \brief Invariant Value Redirection Optimization

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp
@@ -7,6 +7,18 @@
 #define JLM_LLVM_OPT_ALIAS_ANALYSES_MEMORYSTATEENCODER_HPP
 
 #include <memory>
+#include <vector>
+
+namespace rvsdg
+{
+class GammaNode;
+class output;
+class Region;
+class simple_node;
+class StructuralNode;
+class ThetaNode;
+class ThetaOutput;
+}
 
 namespace jlm::util
 {

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
@@ -7,17 +7,44 @@
 #define JLM_LLVM_OPT_ALIAS_ANALYSES_STEENSGAARD_HPP
 
 #include <jlm/llvm/opt/alias-analyses/AliasAnalysis.hpp>
+#include <jlm/llvm/opt/alias-analyses/PointsToGraph.hpp>
 #include <jlm/util/disjointset.hpp>
 
 namespace jlm::rvsdg
 {
 class GammaNode;
+class Graph;
+class output;
+class Region;
+class simple_node;
+class StructuralNode;
 class ThetaNode;
 }
 
-namespace jlm::llvm::aa
+namespace jlm::llvm
 {
 
+namespace delta
+{
+class node;
+}
+
+namespace lambda
+{
+class node;
+}
+
+namespace phi
+{
+class node;
+}
+
+class CallNode;
+class LoadNode;
+class StoreNode;
+
+namespace aa
+{
 class Location;
 class RegisterLocation;
 
@@ -244,6 +271,7 @@ private:
   std::unique_ptr<Context> Context_;
 };
 
+}
 }
 
 #endif

--- a/jlm/llvm/opt/unroll.hpp
+++ b/jlm/llvm/opt/unroll.hpp
@@ -78,8 +78,7 @@ public:
   theta() const noexcept
   {
     auto node = idv()->region()->node();
-    JLM_ASSERT(is<rvsdg::ThetaOperation>(node));
-    return static_cast<rvsdg::ThetaNode *>(node);
+    return util::AssertedCast<rvsdg::ThetaNode>(node);
   }
 
   inline bool

--- a/jlm/util/AnnotationMap.hpp
+++ b/jlm/util/AnnotationMap.hpp
@@ -13,6 +13,7 @@
 #include <string_view>
 #include <unordered_map>
 #include <variant>
+#include <vector>
 
 namespace jlm::util
 {

--- a/jlm/util/intrusive-hash.hpp
+++ b/jlm/util/intrusive-hash.hpp
@@ -9,6 +9,7 @@
 
 #include <functional>
 #include <memory>
+#include <string>
 #include <utility>
 #include <vector>
 


### PR DESCRIPTION
This PR adds support for clang-tidy to the CI. It does not enforce any checks yet, but only adds the necessary infrastructure and fixes the problems in the code such that clang-tidy finishes without errors. Relevant checks will be added in future PRs.

Close #313 