### PR TITLE
Node operator type safety

### DIFF
--- a/jlm/hls/ir/hls.cpp
+++ b/jlm/hls/ir/hls.cpp
@@ -88,6 +88,13 @@ loop_node::AddLoopVar(jlm::rvsdg::output * origin, jlm::rvsdg::output ** buffer)
   return output;
 }
 
+[[nodiscard]] const rvsdg::Operation &
+loop_node::GetOperation() const noexcept
+{
+  static const loop_op singleton;
+  return singleton;
+}
+
 jlm::rvsdg::output *
 loop_node::add_loopconst(jlm::rvsdg::output * origin)
 {

--- a/jlm/hls/ir/hls.hpp
+++ b/jlm/hls/ir/hls.hpp
@@ -751,12 +751,15 @@ public:
 
 private:
   inline loop_node(rvsdg::Region * parent)
-      : StructuralNode(loop_op(), parent, 1)
+      : StructuralNode(parent, 1)
   {}
 
   jlm::rvsdg::node_output * _predicate_buffer;
 
 public:
+  [[nodiscard]] const rvsdg::Operation &
+  GetOperation() const noexcept override;
+
   static loop_node *
   create(rvsdg::Region * parent, bool init = true);
 

--- a/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
+++ b/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
@@ -511,8 +511,9 @@ Convert(const llvm::tac & threeAddressCode, rvsdg::Region & region, llvm::Variab
     operands.push_back(variableMap.lookup(operand));
   }
 
-  auto operation = util::AssertedCast<const TOperation>(&threeAddressCode.operation());
-  auto results = TNode::Create(region, *operation, operands);
+  std::unique_ptr<TOperation> operation(
+      util::AssertedCast<TOperation>(threeAddressCode.operation().copy().release()));
+  auto results = TNode::Create(region, std::move(operation), operands);
 
   JLM_ASSERT(results.size() == threeAddressCode.nresults());
   for (size_t n = 0; n < threeAddressCode.nresults(); n++)

--- a/jlm/llvm/ir/operators/Load.cpp
+++ b/jlm/llvm/ir/operators/Load.cpp
@@ -91,7 +91,9 @@ rvsdg::Node *
 LoadNonVolatileNode::copy(rvsdg::Region * region, const std::vector<rvsdg::output *> & operands)
     const
 {
-  return &CreateNode(*region, GetOperation(), operands);
+  std::unique_ptr<LoadNonVolatileOperation> op(
+      util::AssertedCast<LoadNonVolatileOperation>(GetOperation().copy().release()));
+  return &CreateNode(*region, std::move(op), operands);
 }
 
 LoadVolatileOperation::~LoadVolatileOperation() noexcept = default;
@@ -166,7 +168,9 @@ LoadVolatileNode::CopyWithNewMemoryStates(const std::vector<rvsdg::output *> & m
 rvsdg::Node *
 LoadVolatileNode::copy(rvsdg::Region * region, const std::vector<rvsdg::output *> & operands) const
 {
-  return &CreateNode(*region, GetOperation(), operands);
+  std::unique_ptr<LoadVolatileOperation> op(
+      util::AssertedCast<LoadVolatileOperation>(GetOperation().copy().release()));
+  return &CreateNode(*region, std::move(op), operands);
 }
 
 /* load normal form */

--- a/jlm/llvm/ir/operators/Load.hpp
+++ b/jlm/llvm/ir/operators/Load.hpp
@@ -160,9 +160,9 @@ class LoadNode : public rvsdg::SimpleNode
 protected:
   LoadNode(
       rvsdg::Region & region,
-      const LoadOperation & operation,
+      std::unique_ptr<LoadOperation> operation,
       const std::vector<rvsdg::output *> & operands)
-      : SimpleNode(&region, operation, operands)
+      : SimpleNode(region, std::move(operation), operands)
   {}
 
 public:
@@ -258,9 +258,9 @@ class LoadVolatileNode final : public LoadNode
 private:
   LoadVolatileNode(
       rvsdg::Region & region,
-      const LoadVolatileOperation & operation,
+      std::unique_ptr<LoadVolatileOperation> operation,
       const std::vector<rvsdg::output *> & operands)
-      : LoadNode(region, operation, operands)
+      : LoadNode(region, std::move(operation), operands)
   {}
 
 public:
@@ -298,10 +298,10 @@ public:
   static LoadVolatileNode &
   CreateNode(
       rvsdg::Region & region,
-      const LoadVolatileOperation & loadOperation,
+      std::unique_ptr<LoadVolatileOperation> loadOperation,
       const std::vector<rvsdg::output *> & operands)
   {
-    return *(new LoadVolatileNode(region, loadOperation, operands));
+    return *(new LoadVolatileNode(region, std::move(loadOperation), operands));
   }
 
   static LoadVolatileNode &
@@ -315,17 +315,20 @@ public:
     std::vector<rvsdg::output *> operands({ &address, &iOState });
     operands.insert(operands.end(), memoryStates.begin(), memoryStates.end());
 
-    LoadVolatileOperation operation(std::move(loadedType), memoryStates.size(), alignment);
-    return CreateNode(*address.region(), operation, operands);
+    auto operation = std::make_unique<LoadVolatileOperation>(
+        std::move(loadedType),
+        memoryStates.size(),
+        alignment);
+    return CreateNode(*address.region(), std::move(operation), operands);
   }
 
   static std::vector<rvsdg::output *>
   Create(
       rvsdg::Region & region,
-      const LoadVolatileOperation & loadOperation,
+      std::unique_ptr<LoadVolatileOperation> loadOperation,
       const std::vector<rvsdg::output *> & operands)
   {
-    return rvsdg::outputs(&CreateNode(region, loadOperation, operands));
+    return rvsdg::outputs(&CreateNode(region, std::move(loadOperation), operands));
   }
 };
 
