### PR TITLE
Add missing #include <algorithm>.

### DIFF
--- a/jlm/rvsdg/theta.cpp
+++ b/jlm/rvsdg/theta.cpp
@@ -4,6 +4,7 @@
  * See COPYING for terms of redistribution.
  */
 
+#include <algorithm>
 #include <jlm/rvsdg/substitution.hpp>
 #include <jlm/rvsdg/theta.hpp>
 


### PR DESCRIPTION
This PR adds a missing include which is needed for the `std::sort` in `jlm/rvsdg/theta.cpp` introduced in #720. The include seems not to be needed in the CI build but is necessary on Fedora 41 with LLVM compiled from source.