### PR TITLE
Generate comment in PR from CI if cycles differ

### DIFF
--- a/.github/workflows/hls.yml
+++ b/.github/workflows/hls.yml
@@ -27,13 +27,13 @@ jobs:
     - name: "Run hls-test-suite"
       run: ./scripts/run-hls-test.sh
     - name: "Create comment if cycles differ"
-      if: ${{ hashFiles('./usr/hls-test-suite/Makefile') != '' }}
+      if: ${{ hashFiles('./usr/hls-test-suite/build/cycle-diff.log') != '' }}
       uses: actions/github-script@v7
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
           const fs = require("fs");
-          const comment = fs.readFileSync("./usr/hls-test-suite/Makefile", { encoding: "utf8" });
+          const comment = fs.readFileSync("./usr/hls-test-suite/build/cycle-diff.log", { encoding: "utf8" });
           github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,

--- a/.github/workflows/hls.yml
+++ b/.github/workflows/hls.yml
@@ -26,3 +26,17 @@ jobs:
         install-verilator: true
     - name: "Run hls-test-suite"
       run: ./scripts/run-hls-test.sh
+    - name: "Create comment if cycles differ"
+      if: ${{ hashFiles('./usr/hls-test-suite/build/cycle-diff.log') != '' }}
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          const fs = require("fs");
+          const comment = fs.readFileSync("./usr/hls-test-suite/build/cycle-diff.log", { encoding: "utf8" });
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: "```\n" + comment + "```"
+          });

--- a/.github/workflows/hls.yml
+++ b/.github/workflows/hls.yml
@@ -27,13 +27,13 @@ jobs:
     - name: "Run hls-test-suite"
       run: ./scripts/run-hls-test.sh
     - name: "Create comment if cycles differ"
-      if: ${{ hashFiles('./usr/hls-test-suite/build/cycle-diff.log') != '' }}
+      if: ${{ hashFiles('./usr/hls-test-suite/Makefile') != '' }}
       uses: actions/github-script@v7
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
           const fs = require("fs");
-          const comment = fs.readFileSync("./usr/hls-test-suite/build/cycle-diff.log", { encoding: "utf8" });
+          const comment = fs.readFileSync("./usr/hls-test-suite/Makefile", { encoding: "utf8" });
           github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,

--- a/scripts/run-hls-test.sh
+++ b/scripts/run-hls-test.sh
@@ -3,7 +3,7 @@ set -eu
 
 # URL to the benchmark git repository and the commit to be used
 GIT_REPOSITORY=https://github.com/phate/hls-test-suite.git
-GIT_COMMIT=8ff67e118ab25ce7cbbdc8adfefb19340c54ce83
+GIT_COMMIT=1365c30074f921733dec6c5fc949bd1cb64ae001
 
 # Get the absolute path to this script and set default JLM paths
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"


### PR DESCRIPTION
If the cycle count for one or more of the hls test suite benchmarks results in a different cycle count than expected, then a comment is generated that appears in the PR.