@@ -404,9 +407,9 @@ class LoadNonVolatileNode final : public LoadNode
 private:
   LoadNonVolatileNode(
       rvsdg::Region & region,
-      const LoadNonVolatileOperation & operation,
+      std::unique_ptr<LoadNonVolatileOperation> operation,
       const std::vector<rvsdg::output *> & operands)
-      : LoadNode(region, operation, operands)
+      : LoadNode(region, std::move(operation), operands)
   {}
 
 public:
@@ -445,26 +448,29 @@ public:
     std::vector<rvsdg::output *> operands({ &address });
     operands.insert(operands.end(), memoryStates.begin(), memoryStates.end());
 
-    LoadNonVolatileOperation loadOperation(std::move(loadedType), memoryStates.size(), alignment);
-    return CreateNode(*address.region(), loadOperation, operands);
+    auto operation = std::make_unique<LoadNonVolatileOperation>(
+        std::move(loadedType),
+        memoryStates.size(),
+        alignment);
+    return CreateNode(*address.region(), std::move(operation), operands);
   }
 
   static std::vector<rvsdg::output *>
   Create(
       rvsdg::Region & region,
-      const LoadNonVolatileOperation & loadOperation,
+      std::unique_ptr<LoadNonVolatileOperation> loadOperation,
       const std::vector<rvsdg::output *> & operands)
   {
-    return rvsdg::outputs(&CreateNode(region, loadOperation, operands));
+    return rvsdg::outputs(&CreateNode(region, std::move(loadOperation), operands));
   }
 
   static LoadNonVolatileNode &
   CreateNode(
       rvsdg::Region & region,
-      const LoadNonVolatileOperation & loadOperation,
+      std::unique_ptr<LoadNonVolatileOperation> loadOperation,
       const std::vector<rvsdg::output *> & operands)
   {
-    return *(new LoadNonVolatileNode(region, loadOperation, operands));
+    return *(new LoadNonVolatileNode(region, std::move(loadOperation), operands));
   }
 };
 

--- a/jlm/llvm/ir/operators/Phi.cpp
+++ b/jlm/llvm/ir/operators/Phi.cpp
@@ -36,7 +36,9 @@ node::~node()
 [[nodiscard]] const phi::operation &
 node::GetOperation() const noexcept
 {
-  return *static_cast<const phi::operation *>(&StructuralNode::GetOperation());
+  // Phi nodes are not parameterized, so we can return operation singleton.
+  static const phi::operation singleton;
+  return singleton;
 }
 
 cvinput *

