### PR TITLE
Clean up API of lambda node before RVSDG move

### DIFF
--- a/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.cpp
+++ b/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.cpp
@@ -2819,7 +2819,7 @@ RhlsToFirrtlConverter::MlirGen(const llvm::lambda::node * lambdaNode)
   // Ensure consistent naming across runs
   create_node_names(lambdaNode->subregion());
   // The same name is used for the circuit and main module
-  auto moduleName = Builder_->getStringAttr(lambdaNode->name() + "_lambda_mod");
+  auto moduleName = Builder_->getStringAttr(lambdaNode->GetOperation().name() + "_lambda_mod");
   // Create the top level FIRRTL circuit
   auto circuit = Builder_->create<circt::firrtl::CircuitOp>(Builder_->getUnknownLoc(), moduleName);
   // The body will be populated with a list of modules

--- a/jlm/hls/backend/rhls2firrtl/json-hls.cpp
+++ b/jlm/hls/backend/rhls2firrtl/json-hls.cpp
@@ -14,7 +14,7 @@ JsonHLS::GetText(llvm::RvsdgModule & rm)
 {
   std::ostringstream json;
   const auto & ln = *get_hls_lambda(rm);
-  auto function_name = ln.name();
+  auto function_name = ln.GetOperation().name();
   auto file_name = get_base_file_name(rm);
   json << "{\n";
 

--- a/jlm/hls/backend/rhls2firrtl/verilator-harness-hls.cpp
+++ b/jlm/hls/backend/rhls2firrtl/verilator-harness-hls.cpp
@@ -43,7 +43,7 @@ ConvertToCType(const rvsdg::Type * type)
 std::optional<std::string>
 GetReturnTypeAsC(const llvm::lambda::node & kernel)
 {
-  const auto & results = kernel.type().Results();
+  const auto & results = kernel.GetOperation().type().Results();
 
   if (results.empty())
     return std::nullopt;
@@ -71,7 +71,7 @@ GetParameterListAsC(const llvm::lambda::node & kernel)
   std::ostringstream parameters;
   std::ostringstream arguments;
 
-  for (auto & argType : kernel.type().Arguments())
+  for (auto & argType : kernel.GetOperation().type().Arguments())
   {
     if (rvsdg::is<rvsdg::StateType>(argType))
       continue;
@@ -97,7 +97,7 @@ VerilatorHarnessHLS::GetText(llvm::RvsdgModule & rm)
 {
   std::ostringstream cpp;
   const auto & kernel = *get_hls_lambda(rm);
-  const auto & function_name = kernel.name();
+  const auto & function_name = kernel.GetOperation().name();
 
   // The request and response parts of memory queues
   const auto mem_reqs = get_mem_reqs(kernel);

--- a/jlm/hls/backend/rvsdg2rhls/UnusedStateRemoval.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/UnusedStateRemoval.cpp
@@ -35,7 +35,8 @@ IsPassthroughResult(const rvsdg::input & result)
 static void
 RemoveUnusedStatesFromLambda(llvm::lambda::node & lambdaNode)
 {
-  auto & oldFunctionType = lambdaNode.type();
+  const auto & op = lambdaNode.GetOperation();
+  auto & oldFunctionType = op.type();
 
   std::vector<std::shared_ptr<const jlm::rvsdg::Type>> newArgumentTypes;
   for (size_t i = 0; i < oldFunctionType.NumArguments(); ++i)
@@ -67,9 +68,9 @@ RemoveUnusedStatesFromLambda(llvm::lambda::node & lambdaNode)
   auto newLambda = llvm::lambda::node::create(
       lambdaNode.region(),
       newFunctionType,
-      lambdaNode.name(),
-      lambdaNode.linkage(),
-      lambdaNode.attributes());
+      op.name(),
+      op.linkage(),
+      op.attributes());
 
   rvsdg::SubstitutionMap substitutionMap;
   for (const auto & ctxvar : lambdaNode.GetContextVars())

--- a/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
@@ -31,7 +31,8 @@ get_trigger(rvsdg::Region * region)
 jlm::llvm::lambda::node *
 add_lambda_argument(llvm::lambda::node * ln, std::shared_ptr<const jlm::rvsdg::Type> type)
 {
-  auto old_fcttype = ln->type();
+  const auto & op = ln->GetOperation();
+  auto old_fcttype = op.type();
   std::vector<std::shared_ptr<const jlm::rvsdg::Type>> new_argument_types;
   for (size_t i = 0; i < old_fcttype.NumArguments(); ++i)
   {
@@ -47,9 +48,9 @@ add_lambda_argument(llvm::lambda::node * ln, std::shared_ptr<const jlm::rvsdg::T
   auto new_lambda = llvm::lambda::node::create(
       ln->region(),
       new_fcttype,
-      ln->name(),
-      ln->linkage(),
-      ln->attributes());
+      op.name(),
+      op.linkage(),
+      op.attributes());
 
   rvsdg::SubstitutionMap smap;
   for (const auto & ctxvar : ln->GetContextVars())

--- a/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
@@ -31,15 +31,6 @@ change_function_name(llvm::lambda::node * ln, const std::string & name)
     subregionmap.insert(cv.inner, newcv.inner);
   }
 
-  /* collect function arguments */
-  auto args = ln->GetFunctionArguments();
-  auto new_args = lambda->GetFunctionArguments();
-  for (size_t n = 0; n < args.size(); n++)
-  {
-    lambda->SetArgumentAttributes(*new_args[n], ln->GetArgumentAttributes(*args[n]));
-    subregionmap.insert(args[n], new_args[n]);
-  }
-
   /* copy subregion */
   ln->subregion()->copy(lambda->subregion(), subregionmap, false, false);
 

--- a/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
@@ -30,6 +30,14 @@ change_function_name(llvm::lambda::node * ln, const std::string & name)
     auto newcv = lambda->AddContextVar(*origin);
     subregionmap.insert(cv.inner, newcv.inner);
   }
+  /* collect function arguments */
+  auto args = ln->GetFunctionArguments();
+  auto newArgs = lambda->GetFunctionArguments();
+  JLM_ASSERT(args.size() == newArgs.size());
+  for (std::size_t n = 0; n < args.size(); ++n)
+  {
+    subregionmap.insert(args[n], newArgs[n]);
+  }
 
   /* copy subregion */
   ln->subregion()->copy(lambda->subregion(), subregionmap, false, false);

--- a/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
@@ -18,8 +18,9 @@ namespace jlm::hls
 llvm::lambda::node *
 change_function_name(llvm::lambda::node * ln, const std::string & name)
 {
+  const auto & op = ln->GetOperation();
   auto lambda =
-      llvm::lambda::node::create(ln->region(), ln->Type(), name, ln->linkage(), ln->attributes());
+      llvm::lambda::node::create(ln->region(), op.Type(), name, op.linkage(), op.attributes());
 
   /* add context variables */
   rvsdg::SubstitutionMap subregionmap;
@@ -65,7 +66,7 @@ instrument_ref(llvm::RvsdgModule & rm)
 
   auto newLambda = change_function_name(lambda, "instrumented_ref");
 
-  auto functionType = newLambda->type();
+  auto functionType = newLambda->GetOperation().type();
   auto numArguments = functionType.NumArguments();
   if (numArguments == 0)
   {

--- a/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
@@ -574,7 +574,8 @@ jlm::hls::MemoryConverter(jlm::llvm::RvsdgModule & rm)
   // Converting loads and stores to explicitly use memory ports
   // This modifies the function signature so we create a new lambda node to replace the old one
   //
-  auto oldFunctionType = lambda->type();
+  const auto & op = lambda->GetOperation();
+  auto oldFunctionType = op.type();
   std::vector<std::shared_ptr<const jlm::rvsdg::Type>> newArgumentTypes;
   for (size_t i = 0; i < oldFunctionType.NumArguments(); ++i)
   {
@@ -643,9 +644,9 @@ jlm::hls::MemoryConverter(jlm::llvm::RvsdgModule & rm)
   auto newLambda = jlm::llvm::lambda::node::create(
       lambda->region(),
       newFunctionType,
-      lambda->name(),
-      lambda->linkage(),
-      lambda->attributes());
+      op.name(),
+      op.linkage(),
+      op.attributes());
 
   rvsdg::SubstitutionMap smap;
   for (const auto & ctxvar : lambda->GetContextVars())

--- a/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/remove-unused-state.cpp
@@ -176,7 +176,8 @@ remove_gamma_passthrough(rvsdg::GammaNode * gn)
 jlm::llvm::lambda::node *
 remove_lambda_passthrough(llvm::lambda::node * ln)
 {
-  auto old_fcttype = ln->type();
+  const auto & op = ln->GetOperation();
+  auto old_fcttype = op.type();
   std::vector<std::shared_ptr<const jlm::rvsdg::Type>> new_argument_types;
   for (size_t i = 0; i < old_fcttype.NumArguments(); ++i)
   {
@@ -203,9 +204,9 @@ remove_lambda_passthrough(llvm::lambda::node * ln)
   auto new_lambda = llvm::lambda::node::create(
       ln->region(),
       new_fcttype,
-      ln->name(),
-      ln->linkage(),
-      ln->attributes());
+      op.name(),
+      op.linkage(),
+      op.attributes());
 
   rvsdg::SubstitutionMap smap;
   for (const auto & ctxvar : ln->GetContextVars())

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -294,6 +294,14 @@ change_linkage(llvm::lambda::node * ln, llvm::linkage link)
     auto newcv = lambda->AddContextVar(*origin);
     subregionmap.insert(cv.inner, newcv.inner);
   }
+  /* collect function arguments */
+  auto args = ln->GetFunctionArguments();
+  auto newArgs = lambda->GetFunctionArguments();
+  JLM_ASSERT(args.size() == newArgs.size());
+  for (std::size_t n = 0; n < args.size(); ++n)
+  {
+    subregionmap.insert(args[n], newArgs[n]);
+  }
 
   /* copy subregion */
   ln->subregion()->copy(lambda->subregion(), subregionmap, false, false);

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -295,16 +295,6 @@ change_linkage(llvm::lambda::node * ln, llvm::linkage link)
     subregionmap.insert(cv.inner, newcv.inner);
   }
 
-  /* collect function arguments */
-  auto args = ln->GetFunctionArguments();
-  auto newArgs = lambda->GetFunctionArguments();
-  JLM_ASSERT(args.size() == newArgs.size());
-  for (size_t n = 0; n < args.size(); n++)
-  {
-    lambda->SetArgumentAttributes(*newArgs[n], ln->GetArgumentAttributes(*args[n]));
-    subregionmap.insert(args[n], newArgs[n]);
-  }
-
   /* copy subregion */
   ln->subregion()->copy(lambda->subregion(), subregionmap, false, false);
 

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -100,7 +100,7 @@ bool
 function_match(llvm::lambda::node * ln, const std::string & function_name)
 {
   const std::regex fn_regex(function_name);
-  if (std::regex_match(ln->name(), fn_regex))
+  if (std::regex_match(ln->GetOperation().name(), fn_regex))
   { // TODO: handle C++ name mangling
     return true;
   }
@@ -282,8 +282,9 @@ rename_delta(llvm::delta::node * odn)
 llvm::lambda::node *
 change_linkage(llvm::lambda::node * ln, llvm::linkage link)
 {
+  const auto & op = ln->GetOperation();
   auto lambda =
-      llvm::lambda::node::create(ln->region(), ln->Type(), ln->name(), link, ln->attributes());
+      llvm::lambda::node::create(ln->region(), op.Type(), op.name(), link, op.attributes());
 
   /* add context variables */
   rvsdg::SubstitutionMap subregionmap;
@@ -360,7 +361,8 @@ split_hls_function(llvm::RvsdgModule & rm, const std::string & function_name)
         auto orig_node = orig_node_output->node();
         if (auto oln = dynamic_cast<llvm::lambda::node *>(orig_node))
         {
-          throw jlm::util::error("Inlining of function " + oln->name() + " not supported");
+          throw jlm::util::error(
+              "Inlining of function " + oln->GetOperation().name() + " not supported");
         }
         else if (auto odn = dynamic_cast<llvm::delta::node *>(orig_node))
         {
@@ -393,15 +395,16 @@ split_hls_function(llvm::RvsdgModule & rm, const std::string & function_name)
       auto oldExport = jlm::llvm::ComputeCallSummary(*ln).GetRvsdgExport();
       jlm::llvm::GraphExport::Create(*new_ln->output(), oldExport ? oldExport->Name() : "");
       // add function as input to rm and remove it
+      const auto & op = ln->GetOperation();
       auto & graphImport = llvm::GraphImport::Create(
           rm.Rvsdg(),
-          ln->Type(),
-          ln->Type(),
-          ln->name(),
+          op.Type(),
+          op.Type(),
+          op.name(),
           llvm::linkage::external_linkage); // TODO: change linkage?
       ln->output()->divert_users(&graphImport);
       remove(ln);
-      std::cout << "function " << new_ln->name() << " extracted for HLS\n";
+      std::cout << "function " << new_ln->GetOperation().name() << " extracted for HLS\n";
       return rhls;
     }
   }

--- a/jlm/llvm/Makefile.sub
+++ b/jlm/llvm/Makefile.sub
@@ -23,6 +23,7 @@ libllvm_SOURCES = \
     jlm/llvm/ir/domtree.cpp \
     jlm/llvm/ir/ipgraph.cpp \
     jlm/llvm/ir/ipgraph-module.cpp \
+    jlm/llvm/ir/LambdaMemoryState.cpp \
     jlm/llvm/ir/TypeConverter.cpp \
     jlm/llvm/ir/operators/alloca.cpp \
     jlm/llvm/ir/operators/call.cpp \
@@ -104,6 +105,7 @@ libllvm_HEADERS = \
 	jlm/llvm/ir/Annotation.hpp \
 	jlm/llvm/ir/attribute.hpp \
 	jlm/llvm/ir/CallSummary.hpp \
+	jlm/llvm/ir/LambdaMemoryState.hpp \
 	jlm/llvm/ir/tac.hpp \
 	jlm/llvm/ir/domtree.hpp \
 	jlm/llvm/ir/cfg-node.hpp \

--- a/jlm/llvm/backend/rvsdg2jlm/rvsdg2jlm.cpp
+++ b/jlm/llvm/backend/rvsdg2jlm/rvsdg2jlm.cpp
@@ -131,8 +131,10 @@ create_cfg(const lambda::node & lambda, context & ctx)
   for (auto fctarg : lambda.GetFunctionArguments())
   {
     auto name = util::strfmt("_a", fctarg->index(), "_");
-    auto argument =
-        llvm::argument::create(name, fctarg->Type(), lambda.GetArgumentAttributes(*fctarg));
+    auto argument = llvm::argument::create(
+        name,
+        fctarg->Type(),
+        lambda.GetOperation().GetArgumentAttributes(fctarg->index()));
     auto v = cfg->entry()->append_argument(std::move(argument));
     ctx.insert(fctarg, v);
   }

--- a/jlm/llvm/backend/rvsdg2jlm/rvsdg2jlm.cpp
+++ b/jlm/llvm/backend/rvsdg2jlm/rvsdg2jlm.cpp
@@ -413,12 +413,8 @@ convert_lambda_node(const rvsdg::Node & node, context & ctx)
   auto & module = ctx.module();
   auto & clg = module.ipgraph();
 
-  auto f = function_node::create(
-      clg,
-      lambda->name(),
-      lambda->Type(),
-      lambda->linkage(),
-      lambda->attributes());
+  const auto & op = lambda->GetOperation();
+  auto f = function_node::create(clg, op.name(), op.Type(), op.linkage(), op.attributes());
   auto v = module.create_variable(f);
 
   f->add_cfg(create_cfg(*lambda, ctx));
@@ -449,12 +445,8 @@ convert_phi_node(const rvsdg::Node & node, context & ctx)
 
     if (auto lambda = dynamic_cast<const lambda::node *>(node))
     {
-      auto f = function_node::create(
-          ipg,
-          lambda->name(),
-          lambda->Type(),
-          lambda->linkage(),
-          lambda->attributes());
+      const auto & op = lambda->GetOperation();
+      auto f = function_node::create(ipg, op.name(), op.Type(), op.linkage(), op.attributes());
       ctx.insert(subregion->argument(n), module.create_variable(f));
     }
     else

--- a/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
+++ b/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
@@ -616,7 +616,7 @@ Convert(
     auto lambdaNodeArgument = lambdaArgs[n];
 
     topVariableMap.insert(functionNodeArgument, lambdaNodeArgument);
-    lambdaNode.SetArgumentAttributes(*lambdaNodeArgument, functionNodeArgument->attributes());
+    lambdaNode.GetOperation().SetArgumentAttributes(n, functionNodeArgument->attributes());
   }
 
   /*

--- a/jlm/llvm/ir/LambdaMemoryState.cpp
+++ b/jlm/llvm/ir/LambdaMemoryState.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <jlm/llvm/ir/LambdaMemoryState.hpp>
+#include <jlm/llvm/ir/operators/MemoryStateOperations.hpp>
+
+namespace jlm::llvm
+{
+
+rvsdg::output &
+GetMemoryStateRegionArgument(const lambda::node & lambdaNode) noexcept
+{
+  auto argument = lambdaNode.GetFunctionArguments().back();
+  JLM_ASSERT(is<MemoryStateType>(argument->type()));
+  return *argument;
+}
+
+rvsdg::input &
+GetMemoryStateRegionResult(const lambda::node & lambdaNode) noexcept
+{
+  auto result = lambdaNode.GetFunctionResults().back();
+  JLM_ASSERT(is<MemoryStateType>(result->type()));
+  return *result;
+}
+
+rvsdg::SimpleNode *
+GetMemoryStateExitMerge(const lambda::node & lambdaNode) noexcept
+{
+  auto & result = GetMemoryStateRegionResult(lambdaNode);
+
+  auto node = rvsdg::output::GetNode(*result.origin());
+  return is<LambdaExitMemoryStateMergeOperation>(node) ? dynamic_cast<rvsdg::SimpleNode *>(node)
+                                                       : nullptr;
+}
+
+rvsdg::SimpleNode *
+GetMemoryStateEntrySplit(const lambda::node & lambdaNode) noexcept
+{
+  auto & argument = GetMemoryStateRegionArgument(lambdaNode);
+
+  // If a memory state entry split node is present, then we would expect the node to be the only
+  // user of the memory state argument.
+  if (argument.nusers() != 1)
+    return nullptr;
+
+  auto node = rvsdg::node_input::GetNode(**argument.begin());
+  return is<LambdaEntryMemoryStateSplitOperation>(node) ? dynamic_cast<rvsdg::SimpleNode *>(node)
+                                                        : nullptr;
+}
+
+}

--- a/jlm/llvm/ir/LambdaMemoryState.hpp
+++ b/jlm/llvm/ir/LambdaMemoryState.hpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2018 Nico Reißmann <nico.reissmann@gmail.com>
+ * Copyright 2025 Helge Bahmann <hcb@chaoticmind.net>
+ * See COPYING for terms of redistribution.
+ */
+
+#ifndef JLM_LLVM_IR_LAMBDAMEMORYSTATE_HPP
+#define JLM_LLVM_IR_LAMBDAMEMORYSTATE_HPP
+
+/**
+ * \brief Global memory state passed between functions.
+ *
+ * This file contains various helpers to manage the memory state
+ * as it is passed between llvm functions represented as lambda
+ * operations, and the chosen memory model for this mapping.
+ */
+
+#include <jlm/llvm/ir/operators/lambda.hpp>
+#include <jlm/rvsdg/simple-node.hpp>
+
+namespace jlm::llvm
+{
+
+/**
+ * Determines the formal argument representing global memory state
+ *
+ * \param lambdaNode
+ *   The lambda node to query the memory state for.
+ *
+ * \returns
+ *   The memory state argument of the lambda subregion.
+ *
+ * \pre
+ *   The \p lambdaNode must conform to the modelling assumptions behind
+ *   llvm function representation as lambdas and memory state encoding.
+ */
+[[nodiscard]] rvsdg::output &
+GetMemoryStateRegionArgument(const lambda::node & lambdaNode) noexcept;
+
+/**
+ * Determines the formal return value representing global memory state
+ *
+ * \param lambdaNode
+ *   The lambda node to query the memory state for.
+ *
+ * \returns
+ *   The memory state result of the lambda subregion.
+ *
+ * \pre
+ *   The \p lambdaNode must conform to the modelling assumptions behind
+ *   llvm function representation as lambdas and memory state encoding.
+ */
+[[nodiscard]] rvsdg::input &
+GetMemoryStateRegionResult(const lambda::node & lambdaNode) noexcept;
+
+/**
+ * Determines the memory state split node at entry.
+ *
+ * \param lambdaNode
+ *   The lambda node to query the memory state entry split node for.
+ *
+ * \returns
+ *   The LambdaEntryMemoryStateSplitOperation node connected to the memory
+ *   state input if present, otherwise nullptr.
+ *
+ * \pre
+ *   The \p lambdaNode must conform to the modelling assumptions behind
+ *   llvm function representation as lambdas and memory state encoding.
+ *
+ * \see GetMemoryStateExitMerge()
+ */
+rvsdg::SimpleNode *
+GetMemoryStateEntrySplit(const lambda::node & lambdaNode) noexcept;
+
+/**
+ * Determines the memory state merge node at exit.
+ *
+ * \param lambdaNode
+ *   The lambda node to query the memory state exit mux node for.
+ *
+ * \returns
+ *   The LambdaEntryMemoryStateMergeOperation node connected to the memory
+ *   state input if present, otherwise nullptr.
+ *
+ * \pre
+ *   The \p lambdaNode must conform to the modelling assumptions behind
+ *   llvm function representation as lambdas and memory state encoding.
+ *
+ * \see GetMemoryStateEntrySplit()
+ */
+[[nodiscard]] rvsdg::SimpleNode *
+GetMemoryStateExitMerge(const lambda::node & lambdaNode) noexcept;
+
+}
+
+#endif

--- a/jlm/llvm/ir/operators/lambda.cpp
+++ b/jlm/llvm/ir/operators/lambda.cpp
@@ -8,8 +8,6 @@
 #include <jlm/rvsdg/gamma.hpp>
 #include <jlm/rvsdg/theta.hpp>
 
-#include <deque>
-
 namespace jlm::llvm::lambda
 {
 
@@ -142,47 +140,6 @@ node::AddContextVar(jlm::rvsdg::output & origin)
   auto input = rvsdg::StructuralInput::create(this, &origin, origin.Type());
   auto argument = &rvsdg::RegionArgument::Create(*subregion(), input, origin.Type());
   return ContextVar{ input, argument };
-}
-
-rvsdg::output &
-node::GetMemoryStateRegionArgument() const noexcept
-{
-  auto argument = GetFunctionArguments().back();
-  JLM_ASSERT(is<MemoryStateType>(argument->type()));
-  return *argument;
-}
-
-rvsdg::input &
-node::GetMemoryStateRegionResult() const noexcept
-{
-  auto result = GetFunctionResults().back();
-  JLM_ASSERT(is<MemoryStateType>(result->type()));
-  return *result;
-}
-
-rvsdg::SimpleNode *
-node::GetMemoryStateExitMerge(const lambda::node & lambdaNode) noexcept
-{
-  auto & result = lambdaNode.GetMemoryStateRegionResult();
-
-  auto node = rvsdg::output::GetNode(*result.origin());
-  return is<LambdaExitMemoryStateMergeOperation>(node) ? dynamic_cast<rvsdg::SimpleNode *>(node)
-                                                       : nullptr;
-}
-
-rvsdg::SimpleNode *
-node::GetMemoryStateEntrySplit(const lambda::node & lambdaNode) noexcept
-{
-  auto & argument = lambdaNode.GetMemoryStateRegionArgument();
-
-  // If a memory state entry split node is present, then we would expect the node to be the only
-  // user of the memory state argument.
-  if (argument.nusers() != 1)
-    return nullptr;
-
-  auto node = rvsdg::node_input::GetNode(**argument.begin());
-  return is<LambdaEntryMemoryStateSplitOperation>(node) ? dynamic_cast<rvsdg::SimpleNode *>(node)
-                                                        : nullptr;
 }
 
 lambda::node *

--- a/jlm/llvm/ir/operators/lambda.cpp
+++ b/jlm/llvm/ir/operators/lambda.cpp
@@ -219,6 +219,10 @@ node::copy(rvsdg::Region * region, rvsdg::SubstitutionMap & smap) const
   auto args = GetFunctionArguments();
   auto newArgs = lambda->GetFunctionArguments();
   JLM_ASSERT(args.size() == newArgs.size());
+  for (std::size_t n = 0; n < args.size(); ++n)
+  {
+    subregionmap.insert(args[n], newArgs[n]);
+  }
 
   /* copy subregion */
   subregion()->copy(lambda->subregion(), subregionmap, false, false);

--- a/jlm/llvm/ir/operators/lambda.cpp
+++ b/jlm/llvm/ir/operators/lambda.cpp
@@ -187,14 +187,14 @@ node::finalize(const std::vector<jlm::rvsdg::output *> & results)
     return output();
   }
 
-  if (type().NumResults() != results.size())
+  if (GetOperation().type().NumResults() != results.size())
     throw util::error("Incorrect number of results.");
 
   for (size_t n = 0; n < results.size(); n++)
   {
-    auto & expected = type().ResultType(n);
+    auto & expected = GetOperation().type().ResultType(n);
     auto & received = results[n]->type();
-    if (results[n]->type() != type().ResultType(n))
+    if (results[n]->type() != GetOperation().type().ResultType(n))
       throw util::error("Expected " + expected.debug_string() + ", got " + received.debug_string());
 
     if (results[n]->region() != subregion())
@@ -204,7 +204,7 @@ node::finalize(const std::vector<jlm::rvsdg::output *> & results)
   for (const auto & origin : results)
     rvsdg::RegionResult::Create(*origin->region(), *origin, nullptr, origin->Type());
 
-  return append_output(std::make_unique<rvsdg::StructuralOutput>(this, Type()));
+  return append_output(std::make_unique<rvsdg::StructuralOutput>(this, GetOperation().Type()));
 }
 
 rvsdg::output *
@@ -222,7 +222,8 @@ node::copy(rvsdg::Region * region, const std::vector<jlm::rvsdg::output *> & ope
 lambda::node *
 node::copy(rvsdg::Region * region, rvsdg::SubstitutionMap & smap) const
 {
-  auto lambda = create(region, Type(), name(), linkage(), attributes());
+  const auto & op = GetOperation();
+  auto lambda = create(region, op.Type(), op.name(), op.linkage(), op.attributes());
 
   /* add context variables */
   rvsdg::SubstitutionMap subregionmap;

--- a/jlm/llvm/ir/operators/lambda.hpp
+++ b/jlm/llvm/ir/operators/lambda.hpp
@@ -21,8 +21,6 @@
 namespace jlm::llvm
 {
 
-class CallNode;
-
 namespace lambda
 {
 
@@ -170,12 +168,6 @@ public:
   [[nodiscard]] std::vector<rvsdg::input *>
   GetFunctionResults() const;
 
-  [[nodiscard]] const jlm::llvm::attributeset &
-  GetArgumentAttributes(const rvsdg::output & argument) const noexcept;
-
-  void
-  SetArgumentAttributes(rvsdg::output & argument, const jlm::llvm::attributeset & attributes);
-
   [[nodiscard]] rvsdg::Region *
   subregion() const noexcept
   {
@@ -290,42 +282,6 @@ public:
 
   lambda::node *
   copy(rvsdg::Region * region, rvsdg::SubstitutionMap & smap) const override;
-
-  /**
-   * @return The memory state argument of the lambda subregion.
-   */
-  [[nodiscard]] rvsdg::output &
-  GetMemoryStateRegionArgument() const noexcept;
-
-  /**
-   * @return The memory state result of the lambda subregion.
-   */
-  [[nodiscard]] rvsdg::input &
-  GetMemoryStateRegionResult() const noexcept;
-
-  /**
-   *
-   * @param lambdaNode The lambda node for which to retrieve the
-   * LambdaEntryMemoryStateSplitOperation node.
-   * @return The LambdaEntryMemoryStateSplitOperation node connected to the memory state input if
-   * present, otherwise nullptr.
-   *
-   * @see GetMemoryStateExitMerge()
-   */
-  static rvsdg::SimpleNode *
-  GetMemoryStateEntrySplit(const lambda::node & lambdaNode) noexcept;
-
-  /**
-   *
-   * @param lambdaNode The lambda node for which to retrieve the
-   * LambdaExitMemoryStateMergeOperation node.
-   * @return The LambdaExitMemoryStateMergeOperation node connected to the memory state output if
-   * present, otherwise nullptr.
-   *
-   * @see GetMemoryStateEntrySplit()
-   */
-  [[nodiscard]] static rvsdg::SimpleNode *
-  GetMemoryStateExitMerge(const lambda::node & lambdaNode) noexcept;
 
   /**
    * Creates a lambda node in the region \p parent with the function type \p type and name \p name.

--- a/jlm/llvm/ir/operators/lambda.hpp
+++ b/jlm/llvm/ir/operators/lambda.hpp
@@ -183,36 +183,6 @@ public:
   [[nodiscard]] const lambda::operation &
   GetOperation() const noexcept override;
 
-  [[nodiscard]] const jlm::rvsdg::FunctionType &
-  type() const noexcept
-  {
-    return GetOperation().type();
-  }
-
-  [[nodiscard]] const std::shared_ptr<const jlm::rvsdg::FunctionType> &
-  Type() const noexcept
-  {
-    return GetOperation().Type();
-  }
-
-  [[nodiscard]] const std::string &
-  name() const noexcept
-  {
-    return GetOperation().name();
-  }
-
-  [[nodiscard]] const jlm::llvm::linkage &
-  linkage() const noexcept
-  {
-    return GetOperation().linkage();
-  }
-
-  [[nodiscard]] const jlm::llvm::attributeset &
-  attributes() const noexcept
-  {
-    return GetOperation().attributes();
-  }
-
   /**
    * \brief Adds a context/free variable to the lambda node.
    *

--- a/jlm/llvm/ir/operators/lambda.hpp
+++ b/jlm/llvm/ir/operators/lambda.hpp
@@ -39,12 +39,7 @@ public:
       std::shared_ptr<const jlm::rvsdg::FunctionType> type,
       std::string name,
       const jlm::llvm::linkage & linkage,
-      jlm::llvm::attributeset attributes)
-      : type_(std::move(type)),
-        name_(std::move(name)),
-        linkage_(linkage),
-        attributes_(std::move(attributes))
-  {}
+      jlm::llvm::attributeset attributes);
 
   operation(const operation & other) = default;
 
@@ -95,11 +90,18 @@ public:
   [[nodiscard]] std::unique_ptr<Operation>
   copy() const override;
 
+  [[nodiscard]] const jlm::llvm::attributeset &
+  GetArgumentAttributes(std::size_t index) const noexcept;
+
+  void
+  SetArgumentAttributes(std::size_t index, const jlm::llvm::attributeset & attributes);
+
 private:
   std::shared_ptr<const jlm::rvsdg::FunctionType> type_;
   std::string name_;
   jlm::llvm::linkage linkage_;
   jlm::llvm::attributeset attributes_;
+  std::vector<jlm::llvm::attributeset> ArgumentAttributes_;
 };
 
 /** \brief Lambda node
@@ -180,7 +182,7 @@ public:
     return StructuralNode::subregion(0);
   }
 
-  [[nodiscard]] const lambda::operation &
+  [[nodiscard]] lambda::operation &
   GetOperation() const noexcept override;
 
   /**
@@ -371,7 +373,6 @@ public:
   finalize(const std::vector<jlm::rvsdg::output *> & results);
 
 private:
-  std::vector<jlm::llvm::attributeset> ArgumentAttributes_;
   std::unique_ptr<lambda::operation> Operation_;
 };
 

--- a/jlm/llvm/opt/InvariantValueRedirection.cpp
+++ b/jlm/llvm/opt/InvariantValueRedirection.cpp
@@ -3,6 +3,7 @@
  * See COPYING for terms of redistribution.
  */
 
+#include <jlm/llvm/ir/LambdaMemoryState.hpp>
 #include <jlm/llvm/ir/operators/call.hpp>
 #include <jlm/llvm/ir/operators/delta.hpp>
 #include <jlm/llvm/ir/operators/FunctionPointer.hpp>
@@ -207,8 +208,8 @@ InvariantValueRedirection::RedirectCallOutputs(CallNode & callNode)
 
     if (shouldHandleMemoryStateOperations)
     {
-      auto lambdaEntrySplit = lambda::node::GetMemoryStateEntrySplit(lambdaNode);
-      auto lambdaExitMerge = lambda::node::GetMemoryStateExitMerge(lambdaNode);
+      auto lambdaEntrySplit = GetMemoryStateEntrySplit(lambdaNode);
+      auto lambdaExitMerge = GetMemoryStateExitMerge(lambdaNode);
       auto callEntryMerge = CallNode::GetMemoryStateEntryMerge(callNode);
 
       // The callExitSplit is present. We therefore expect the other nodes to be present as well.

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
@@ -3,6 +3,7 @@
  * See COPYING for terms of redistribution.
  */
 
+#include <jlm/llvm/ir/LambdaMemoryState.hpp>
 #include <jlm/llvm/ir/operators.hpp>
 #include <jlm/llvm/ir/operators/MemoryStateOperations.hpp>
 #include <jlm/llvm/opt/alias-analyses/MemoryNodeProvider.hpp>
@@ -766,7 +767,7 @@ MemoryStateEncoder::EncodeLambda(const lambda::node & lambdaNode)
 void
 MemoryStateEncoder::EncodeLambdaEntry(const lambda::node & lambdaNode)
 {
-  auto & memoryStateArgument = lambdaNode.GetMemoryStateRegionArgument();
+  auto & memoryStateArgument = GetMemoryStateRegionArgument(lambdaNode);
   JLM_ASSERT(memoryStateArgument.nusers() == 1);
   auto memoryStateArgumentUser = *memoryStateArgument.begin();
 
@@ -809,7 +810,7 @@ MemoryStateEncoder::EncodeLambdaExit(const lambda::node & lambdaNode)
   auto subregion = lambdaNode.subregion();
   auto & memoryNodes = Context_->GetMemoryNodeProvisioning().GetLambdaExitNodes(lambdaNode);
   auto & stateMap = Context_->GetRegionalizedStateMap();
-  auto & memoryStateResult = lambdaNode.GetMemoryStateRegionResult();
+  auto & memoryStateResult = GetMemoryStateRegionResult(lambdaNode);
 
   auto memoryNodeStatePairs = stateMap.GetStates(*subregion, memoryNodes);
   auto states = StateMap::MemoryNodeStatePair::States(memoryNodeStatePairs);

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
@@ -5,7 +5,6 @@
 
 #include <jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp>
 
-#include <jlm/llvm/ir/operators/call.hpp>
 #include <jlm/llvm/opt/alias-analyses/DifferencePropagation.hpp>
 #include <jlm/llvm/opt/alias-analyses/LazyCycleDetection.hpp>
 #include <jlm/llvm/opt/alias-analyses/OnlineCycleDetection.hpp>

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
@@ -6,6 +6,7 @@
 #ifndef JLM_LLVM_OPT_ALIAS_ANALYSES_POINTEROBJECTSET_HPP
 #define JLM_LLVM_OPT_ALIAS_ANALYSES_POINTEROBJECTSET_HPP
 
+#include <jlm/llvm/ir/operators/call.hpp>
 #include <jlm/llvm/ir/operators/delta.hpp>
 #include <jlm/llvm/ir/operators/lambda.hpp>
 #include <jlm/llvm/ir/RvsdgModule.hpp>

--- a/jlm/mlir/backend/JlmToMlirConverter.cpp
+++ b/jlm/mlir/backend/JlmToMlirConverter.cpp
@@ -415,11 +415,11 @@ JlmToMlirConverter::ConvertLambda(const llvm::lambda::node & lambdaNode, ::mlir:
   ::llvm::SmallVector<::mlir::NamedAttribute> attributes;
   auto symbolName = Builder_->getNamedAttr(
       Builder_->getStringAttr("sym_name"),
-      Builder_->getStringAttr(lambdaNode.name()));
+      Builder_->getStringAttr(lambdaNode.GetOperation().name()));
   attributes.push_back(symbolName);
   auto linkage = Builder_->getNamedAttr(
       Builder_->getStringAttr("linkage"),
-      Builder_->getStringAttr(llvm::ToString(lambdaNode.linkage())));
+      Builder_->getStringAttr(llvm::ToString(lambdaNode.GetOperation().linkage())));
   attributes.push_back(linkage);
 
   auto lambda = Builder_->create<::mlir::rvsdg::LambdaNode>(

--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -393,7 +393,7 @@ Bits2PtrTest::SetupRvsdg()
 
     auto & call = CallNode::CreateNode(
         cvbits2ptr,
-        rvsdg::AssertGetOwnerNode<lambda::node>(*b2p).Type(),
+        rvsdg::AssertGetOwnerNode<lambda::node>(*b2p).GetOperation().Type(),
         { valueArgument, iOStateArgument, memoryStateArgument });
 
     lambda->finalize({ call.GetIoStateOutput(), call.GetMemoryStateOutput() });
@@ -570,10 +570,13 @@ CallTest1::SetupRvsdg()
     auto sty = StoreNonVolatileNode::Create(y[0], six, { stx[0] }, 4);
     auto stz = StoreNonVolatileNode::Create(z[0], seven, { sty[0] }, 4);
 
-    auto & callF = CallNode::CreateNode(cvf, f->Type(), { x[0], y[0], iOStateArgument, stz[0] });
+    auto & callF = CallNode::CreateNode(
+        cvf,
+        f->GetOperation().Type(),
+        { x[0], y[0], iOStateArgument, stz[0] });
     auto & callG = CallNode::CreateNode(
         cvg,
-        g->Type(),
+        g->GetOperation().Type(),
         { z[0], z[0], callF.GetIoStateOutput(), callF.GetMemoryStateOutput() });
 
     auto sum = jlm::rvsdg::bitadd_op::create(32, callF.Result(0), callG.Result(0));
@@ -700,20 +703,20 @@ CallTest2::SetupRvsdg()
 
     auto & create1 = CallNode::CreateNode(
         create_cv,
-        lambdaCreate->Type(),
+        lambdaCreate->GetOperation().Type(),
         { six, iOStateArgument, memoryStateArgument });
     auto & create2 = CallNode::CreateNode(
         create_cv,
-        lambdaCreate->Type(),
+        lambdaCreate->GetOperation().Type(),
         { seven, create1.GetIoStateOutput(), create1.GetMemoryStateOutput() });
 
     auto & destroy1 = CallNode::CreateNode(
         destroy_cv,
-        lambdaDestroy->Type(),
+        lambdaDestroy->GetOperation().Type(),
         { create1.Result(0), create2.GetIoStateOutput(), create2.GetMemoryStateOutput() });
     auto & destroy2 = CallNode::CreateNode(
         destroy_cv,
-        lambdaDestroy->Type(),
+        lambdaDestroy->GetOperation().Type(),
         { create2.Result(0), destroy1.GetIoStateOutput(), destroy1.GetMemoryStateOutput() });
 
     lambda->finalize({ destroy2.GetIoStateOutput(), destroy2.GetMemoryStateOutput() });
@@ -827,11 +830,11 @@ IndirectCallTest1::SetupRvsdg()
 
     auto & call_four = CallNode::CreateNode(
         fctindcall_cv,
-        rvsdg::AssertGetOwnerNode<lambda::node>(*fctindcall).Type(),
+        rvsdg::AssertGetOwnerNode<lambda::node>(*fctindcall).GetOperation().Type(),
         { fctfour_cv, iOStateArgument, memoryStateArgument });
     auto & call_three = CallNode::CreateNode(
         fctindcall_cv,
-        rvsdg::AssertGetOwnerNode<lambda::node>(*fctindcall).Type(),
+        rvsdg::AssertGetOwnerNode<lambda::node>(*fctindcall).GetOperation().Type(),
         { fctthree_cv, call_four.GetIoStateOutput(), call_four.GetMemoryStateOutput() });
 
     auto add = jlm::rvsdg::bitadd_op::create(32, call_four.Result(0), call_three.Result(0));
@@ -1030,12 +1033,12 @@ IndirectCallTest2::SetupRvsdg()
 
     auto & callX = CallNode::CreateNode(
         functionXCv,
-        rvsdg::AssertGetOwnerNode<lambda::node>(functionX).Type(),
+        rvsdg::AssertGetOwnerNode<lambda::node>(functionX).GetOperation().Type(),
         { pxAlloca[0], iOStateArgument, pyMerge });
 
     auto & callY = CallNode::CreateNode(
         functionYCv,
-        rvsdg::AssertGetOwnerNode<lambda::node>(functionY).Type(),
+        rvsdg::AssertGetOwnerNode<lambda::node>(functionY).GetOperation().Type(),
         { pyAlloca[0], callX.GetIoStateOutput(), callX.GetMemoryStateOutput() });
 
     auto loadG1 = LoadNonVolatileNode::Create(
@@ -1086,7 +1089,7 @@ IndirectCallTest2::SetupRvsdg()
 
     auto & callX = CallNode::CreateNode(
         functionXCv,
-        rvsdg::AssertGetOwnerNode<lambda::node>(functionX).Type(),
+        rvsdg::AssertGetOwnerNode<lambda::node>(functionX).GetOperation().Type(),
         { pzAlloca[0], iOStateArgument, pzMerge });
 
     auto lambdaOutput = lambda->finalize(callX.Results());
@@ -1540,7 +1543,7 @@ GammaTest2::SetupRvsdg()
 
     auto & call = CallNode::CreateNode(
         lambdaFArgument,
-        rvsdg::AssertGetOwnerNode<lambda::node>(lambdaF).Type(),
+        rvsdg::AssertGetOwnerNode<lambda::node>(lambdaF).GetOperation().Type(),
         { predicate, allocaXResults[0], allocaYResults[0], iOStateArgument, storeYResults[0] });
 
     lambda->finalize(call.Results());
@@ -1701,7 +1704,7 @@ DeltaTest1::SetupRvsdg()
     auto st = StoreNonVolatileNode::Create(cvf, five, { memoryStateArgument }, 4);
     auto & callG = CallNode::CreateNode(
         cvg,
-        rvsdg::AssertGetOwnerNode<lambda::node>(*g).Type(),
+        rvsdg::AssertGetOwnerNode<lambda::node>(*g).GetOperation().Type(),
         { cvf, iOStateArgument, st[0] });
 
     auto lambdaOutput = lambda->finalize(callG.Results());
@@ -1814,7 +1817,7 @@ DeltaTest2::SetupRvsdg()
     auto st = StoreNonVolatileNode::Create(cvd1, b5, { memoryStateArgument }, 4);
     auto & call = CallNode::CreateNode(
         cvf1,
-        rvsdg::AssertGetOwnerNode<lambda::node>(*f1).Type(),
+        rvsdg::AssertGetOwnerNode<lambda::node>(*f1).GetOperation().Type(),
         { iOStateArgument, st[0] });
     st = StoreNonVolatileNode::Create(cvd2, b42, { call.GetMemoryStateOutput() }, 4);
 
@@ -1928,7 +1931,7 @@ DeltaTest3::SetupRvsdg()
 
     auto & call = CallNode::CreateNode(
         lambdaFArgument,
-        rvsdg::AssertGetOwnerNode<lambda::node>(lambdaF).Type(),
+        rvsdg::AssertGetOwnerNode<lambda::node>(lambdaF).GetOperation().Type(),
         { iOStateArgument, memoryStateArgument });
 
     auto lambdaOutput = lambda->finalize({ call.GetIoStateOutput(), call.GetMemoryStateOutput() });
@@ -2012,7 +2015,7 @@ ImportTest::SetupRvsdg()
     auto st = StoreNonVolatileNode::Create(cvd1, b2, { memoryStateArgument }, 4);
     auto & call = CallNode::CreateNode(
         cvf1,
-        rvsdg::AssertGetOwnerNode<lambda::node>(*f1).Type(),
+        rvsdg::AssertGetOwnerNode<lambda::node>(*f1).GetOperation().Type(),
         { iOStateArgument, st[0] });
     st = StoreNonVolatileNode::Create(cvd2, b21, { call.GetMemoryStateOutput() }, 4);
 
@@ -3185,7 +3188,7 @@ MemcpyTest::SetupRvsdg()
 
     auto & call = CallNode::CreateNode(
         functionFArgument,
-        rvsdg::AssertGetOwnerNode<lambda::node>(lambdaF).Type(),
+        rvsdg::AssertGetOwnerNode<lambda::node>(lambdaF).GetOperation().Type(),
         { iOStateArgument, memcpyResults[0] });
 
     auto lambdaOutput = lambda->finalize(call.Results());
@@ -3293,7 +3296,7 @@ MemcpyTest2::SetupRvsdg()
 
     auto & call = CallNode::CreateNode(
         functionFArgument,
-        rvsdg::AssertGetOwnerNode<lambda::node>(functionF).Type(),
+        rvsdg::AssertGetOwnerNode<lambda::node>(functionF).GetOperation().Type(),
         { ldS1[0], ldS2[0], iOStateArgument, ldS2[1] });
 
     auto lambdaOutput = lambda->finalize(call.Results());

--- a/tests/jlm/llvm/opt/InvariantValueRedirectionTests.cpp
+++ b/tests/jlm/llvm/opt/InvariantValueRedirectionTests.cpp
@@ -12,6 +12,7 @@
 #include <jlm/rvsdg/theta.hpp>
 #include <jlm/rvsdg/view.hpp>
 
+#include <jlm/llvm/ir/LambdaMemoryState.hpp>
 #include <jlm/llvm/ir/operators/call.hpp>
 #include <jlm/llvm/ir/RvsdgModule.hpp>
 #include <jlm/llvm/opt/InvariantValueRedirection.hpp>
@@ -332,8 +333,8 @@ TestCallWithMemoryStateNodes()
   assert(lambdaNode.GetFunctionResults()[0]->origin() == lambdaNode.GetFunctionArguments()[0]);
   assert(lambdaNode.GetFunctionResults()[1]->origin() == lambdaNode.GetFunctionArguments()[1]);
 
-  auto lambdaEntrySplit = lambda::node::GetMemoryStateEntrySplit(lambdaNode);
-  auto lambdaExitMerge = lambda::node::GetMemoryStateExitMerge(lambdaNode);
+  auto lambdaEntrySplit = GetMemoryStateEntrySplit(lambdaNode);
+  auto lambdaExitMerge = GetMemoryStateExitMerge(lambdaNode);
 
   assert(lambdaEntrySplit->noutputs() == 2);
   assert(lambdaExitMerge->ninputs() == 2);

--- a/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
@@ -9,6 +9,7 @@
 
 #include <jlm/rvsdg/view.hpp>
 
+#include <jlm/llvm/ir/LambdaMemoryState.hpp>
 #include <jlm/llvm/ir/operators/MemoryStateOperations.hpp>
 #include <jlm/llvm/opt/alias-analyses/AgnosticMemoryNodeProvider.hpp>
 #include <jlm/llvm/opt/alias-analyses/EliminatedMemoryNodeProvider.hpp>
@@ -2160,7 +2161,7 @@ ValidateFreeNullTestSteensgaardAgnostic(const jlm::tests::FreeNullTest & test)
   using namespace jlm::rvsdg;
 
   auto lambdaExitMerge =
-      jlm::rvsdg::output::GetNode(*test.LambdaMain().GetMemoryStateRegionResult().origin());
+      jlm::rvsdg::output::GetNode(*GetMemoryStateRegionResult(test.LambdaMain()).origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 2, 1));
 
   auto free = jlm::rvsdg::output::GetNode(*test.LambdaMain().GetFunctionResults()[0]->origin());

--- a/tests/jlm/llvm/opt/test-inlining.cpp
+++ b/tests/jlm/llvm/opt/test-inlining.cpp
@@ -79,7 +79,7 @@ test1()
 
     auto callResults = CallNode::Create(
         gammaInputF1.branchArgument[0],
-        jlm::rvsdg::AssertGetOwnerNode<lambda::node>(*f1).Type(),
+        jlm::rvsdg::AssertGetOwnerNode<lambda::node>(*f1).GetOperation().Type(),
         { gammaInputValue.branchArgument[0],
           gammaInputIoState.branchArgument[0],
           gammaInputMemoryState.branchArgument[0] });


### PR DESCRIPTION
Remove all non-orthogonal convenience member functions (i.e.
functions reaching from lambda::node into lambda::operation).
Redudant helpers may save typing, but generally cause churn
during decoupling.

Extract memory state modelling from lambda node: The modelling
is quite specific to how llvm-level transformations represent functions
etc. Everything related to that modelling should probably be
consolidated into a location (i.e. the "memory encoding bits")
rather than being spread out to the pieces they apply to.

Move argument attributes to lambda operation: This removes the last
bit of state from the lambda node which now really only contains graph
structural information.
    
Moving the attributes also has the effect of subjecting them to implicit
copy, removing the need to manually copy them in various places.
