### PR TITLE
Add andersen top down lifetime aware optimization to jlm-opt

### DIFF
--- a/jlm/llvm/opt/alias-analyses/EliminatedMemoryNodeProvider.hpp
+++ b/jlm/llvm/opt/alias-analyses/EliminatedMemoryNodeProvider.hpp
@@ -59,6 +59,16 @@ public:
     return Eliminator_.EliminateMemoryNodes(rvsdgModule, *seedProvisioning, statisticsCollector);
   }
 
+  static std::unique_ptr<MemoryNodeProvisioning>
+  Create(
+      const RvsdgModule & rvsdgModule,
+      const PointsToGraph & pointsToGraph,
+      util::StatisticsCollector & statisticsCollector)
+  {
+    EliminatedMemoryNodeProvider provider{};
+    return provider.ProvisionMemoryNodes(rvsdgModule, pointsToGraph, statisticsCollector);
+  }
+
 private:
   Provider Provider_;
   Eliminator Eliminator_;

--- a/jlm/llvm/opt/alias-analyses/Optimization.cpp
+++ b/jlm/llvm/opt/alias-analyses/Optimization.cpp
@@ -4,9 +4,9 @@
  * See COPYING for terms of redistribution.
  */
 
-#include "jlm/llvm/opt/alias-analyses/EliminatedMemoryNodeProvider.hpp"
 #include <jlm/llvm/opt/alias-analyses/AgnosticMemoryNodeProvider.hpp>
 #include <jlm/llvm/opt/alias-analyses/Andersen.hpp>
+#include <jlm/llvm/opt/alias-analyses/EliminatedMemoryNodeProvider.hpp>
 #include <jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp>
 #include <jlm/llvm/opt/alias-analyses/Optimization.hpp>
 #include <jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.hpp>

--- a/jlm/llvm/opt/alias-analyses/Optimization.cpp
+++ b/jlm/llvm/opt/alias-analyses/Optimization.cpp
@@ -4,12 +4,14 @@
  * See COPYING for terms of redistribution.
  */
 
+#include "jlm/llvm/opt/alias-analyses/EliminatedMemoryNodeProvider.hpp"
 #include <jlm/llvm/opt/alias-analyses/AgnosticMemoryNodeProvider.hpp>
 #include <jlm/llvm/opt/alias-analyses/Andersen.hpp>
 #include <jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp>
 #include <jlm/llvm/opt/alias-analyses/Optimization.hpp>
 #include <jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.hpp>
 #include <jlm/llvm/opt/alias-analyses/Steensgaard.hpp>
+#include <jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.hpp>
 
 namespace jlm::llvm::aa
 {
@@ -38,5 +40,8 @@ template class AliasAnalysisStateEncoder<Steensgaard, AgnosticMemoryNodeProvider
 template class AliasAnalysisStateEncoder<Steensgaard, RegionAwareMemoryNodeProvider>;
 template class AliasAnalysisStateEncoder<Andersen, AgnosticMemoryNodeProvider>;
 template class AliasAnalysisStateEncoder<Andersen, RegionAwareMemoryNodeProvider>;
+template class AliasAnalysisStateEncoder<
+    Andersen,
+    EliminatedMemoryNodeProvider<AgnosticMemoryNodeProvider, TopDownMemoryNodeEliminator>>;
 
 }

--- a/jlm/tooling/Command.cpp
+++ b/jlm/tooling/Command.cpp
@@ -12,9 +12,11 @@
 #include <jlm/llvm/ir/RvsdgModule.hpp>
 #include <jlm/llvm/opt/alias-analyses/AgnosticMemoryNodeProvider.hpp>
 #include <jlm/llvm/opt/alias-analyses/Andersen.hpp>
+#include <jlm/llvm/opt/alias-analyses/EliminatedMemoryNodeProvider.hpp>
 #include <jlm/llvm/opt/alias-analyses/Optimization.hpp>
 #include <jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.hpp>
 #include <jlm/llvm/opt/alias-analyses/Steensgaard.hpp>
+#include <jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.hpp>
 #include <jlm/llvm/opt/cne.hpp>
 #include <jlm/llvm/opt/DeadNodeElimination.hpp>
 #include <jlm/llvm/opt/inlining.hpp>
