### PR TITLE
Clean up theta dead node elimination

### DIFF
--- a/jlm/rvsdg/theta.cpp
+++ b/jlm/rvsdg/theta.cpp
@@ -47,6 +47,31 @@ ThetaNode::AddLoopVar(rvsdg::output * origin)
   return LoopVar{ input, &thetaArgument, &thetaResult, output };
 }
 
+void
+ThetaNode::RemoveLoopVars(std::vector<LoopVar> loopvars)
+{
+  // Sort them by descending index to avoid renumbering issues.
+  std::sort(
+      loopvars.begin(),
+      loopvars.end(),
+      [](const LoopVar & x, const LoopVar & y)
+      {
+        return x.input->index() > y.input->index();
+      });
+
+  for (const auto & loopvar : loopvars)
+  {
+    JLM_ASSERT(loopvar.output->IsDead());
+    JLM_ASSERT(loopvar.post->origin() == loopvar.pre);
+    JLM_ASSERT(loopvar.pre->nusers() == 1);
+
+    subregion()->RemoveResult(loopvar.post->index());
+    subregion()->RemoveArgument(loopvar.pre->index());
+    RemoveOutput(loopvar.output->index());
+    RemoveInput(loopvar.input->index());
+  }
+}
+
 ThetaNode *
 ThetaNode::copy(rvsdg::Region * region, rvsdg::SubstitutionMap & smap) const
 {
@@ -85,22 +110,20 @@ ThetaNode::copy(rvsdg::Region * region, rvsdg::SubstitutionMap & smap) const
 ThetaNode::MapInputLoopVar(const rvsdg::input & input) const
 {
   JLM_ASSERT(rvsdg::TryGetOwnerNode<ThetaNode>(input) == this);
-  auto peer = MapInputToOutputIndex(input.index());
   return LoopVar{ const_cast<rvsdg::input *>(&input),
                   subregion()->argument(input.index()),
-                  peer ? subregion()->result(*peer + 1) : nullptr,
-                  peer ? output(*peer) : nullptr };
+                  subregion()->result(input.index() + 1),
+                  output(input.index()) };
 }
 
 [[nodiscard]] ThetaNode::LoopVar
 ThetaNode::MapPreLoopVar(const rvsdg::output & argument) const
 {
   JLM_ASSERT(rvsdg::TryGetRegionParentNode<ThetaNode>(argument) == this);
-  auto peer = MapInputToOutputIndex(argument.index());
   return LoopVar{ input(argument.index()),
                   const_cast<rvsdg::output *>(&argument),
-                  peer ? subregion()->result(*peer + 1) : nullptr,
-                  peer ? output(*peer) : nullptr };
+                  subregion()->result(argument.index() + 1),
+                  output(argument.index()) };
 }
 
 [[nodiscard]] ThetaNode::LoopVar
@@ -113,9 +136,8 @@ ThetaNode::MapPostLoopVar(const rvsdg::input & result) const
     // There is nothing sensible to return here.
     throw std::logic_error("cannot map loop continuation predicate to loop variable");
   }
-  auto peer = MapOutputToInputIndex(result.index() - 1);
-  return LoopVar{ peer ? input(*peer) : nullptr,
-                  peer ? subregion()->argument(*peer) : nullptr,
+  return LoopVar{ input(result.index() - 1),
+                  subregion()->argument(result.index() - 1),
                   const_cast<rvsdg::input *>(&result),
                   output(result.index() - 1) };
 }
