### PR TITLE
Convert more tests to the new reduction interface

### DIFF
--- a/jlm/rvsdg/binary.cpp
+++ b/jlm/rvsdg/binary.cpp
@@ -367,16 +367,16 @@ NormalizeBinaryOperation(
 
   auto newOperands = reduce_operands(operation, operands);
 
-  if (newOperands == operands)
-  {
-    // The operands did not change, which means that none of the normalizations triggered.
-    return std::nullopt;
-  }
-
   if (newOperands.size() == 1)
   {
     // The operands could be reduced to a single value by applying constant folding.
     return newOperands;
+  }
+
+  if (newOperands == operands)
+  {
+    // The operands did not change, which means that none of the normalizations triggered.
+    return std::nullopt;
   }
 
   JLM_ASSERT(newOperands.size() == 2);

--- a/jlm/rvsdg/bitstring/concat.cpp
+++ b/jlm/rvsdg/bitstring/concat.cpp
@@ -327,15 +327,9 @@ bitconcat_op::reduce_operand_pair(
     auto & arg1_constant = static_cast<const bitconstant_op &>(node1->GetOperation());
     auto & arg2_constant = static_cast<const bitconstant_op &>(node2->GetOperation());
 
-    size_t nbits = arg1_constant.value().nbits() + arg2_constant.value().nbits();
-    std::vector<char> bits(nbits);
-    memcpy(&bits[0], &arg1_constant.value()[0], arg1_constant.value().nbits());
-    memcpy(
-        &bits[0] + arg1_constant.value().nbits(),
-        &arg2_constant.value()[0],
-        arg2_constant.value().nbits());
-
-    return create_bitconstant(arg1->region(), &bits[0]);
+    bitvalue_repr bits(arg1_constant.value());
+    bits.Append(arg2_constant.value());
+    return create_bitconstant(arg1->region(), std::move(bits));
   }
 
   if (path == binop_reduction_merge)

--- a/jlm/rvsdg/bitstring/value-representation.hpp
+++ b/jlm/rvsdg/bitstring/value-representation.hpp
@@ -689,6 +689,12 @@ public:
     return product.slice(nbits(), 2 * nbits());
   }
 
+  void
+  Append(const bitvalue_repr & other)
+  {
+    data_.insert(data_.end(), other.data_.begin(), other.data_.end());
+  }
+
 private:
   /* [lsb ... msb] */
   std::vector<char> data_;