@@ -382,6 +384,8 @@ JlmOptCommand::CreateOptimization(
   using Steensgaard = llvm::aa::Steensgaard;
   using AgnosticMnp = llvm::aa::AgnosticMemoryNodeProvider;
   using RegionAwareMnp = llvm::aa::RegionAwareMemoryNodeProvider;
+  using TopDownLifetimeMnp =
+      llvm::aa::EliminatedMemoryNodeProvider<AgnosticMnp, llvm::aa::TopDownMemoryNodeEliminator>;
 
   switch (optimizationId)
   {
@@ -389,6 +393,8 @@ JlmOptCommand::CreateOptimization(
     return std::make_unique<llvm::aa::AliasAnalysisStateEncoder<Andersen, AgnosticMnp>>();
   case JlmOptCommandLineOptions::OptimizationId::AAAndersenRegionAware:
     return std::make_unique<llvm::aa::AliasAnalysisStateEncoder<Andersen, RegionAwareMnp>>();
+  case JlmOptCommandLineOptions::OptimizationId::AAAndersenTopDownLifetimeAware:
+    return std::make_unique<llvm::aa::AliasAnalysisStateEncoder<Andersen, TopDownLifetimeMnp>>();
   case JlmOptCommandLineOptions::OptimizationId::AASteensgaardAgnostic:
     return std::make_unique<llvm::aa::AliasAnalysisStateEncoder<Steensgaard, AgnosticMnp>>();
   case JlmOptCommandLineOptions::OptimizationId::AASteensgaardRegionAware:

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -108,6 +108,8 @@ JlmOptCommandLineOptions::FromCommandLineArgumentToOptimizationId(
           OptimizationId::AAAndersenAgnostic },
         { OptimizationCommandLineArgument::AaAndersenRegionAware_,
           OptimizationId::AAAndersenRegionAware },
+        { OptimizationCommandLineArgument::AaAndersenTopDownLifetimeAware_,
+          OptimizationId::AAAndersenTopDownLifetimeAware },
         { OptimizationCommandLineArgument::AaSteensgaardAgnostic_,
           OptimizationId::AASteensgaardAgnostic },
         { OptimizationCommandLineArgument::AaSteensgaardRegionAware_,
@@ -141,6 +143,8 @@ JlmOptCommandLineOptions::ToCommandLineArgument(OptimizationId optimizationId)
           OptimizationCommandLineArgument::AaAndersenAgnostic_ },
         { OptimizationId::AAAndersenRegionAware,
           OptimizationCommandLineArgument::AaAndersenRegionAware_ },
+        { OptimizationId::AAAndersenTopDownLifetimeAware,
+          OptimizationCommandLineArgument::AaAndersenTopDownLifetimeAware_ },
         { OptimizationId::AASteensgaardAgnostic,
           OptimizationCommandLineArgument::AaSteensgaardAgnostic_ },
         { OptimizationId::AASteensgaardRegionAware,
@@ -806,6 +810,8 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, const char * const 
 
   auto aAAndersenAgnostic = JlmOptCommandLineOptions::OptimizationId::AAAndersenAgnostic;
   auto aAAndersenRegionAware = JlmOptCommandLineOptions::OptimizationId::AAAndersenRegionAware;
+  auto aAAndersenTopDownLifetimeAware =
+      JlmOptCommandLineOptions::OptimizationId::AAAndersenTopDownLifetimeAware;
   auto aASteensgaardAgnostic = JlmOptCommandLineOptions::OptimizationId::AASteensgaardAgnostic;
   auto aASteensgaardRegionAware =
       JlmOptCommandLineOptions::OptimizationId::AASteensgaardRegionAware;
@@ -831,6 +837,10 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, const char * const 
               aAAndersenRegionAware,
               JlmOptCommandLineOptions::ToCommandLineArgument(aAAndersenRegionAware),
               "Andersen alias analysis with region-aware memory state encoding"),
+          ::clEnumValN(
+              aAAndersenTopDownLifetimeAware,
+              JlmOptCommandLineOptions::ToCommandLineArgument(aAAndersenTopDownLifetimeAware),
+              "Andersen alias analysis with top-down lifetime-aware memory node elimination"),
           ::clEnumValN(
               aASteensgaardAgnostic,
               JlmOptCommandLineOptions::ToCommandLineArgument(aASteensgaardAgnostic),

--- a/jlm/tooling/CommandLine.hpp
+++ b/jlm/tooling/CommandLine.hpp
@@ -68,6 +68,7 @@ public:
 
     AAAndersenAgnostic,
     AAAndersenRegionAware,
+    AAAndersenTopDownLifetimeAware,
     AASteensgaardAgnostic,
     AASteensgaardRegionAware,
     CommonNodeElimination,
@@ -197,6 +198,7 @@ private:
   {
     inline static const char * AaAndersenAgnostic_ = "AAAndersenAgnostic";
     inline static const char * AaAndersenRegionAware_ = "AAAndersenRegionAware";
+    inline static const char * AaAndersenTopDownLifetimeAware_ = "AAAndersenTopDownLifetimeAware";
     inline static const char * AaSteensgaardAgnostic_ = "AASteensgaardAgnostic";
     inline static const char * AaSteensgaardRegionAware_ = "AASteensgaardRegionAware";
     inline static const char * CommonNodeElimination_ = "CommonNodeElimination";


### PR DESCRIPTION
This PR adds the `AAAndersenTopDownLifetimeAware` optimization. It builds on the existing `Andersen` alias analysis in combination with the `TopDownMemoryNodeEliminator`.