### PR TITLE
Make use of debug_string() for arguments and results in dot output

### DIFF
--- a/jlm/llvm/backend/dot/DotWriter.cpp
+++ b/jlm/llvm/backend/dot/DotWriter.cpp
@@ -144,15 +144,18 @@ CreateGraphNodes(util::Graph & graph, rvsdg::Region & region, util::Graph * type
     auto & argument = *region.argument(n);
     AttachNodeOutput(node, argument, typeGraph);
 
-    // Give the argument a label using its local index, not the global argument index
-    node.SetLabel(util::strfmt("a", n));
+    // Include the index among the region's attributes
+    node.SetAttribute("index", std::to_string(n));
+
+    // Use the debug string as the label
+    node.SetLabel(argument.debug_string());
 
     // If this argument corresponds to one of the structural node's inputs, reference it
     if (argument.input())
     {
       node.SetAttributeObject("input", *argument.input());
       // Include the local index of the node's input in the label
-      node.AppendToLabel(util::strfmt("<- i", argument.input()->index()), " ");
+      node.AppendToLabel(util::strfmt("<- ", argument.input()->debug_string()), " ");
     }
   }
 
@@ -189,15 +192,18 @@ CreateGraphNodes(util::Graph & graph, rvsdg::Region & region, util::Graph * type
     auto & result = *region.result(n);
     AttachNodeInput(node, result);
 
-    // Use the result's local index as the label
-    node.SetLabel(util::strfmt("r", n));
+    // Include the index among the region's results
+    node.SetAttribute("index", std::to_string(n));
+
+    // Use the debug string as the label
+    node.SetLabel(result.debug_string());
 
     // If this result corresponds to one of the structural node's outputs, reference it
     if (result.output())
     {
       node.SetAttributeObject("output", *result.output());
       // Include the local index of the node's output in the label
-      node.AppendToLabel(util::strfmt("-> o", result.output()->index()), " ");
+      node.AppendToLabel(util::strfmt("-> ", result.output()->debug_string()), " ");
     }
   }
 }

--- a/jlm/rvsdg/graph.cpp
+++ b/jlm/rvsdg/graph.cpp
@@ -19,10 +19,22 @@ GraphImport::GraphImport(Graph & graph, std::shared_ptr<const rvsdg::Type> type,
       Name_(std::move(name))
 {}
 
+std::string
+GraphImport::debug_string() const
+{
+  return util::strfmt("import[", Name_, "]");
+}
+
 GraphExport::GraphExport(rvsdg::output & origin, std::string name)
     : RegionResult(&origin.region()->graph()->GetRootRegion(), &origin, nullptr, origin.Type()),
       Name_(std::move(name))
 {}
+
+std::string
+GraphExport::debug_string() const
+{
+  return util::strfmt("export[", Name_, "]");
+}
 
 Graph::~Graph()
 {

--- a/jlm/rvsdg/graph.hpp
+++ b/jlm/rvsdg/graph.hpp
@@ -29,6 +29,9 @@ public:
     return Name_;
   }
 
+  [[nodiscard]] std::string
+  debug_string() const override;
+
 private:
   std::string Name_;
 };
@@ -47,6 +50,9 @@ public:
   {
     return Name_;
   }
+
+  [[nodiscard]] std::string
+  debug_string() const override;
 
 private:
   std::string Name_;

--- a/jlm/rvsdg/node.cpp
+++ b/jlm/rvsdg/node.cpp
@@ -42,7 +42,7 @@ input::input(
 std::string
 input::debug_string() const
 {
-  return jlm::util::strfmt(index());
+  return jlm::util::strfmt("i", index());
 }
 
 void
@@ -92,7 +92,7 @@ output::output(rvsdg::Region * region, std::shared_ptr<const rvsdg::Type> type)
 std::string
 output::debug_string() const
 {
-  return jlm::util::strfmt(index());
+  return jlm::util::strfmt("o", index());
 }
 
 Node *

--- a/jlm/rvsdg/region.cpp
+++ b/jlm/rvsdg/region.cpp
@@ -43,6 +43,12 @@ RegionArgument::RegionArgument(
   }
 }
 
+std::string
+RegionArgument::debug_string() const
+{
+  return util::strfmt("a", index());
+}
+
 [[nodiscard]] std::variant<Node *, Region *>
 RegionArgument::GetOwner() const noexcept
 {
@@ -94,6 +100,12 @@ RegionResult::RegionResult(
 
     output->results.push_back(this);
   }
+}
+
+std::string
+RegionResult::debug_string() const
+{
+  return util::strfmt("r", index());
 }
 
 [[nodiscard]] std::variant<Node *, Region *>

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -62,6 +62,9 @@ public:
   RegionArgument &
   operator=(RegionArgument &&) = delete;
 
+  [[nodiscard]] std::string
+  debug_string() const override;
+
   [[nodiscard]] StructuralInput *
   input() const noexcept
   {
@@ -141,6 +144,9 @@ public:
 
   RegionResult &
   operator=(RegionResult &&) = delete;
+
+  [[nodiscard]] std::string
+  debug_string() const override;
 
   [[nodiscard]] StructuralOutput *
   output() const noexcept

--- a/jlm/util/GraphWriter.cpp
+++ b/jlm/util/GraphWriter.cpp
@@ -1347,7 +1347,9 @@ Graph::OutputDot(std::ostream & out, size_t indent) const
   indent++;
 
   // Default node attributes. Filling nodes by default makes them easier to click
-  out << Indent(indent) << "node[shape=box style=filled fillcolor=white];" << std::endl;
+  out << Indent(indent)
+      << "node[shape=box style=filled fillcolor=white width=0.1 height=0.1 margin=0.05];"
+      << std::endl;
   out << Indent(indent) << "penwidth=6;" << std::endl;
   if (HasLabel())
   {

--- a/tests/jlm/llvm/backend/dot/DotWriterTests.cpp
+++ b/tests/jlm/llvm/backend/dot/DotWriterTests.cpp
@@ -69,6 +69,12 @@ TestWriteGraphs()
   assert(stateConnections.size() == 1);
   assert(stateConnections.front()->GetAttributeString("color") == "#FF0000");
 
+  // Check that the output of the lambda leads to a graph export
+  auto & lambdaConnections = lambdaNode.GetOutputPort(0).GetConnections();
+  assert(lambdaConnections.size() == 1);
+  auto & graphExport = lambdaConnections.front()->GetTo().GetNode();
+  assert(graphExport.GetLabel() == "export[f]");
+
   return 0;
 }
 JLM_UNIT_TEST_REGISTER("jlm/llvm/backend/dot/DotWriterTests-TestWriteGraphs", TestWriteGraphs)


### PR DESCRIPTION
It was a bit annoying to only see "a1", "r5" in the root RVSDG region, so this change makes use of "debug_string()" on inputs, outputs, results and arguments.

![image](https://github.com/user-attachments/assets/1cf6884a-d45a-4294-a5b0-2e2c0c085448)

The `debug_string()` method was not overridden by the subclasses, so I added that. In general they were not really used anywhere, so adding the extra info did not break anything existing.

Finally, since I was touching the graph output, I decided to reduce the margins on argument and result nodes, which were previously very big.