--- a/jlm/llvm/ir/operators/Phi.hpp
+++ b/jlm/llvm/ir/operators/Phi.hpp
@@ -304,17 +304,20 @@ public:
   ~node() override;
 
 private:
-  node(rvsdg::Region * parent, const phi::operation & op)
-      : StructuralNode(op, parent, 1)
+  explicit node(rvsdg::Region * parent)
+      : StructuralNode(parent, 1)
   {}
 
   static phi::node *
-  create(rvsdg::Region * parent, const phi::operation & op)
+  create(rvsdg::Region * parent)
   {
-    return new phi::node(parent, op);
+    return new phi::node(parent);
   }
 
 public:
+  [[nodiscard]] const phi::operation &
+  GetOperation() const noexcept override;
+
   cvconstiterator
   begin_cv() const
   {
@@ -380,9 +383,6 @@ public:
   {
     return StructuralNode::subregion(0);
   }
-
-  [[nodiscard]] const phi::operation &
-  GetOperation() const noexcept override;
 
   cvargument *
   add_ctxvar(jlm::rvsdg::output * origin);
@@ -520,7 +520,7 @@ public:
     if (node_)
       return;
 
-    node_ = phi::node::create(parent, phi::operation());
+    node_ = phi::node::create(parent);
   }
 
   phi::cvargument *

--- a/jlm/llvm/ir/operators/Store.cpp
+++ b/jlm/llvm/ir/operators/Store.cpp
@@ -89,7 +89,9 @@ rvsdg::Node *
 StoreNonVolatileNode::copy(rvsdg::Region * region, const std::vector<rvsdg::output *> & operands)
     const
 {
-  return &CreateNode(*region, GetOperation(), operands);
+  std::unique_ptr<StoreNonVolatileOperation> op(
+      util::AssertedCast<StoreNonVolatileOperation>(GetOperation().copy().release()));
+  return &CreateNode(*region, std::move(op), operands);
 }
 
 StoreVolatileOperation::~StoreVolatileOperation() noexcept = default;
@@ -164,7 +166,9 @@ StoreVolatileNode::CopyWithNewMemoryStates(const std::vector<rvsdg::output *> & 
 rvsdg::Node *
 StoreVolatileNode::copy(rvsdg::Region * region, const std::vector<rvsdg::output *> & operands) const
 {
-  return &CreateNode(*region, GetOperation(), operands);
+  std::unique_ptr<StoreVolatileOperation> op(
+      util::AssertedCast<StoreVolatileOperation>(GetOperation().copy().release()));
+  return &CreateNode(*region, std::move(op), operands);
 }
 
 /* store normal form */

--- a/jlm/llvm/ir/operators/Store.hpp
+++ b/jlm/llvm/ir/operators/Store.hpp
@@ -148,9 +148,9 @@ class StoreNode : public rvsdg::SimpleNode
 protected:
   StoreNode(
       rvsdg::Region & region,
-      const StoreOperation & operation,
+      std::unique_ptr<StoreOperation> operation,
       const std::vector<rvsdg::output *> & operands)
-      : SimpleNode(&region, operation, operands)
+      : SimpleNode(region, std::move(operation), operands)
   {}
 
 public:
@@ -246,9 +246,9 @@ class StoreNonVolatileNode final : public StoreNode
 private:
   StoreNonVolatileNode(
       rvsdg::Region & region,
-      const StoreNonVolatileOperation & operation,
+      std::unique_ptr<StoreNonVolatileOperation> operation,
       const std::vector<jlm::rvsdg::output *> & operands)
-      : StoreNode(region, operation, operands)
+      : StoreNode(region, std::move(operation), operands)
   {}
 
 public:
@@ -289,26 +289,29 @@ public:
     std::vector<rvsdg::output *> operands({ &address, &value });
     operands.insert(operands.end(), memoryStates.begin(), memoryStates.end());
 
-    StoreNonVolatileOperation storeOperation(std::move(storedType), memoryStates.size(), alignment);
-    return CreateNode(*address.region(), storeOperation, operands);
+    auto operation = std::make_unique<StoreNonVolatileOperation>(
+        std::move(storedType),
+        memoryStates.size(),
+        alignment);
+    return CreateNode(*address.region(), std::move(operation), operands);
   }
 
   static std::vector<rvsdg::output *>
   Create(
       rvsdg::Region & region,
-      const StoreNonVolatileOperation & storeOperation,
+      std::unique_ptr<StoreNonVolatileOperation> storeOperation,
       const std::vector<rvsdg::output *> & operands)
   {
-    return rvsdg::outputs(&CreateNode(region, storeOperation, operands));
+    return rvsdg::outputs(&CreateNode(region, std::move(storeOperation), operands));
   }
 
   static StoreNonVolatileNode &
   CreateNode(
       rvsdg::Region & region,
-      const StoreNonVolatileOperation & storeOperation,
+      std::unique_ptr<StoreNonVolatileOperation> storeOperation,
       const std::vector<rvsdg::output *> & operands)
   {
-    return *(new StoreNonVolatileNode(region, storeOperation, operands));
+    return *(new StoreNonVolatileNode(region, std::move(storeOperation), operands));
   }
 
 private:
@@ -417,9 +420,9 @@ class StoreVolatileNode final : public StoreNode
 {
   StoreVolatileNode(
       rvsdg::Region & region,
-      const StoreVolatileOperation & operation,
+      std::unique_ptr<StoreVolatileOperation> operation,
       const std::vector<rvsdg::output *> & operands)
-      : StoreNode(region, operation, operands)
+      : StoreNode(region, std::move(operation), operands)
   {}
 
 public:
@@ -457,10 +460,10 @@ public:
   static StoreVolatileNode &
   CreateNode(
       rvsdg::Region & region,
-      const StoreVolatileOperation & storeOperation,
+      std::unique_ptr<StoreVolatileOperation> storeOperation,
       const std::vector<rvsdg::output *> & operands)
   {
-    return *(new StoreVolatileNode(region, storeOperation, operands));
+    return *(new StoreVolatileNode(region, std::move(storeOperation), operands));
   }
 
   static StoreVolatileNode &
@@ -476,17 +479,18 @@ public:
     std::vector<rvsdg::output *> operands({ &address, &value, &ioState });
     operands.insert(operands.end(), memoryStates.begin(), memoryStates.end());
 
-    StoreVolatileOperation storeOperation(storedType, memoryStates.size(), alignment);
-    return CreateNode(*address.region(), storeOperation, operands);
+    auto operation =
+        std::make_unique<StoreVolatileOperation>(storedType, memoryStates.size(), alignment);
+    return CreateNode(*address.region(), std::move(operation), operands);
   }
 
   static std::vector<rvsdg::output *>
   Create(
       rvsdg::Region & region,
-      const StoreVolatileOperation & loadOperation,
+      std::unique_ptr<StoreVolatileOperation> storeOperation,
       const std::vector<rvsdg::output *> & operands)
   {
-    return rvsdg::outputs(&CreateNode(region, loadOperation, operands));
+    return rvsdg::outputs(&CreateNode(region, std::move(storeOperation), operands));
   }
 
 private:

--- a/jlm/llvm/ir/operators/call.cpp
+++ b/jlm/llvm/ir/operators/call.cpp
@@ -156,7 +156,9 @@ CallOperation::copy() const
 rvsdg::Node *
 CallNode::copy(rvsdg::Region * region, const std::vector<rvsdg::output *> & operands) const
 {
-  return &CreateNode(*region, GetOperation(), operands);
+  std::unique_ptr<CallOperation> op(
+      util::AssertedCast<CallOperation>(GetOperation().copy().release()));
+  return &CreateNode(*region, std::move(op), operands);
 }
 
 rvsdg::output *

