### PR TITLE
Ignore UndefValueOperation returning MemoryStateType in llvm backend.

### DIFF
--- a/jlm/llvm/Makefile.sub
+++ b/jlm/llvm/Makefile.sub
@@ -153,6 +153,7 @@ libllvm_TESTS += \
     tests/jlm/llvm/backend/llvm/jlm-llvm/TestAttributeConversion \
     tests/jlm/llvm/backend/llvm/jlm-llvm/test-bitconstant \
     tests/jlm/llvm/backend/llvm/jlm-llvm/test-function-calls \
+    tests/jlm/llvm/backend/llvm/jlm-llvm/test-ignore-memory-state \
     tests/jlm/llvm/backend/llvm/jlm-llvm/test-select-with-state \
     tests/jlm/llvm/backend/llvm/jlm-llvm/test-type-conversion \
     tests/jlm/llvm/frontend/llvm/LlvmTypeConversionTests  \

--- a/jlm/llvm/backend/jlm2llvm/instruction.cpp
+++ b/jlm/llvm/backend/jlm2llvm/instruction.cpp
@@ -162,7 +162,14 @@ convert_undef(
     context & ctx)
 {
   JLM_ASSERT(is<UndefValueOperation>(op));
-  return ::llvm::UndefValue::get(convert_type(*op.result(0), ctx));
+
+  auto & resultType = *op.result(0);
+
+  // MemoryState has no llvm representation.
+  if (is<MemoryStateType>(resultType))
+    return nullptr;
+
+  return ::llvm::UndefValue::get(convert_type(resultType, ctx));
 }
 
 static ::llvm::Value *

--- a/tests/jlm/llvm/backend/llvm/jlm-llvm/test-ignore-memory-state.cpp
+++ b/tests/jlm/llvm/backend/llvm/jlm-llvm/test-ignore-memory-state.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 Felix Reißmann <felix.rm.153@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include "test-registry.hpp"
+#include "test-types.hpp"
+
+#include <jlm/llvm/backend/jlm2llvm/jlm2llvm.hpp>
+#include <jlm/llvm/ir/ipgraph-module.hpp>
+#include <jlm/llvm/ir/operators.hpp>
+#include <jlm/llvm/ir/print.hpp>
+
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
+
+static int
+test()
+{
+  using namespace jlm::rvsdg;
+  using namespace jlm::llvm;
+
+  auto mt = MemoryStateType::Create();
+  ipgraph_module m(jlm::util::filepath(""), "", "");
+
+  std::unique_ptr<jlm::llvm::cfg> cfg(new jlm::llvm::cfg(m));
+  auto bb = basic_block::create(*cfg);
+  cfg->exit()->divert_inedges(bb);
+  bb->add_outedge(cfg->exit());
+
+  bb->append_last(UndefValueOperation::Create(mt, "s1"));
+  auto s1 = bb->last()->result(0);
+
+  cfg->exit()->append_result(s1);
+
+  auto ft = FunctionType::Create({}, { mt });
+  auto f = function_node::create(m.ipgraph(), "f", ft, linkage::external_linkage);
+  f->add_cfg(std::move(cfg));
+
+  llvm::LLVMContext ctx;
+  jlm2llvm::convert(m, ctx);
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER("jlm/llvm/backend/llvm/jlm-llvm/test-ignore-memory-state", test)


### PR DESCRIPTION
This PR fixes the compiler crash mentioned in #703 by skipping over `UndefValueOperation`s with a return type of `MemoryStateType` in the `jlm2llvm` backend. These operations are generated during `MemoryStateEncoder::EncodeCallEntry` after using the lifetime aware optimization added in #703.