### PR TITLE
Simplify HLS loop dead node elimination

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/distribute-constants.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/distribute-constants.cpp
@@ -36,10 +36,8 @@ distribute_constant(const rvsdg::SimpleOperation & op, rvsdg::simple_output * ou
           loopvar.output->divert_users(
               rvsdg::SimpleNode::create_normalized(out->region(), op, {})[0]);
           distribute_constant(op, arg_replacement);
-          theta->subregion()->RemoveResult(loopvar.post->index());
-          theta->subregion()->RemoveArgument(loopvar.pre->index());
-          theta->RemoveInput(loopvar.input->index());
-          theta->RemoveOutput(loopvar.output->index());
+          loopvar.post->divert_to(loopvar.pre);
+          theta->RemoveLoopVars({ loopvar });
           changed = true;
           break;
         }

--- a/tests/jlm/hls/backend/rvsdg2rhls/UnusedStateRemovalTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/UnusedStateRemovalTests.cpp
@@ -112,12 +112,7 @@ TestTheta()
   jlm::hls::RemoveUnusedStates(*rvsdgModule);
 
   // Assert
-  // This assert is only here so that we do not forget this test when we refactor the code
-  assert(thetaNode->ninputs() == 1);
-
-  // FIXME: This transformation is broken for theta nodes. For the setup above, it
-  // removes all inputs/outputs, except the predicate. However, the only
-  // input and output it should remove are input 1 and output 0, respectively.
+  assert(thetaNode->ninputs() == 3);
 }
 
 static void


### PR DESCRIPTION
After removing theta invariant violation from dead node elimination from llvm/opt, try to make HLS handling similarly regular.