--- a/tests/jlm/rvsdg/bitstring/bitstring.cpp
+++ b/tests/jlm/rvsdg/bitstring/bitstring.cpp
@@ -1520,14 +1520,25 @@ SliceOfSlice()
 {
   using namespace jlm::rvsdg;
 
-  // Arrange & Act
+  // Arrange
   Graph graph;
+  auto nf = graph.GetNodeNormalForm(typeid(Operation));
+  nf->set_mutable(false);
+
+  auto bit4Type = bittype::Create(4);
+
   auto x = &jlm::tests::GraphImport::Create(graph, bittype::Create(8), "x");
 
   auto slice1 = bitslice(x, 2, 6);
-  auto slice2 = bitslice(slice1, 1, 3);
+  auto & sliceNode2 = CreateOpNode<bitslice_op>({ slice1 }, bit4Type, 1, 3);
 
-  auto & ex = jlm::tests::GraphExport::Create(*slice2, "dummy");
+  auto & ex = jlm::tests::GraphExport::Create(*sliceNode2.output(0), "dummy");
+  view(graph, stdout);
+
+  // Act
+  ReduceNode<bitslice_op>(NormalizeUnaryOperation, sliceNode2);
+  graph.PruneNodes();
+
   view(graph, stdout);
 
   // Assert

--- a/tests/jlm/rvsdg/bitstring/bitstring.cpp
+++ b/tests/jlm/rvsdg/bitstring/bitstring.cpp
@@ -1486,11 +1486,22 @@ SliceOfConstant()
 {
   using namespace jlm::rvsdg;
 
-  // Arrange & Act
-  const Graph graph;
+  // Arrange
+  Graph graph;
+  auto nf = graph.GetNodeNormalForm(typeid(Operation));
+  nf->set_mutable(false);
+
+  auto bit8Type = bittype::Create(8);
+
   const auto constant = create_bitconstant(&graph.GetRootRegion(), "00110111");
-  const auto slice = bitslice(constant, 2, 6);
-  auto & ex = jlm::tests::GraphExport::Create(*slice, "dummy");
+  auto & sliceNode = CreateOpNode<bitslice_op>({ constant }, bit8Type, 2, 6);
+  auto & ex = jlm::tests::GraphExport::Create(*sliceNode.output(0), "dummy");
+
+  view(graph, stdout);
+
+  // Act
+  ReduceNode<bitslice_op>(NormalizeUnaryOperation, sliceNode);
+  graph.PruneNodes();
 
   view(graph, stdout);
 

--- a/tests/jlm/rvsdg/bitstring/bitstring.cpp
+++ b/tests/jlm/rvsdg/bitstring/bitstring.cpp
@@ -1744,8 +1744,10 @@ ConcatOfConstants()
 {
   using namespace jlm::rvsdg;
 
-  // Arrange & Act
+  // Arrange
   Graph graph;
+  auto nf = graph.GetNodeNormalForm(typeid(Operation));
+  nf->set_mutable(false);
 
   auto c1 = create_bitconstant(&graph.GetRootRegion(), "00110111");
   auto c2 = create_bitconstant(&graph.GetRootRegion(), "11001000");
@@ -1754,6 +1756,9 @@ ConcatOfConstants()
 
   auto & ex = jlm::tests::GraphExport::Create(*concatResult, "dummy");
   view(graph, stdout);
+
+  // Act
+  ReduceNode<bitconcat_op>(NormalizeBinaryOperation, *output::GetNode(*ex.origin()));
 
   // Assert
   auto node = output::GetNode(*ex.origin());

--- a/tests/jlm/rvsdg/bitstring/bitstring.cpp
+++ b/tests/jlm/rvsdg/bitstring/bitstring.cpp
@@ -1556,13 +1556,24 @@ SliceOfFullNode()
 {
   using namespace jlm::rvsdg;
 
-  // Arrange & Act
+  // Arrange
   Graph graph;
+  auto nf = graph.GetNodeNormalForm(typeid(Operation));
+  nf->set_mutable(false);
+
+  auto bit8Type = bittype::Create(8);
+
   const auto x = &jlm::tests::GraphImport::Create(graph, bittype::Create(8), "x");
 
-  auto sliceResult = bitslice(x, 0, 8);
+  auto & sliceNode = CreateOpNode<bitslice_op>({ x }, bit8Type, 0, 8);
 
-  auto & ex = jlm::tests::GraphExport::Create(*sliceResult, "dummy");
+  auto & ex = jlm::tests::GraphExport::Create(*sliceNode.output(0), "dummy");
+  view(graph, stdout);
+
+  // Act
+  ReduceNode<bitslice_op>(NormalizeUnaryOperation, sliceNode);
+  graph.PruneNodes();
+
   view(graph, stdout);
 
   // Assert

--- a/tests/jlm/rvsdg/bitstring/bitstring.cpp
+++ b/tests/jlm/rvsdg/bitstring/bitstring.cpp
@@ -1671,14 +1671,25 @@ ConcatWithSingleOperand()
 {
   using namespace jlm::rvsdg;
 
-  // Arrange & Act
+  // Arrange
   Graph graph;
+  auto nf = graph.GetNodeNormalForm(typeid(Operation));
+  nf->set_mutable(false);
 
-  auto x = &jlm::tests::GraphImport::Create(graph, bittype::Create(8), "x");
+  auto bit8Type = bittype::Create(8);
+  std::vector bit8Types({ bit8Type });
 
-  const auto concatResult = bitconcat({ x });
+  auto x = &jlm::tests::GraphImport::Create(graph, bit8Type, "x");
 
-  auto & ex = jlm::tests::GraphExport::Create(*concatResult, "dummy");
+  auto & concatNode = CreateOpNode<bitconcat_op>({ x }, bit8Types);
+
+  auto & ex = jlm::tests::GraphExport::Create(*concatNode.output(0), "dummy");
+  view(graph, stdout);
+
+  // Act
+  ReduceNode<bitconcat_op>(NormalizeBinaryOperation, concatNode);
+  graph.PruneNodes();
+
   view(graph, stdout);
 
   // Assert


### PR DESCRIPTION
Converts more tests to the new reduction interface and fixes 1 bug that occurred while doing so.