--- a/jlm/llvm/ir/operators/call.hpp
+++ b/jlm/llvm/ir/operators/call.hpp
@@ -290,9 +290,9 @@ class CallNode final : public jlm::rvsdg::SimpleNode
 private:
   CallNode(
       rvsdg::Region & region,
-      const CallOperation & operation,
+      std::unique_ptr<CallOperation> operation,
       const std::vector<jlm::rvsdg::output *> & operands)
-      : SimpleNode(&region, operation, operands)
+      : SimpleNode(region, std::move(operation), operands)
   {}
 
 public:
@@ -463,21 +463,21 @@ public:
   static std::vector<jlm::rvsdg::output *>
   Create(
       rvsdg::Region & region,
-      const CallOperation & callOperation,
+      std::unique_ptr<CallOperation> callOperation,
       const std::vector<rvsdg::output *> & operands)
   {
-    return CreateNode(region, callOperation, operands).Results();
+    return CreateNode(region, std::move(callOperation), operands).Results();
   }
 
   static CallNode &
   CreateNode(
       rvsdg::Region & region,
-      const CallOperation & callOperation,
+      std::unique_ptr<CallOperation> callOperation,
       const std::vector<rvsdg::output *> & operands)
   {
-    CheckFunctionType(*callOperation.GetFunctionType());
+    CheckFunctionType(*callOperation->GetFunctionType());
 
-    return *(new CallNode(region, callOperation, operands));
+    return *(new CallNode(region, std::move(callOperation), operands));
   }
 
   static CallNode &
@@ -488,11 +488,11 @@ public:
   {
     CheckFunctionInputType(function->type());
 
-    CallOperation callOperation(std::move(functionType));
+    auto callOperation = std::make_unique<CallOperation>(std::move(functionType));
     std::vector<rvsdg::output *> operands({ function });
     operands.insert(operands.end(), arguments.begin(), arguments.end());
 
-    return CreateNode(*function->region(), callOperation, operands);
+    return CreateNode(*function->region(), std::move(callOperation), operands);
   }
 
   /**

--- a/jlm/llvm/ir/operators/delta.cpp
+++ b/jlm/llvm/ir/operators/delta.cpp
@@ -45,7 +45,7 @@ node::~node()
 const delta::operation &
 node::GetOperation() const noexcept
 {
-  return *util::AssertedCast<const delta::operation>(&StructuralNode::GetOperation());
+  return *Operation_;
 }
 
 delta::node *

--- a/jlm/llvm/ir/operators/delta.hpp
+++ b/jlm/llvm/ir/operators/delta.hpp
@@ -139,8 +139,9 @@ public:
   ~node() override;
 
 private:
-  node(rvsdg::Region * parent, delta::operation && op)
-      : StructuralNode(op, parent, 1)
+  node(rvsdg::Region * parent, std::unique_ptr<delta::operation> op)
+      : StructuralNode(parent, 1),
+        Operation_(std::move(op))
   {}
 
 public:
@@ -285,7 +286,12 @@ public:
       std::string section,
       bool constant)
   {
-    delta::operation op(std::move(type), name, linkage, std::move(section), constant);
+    auto op = std::make_unique<delta::operation>(
+        std::move(type),
+        name,
+        linkage,
+        std::move(section),
+        constant);
     return new delta::node(parent, std::move(op));
   }
 
@@ -298,6 +304,9 @@ public:
    */
   delta::output *
   finalize(rvsdg::output * result);
