### PR TITLE
SimpleNode: convenience builder functions

### DIFF
--- a/jlm/rvsdg/simple-node.cpp
+++ b/jlm/rvsdg/simple-node.cpp
@@ -67,6 +67,32 @@ SimpleNode::SimpleNode(
   on_node_create(this);
 }
 
+SimpleNode::SimpleNode(
+    rvsdg::Region & region,
+    std::unique_ptr<SimpleOperation> operation,
+    const std::vector<jlm::rvsdg::output *> & operands)
+    : Node(std::move(operation), &region)
+{
+  if (SimpleNode::GetOperation().narguments() != operands.size())
+    throw jlm::util::error(jlm::util::strfmt(
+        "Argument error - expected ",
+        SimpleNode::GetOperation().narguments(),
+        ", received ",
+        operands.size(),
+        " arguments."));
+
+  for (size_t n = 0; n < SimpleNode::GetOperation().narguments(); n++)
+  {
+    add_input(
+        std::make_unique<simple_input>(this, operands[n], SimpleNode::GetOperation().argument(n)));
+  }
+
+  for (size_t n = 0; n < SimpleNode::GetOperation().nresults(); n++)
+    add_output(std::make_unique<simple_output>(this, SimpleNode::GetOperation().result(n)));
+
+  on_node_create(this);
+}
+
 const SimpleOperation &
 SimpleNode::GetOperation() const noexcept
 {


### PR DESCRIPTION
Add constructor as well as helper function to create simple and its operator in a single call. Allow to move the created operator in (instead of copying it).