### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ Makefile.custom
 .idea
 docs/html
 build
-build-*
+build-*/
 usr


### PR DESCRIPTION
build-* will tell git to ignore folders and filenames prefixed with build- when committing. However, this would cause the changes to scripts/build-circt.sh and build-mlir.sh to also be ignored.

So, it seems like build-*/ is working as expected.