+
+private:
+  std::unique_ptr<delta::operation> Operation_;
 };
 
 /** \brief Delta context variable input

--- a/jlm/llvm/ir/operators/lambda.hpp
+++ b/jlm/llvm/ir/operators/lambda.hpp
@@ -132,7 +132,7 @@ public:
   ~node() override;
 
 private:
-  node(rvsdg::Region & parent, lambda::operation op);
+  node(rvsdg::Region & parent, std::unique_ptr<lambda::operation> op);
 
 public:
   /**
@@ -423,6 +423,7 @@ public:
 
 private:
   std::vector<jlm::llvm::attributeset> ArgumentAttributes_;
+  std::unique_ptr<lambda::operation> Operation_;
 };
 
 /**

--- a/jlm/rvsdg/gamma.cpp
+++ b/jlm/rvsdg/gamma.cpp
@@ -214,10 +214,17 @@ GammaOperation::operator==(const Operation & other) const noexcept
 GammaNode::~GammaNode() noexcept = default;
 
 GammaNode::GammaNode(rvsdg::output * predicate, size_t nalternatives)
-    : StructuralNode(GammaOperation(nalternatives), predicate->region(), nalternatives)
+    : StructuralNode(predicate->region(), nalternatives),
+      Operation_(nalternatives)
 {
   add_input(std::unique_ptr<node_input>(
       new StructuralInput(this, predicate, ControlType::Create(nalternatives))));
+}
+
+[[nodiscard]] const GammaOperation &
+GammaNode::GetOperation() const noexcept
+{
+  return Operation_;
 }
 
 GammaNode::EntryVar

--- a/jlm/rvsdg/gamma.hpp
+++ b/jlm/rvsdg/gamma.hpp
@@ -88,6 +88,9 @@ public:
     rvsdg::output * output;
   };
 
+  [[nodiscard]] const GammaOperation &
+  GetOperation() const noexcept override;
+
   static GammaNode *
   create(jlm::rvsdg::output * predicate, size_t nalternatives)
   {
@@ -257,6 +260,9 @@ public:
 
   virtual GammaNode *
   copy(jlm::rvsdg::Region * region, SubstitutionMap & smap) const override;
+
+private:
+  GammaOperation Operation_;
 };
 
 /**

--- a/jlm/rvsdg/node.cpp
+++ b/jlm/rvsdg/node.cpp
@@ -188,11 +188,10 @@ node_output::GetOwner() const noexcept
 
 /* node class */
 
-Node::Node(std::unique_ptr<Operation> op, Region * region)
+Node::Node(Region * region)
     : depth_(0),
       graph_(region->graph()),
-      region_(region),
-      operation_(std::move(op))
+      region_(region)
 {
   bool wasAdded = region->AddBottomNode(*this);
   JLM_ASSERT(wasAdded);

--- a/jlm/rvsdg/node.hpp
+++ b/jlm/rvsdg/node.hpp
@@ -627,13 +627,10 @@ class Node
 public:
   virtual ~Node();
 
-  Node(std::unique_ptr<Operation> op, Region * region);
+  explicit Node(Region * region);
 
   [[nodiscard]] virtual const Operation &
-  GetOperation() const noexcept
-  {
-    return *operation_;
-  }
+  GetOperation() const noexcept = 0;
 
   inline bool
   has_users() const noexcept
@@ -877,7 +874,6 @@ private:
   size_t depth_;
   Graph * graph_;
   rvsdg::Region * region_;
-  std::unique_ptr<Operation> operation_;
   std::vector<std::unique_ptr<node_input>> inputs_;
   std::vector<std::unique_ptr<node_output>> outputs_;
 };

--- a/jlm/rvsdg/simple-node.cpp
+++ b/jlm/rvsdg/simple-node.cpp
@@ -45,7 +45,8 @@ SimpleNode::SimpleNode(
     rvsdg::Region * region,
     const SimpleOperation & op,
     const std::vector<jlm::rvsdg::output *> & operands)
