### PR TITLE
Make use of jlm::util::filepath where applicable

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -410,7 +410,7 @@ split_hls_function(llvm::RvsdgModule & rm, const std::string & function_name)
 }
 
 void
-rvsdg2ref(llvm::RvsdgModule & rhls, std::string path)
+rvsdg2ref(llvm::RvsdgModule & rhls, const util::filepath & path)
 {
   dump_ref(rhls, path);
 }
@@ -448,7 +448,7 @@ rvsdg2rhls(llvm::RvsdgModule & rhls, util::StatisticsCollector & collector)
 }
 
 void
-dump_ref(llvm::RvsdgModule & rhls, std::string & path)
+dump_ref(llvm::RvsdgModule & rhls, const util::filepath & path)
 {
   auto reference =
       llvm::RvsdgModule::Create(rhls.SourceFileName(), rhls.TargetTriple(), rhls.DataLayout());
@@ -468,7 +468,7 @@ dump_ref(llvm::RvsdgModule & rhls, std::string & path)
   auto jm2 = llvm::rvsdg2jlm::rvsdg2jlm(*reference, statisticsCollector);
   auto lm2 = llvm::jlm2llvm::convert(*jm2, ctx);
   std::error_code EC;
-  ::llvm::raw_fd_ostream os(path, EC);
+  ::llvm::raw_fd_ostream os(path.to_str(), EC);
   lm2->print(os, nullptr);
 }
 

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.hpp
@@ -27,10 +27,10 @@ void
 rvsdg2rhls(llvm::RvsdgModule & rm, util::StatisticsCollector & collector);
 
 void
-rvsdg2ref(llvm::RvsdgModule & rm, std::string path);
+rvsdg2ref(llvm::RvsdgModule & rm, const util::filepath & function_name);
 
 void
-dump_ref(llvm::RvsdgModule & rhls, std::string & path);
+dump_ref(llvm::RvsdgModule & rhls, const util::filepath & function_name);
 
 const jlm::rvsdg::output *
 trace_call(jlm::rvsdg::input * input);

