### PR TITLE
Distinguish between "function" and "pointer" types

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/add-prints.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-prints.cpp
@@ -63,7 +63,7 @@ convert_prints(llvm::RvsdgModule & rm)
   auto fct =
       llvm::FunctionType::Create({ rvsdg::bittype::Create(64), rvsdg::bittype::Create(64) }, {});
   auto & printf =
-      llvm::GraphImport::Create(graph, fct, "printnode", llvm::linkage::external_linkage);
+      llvm::GraphImport::Create(graph, fct, fct, "printnode", llvm::linkage::external_linkage);
   convert_prints(root, &printf, fct);
 }
 

--- a/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
@@ -92,6 +92,7 @@ instrument_ref(llvm::RvsdgModule & rm)
   auto & reference_load = llvm::GraphImport::Create(
       graph,
       loadFunctionType,
+      loadFunctionType,
       "reference_load",
       llvm::linkage::external_linkage);
   // addr, data, width, memstate
@@ -105,6 +106,7 @@ instrument_ref(llvm::RvsdgModule & rm)
   auto & reference_store = llvm::GraphImport::Create(
       graph,
       storeFunctionType,
+      storeFunctionType,
       "reference_store",
       llvm::linkage::external_linkage);
   // addr, size, memstate
@@ -116,6 +118,7 @@ instrument_ref(llvm::RvsdgModule & rm)
       { llvm::iostatetype::Create(), jlm::llvm::MemoryStateType::Create() });
   auto & reference_alloca = llvm::GraphImport::Create(
       graph,
+      allocaFunctionType,
       allocaFunctionType,
       "reference_alloca",
       llvm::linkage::external_linkage);

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -351,6 +351,7 @@ split_hls_function(llvm::RvsdgModule & rm, const std::string & function_name)
           auto & newGraphImport = llvm::GraphImport::Create(
               rhls->Rvsdg(),
               oldGraphImport->ValueType(),
+              oldGraphImport->ImportedType(),
               oldGraphImport->Name(),
               oldGraphImport->Linkage());
           smap.insert(ln->input(i)->origin(), &newGraphImport);
@@ -373,6 +374,7 @@ split_hls_function(llvm::RvsdgModule & rm, const std::string & function_name)
           auto & graphImport = llvm::GraphImport::Create(
               rhls->Rvsdg(),
               odn->Type(),
+              llvm::PointerType::Create(),
               odn->name(),
               llvm::linkage::external_linkage);
           smap.insert(ln->input(i)->origin(), &graphImport);
@@ -393,6 +395,7 @@ split_hls_function(llvm::RvsdgModule & rm, const std::string & function_name)
       // add function as input to rm and remove it
       auto & graphImport = llvm::GraphImport::Create(
           rm.Rvsdg(),
+          ln->Type(),
           ln->Type(),
           ln->name(),
           llvm::linkage::external_linkage); // TODO: change linkage?

--- a/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
+++ b/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
@@ -994,6 +994,7 @@ ConvertFunctionNode(
     return &GraphImport::Create(
         *region.graph(),
         functionNode.GetFunctionType(),
+        functionNode.GetFunctionType(),
         functionNode.name(),
         functionNode.linkage());
   }
@@ -1035,6 +1036,7 @@ ConvertDataNode(
       return &GraphImport::Create(
           *region.graph(),
           dataNode.GetValueType(),
+          PointerType::Create(),
           dataNode.name(),
           dataNode.linkage());
     }

