### PR TITLE
Print the failing command when subprocesses fail

### DIFF
--- a/jlm/tooling/Command.cpp
+++ b/jlm/tooling/Command.cpp
@@ -52,6 +52,18 @@ namespace jlm::tooling
 
 Command::~Command() = default;
 
+void
+Command::Run() const
+{
+  const auto command = ToString();
+  const auto returnCode = system(command.c_str());
+  if (returnCode != EXIT_SUCCESS)
+  {
+    throw util::error(
+        util::strfmt("Subcommand failed with status code ", returnCode, ": ", command));
+  }
+}
+
 PrintCommandsCommand::~PrintCommandsCommand() = default;
 
 std::string
@@ -227,13 +239,6 @@ ClangCommand::ReplaceAll(std::string str, const std::string & from, const std::s
   return str;
 }
 
-void
-ClangCommand::Run() const
-{
-  if (system(ToString().c_str()))
-    exit(EXIT_FAILURE);
-}
-
 LlcCommand::~LlcCommand() = default;
 
 std::string
@@ -252,13 +257,6 @@ LlcCommand::ToString() const
       OutputFile_.to_str(),
       " ",
       InputFile_.to_str());
-}
-
-void
-LlcCommand::Run() const
-{
-  if (system(ToString().c_str()))
-    exit(EXIT_FAILURE);
 }
 
 std::string
@@ -693,13 +691,6 @@ LlvmOptCommand::ToString() const
       InputFile_.to_str());
 }
 
-void
-LlvmOptCommand::Run() const
-{
-  if (system(ToString().c_str()))
-    exit(EXIT_FAILURE);
-}
-
 std::string
 LlvmOptCommand::ToString(const Optimization & optimization)
 {
@@ -731,26 +722,12 @@ LlvmLinkCommand::ToString() const
       inputFilesArgument);
 }
 
-void
-LlvmLinkCommand::Run() const
-{
-  if (system(ToString().c_str()))
-    exit(EXIT_FAILURE);
-}
-
 JlmHlsCommand::~JlmHlsCommand() noexcept = default;
 
 std::string
 JlmHlsCommand::ToString() const
 {
   return util::strfmt("jlm-hls ", "-o ", OutputFolder_.to_str(), " ", InputFile_.to_str());
-}
-
-void
-JlmHlsCommand::Run() const
-{
-  if (system(ToString().c_str()))
-    exit(EXIT_FAILURE);
 }
 
 JlmHlsExtractCommand::~JlmHlsExtractCommand() noexcept = default;
@@ -768,13 +745,6 @@ JlmHlsExtractCommand::ToString() const
       OutputFolder_.to_str(),
       " ",
       InputFile().to_str());
-}
-
-void
-JlmHlsExtractCommand::Run() const
-{
-  if (system(ToString().c_str()))
-    exit(EXIT_FAILURE);
 }
 
 }

--- a/jlm/tooling/Command.hpp
+++ b/jlm/tooling/Command.hpp
@@ -32,7 +32,7 @@ public:
   ToString() const = 0;
 
   virtual void
-  Run() const = 0;
+  Run() const;
 };
 
 /**
@@ -160,9 +160,6 @@ public:
 
   [[nodiscard]] std::string
   ToString() const override;
-
-  void
-  Run() const override;
 
   [[nodiscard]] const util::filepath &
   OutputFile() const noexcept
@@ -297,9 +294,6 @@ public:
 
   [[nodiscard]] std::string
   ToString() const override;
-
-  void
-  Run() const override;
 
   [[nodiscard]] const util::filepath &
   OutputFile() const noexcept
@@ -498,9 +492,6 @@ public:
     return OutputFile_;
   }
 
-  void
-  Run() const override;
-
   static CommandGraph::Node &
   Create(
       CommandGraph & commandGraph,
@@ -547,9 +538,6 @@ public:
 
   [[nodiscard]] std::string
   ToString() const override;
-
-  void
-  Run() const override;
 
   [[nodiscard]] const util::filepath &
   OutputFile() const noexcept
@@ -599,9 +587,6 @@ public:
 
   [[nodiscard]] std::string
   ToString() const override;
-
-  void
-  Run() const override;
 
   [[nodiscard]] util::filepath
   FirrtlFile() const noexcept
@@ -668,9 +653,6 @@ public:
 
   [[nodiscard]] std::string
   ToString() const override;
-
-  void
-  Run() const override;
 
   [[nodiscard]] util::filepath
   HlsFunctionFile() const noexcept


### PR DESCRIPTION
This PR gives the `Command` class a default implementation of `Run()`, which does what most subclasses did already, but prints the command when the command fails.