--- a/jlm/tooling/Command.cpp
+++ b/jlm/tooling/Command.cpp
@@ -684,7 +684,8 @@ LlvmOptCommand::ToString() const
   }
 
   return util::strfmt(
-      clangpath.path() + "opt ",
+      clangpath.Dirname().Join("opt").to_str(),
+      " ",
       optimizationArguments,
       WriteLlvmAssembly_ ? "-S " : "",
       "-o ",
@@ -721,8 +722,8 @@ LlvmLinkCommand::ToString() const
     inputFilesArgument += inputFile.to_str() + " ";
 
   return util::strfmt(
-      clangpath.path(),
-      "llvm-link ",
+      clangpath.Dirname().Join("llvm-link").to_str(),
+      " ",
       WriteLlvmAssembly_ ? "-S " : "",
       Verbose_ ? "-v " : "",
       "-o ",

--- a/jlm/tooling/Command.hpp
+++ b/jlm/tooling/Command.hpp
@@ -606,25 +606,25 @@ public:
   [[nodiscard]] util::filepath
   FirrtlFile() const noexcept
   {
-    return OutputFolder_.to_str() + ".fir";
+    return OutputFolder_.WithSuffix(".fir");
   }
 
   [[nodiscard]] util::filepath
   LlvmFile() const noexcept
   {
-    return OutputFolder_.to_str() + ".rest.ll";
+    return OutputFolder_.WithSuffix(".rest.ll");
   }
 
   [[nodiscard]] util::filepath
   RefFile() const noexcept
   {
-    return OutputFolder_.to_str() + ".ref.ll";
+    return OutputFolder_.WithSuffix(".ref.ll");
   }
 
   [[nodiscard]] util::filepath
   HarnessFile() const noexcept
   {
-    return OutputFolder_.to_str() + ".harness.cpp";
+    return OutputFolder_.WithSuffix(".harness.cpp");
   }
 
   [[nodiscard]] const util::filepath &
@@ -675,13 +675,13 @@ public:
   [[nodiscard]] util::filepath
   HlsFunctionFile() const noexcept
   {
-    return OutputFolder_.to_str() + ".function.ll";
+    return OutputFolder_.WithSuffix(".function.ll");
   }
 
   [[nodiscard]] util::filepath
   LlvmFile() const noexcept
   {
-    return OutputFolder_.to_str() + ".rest.ll";
+    return OutputFolder_.WithSuffix(".rest.ll");
   }
 
   [[nodiscard]] const util::filepath &

--- a/jlm/tooling/CommandGraphGenerator.cpp
+++ b/jlm/tooling/CommandGraphGenerator.cpp
@@ -22,7 +22,7 @@ util::filepath
 JlcCommandGraphGenerator::CreateJlmOptCommandOutputFile(const util::filepath & inputFile)
 {
   return util::filepath::CreateUniqueFileName(
-      std::filesystem::temp_directory_path().string(),
+      util::filepath::TempDirectoryPath(),
       inputFile.base() + "-",
       "-jlm-opt.ll");
 }
@@ -31,7 +31,7 @@ util::filepath
 JlcCommandGraphGenerator::CreateParserCommandOutputFile(const util::filepath & inputFile)
 {
   return util::filepath::CreateUniqueFileName(
-      std::filesystem::temp_directory_path().string(),
+      util::filepath::TempDirectoryPath(),
       inputFile.base() + "-",
       "-clang.ll");
 }
@@ -127,12 +127,11 @@ JlcCommandGraphGenerator::GenerateCommandGraph(const JlcCommandLineOptions & com
 
     if (compilation.RequiresOptimization())
     {
-      util::filepath tempDirectory(std::filesystem::temp_directory_path());
       auto clangCommand = util::AssertedCast<ClangCommand>(&lastNode->GetCommand());
 
       util::StatisticsCollectorSettings statisticsCollectorSettings(
           commandLineOptions.JlmOptPassStatistics_,
-          tempDirectory,
+          util::filepath::TempDirectoryPath(),
           compilation.InputFile().base());
 
       JlmOptCommandLineOptions jlmOptCommandLineOptions(
@@ -272,17 +271,16 @@ JhlsCommandGraphGenerator::GenerateCommandGraph(const JhlsCommandLineOptions & c
   std::vector<util::filepath> llir_files;
 
   // Create directory in /tmp for storing temporary files
-  std::string tmp_identifier;
+  std::string tmp_identifier = "jhls-";
   for (const auto & compilation : commandLineOptions.Compilations_)
   {
-    tmp_identifier += compilation.InputFile().name() + "_";
+    tmp_identifier += compilation.InputFile().name() + "-";
     if (tmp_identifier.length() > 30)
       break;
   }
-  srandom((unsigned)time(nullptr) * getpid());
-  tmp_identifier += std::to_string(random());
-  util::filepath tmp_folder(
-      std::filesystem::temp_directory_path().string() + "/" + tmp_identifier + "/");
+
+  const auto tmp_folder =
+      util::filepath::CreateUniqueFileName(util::filepath::TempDirectoryPath(), tmp_identifier, "");
   auto & mkdir = MkdirCommand::Create(*commandGraph, tmp_folder);
   commandGraph->GetEntryNode().AddEdge(mkdir);
 
@@ -295,7 +293,7 @@ JhlsCommandGraphGenerator::GenerateCommandGraph(const JhlsCommandLineOptions & c
       auto & parserNode = ClangCommand::CreateParsingCommand(
           *commandGraph,
           compilation.InputFile(),
-          CreateParserCommandOutputFile(tmp_folder, compilation.InputFile()).to_str(),
+          CreateParserCommandOutputFile(tmp_folder, compilation.InputFile()),
           compilation.DependencyFile(),
           commandLineOptions.IncludePaths_,
           commandLineOptions.MacroDefinitions_,

--- a/jlm/tooling/CommandLine.hpp
+++ b/jlm/tooling/CommandLine.hpp
@@ -619,13 +619,13 @@ private:
   static util::filepath
   ToObjectFile(const util::filepath & file)
   {
-    return { file.path() + file.base() + ".o" };
+    return file.Dirname().Join(file.base() + ".o");
   }
 
   static util::filepath
   ToDependencyFile(const util::filepath & file)
   {
-    return { file.path() + file.base() + ".d" };
+    return file.Dirname().Join(file.base() + ".d");
   }
 
   JlcCommandLineOptions CommandLineOptions_;

--- a/jlm/util/Statistics.cpp
+++ b/jlm/util/Statistics.cpp
@@ -201,7 +201,7 @@ StatisticsCollector::CreateOutputFile(std::string fileNameSuffix, bool includeCo
   const auto fileName =
       strfmt(Settings_.GetModuleName(), '-', Settings_.GetUniqueString(), '-', fileNameSuffix);
 
-  auto fullPath = directory.join(fileName);
+  auto fullPath = directory.Join(fileName);
   if (fullPath.Exists())
     throw error("The generated output file name already exists: " + fullPath.to_str());
 

--- a/tests/jlm/llvm/opt/RvsdgTreePrinterTests.cpp
+++ b/tests/jlm/llvm/opt/RvsdgTreePrinterTests.cpp
@@ -14,9 +14,9 @@
 #include <fstream>
 
 static std::string
-ReadFile(const std::string & outputFilePath)
+ReadFile(const jlm::util::filepath & outputFilePath)
 {
-  std::ifstream file(outputFilePath);
+  std::ifstream file(outputFilePath.to_str());
   std::stringstream buffer;
   buffer << file.rdbuf();
 
@@ -31,17 +31,17 @@ RunAndExtractFile(jlm::llvm::RvsdgModule & module, jlm::llvm::RvsdgTreePrinter &
 {
   using namespace jlm::util;
 
-  auto tmpDir = std::filesystem::temp_directory_path();
-  StatisticsCollectorSettings settings({}, filepath(tmpDir), "TestTreePrinter");
+  const auto tmpDir = filepath::TempDirectoryPath();
+  StatisticsCollectorSettings settings({}, tmpDir, "TestTreePrinter");
   StatisticsCollector collector(settings);
 
   printer.run(module, collector);
 
-  auto fileName = tmpDir / ("TestTreePrinter-" + settings.GetUniqueString() + "-rvsdgTree-0.txt");
+  auto fileName = tmpDir.Join("TestTreePrinter-" + settings.GetUniqueString() + "-rvsdgTree-0.txt");
   auto result = ReadFile(fileName);
 
   // Cleanup
-  std::filesystem::remove(fileName);
+  std::filesystem::remove(fileName.to_str());
 
   return result;
 }
@@ -53,7 +53,7 @@ PrintRvsdgTree()
   using namespace jlm::util;
 
   // Arrange
-  auto rvsdgModule = RvsdgModule::Create({ "" }, "", "");
+  auto rvsdgModule = RvsdgModule::Create(filepath(""), "", "");
 
   auto functionType = jlm::rvsdg::FunctionType::Create(
       { MemoryStateType::Create() },
@@ -92,7 +92,7 @@ PrintNumRvsdgNodesAnnotation()
   using namespace jlm::util;
 
   // Arrange
-  auto rvsdgModule = RvsdgModule::Create({ "" }, "", "");
+  auto rvsdgModule = RvsdgModule::Create(filepath(""), "", "");
   auto rootRegion = &rvsdgModule->Rvsdg().GetRootRegion();
 
   auto structuralNode = jlm::tests::structural_node::create(rootRegion, 2);
@@ -134,7 +134,7 @@ PrintNumMemoryStateInputsOutputsAnnotation()
   auto memoryStateType = MemoryStateType::Create();
   auto valueType = jlm::tests::valuetype::Create();
 
-  auto rvsdgModule = RvsdgModule::Create({ "" }, "", "");
+  auto rvsdgModule = RvsdgModule::Create(filepath(""), "", "");
   auto & rvsdg = rvsdgModule->Rvsdg();
 
   auto & x = jlm::tests::GraphImport::Create(rvsdg, memoryStateType, "x");

--- a/tests/jlm/tooling/TestJlcCommandGraphGenerator.cpp
+++ b/tests/jlm/tooling/TestJlcCommandGraphGenerator.cpp
@@ -11,95 +11,102 @@
 
 #include <cassert>
 
-static void
-Test1()
+static int
+TestJlcCompiling()
 {
   using namespace jlm::tooling;
+  using namespace jlm::util;
 
-  /*
-   * Arrange
-   */
+  // Arrange
   JlcCommandLineOptions commandLineOptions;
-  commandLineOptions.Compilations_.push_back(
-      { { "foo.c" }, { "foo.d" }, { "foo.o" }, "foo.o", true, true, true, false });
+  commandLineOptions.Compilations_.push_back({ filepath("foo.c"),
+                                               filepath("foo.d"),
+                                               filepath("foo.o"),
+                                               "foo.o",
+                                               true,
+                                               true,
+                                               true,
+                                               false });
 
-  /*
-   * Act
-   */
+  // Act
   auto commandGraph = JlcCommandGraphGenerator::Generate(commandLineOptions);
 
-  /*
-   * Assert
-   */
-  auto & commandNode = (*commandGraph->GetExitNode().IncomingEdges().begin()).GetSource();
+  // Assert
+  assert(commandGraph->NumNodes() == 5);
+  auto & commandNode = commandGraph->GetExitNode().IncomingEdges().begin()->GetSource();
   auto command = dynamic_cast<const LlcCommand *>(&commandNode.GetCommand());
   assert(command && command->OutputFile() == "foo.o");
+
+  return 0;
 }
 
-static void
-Test2()
+JLM_UNIT_TEST_REGISTER(
+    "jlm/tooling/TestJlcCommandGraphGenerator-TestJlcCompiling",
+    TestJlcCompiling);
+
+static int
+TestJlcLinking()
 {
   using namespace jlm::tooling;
+  using namespace jlm::util;
 
-  /*
-   * Arrange
-   */
+  // Arrange
   JlcCommandLineOptions commandLineOptions;
   commandLineOptions.Compilations_.push_back(
-      { { "foo.o" }, { "" }, { "foo.o" }, "foo.o", false, false, false, true });
-  commandLineOptions.OutputFile_ = { "foobar" };
+      { filepath("foo.o"), filepath(""), filepath("foo.o"), "foo.o", false, false, false, true });
+  commandLineOptions.OutputFile_ = filepath("foobar");
 
-  /*
-   * Act
-   */
+  // Act
   auto commandGraph = JlcCommandGraphGenerator::Generate(commandLineOptions);
 
-  /*
-   * Assert
-   */
+  // Assert
   assert(commandGraph->NumNodes() == 3);
-
-  auto & commandNode = (*commandGraph->GetExitNode().IncomingEdges().begin()).GetSource();
+  auto & commandNode = commandGraph->GetExitNode().IncomingEdges().begin()->GetSource();
   auto command = dynamic_cast<const ClangCommand *>(&commandNode.GetCommand());
   assert(command->InputFiles()[0] == "foo.o" && command->OutputFile() == "foobar");
+
+  return 0;
 }
 
-static void
+JLM_UNIT_TEST_REGISTER("jlm/tooling/TestJlcCommandGraphGenerator-TestJlcLinking", TestJlcLinking);
+
+static int
 TestJlmOptOptimizations()
 {
   using namespace jlm::tooling;
+  using namespace jlm::util;
 
-  /*
-   * Arrange
-   */
+  // Arrange
   JlcCommandLineOptions commandLineOptions;
   commandLineOptions.Compilations_.push_back(
-      { { "foo.o" }, { "" }, { "foo.o" }, "foo.o", true, true, true, true });
-  commandLineOptions.OutputFile_ = { "foobar" };
+      { filepath("foo.o"), filepath(""), filepath("foo.o"), "foo.o", true, true, true, true });
+  commandLineOptions.OutputFile_ = filepath("foobar");
   commandLineOptions.JlmOptOptimizations_.push_back(
       JlmOptCommandLineOptions::OptimizationId::CommonNodeElimination);
   commandLineOptions.JlmOptOptimizations_.push_back(
       JlmOptCommandLineOptions::OptimizationId::DeadNodeElimination);
 
-  /*
-   * Act
-   */
+  // Act
   auto commandGraph = JlcCommandGraphGenerator::Generate(commandLineOptions);
 
-  /*
-   * Assert
-   */
-  auto & clangCommandNode = (*commandGraph->GetEntryNode().OutgoingEdges().begin()).GetSink();
-  auto & jlmOptCommandNode = (clangCommandNode.OutgoingEdges().begin())->GetSink();
+  // Assert
+  auto & clangCommandNode = commandGraph->GetEntryNode().OutgoingEdges().begin()->GetSink();
+  auto & jlmOptCommandNode = clangCommandNode.OutgoingEdges().begin()->GetSink();
   auto & jlmOptCommand = *dynamic_cast<const JlmOptCommand *>(&jlmOptCommandNode.GetCommand());
   auto & optimizations = jlmOptCommand.GetCommandLineOptions().GetOptimizationIds();
 
   assert(optimizations.size() == 2);
   assert(optimizations[0] == JlmOptCommandLineOptions::OptimizationId::CommonNodeElimination);
   assert(optimizations[1] == JlmOptCommandLineOptions::OptimizationId::DeadNodeElimination);
+
+  return 0;
 }
 
-static void
+JLM_UNIT_TEST_REGISTER(
+    "jlm/tooling/TestJlcCommandGraphGenerator-TestJlmOptOptimizations",
+    TestJlmOptOptimizations);
+
+static int
 TestJlmOptStatistics()
 {
   using namespace jlm::util;
@@ -110,33 +117,26 @@ TestJlmOptStatistics()
 
   jlm::tooling::JlcCommandLineOptions commandLineOptions;
   commandLineOptions.Compilations_.push_back(
-      { { "foo.o" }, { "" }, { "foo.o" }, "foo.o", true, true, true, true });
-  commandLineOptions.OutputFile_ = { "foobar" };
+      { filepath("foo.o"), filepath(""), filepath("foo.o"), "foo.o", true, true, true, true });
+  commandLineOptions.OutputFile_ = filepath("foobar");
   commandLineOptions.JlmOptPassStatistics_ = expectedStatistics;
 
   // Act
   auto commandGraph = jlm::tooling::JlcCommandGraphGenerator::Generate(commandLineOptions);
 
   // Assert
-  auto & clangCommandNode = (*commandGraph->GetEntryNode().OutgoingEdges().begin()).GetSink();
-  auto & jlmOptCommandNode = (clangCommandNode.OutgoingEdges().begin())->GetSink();
+  auto & clangCommandNode = commandGraph->GetEntryNode().OutgoingEdges().begin()->GetSink();
+  auto & jlmOptCommandNode = clangCommandNode.OutgoingEdges().begin()->GetSink();
   auto & jlmOptCommand =
       *dynamic_cast<const jlm::tooling::JlmOptCommand *>(&jlmOptCommandNode.GetCommand());
   auto & statisticsCollectorSettings =
       jlmOptCommand.GetCommandLineOptions().GetStatisticsCollectorSettings();
 
   assert(statisticsCollectorSettings.GetDemandedStatistics() == expectedStatistics);
-}
-
-static int
-Test()
-{
-  Test1();
-  Test2();
-  TestJlmOptOptimizations();
-  TestJlmOptStatistics();
 
   return 0;
 }
 
-JLM_UNIT_TEST_REGISTER("jlm/tooling/TestJlcCommandGraphGenerator", Test)
+JLM_UNIT_TEST_REGISTER(
+    "jlm/tooling/TestJlcCommandGraphGenerator-TestJlmOptStatistics",
+    TestJlmOptStatistics);

--- a/tests/jlm/tooling/TestJlmOptCommand.cpp
+++ b/tests/jlm/tooling/TestJlmOptCommand.cpp
@@ -12,7 +12,7 @@
 
 #include <fstream>
 
-static void
+static int
 TestStatistics()
 {
   using namespace jlm::llvm;
@@ -20,7 +20,7 @@ TestStatistics()
   using namespace jlm::util;
 
   // Arrange
-  std::string expectedStatisticsDir = "/myStatisticsDir/";
+  filepath expectedStatisticsDir("/myStatisticsDir/");
 
   jlm::util::StatisticsCollectorSettings statisticsCollectorSettings(
       { jlm::util::Statistics::Id::SteensgaardAnalysis },
@@ -47,23 +47,17 @@ TestStatistics()
       "jlm-opt ",
       "--llvm ",
       "--DeadNodeElimination --LoopUnrolling ",
-      "-s " + expectedStatisticsDir + " ",
+      "-s " + expectedStatisticsDir.to_str() + " ",
       "--print-steensgaard-analysis ",
       "-o outputFile.ll ",
       "inputFile.ll");
 
   assert(receivedCommandLine == expectedCommandLine);
-}
-
-static int
-TestJlmOptCommand()
-{
-  TestStatistics();
 
   return 0;
 }
 
-JLM_UNIT_TEST_REGISTER("jlm/tooling/TestJlmOptCommand", TestJlmOptCommand)
+JLM_UNIT_TEST_REGISTER("jlm/tooling/TestJlmOptCommand-TestStatistics", TestStatistics)
 
 static int
 OptimizationIdToOptimizationTranslation()

--- a/tests/jlm/util/TestFile.cpp
+++ b/tests/jlm/util/TestFile.cpp
@@ -21,7 +21,7 @@ TestFilePathMethods()
   assert(f.base() == "archive");
   assert(f.suffix() == "gz");
   assert(f.complete_suffix() == "tar.gz");
-  assert(f.path() == "/tmp/");
+  assert(f.Dirname() == "/tmp/");
 
   std::vector<std::pair<std::string, std::string>> pathPairs = { { "/tmp/jlm/", "/tmp/" },
                                                                  { "/tmp/", "/" },
@@ -33,7 +33,7 @@ TestFilePathMethods()
                                                                  { "", "" } };
   for (const auto & [fullPath, path] : pathPairs)
   {
-    assert(jlm::util::filepath(fullPath).path() == path);
+    assert(jlm::util::filepath(fullPath).Dirname() == path);
   }
 
   return 0;
@@ -44,22 +44,21 @@ JLM_UNIT_TEST_REGISTER("jlm/util/TestFile-TestFilePathMethods", TestFilePathMeth
 static int
 TestCreateDirectory()
 {
-  const auto path = std::filesystem::temp_directory_path() / "jlm-test-create-dir";
-  const jlm::util::filepath filepath(path);
+  const auto filePath = jlm::util::filepath::TempDirectoryPath().Join("jlm-test-create-dir");
 
   // Remove the directory if it survived from a previous test
-  if (filepath.Exists())
-    std::filesystem::remove(path);
-  assert(!filepath.Exists());
+  if (filePath.Exists())
+    std::filesystem::remove(filePath.to_str());
+  assert(!filePath.Exists());
 
   // Act
-  filepath.CreateDirectory();
+  filePath.CreateDirectory();
 
   // Assert that the directory now exists
-  assert(filepath.Exists() && filepath.IsDirectory());
+  assert(filePath.Exists() && filePath.IsDirectory());
 
   // Try creating a directory that already exists, should be no issue
-  filepath.CreateDirectory();
+  filePath.CreateDirectory();
 
   // Try creating a directory in a location that does not exist
   try
@@ -72,7 +71,7 @@ TestCreateDirectory()
   {}
 
   // Cleanup
-  std::filesystem::remove(path);
+  std::filesystem::remove(filePath.to_str());
 
   return 0;
 }
@@ -86,11 +85,11 @@ TestFilepathJoin()
   const jlm::util::filepath path2("a/b/");
   const jlm::util::filepath path3("/c/d");
 
-  assert(path1.join(path2).to_str() == "tmp/a/b/");
-  assert(path2.join(path1).to_str() == "a/b/tmp");
+  assert(path1.Join(path2).to_str() == "tmp/a/b/");
+  assert(path2.Join(path1).to_str() == "a/b/tmp");
 
-  assert(path1.join(path3).to_str() == "/c/d");
-  assert(path3.join(path1).to_str() == "/c/d/tmp");
+  assert(path1.Join(path3).to_str() == "/c/d");
+  assert(path3.Join(path1).to_str() == "/c/d/tmp");
 
   return 0;
 }
@@ -102,13 +101,13 @@ TestCreateUniqueFileName()
 {
   // Arrange
   auto randomString = jlm::util::CreateRandomAlphanumericString(6);
-  auto tmpDirectory = std::filesystem::temp_directory_path().string() + "/" + randomString;
+  auto tmpDirectory = jlm::util::filepath::TempDirectoryPath().Join(randomString);
 
   // Act
   auto filePath = jlm::util::filepath::CreateUniqueFileName(tmpDirectory, "myPrefix", "mySuffix");
 
   // Assert
-  assert(filePath.path() == (tmpDirectory + "/"));
+  assert(filePath.Dirname() == (tmpDirectory.to_str() + "/"));
 
   return 0;
 }

--- a/tests/jlm/util/TestStatistics.cpp
+++ b/tests/jlm/util/TestStatistics.cpp
@@ -129,16 +129,15 @@ TestStatisticsPrinting()
   using namespace jlm::util;
 
   // Arrange
-  auto testOutputDir = std::filesystem::temp_directory_path() / "jlm-test-statistics";
-  auto testOutputPath = filepath(testOutputDir);
+  auto testOutputDir = filepath::TempDirectoryPath().Join("jlm-test-statistics");
 
   // Remove the output dir if it was not properly cleaned up last time
-  std::filesystem::remove(testOutputDir);
-  assert(!testOutputPath.Exists());
+  std::filesystem::remove(testOutputDir.to_str());
+  assert(!testOutputDir.Exists());
 
   StatisticsCollectorSettings settings(
       { Statistics::Id::Aggregation },
-      testOutputPath,
+      testOutputDir,
       "test-module");
 
   StatisticsCollector collector(settings);
@@ -155,10 +154,10 @@ TestStatisticsPrinting()
   collector.PrintStatistics();
 
   // Assert
-  assert(testOutputPath.IsDirectory());
+  assert(testOutputDir.IsDirectory());
 
   const auto outputFileName = "test-module-" + settings.GetUniqueString() + "-statistics.log";
-  std::ifstream file(testOutputDir / outputFileName);
+  std::ifstream file(testOutputDir.Join(outputFileName).to_str());
   std::string name, fileName, measurement;
   file >> name >> fileName >> measurement;
 
@@ -167,7 +166,7 @@ TestStatisticsPrinting()
   assert(measurement == "count:10");
 
   // Cleanup
-  std::filesystem::remove_all(testOutputDir);
+  std::filesystem::remove_all(testOutputDir.to_str());
 
   return 0;
 }


### PR DESCRIPTION
In a couple of places `std::string` was used for file paths, which I changed.

Makes the constructor of `jlm::util::filepath` explicit, which exposed a few places where implicit conversions were used.

In order to make it more ergonomic to use `filepath`, an overload for `Join` taking a string was added, and `WithSuffix` was added.

`filepath` also got a helper for getting the path to the temp directory.