-    : Node(op.copy(), region)
+    : Node(region),
+      Operation_(static_cast<SimpleOperation *>(op.copy().release()))
 {
   if (SimpleNode::GetOperation().narguments() != operands.size())
     throw jlm::util::error(jlm::util::strfmt(
@@ -71,9 +72,10 @@ SimpleNode::SimpleNode(
     rvsdg::Region & region,
     std::unique_ptr<SimpleOperation> operation,
     const std::vector<jlm::rvsdg::output *> & operands)
-    : Node(std::move(operation), &region)
+    : Node(&region),
+      Operation_(std::move(operation))
 {
-  if (SimpleNode::GetOperation().narguments() != operands.size())
+  if (GetOperation().narguments() != operands.size())
     throw jlm::util::error(jlm::util::strfmt(
         "Argument error - expected ",
         SimpleNode::GetOperation().narguments(),
@@ -96,7 +98,7 @@ SimpleNode::SimpleNode(
 const SimpleOperation &
 SimpleNode::GetOperation() const noexcept
 {
-  return *util::AssertedCast<const SimpleOperation>(&Node::GetOperation());
+  return *Operation_;
 }
 
 Node *

--- a/jlm/rvsdg/simple-node.cpp
+++ b/jlm/rvsdg/simple-node.cpp
@@ -42,33 +42,6 @@ SimpleNode::~SimpleNode()
 }
 
 SimpleNode::SimpleNode(
-    rvsdg::Region * region,
-    const SimpleOperation & op,
-    const std::vector<jlm::rvsdg::output *> & operands)
-    : Node(region),
-      Operation_(static_cast<SimpleOperation *>(op.copy().release()))
-{
-  if (SimpleNode::GetOperation().narguments() != operands.size())
-    throw jlm::util::error(jlm::util::strfmt(
-        "Argument error - expected ",
-        SimpleNode::GetOperation().narguments(),
-        ", received ",
-        operands.size(),
-        " arguments."));
-
-  for (size_t n = 0; n < SimpleNode::GetOperation().narguments(); n++)
-  {
-    add_input(
-        std::make_unique<simple_input>(this, operands[n], SimpleNode::GetOperation().argument(n)));
-  }
-
-  for (size_t n = 0; n < SimpleNode::GetOperation().nresults(); n++)
-    add_output(std::make_unique<simple_output>(this, SimpleNode::GetOperation().result(n)));
-
-  on_node_create(this);
-}
-
-SimpleNode::SimpleNode(
     rvsdg::Region & region,
     std::unique_ptr<SimpleOperation> operation,
     const std::vector<jlm::rvsdg::output *> & operands)

--- a/jlm/rvsdg/simple-node.hpp
+++ b/jlm/rvsdg/simple-node.hpp
@@ -77,6 +77,9 @@ public:
     auto nf = static_cast<simple_normal_form *>(region->graph()->GetNodeNormalForm(typeid(op)));
     return nf->normalized_create(region, op, operands);
   }
+
+private:
+  std::unique_ptr<SimpleOperation> Operation_;
 };
 
 /* inputs */

--- a/jlm/rvsdg/simple-node.hpp
+++ b/jlm/rvsdg/simple-node.hpp
@@ -25,11 +25,6 @@ public:
 
 protected:
   SimpleNode(
-      rvsdg::Region * region,
-      const SimpleOperation & op,
-      const std::vector<jlm::rvsdg::output *> & operands);
-
-  SimpleNode(
       rvsdg::Region & region,
       std::unique_ptr<SimpleOperation> operation,
       const std::vector<jlm::rvsdg::output *> & operands);
@@ -56,7 +51,9 @@ public:
       const SimpleOperation & op,
       const std::vector<jlm::rvsdg::output *> & operands)
   {
-    return new SimpleNode(region, op, operands);
+    std::unique_ptr<SimpleOperation> newOp(
+        util::AssertedCast<SimpleOperation>(op.copy().release()));
+    return new SimpleNode(*region, std::move(newOp), operands);
   }
 
   static inline jlm::rvsdg::SimpleNode &

--- a/jlm/rvsdg/structural-node.cpp
+++ b/jlm/rvsdg/structural-node.cpp
@@ -53,11 +53,8 @@ StructuralNode::~StructuralNode() noexcept
   subregions_.clear();
 }
 
-StructuralNode::StructuralNode(
-    const StructuralOperation & op,
-    rvsdg::Region * region,
-    size_t nsubregions)
-    : Node(op.copy(), region)
+StructuralNode::StructuralNode(rvsdg::Region * region, size_t nsubregions)
+    : Node(region)
 {
   if (nsubregions == 0)
     throw jlm::util::error("Number of subregions must be greater than zero.");

--- a/jlm/rvsdg/structural-node.hpp
+++ b/jlm/rvsdg/structural-node.hpp
@@ -24,11 +24,7 @@ public:
   ~StructuralNode() noexcept override;
 
 protected:
-  StructuralNode(
-      /* FIXME: use move semantics instead of copy semantics for op */
-      const StructuralOperation & op,
-      rvsdg::Region * region,
-      size_t nsubregions);
+  StructuralNode(rvsdg::Region * region, size_t nsubregions);
 
 public:
   inline size_t

--- a/jlm/rvsdg/theta.cpp
+++ b/jlm/rvsdg/theta.cpp
@@ -26,8 +26,17 @@ ThetaOperation::copy() const
 
 ThetaNode::~ThetaNode() noexcept = default;
 
+[[nodiscard]] const ThetaOperation &
+ThetaNode::GetOperation() const noexcept
+{
+  // Theta presently has no parametrization, so we can indeed
+  // just return a singleton here.
+  static const ThetaOperation singleton;
+  return singleton;
+}
+
 ThetaNode::ThetaNode(rvsdg::Region & parent)
-    : StructuralNode(ThetaOperation(), &parent, 1)
+    : StructuralNode(&parent, 1)
 {
   auto predicate = control_false(subregion());
   RegionResult::Create(*subregion(), *predicate, nullptr, ControlType::Create(2));

--- a/jlm/rvsdg/theta.hpp
+++ b/jlm/rvsdg/theta.hpp
@@ -66,6 +66,9 @@ public:
     rvsdg::output * output;
   };
 
+  [[nodiscard]] const ThetaOperation &
+  GetOperation() const noexcept override;
+
   static ThetaNode *
   create(rvsdg::Region * parent)
   {

--- a/tests/test-operation.cpp
+++ b/tests/test-operation.cpp
@@ -154,6 +154,13 @@ structural_op::copy() const
 structural_node::~structural_node()
 {}
 
+[[nodiscard]] const structural_op &
+structural_node::GetOperation() const noexcept
+{
+  static structural_op singleton;
+  return singleton;
+}
+
 structural_node *
 structural_node::copy(rvsdg::Region * parent, rvsdg::SubstitutionMap & smap) const
 {

--- a/tests/test-operation.hpp
+++ b/tests/test-operation.hpp
@@ -416,9 +416,9 @@ class SimpleNode final : public rvsdg::SimpleNode
 private:
   SimpleNode(
       rvsdg::Region & region,
-      const test_op & operation,
+      std::unique_ptr<test_op> operation,
       const std::vector<rvsdg::output *> & operands)
-      : rvsdg::SimpleNode(&region, operation, operands)
+      : rvsdg::SimpleNode(region, std::move(operation), operands)
   {}
 
 public:
@@ -433,9 +433,9 @@ public:
       std::vector<std::shared_ptr<const rvsdg::Type>> resultTypes)
   {
     auto operandTypes = ExtractTypes(operands);
-    test_op operation(std::move(operandTypes), std::move(resultTypes));
+    auto operation = std::make_unique<test_op>(std::move(operandTypes), std::move(resultTypes));
 
-    auto node = new SimpleNode(region, operation, operands);
+    auto node = new SimpleNode(region, std::move(operation), operands);
     return *node;
   }
 

--- a/tests/test-operation.hpp
+++ b/tests/test-operation.hpp
@@ -216,10 +216,13 @@ public:
 
 private:
   structural_node(rvsdg::Region * parent, size_t nsubregions)
-      : rvsdg::StructuralNode(structural_op(), parent, nsubregions)
+      : rvsdg::StructuralNode(parent, nsubregions)
   {}
 
 public:
+  [[nodiscard]] const structural_op &
+  GetOperation() const noexcept override;
+
   StructuralNodeInput &
   AddInput(rvsdg::output & origin);
 


### PR DESCRIPTION
Merge two commits:

1.  Make node operations type-safe
    
    Only override Node::GetOperation in the most derived subclasses, and
    let them store properly typed operation classes (instead of downcasting
    them on each access).
    
    This later also allows to more flexibly handle contents of operations in
    a node-specific fashions.


2.  Avoid operator copy on construction of SimpleNode
    
    Remove remaining constructor of SimpleNode that makes a copy of the given
    operator. Leave only the one that allows moving an operator in.

This moves the architecture further towards making the nodes mostly "shells"
that contain graph-connectivity information, while the business logic is associated
with the operators.