--- a/jlm/llvm/frontend/LlvmInstructionConversion.cpp
+++ b/jlm/llvm/frontend/LlvmInstructionConversion.cpp
@@ -16,8 +16,13 @@
 namespace jlm::llvm
 {
 
+// Converts a value into a variable either representing the llvm
+// value or representing a function object.
+// The distinction stems from the fact that llvm treats functions simply
+// as pointers to the function code while we distinguish between the two.
+// This function can return either and caller needs to check / adapt.
 const variable *
-ConvertValue(::llvm::Value * v, tacsvector_t & tacs, context & ctx)
+ConvertValueOrFunction(::llvm::Value * v, tacsvector_t & tacs, context & ctx)
 {
   auto node = ctx.node();
   if (node && ctx.has_value(v))
@@ -36,6 +41,20 @@ ConvertValue(::llvm::Value * v, tacsvector_t & tacs, context & ctx)
     return ConvertConstant(c, tacs, ctx);
 
   JLM_UNREACHABLE("This should not have happened!");
+}
+
+// Converts a value into a variable representing the llvm value.
+const variable *
+ConvertValue(::llvm::Value * v, tacsvector_t & tacs, context & ctx)
+{
+  const variable * var = ConvertValueOrFunction(v, tacs, ctx);
+  if (auto fntype = std::dynamic_pointer_cast<const FunctionType>(var->Type()))
+  {
+    std::unique_ptr<tac> ptr_cast = tac::create(FunctionToPointerOperation(fntype), { var });
+    var = ptr_cast->result(0);
+    tacs.push_back(std::move(ptr_cast));
+  }
+  return var;
 }
 
 /* constant */
@@ -886,6 +905,7 @@ convert_call_instruction(::llvm::Instruction * instruction, tacsvector_t & tacs,
     return convert_memcpy_call(i, tacs, ctx);
 
   auto ftype = i->getFunctionType();
+  auto convertedFType = ConvertFunctionType(ftype, ctx);
 
   auto arguments = create_arguments(i, tacs, ctx);
   if (ftype->isVarArg())
@@ -893,8 +913,42 @@ convert_call_instruction(::llvm::Instruction * instruction, tacsvector_t & tacs,
   arguments.push_back(ctx.iostate());
   arguments.push_back(ctx.memory_state());
 
-  auto fctvar = ConvertValue(i->getCalledOperand(), tacs, ctx);
-  auto call = CallOperation::create(fctvar, ConvertFunctionType(ftype, ctx), arguments);
+  const variable * callee = ConvertValueOrFunction(i->getCalledOperand(), tacs, ctx);
+  // Llvm does not distinguish between "function objects" and
+  // "pointers to functions" while we need to be precise in modelling.
+  // If the called object is a function object, then we can just
+  // feed it to the call operator directly, otherwise we have
+  // to cast it into a function object.
+  if (is<PointerType>(*callee->Type()))
+  {
+    std::unique_ptr<tac> callee_cast =
+        tac::create(PointerToFunctionOperation(convertedFType), { callee });
+    callee = callee_cast->result(0);
+    tacs.push_back(std::move(callee_cast));
+  }
+  else if (auto fntype = std::dynamic_pointer_cast<const FunctionType>(callee->Type()))
+  {
+    // Llvm also allows argument type mismatches if the function
+    // features varargs. The code here could be made more precise by
+    // validating and accepting only vararg-related mismatches.
+    if (*convertedFType != *fntype)
+    {
+      // Since vararg passing is not modelled explicitly, simply hide the
+      // argument mismtach via pointer casts.
+      std::unique_ptr<tac> ptrCast = tac::create(FunctionToPointerOperation(fntype), { callee });
+      std::unique_ptr<tac> fnCast =
+          tac::create(PointerToFunctionOperation(convertedFType), { ptrCast->result(0) });
+      callee = fnCast->result(0);
+      tacs.push_back(std::move(ptrCast));
+      tacs.push_back(std::move(fnCast));
+    }
+  }
+  else
+  {
+    throw std::runtime_error("Unexpected callee type: " + callee->Type()->debug_string());
+  }
+
+  auto call = CallOperation::create(callee, convertedFType, arguments);
 
   auto result = call->result(0);
   auto iostate = call->result(call->nresults() - 2);

--- a/jlm/llvm/ir/RvsdgModule.cpp
+++ b/jlm/llvm/ir/RvsdgModule.cpp
@@ -11,7 +11,7 @@ namespace jlm::llvm
 GraphImport &
 GraphImport::Copy(rvsdg::Region & region, rvsdg::StructuralInput *)
 {
-  return GraphImport::Create(*region.graph(), ValueType(), Name(), Linkage());
+  return GraphImport::Create(*region.graph(), ValueType(), ImportedType(), Name(), Linkage());
 }
 
 GraphExport &

--- a/jlm/llvm/ir/RvsdgModule.hpp
+++ b/jlm/llvm/ir/RvsdgModule.hpp
@@ -24,11 +24,13 @@ private:
   GraphImport(
       rvsdg::Graph & graph,
       std::shared_ptr<const rvsdg::ValueType> valueType,
+      std::shared_ptr<const rvsdg::ValueType> importedType,
       std::string name,
       llvm::linkage linkage)
-      : rvsdg::GraphImport(graph, PointerType::Create(), std::move(name)),
+      : rvsdg::GraphImport(graph, importedType, std::move(name)),
         Linkage_(std::move(linkage)),
-        ValueType_(std::move(valueType))
+        ValueType_(std::move(valueType)),
+        ImportedType_(std::move(importedType))
   {}
 
 public:
@@ -44,6 +46,12 @@ public:
     return ValueType_;
   }
 
+  [[nodiscard]] const std::shared_ptr<const jlm::rvsdg::ValueType> &
+  ImportedType() const noexcept
+  {
+    return ImportedType_;
+  }
+
   GraphImport &
   Copy(rvsdg::Region & region, rvsdg::StructuralInput * input) override;
 
@@ -51,11 +59,16 @@ public:
   Create(
       rvsdg::Graph & graph,
       std::shared_ptr<const rvsdg::ValueType> valueType,
+      std::shared_ptr<const rvsdg::ValueType> importedType,
       std::string name,
       llvm::linkage linkage)
   {
-    auto graphImport =
-        new GraphImport(graph, std::move(valueType), std::move(name), std::move(linkage));
+    auto graphImport = new GraphImport(
+        graph,
+        std::move(valueType),
+        std::move(importedType),
+        std::move(name),
+        std::move(linkage));
     graph.GetRootRegion().append_argument(graphImport);
     return *graphImport;
   }
@@ -63,6 +76,7 @@ public:
 private:
   llvm::linkage Linkage_;
   std::shared_ptr<const rvsdg::ValueType> ValueType_;
+  std::shared_ptr<const rvsdg::ValueType> ImportedType_;
 };
 
 /**

--- a/jlm/llvm/ir/ipgraph.cpp
+++ b/jlm/llvm/ir/ipgraph.cpp
@@ -111,14 +111,13 @@ function_node::name() const noexcept
 const jlm::rvsdg::Type &
 function_node::type() const noexcept
 {
-  static PointerType pointerType;
-  return pointerType;
+  return *FunctionType_;
 }
 
 std::shared_ptr<const jlm::rvsdg::Type>
 function_node::Type() const
 {
-  return PointerType::Create();
+  return FunctionType_;
 }
 
 const llvm::linkage &

--- a/jlm/llvm/ir/operators.hpp
+++ b/jlm/llvm/ir/operators.hpp
@@ -9,6 +9,7 @@
 #include <jlm/llvm/ir/operators/alloca.hpp>
 #include <jlm/llvm/ir/operators/call.hpp>
 #include <jlm/llvm/ir/operators/delta.hpp>
+#include <jlm/llvm/ir/operators/FunctionPointer.hpp>
 #include <jlm/llvm/ir/operators/GetElementPtr.hpp>
 #include <jlm/llvm/ir/operators/lambda.hpp>
 #include <jlm/llvm/ir/operators/Load.hpp>

--- a/jlm/llvm/ir/operators/call.hpp
+++ b/jlm/llvm/ir/operators/call.hpp
@@ -25,7 +25,7 @@ public:
   ~CallOperation() override;
 
   explicit CallOperation(std::shared_ptr<const FunctionType> functionType)
-      : SimpleOperation(create_srctypes(*functionType), functionType->Results()),
+      : SimpleOperation(create_srctypes(functionType), functionType->Results()),
         FunctionType_(std::move(functionType))
   {}
 
@@ -60,10 +60,10 @@ public:
 
 private:
   static inline std::vector<std::shared_ptr<const rvsdg::Type>>
-  create_srctypes(const FunctionType & functionType)
+  create_srctypes(const std::shared_ptr<const FunctionType> & functionType)
   {
-    std::vector<std::shared_ptr<const rvsdg::Type>> types({ PointerType::Create() });
-    for (auto & argumentType : functionType.Arguments())
+    std::vector<std::shared_ptr<const rvsdg::Type>> types({ functionType });
+    for (auto & argumentType : functionType->Arguments())
       types.emplace_back(argumentType);
 
     return types;
@@ -72,8 +72,8 @@ private:
   static void
   CheckFunctionInputType(const jlm::rvsdg::Type & type)
   {
-    if (!is<PointerType>(type))
-      throw jlm::util::error("Expected pointer type.");
+    if (!is<FunctionType>(type))
+      throw jlm::util::error("Expected function type.");
   }
 
   std::shared_ptr<const FunctionType> FunctionType_;
@@ -360,7 +360,7 @@ public:
   GetFunctionInput() const noexcept
   {
     auto functionInput = input(0);
-    JLM_ASSERT(is<PointerType>(functionInput->type()));
+    JLM_ASSERT(is<FunctionType>(functionInput->type()));
     return functionInput;
   }
 
@@ -523,8 +523,8 @@ private:
   static void
   CheckFunctionInputType(const jlm::rvsdg::Type & type)
   {
-    if (!is<PointerType>(type))
-      throw jlm::util::error("Expected pointer type.");
+    if (!is<FunctionType>(type))
+      throw jlm::util::error("Expected function type.");
   }
 
   static void

--- a/jlm/llvm/ir/operators/lambda.cpp
+++ b/jlm/llvm/ir/operators/lambda.cpp
@@ -203,7 +203,7 @@ node::finalize(const std::vector<jlm::rvsdg::output *> & results)
   for (const auto & origin : results)
     rvsdg::RegionResult::Create(*origin->region(), *origin, nullptr, origin->Type());
 
-  return append_output(std::make_unique<rvsdg::StructuralOutput>(this, PointerType::Create()));
+  return append_output(std::make_unique<rvsdg::StructuralOutput>(this, Type()));
 }
 
 rvsdg::output *

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -19,7 +19,7 @@ namespace jlm::llvm::aa
 bool
 IsOrContainsPointerType(const rvsdg::Type & type)
 {
-  return IsOrContains<PointerType>(type);
+  return IsOrContains<PointerType>(type) || is<llvm::FunctionType>(type);
 }
 
 std::string
@@ -646,6 +646,10 @@ Andersen::AnalyzeSimpleNode(const rvsdg::SimpleNode & node)
     AnalyzeExtractValue(node);
   else if (is<valist_op>(op))
     AnalyzeValist(node);
+  else if (is<PointerToFunctionOperation>(op))
+    AnalyzePointerToFunction(node);
+  else if (is<FunctionToPointerOperation>(op))
+    AnalyzeFunctionToPointer(node);
   else if (is<FreeOperation>(op) || is<ptrcmp_op>(op))
   {
     // These operations take pointers as input, but do not affect any points-to sets
@@ -947,6 +951,36 @@ Andersen::AnalyzeValist(const rvsdg::SimpleNode & node)
     const auto inputRegisterPO = Set_->GetRegisterPointerObject(inputRegister);
     Constraints_->AddRegisterContentEscapedConstraint(inputRegisterPO);
   }
+}
+
+void
+Andersen::AnalyzePointerToFunction(const rvsdg::SimpleNode & node)
+{
+  JLM_ASSERT(is<PointerToFunctionOperation>(&node));
+
+  // For pointer analysis purposes, function objects and pointers
+  // to functions are treated as being the same.
+  const auto & baseRegister = *node.input(0)->origin();
+  JLM_ASSERT(is<PointerType>(baseRegister.type()));
+
+  const auto baseRegisterPO = Set_->GetRegisterPointerObject(baseRegister);
+  const auto & outputRegister = *node.output(0);
+  Set_->MapRegisterToExistingPointerObject(outputRegister, baseRegisterPO);
+}
+
+void
+Andersen::AnalyzeFunctionToPointer(const rvsdg::SimpleNode & node)
+{
+  JLM_ASSERT(is<FunctionToPointerOperation>(&node));
+
+  // For pointer analysis purposes, function objects and pointers
+  // to functions are treated as being the same.
+  const auto & baseRegister = *node.input(0)->origin();
+  JLM_ASSERT(is<FunctionType>(baseRegister.type()));
+
+  const auto baseRegisterPO = Set_->GetRegisterPointerObject(baseRegister);
+  const auto & outputRegister = *node.output(0);
+  Set_->MapRegisterToExistingPointerObject(outputRegister, baseRegisterPO);
 }
 
 void

--- a/jlm/llvm/opt/alias-analyses/Andersen.hpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.hpp
@@ -402,6 +402,12 @@ private:
   AnalyzeValist(const rvsdg::SimpleNode & node);
 
   void
+  AnalyzePointerToFunction(const rvsdg::SimpleNode & node);
+
+  void
+  AnalyzeFunctionToPointer(const rvsdg::SimpleNode & node);
+
+  void
   AnalyzeStructuralNode(const rvsdg::StructuralNode & node);
 
   void

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
@@ -183,6 +183,12 @@ private:
   void
   AnalyzeVaList(const rvsdg::SimpleNode & node);
 
+  void
+  AnalyzePointerToFunction(const rvsdg::SimpleNode & node);
+
+  void
+  AnalyzeFunctionToPointer(const rvsdg::SimpleNode & node);
+
   /**
    * Marks register \p output as escaping the module. This indicates that the pointer in \p output
    * is going outside the module, where we do not know what happens with it. Consequently, the

--- a/tests/jlm/llvm/backend/llvm/r2j/test-recursive-data.cpp
+++ b/tests/jlm/llvm/backend/llvm/r2j/test-recursive-data.cpp
@@ -27,7 +27,7 @@ test()
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
 
-  auto imp = &GraphImport::Create(rm.Rvsdg(), vt, "", linkage::external_linkage);
+  auto imp = &GraphImport::Create(rm.Rvsdg(), vt, pt, "", linkage::external_linkage);
 
   phi::builder pb;
   pb.begin(&rm.Rvsdg().GetRootRegion());

--- a/tests/jlm/llvm/ir/operators/TestLambda.cpp
+++ b/tests/jlm/llvm/ir/operators/TestLambda.cpp
@@ -472,7 +472,9 @@ TestCallSummaryComputationFunctionPointerInDelta()
       linkage::external_linkage,
       "",
       false);
-  auto argument = deltaNode->add_ctxvar(lambdaNode->output());
+  auto argument = deltaNode->add_ctxvar(
+      jlm::rvsdg::CreateOpNode<FunctionToPointerOperation>({ lambdaNode->output() }, functionType)
+          .output(0));
   deltaNode->finalize(argument);
 
   GraphExport::Create(*deltaNode->output(), "fp");
@@ -508,7 +510,9 @@ TestCallSummaryComputationLambdaResult()
   auto lambdaNodeF =
       lambda::node::create(&rvsdg.GetRootRegion(), functionTypeF, "f", linkage::external_linkage);
   auto lambdaGArgument = lambdaNodeF->AddContextVar(*lambdaOutputG).inner;
-  auto lambdaOutputF = lambdaNodeF->finalize({ lambdaGArgument });
+  auto lambdaOutputF = lambdaNodeF->finalize(
+      { jlm::rvsdg::CreateOpNode<FunctionToPointerOperation>({ lambdaGArgument }, functionTypeG)
+            .output(0) });
 
   GraphExport::Create(*lambdaOutputF, "f");
 

--- a/tests/jlm/llvm/ir/operators/TestPhi.cpp
+++ b/tests/jlm/llvm/ir/operators/TestPhi.cpp
@@ -54,9 +54,9 @@ TestPhiCreation()
 
   phi::builder pb;
   pb.begin(&graph.GetRootRegion());
-  auto rv1 = pb.add_recvar(PointerType::Create());
-  auto rv2 = pb.add_recvar(PointerType::Create());
-  auto rv3 = pb.add_recvar(PointerType::Create());
+  auto rv1 = pb.add_recvar(f0type);
+  auto rv2 = pb.add_recvar(f0type);
+  auto rv3 = pb.add_recvar(f1type);
 
   auto lambdaOutput0 = SetupEmptyLambda(pb.subregion(), "f0");
   auto lambdaOutput1 = SetupEmptyLambda(pb.subregion(), "f1");

--- a/tests/jlm/llvm/opt/TestDeadNodeElimination.cpp
+++ b/tests/jlm/llvm/opt/TestDeadNodeElimination.cpp
@@ -348,10 +348,10 @@ TestPhi()
   phiBuilder.begin(&rvsdg.GetRootRegion());
   auto & phiSubregion = *phiBuilder.subregion();
 
-  auto rv1 = phiBuilder.add_recvar(PointerType::Create());
-  auto rv2 = phiBuilder.add_recvar(PointerType::Create());
-  auto rv3 = phiBuilder.add_recvar(PointerType::Create());
-  auto rv4 = phiBuilder.add_recvar(PointerType::Create());
+  auto rv1 = phiBuilder.add_recvar(functionType);
+  auto rv2 = phiBuilder.add_recvar(functionType);
+  auto rv3 = phiBuilder.add_recvar(functionType);
+  auto rv4 = phiBuilder.add_recvar(functionType);
   auto dx = phiBuilder.add_ctxvar(x);
   auto dy = phiBuilder.add_ctxvar(y);
   auto dz = phiBuilder.add_ctxvar(z);

--- a/tests/jlm/llvm/opt/alias-analyses/TestAndersen.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestAndersen.cpp
@@ -446,7 +446,7 @@ TestIndirectCall1()
 
   assert(ptg->NumLambdaNodes() == 4);
   assert(ptg->NumImportNodes() == 0);
-  assert(ptg->NumMappedRegisters() == 8);
+  assert(ptg->NumMappedRegisters() == 11);
 
   auto & lambda_three = ptg->GetLambdaNode(test.GetLambdaThree());
   auto & lambda_three_out = ptg->GetRegisterNode(*test.GetLambdaThree().output());
@@ -494,7 +494,7 @@ TestIndirectCall2()
   assert(ptg->NumAllocaNodes() == 3);
   assert(ptg->NumLambdaNodes() == 7);
   assert(ptg->NumDeltaNodes() == 2);
-  assert(ptg->NumMappedRegisters() == 24);
+  assert(ptg->NumMappedRegisters() == 27);
 
   auto & lambdaThree = ptg->GetLambdaNode(test.GetLambdaThree());
   auto & lambdaThreeOutput = ptg->GetRegisterNode(*test.GetLambdaThree().output());

--- a/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
@@ -782,7 +782,7 @@ ValidateIndirectCallTest1SteensgaardAgnostic(const jlm::tests::IndirectCallTest1
 
   /* validate indcall function */
   {
-    assert(test.GetLambdaIndcall().subregion()->nnodes() == 5);
+    assert(test.GetLambdaIndcall().subregion()->nnodes() == 6);
 
     auto lambda_exit_mux =
         jlm::rvsdg::output::GetNode(*test.GetLambdaIndcall().GetFunctionResults()[2]->origin());
@@ -839,7 +839,7 @@ ValidateIndirectCallTest1SteensgaardRegionAware(const jlm::tests::IndirectCallTe
 
   /* validate indcall function */
   {
-    assert(test.GetLambdaIndcall().subregion()->nnodes() == 5);
+    assert(test.GetLambdaIndcall().subregion()->nnodes() == 6);
 
     auto lambdaExitMerge =
         jlm::rvsdg::output::GetNode(*test.GetLambdaIndcall().GetFunctionResults()[2]->origin());
@@ -896,7 +896,7 @@ ValidateIndirectCallTest1SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
 
   // validate indcall function
   {
-    assert(test.GetLambdaIndcall().subregion()->nnodes() == 5);
+    assert(test.GetLambdaIndcall().subregion()->nnodes() == 6);
 
     auto lambda_exit_mux =
         jlm::rvsdg::output::GetNode(*test.GetLambdaIndcall().GetFunctionResults()[2]->origin());
@@ -979,7 +979,7 @@ ValidateIndirectCallTest2SteensgaardAgnostic(const jlm::tests::IndirectCallTest2
 
   // validate function i()
   {
-    assert(test.GetLambdaI().subregion()->nnodes() == 5);
+    assert(test.GetLambdaI().subregion()->nnodes() == 6);
 
     auto lambdaExitMerge =
         jlm::rvsdg::output::GetNode(*test.GetLambdaI().GetFunctionResults()[2]->origin());
@@ -1021,7 +1021,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
 
   // validate function i()
   {
-    assert(test.GetLambdaI().subregion()->nnodes() == 5);
+    assert(test.GetLambdaI().subregion()->nnodes() == 6);
 
     auto lambdaExitMerge =
         jlm::rvsdg::output::GetNode(*test.GetLambdaI().GetFunctionResults()[2]->origin());
@@ -1039,7 +1039,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
 
   // validate function x()
   {
-    assert(test.GetLambdaX().subregion()->nnodes() == 7);
+    assert(test.GetLambdaX().subregion()->nnodes() == 8);
 
     auto lambdaExitMerge =
         jlm::rvsdg::output::GetNode(*test.GetLambdaX().GetFunctionResults()[2]->origin());
@@ -1076,7 +1076,7 @@ ValidateIndirectCallTest2SteensgaardRegionAware(const jlm::tests::IndirectCallTe
 
   // validate function y()
   {
-    assert(test.GetLambdaY().subregion()->nnodes() == 7);
+    assert(test.GetLambdaY().subregion()->nnodes() == 8);
 
     auto lambdaExitMerge =
         jlm::rvsdg::output::GetNode(*test.GetLambdaY().GetFunctionResults()[2]->origin());
@@ -1179,7 +1179,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
 
   // validate function i()
   {
-    assert(test.GetLambdaI().subregion()->nnodes() == 5);
+    assert(test.GetLambdaI().subregion()->nnodes() == 6);
 
     auto lambdaExitMerge =
         jlm::rvsdg::output::GetNode(*test.GetLambdaI().GetFunctionResults()[2]->origin());
@@ -1197,7 +1197,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
 
   // validate function x()
   {
-    assert(test.GetLambdaX().subregion()->nnodes() == 7);
+    assert(test.GetLambdaX().subregion()->nnodes() == 8);
 
     auto lambdaExitMerge =
         jlm::rvsdg::output::GetNode(*test.GetLambdaX().GetFunctionResults()[2]->origin());
@@ -1234,7 +1234,7 @@ ValidateIndirectCallTest2SteensgaardAgnosticTopDown(const jlm::tests::IndirectCa
 
   // validate function y()
   {
-    assert(test.GetLambdaY().subregion()->nnodes() == 8);
+    assert(test.GetLambdaY().subregion()->nnodes() == 9);
 
     auto lambdaExitMerge =
         jlm::rvsdg::output::GetNode(*test.GetLambdaY().GetFunctionResults()[2]->origin());

--- a/tests/jlm/llvm/opt/test-cne.cpp
+++ b/tests/jlm/llvm/opt/test-cne.cpp
@@ -442,8 +442,8 @@ test_phi()
   auto d1 = pb.add_ctxvar(x);
   auto d2 = pb.add_ctxvar(x);
 
-  auto r1 = pb.add_recvar(PointerType::Create());
-  auto r2 = pb.add_recvar(PointerType::Create());
+  auto r1 = pb.add_recvar(ft);
+  auto r2 = pb.add_recvar(ft);
 
   auto lambda1 = lambda::node::create(region, ft, "f", linkage::external_linkage);
   auto cv1 = lambda1->AddContextVar(*d1).inner;

--- a/tests/jlm/llvm/opt/test-inlining.cpp
+++ b/tests/jlm/llvm/opt/test-inlining.cpp
@@ -132,7 +132,7 @@ test2()
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
   auto & graph = rm.Rvsdg();
-  auto i = &jlm::tests::GraphImport::Create(graph, pt, "i");
+  auto i = &jlm::tests::GraphImport::Create(graph, functionType2, "i");
 
   auto SetupF1 = [&](const std::shared_ptr<const FunctionType> & functionType)
   {
@@ -164,7 +164,8 @@ test2()
   };
 
   auto f1 = SetupF1(functionType1);
-  auto f2 = SetupF2(f1);
+  auto f2 = SetupF2(
+      jlm::rvsdg::CreateOpNode<FunctionToPointerOperation>({ f1 }, functionType1).output(0));
 
   GraphExport::Create(*f2, "f2");
 


### PR DESCRIPTION
Make the lambda operator return a "function" object (instead of pointer) and make the call operator require a "function" object (instead of a pointer). Introduce pointer-to-function and function-to-pointer conversions in places where references to functions are stored in machine data structures or passed as machine-representable values across functions.

In pointer analysis, unify functions and pointers to functions as the same objects. Possibly function objects should be represented as "pointees" instead, but for now simply blurring the distinction between the two delivers the desired results.