@@ -124,9 +146,8 @@ ThetaNode::MapPostLoopVar(const rvsdg::input & result) const
 ThetaNode::MapOutputLoopVar(const rvsdg::output & output) const
 {
   JLM_ASSERT(rvsdg::TryGetOwnerNode<ThetaNode>(output) == this);
-  auto peer = MapOutputToInputIndex(output.index());
-  return LoopVar{ peer ? input(*peer) : nullptr,
-                  peer ? subregion()->argument(*peer) : nullptr,
+  return LoopVar{ input(output.index()),
+                  subregion()->argument(output.index()),
                   subregion()->result(output.index() + 1),
                   const_cast<rvsdg::output *>(&output) };
 }
@@ -135,119 +156,14 @@ ThetaNode::MapOutputLoopVar(const rvsdg::output & output) const
 ThetaNode::GetLoopVars() const
 {
   std::vector<LoopVar> loopvars;
-  for (size_t input_index = 0; input_index < ninputs(); ++input_index)
+  for (size_t index = 0; index < ninputs(); ++index)
   {
-    // Check if there is a matching input/output -- if we are in
-    // the process of deleting a loop variable, inputs and outputs
-    // might be unmatched.
-    auto output_index = MapInputToOutputIndex(input_index);
-    if (output_index)
-    {
-      loopvars.push_back(LoopVar{ input(input_index),
-                                  subregion()->argument(input_index),
-                                  subregion()->result(*output_index + 1),
-                                  output(*output_index) });
-    }
+    loopvars.push_back(LoopVar{ input(index),
+                                subregion()->argument(index),
+                                subregion()->result(index + 1),
+                                output(index) });
   }
   return loopvars;
-}
-
-std::optional<std::size_t>
-ThetaNode::MapInputToOutputIndex(std::size_t index) const noexcept
-{
-  std::size_t offset = 0;
-  for (std::size_t unmatched : unmatchedInputs)
-  {
-    if (unmatched == index)
-    {
-      return std::nullopt;
-    }
-    if (unmatched < index)
-    {
-      ++offset;
-    }
-  }
-
-  index -= offset;
-  offset = 0;
-  for (std::size_t unmatched : unmatchedOutputs)
-  {
-    if (unmatched <= index)
-    {
-      ++offset;
-    }
-  }
-  return index + offset;
-}
-
-std::optional<std::size_t>
-ThetaNode::MapOutputToInputIndex(std::size_t index) const noexcept
-{
-  std::size_t offset = 0;
-  for (std::size_t unmatched : unmatchedOutputs)
-  {
-    if (unmatched == index)
-    {
-      return std::nullopt;
-    }
-    if (unmatched < index)
-    {
-      ++offset;
-    }
-  }
-
-  index -= offset;
-  offset = 0;
-  for (std::size_t unmatched : unmatchedInputs)
-  {
-    if (unmatched <= index)
-    {
-      ++offset;
-    }
-  }
-  return index + offset;
-}
-
-void
-ThetaNode::MarkInputIndexErased(std::size_t index) noexcept
-{
-  if (auto peer = MapInputToOutputIndex(index))
-  {
-    unmatchedOutputs.push_back(*peer);
-  }
-  else
-  {
-    auto i = std::remove(unmatchedInputs.begin(), unmatchedInputs.end(), index);
-    unmatchedInputs.erase(i, unmatchedInputs.end());
-  }
-  for (auto & unmatched : unmatchedInputs)
-  {
-    if (unmatched > index)
-    {
-      unmatched -= 1;
-    }
-  }
-}
-
-void
-ThetaNode::MarkOutputIndexErased(std::size_t index) noexcept
-{
-  if (auto peer = MapOutputToInputIndex(index))
-  {
-    unmatchedInputs.push_back(*peer);
-  }
-  else
-  {
-    auto i = std::remove(unmatchedOutputs.begin(), unmatchedOutputs.end(), index);
-    unmatchedOutputs.erase(i, unmatchedOutputs.end());
-  }
-  for (auto & unmatched : unmatchedOutputs)
-  {
-    if (unmatched > index)
-    {
-      unmatched -= 1;
-    }
-  }
 }
 
 }


### PR DESCRIPTION
Restructure dead node elimination such that it never requires "unbalanced" theta inputs / outputs -- interleave cleaning up the subregion instead.

Remove the support from theta node to deal with temporary invariant violation by inbalanced input / output. Introduce a method instead that can remove loop-invariant dead variables. It turns out that this is all that dead node elimination needs in practice.