### PR TITLE
Move and rename lambda node

### DIFF
--- a/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.cpp
+++ b/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.cpp
@@ -2813,13 +2813,14 @@ RhlsToFirrtlConverter::TraceStructuralOutput(rvsdg::StructuralOutput * output)
 
 // Emit a circuit
 circt::firrtl::CircuitOp
-RhlsToFirrtlConverter::MlirGen(const llvm::lambda::node * lambdaNode)
+RhlsToFirrtlConverter::MlirGen(const rvsdg::LambdaNode * lambdaNode)
 {
 
   // Ensure consistent naming across runs
   create_node_names(lambdaNode->subregion());
   // The same name is used for the circuit and main module
-  auto moduleName = Builder_->getStringAttr(lambdaNode->GetOperation().name() + "_lambda_mod");
+  auto moduleName = Builder_->getStringAttr(
+      dynamic_cast<llvm::LlvmLambdaOperation &>(lambdaNode->GetOperation()).name() + "_lambda_mod");
   // Create the top level FIRRTL circuit
   auto circuit = Builder_->create<circt::firrtl::CircuitOp>(Builder_->getUnknownLoc(), moduleName);
   // The body will be populated with a list of modules

--- a/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.hpp
+++ b/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.hpp
@@ -67,7 +67,7 @@ public:
   operator=(RhlsToFirrtlConverter &&) = delete;
 
   circt::firrtl::CircuitOp
-  MlirGen(const llvm::lambda::node * lamdaNode);
+  MlirGen(const rvsdg::LambdaNode * lamdaNode);
 
   void
   WriteModuleToFile(const circt::firrtl::FModuleOp fModuleOp, const rvsdg::Node * node);

--- a/jlm/hls/backend/rhls2firrtl/base-hls.cpp
+++ b/jlm/hls/backend/rhls2firrtl/base-hls.cpp
@@ -159,11 +159,11 @@ BaseHLS::create_node_names(rvsdg::Region * r)
   }
 }
 
-const jlm::llvm::lambda::node *
+const jlm::rvsdg::LambdaNode *
 BaseHLS::get_hls_lambda(llvm::RvsdgModule & rm)
 {
   auto region = &rm.Rvsdg().GetRootRegion();
-  auto ln = dynamic_cast<const llvm::lambda::node *>(region->Nodes().begin().ptr());
+  auto ln = dynamic_cast<const rvsdg::LambdaNode *>(region->Nodes().begin().ptr());
   if (region->nnodes() == 1 && ln)
   {
     return ln;

--- a/jlm/hls/backend/rhls2firrtl/base-hls.hpp
+++ b/jlm/hls/backend/rhls2firrtl/base-hls.hpp
@@ -62,7 +62,7 @@ protected:
   static std::string
   get_port_name(jlm::rvsdg::output * port);
 
-  const llvm::lambda::node *
+  const rvsdg::LambdaNode *
   get_hls_lambda(llvm::RvsdgModule & rm);
 
   void
@@ -81,7 +81,7 @@ protected:
    * @return the arguments that represent memory responses
    */
   std::vector<rvsdg::RegionArgument *>
-  get_mem_resps(const llvm::lambda::node & lambda)
+  get_mem_resps(const rvsdg::LambdaNode & lambda)
   {
     std::vector<rvsdg::RegionArgument *> mem_resps;
     for (auto arg : lambda.subregion()->Arguments())
@@ -99,7 +99,7 @@ protected:
    * @return the results that represent memory requests
    */
   std::vector<rvsdg::RegionResult *>
-  get_mem_reqs(const llvm::lambda::node & lambda)
+  get_mem_reqs(const rvsdg::LambdaNode & lambda)
   {
     std::vector<rvsdg::RegionResult *> mem_resps;
     for (auto result : lambda.subregion()->Results())
@@ -118,7 +118,7 @@ protected:
    * @return the arguments of the lambda that represent kernel inputs
    */
   std::vector<rvsdg::RegionArgument *>
-  get_reg_args(const llvm::lambda::node & lambda)
+  get_reg_args(const rvsdg::LambdaNode & lambda)
   {
     std::vector<rvsdg::RegionArgument *> args;
     for (auto argument : lambda.subregion()->Arguments())
@@ -136,7 +136,7 @@ protected:
    * @return the results of the lambda that represent the kernel outputs
    */
   std::vector<rvsdg::RegionResult *>
-  get_reg_results(const llvm::lambda::node & lambda)
+  get_reg_results(const rvsdg::LambdaNode & lambda)
   {
     std::vector<rvsdg::RegionResult *> results;
     for (auto result : lambda.subregion()->Results())

--- a/jlm/hls/backend/rhls2firrtl/json-hls.cpp
+++ b/jlm/hls/backend/rhls2firrtl/json-hls.cpp
@@ -14,7 +14,7 @@ JsonHLS::GetText(llvm::RvsdgModule & rm)
 {
   std::ostringstream json;
   const auto & ln = *get_hls_lambda(rm);
-  auto function_name = ln.GetOperation().name();
+  auto function_name = dynamic_cast<llvm::LlvmLambdaOperation &>(ln.GetOperation()).name();
   auto file_name = get_base_file_name(rm);
   json << "{\n";
 

--- a/jlm/hls/backend/rhls2firrtl/verilator-harness-hls.cpp
+++ b/jlm/hls/backend/rhls2firrtl/verilator-harness-hls.cpp
@@ -41,7 +41,7 @@ ConvertToCType(const rvsdg::Type * type)
  * @return the return type of the kernel as written in C, or nullopt if it has no return value.
  */
 std::optional<std::string>
-GetReturnTypeAsC(const llvm::lambda::node & kernel)
+GetReturnTypeAsC(const rvsdg::LambdaNode & kernel)
 {
   const auto & results = kernel.GetOperation().type().Results();
 
@@ -65,7 +65,7 @@ GetReturnTypeAsC(const llvm::lambda::node & kernel)
  * @return a tuple (number of parameters, string of parameters, string of call arguments)
  */
 std::tuple<size_t, std::string, std::string>
-GetParameterListAsC(const llvm::lambda::node & kernel)
+GetParameterListAsC(const rvsdg::LambdaNode & kernel)
 {
   size_t argument_index = 0;
   std::ostringstream parameters;
@@ -97,7 +97,8 @@ VerilatorHarnessHLS::GetText(llvm::RvsdgModule & rm)
 {
   std::ostringstream cpp;
   const auto & kernel = *get_hls_lambda(rm);
-  const auto & function_name = kernel.GetOperation().name();
+  const auto & function_name =
+      dynamic_cast<llvm::LlvmLambdaOperation &>(kernel.GetOperation()).name();
 
   // The request and response parts of memory queues
   const auto mem_reqs = get_mem_reqs(kernel);

--- a/jlm/hls/backend/rvsdg2rhls/DeadNodeElimination.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/DeadNodeElimination.cpp
@@ -120,7 +120,7 @@ EliminateDeadNodes(llvm::RvsdgModule & rvsdgModule)
     throw util::error("Root should have only one node now");
   }
 
-  auto lambdaNode = dynamic_cast<const llvm::lambda::node *>(rootRegion.Nodes().begin().ptr());
+  auto lambdaNode = dynamic_cast<const rvsdg::LambdaNode *>(rootRegion.Nodes().begin().ptr());
   if (!lambdaNode)
   {
     throw util::error("Node needs to be a lambda");

--- a/jlm/hls/backend/rvsdg2rhls/UnusedStateRemoval.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/UnusedStateRemoval.cpp
@@ -33,9 +33,9 @@ IsPassthroughResult(const rvsdg::input & result)
 }
 
 static void
-RemoveUnusedStatesFromLambda(llvm::lambda::node & lambdaNode)
+RemoveUnusedStatesFromLambda(rvsdg::LambdaNode & lambdaNode)
 {
-  const auto & op = lambdaNode.GetOperation();
+  const auto & op = dynamic_cast<llvm::LlvmLambdaOperation &>(lambdaNode.GetOperation());
   auto & oldFunctionType = op.type();
 
   std::vector<std::shared_ptr<const jlm::rvsdg::Type>> newArgumentTypes;
@@ -65,12 +65,9 @@ RemoveUnusedStatesFromLambda(llvm::lambda::node & lambdaNode)
   }
 
   auto newFunctionType = rvsdg::FunctionType::Create(newArgumentTypes, newResultTypes);
-  auto newLambda = llvm::lambda::node::create(
-      lambdaNode.region(),
-      newFunctionType,
-      op.name(),
-      op.linkage(),
-      op.attributes());
+  auto newLambda = rvsdg::LambdaNode::Create(
+      *lambdaNode.region(),
+      llvm::LlvmLambdaOperation::Create(newFunctionType, op.name(), op.linkage(), op.attributes()));
 
   rvsdg::SubstitutionMap substitutionMap;
   for (const auto & ctxvar : lambdaNode.GetContextVars())
@@ -210,7 +207,7 @@ RemoveUnusedStatesInStructuralNode(rvsdg::StructuralNode & structuralNode)
   {
     RemoveUnusedStatesFromThetaNode(*thetaNode);
   }
-  else if (auto lambdaNode = dynamic_cast<llvm::lambda::node *>(&structuralNode))
+  else if (auto lambdaNode = dynamic_cast<rvsdg::LambdaNode *>(&structuralNode))
   {
     RemoveUnusedStatesFromLambda(*lambdaNode);
   }

--- a/jlm/hls/backend/rvsdg2rhls/add-prints.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-prints.cpp
@@ -86,7 +86,7 @@ route_to_region(jlm::rvsdg::output * output, rvsdg::Region * region)
   {
     output = theta->AddLoopVar(output).pre;
   }
-  else if (auto lambda = dynamic_cast<llvm::lambda::node *>(region->node()))
+  else if (auto lambda = dynamic_cast<rvsdg::LambdaNode *>(region->node()))
   {
     output = lambda->AddContextVar(*output).inner;
   }

--- a/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-triggers.cpp
@@ -28,10 +28,10 @@ get_trigger(rvsdg::Region * region)
   return nullptr;
 }
 
-jlm::llvm::lambda::node *
-add_lambda_argument(llvm::lambda::node * ln, std::shared_ptr<const jlm::rvsdg::Type> type)
+jlm::rvsdg::LambdaNode *
+add_lambda_argument(rvsdg::LambdaNode * ln, std::shared_ptr<const jlm::rvsdg::Type> type)
 {
-  const auto & op = ln->GetOperation();
+  const auto & op = dynamic_cast<llvm::LlvmLambdaOperation &>(ln->GetOperation());
   auto old_fcttype = op.type();
   std::vector<std::shared_ptr<const jlm::rvsdg::Type>> new_argument_types;
   for (size_t i = 0; i < old_fcttype.NumArguments(); ++i)
@@ -45,12 +45,9 @@ add_lambda_argument(llvm::lambda::node * ln, std::shared_ptr<const jlm::rvsdg::T
     new_result_types.push_back(old_fcttype.Results()[i]);
   }
   auto new_fcttype = rvsdg::FunctionType::Create(new_argument_types, new_result_types);
-  auto new_lambda = llvm::lambda::node::create(
-      ln->region(),
-      new_fcttype,
-      op.name(),
-      op.linkage(),
-      op.attributes());
+  auto new_lambda = rvsdg::LambdaNode::Create(
+      *ln->region(),
+      llvm::LlvmLambdaOperation::Create(new_fcttype, op.name(), op.linkage(), op.attributes()));
 
   rvsdg::SubstitutionMap smap;
   for (const auto & ctxvar : ln->GetContextVars())
@@ -95,7 +92,7 @@ add_triggers(rvsdg::Region * region)
   {
     if (rvsdg::is<rvsdg::StructuralOperation>(node))
     {
-      if (auto ln = dynamic_cast<llvm::lambda::node *>(node))
+      if (auto ln = dynamic_cast<rvsdg::LambdaNode *>(node))
       {
         // check here in order not to process removed and re-added node twice
         if (!get_trigger(ln->subregion()))

--- a/jlm/hls/backend/rvsdg2rhls/add-triggers.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-triggers.hpp
@@ -16,8 +16,8 @@ namespace jlm::hls
 rvsdg::output *
 get_trigger(rvsdg::Region * region);
 
-llvm::lambda::node *
-add_lambda_argument(llvm::lambda::node * ln, const rvsdg::Type * type);
+rvsdg::LambdaNode *
+add_lambda_argument(rvsdg::LambdaNode * ln, const rvsdg::Type * type);
 
 void
 add_triggers(rvsdg::Region * region);

--- a/jlm/hls/backend/rvsdg2rhls/check-rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/check-rhls.cpp
@@ -51,7 +51,7 @@ check_rhls(llvm::RvsdgModule & rm)
   {
     throw jlm::util::error("Root should have only one node now");
   }
-  auto ln = dynamic_cast<const llvm::lambda::node *>(root->Nodes().begin().ptr());
+  auto ln = dynamic_cast<const rvsdg::LambdaNode *>(root->Nodes().begin().ptr());
   if (!ln)
   {
     throw jlm::util::error("Node needs to be a lambda");

--- a/jlm/hls/backend/rvsdg2rhls/dae-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/dae-conv.cpp
@@ -465,7 +465,7 @@ process_loopnode(loop_node * loopNode)
 void
 dae_conv(rvsdg::Region * region)
 {
-  auto lambda = dynamic_cast<const jlm::llvm::lambda::node *>(region->Nodes().begin().ptr());
+  auto lambda = dynamic_cast<const jlm::rvsdg::LambdaNode *>(region->Nodes().begin().ptr());
   bool changed;
   do
   {

--- a/jlm/hls/backend/rvsdg2rhls/distribute-constants.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/distribute-constants.cpp
@@ -75,7 +75,7 @@ hls::distribute_constants(rvsdg::Region * region)
   {
     if (rvsdg::is<rvsdg::StructuralOperation>(node))
     {
-      if (auto ln = dynamic_cast<llvm::lambda::node *>(node))
+      if (auto ln = dynamic_cast<rvsdg::LambdaNode *>(node))
       {
         distribute_constants(ln->subregion());
       }

--- a/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/instrument-ref.cpp
@@ -15,12 +15,13 @@
 namespace jlm::hls
 {
 
-llvm::lambda::node *
-change_function_name(llvm::lambda::node * ln, const std::string & name)
+rvsdg::LambdaNode *
+change_function_name(rvsdg::LambdaNode * ln, const std::string & name)
 {
-  const auto & op = ln->GetOperation();
-  auto lambda =
-      llvm::lambda::node::create(ln->region(), op.Type(), name, op.linkage(), op.attributes());
+  const auto & op = dynamic_cast<llvm::LlvmLambdaOperation &>(ln->GetOperation());
+  auto lambda = rvsdg::LambdaNode::Create(
+      *ln->region(),
+      llvm::LlvmLambdaOperation::Create(op.Type(), name, op.linkage(), op.attributes()));
 
   /* add context variables */
   rvsdg::SubstitutionMap subregionmap;
@@ -61,7 +62,7 @@ instrument_ref(llvm::RvsdgModule & rm)
 {
   auto & graph = rm.Rvsdg();
   auto root = &graph.GetRootRegion();
-  auto lambda = dynamic_cast<llvm::lambda::node *>(root->Nodes().begin().ptr());
+  auto lambda = dynamic_cast<rvsdg::LambdaNode *>(root->Nodes().begin().ptr());
 
   auto newLambda = change_function_name(lambda, "instrumented_ref");
 

--- a/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
@@ -233,7 +233,7 @@ trace_function_calls(
 
 jlm::rvsdg::SimpleNode *
 find_decouple_response(
-    const jlm::llvm::lambda::node * lambda,
+    const jlm::rvsdg::LambdaNode * lambda,
     const jlm::rvsdg::bitconstant_op * request_constant)
 {
   jlm::rvsdg::output * response_function = nullptr;
@@ -264,7 +264,7 @@ find_decouple_response(
 
 jlm::rvsdg::SimpleNode *
 replace_decouple(
-    const jlm::llvm::lambda::node * lambda,
+    const jlm::rvsdg::LambdaNode * lambda,
     jlm::rvsdg::SimpleNode * decouple_request,
     jlm::rvsdg::output * resp)
 {
@@ -527,7 +527,7 @@ IsDecoupledFunctionPointer(
 
 void
 jlm::hls::TracePointerArguments(
-    const jlm::llvm::lambda::node * lambda,
+    const jlm::rvsdg::LambdaNode * lambda,
     port_load_store_decouple & portNodes)
 {
   for (size_t i = 0; i < lambda->subregion()->narguments(); ++i)
@@ -568,13 +568,13 @@ jlm::hls::MemoryConverter(jlm::llvm::RvsdgModule & rm)
   //
 
   auto root = &rm.Rvsdg().GetRootRegion();
-  auto lambda = dynamic_cast<jlm::llvm::lambda::node *>(root->Nodes().begin().ptr());
+  auto lambda = dynamic_cast<jlm::rvsdg::LambdaNode *>(root->Nodes().begin().ptr());
 
   //
   // Converting loads and stores to explicitly use memory ports
   // This modifies the function signature so we create a new lambda node to replace the old one
   //
-  const auto & op = lambda->GetOperation();
+  const auto & op = dynamic_cast<llvm::LlvmLambdaOperation &>(lambda->GetOperation());
   auto oldFunctionType = op.type();
   std::vector<std::shared_ptr<const jlm::rvsdg::Type>> newArgumentTypes;
   for (size_t i = 0; i < oldFunctionType.NumArguments(); ++i)
@@ -641,12 +641,9 @@ jlm::hls::MemoryConverter(jlm::llvm::RvsdgModule & rm)
   // Create new lambda and copy the region from the old lambda
   //
   auto newFunctionType = jlm::rvsdg::FunctionType::Create(newArgumentTypes, newResultTypes);
-  auto newLambda = jlm::llvm::lambda::node::create(
-      lambda->region(),
-      newFunctionType,
-      op.name(),
-      op.linkage(),
-      op.attributes());
+  auto newLambda = jlm::rvsdg::LambdaNode::Create(
+      *lambda->region(),
+      llvm::LlvmLambdaOperation::Create(newFunctionType, op.name(), op.linkage(), op.attributes()));
 
   rvsdg::SubstitutionMap smap;
   for (const auto & ctxvar : lambda->GetContextVars())
@@ -727,7 +724,7 @@ jlm::hls::MemoryConverter(jlm::llvm::RvsdgModule & rm)
 
   // Need to get the lambda from the root since remote_unused_state replaces the lambda
   JLM_ASSERT(root->nnodes() == 1);
-  newLambda = jlm::util::AssertedCast<jlm::llvm::lambda::node>(root->Nodes().begin().ptr());
+  newLambda = jlm::util::AssertedCast<jlm::rvsdg::LambdaNode>(root->Nodes().begin().ptr());
 
   // Go through in reverse since we are removing things
   auto ctxvars = newLambda->GetContextVars();
@@ -755,7 +752,7 @@ jlm::hls::MemoryConverter(jlm::llvm::RvsdgModule & rm)
 
 jlm::rvsdg::output *
 jlm::hls::ConnectRequestResponseMemPorts(
-    const jlm::llvm::lambda::node * lambda,
+    const jlm::rvsdg::LambdaNode * lambda,
     size_t argumentIndex,
     rvsdg::SubstitutionMap & smap,
     const std::vector<jlm::rvsdg::SimpleNode *> & originalLoadNodes,
@@ -926,7 +923,7 @@ jlm::hls::ReplaceStore(rvsdg::SubstitutionMap & smap, const jlm::rvsdg::SimpleNo
 jlm::rvsdg::SimpleNode *
 ReplaceDecouple(
     jlm::rvsdg::SubstitutionMap & smap,
-    const jlm::llvm::lambda::node * lambda,
+    const jlm::rvsdg::LambdaNode * lambda,
     jlm::rvsdg::SimpleNode * originalDecoupleRequest,
     jlm::rvsdg::output * response)
 {

--- a/jlm/hls/backend/rvsdg2rhls/mem-conv.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-conv.hpp
@@ -25,7 +25,7 @@ typedef std::vector<std::tuple<
  * @param portNodes A vector where each element contains all memory operations traced from a pointer
  */
 void
-TracePointerArguments(const llvm::lambda::node * lambda, port_load_store_decouple & portNodes);
+TracePointerArguments(const rvsdg::LambdaNode * lambda, port_load_store_decouple & portNodes);
 
 void
 MemoryConverter(llvm::RvsdgModule & rm);
@@ -42,7 +42,7 @@ MemoryConverter(llvm::RvsdgModule & rm);
  */
 jlm::rvsdg::output *
 ConnectRequestResponseMemPorts(
-    const llvm::lambda::node * lambda,
+    const rvsdg::LambdaNode * lambda,
     size_t argumentIndex,
     rvsdg::SubstitutionMap & smap,
     const std::vector<jlm::rvsdg::SimpleNode *> & originalLoadNodes,

--- a/jlm/hls/backend/rvsdg2rhls/mem-queue.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-queue.cpp
@@ -140,7 +140,7 @@ get_parent_regions(jlm::rvsdg::Region * region)
   std::deque<jlm::rvsdg::Region *> regions;
   jlm::rvsdg::Region * target_region = region;
   while (
-      !dynamic_cast<const jlm::llvm::lambda::operation *>(&target_region->node()->GetOperation()))
+      !dynamic_cast<const jlm::llvm::LlvmLambdaOperation *>(&target_region->node()->GetOperation()))
   {
     regions.push_front(target_region);
     target_region = target_region->node()->region();
@@ -521,7 +521,7 @@ void
 jlm::hls::mem_queue(jlm::rvsdg::Region * region)
 {
   auto lambda =
-      jlm::util::AssertedCast<const jlm::llvm::lambda::node>(region->Nodes().begin().ptr());
+      jlm::util::AssertedCast<const jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
   auto state_arg = GetMemoryStateArgument(*lambda);
   if (!state_arg)
   {

--- a/jlm/hls/backend/rvsdg2rhls/mem-sep.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-sep.cpp
@@ -40,7 +40,7 @@ mem_sep_argument(llvm::RvsdgModule & rm)
 
 // from MemoryStateEncoder.cpp
 rvsdg::RegionArgument *
-GetMemoryStateArgument(const llvm::lambda::node & lambda)
+GetMemoryStateArgument(const rvsdg::LambdaNode & lambda)
 {
   auto subregion = lambda.subregion();
   for (size_t n = 0; n < subregion->narguments(); n++)
@@ -53,7 +53,7 @@ GetMemoryStateArgument(const llvm::lambda::node & lambda)
 }
 
 rvsdg::RegionResult *
-GetMemoryStateResult(const llvm::lambda::node & lambda)
+GetMemoryStateResult(const rvsdg::LambdaNode & lambda)
 {
   auto subregion = lambda.subregion();
   for (size_t n = 0; n < subregion->nresults(); n++)
@@ -128,7 +128,7 @@ route_through(rvsdg::Region * target, jlm::rvsdg::output * response)
 void
 mem_sep_independent(rvsdg::Region * region)
 {
-  auto lambda = dynamic_cast<const llvm::lambda::node *>(region->Nodes().begin().ptr());
+  auto lambda = dynamic_cast<const rvsdg::LambdaNode *>(region->Nodes().begin().ptr());
   auto lambda_region = lambda->subregion();
   auto state_arg = GetMemoryStateArgument(*lambda);
   if (!state_arg)
@@ -273,7 +273,7 @@ trace_edge(
 void
 mem_sep_argument(rvsdg::Region * region)
 {
-  auto lambda = dynamic_cast<const llvm::lambda::node *>(region->Nodes().begin().ptr());
+  auto lambda = dynamic_cast<const rvsdg::LambdaNode *>(region->Nodes().begin().ptr());
   auto lambda_region = lambda->subregion();
   auto state_arg = GetMemoryStateArgument(*lambda);
   if (!state_arg)

--- a/jlm/hls/backend/rvsdg2rhls/mem-sep.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-sep.hpp
@@ -24,10 +24,10 @@ void
 mem_sep_argument(llvm::RvsdgModule & rm);
 
 rvsdg::RegionArgument *
-GetMemoryStateArgument(const llvm::lambda::node & lambda);
+GetMemoryStateArgument(const rvsdg::LambdaNode & lambda);
 
 rvsdg::RegionResult *
-GetMemoryStateResult(const llvm::lambda::node & lambda);
+GetMemoryStateResult(const rvsdg::LambdaNode & lambda);
 
 } // namespace jlm::hls
 

--- a/jlm/hls/backend/rvsdg2rhls/remove-unused-state.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/remove-unused-state.hpp
@@ -20,8 +20,8 @@ is_passthrough(const rvsdg::output * arg);
 bool
 is_passthrough(const rvsdg::input * res);
 
-llvm::lambda::node *
-remove_lambda_passthrough(llvm::lambda::node * ln);
+rvsdg::LambdaNode *
+remove_lambda_passthrough(rvsdg::LambdaNode * ln);
 
 void
 remove_region_passthrough(const rvsdg::RegionArgument * arg);

--- a/jlm/hls/backend/rvsdg2rhls/rhls-dne.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rhls-dne.cpp
@@ -330,7 +330,7 @@ dne(llvm::RvsdgModule & rm)
   {
     throw util::error("Root should have only one node now");
   }
-  auto ln = dynamic_cast<const llvm::lambda::node *>(root->Nodes().begin().ptr());
+  auto ln = dynamic_cast<const rvsdg::LambdaNode *>(root->Nodes().begin().ptr());
   if (!ln)
   {
     throw util::error("Node needs to be a lambda");

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -97,10 +97,12 @@ dump_xml(llvm::RvsdgModule & rvsdgModule, const std::string & file_name)
 }
 
 bool
-function_match(llvm::lambda::node * ln, const std::string & function_name)
+function_match(rvsdg::LambdaNode * ln, const std::string & function_name)
 {
   const std::regex fn_regex(function_name);
-  if (std::regex_match(ln->GetOperation().name(), fn_regex))
+  if (std::regex_match(
+          dynamic_cast<llvm::LlvmLambdaOperation &>(ln->GetOperation()).name(),
+          fn_regex))
   { // TODO: handle C++ name mangling
     return true;
   }
@@ -162,11 +164,11 @@ inline_calls(rvsdg::Region * region)
           throw jlm::util::error("can not inline external function " + graphImport->Name());
         }
       }
-      JLM_ASSERT(rvsdg::is<llvm::lambda::operation>(so->node()));
+      JLM_ASSERT(rvsdg::is<rvsdg::LambdaOperation>(so->node()));
       auto ln = dynamic_cast<const rvsdg::StructuralOutput *>(traced)->node();
       llvm::inlineCall(
           dynamic_cast<jlm::rvsdg::SimpleNode *>(node),
-          dynamic_cast<const llvm::lambda::node *>(ln));
+          dynamic_cast<const rvsdg::LambdaNode *>(ln));
       // restart for this region
       inline_calls(region);
       return;
@@ -279,12 +281,13 @@ rename_delta(llvm::delta::node * odn)
   return static_cast<llvm::delta::node *>(jlm::rvsdg::output::GetNode(*data));
 }
 
-llvm::lambda::node *
-change_linkage(llvm::lambda::node * ln, llvm::linkage link)
+rvsdg::LambdaNode *
+change_linkage(rvsdg::LambdaNode * ln, llvm::linkage link)
 {
-  const auto & op = ln->GetOperation();
-  auto lambda =
-      llvm::lambda::node::create(ln->region(), op.Type(), op.name(), link, op.attributes());
+  const auto & op = dynamic_cast<llvm::LlvmLambdaOperation &>(ln->GetOperation());
+  auto lambda = rvsdg::LambdaNode::Create(
+      *ln->region(),
+      llvm::LlvmLambdaOperation::Create(op.Type(), op.name(), link, op.attributes()));
 
   /* add context variables */
   rvsdg::SubstitutionMap subregionmap;
@@ -330,7 +333,7 @@ split_hls_function(llvm::RvsdgModule & rm, const std::string & function_name)
   auto root = &rm.Rvsdg().GetRootRegion();
   for (auto node : rvsdg::TopDownTraverser(root))
   {
-    if (auto ln = dynamic_cast<llvm::lambda::node *>(node))
+    if (auto ln = dynamic_cast<rvsdg::LambdaNode *>(node))
     {
       if (!function_match(ln, function_name))
       {
@@ -357,10 +360,12 @@ split_hls_function(llvm::RvsdgModule & rm, const std::string & function_name)
           continue;
         }
         auto orig_node = orig_node_output->node();
-        if (auto oln = dynamic_cast<llvm::lambda::node *>(orig_node))
+        if (auto oln = dynamic_cast<rvsdg::LambdaNode *>(orig_node))
         {
           throw jlm::util::error(
-              "Inlining of function " + oln->GetOperation().name() + " not supported");
+              "Inlining of function "
+              + dynamic_cast<llvm::LlvmLambdaOperation &>(oln->GetOperation()).name()
+              + " not supported");
         }
         else if (auto odn = dynamic_cast<llvm::delta::node *>(orig_node))
         {
@@ -393,7 +398,7 @@ split_hls_function(llvm::RvsdgModule & rm, const std::string & function_name)
       auto oldExport = jlm::llvm::ComputeCallSummary(*ln).GetRvsdgExport();
       jlm::llvm::GraphExport::Create(*new_ln->output(), oldExport ? oldExport->Name() : "");
       // add function as input to rm and remove it
-      const auto & op = ln->GetOperation();
+      const auto & op = dynamic_cast<llvm::LlvmLambdaOperation &>(ln->GetOperation());
       auto & graphImport = llvm::GraphImport::Create(
           rm.Rvsdg(),
           op.Type(),
@@ -402,7 +407,9 @@ split_hls_function(llvm::RvsdgModule & rm, const std::string & function_name)
           llvm::linkage::external_linkage); // TODO: change linkage?
       ln->output()->divert_users(&graphImport);
       remove(ln);
-      std::cout << "function " << new_ln->GetOperation().name() << " extracted for HLS\n";
+      std::cout << "function "
+                << dynamic_cast<llvm::LlvmLambdaOperation &>(new_ln->GetOperation()).name()
+                << " extracted for HLS\n";
       return rhls;
     }
   }

--- a/jlm/hls/opt/cne.cpp
+++ b/jlm/hls/opt/cne.cpp
@@ -381,7 +381,7 @@ mark_loop(const rvsdg::StructuralNode * node, cnectx & ctx)
 static void
 mark_lambda(const rvsdg::StructuralNode * node, cnectx & ctx)
 {
-  JLM_ASSERT(jlm::rvsdg::is<llvm::lambda::operation>(node));
+  JLM_ASSERT(jlm::rvsdg::is<rvsdg::LambdaOperation>(node));
 
   /* mark dependencies */
   for (size_t i1 = 0; i1 < node->ninputs(); i1++)
@@ -428,16 +428,15 @@ static void
 mark(const rvsdg::StructuralNode * node, cnectx & ctx)
 {
   static std::unordered_map<std::type_index, void (*)(const rvsdg::StructuralNode *, cnectx &)> map(
-      { { std::type_index(typeid(rvsdg::GammaOperation)), mark_gamma },
-        { std::type_index(typeid(ThetaOperation)), mark_theta },
-        { std::type_index(typeid(jlm::hls::loop_op)), mark_loop },
-        { typeid(llvm::lambda::operation), mark_lambda },
-        { typeid(llvm::phi::operation), mark_phi },
-        { typeid(llvm::delta::operation), mark_delta } });
+      { { std::type_index(typeid(GammaNode)), mark_gamma },
+        { std::type_index(typeid(ThetaNode)), mark_theta },
+        { std::type_index(typeid(jlm::hls::loop_node)), mark_loop },
+        { typeid(LambdaNode), mark_lambda },
+        { typeid(llvm::phi::node), mark_phi },
+        { typeid(llvm::delta::node), mark_delta } });
 
-  auto & op = node->GetOperation();
-  JLM_ASSERT(map.find(typeid(op)) != map.end());
-  map[typeid(op)](node, ctx);
+  JLM_ASSERT(map.find(typeid(*node)) != map.end());
+  map[typeid(*node)](node, ctx);
 }
 
 static void
@@ -565,7 +564,7 @@ divert_loop(rvsdg::StructuralNode * node, cnectx & ctx)
 static void
 divert_lambda(rvsdg::StructuralNode * node, cnectx & ctx)
 {
-  JLM_ASSERT(jlm::rvsdg::is<llvm::lambda::operation>(node));
+  JLM_ASSERT(jlm::rvsdg::is<rvsdg::LambdaOperation>(node));
 
   divert_arguments(node->subregion(0), ctx);
   divert(node->subregion(0), ctx);
@@ -590,16 +589,15 @@ static void
 divert(rvsdg::StructuralNode * node, cnectx & ctx)
 {
   static std::unordered_map<std::type_index, void (*)(rvsdg::StructuralNode *, cnectx &)> map(
-      { { std::type_index(typeid(rvsdg::GammaOperation)), divert_gamma },
-        { std::type_index(typeid(ThetaOperation)), divert_theta },
-        { std::type_index(typeid(jlm::hls::loop_op)), divert_loop },
-        { typeid(llvm::lambda::operation), divert_lambda },
-        { typeid(llvm::phi::operation), divert_phi },
-        { typeid(llvm::delta::operation), divert_delta } });
+      { { std::type_index(typeid(rvsdg::GammaNode)), divert_gamma },
+        { std::type_index(typeid(ThetaNode)), divert_theta },
+        { std::type_index(typeid(jlm::hls::loop_node)), divert_loop },
+        { typeid(rvsdg::LambdaNode), divert_lambda },
+        { typeid(llvm::phi::node), divert_phi },
+        { typeid(llvm::delta::node), divert_delta } });
 
-  auto & op = node->GetOperation();
-  JLM_ASSERT(map.find(typeid(op)) != map.end());
-  map[typeid(op)](node, ctx);
+  JLM_ASSERT(map.find(typeid(*node)) != map.end());
+  map[typeid(*node)](node, ctx);
 }
 
 static void

--- a/jlm/llvm/ir/CallSummary.cpp
+++ b/jlm/llvm/ir/CallSummary.cpp
@@ -18,7 +18,7 @@ namespace jlm::llvm
 {
 
 CallSummary
-ComputeCallSummary(const lambda::node & lambdaNode)
+ComputeCallSummary(const rvsdg::LambdaNode & lambdaNode)
 {
   std::deque<rvsdg::input *> worklist;
   worklist.insert(worklist.end(), lambdaNode.output()->begin(), lambdaNode.output()->end());
@@ -34,14 +34,14 @@ ComputeCallSummary(const lambda::node & lambdaNode)
 
     auto inputNode = rvsdg::input::GetNode(*input);
 
-    if (auto lambdaNode = rvsdg::TryGetOwnerNode<lambda::node>(*input))
+    if (auto lambdaNode = rvsdg::TryGetOwnerNode<rvsdg::LambdaNode>(*input))
     {
       auto & argument = *lambdaNode->MapInputContextVar(*input).inner;
       worklist.insert(worklist.end(), argument.begin(), argument.end());
       continue;
     }
 
-    if (rvsdg::TryGetRegionParentNode<lambda::node>(*input))
+    if (rvsdg::TryGetRegionParentNode<rvsdg::LambdaNode>(*input))
     {
       otherUsers.emplace_back(input);
       continue;

--- a/jlm/llvm/ir/CallSummary.hpp
+++ b/jlm/llvm/ir/CallSummary.hpp
@@ -191,7 +191,7 @@ private:
 };
 
 CallSummary
-ComputeCallSummary(const lambda::node & lambdaNode);
+ComputeCallSummary(const rvsdg::LambdaNode & lambdaNode);
 
 }
 

--- a/jlm/llvm/ir/LambdaMemoryState.cpp
+++ b/jlm/llvm/ir/LambdaMemoryState.cpp
@@ -10,7 +10,7 @@ namespace jlm::llvm
 {
 
 rvsdg::output &
-GetMemoryStateRegionArgument(const lambda::node & lambdaNode) noexcept
+GetMemoryStateRegionArgument(const rvsdg::LambdaNode & lambdaNode) noexcept
 {
   auto argument = lambdaNode.GetFunctionArguments().back();
   JLM_ASSERT(is<MemoryStateType>(argument->type()));
@@ -18,7 +18,7 @@ GetMemoryStateRegionArgument(const lambda::node & lambdaNode) noexcept
 }
 
 rvsdg::input &
-GetMemoryStateRegionResult(const lambda::node & lambdaNode) noexcept
+GetMemoryStateRegionResult(const rvsdg::LambdaNode & lambdaNode) noexcept
 {
   auto result = lambdaNode.GetFunctionResults().back();
   JLM_ASSERT(is<MemoryStateType>(result->type()));
@@ -26,7 +26,7 @@ GetMemoryStateRegionResult(const lambda::node & lambdaNode) noexcept
 }
 
 rvsdg::SimpleNode *
-GetMemoryStateExitMerge(const lambda::node & lambdaNode) noexcept
+GetMemoryStateExitMerge(const rvsdg::LambdaNode & lambdaNode) noexcept
 {
   auto & result = GetMemoryStateRegionResult(lambdaNode);
 
@@ -36,7 +36,7 @@ GetMemoryStateExitMerge(const lambda::node & lambdaNode) noexcept
 }
 
 rvsdg::SimpleNode *
-GetMemoryStateEntrySplit(const lambda::node & lambdaNode) noexcept
+GetMemoryStateEntrySplit(const rvsdg::LambdaNode & lambdaNode) noexcept
 {
   auto & argument = GetMemoryStateRegionArgument(lambdaNode);
 

--- a/jlm/llvm/ir/LambdaMemoryState.hpp
+++ b/jlm/llvm/ir/LambdaMemoryState.hpp
@@ -35,7 +35,7 @@ namespace jlm::llvm
  *   llvm function representation as lambdas and memory state encoding.
  */
 [[nodiscard]] rvsdg::output &
-GetMemoryStateRegionArgument(const lambda::node & lambdaNode) noexcept;
+GetMemoryStateRegionArgument(const rvsdg::LambdaNode & lambdaNode) noexcept;
 
 /**
  * Determines the formal return value representing global memory state
@@ -51,7 +51,7 @@ GetMemoryStateRegionArgument(const lambda::node & lambdaNode) noexcept;
  *   llvm function representation as lambdas and memory state encoding.
  */
 [[nodiscard]] rvsdg::input &
-GetMemoryStateRegionResult(const lambda::node & lambdaNode) noexcept;
+GetMemoryStateRegionResult(const rvsdg::LambdaNode & lambdaNode) noexcept;
 
 /**
  * Determines the memory state split node at entry.
@@ -70,7 +70,7 @@ GetMemoryStateRegionResult(const lambda::node & lambdaNode) noexcept;
  * \see GetMemoryStateExitMerge()
  */
 rvsdg::SimpleNode *
-GetMemoryStateEntrySplit(const lambda::node & lambdaNode) noexcept;
+GetMemoryStateEntrySplit(const rvsdg::LambdaNode & lambdaNode) noexcept;
 
 /**
  * Determines the memory state merge node at exit.
@@ -89,7 +89,7 @@ GetMemoryStateEntrySplit(const lambda::node & lambdaNode) noexcept;
  * \see GetMemoryStateEntrySplit()
  */
 [[nodiscard]] rvsdg::SimpleNode *
-GetMemoryStateExitMerge(const lambda::node & lambdaNode) noexcept;
+GetMemoryStateExitMerge(const rvsdg::LambdaNode & lambdaNode) noexcept;
 
 }
 

--- a/jlm/llvm/ir/operators/Phi.cpp
+++ b/jlm/llvm/ir/operators/Phi.cpp
@@ -100,15 +100,15 @@ node::copy(rvsdg::Region * region, rvsdg::SubstitutionMap & smap) const
   return pb.end();
 }
 
-std::vector<lambda::node *>
+std::vector<rvsdg::LambdaNode *>
 node::ExtractLambdaNodes(const phi::node & phiNode)
 {
-  std::function<void(const phi::node &, std::vector<lambda::node *> &)> extractLambdaNodes =
+  std::function<void(const phi::node &, std::vector<rvsdg::LambdaNode *> &)> extractLambdaNodes =
       [&](auto & phiNode, auto & lambdaNodes)
   {
     for (auto & node : phiNode.subregion()->Nodes())
     {
-      if (auto lambdaNode = dynamic_cast<lambda::node *>(&node))
+      if (auto lambdaNode = dynamic_cast<rvsdg::LambdaNode *>(&node))
       {
         lambdaNodes.push_back(lambdaNode);
       }
@@ -119,7 +119,7 @@ node::ExtractLambdaNodes(const phi::node & phiNode)
     }
   };
 
-  std::vector<lambda::node *> lambdaNodes;
+  std::vector<rvsdg::LambdaNode *> lambdaNodes;
   extractLambdaNodes(phiNode, lambdaNodes);
 
   return lambdaNodes;

--- a/jlm/llvm/ir/operators/Phi.hpp
+++ b/jlm/llvm/ir/operators/Phi.hpp
@@ -8,6 +8,7 @@
 #define JLM_LLVM_IR_OPERATORS_PHI_HPP
 
 #include <jlm/rvsdg/graph.hpp>
+#include <jlm/rvsdg/lambda.hpp>
 #include <jlm/rvsdg/node.hpp>
 #include <jlm/rvsdg/region.hpp>
 #include <jlm/rvsdg/structural-node.hpp>
@@ -15,11 +16,6 @@
 
 namespace jlm::llvm
 {
-
-namespace lambda
-{
-class node;
-}
 
 namespace phi
 {
@@ -493,7 +489,7 @@ public:
    * @param phiNode The phi node from which the lambda nodes should be extracted.
    * @return A vector of lambda nodes.
    */
-  static std::vector<lambda::node *>
+  static std::vector<rvsdg::LambdaNode *>
   ExtractLambdaNodes(const phi::node & phiNode);
 };
 

--- a/jlm/llvm/ir/operators/call.cpp
+++ b/jlm/llvm/ir/operators/call.cpp
@@ -168,7 +168,7 @@ CallNode::TraceFunctionInput(const CallNode & callNode)
 
   while (true)
   {
-    if (rvsdg::TryGetOwnerNode<lambda::node>(*origin))
+    if (rvsdg::TryGetOwnerNode<rvsdg::LambdaNode>(*origin))
       return origin;
 
     if (is<rvsdg::GraphImport>(origin))
@@ -182,7 +182,7 @@ CallNode::TraceFunctionInput(const CallNode & callNode)
       return origin;
     }
 
-    if (auto lambda = rvsdg::TryGetRegionParentNode<lambda::node>(*origin))
+    if (auto lambda = rvsdg::TryGetRegionParentNode<rvsdg::LambdaNode>(*origin))
     {
       if (auto ctxvar = lambda->MapBinderContextVar(*origin))
       {
@@ -255,7 +255,7 @@ CallNode::ClassifyCall(const CallNode & callNode)
 {
   auto output = CallNode::TraceFunctionInput(callNode);
 
-  if (rvsdg::TryGetOwnerNode<lambda::node>(*output))
+  if (rvsdg::TryGetOwnerNode<rvsdg::LambdaNode>(*output))
   {
     return CallTypeClassifier::CreateNonRecursiveDirectCallClassifier(*output);
   }

--- a/jlm/llvm/ir/operators/call.hpp
+++ b/jlm/llvm/ir/operators/call.hpp
@@ -229,7 +229,7 @@ public:
   static std::unique_ptr<CallTypeClassifier>
   CreateNonRecursiveDirectCallClassifier(rvsdg::output & output)
   {
-    rvsdg::AssertGetOwnerNode<lambda::node>(output);
+    rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(output);
     return std::make_unique<CallTypeClassifier>(CallType::NonRecursiveDirectCall, output);
   }
 

--- a/jlm/llvm/ir/operators/lambda.cpp
+++ b/jlm/llvm/ir/operators/lambda.cpp
@@ -8,17 +8,17 @@
 #include <jlm/rvsdg/gamma.hpp>
 #include <jlm/rvsdg/theta.hpp>
 
-namespace jlm::llvm::lambda
+namespace jlm::llvm
 {
 
-operation::~operation() = default;
+LlvmLambdaOperation::~LlvmLambdaOperation() = default;
 
-operation::operation(
+LlvmLambdaOperation::LlvmLambdaOperation(
     std::shared_ptr<const jlm::rvsdg::FunctionType> type,
     std::string name,
     const jlm::llvm::linkage & linkage,
     jlm::llvm::attributeset attributes)
-    : type_(std::move(type)),
+    : rvsdg::LambdaOperation(std::move(type)),
       name_(std::move(name)),
       linkage_(linkage),
       attributes_(std::move(attributes))
@@ -27,216 +27,39 @@ operation::operation(
 }
 
 std::string
-operation::debug_string() const
+LlvmLambdaOperation::debug_string() const
 {
   return util::strfmt("LAMBDA[", name(), "]");
 }
 
 bool
-operation::operator==(const Operation & other) const noexcept
+LlvmLambdaOperation::operator==(const Operation & other) const noexcept
 {
-  auto op = dynamic_cast<const lambda::operation *>(&other);
+  auto op = dynamic_cast<const LlvmLambdaOperation *>(&other);
   return op && op->type() == type() && op->name() == name() && op->linkage() == linkage()
       && op->attributes() == attributes();
 }
 
 std::unique_ptr<rvsdg::Operation>
-operation::copy() const
+LlvmLambdaOperation::copy() const
 {
-  return std::make_unique<lambda::operation>(*this);
+  return std::make_unique<LlvmLambdaOperation>(*this);
 }
 
 [[nodiscard]] const jlm::llvm::attributeset &
-operation::GetArgumentAttributes(std::size_t index) const noexcept
+LlvmLambdaOperation::GetArgumentAttributes(std::size_t index) const noexcept
 {
   JLM_ASSERT(index < ArgumentAttributes_.size());
   return ArgumentAttributes_[index];
 }
 
 void
-operation::SetArgumentAttributes(std::size_t index, const jlm::llvm::attributeset & attributes)
+LlvmLambdaOperation::SetArgumentAttributes(
+    std::size_t index,
+    const jlm::llvm::attributeset & attributes)
 {
   JLM_ASSERT(index < ArgumentAttributes_.size());
   ArgumentAttributes_[index] = attributes;
-}
-
-/* lambda node class */
-
-node::~node() = default;
-
-node::node(rvsdg::Region & parent, std::unique_ptr<lambda::operation> op)
-    : StructuralNode(&parent, 1),
-      Operation_(std::move(op))
-{}
-
-lambda::operation &
-node::GetOperation() const noexcept
-{
-  return *Operation_;
-}
-
-[[nodiscard]] std::vector<rvsdg::output *>
-node::GetFunctionArguments() const
-{
-  std::vector<rvsdg::output *> arguments;
-  const auto & type = GetOperation().Type();
-  for (std::size_t n = 0; n < type->Arguments().size(); ++n)
-  {
-    arguments.push_back(subregion()->argument(n));
-  }
-  return arguments;
-}
-
-[[nodiscard]] std::vector<rvsdg::input *>
-node::GetFunctionResults() const
-{
-  std::vector<rvsdg::input *> results;
-  for (std::size_t n = 0; n < subregion()->nresults(); ++n)
-  {
-    results.push_back(subregion()->result(n));
-  }
-  return results;
-}
-
-[[nodiscard]] node::ContextVar
-node::MapInputContextVar(const rvsdg::input & input) const noexcept
-{
-  JLM_ASSERT(rvsdg::TryGetOwnerNode<node>(input) == this);
-  return ContextVar{ const_cast<rvsdg::input *>(&input),
-                     subregion()->argument(GetOperation().Type()->NumArguments() + input.index()) };
-}
-
-[[nodiscard]] std::optional<node::ContextVar>
-node::MapBinderContextVar(const rvsdg::output & output) const noexcept
-{
-  JLM_ASSERT(rvsdg::TryGetOwnerRegion(output) == subregion());
-  auto numArguments = GetOperation().Type()->NumArguments();
-  if (output.index() >= numArguments)
-  {
-    return ContextVar{ input(output.index() - GetOperation().Type()->NumArguments()),
-                       const_cast<rvsdg::output *>(&output) };
-  }
-  else
-  {
-    return std::nullopt;
-  }
-}
-
-[[nodiscard]] std::vector<node::ContextVar>
-node::GetContextVars() const noexcept
-{
-  std::vector<ContextVar> vars;
-  for (size_t n = 0; n < ninputs(); ++n)
-  {
-    vars.push_back(
-        ContextVar{ input(n), subregion()->argument(n + GetOperation().Type()->NumArguments()) });
-  }
-  return vars;
-}
-
-node::ContextVar
-node::AddContextVar(jlm::rvsdg::output & origin)
-{
-  auto input = rvsdg::StructuralInput::create(this, &origin, origin.Type());
-  auto argument = &rvsdg::RegionArgument::Create(*subregion(), input, origin.Type());
-  return ContextVar{ input, argument };
-}
-
-lambda::node *
-node::create(
-    rvsdg::Region * parent,
-    std::shared_ptr<const jlm::rvsdg::FunctionType> type,
-    const std::string & name,
-    const llvm::linkage & linkage,
-    const attributeset & attributes)
-{
-  auto op = std::make_unique<lambda::operation>(type, name, linkage, attributes);
-  auto node = new lambda::node(*parent, std::move(op));
-
-  for (auto & argumentType : type->Arguments())
-    rvsdg::RegionArgument::Create(*node->subregion(), nullptr, argumentType);
-
-  return node;
-}
-
-rvsdg::output *
-node::finalize(const std::vector<jlm::rvsdg::output *> & results)
-{
-  /* check if finalized was already called */
-  if (noutputs() > 0)
-  {
-    JLM_ASSERT(noutputs() == 1);
-    return output();
-  }
-
-  if (GetOperation().type().NumResults() != results.size())
-    throw util::error("Incorrect number of results.");
-
-  for (size_t n = 0; n < results.size(); n++)
-  {
-    auto & expected = GetOperation().type().ResultType(n);
-    auto & received = results[n]->type();
-    if (results[n]->type() != GetOperation().type().ResultType(n))
-      throw util::error("Expected " + expected.debug_string() + ", got " + received.debug_string());
-
-    if (results[n]->region() != subregion())
-      throw util::error("Invalid operand region.");
-  }
-
-  for (const auto & origin : results)
-    rvsdg::RegionResult::Create(*origin->region(), *origin, nullptr, origin->Type());
-
-  return append_output(std::make_unique<rvsdg::StructuralOutput>(this, GetOperation().Type()));
-}
-
-rvsdg::output *
-node::output() const noexcept
-{
-  return StructuralNode::output(0);
-}
-
-lambda::node *
-node::copy(rvsdg::Region * region, const std::vector<jlm::rvsdg::output *> & operands) const
-{
-  return util::AssertedCast<lambda::node>(rvsdg::Node::copy(region, operands));
-}
-
-lambda::node *
-node::copy(rvsdg::Region * region, rvsdg::SubstitutionMap & smap) const
-{
-  const auto & op = GetOperation();
-  auto lambda = create(region, op.Type(), op.name(), op.linkage(), op.attributes());
-
-  /* add context variables */
-  rvsdg::SubstitutionMap subregionmap;
-  for (const auto & cv : GetContextVars())
-  {
-    auto origin = smap.lookup(cv.input->origin());
-    subregionmap.insert(cv.inner, lambda->AddContextVar(*origin).inner);
-  }
-
-  /* collect function arguments */
-  auto args = GetFunctionArguments();
-  auto newArgs = lambda->GetFunctionArguments();
-  JLM_ASSERT(args.size() == newArgs.size());
-  for (std::size_t n = 0; n < args.size(); ++n)
-  {
-    subregionmap.insert(args[n], newArgs[n]);
-  }
-
-  /* copy subregion */
-  subregion()->copy(lambda->subregion(), subregionmap, false, false);
-
-  /* collect function results */
-  std::vector<jlm::rvsdg::output *> results;
-  for (auto result : GetFunctionResults())
-    results.push_back(subregionmap.lookup(result->origin()));
-
-  /* finalize lambda */
-  auto o = lambda->finalize(results);
-  smap.insert(output(), o);
-
-  return lambda;
 }
 
 }

--- a/jlm/llvm/ir/operators/lambda.hpp
+++ b/jlm/llvm/ir/operators/lambda.hpp
@@ -11,6 +11,7 @@
 #include <jlm/llvm/ir/RvsdgModule.hpp>
 #include <jlm/llvm/ir/types.hpp>
 #include <jlm/rvsdg/graph.hpp>
+#include <jlm/rvsdg/lambda.hpp>
 #include <jlm/rvsdg/structural-node.hpp>
 #include <jlm/rvsdg/substitution.hpp>
 #include <jlm/util/iterator_range.hpp>
@@ -21,45 +22,20 @@
 namespace jlm::llvm
 {
 
-namespace lambda
-{
-
 /** \brief Lambda operation
  *
  * A lambda operation determines a lambda's name and \ref rvsdg::FunctionType "function type".
  */
-class operation final : public rvsdg::StructuralOperation
+class LlvmLambdaOperation final : public rvsdg::LambdaOperation
 {
 public:
-  ~operation() override;
+  ~LlvmLambdaOperation() override;
 
-  operation(
+  LlvmLambdaOperation(
       std::shared_ptr<const jlm::rvsdg::FunctionType> type,
       std::string name,
       const jlm::llvm::linkage & linkage,
       jlm::llvm::attributeset attributes);
-
-  operation(const operation & other) = default;
-
-  operation(operation && other) noexcept = default;
-
-  operation &
-  operator=(const operation & other) = default;
-
-  operation &
-  operator=(operation && other) noexcept = default;
-
-  [[nodiscard]] const jlm::rvsdg::FunctionType &
-  type() const noexcept
-  {
-    return *type_;
-  }
-
-  [[nodiscard]] const std::shared_ptr<const jlm::rvsdg::FunctionType> &
-  Type() const noexcept
-  {
-    return type_;
-  }
 
   [[nodiscard]] const std::string &
   name() const noexcept
@@ -94,268 +70,40 @@ public:
   void
   SetArgumentAttributes(std::size_t index, const jlm::llvm::attributeset & attributes);
 
+  static std::unique_ptr<LlvmLambdaOperation>
+  Create(
+      std::shared_ptr<const jlm::rvsdg::FunctionType> type,
+      std::string name,
+      const jlm::llvm::linkage & linkage,
+      jlm::llvm::attributeset attributes)
+  {
+    return std::make_unique<LlvmLambdaOperation>(
+        std::move(type),
+        std::move(name),
+        linkage,
+        std::move(attributes));
+  }
+
+  static std::unique_ptr<LlvmLambdaOperation>
+  Create(
+      std::shared_ptr<const jlm::rvsdg::FunctionType> type,
+      std::string name,
+      const jlm::llvm::linkage & linkage)
+  {
+    return std::make_unique<LlvmLambdaOperation>(
+        std::move(type),
+        std::move(name),
+        linkage,
+        jlm::llvm::attributeset{});
+  }
+
 private:
-  std::shared_ptr<const jlm::rvsdg::FunctionType> type_;
   std::string name_;
   jlm::llvm::linkage linkage_;
   jlm::llvm::attributeset attributes_;
   std::vector<jlm::llvm::attributeset> ArgumentAttributes_;
 };
 
-/** \brief Lambda node
- *
- * A lambda node represents a lambda expression in the RVSDG. Its creation requires the invocation
- * of two functions: \ref create() and \ref finalize(). First, a node with only the function
- * arguments is created by invoking \ref create(). The free variables of the lambda expression can
- * then be added to the lambda node using the \ref AddContextVar() method, and the body of the
- * lambda node can be created. Finally, the lambda node can be finalized by invoking \ref
- * finalize().
- *
- * The following snippet illustrates the creation of lambda nodes:
- *
- * \code{.cpp}
- *   auto lambda = lambda::node::create(...);
- *   ...
- *   auto cv1 = lambda->AddContextVar(...);
- *   auto cv2 = lambda->AddContextVar(...);
- *   ...
- *   // generate lambda body
- *   ...
- *   auto output = lambda->finalize(...);
- * \endcode
- */
-class node final : public rvsdg::StructuralNode
-{
-public:
-  ~node() override;
-
-private:
-  node(rvsdg::Region & parent, std::unique_ptr<lambda::operation> op);
-
-public:
-  /**
-   * \brief Bound context variable
-   *
-   * Context variables may be bound at the point of creation of a
-   * lambda abstraction. These are represented as inputs to the
-   * lambda node itself, and made accessible to the body of the
-   * lambda in the form of an initial argument to the subregion.
-   */
-  struct ContextVar
-  {
-    /**
-     * \brief Input variable bound into lambda node
-     *
-     * The input port into the lambda node that supplies the value
-     * of the context variable bound into the lambda at the
-     * time the lambda abstraction is built.
-     */
-    rvsdg::input * input;
-
-    /**
-     * \brief Access to bound object in subregion.
-     *
-     * Supplies access to the value bound into the lambda abstraction
-     * from inside the region contained in the lambda node. This
-     * evaluates to the value bound into the lambda.
-     */
-    rvsdg::output * inner;
-  };
-
-  [[nodiscard]] std::vector<rvsdg::output *>
-  GetFunctionArguments() const;
-
-  [[nodiscard]] std::vector<rvsdg::input *>
-  GetFunctionResults() const;
-
-  [[nodiscard]] rvsdg::Region *
-  subregion() const noexcept
-  {
-    return StructuralNode::subregion(0);
-  }
-
-  [[nodiscard]] lambda::operation &
-  GetOperation() const noexcept override;
-
-  /**
-   * \brief Adds a context/free variable to the lambda node.
-   *
-   * \param origin
-   *   The value to be bound into the lambda node.
-   *
-   * \pre
-   *   \p origin must be from the same region as the lambda node.
-   *
-   * \return The context variable argument of the lambda abstraction.
-   */
-  ContextVar
-  AddContextVar(jlm::rvsdg::output & origin);
-
-  /**
-   * \brief Maps input to context variable.
-   *
-   * \param input
-   *   Input to the lambda node.
-   *
-   * \returns
-   *   The context variable description corresponding to the input.
-   *
-   * \pre
-   *   \p input must be input to this node.
-   *
-   * Returns the context variable description corresponding
-   * to this input of the lambda node. All inputs to the lambda
-   * node are by definition bound context variables that are
-   * accessible in the subregion through the corresponding
-   * argument.
-   */
-  [[nodiscard]] ContextVar
-  MapInputContextVar(const rvsdg::input & input) const noexcept;
-
-  /**
-   * \brief Maps bound variable reference to context variable
-   *
-   * \param output
-   *   Region argument to lambda subregion
-   *
-   * \returns
-   *   The context variable description corresponding to the argument
-   *
-   * \pre
-   *   \p output must be an argument to the subregion of this node
-   *
-   * Returns the context variable description corresponding
-   * to this bound variable reference in the lambda node region.
-   * Note that some arguments of the region are formal call arguments
-   * and do not have an associated context variable description.
-   */
-  [[nodiscard]] std::optional<ContextVar>
-  MapBinderContextVar(const rvsdg::output & output) const noexcept;
-
-  /**
-   * \brief Gets all bound context variables
-   *
-   * \returns
-   *   The context variable descriptions.
-   *
-   * Returns all context variable descriptions.
-   */
-  [[nodiscard]] std::vector<ContextVar>
-  GetContextVars() const noexcept;
-
-  /**
-   * Remove lambda inputs and their respective arguments.
-   *
-   * An input must match the condition specified by \p match and its argument must be dead.
-   *
-   * @tparam F A type that supports the function call operator: bool operator(const rvsdg::input&)
-   * @param match Defines the condition of the elements to remove.
-   * @return The number of removed inputs.
-   */
-  template<typename F>
-  size_t
-  RemoveLambdaInputsWhere(const F & match);
-
-  /**
-   * Remove all dead inputs.
-   *
-   * @return The number of removed inputs.
-   *
-   * \see RemoveLambdaInputsWhere()
-   */
-  size_t
-  PruneLambdaInputs()
-  {
-    auto match = [](const rvsdg::input &)
-    {
-      return true;
-    };
-
-    return RemoveLambdaInputsWhere(match);
-  }
-
-  [[nodiscard]] rvsdg::output *
-  output() const noexcept;
-
-  lambda::node *
-  copy(rvsdg::Region * region, const std::vector<jlm::rvsdg::output *> & operands) const override;
-
-  lambda::node *
-  copy(rvsdg::Region * region, rvsdg::SubstitutionMap & smap) const override;
-
-  /**
-   * Creates a lambda node in the region \p parent with the function type \p type and name \p name.
-   * After the invocation of \ref create(), the lambda node only features the function arguments.
-   * Free variables can be added to the function node using \ref AddContextVar(). The generation of
-   * the node can be finished using the \ref finalize() method.
-   *
-   * \param parent The region where the lambda node is created.
-   * \param type The lambda node's type.
-   * \param name The lambda node's name.
-   * \param linkage The lambda node's linkage.
-   * \param attributes The lambda node's attributes.
-   *
-   * \return A lambda node featuring only function arguments.
-   */
-  static node *
-  create(
-      rvsdg::Region * parent,
-      std::shared_ptr<const jlm::rvsdg::FunctionType> type,
-      const std::string & name,
-      const jlm::llvm::linkage & linkage,
-      const jlm::llvm::attributeset & attributes);
-
-  /**
-   * See \ref create().
-   */
-  static node *
-  create(
-      rvsdg::Region * parent,
-      std::shared_ptr<const jlm::rvsdg::FunctionType> type,
-      const std::string & name,
-      const jlm::llvm::linkage & linkage)
-  {
-    return create(parent, type, name, linkage, {});
-  }
-
-  /**
-   * Finalizes the creation of a lambda node.
-   *
-   * \param results The result values of the lambda expression, originating from the lambda region.
-   *
-   * \return The output of the lambda node.
-   */
-  rvsdg::output *
-  finalize(const std::vector<jlm::rvsdg::output *> & results);
-
-private:
-  std::unique_ptr<lambda::operation> Operation_;
-};
-
-template<typename F>
-size_t
-lambda::node::RemoveLambdaInputsWhere(const F & match)
-{
-  size_t numRemovedInputs = 0;
-
-  // iterate backwards to avoid the invalidation of 'n' by RemoveInput()
-  for (size_t n = ninputs() - 1; n != static_cast<size_t>(-1); n--)
-  {
-    auto lambdaInput = input(n);
-    auto & argument = *MapInputContextVar(*lambdaInput).inner;
-
-    if (argument.IsDead() && match(*lambdaInput))
-    {
-      subregion()->RemoveArgument(argument.index());
-      RemoveInput(n);
-      numRemovedInputs++;
-    }
-  }
-
-  return numRemovedInputs;
-}
-
-}
 }
 
 #endif

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -235,7 +235,7 @@ DeadNodeElimination::MarkOutput(const jlm::rvsdg::output & output)
     return;
   }
 
-  if (auto lambda = rvsdg::TryGetOwnerNode<lambda::node>(output))
+  if (auto lambda = rvsdg::TryGetOwnerNode<rvsdg::LambdaNode>(output))
   {
     for (auto & result : lambda->GetFunctionResults())
     {
@@ -244,7 +244,7 @@ DeadNodeElimination::MarkOutput(const jlm::rvsdg::output & output)
     return;
   }
 
-  if (auto lambda = rvsdg::TryGetRegionParentNode<lambda::node>(output))
+  if (auto lambda = rvsdg::TryGetRegionParentNode<rvsdg::LambdaNode>(output))
   {
     if (auto ctxvar = lambda->MapBinderContextVar(output))
     {
@@ -361,7 +361,7 @@ DeadNodeElimination::SweepStructuralNode(rvsdg::StructuralNode & node) const
   };
   auto sweepLambda = [](auto & d, auto & n)
   {
-    d.SweepLambda(*util::AssertedCast<lambda::node>(&n));
+    d.SweepLambda(*util::AssertedCast<rvsdg::LambdaNode>(&n));
   };
   auto sweepPhi = [](auto & d, auto & n)
   {
@@ -377,7 +377,7 @@ DeadNodeElimination::SweepStructuralNode(rvsdg::StructuralNode & node) const
       std::function<void(const DeadNodeElimination &, rvsdg::StructuralNode &)>>
       map({ { typeid(rvsdg::GammaOperation), sweepGamma },
             { typeid(rvsdg::ThetaOperation), sweepTheta },
-            { typeid(lambda::operation), sweepLambda },
+            { typeid(llvm::LlvmLambdaOperation), sweepLambda },
             { typeid(phi::operation), sweepPhi },
             { typeid(delta::operation), sweepDelta } });
 
@@ -463,7 +463,7 @@ DeadNodeElimination::SweepTheta(rvsdg::ThetaNode & thetaNode) const
 }
 
 void
-DeadNodeElimination::SweepLambda(lambda::node & lambdaNode) const
+DeadNodeElimination::SweepLambda(rvsdg::LambdaNode & lambdaNode) const
 {
   SweepRegion(*lambdaNode.subregion());
   lambdaNode.PruneLambdaInputs();

--- a/jlm/llvm/opt/DeadNodeElimination.hpp
+++ b/jlm/llvm/opt/DeadNodeElimination.hpp
@@ -6,6 +6,7 @@
 #ifndef JLM_LLVM_OPT_DEADNODEELIMINATION_HPP
 #define JLM_LLVM_OPT_DEADNODEELIMINATION_HPP
 
+#include <jlm/rvsdg/lambda.hpp>
 #include <jlm/rvsdg/Transformation.hpp>
 
 namespace jlm::rvsdg
@@ -26,10 +27,7 @@ namespace delta
 class node;
 }
 
-namespace lambda
-{
-class node;
-}
+class LambdaNode;
 
 namespace phi
 {
@@ -100,7 +98,7 @@ private:
   SweepTheta(rvsdg::ThetaNode & thetaNode) const;
 
   void
-  SweepLambda(lambda::node & lambdaNode) const;
+  SweepLambda(rvsdg::LambdaNode & lambdaNode) const;
 
   void
   SweepPhi(phi::node & phiNode) const;

--- a/jlm/llvm/opt/InvariantValueRedirection.cpp
+++ b/jlm/llvm/opt/InvariantValueRedirection.cpp
@@ -69,7 +69,7 @@ InvariantValueRedirection::RedirectInRootRegion(rvsdg::Graph & rvsdg)
   // subregion before we try to detect invariant call outputs.
   for (auto node : rvsdg::TopDownTraverser(&rvsdg.GetRootRegion()))
   {
-    if (auto lambdaNode = dynamic_cast<lambda::node *>(node))
+    if (auto lambdaNode = dynamic_cast<rvsdg::LambdaNode *>(node))
     {
       RedirectInRegion(*lambdaNode->subregion());
     }
@@ -104,7 +104,7 @@ InvariantValueRedirection::RedirectInRegion(rvsdg::Region & region)
 {
   auto isGammaNode = is<rvsdg::GammaOperation>(region.node());
   auto isThetaNode = is<rvsdg::ThetaOperation>(region.node());
-  auto isLambdaNode = is<lambda::operation>(region.node());
+  auto isLambdaNode = is<rvsdg::LambdaOperation>(region.node());
   JLM_ASSERT(isGammaNode || isThetaNode || isLambdaNode);
 
   // We do not need a traverser here and can just iterate through all the nodes of a region as
@@ -185,7 +185,7 @@ InvariantValueRedirection::RedirectCallOutputs(CallNode & callNode)
     return;
 
   auto & lambdaNode =
-      rvsdg::AssertGetOwnerNode<lambda::node>(callTypeClassifier->GetLambdaOutput());
+      rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(callTypeClassifier->GetLambdaOutput());
 
   // LLVM permits code where it can happen that the number and type of arguments handed in to the
   // call node do not agree with the number and type of lambda parameters, even though it is a
@@ -237,7 +237,7 @@ InvariantValueRedirection::RedirectCallOutputs(CallNode & callNode)
     {
       auto & lambdaResult = *results[n];
       auto origin = lambdaResult.origin();
-      if (rvsdg::TryGetRegionParentNode<lambda::node>(*origin) == &lambdaNode)
+      if (rvsdg::TryGetRegionParentNode<rvsdg::LambdaNode>(*origin) == &lambdaNode)
       {
         if (auto ctxvar = lambdaNode.MapBinderContextVar(*origin))
         {

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -986,7 +986,7 @@ Andersen::AnalyzeFunctionToPointer(const rvsdg::SimpleNode & node)
 void
 Andersen::AnalyzeStructuralNode(const rvsdg::StructuralNode & node)
 {
-  if (const auto lambdaNode = dynamic_cast<const lambda::node *>(&node))
+  if (const auto lambdaNode = dynamic_cast<const rvsdg::LambdaNode *>(&node))
     AnalyzeLambda(*lambdaNode);
   else if (const auto deltaNode = dynamic_cast<const delta::node *>(&node))
     AnalyzeDelta(*deltaNode);
@@ -1001,7 +1001,7 @@ Andersen::AnalyzeStructuralNode(const rvsdg::StructuralNode & node)
 }
 
 void
-Andersen::AnalyzeLambda(const lambda::node & lambda)
+Andersen::AnalyzeLambda(const rvsdg::LambdaNode & lambda)
 {
   // Handle context variables
   for (const auto & cv : lambda.GetContextVars())

--- a/jlm/llvm/opt/alias-analyses/Andersen.hpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.hpp
@@ -412,7 +412,7 @@ private:
   AnalyzeStructuralNode(const rvsdg::StructuralNode & node);
 
   void
-  AnalyzeLambda(const lambda::node & node);
+  AnalyzeLambda(const rvsdg::LambdaNode & node);
 
   void
   AnalyzeDelta(const delta::node & node);

--- a/jlm/llvm/opt/alias-analyses/MemoryNodeProvisioning.hpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryNodeProvisioning.hpp
@@ -45,13 +45,13 @@ public:
   GetOutputNodes(const jlm::rvsdg::output & output) const = 0;
 
   [[nodiscard]] virtual const jlm::util::HashSet<const PointsToGraph::MemoryNode *> &
-  GetLambdaEntryNodes(const lambda::node & lambdaNode) const
+  GetLambdaEntryNodes(const rvsdg::LambdaNode & lambdaNode) const
   {
     return GetRegionEntryNodes(*lambdaNode.subregion());
   }
 
   [[nodiscard]] virtual const jlm::util::HashSet<const PointsToGraph::MemoryNode *> &
-  GetLambdaExitNodes(const lambda::node & lambdaNode) const
+  GetLambdaExitNodes(const rvsdg::LambdaNode & lambdaNode) const
   {
     return GetRegionExitNodes(*lambdaNode.subregion());
   }

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
@@ -511,7 +511,7 @@ MemoryStateEncoder::EncodeRegion(rvsdg::Region & region)
 void
 MemoryStateEncoder::EncodeStructuralNode(rvsdg::StructuralNode & structuralNode)
 {
-  if (auto lambdaNode = dynamic_cast<const lambda::node *>(&structuralNode))
+  if (auto lambdaNode = dynamic_cast<const rvsdg::LambdaNode *>(&structuralNode))
   {
     EncodeLambda(*lambdaNode);
   }
@@ -757,7 +757,7 @@ MemoryStateEncoder::EncodeMemcpy(const rvsdg::SimpleNode & memcpyNode)
 }
 
 void
-MemoryStateEncoder::EncodeLambda(const lambda::node & lambdaNode)
+MemoryStateEncoder::EncodeLambda(const rvsdg::LambdaNode & lambdaNode)
 {
   EncodeLambdaEntry(lambdaNode);
   EncodeRegion(*lambdaNode.subregion());
@@ -765,7 +765,7 @@ MemoryStateEncoder::EncodeLambda(const lambda::node & lambdaNode)
 }
 
 void
-MemoryStateEncoder::EncodeLambdaEntry(const lambda::node & lambdaNode)
+MemoryStateEncoder::EncodeLambdaEntry(const rvsdg::LambdaNode & lambdaNode)
 {
   auto & memoryStateArgument = GetMemoryStateRegionArgument(lambdaNode);
   JLM_ASSERT(memoryStateArgument.nusers() == 1);
@@ -805,7 +805,7 @@ MemoryStateEncoder::EncodeLambdaEntry(const lambda::node & lambdaNode)
 }
 
 void
-MemoryStateEncoder::EncodeLambdaExit(const lambda::node & lambdaNode)
+MemoryStateEncoder::EncodeLambdaExit(const rvsdg::LambdaNode & lambdaNode)
 {
   auto subregion = lambdaNode.subregion();
   auto & memoryNodes = Context_->GetMemoryNodeProvisioning().GetLambdaExitNodes(lambdaNode);

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp
@@ -132,13 +132,13 @@ private:
   EncodeMemcpy(const rvsdg::SimpleNode & memcpyNode);
 
   void
-  EncodeLambda(const lambda::node & lambda);
+  EncodeLambda(const rvsdg::LambdaNode & lambda);
 
   void
-  EncodeLambdaEntry(const lambda::node & lambdaNode);
+  EncodeLambdaEntry(const rvsdg::LambdaNode & lambdaNode);
 
   void
-  EncodeLambdaExit(const lambda::node & lambdaNode);
+  EncodeLambdaExit(const rvsdg::LambdaNode & lambdaNode);
 
   void
   EncodePhi(const phi::node & phiNode);

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.hpp
@@ -12,6 +12,7 @@
 namespace rvsdg
 {
 class GammaNode;
+class LambdaNode;
 class output;
 class Region;
 class RvsdgModule;

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
@@ -143,7 +143,7 @@ PointerObjectSet::CreateGlobalMemoryObject(const delta::node & deltaNode, bool c
 }
 
 PointerObjectIndex
-PointerObjectSet::CreateFunctionMemoryObject(const lambda::node & lambdaNode)
+PointerObjectSet::CreateFunctionMemoryObject(const rvsdg::LambdaNode & lambdaNode)
 {
   JLM_ASSERT(!FunctionMap_.HasKey(&lambdaNode));
   const auto pointerObject = AddPointerObject(PointerObjectKind::FunctionMemoryObject, false);
@@ -152,13 +152,13 @@ PointerObjectSet::CreateFunctionMemoryObject(const lambda::node & lambdaNode)
 }
 
 PointerObjectIndex
-PointerObjectSet::GetFunctionMemoryObject(const lambda::node & lambdaNode) const
+PointerObjectSet::GetFunctionMemoryObject(const rvsdg::LambdaNode & lambdaNode) const
 {
   JLM_ASSERT(FunctionMap_.HasKey(&lambdaNode));
   return FunctionMap_.LookupKey(&lambdaNode);
 }
 
-const lambda::node &
+const rvsdg::LambdaNode &
 PointerObjectSet::GetLambdaNodeFromFunctionMemoryObject(PointerObjectIndex index) const
 {
   JLM_ASSERT(FunctionMap_.HasValue(index));
@@ -204,7 +204,7 @@ PointerObjectSet::GetGlobalMap() const noexcept
   return GlobalMap_;
 }
 
-const util::BijectiveMap<const lambda::node *, PointerObjectIndex> &
+const util::BijectiveMap<const rvsdg::LambdaNode *, PointerObjectIndex> &
 PointerObjectSet::GetFunctionMap() const noexcept
 {
   return FunctionMap_;
@@ -668,7 +668,7 @@ static void
 HandleLambdaCallParameters(
     PointerObjectSet & set,
     const jlm::llvm::CallNode & callNode,
-    const lambda::node & lambdaNode,
+    const rvsdg::LambdaNode & lambdaNode,
     MakeSupersetFunctor & makeSuperset)
 {
   auto lambdaArgs = lambdaNode.GetFunctionArguments();
@@ -695,7 +695,7 @@ static void
 HandleLambdaCallReturnValues(
     PointerObjectSet & set,
     const jlm::llvm::CallNode & callNode,
-    const lambda::node & lambdaNode,
+    const rvsdg::LambdaNode & lambdaNode,
     MakeSupersetFunctor & makeSuperset)
 {
   auto lambdaResults = lambdaNode.GetFunctionResults();

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
@@ -174,7 +174,7 @@ class PointerObjectSet final
 
   std::unordered_map<const delta::node *, PointerObjectIndex> GlobalMap_;
 
-  util::BijectiveMap<const lambda::node *, PointerObjectIndex> FunctionMap_;
+  util::BijectiveMap<const rvsdg::LambdaNode *, PointerObjectIndex> FunctionMap_;
 
   std::unordered_map<const GraphImport *, PointerObjectIndex> ImportMap_;
 
@@ -289,7 +289,7 @@ public:
    * @return the index of the new PointerObject in the PointerObjectSet
    */
   [[nodiscard]] PointerObjectIndex
-  CreateFunctionMemoryObject(const lambda::node & lambdaNode);
+  CreateFunctionMemoryObject(const rvsdg::LambdaNode & lambdaNode);
 
   /**
    * Retrieves the PointerObject of Function kind associated with the given lambda node
@@ -297,14 +297,14 @@ public:
    * @return the index of the associated PointerObject
    */
   [[nodiscard]] PointerObjectIndex
-  GetFunctionMemoryObject(const lambda::node & lambdaNode) const;
+  GetFunctionMemoryObject(const rvsdg::LambdaNode & lambdaNode) const;
 
   /**
    * Gets the lambda node associated with a given PointerObject.
    * @param index the index of the PointerObject
    * @return the lambda node associated with the PointerObject
    */
-  [[nodiscard]] const lambda::node &
+  [[nodiscard]] const rvsdg::LambdaNode &
   GetLambdaNodeFromFunctionMemoryObject(PointerObjectIndex index) const;
 
   [[nodiscard]] PointerObjectIndex
@@ -322,7 +322,7 @@ public:
   const std::unordered_map<const delta::node *, PointerObjectIndex> &
   GetGlobalMap() const noexcept;
 
-  const util::BijectiveMap<const lambda::node *, PointerObjectIndex> &
+  const util::BijectiveMap<const rvsdg::LambdaNode *, PointerObjectIndex> &
   GetFunctionMap() const noexcept;
 
   const std::unordered_map<const GraphImport *, PointerObjectIndex> &

--- a/jlm/llvm/opt/alias-analyses/PointsToGraph.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraph.hpp
@@ -55,7 +55,7 @@ public:
   using ImportNodeMap =
       std::unordered_map<const rvsdg::RegionArgument *, std::unique_ptr<PointsToGraph::ImportNode>>;
   using LambdaNodeMap =
-      std::unordered_map<const lambda::node *, std::unique_ptr<PointsToGraph::LambdaNode>>;
+      std::unordered_map<const rvsdg::LambdaNode *, std::unique_ptr<PointsToGraph::LambdaNode>>;
   using MallocNodeMap = std::unordered_map<const rvsdg::Node *, std::unique_ptr<MallocNode>>;
   using RegisterNodeMap = std::unordered_map<const rvsdg::output *, PointsToGraph::RegisterNode *>;
   using RegisterNodeVector = std::vector<std::unique_ptr<PointsToGraph::RegisterNode>>;
@@ -297,7 +297,7 @@ public:
   }
 
   const PointsToGraph::LambdaNode &
-  GetLambdaNode(const lambda::node & node) const
+  GetLambdaNode(const rvsdg::LambdaNode & node) const
   {
     auto it = LambdaNodes_.find(&node);
     if (it == LambdaNodes_.end())
@@ -726,15 +726,15 @@ public:
   ~LambdaNode() noexcept override;
 
 private:
-  LambdaNode(PointsToGraph & pointsToGraph, const lambda::node & lambdaNode)
+  LambdaNode(PointsToGraph & pointsToGraph, const rvsdg::LambdaNode & lambdaNode)
       : MemoryNode(pointsToGraph),
         LambdaNode_(&lambdaNode)
   {
-    JLM_ASSERT(is<lambda::operation>(&lambdaNode));
+    JLM_ASSERT(is<llvm::LlvmLambdaOperation>(&lambdaNode));
   }
 
 public:
-  const lambda::node &
+  const rvsdg::LambdaNode &
   GetLambdaNode() const noexcept
   {
     return *LambdaNode_;
@@ -744,14 +744,14 @@ public:
   DebugString() const override;
 
   static PointsToGraph::LambdaNode &
-  Create(PointsToGraph & pointsToGraph, const lambda::node & lambdaNode)
+  Create(PointsToGraph & pointsToGraph, const rvsdg::LambdaNode & lambdaNode)
   {
     auto n = std::unique_ptr<PointsToGraph::LambdaNode>(new LambdaNode(pointsToGraph, lambdaNode));
     return pointsToGraph.AddLambdaNode(std::move(n));
   }
 
 private:
-  const lambda::node * LambdaNode_;
+  const rvsdg::LambdaNode * LambdaNode_;
 };
 
 /** \brief PointsTo graph import node

--- a/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.cpp
+++ b/jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.cpp
@@ -381,7 +381,7 @@ public:
         || callTypeClassifier->IsRecursiveDirectCall())
     {
       auto & lambdaNode =
-          rvsdg::AssertGetOwnerNode<lambda::node>(callTypeClassifier->GetLambdaOutput());
+          rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(callTypeClassifier->GetLambdaOutput());
       return GetLambdaEntryNodes(lambdaNode);
     }
     else if (callTypeClassifier->IsExternalCall())
@@ -406,7 +406,7 @@ public:
         || callTypeClassifier->IsRecursiveDirectCall())
     {
       auto & lambdaNode =
-          rvsdg::AssertGetOwnerNode<lambda::node>(callTypeClassifier->GetLambdaOutput());
+          rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(callTypeClassifier->GetLambdaOutput());
       return GetLambdaExitNodes(lambdaNode);
     }
     else if (callTypeClassifier->IsExternalCall())
@@ -568,7 +568,7 @@ public:
 
       auto callTypeClassifier = CallNode::ClassifyCall(callNode);
       auto & lambdaRegion =
-          *rvsdg::AssertGetOwnerNode<llvm::lambda::node>(callTypeClassifier->GetLambdaOutput())
+          *rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(callTypeClassifier->GetLambdaOutput())
                .subregion();
       auto & lambdaRegionSummary = provisioning.GetRegionSummary(lambdaRegion);
       auto & lambdaRegionMemoryNodes = lambdaRegionSummary.GetMemoryNodes();
@@ -862,7 +862,7 @@ RegionAwareMemoryNodeProvider::Propagate(const rvsdg::RvsdgModule & rvsdgModule)
   rvsdg::TopDownTraverser traverser(&rvsdgModule.Rvsdg().GetRootRegion());
   for (auto & node : traverser)
   {
-    if (auto lambdaNode = dynamic_cast<const lambda::node *>(node))
+    if (auto lambdaNode = dynamic_cast<const rvsdg::LambdaNode *>(node))
     {
       PropagateRegion(*lambdaNode->subregion());
     }
@@ -963,7 +963,8 @@ RegionAwareMemoryNodeProvider::PropagateRegion(const rvsdg::Region & region)
   {
     auto callTypeClassifier = CallNode::ClassifyCall(*callNode);
     auto & lambdaRegion =
-        *rvsdg::AssertGetOwnerNode<lambda::node>(callTypeClassifier->GetLambdaOutput()).subregion();
+        *rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(callTypeClassifier->GetLambdaOutput())
+             .subregion();
     auto & lambdaRegionSummary = Provisioning_->GetRegionSummary(lambdaRegion);
 
     RegionSummary::Propagate(regionSummary, lambdaRegionSummary);
@@ -974,7 +975,7 @@ void
 RegionAwareMemoryNodeProvider::ResolveUnknownMemoryNodeReferences(
     const rvsdg::RvsdgModule & rvsdgModule)
 {
-  auto ResolveLambda = [&](const lambda::node & lambda)
+  auto ResolveLambda = [&](const rvsdg::LambdaNode & lambda)
   {
     auto & lambdaRegionSummary = Provisioning_->GetRegionSummary(*lambda.subregion());
 
@@ -989,7 +990,7 @@ RegionAwareMemoryNodeProvider::ResolveUnknownMemoryNodeReferences(
   auto nodes = rvsdg::Graph::ExtractTailNodes(rvsdgModule.Rvsdg());
   for (auto & node : nodes)
   {
-    if (auto lambdaNode = dynamic_cast<const lambda::node *>(node))
+    if (auto lambdaNode = dynamic_cast<const rvsdg::LambdaNode *>(node))
     {
       ResolveLambda(*lambdaNode);
     }

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -210,7 +210,7 @@ public:
       return jlm::util::strfmt(nodestr, ":", index, "[" + outputstr + "]");
     }
 
-    if (auto node = rvsdg::TryGetRegionParentNode<lambda::node>(*Output_))
+    if (auto node = rvsdg::TryGetRegionParentNode<rvsdg::LambdaNode>(*Output_))
     {
       auto dbgstr = node->GetOperation().debug_string();
       if (auto ctxvar = node->MapBinderContextVar(*Output_))
@@ -393,13 +393,13 @@ class LambdaLocation final : public MemoryLocation
 {
   ~LambdaLocation() override = default;
 
-  constexpr explicit LambdaLocation(const lambda::node & lambda)
+  constexpr explicit LambdaLocation(const rvsdg::LambdaNode & lambda)
       : MemoryLocation(),
         Lambda_(lambda)
   {}
 
 public:
-  [[nodiscard]] const lambda::node &
+  [[nodiscard]] const rvsdg::LambdaNode &
   GetNode() const noexcept
   {
     return Lambda_;
@@ -412,13 +412,13 @@ public:
   }
 
   static std::unique_ptr<Location>
-  Create(const lambda::node & node)
+  Create(const rvsdg::LambdaNode & node)
   {
     return std::unique_ptr<Location>(new LambdaLocation(node));
   }
 
 private:
-  const lambda::node & Lambda_;
+  const rvsdg::LambdaNode & Lambda_;
 };
 
 /** \brief DeltaLocation class
@@ -587,7 +587,7 @@ public:
   }
 
   Location &
-  InsertLambdaLocation(const lambda::node & lambda)
+  InsertLambdaLocation(const rvsdg::LambdaNode & lambda)
   {
     Locations_.push_back(LambdaLocation::Create(lambda));
     auto location = Locations_.back().get();
@@ -1156,7 +1156,7 @@ Steensgaard::AnalyzeCall(const CallNode & callNode)
   case CallTypeClassifier::CallType::RecursiveDirectCall:
     AnalyzeDirectCall(
         callNode,
-        rvsdg::AssertGetOwnerNode<lambda::node>(callTypeClassifier->GetLambdaOutput()));
+        rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(callTypeClassifier->GetLambdaOutput()));
     break;
   case CallTypeClassifier::CallType::ExternalCall:
     AnalyzeExternalCall(callNode);
@@ -1170,7 +1170,7 @@ Steensgaard::AnalyzeCall(const CallNode & callNode)
 }
 
 void
-Steensgaard::AnalyzeDirectCall(const CallNode & callNode, const lambda::node & lambdaNode)
+Steensgaard::AnalyzeDirectCall(const CallNode & callNode, const rvsdg::LambdaNode & lambdaNode)
 {
   auto & lambdaFunctionType = lambdaNode.GetOperation().type();
   auto & callFunctionType = *callNode.GetOperation().GetFunctionType();
@@ -1500,7 +1500,7 @@ Steensgaard::AnalyzePointerToFunction(const rvsdg::SimpleNode & node)
 }
 
 void
-Steensgaard::AnalyzeLambda(const lambda::node & lambda)
+Steensgaard::AnalyzeLambda(const rvsdg::LambdaNode & lambda)
 {
   // Handle context variables
   for (const auto & cv : lambda.GetContextVars())
@@ -1713,7 +1713,7 @@ Steensgaard::AnalyzeTheta(const rvsdg::ThetaNode & theta)
 void
 Steensgaard::AnalyzeStructuralNode(const rvsdg::StructuralNode & node)
 {
-  if (auto lambdaNode = dynamic_cast<const lambda::node *>(&node))
+  if (auto lambdaNode = dynamic_cast<const rvsdg::LambdaNode *>(&node))
   {
     AnalyzeLambda(*lambdaNode);
   }

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
@@ -103,7 +103,7 @@ private:
   AnalyzeRegion(rvsdg::Region & region);
 
   void
-  AnalyzeLambda(const lambda::node & node);
+  AnalyzeLambda(const rvsdg::LambdaNode & node);
 
   void
   AnalyzeDelta(const delta::node & node);
@@ -139,7 +139,7 @@ private:
   AnalyzeCall(const CallNode & callNode);
 
   void
-  AnalyzeDirectCall(const CallNode & callNode, const lambda::node & lambdaNode);
+  AnalyzeDirectCall(const CallNode & callNode, const rvsdg::LambdaNode & lambdaNode);
 
   void
   AnalyzeExternalCall(const CallNode & callNode);

--- a/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.cpp
+++ b/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.cpp
@@ -97,7 +97,7 @@ public:
         || callTypeClassifier->IsRecursiveDirectCall())
     {
       auto & lambdaNode =
-          rvsdg::AssertGetOwnerNode<lambda::node>(callTypeClassifier->GetLambdaOutput());
+          rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(callTypeClassifier->GetLambdaOutput());
       return GetLambdaEntryNodes(lambdaNode);
     }
     else if (callTypeClassifier->IsExternalCall())
@@ -121,7 +121,7 @@ public:
         || callTypeClassifier->IsRecursiveDirectCall())
     {
       auto & lambdaNode =
-          rvsdg::AssertGetOwnerNode<lambda::node>(callTypeClassifier->GetLambdaOutput());
+          rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(callTypeClassifier->GetLambdaOutput());
       return GetLambdaExitNodes(lambdaNode);
     }
     else if (callTypeClassifier->IsExternalCall())
@@ -364,7 +364,7 @@ public:
    * @return True if \p lambdaNode has annotated live nodes, otherwise false.
    */
   bool
-  HasAnnotatedLiveNodes(const lambda::node & lambdaNode) const noexcept
+  HasAnnotatedLiveNodes(const rvsdg::LambdaNode & lambdaNode) const noexcept
   {
     return LiveNodesAnnotatedLambdaNodes_.Contains(&lambdaNode);
   }
@@ -375,7 +375,7 @@ public:
    * @param lambdaNode The lambda node which is marked.
    */
   void
-  AddLiveNodesAnnotatedLambda(const lambda::node & lambdaNode)
+  AddLiveNodesAnnotatedLambda(const rvsdg::LambdaNode & lambdaNode)
   {
     LiveNodesAnnotatedLambdaNodes_.Insert(&lambdaNode);
   }
@@ -413,7 +413,7 @@ private:
 
   // Keeps track of all lambda nodes where we annotated live nodes BEFORE traversing the lambda
   // subregion.
-  util::HashSet<const lambda::node *> LiveNodesAnnotatedLambdaNodes_;
+  util::HashSet<const rvsdg::LambdaNode *> LiveNodesAnnotatedLambdaNodes_;
 };
 
 TopDownMemoryNodeEliminator::~TopDownMemoryNodeEliminator() noexcept = default;
@@ -484,7 +484,7 @@ TopDownMemoryNodeEliminator::EliminateTopDownRootRegion(rvsdg::Region & region)
   rvsdg::BottomUpTraverser traverser(&region);
   for (auto & node : traverser)
   {
-    if (auto lambdaNode = dynamic_cast<const lambda::node *>(node))
+    if (auto lambdaNode = dynamic_cast<const rvsdg::LambdaNode *>(node))
     {
       EliminateTopDownLambda(*lambdaNode);
     }
@@ -512,7 +512,7 @@ TopDownMemoryNodeEliminator::EliminateTopDownRootRegion(rvsdg::Region & region)
 void
 TopDownMemoryNodeEliminator::EliminateTopDownRegion(rvsdg::Region & region)
 {
-  auto isLambdaSubregion = rvsdg::is<lambda::operation>(region.node());
+  auto isLambdaSubregion = rvsdg::is<rvsdg::LambdaOperation>(region.node());
   auto isThetaSubregion = rvsdg::is<rvsdg::ThetaOperation>(region.node());
   auto isGammaSubregion = rvsdg::is<rvsdg::GammaOperation>(region.node());
   JLM_ASSERT(isLambdaSubregion || isThetaSubregion || isGammaSubregion);
@@ -557,7 +557,7 @@ TopDownMemoryNodeEliminator::EliminateTopDownStructuralNode(
 }
 
 void
-TopDownMemoryNodeEliminator::EliminateTopDownLambda(const lambda::node & lambdaNode)
+TopDownMemoryNodeEliminator::EliminateTopDownLambda(const rvsdg::LambdaNode & lambdaNode)
 {
   EliminateTopDownLambdaEntry(lambdaNode);
   EliminateTopDownRegion(*lambdaNode.subregion());
@@ -565,7 +565,7 @@ TopDownMemoryNodeEliminator::EliminateTopDownLambda(const lambda::node & lambdaN
 }
 
 void
-TopDownMemoryNodeEliminator::EliminateTopDownLambdaEntry(const lambda::node & lambdaNode)
+TopDownMemoryNodeEliminator::EliminateTopDownLambdaEntry(const rvsdg::LambdaNode & lambdaNode)
 {
   auto & lambdaSubregion = *lambdaNode.subregion();
   auto & provisioning = Context_->GetProvisioning();
@@ -595,7 +595,7 @@ TopDownMemoryNodeEliminator::EliminateTopDownLambdaEntry(const lambda::node & la
 }
 
 void
-TopDownMemoryNodeEliminator::EliminateTopDownLambdaExit(const lambda::node & lambdaNode)
+TopDownMemoryNodeEliminator::EliminateTopDownLambdaExit(const rvsdg::LambdaNode & lambdaNode)
 {
   auto & lambdaSubregion = *lambdaNode.subregion();
   auto & provisioning = Context_->GetProvisioning();
@@ -628,11 +628,11 @@ TopDownMemoryNodeEliminator::EliminateTopDownPhi(const phi::node & phiNode)
 {
   auto unifyLiveNodes = [&](const rvsdg::Region & phiSubregion)
   {
-    std::vector<const lambda::node *> lambdaNodes;
+    std::vector<const rvsdg::LambdaNode *> lambdaNodes;
     util::HashSet<const PointsToGraph::MemoryNode *> liveNodes;
     for (auto & node : phiSubregion.Nodes())
     {
-      if (auto lambdaNode = dynamic_cast<const lambda::node *>(&node))
+      if (auto lambdaNode = dynamic_cast<const rvsdg::LambdaNode *>(&node))
       {
         lambdaNodes.emplace_back(lambdaNode);
 
@@ -816,7 +816,8 @@ TopDownMemoryNodeEliminator::EliminateTopDownNonRecursiveDirectCall(
   JLM_ASSERT(callTypeClassifier.IsNonRecursiveDirectCall());
 
   auto & liveNodes = Context_->GetLiveNodes(*callNode.region());
-  auto & lambdaNode = rvsdg::AssertGetOwnerNode<lambda::node>(callTypeClassifier.GetLambdaOutput());
+  auto & lambdaNode =
+      rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(callTypeClassifier.GetLambdaOutput());
 
   Context_->AddLiveNodes(*lambdaNode.subregion(), liveNodes);
   Context_->AddLiveNodesAnnotatedLambda(lambdaNode);
@@ -830,7 +831,8 @@ TopDownMemoryNodeEliminator::EliminateTopDownRecursiveDirectCall(
   JLM_ASSERT(callTypeClassifier.IsRecursiveDirectCall());
 
   auto & liveNodes = Context_->GetLiveNodes(*callNode.region());
-  auto & lambdaNode = rvsdg::AssertGetOwnerNode<lambda::node>(callTypeClassifier.GetLambdaOutput());
+  auto & lambdaNode =
+      rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(callTypeClassifier.GetLambdaOutput());
 
   Context_->AddLiveNodes(*lambdaNode.subregion(), liveNodes);
   Context_->AddLiveNodesAnnotatedLambda(lambdaNode);
@@ -879,7 +881,7 @@ TopDownMemoryNodeEliminator::InitializeLiveNodesOfTailLambdas(
   auto nodes = rvsdg::Graph::ExtractTailNodes(rvsdgModule.Rvsdg());
   for (auto & node : nodes)
   {
-    if (auto lambdaNode = dynamic_cast<const lambda::node *>(node))
+    if (auto lambdaNode = dynamic_cast<const rvsdg::LambdaNode *>(node))
     {
       InitializeLiveNodesOfTailLambda(*lambdaNode);
     }
@@ -903,7 +905,8 @@ TopDownMemoryNodeEliminator::InitializeLiveNodesOfTailLambdas(
 }
 
 void
-TopDownMemoryNodeEliminator::InitializeLiveNodesOfTailLambda(const lambda::node & tailLambdaNode)
+TopDownMemoryNodeEliminator::InitializeLiveNodesOfTailLambda(
+    const rvsdg::LambdaNode & tailLambdaNode)
 {
   auto IsUnescapedAllocaNode = [&](const PointsToGraph::MemoryNode * memoryNode)
   {
@@ -939,7 +942,7 @@ TopDownMemoryNodeEliminator::CheckInvariants(
   {
     for (auto & node : rootRegion.Nodes())
     {
-      if (auto lambdaNode = dynamic_cast<const lambda::node *>(&node))
+      if (auto lambdaNode = dynamic_cast<const rvsdg::LambdaNode *>(&node))
       {
         auto lambdaSubregion = lambdaNode->subregion();
         regions.push_back(lambdaSubregion);

--- a/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.hpp
+++ b/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.hpp
@@ -28,6 +28,7 @@ class node;
 namespace jlm::rvsdg
 {
 class GammaNode;
+class LambdaNode;
 class Node;
 class Region;
 class SimpleNode;

--- a/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.hpp
+++ b/jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.hpp
@@ -137,13 +137,13 @@ private:
   EliminateTopDownStructuralNode(const rvsdg::StructuralNode & structuralNode);
 
   void
-  EliminateTopDownLambda(const lambda::node & lambdaNode);
+  EliminateTopDownLambda(const rvsdg::LambdaNode & lambdaNode);
 
   void
-  EliminateTopDownLambdaEntry(const lambda::node & lambdaNode);
+  EliminateTopDownLambdaEntry(const rvsdg::LambdaNode & lambdaNode);
 
   void
-  EliminateTopDownLambdaExit(const lambda::node & lambdaNode);
+  EliminateTopDownLambdaExit(const rvsdg::LambdaNode & lambdaNode);
 
   void
   EliminateTopDownPhi(const phi::node & phiNode);
@@ -203,7 +203,7 @@ private:
    * @see InitializeLiveNodesOfTailLambdas()
    */
   void
-  InitializeLiveNodesOfTailLambda(const lambda::node & tailLambdaNode);
+  InitializeLiveNodesOfTailLambda(const rvsdg::LambdaNode & tailLambdaNode);
 
   /**
    * The function checks the following invariants:

--- a/jlm/llvm/opt/cne.cpp
+++ b/jlm/llvm/opt/cne.cpp
@@ -340,7 +340,7 @@ mark_theta(const rvsdg::StructuralNode * node, cnectx & ctx)
 static void
 mark_lambda(const rvsdg::StructuralNode * node, cnectx & ctx)
 {
-  JLM_ASSERT(jlm::rvsdg::is<lambda::operation>(node));
+  JLM_ASSERT(jlm::rvsdg::is<rvsdg::LambdaOperation>(node));
 
   /* mark dependencies */
   for (size_t i1 = 0; i1 < node->ninputs(); i1++)
@@ -387,15 +387,14 @@ static void
 mark(const rvsdg::StructuralNode * node, cnectx & ctx)
 {
   static std::unordered_map<std::type_index, void (*)(const rvsdg::StructuralNode *, cnectx &)> map(
-      { { std::type_index(typeid(rvsdg::GammaOperation)), mark_gamma },
-        { std::type_index(typeid(rvsdg::ThetaOperation)), mark_theta },
-        { typeid(lambda::operation), mark_lambda },
-        { typeid(phi::operation), mark_phi },
-        { typeid(delta::operation), mark_delta } });
+      { { std::type_index(typeid(rvsdg::GammaNode)), mark_gamma },
+        { std::type_index(typeid(rvsdg::ThetaNode)), mark_theta },
+        { typeid(rvsdg::LambdaNode), mark_lambda },
+        { typeid(phi::node), mark_phi },
+        { typeid(delta::node), mark_delta } });
 
-  auto & op = node->GetOperation();
-  JLM_ASSERT(map.find(typeid(op)) != map.end());
-  map[typeid(op)](node, ctx);
+  JLM_ASSERT(map.find(typeid(*node)) != map.end());
+  map[typeid(*node)](node, ctx);
 }
 
 static void
@@ -515,7 +514,7 @@ divert_theta(rvsdg::StructuralNode * node, cnectx & ctx)
 static void
 divert_lambda(rvsdg::StructuralNode * node, cnectx & ctx)
 {
-  JLM_ASSERT(jlm::rvsdg::is<lambda::operation>(node));
+  JLM_ASSERT(jlm::rvsdg::is<rvsdg::LambdaOperation>(node));
 
   divert_arguments(node->subregion(0), ctx);
   divert(node->subregion(0), ctx);
@@ -540,15 +539,14 @@ static void
 divert(rvsdg::StructuralNode * node, cnectx & ctx)
 {
   static std::unordered_map<std::type_index, void (*)(rvsdg::StructuralNode *, cnectx &)> map(
-      { { std::type_index(typeid(rvsdg::GammaOperation)), divert_gamma },
-        { std::type_index(typeid(rvsdg::ThetaOperation)), divert_theta },
-        { typeid(lambda::operation), divert_lambda },
-        { typeid(phi::operation), divert_phi },
-        { typeid(delta::operation), divert_delta } });
+      { { std::type_index(typeid(rvsdg::GammaNode)), divert_gamma },
+        { std::type_index(typeid(rvsdg::ThetaNode)), divert_theta },
+        { typeid(rvsdg::LambdaNode), divert_lambda },
+        { typeid(phi::node), divert_phi },
+        { typeid(delta::node), divert_delta } });
 
-  auto & op = node->GetOperation();
-  JLM_ASSERT(map.find(typeid(op)) != map.end());
-  map[typeid(op)](node, ctx);
+  JLM_ASSERT(map.find(typeid(*node)) != map.end());
+  map[typeid(*node)](node, ctx);
 }
 
 static void

--- a/jlm/llvm/opt/inlining.cpp
+++ b/jlm/llvm/opt/inlining.cpp
@@ -81,7 +81,7 @@ route_to_region(jlm::rvsdg::output * output, rvsdg::Region * region)
   {
     output = theta->AddLoopVar(output).pre;
   }
-  else if (auto lambda = dynamic_cast<lambda::node *>(region->node()))
+  else if (auto lambda = dynamic_cast<rvsdg::LambdaNode *>(region->node()))
   {
     output = lambda->AddContextVar(*output).inner;
   }
@@ -98,7 +98,7 @@ route_to_region(jlm::rvsdg::output * output, rvsdg::Region * region)
 }
 
 static std::vector<jlm::rvsdg::output *>
-route_dependencies(const lambda::node * lambda, const jlm::rvsdg::SimpleNode * apply)
+route_dependencies(const rvsdg::LambdaNode * lambda, const jlm::rvsdg::SimpleNode * apply)
 {
   JLM_ASSERT(is<CallOperation>(apply));
 
@@ -115,7 +115,7 @@ route_dependencies(const lambda::node * lambda, const jlm::rvsdg::SimpleNode * a
 }
 
 void
-inlineCall(jlm::rvsdg::SimpleNode * call, const lambda::node * lambda)
+inlineCall(jlm::rvsdg::SimpleNode * call, const rvsdg::LambdaNode * lambda)
 {
   JLM_ASSERT(is<CallOperation>(call));
 
@@ -149,7 +149,7 @@ inlining(rvsdg::Graph & rvsdg)
 {
   for (auto node : rvsdg::TopDownTraverser(&rvsdg.GetRootRegion()))
   {
-    if (auto lambda = dynamic_cast<const lambda::node *>(node))
+    if (auto lambda = dynamic_cast<const rvsdg::LambdaNode *>(node))
     {
       auto callSummary = jlm::llvm::ComputeCallSummary(*lambda);
 

--- a/jlm/llvm/opt/inlining.hpp
+++ b/jlm/llvm/opt/inlining.hpp
@@ -28,7 +28,7 @@ jlm::rvsdg::output *
 find_producer(jlm::rvsdg::input * input);
 
 void
-inlineCall(jlm::rvsdg::SimpleNode * call, const lambda::node * lambda);
+inlineCall(jlm::rvsdg::SimpleNode * call, const rvsdg::LambdaNode * lambda);
 
 }
 

--- a/jlm/mlir/backend/JlmToMlirConverter.cpp
+++ b/jlm/mlir/backend/JlmToMlirConverter.cpp
@@ -157,7 +157,7 @@ JlmToMlirConverter::ConvertNode(
   {
     return ConvertSimpleNode(*simpleNode, block, inputs);
   }
-  else if (auto lambda = dynamic_cast<const llvm::lambda::node *>(&node))
+  else if (auto lambda = dynamic_cast<const rvsdg::LambdaNode *>(&node))
   {
     return ConvertLambda(*lambda, block);
   }
@@ -387,7 +387,7 @@ JlmToMlirConverter::ConvertSimpleNode(
 }
 
 ::mlir::Operation *
-JlmToMlirConverter::ConvertLambda(const llvm::lambda::node & lambdaNode, ::mlir::Block & block)
+JlmToMlirConverter::ConvertLambda(const rvsdg::LambdaNode & lambdaNode, ::mlir::Block & block)
 {
   ::llvm::SmallVector<::mlir::Type> arguments;
   for (auto arg : lambdaNode.GetFunctionArguments())
@@ -415,11 +415,13 @@ JlmToMlirConverter::ConvertLambda(const llvm::lambda::node & lambdaNode, ::mlir:
   ::llvm::SmallVector<::mlir::NamedAttribute> attributes;
   auto symbolName = Builder_->getNamedAttr(
       Builder_->getStringAttr("sym_name"),
-      Builder_->getStringAttr(lambdaNode.GetOperation().name()));
+      Builder_->getStringAttr(
+          dynamic_cast<llvm::LlvmLambdaOperation &>(lambdaNode.GetOperation()).name()));
   attributes.push_back(symbolName);
   auto linkage = Builder_->getNamedAttr(
       Builder_->getStringAttr("linkage"),
-      Builder_->getStringAttr(llvm::ToString(lambdaNode.GetOperation().linkage())));
+      Builder_->getStringAttr(llvm::ToString(
+          dynamic_cast<llvm::LlvmLambdaOperation &>(lambdaNode.GetOperation()).linkage())));
   attributes.push_back(linkage);
 
   auto lambda = Builder_->create<::mlir::rvsdg::LambdaNode>(

--- a/jlm/mlir/backend/JlmToMlirConverter.hpp
+++ b/jlm/mlir/backend/JlmToMlirConverter.hpp
@@ -153,7 +153,7 @@ private:
    * \return The converted MLIR RVSDG LambdaNode.
    */
   ::mlir::Operation *
-  ConvertLambda(const llvm::lambda::node & node, ::mlir::Block & block);
+  ConvertLambda(const rvsdg::LambdaNode & node, ::mlir::Block & block);
 
   /**
    * Converts an RVSDG gamma node to an MLIR RVSDG GammaNode.

--- a/jlm/mlir/frontend/MlirToJlmConverter.cpp
+++ b/jlm/mlir/frontend/MlirToJlmConverter.cpp
@@ -458,11 +458,12 @@ MlirToJlmConverter::ConvertLambda(::mlir::Operation & mlirLambda, rvsdg::Region 
 
   // FIXME
   // The linkage should be part of the MLIR attributes so it can be extracted here
-  auto rvsdgLambda = llvm::lambda::node::create(
-      &rvsdgRegion,
-      functionType,
-      functionName.getValue().str(),
-      llvm::linkage::external_linkage);
+  auto rvsdgLambda = rvsdg::LambdaNode::Create(
+      rvsdgRegion,
+      llvm::LlvmLambdaOperation::Create(
+          functionType,
+          functionName.getValue().str(),
+          llvm::linkage::external_linkage));
 
   auto lambdaRegion = rvsdgLambda->subregion();
   auto regionResults = ConvertRegion(mlirLambda.getRegion(0), *lambdaRegion);

--- a/jlm/rvsdg/Makefile.sub
+++ b/jlm/rvsdg/Makefile.sub
@@ -4,6 +4,7 @@ librvsdg_SOURCES = \
 	jlm/rvsdg/FunctionType.cpp \
 	jlm/rvsdg/gamma.cpp \
 	jlm/rvsdg/graph.cpp \
+	jlm/rvsdg/lambda.cpp \
 	jlm/rvsdg/node.cpp \
 	jlm/rvsdg/notifiers.cpp \
 	jlm/rvsdg/nullary.cpp \
@@ -46,6 +47,7 @@ librvsdg_HEADERS = \
 	jlm/rvsdg/view.hpp \
 	jlm/rvsdg/traverser.hpp \
 	jlm/rvsdg/graph.hpp \
+	jlm/rvsdg/lambda.hpp \
 	jlm/rvsdg/substitution.hpp \
 	jlm/rvsdg/unary.hpp \
 	jlm/rvsdg/tracker.hpp \

--- a/jlm/rvsdg/lambda.cpp
+++ b/jlm/rvsdg/lambda.cpp
@@ -18,7 +18,7 @@ LambdaOperation::LambdaOperation(std::shared_ptr<const FunctionType> type)
 std::string
 LambdaOperation::debug_string() const
 {
-  return util::strfmt("LAMBDA[", Type()->debug_string(), "]");
+  return util::strfmt("Lambda[", Type()->debug_string(), "]");
 }
 
 bool
@@ -33,8 +33,6 @@ LambdaOperation::copy() const
 {
   return std::make_unique<LambdaOperation>(*this);
 }
-
-/* lambda node class */
 
 LambdaNode::~LambdaNode() = default;
 

--- a/jlm/rvsdg/lambda.cpp
+++ b/jlm/rvsdg/lambda.cpp
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2018 Nico Reißmann <nico.reissmann@gmail.com>
+ * Copyright 2025 Helge Bahmann <hcb@chaoticmind.net>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <jlm/rvsdg/lambda.hpp>
+
+namespace jlm::rvsdg
+{
+
+LambdaOperation::~LambdaOperation() = default;
+
+LambdaOperation::LambdaOperation(std::shared_ptr<const FunctionType> type)
+    : type_(std::move(type))
+{}
+
+std::string
+LambdaOperation::debug_string() const
+{
+  return util::strfmt("LAMBDA[", Type()->debug_string(), "]");
+}
+
+bool
+LambdaOperation::operator==(const Operation & other) const noexcept
+{
+  auto op = dynamic_cast<const LambdaOperation *>(&other);
+  return op && op->type() == type();
+}
+
+std::unique_ptr<rvsdg::Operation>
+LambdaOperation::copy() const
+{
+  return std::make_unique<LambdaOperation>(*this);
+}
+
+/* lambda node class */
+
+LambdaNode::~LambdaNode() = default;
+
+LambdaNode::LambdaNode(rvsdg::Region & parent, std::unique_ptr<LambdaOperation> op)
+    : StructuralNode(&parent, 1),
+      Operation_(std::move(op))
+{
+  for (auto & argumentType : GetOperation().Type()->Arguments())
+  {
+    rvsdg::RegionArgument::Create(*subregion(), nullptr, argumentType);
+  }
+}
+
+LambdaOperation &
+LambdaNode::GetOperation() const noexcept
+{
+  return *Operation_;
+}
+
+[[nodiscard]] std::vector<rvsdg::output *>
+LambdaNode::GetFunctionArguments() const
+{
+  std::vector<rvsdg::output *> arguments;
+  const auto & type = GetOperation().Type();
+  for (std::size_t n = 0; n < type->Arguments().size(); ++n)
+  {
+    arguments.push_back(subregion()->argument(n));
+  }
+  return arguments;
+}
+
+[[nodiscard]] std::vector<rvsdg::input *>
+LambdaNode::GetFunctionResults() const
+{
+  std::vector<rvsdg::input *> results;
+  for (std::size_t n = 0; n < subregion()->nresults(); ++n)
+  {
+    results.push_back(subregion()->result(n));
+  }
+  return results;
+}
+
+[[nodiscard]] LambdaNode::ContextVar
+LambdaNode::MapInputContextVar(const rvsdg::input & input) const noexcept
+{
+  JLM_ASSERT(rvsdg::TryGetOwnerNode<LambdaNode>(input) == this);
+  return ContextVar{ const_cast<rvsdg::input *>(&input),
+                     subregion()->argument(GetOperation().Type()->NumArguments() + input.index()) };
+}
+
+[[nodiscard]] std::optional<LambdaNode::ContextVar>
+LambdaNode::MapBinderContextVar(const rvsdg::output & output) const noexcept
+{
+  JLM_ASSERT(rvsdg::TryGetOwnerRegion(output) == subregion());
+  auto numArguments = GetOperation().Type()->NumArguments();
+  if (output.index() >= numArguments)
+  {
+    return ContextVar{ input(output.index() - GetOperation().Type()->NumArguments()),
+                       const_cast<rvsdg::output *>(&output) };
+  }
+  else
+  {
+    return std::nullopt;
+  }
+}
+
+[[nodiscard]] std::vector<LambdaNode::ContextVar>
+LambdaNode::GetContextVars() const noexcept
+{
+  std::vector<ContextVar> vars;
+  for (size_t n = 0; n < ninputs(); ++n)
+  {
+    vars.push_back(
+        ContextVar{ input(n), subregion()->argument(n + GetOperation().Type()->NumArguments()) });
+  }
+  return vars;
+}
+
+LambdaNode::ContextVar
+LambdaNode::AddContextVar(jlm::rvsdg::output & origin)
+{
+  auto input = rvsdg::StructuralInput::create(this, &origin, origin.Type());
+  auto argument = &rvsdg::RegionArgument::Create(*subregion(), input, origin.Type());
+  return ContextVar{ input, argument };
+}
+
+LambdaNode *
+LambdaNode::Create(rvsdg::Region & parent, std::unique_ptr<LambdaOperation> operation)
+{
+  return new LambdaNode(parent, std::move(operation));
+}
+
+rvsdg::output *
+LambdaNode::finalize(const std::vector<jlm::rvsdg::output *> & results)
+{
+  /* check if finalized was already called */
+  if (noutputs() > 0)
+  {
+    JLM_ASSERT(noutputs() == 1);
+    return output();
+  }
+
+  if (GetOperation().type().NumResults() != results.size())
+    throw util::error("Incorrect number of results.");
+
+  for (size_t n = 0; n < results.size(); n++)
+  {
+    auto & expected = GetOperation().type().ResultType(n);
+    auto & received = results[n]->type();
+    if (results[n]->type() != GetOperation().type().ResultType(n))
+      throw util::error("Expected " + expected.debug_string() + ", got " + received.debug_string());
+
+    if (results[n]->region() != subregion())
+      throw util::error("Invalid operand region.");
+  }
+
+  for (const auto & origin : results)
+    rvsdg::RegionResult::Create(*origin->region(), *origin, nullptr, origin->Type());
+
+  return append_output(std::make_unique<rvsdg::StructuralOutput>(this, GetOperation().Type()));
+}
+
+rvsdg::output *
+LambdaNode::output() const noexcept
+{
+  return StructuralNode::output(0);
+}
+
+LambdaNode *
+LambdaNode::copy(rvsdg::Region * region, const std::vector<jlm::rvsdg::output *> & operands) const
+{
+  return util::AssertedCast<LambdaNode>(rvsdg::Node::copy(region, operands));
+}
+
+LambdaNode *
+LambdaNode::copy(rvsdg::Region * region, rvsdg::SubstitutionMap & smap) const
+{
+  const auto & op = GetOperation();
+  auto lambda = Create(
+      *region,
+      std::unique_ptr<LambdaOperation>(util::AssertedCast<LambdaOperation>(op.copy().release())));
+
+  /* add context variables */
+  rvsdg::SubstitutionMap subregionmap;
+  for (const auto & cv : GetContextVars())
+  {
+    auto origin = smap.lookup(cv.input->origin());
+    subregionmap.insert(cv.inner, lambda->AddContextVar(*origin).inner);
+  }
+
+  /* collect function arguments */
+  auto args = GetFunctionArguments();
+  auto newArgs = lambda->GetFunctionArguments();
+  JLM_ASSERT(args.size() == newArgs.size());
+  for (std::size_t n = 0; n < args.size(); ++n)
+  {
+    subregionmap.insert(args[n], newArgs[n]);
+  }
+
+  /* copy subregion */
+  subregion()->copy(lambda->subregion(), subregionmap, false, false);
+
+  /* collect function results */
+  std::vector<jlm::rvsdg::output *> results;
+  for (auto result : GetFunctionResults())
+    results.push_back(subregionmap.lookup(result->origin()));
+
+  /* finalize lambda */
+  auto o = lambda->finalize(results);
+  smap.insert(output(), o);
+
+  return lambda;
+}
+
+}

--- a/jlm/rvsdg/lambda.hpp
+++ b/jlm/rvsdg/lambda.hpp
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2018 Nico Reißmann <nico.reissmann@gmail.com>
+ * Copyright 2025 Helge Bahmann <hcb@chaoticmind.net>
+ * See COPYING for terms of redistribution.
+ */
+
+#ifndef JLM_RVSDG_LAMBDA_HPP
+#define JLM_RVSDG_LAMBDA_HPP
+
+#include <jlm/rvsdg/FunctionType.hpp>
+#include <jlm/rvsdg/graph.hpp>
+#include <jlm/rvsdg/structural-node.hpp>
+#include <jlm/rvsdg/substitution.hpp>
+#include <jlm/util/iterator_range.hpp>
+
+#include <optional>
+#include <utility>
+
+namespace jlm::rvsdg
+{
+
+/** \brief Lambda operation
+ *
+ * A lambda operation determines a lambda's name and \ref FunctionType "function type".
+ */
+class LambdaOperation : public rvsdg::StructuralOperation
+{
+public:
+  ~LambdaOperation() override;
+
+  LambdaOperation(std::shared_ptr<const FunctionType> type);
+
+  LambdaOperation(const LambdaOperation & other) = default;
+
+  LambdaOperation(LambdaOperation && other) noexcept = default;
+
+  LambdaOperation &
+  operator=(const LambdaOperation & other) = default;
+
+  LambdaOperation &
+  operator=(LambdaOperation && other) noexcept = default;
+
+  [[nodiscard]] const FunctionType &
+  type() const noexcept
+  {
+    return *type_;
+  }
+
+  [[nodiscard]] const std::shared_ptr<const FunctionType> &
+  Type() const noexcept
+  {
+    return type_;
+  }
+
+  [[nodiscard]] std::string
+  debug_string() const override;
+
+  bool
+  operator==(const Operation & other) const noexcept override;
+
+  [[nodiscard]] std::unique_ptr<Operation>
+  copy() const override;
+
+private:
+  std::shared_ptr<const FunctionType> type_;
+};
+
+/** \brief Lambda node
+ *
+ * A lambda node represents a lambda expression in the RVSDG. Its creation requires the invocation
+ * of two functions: \ref Create() and \ref finalize(). First, a node with only the function
+ * arguments is created by invoking \ref Create(). The free variables of the lambda expression can
+ * then be added to the lambda node using the \ref AddContextVar() method, and the body of the
+ * lambda node can be created. Finally, the lambda node can be finalized by invoking \ref
+ * finalize().
+ *
+ * The following snippet illustrates the creation of lambda nodes:
+ *
+ * \code{.cpp}
+ *   auto lambda = LambdaNode::create(...);
+ *   ...
+ *   auto cv1 = lambda->AddContextVar(...);
+ *   auto cv2 = lambda->AddContextVar(...);
+ *   ...
+ *   // generate lambda body
+ *   ...
+ *   auto output = lambda->finalize(...);
+ * \endcode
+ */
+class LambdaNode final : public rvsdg::StructuralNode
+{
+public:
+  ~LambdaNode() override;
+
+private:
+  LambdaNode(rvsdg::Region & parent, std::unique_ptr<LambdaOperation> op);
+
+public:
+  /**
+   * \brief Bound context variable
+   *
+   * Context variables may be bound at the point of creation of a
+   * lambda abstraction. These are represented as inputs to the
+   * lambda node itself, and made accessible to the body of the
+   * lambda in the form of an initial argument to the subregion.
+   */
+  struct ContextVar
+  {
+    /**
+     * \brief Input variable bound into lambda node
+     *
+     * The input port into the lambda node that supplies the value
+     * of the context variable bound into the lambda at the
+     * time the lambda abstraction is built.
+     */
+    rvsdg::input * input;
+
+    /**
+     * \brief Access to bound object in subregion.
+     *
+     * Supplies access to the value bound into the lambda abstraction
+     * from inside the region contained in the lambda node. This
+     * evaluates to the value bound into the lambda.
+     */
+    rvsdg::output * inner;
+  };
+
+  [[nodiscard]] std::vector<rvsdg::output *>
+  GetFunctionArguments() const;
+
+  [[nodiscard]] std::vector<rvsdg::input *>
+  GetFunctionResults() const;
+
+  [[nodiscard]] rvsdg::Region *
+  subregion() const noexcept
+  {
+    return StructuralNode::subregion(0);
+  }
+
+  [[nodiscard]] LambdaOperation &
+  GetOperation() const noexcept override;
+
+  /**
+   * \brief Adds a context/free variable to the lambda node.
+   *
+   * \param origin
+   *   The value to be bound into the lambda node.
+   *
+   * \pre
+   *   \p origin must be from the same region as the lambda node.
+   *
+   * \return The context variable argument of the lambda abstraction.
+   */
+  ContextVar
+  AddContextVar(jlm::rvsdg::output & origin);
+
+  /**
+   * \brief Maps input to context variable.
+   *
+   * \param input
+   *   Input to the lambda node.
+   *
+   * \returns
+   *   The context variable description corresponding to the input.
+   *
+   * \pre
+   *   \p input must be input to this node.
+   *
+   * Returns the context variable description corresponding
+   * to this input of the lambda node. All inputs to the lambda
+   * node are by definition bound context variables that are
+   * accessible in the subregion through the corresponding
+   * argument.
+   */
+  [[nodiscard]] ContextVar
+  MapInputContextVar(const rvsdg::input & input) const noexcept;
+
+  /**
+   * \brief Maps bound variable reference to context variable
+   *
+   * \param output
+   *   Region argument to lambda subregion
+   *
+   * \returns
+   *   The context variable description corresponding to the argument
+   *
+   * \pre
+   *   \p output must be an argument to the subregion of this node
+   *
+   * Returns the context variable description corresponding
+   * to this bound variable reference in the lambda node region.
+   * Note that some arguments of the region are formal call arguments
+   * and do not have an associated context variable description.
+   */
+  [[nodiscard]] std::optional<ContextVar>
+  MapBinderContextVar(const rvsdg::output & output) const noexcept;
+
+  /**
+   * \brief Gets all bound context variables
+   *
+   * \returns
+   *   The context variable descriptions.
+   *
+   * Returns all context variable descriptions.
+   */
+  [[nodiscard]] std::vector<ContextVar>
+  GetContextVars() const noexcept;
+
+  /**
+   * Remove lambda inputs and their respective arguments.
+   *
+   * An input must match the condition specified by \p match and its argument must be dead.
+   *
+   * @tparam F A type that supports the function call operator: bool operator(const rvsdg::input&)
+   * @param match Defines the condition of the elements to remove.
+   * @return The number of removed inputs.
+   */
+  template<typename F>
+  size_t
+  RemoveLambdaInputsWhere(const F & match);
+
+  /**
+   * Remove all dead inputs.
+   *
+   * @return The number of removed inputs.
+   *
+   * \see RemoveLambdaInputsWhere()
+   */
+  size_t
+  PruneLambdaInputs()
+  {
+    auto match = [](const rvsdg::input &)
+    {
+      return true;
+    };
+
+    return RemoveLambdaInputsWhere(match);
+  }
+
+  [[nodiscard]] rvsdg::output *
+  output() const noexcept;
+
+  LambdaNode *
+  copy(rvsdg::Region * region, const std::vector<jlm::rvsdg::output *> & operands) const override;
+
+  LambdaNode *
+  copy(rvsdg::Region * region, rvsdg::SubstitutionMap & smap) const override;
+
+  /**
+   * Creates a lambda node in the region \p parent with the function type \p type and name \p name.
+   * After the invocation of \ref Create(), the lambda node only features the function arguments.
+   * Free variables can be added to the function node using \ref AddContextVar(). The generation of
+   * the node can be finished using the \ref finalize() method.
+   *
+   * \param parent The region where the lambda node is created.
+   * \param operation Operational details for lambda node (including function signature).
+   *
+   * \return A lambda node featuring only function arguments.
+   */
+  static LambdaNode *
+  Create(rvsdg::Region & parent, std::unique_ptr<LambdaOperation> operation);
+
+  /**
+   * Finalizes the creation of a lambda node.
+   *
+   * \param results The result values of the lambda expression, originating from the lambda region.
+   *
+   * \return The output of the lambda node.
+   */
+  rvsdg::output *
+  finalize(const std::vector<jlm::rvsdg::output *> & results);
+
+private:
+  std::unique_ptr<LambdaOperation> Operation_;
+};
+
+template<typename F>
+size_t
+LambdaNode::RemoveLambdaInputsWhere(const F & match)
+{
+  size_t numRemovedInputs = 0;
+
+  // iterate backwards to avoid the invalidation of 'n' by RemoveInput()
+  for (size_t n = ninputs() - 1; n != static_cast<size_t>(-1); n--)
+  {
+    auto lambdaInput = input(n);
+    auto & argument = *MapInputContextVar(*lambdaInput).inner;
+
+    if (argument.IsDead() && match(*lambdaInput))
+    {
+      subregion()->RemoveArgument(argument.index());
+      RemoveInput(n);
+      numRemovedInputs++;
+    }
+  }
+
+  return numRemovedInputs;
+}
+
+}
+
+#endif

--- a/jlm/rvsdg/lambda.hpp
+++ b/jlm/rvsdg/lambda.hpp
@@ -21,24 +21,14 @@ namespace jlm::rvsdg
 
 /** \brief Lambda operation
  *
- * A lambda operation determines a lambda's name and \ref FunctionType "function type".
+ * A lambda operation determines a lambda's \ref FunctionType "function type".
  */
 class LambdaOperation : public rvsdg::StructuralOperation
 {
 public:
   ~LambdaOperation() override;
 
-  LambdaOperation(std::shared_ptr<const FunctionType> type);
-
-  LambdaOperation(const LambdaOperation & other) = default;
-
-  LambdaOperation(LambdaOperation && other) noexcept = default;
-
-  LambdaOperation &
-  operator=(const LambdaOperation & other) = default;
-
-  LambdaOperation &
-  operator=(LambdaOperation && other) noexcept = default;
+  explicit LambdaOperation(std::shared_ptr<const FunctionType> type);
 
   [[nodiscard]] const FunctionType &
   type() const noexcept

--- a/jlm/rvsdg/node.cpp
+++ b/jlm/rvsdg/node.cpp
@@ -367,7 +367,7 @@ producer(const jlm::rvsdg::output * output) noexcept
 
   Example:
   \code
-  if (auto lambda = rvsdg::TryGetOwnerNode<lambda::node>(def))
+  if (auto lambda = rvsdg::TryGetOwnerNode<LambdaNode>(def))
   {
     // This is an output of a lambda node -- so this must
     // be a function definition.

--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -20,7 +20,9 @@ StoreTest1::SetupRvsdg()
   auto module = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto graph = &module->Rvsdg();
 
-  auto fct = lambda::node::create(&graph->GetRootRegion(), fcttype, "f", linkage::external_linkage);
+  auto fct = rvsdg::LambdaNode::Create(
+      graph->GetRootRegion(),
+      llvm::LlvmLambdaOperation::Create(fcttype, "f", linkage::external_linkage));
 
   auto csize = jlm::rvsdg::create_bitconstant(fct->subregion(), 32, 4);
 
@@ -72,7 +74,9 @@ StoreTest2::SetupRvsdg()
   auto module = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto graph = &module->Rvsdg();
 
-  auto fct = lambda::node::create(&graph->GetRootRegion(), fcttype, "f", linkage::external_linkage);
+  auto fct = rvsdg::LambdaNode::Create(
+      graph->GetRootRegion(),
+      llvm::LlvmLambdaOperation::Create(fcttype, "f", linkage::external_linkage));
 
   auto csize = jlm::rvsdg::create_bitconstant(fct->subregion(), 32, 4);
 
@@ -131,7 +135,9 @@ LoadTest1::SetupRvsdg()
   auto module = RvsdgModule::Create(jlm::util::filepath("LoadTest1.c"), "", "");
   auto graph = &module->Rvsdg();
 
-  auto fct = lambda::node::create(&graph->GetRootRegion(), fcttype, "f", linkage::external_linkage);
+  auto fct = rvsdg::LambdaNode::Create(
+      graph->GetRootRegion(),
+      llvm::LlvmLambdaOperation::Create(fcttype, "f", linkage::external_linkage));
 
   auto ld1 = LoadNonVolatileNode::Create(
       fct->GetFunctionArguments()[0],
@@ -167,7 +173,9 @@ LoadTest2::SetupRvsdg()
   auto module = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto graph = &module->Rvsdg();
 
-  auto fct = lambda::node::create(&graph->GetRootRegion(), fcttype, "f", linkage::external_linkage);
+  auto fct = rvsdg::LambdaNode::Create(
+      graph->GetRootRegion(),
+      llvm::LlvmLambdaOperation::Create(fcttype, "f", linkage::external_linkage));
 
   auto csize = jlm::rvsdg::create_bitconstant(fct->subregion(), 32, 4);
 
@@ -232,8 +240,9 @@ LoadFromUndefTest::SetupRvsdg()
   auto rvsdgModule = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto & rvsdg = rvsdgModule->Rvsdg();
 
-  Lambda_ =
-      lambda::node::create(&rvsdg.GetRootRegion(), functionType, "f", linkage::external_linkage);
+  Lambda_ = rvsdg::LambdaNode::Create(
+      rvsdg.GetRootRegion(),
+      llvm::LlvmLambdaOperation::Create(functionType, "f", linkage::external_linkage));
 
   auto undefValue = UndefValueOperation::Create(*Lambda_->subregion(), pointerType);
   auto loadResults = LoadNonVolatileNode::Create(
@@ -271,7 +280,9 @@ GetElementPtrTest::SetupRvsdg()
       { PointerType::Create(), MemoryStateType::Create() },
       { jlm::rvsdg::bittype::Create(32), MemoryStateType::Create() });
 
-  auto fct = lambda::node::create(&graph->GetRootRegion(), fcttype, "f", linkage::external_linkage);
+  auto fct = rvsdg::LambdaNode::Create(
+      graph->GetRootRegion(),
+      llvm::LlvmLambdaOperation::Create(fcttype, "f", linkage::external_linkage));
 
   auto zero = jlm::rvsdg::create_bitconstant(fct->subregion(), 32, 0);
   auto one = jlm::rvsdg::create_bitconstant(fct->subregion(), 32, 1);
@@ -322,7 +333,9 @@ BitCastTest::SetupRvsdg()
   auto module = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto graph = &module->Rvsdg();
 
-  auto fct = lambda::node::create(&graph->GetRootRegion(), fcttype, "f", linkage::external_linkage);
+  auto fct = rvsdg::LambdaNode::Create(
+      graph->GetRootRegion(),
+      llvm::LlvmLambdaOperation::Create(fcttype, "f", linkage::external_linkage));
 
   auto cast = bitcast_op::create(fct->GetFunctionArguments()[0], pointerType);
 
@@ -356,11 +369,9 @@ Bits2PtrTest::SetupRvsdg()
         { jlm::rvsdg::bittype::Create(64), IOStateType::Create(), MemoryStateType::Create() },
         { PointerType::Create(), IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        functionType,
-        "bit2ptr",
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "bit2ptr", linkage::external_linkage));
     auto valueArgument = lambda->GetFunctionArguments()[0];
     auto iOStateArgument = lambda->GetFunctionArguments()[1];
     auto memoryStateArgument = lambda->GetFunctionArguments()[2];
@@ -380,11 +391,9 @@ Bits2PtrTest::SetupRvsdg()
         { jlm::rvsdg::bittype::Create(64), IOStateType::Create(), MemoryStateType::Create() },
         { IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        functionType,
-        "test",
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "test", linkage::external_linkage));
     auto valueArgument = lambda->GetFunctionArguments()[0];
     auto iOStateArgument = lambda->GetFunctionArguments()[1];
     auto memoryStateArgument = lambda->GetFunctionArguments()[2];
@@ -393,7 +402,7 @@ Bits2PtrTest::SetupRvsdg()
 
     auto & call = CallNode::CreateNode(
         cvbits2ptr,
-        rvsdg::AssertGetOwnerNode<lambda::node>(*b2p).GetOperation().Type(),
+        rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*b2p).GetOperation().Type(),
         { valueArgument, iOStateArgument, memoryStateArgument });
 
     lambda->finalize({ call.GetIoStateOutput(), call.GetMemoryStateOutput() });
@@ -430,7 +439,9 @@ ConstantPointerNullTest::SetupRvsdg()
   auto module = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto graph = &module->Rvsdg();
 
-  auto fct = lambda::node::create(&graph->GetRootRegion(), fcttype, "f", linkage::external_linkage);
+  auto fct = rvsdg::LambdaNode::Create(
+      graph->GetRootRegion(),
+      llvm::LlvmLambdaOperation::Create(fcttype, "f", linkage::external_linkage));
 
   auto constantPointerNullResult =
       ConstantPointerNullOperation::Create(fct->subregion(), pointerType);
@@ -473,8 +484,9 @@ CallTest1::SetupRvsdg()
           MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda =
-        lambda::node::create(&graph->GetRootRegion(), functionType, "f", linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "f", linkage::external_linkage));
     auto pointerArgument1 = lambda->GetFunctionArguments()[0];
     auto pointerArgument2 = lambda->GetFunctionArguments()[1];
     auto iOStateArgument = lambda->GetFunctionArguments()[2];
@@ -510,8 +522,9 @@ CallTest1::SetupRvsdg()
           MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda =
-        lambda::node::create(&graph->GetRootRegion(), functionType, "g", linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "g", linkage::external_linkage));
     auto pointerArgument1 = lambda->GetFunctionArguments()[0];
     auto pointerArgument2 = lambda->GetFunctionArguments()[1];
     auto iOStateArgument = lambda->GetFunctionArguments()[2];
@@ -535,7 +548,7 @@ CallTest1::SetupRvsdg()
     return lambda;
   };
 
-  auto SetupH = [&](lambda::node * f, lambda::node * g)
+  auto SetupH = [&](rvsdg::LambdaNode * f, rvsdg::LambdaNode * g)
   {
     auto iOStateType = IOStateType::Create();
     auto memoryStateType = MemoryStateType::Create();
@@ -543,8 +556,9 @@ CallTest1::SetupRvsdg()
         { IOStateType::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda =
-        lambda::node::create(&graph->GetRootRegion(), functionType, "h", linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "h", linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -629,11 +643,9 @@ CallTest2::SetupRvsdg()
         { jlm::rvsdg::bittype::Create(32), IOStateType::Create(), MemoryStateType::Create() },
         { PointerType::Create(), IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        functionType,
-        "create",
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "create", linkage::external_linkage));
     auto valueArgument = lambda->GetFunctionArguments()[0];
     auto iOStateArgument = lambda->GetFunctionArguments()[1];
     auto memoryStateArgument = lambda->GetFunctionArguments()[2];
@@ -661,11 +673,9 @@ CallTest2::SetupRvsdg()
         { PointerType::Create(), IOStateType::Create(), MemoryStateType::Create() },
         { IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        functionType,
-        "destroy",
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "destroy", linkage::external_linkage));
     auto pointerArgument = lambda->GetFunctionArguments()[0];
     auto iOStateArgument = lambda->GetFunctionArguments()[1];
     auto memoryStateArgument = lambda->GetFunctionArguments()[2];
@@ -679,7 +689,7 @@ CallTest2::SetupRvsdg()
     return std::make_tuple(lambda, freeNode);
   };
 
-  auto SetupTest = [&](lambda::node * lambdaCreate, lambda::node * lambdaDestroy)
+  auto SetupTest = [&](rvsdg::LambdaNode * lambdaCreate, rvsdg::LambdaNode * lambdaDestroy)
   {
     auto iOStateType = IOStateType::Create();
     auto memoryStateType = MemoryStateType::Create();
@@ -687,11 +697,9 @@ CallTest2::SetupRvsdg()
         { IOStateType::Create(), MemoryStateType::Create() },
         { IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        functionType,
-        "test",
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "test", linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -766,11 +774,9 @@ IndirectCallTest1::SetupRvsdg()
 
   auto SetupConstantFunction = [&](ssize_t n, const std::string & name)
   {
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        constantFunctionType,
-        name,
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(constantFunctionType, name, linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -787,11 +793,9 @@ IndirectCallTest1::SetupRvsdg()
         { PointerType::Create(), IOStateType::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        functionType,
-        "indcall",
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "indcall", linkage::external_linkage));
     auto pointerArgument = lambda->GetFunctionArguments()[0];
     auto functionOfPointer =
         rvsdg::CreateOpNode<PointerToFunctionOperation>({ pointerArgument }, constantFunctionType)
@@ -816,11 +820,9 @@ IndirectCallTest1::SetupRvsdg()
         { IOStateType::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        functionType,
-        "test",
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "test", linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -830,11 +832,11 @@ IndirectCallTest1::SetupRvsdg()
 
     auto & call_four = CallNode::CreateNode(
         fctindcall_cv,
-        rvsdg::AssertGetOwnerNode<lambda::node>(*fctindcall).GetOperation().Type(),
+        rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*fctindcall).GetOperation().Type(),
         { fctfour_cv, iOStateArgument, memoryStateArgument });
     auto & call_three = CallNode::CreateNode(
         fctindcall_cv,
-        rvsdg::AssertGetOwnerNode<lambda::node>(*fctindcall).GetOperation().Type(),
+        rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*fctindcall).GetOperation().Type(),
         { fctthree_cv, call_four.GetIoStateOutput(), call_four.GetMemoryStateOutput() });
 
     auto add = jlm::rvsdg::bitadd_op::create(32, call_four.Result(0), call_three.Result(0));
@@ -857,10 +859,10 @@ IndirectCallTest1::SetupRvsdg()
   /*
    * Assign
    */
-  this->LambdaThree_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*fctthree);
-  this->LambdaFour_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*fctfour);
-  this->LambdaIndcall_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*fctindcall);
-  this->LambdaTest_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*fcttest);
+  this->LambdaThree_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*fctthree);
+  this->LambdaFour_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*fctfour);
+  this->LambdaIndcall_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*fctindcall);
+  this->LambdaTest_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*fcttest);
 
   this->CallIndcall_ = callIndirectFunction;
   this->CallThree_ = callFunctionThree;
@@ -916,11 +918,9 @@ IndirectCallTest2::SetupRvsdg()
 
   auto SetupConstantFunction = [&](ssize_t n, const std::string & name)
   {
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        constantFunctionType,
-        name,
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(constantFunctionType, name, linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -938,11 +938,9 @@ IndirectCallTest2::SetupRvsdg()
     auto iOStateType = IOStateType::Create();
     auto memoryStateType = MemoryStateType::Create();
 
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        functionIType,
-        "i",
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionIType, "i", linkage::external_linkage));
     auto pointerArgument = lambda->GetFunctionArguments()[0];
     auto iOStateArgument = lambda->GetFunctionArguments()[1];
     auto memoryStateArgument = lambda->GetFunctionArguments()[2];
@@ -969,11 +967,9 @@ IndirectCallTest2::SetupRvsdg()
         { PointerType::Create(), IOStateType::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        functionType,
-        name,
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, name, linkage::external_linkage));
     auto pointerArgument = lambda->GetFunctionArguments()[0];
     auto iOStateArgument = lambda->GetFunctionArguments()[1];
     auto memoryStateArgument = lambda->GetFunctionArguments()[2];
@@ -1008,11 +1004,9 @@ IndirectCallTest2::SetupRvsdg()
         { IOStateType::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        functionType,
-        "test",
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "test", linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -1033,12 +1027,12 @@ IndirectCallTest2::SetupRvsdg()
 
     auto & callX = CallNode::CreateNode(
         functionXCv,
-        rvsdg::AssertGetOwnerNode<lambda::node>(functionX).GetOperation().Type(),
+        rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(functionX).GetOperation().Type(),
         { pxAlloca[0], iOStateArgument, pyMerge });
 
     auto & callY = CallNode::CreateNode(
         functionYCv,
-        rvsdg::AssertGetOwnerNode<lambda::node>(functionY).GetOperation().Type(),
+        rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(functionY).GetOperation().Type(),
         { pyAlloca[0], callX.GetIoStateOutput(), callX.GetMemoryStateOutput() });
 
     auto loadG1 = LoadNonVolatileNode::Create(
@@ -1071,11 +1065,9 @@ IndirectCallTest2::SetupRvsdg()
         { IOStateType::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        functionType,
-        "test2",
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "test2", linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -1089,7 +1081,7 @@ IndirectCallTest2::SetupRvsdg()
 
     auto & callX = CallNode::CreateNode(
         functionXCv,
-        rvsdg::AssertGetOwnerNode<lambda::node>(functionX).GetOperation().Type(),
+        rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(functionX).GetOperation().Type(),
         { pzAlloca[0], iOStateArgument, pzMerge });
 
     auto lambdaOutput = lambda->finalize(callX.Results());
@@ -1117,13 +1109,13 @@ IndirectCallTest2::SetupRvsdg()
    */
   this->DeltaG1_ = deltaG1->node();
   this->DeltaG2_ = deltaG2->node();
-  this->LambdaThree_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaThree);
-  this->LambdaFour_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaFour);
-  this->LambdaI_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaI);
-  this->LambdaX_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaX);
-  this->LambdaY_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaY);
-  this->LambdaTest_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaTest);
-  this->LambdaTest2_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaTest2);
+  this->LambdaThree_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaThree);
+  this->LambdaFour_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaFour);
+  this->LambdaI_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaI);
+  this->LambdaX_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaX);
+  this->LambdaY_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaY);
+  this->LambdaTest_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaTest);
+  this->LambdaTest2_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaTest2);
 
   this->IndirectCall_ = indirectCall;
   this->CallIWithThree_ = callIWithThree;
@@ -1179,8 +1171,9 @@ ExternalCallTest1::SetupRvsdg()
           MemoryStateType::Create() },
         { PointerType::Create(), IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda =
-        lambda::node::create(&rvsdg->GetRootRegion(), functionType, "f", linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        rvsdg->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "f", linkage::external_linkage));
     auto pathArgument = lambda->GetFunctionArguments()[0];
     auto modeArgument = lambda->GetFunctionArguments()[1];
     auto iOStateArgument = lambda->GetFunctionArguments()[2];
@@ -1277,8 +1270,9 @@ ExternalCallTest2::SetupRvsdg()
       &GraphImport::Create(rvsdg, lambdaFType, lambdaFType, "f", linkage::external_linkage);
 
   // Setup function g()
-  LambdaG_ =
-      lambda::node::create(&rvsdg.GetRootRegion(), lambdaGType, "g", linkage::external_linkage);
+  LambdaG_ = rvsdg::LambdaNode::Create(
+      rvsdg.GetRootRegion(),
+      llvm::LlvmLambdaOperation::Create(lambdaGType, "g", linkage::external_linkage));
   auto iOStateArgument = LambdaG_->GetFunctionArguments()[0];
   auto memoryStateArgument = LambdaG_->GetFunctionArguments()[1];
   auto llvmLifetimeStartArgument = LambdaG_->AddContextVar(*llvmLifetimeStart).inner;
@@ -1356,7 +1350,9 @@ GammaTest::SetupRvsdg()
   auto module = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto graph = &module->Rvsdg();
 
-  auto fct = lambda::node::create(&graph->GetRootRegion(), fcttype, "f", linkage::external_linkage);
+  auto fct = rvsdg::LambdaNode::Create(
+      graph->GetRootRegion(),
+      llvm::LlvmLambdaOperation::Create(fcttype, "f", linkage::external_linkage));
 
   auto zero = jlm::rvsdg::create_bitconstant(fct->subregion(), 32, 0);
   auto biteq = jlm::rvsdg::biteq_op::create(32, fct->GetFunctionArguments()[0], zero);
@@ -1457,8 +1453,9 @@ GammaTest2::SetupRvsdg()
           MemoryStateType::Create() },
         { rvsdg::bittype::Create(32), IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda =
-        lambda::node::create(&rvsdg->GetRootRegion(), functionType, "f", linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        rvsdg->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "f", linkage::external_linkage));
     auto cArgument = lambda->GetFunctionArguments()[0];
     auto xArgument = lambda->GetFunctionArguments()[1];
     auto yArgument = lambda->GetFunctionArguments()[2];
@@ -1512,11 +1509,9 @@ GammaTest2::SetupRvsdg()
         { IOStateType::Create(), MemoryStateType::Create() },
         { rvsdg::bittype::Create(32), IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda = lambda::node::create(
-        &rvsdg->GetRootRegion(),
-        functionType,
-        functionName,
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        rvsdg->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, functionName, linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
     auto lambdaFArgument = lambda->AddContextVar(lambdaF).inner;
@@ -1543,7 +1538,7 @@ GammaTest2::SetupRvsdg()
 
     auto & call = CallNode::CreateNode(
         lambdaFArgument,
-        rvsdg::AssertGetOwnerNode<lambda::node>(lambdaF).GetOperation().Type(),
+        rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(lambdaF).GetOperation().Type(),
         { predicate, allocaXResults[0], allocaYResults[0], iOStateArgument, storeYResults[0] });
 
     lambda->finalize(call.Results());
@@ -1561,9 +1556,9 @@ GammaTest2::SetupRvsdg()
   auto [lambdaH, callFromH, allocaXFromH, allocaYFromH] = SetupLambdaGH(*lambdaF, 1, 3, 4, "h");
 
   // Assign nodes
-  this->LambdaF_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaF);
-  this->LambdaG_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaG);
-  this->LambdaH_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaH);
+  this->LambdaF_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaF);
+  this->LambdaG_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaG);
+  this->LambdaH_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaH);
 
   this->Gamma_ = gammaNode;
 
@@ -1596,7 +1591,9 @@ ThetaTest::SetupRvsdg()
   auto module = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto graph = &module->Rvsdg();
 
-  auto fct = lambda::node::create(&graph->GetRootRegion(), fcttype, "f", linkage::external_linkage);
+  auto fct = rvsdg::LambdaNode::Create(
+      graph->GetRootRegion(),
+      llvm::LlvmLambdaOperation::Create(fcttype, "f", linkage::external_linkage));
 
   auto zero = jlm::rvsdg::create_bitconstant(fct->subregion(), 32, 0);
 
@@ -1669,8 +1666,9 @@ DeltaTest1::SetupRvsdg()
         { PointerType::Create(), IOStateType::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda =
-        lambda::node::create(&graph->GetRootRegion(), functionType, "g", linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "g", linkage::external_linkage));
     auto pointerArgument = lambda->GetFunctionArguments()[0];
     auto iOStateArgument = lambda->GetFunctionArguments()[1];
     auto memoryStateArgument = lambda->GetFunctionArguments()[2];
@@ -1692,8 +1690,9 @@ DeltaTest1::SetupRvsdg()
         { IOStateType::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda =
-        lambda::node::create(&graph->GetRootRegion(), functionType, "h", linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "h", linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -1704,7 +1703,7 @@ DeltaTest1::SetupRvsdg()
     auto st = StoreNonVolatileNode::Create(cvf, five, { memoryStateArgument }, 4);
     auto & callG = CallNode::CreateNode(
         cvg,
-        rvsdg::AssertGetOwnerNode<lambda::node>(*g).GetOperation().Type(),
+        rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*g).GetOperation().Type(),
         { cvf, iOStateArgument, st[0] });
 
     auto lambdaOutput = lambda->finalize(callG.Results());
@@ -1720,8 +1719,8 @@ DeltaTest1::SetupRvsdg()
   /*
    * Assign nodes
    */
-  this->lambda_g = &rvsdg::AssertGetOwnerNode<lambda::node>(*g);
-  this->lambda_h = &rvsdg::AssertGetOwnerNode<lambda::node>(*h);
+  this->lambda_g = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*g);
+  this->lambda_h = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*h);
 
   this->delta_f = f->node();
 
@@ -1777,11 +1776,9 @@ DeltaTest2::SetupRvsdg()
         { IOStateType::Create(), MemoryStateType::Create() },
         { IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        functionType,
-        "f1",
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "f1", linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -1800,11 +1797,9 @@ DeltaTest2::SetupRvsdg()
         { IOStateType::Create(), MemoryStateType::Create() },
         { IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        functionType,
-        "f2",
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "f2", linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -1817,7 +1812,7 @@ DeltaTest2::SetupRvsdg()
     auto st = StoreNonVolatileNode::Create(cvd1, b5, { memoryStateArgument }, 4);
     auto & call = CallNode::CreateNode(
         cvf1,
-        rvsdg::AssertGetOwnerNode<lambda::node>(*f1).GetOperation().Type(),
+        rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*f1).GetOperation().Type(),
         { iOStateArgument, st[0] });
     st = StoreNonVolatileNode::Create(cvd2, b42, { call.GetMemoryStateOutput() }, 4);
 
@@ -1833,8 +1828,8 @@ DeltaTest2::SetupRvsdg()
   auto [f2, callF1] = SetupF2(f1, d1, d2);
 
   // Assign nodes
-  this->lambda_f1 = &rvsdg::AssertGetOwnerNode<lambda::node>(*f1);
-  this->lambda_f2 = &rvsdg::AssertGetOwnerNode<lambda::node>(*f2);
+  this->lambda_f1 = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*f1);
+  this->lambda_f2 = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*f2);
 
   this->delta_d1 = d1->node();
   this->delta_d2 = d2->node();
@@ -1892,8 +1887,9 @@ DeltaTest3::SetupRvsdg()
         { IOStateType::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(16), IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda =
-        lambda::node::create(&graph->GetRootRegion(), functionType, "f", linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "f", linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
     auto g1CtxVar = lambda->AddContextVar(g1).inner;
@@ -1919,11 +1915,9 @@ DeltaTest3::SetupRvsdg()
         { IOStateType::Create(), MemoryStateType::Create() },
         { IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        functionType,
-        "test",
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "test", linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -1931,7 +1925,7 @@ DeltaTest3::SetupRvsdg()
 
     auto & call = CallNode::CreateNode(
         lambdaFArgument,
-        rvsdg::AssertGetOwnerNode<lambda::node>(lambdaF).GetOperation().Type(),
+        rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(lambdaF).GetOperation().Type(),
         { iOStateArgument, memoryStateArgument });
 
     auto lambdaOutput = lambda->finalize({ call.GetIoStateOutput(), call.GetMemoryStateOutput() });
@@ -1948,8 +1942,8 @@ DeltaTest3::SetupRvsdg()
   /*
    * Assign nodes
    */
-  this->LambdaF_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*f);
-  this->LambdaTest_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*test);
+  this->LambdaF_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*f);
+  this->LambdaTest_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*test);
 
   this->DeltaG1_ = g1->node();
   this->DeltaG2_ = g2->node();
@@ -1975,11 +1969,9 @@ ImportTest::SetupRvsdg()
         { IOStateType::Create(), MemoryStateType::Create() },
         { IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        functionType,
-        "f1",
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "f1", linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -1999,11 +1991,9 @@ ImportTest::SetupRvsdg()
         { IOStateType::Create(), MemoryStateType::Create() },
         { IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        functionType,
-        "f2",
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "f2", linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -2015,7 +2005,7 @@ ImportTest::SetupRvsdg()
     auto st = StoreNonVolatileNode::Create(cvd1, b2, { memoryStateArgument }, 4);
     auto & call = CallNode::CreateNode(
         cvf1,
-        rvsdg::AssertGetOwnerNode<lambda::node>(*f1).GetOperation().Type(),
+        rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*f1).GetOperation().Type(),
         { iOStateArgument, st[0] });
     st = StoreNonVolatileNode::Create(cvd2, b21, { call.GetMemoryStateOutput() }, 4);
 
@@ -2042,8 +2032,8 @@ ImportTest::SetupRvsdg()
   auto [f2, callF1] = SetupF2(f1, d1, d2);
 
   // Assign nodes
-  this->lambda_f1 = &rvsdg::AssertGetOwnerNode<lambda::node>(*f1);
-  this->lambda_f2 = &rvsdg::AssertGetOwnerNode<lambda::node>(*f2);
+  this->lambda_f1 = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*f1);
+  this->lambda_f2 = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*f2);
 
   this->CallF1_ = callF1;
 
@@ -2079,8 +2069,9 @@ PhiTest1::SetupRvsdg()
     pb.begin(&graph->GetRootRegion());
     auto fibrv = pb.add_recvar(fibFunctionType);
 
-    auto lambda =
-        lambda::node::create(pb.subregion(), fibFunctionType, "fib", linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        *pb.subregion(),
+        llvm::LlvmLambdaOperation::Create(fibFunctionType, "fib", linkage::external_linkage));
     auto valueArgument = lambda->GetFunctionArguments()[0];
     auto pointerArgument = lambda->GetFunctionArguments()[1];
     auto iOStateArgument = lambda->GetFunctionArguments()[2];
@@ -2173,11 +2164,9 @@ PhiTest1::SetupRvsdg()
         { IOStateType::Create(), MemoryStateType::Create() },
         { IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        functionType,
-        "test",
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "test", linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
     auto fibcv = lambda->AddContextVar(*phiNode->output(0)).inner;
@@ -2203,8 +2192,8 @@ PhiTest1::SetupRvsdg()
   auto [testfct, callFib, alloca] = SetupTestFunction(phiNode);
 
   // Assign nodes
-  this->lambda_fib = &rvsdg::AssertGetOwnerNode<lambda::node>(*fibfct);
-  this->lambda_test = &rvsdg::AssertGetOwnerNode<lambda::node>(*testfct);
+  this->lambda_fib = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*fibfct);
+  this->lambda_test = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*testfct);
 
   this->gamma = gammaNode;
   this->phi = phiNode;
@@ -2250,11 +2239,12 @@ PhiTest2::SetupRvsdg()
 
   auto SetupEight = [&]()
   {
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        constantFunctionType,
-        "eight",
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(
+            constantFunctionType,
+            "eight",
+            linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -2265,11 +2255,9 @@ PhiTest2::SetupRvsdg()
 
   auto SetupI = [&]()
   {
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        functionIType,
-        "i",
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionIType, "i", linkage::external_linkage));
     auto pointerArgument = lambda->GetFunctionArguments()[0];
     auto functionArgument =
         rvsdg::CreateOpNode<PointerToFunctionOperation>({ pointerArgument }, constantFunctionType)
@@ -2290,7 +2278,9 @@ PhiTest2::SetupRvsdg()
   auto SetupA =
       [&](jlm::rvsdg::Region & region, phi::rvargument & functionB, phi::rvargument & functionD)
   {
-    auto lambda = lambda::node::create(&region, recFunctionType, "a", linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        region,
+        llvm::LlvmLambdaOperation::Create(recFunctionType, "a", linkage::external_linkage));
     auto pointerArgument = lambda->GetFunctionArguments()[0];
     auto iOStateArgument = lambda->GetFunctionArguments()[1];
     auto memoryStateArgument = lambda->GetFunctionArguments()[2];
@@ -2333,7 +2323,9 @@ PhiTest2::SetupRvsdg()
                     phi::rvargument & functionC,
                     phi::cvargument & functionEight)
   {
-    auto lambda = lambda::node::create(&region, recFunctionType, "b", linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        region,
+        llvm::LlvmLambdaOperation::Create(recFunctionType, "b", linkage::external_linkage));
     auto pointerArgument = lambda->GetFunctionArguments()[0];
     auto iOStateArgument = lambda->GetFunctionArguments()[1];
     auto memoryStateArgument = lambda->GetFunctionArguments()[2];
@@ -2377,7 +2369,9 @@ PhiTest2::SetupRvsdg()
 
   auto SetupC = [&](jlm::rvsdg::Region & region, phi::rvargument & functionA)
   {
-    auto lambda = lambda::node::create(&region, recFunctionType, "c", linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        region,
+        llvm::LlvmLambdaOperation::Create(recFunctionType, "c", linkage::external_linkage));
     auto xArgument = lambda->GetFunctionArguments()[0];
     auto iOStateArgument = lambda->GetFunctionArguments()[1];
     auto memoryStateArgument = lambda->GetFunctionArguments()[2];
@@ -2415,7 +2409,9 @@ PhiTest2::SetupRvsdg()
 
   auto SetupD = [&](jlm::rvsdg::Region & region, phi::rvargument & functionA)
   {
-    auto lambda = lambda::node::create(&region, recFunctionType, "d", linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        region,
+        llvm::LlvmLambdaOperation::Create(recFunctionType, "d", linkage::external_linkage));
     auto xArgument = lambda->GetFunctionArguments()[0];
     auto iOStateArgument = lambda->GetFunctionArguments()[1];
     auto memoryStateArgument = lambda->GetFunctionArguments()[2];
@@ -2497,11 +2493,9 @@ PhiTest2::SetupRvsdg()
         { IOStateType::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        functionType,
-        "test",
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "test", linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -2551,13 +2545,13 @@ PhiTest2::SetupRvsdg()
   /*
    * Assign nodes
    */
-  this->LambdaEight_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaEight);
-  this->LambdaI_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaI);
-  this->LambdaA_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaA->result()->origin());
-  this->LambdaB_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaB->result()->origin());
-  this->LambdaC_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaC->result()->origin());
-  this->LambdaD_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaD->result()->origin());
-  this->LambdaTest_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaTest);
+  this->LambdaEight_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaEight);
+  this->LambdaI_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaI);
+  this->LambdaA_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaA->result()->origin());
+  this->LambdaB_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaB->result()->origin());
+  this->LambdaC_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaC->result()->origin());
+  this->LambdaD_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaD->result()->origin());
+  this->LambdaTest_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaTest);
 
   this->CallAFromTest_ = callAFromTest;
   this->CallAFromC_ = callAFromC;
@@ -2636,7 +2630,9 @@ ExternalMemoryTest::SetupRvsdg()
   /**
    * Setup function f.
    */
-  LambdaF = lambda::node::create(&graph->GetRootRegion(), ft, "f", linkage::external_linkage);
+  LambdaF = rvsdg::LambdaNode::Create(
+      graph->GetRootRegion(),
+      llvm::LlvmLambdaOperation::Create(ft, "f", linkage::external_linkage));
   auto x = LambdaF->GetFunctionArguments()[0];
   auto y = LambdaF->GetFunctionArguments()[1];
   auto state = LambdaF->GetFunctionArguments()[2];
@@ -2737,11 +2733,9 @@ EscapedMemoryTest1::SetupRvsdg()
         { PointerType::Create(), IOStateType::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda = lambda::node::create(
-        &rvsdg->GetRootRegion(),
-        functionType,
-        "test",
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        rvsdg->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "test", linkage::external_linkage));
     auto pointerArgument = lambda->GetFunctionArguments()[0];
     auto iOStateArgument = lambda->GetFunctionArguments()[1];
     auto memoryStateArgument = lambda->GetFunctionArguments()[2];
@@ -2779,7 +2773,7 @@ EscapedMemoryTest1::SetupRvsdg()
   /*
    * Assign nodes
    */
-  this->LambdaTest = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaTest);
+  this->LambdaTest = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaTest);
 
   this->DeltaA = deltaA->node();
   this->DeltaB = deltaB->node();
@@ -2840,11 +2834,12 @@ EscapedMemoryTest2::SetupRvsdg()
         { IOStateType::Create(), MemoryStateType::Create() },
         { PointerType::Create(), IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda = lambda::node::create(
-        &rvsdg->GetRootRegion(),
-        functionType,
-        "ReturnAddress",
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        rvsdg->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(
+            functionType,
+            "ReturnAddress",
+            linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -2869,11 +2864,12 @@ EscapedMemoryTest2::SetupRvsdg()
         { IOStateType::Create(), MemoryStateType::Create() },
         { IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda = lambda::node::create(
-        &rvsdg->GetRootRegion(),
-        functionType,
-        "CallExternalFunction1",
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        rvsdg->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(
+            functionType,
+            "CallExternalFunction1",
+            linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -2905,11 +2901,12 @@ EscapedMemoryTest2::SetupRvsdg()
         { IOStateType::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda = lambda::node::create(
-        &rvsdg->GetRootRegion(),
-        functionType,
-        "CallExternalFunction2",
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        rvsdg->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(
+            functionType,
+            "CallExternalFunction2",
+            linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -2949,9 +2946,12 @@ EscapedMemoryTest2::SetupRvsdg()
   /*
    * Assign nodes
    */
-  this->ReturnAddressFunction = &rvsdg::AssertGetOwnerNode<lambda::node>(*returnAddressFunction);
-  this->CallExternalFunction1 = &rvsdg::AssertGetOwnerNode<lambda::node>(*callExternalFunction1);
-  this->CallExternalFunction2 = &rvsdg::AssertGetOwnerNode<lambda::node>(*callExternalFunction2);
+  this->ReturnAddressFunction =
+      &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*returnAddressFunction);
+  this->CallExternalFunction1 =
+      &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*callExternalFunction1);
+  this->CallExternalFunction2 =
+      &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*callExternalFunction2);
 
   this->ExternalFunction1Call = externalFunction1Call;
   this->ExternalFunction2Call = externalFunction2Call;
@@ -3019,11 +3019,9 @@ EscapedMemoryTest3::SetupRvsdg()
         { IOStateType::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda = lambda::node::create(
-        &rvsdg->GetRootRegion(),
-        functionType,
-        "test",
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        rvsdg->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "test", linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -3057,7 +3055,7 @@ EscapedMemoryTest3::SetupRvsdg()
   auto [lambdaTest, callExternalFunction, loadNode] = SetupTestFunction(importExternalFunction);
 
   // Assign nodes
-  this->LambdaTest = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaTest);
+  this->LambdaTest = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaTest);
   this->DeltaGlobal = deltaGlobal->node();
   this->ImportExternalFunction = importExternalFunction;
   this->CallExternalFunction = callExternalFunction;
@@ -3128,8 +3126,9 @@ MemcpyTest::SetupRvsdg()
         { IOStateType::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda =
-        lambda::node::create(&rvsdg->GetRootRegion(), functionType, "f", linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        rvsdg->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "f", linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -3166,8 +3165,9 @@ MemcpyTest::SetupRvsdg()
         { IOStateType::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda =
-        lambda::node::create(&rvsdg->GetRootRegion(), functionType, "g", linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        rvsdg->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "g", linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -3188,7 +3188,7 @@ MemcpyTest::SetupRvsdg()
 
     auto & call = CallNode::CreateNode(
         functionFArgument,
-        rvsdg::AssertGetOwnerNode<lambda::node>(lambdaF).GetOperation().Type(),
+        rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(lambdaF).GetOperation().Type(),
         { iOStateArgument, memcpyResults[0] });
 
     auto lambdaOutput = lambda->finalize(call.Results());
@@ -3206,8 +3206,8 @@ MemcpyTest::SetupRvsdg()
   /*
    * Assign nodes
    */
-  this->LambdaF_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaF);
-  this->LambdaG_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaG);
+  this->LambdaF_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaF);
+  this->LambdaG_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaG);
   this->LocalArray_ = localArray->node();
   this->GlobalArray_ = globalArray->node();
   this->CallF_ = callF;
@@ -3241,8 +3241,9 @@ MemcpyTest2::SetupRvsdg()
           MemoryStateType::Create() },
         { IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda =
-        lambda::node::create(&rvsdg->GetRootRegion(), functionType, "g", linkage::internal_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        rvsdg->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "g", linkage::internal_linkage));
     auto s1Argument = lambda->GetFunctionArguments()[0];
     auto s2Argument = lambda->GetFunctionArguments()[1];
     auto iOStateArgument = lambda->GetFunctionArguments()[2];
@@ -3277,8 +3278,9 @@ MemcpyTest2::SetupRvsdg()
           MemoryStateType::Create() },
         { IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda =
-        lambda::node::create(&rvsdg->GetRootRegion(), functionType, "f", linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        rvsdg->GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "f", linkage::external_linkage));
     auto s1Argument = lambda->GetFunctionArguments()[0];
     auto s2Argument = lambda->GetFunctionArguments()[1];
     auto iOStateArgument = lambda->GetFunctionArguments()[2];
@@ -3296,7 +3298,7 @@ MemcpyTest2::SetupRvsdg()
 
     auto & call = CallNode::CreateNode(
         functionFArgument,
-        rvsdg::AssertGetOwnerNode<lambda::node>(functionF).GetOperation().Type(),
+        rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(functionF).GetOperation().Type(),
         { ldS1[0], ldS2[0], iOStateArgument, ldS2[1] });
 
     auto lambdaOutput = lambda->finalize(call.Results());
@@ -3309,8 +3311,8 @@ MemcpyTest2::SetupRvsdg()
   auto [lambdaG, memcpyNode] = SetupFunctionG();
   auto [lambdaF, callG] = SetupFunctionF(*lambdaG);
 
-  this->LambdaF_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaF);
-  this->LambdaG_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaG);
+  this->LambdaF_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaF);
+  this->LambdaG_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaG);
   this->CallG_ = callG;
   this->Memcpy_ = memcpyNode;
 
@@ -3336,8 +3338,9 @@ MemcpyTest3::SetupRvsdg()
       { PointerType::Create(), IOStateType::Create(), MemoryStateType::Create() },
       { IOStateType::Create(), MemoryStateType::Create() });
 
-  Lambda_ =
-      lambda::node::create(&rvsdg->GetRootRegion(), functionType, "f", linkage::internal_linkage);
+  Lambda_ = rvsdg::LambdaNode::Create(
+      rvsdg->GetRootRegion(),
+      llvm::LlvmLambdaOperation::Create(functionType, "f", linkage::internal_linkage));
   auto pArgument = Lambda_->GetFunctionArguments()[0];
   auto iOStateArgument = Lambda_->GetFunctionArguments()[1];
   auto memoryStateArgument = Lambda_->GetFunctionArguments()[2];
@@ -3413,11 +3416,9 @@ LinkedListTest::SetupRvsdg()
         { IOStateType::Create(), MemoryStateType::Create() },
         { PointerType::Create(), IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda = lambda::node::create(
-        &rvsdg.GetRootRegion(),
-        functionType,
-        "next",
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        rvsdg.GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "next", linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -3454,7 +3455,7 @@ LinkedListTest::SetupRvsdg()
    * Assign nodes
    */
   this->DeltaMyList_ = deltaMyList->node();
-  this->LambdaNext_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaNext);
+  this->LambdaNext_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaNext);
   this->Alloca_ = alloca;
 
   return rvsdgModule;
@@ -3494,7 +3495,9 @@ AllMemoryNodesTest::SetupRvsdg()
   Delta_->finalize(constantPointerNullResult);
 
   // Start of function "f"
-  Lambda_ = lambda::node::create(&graph->GetRootRegion(), fcttype, "f", linkage::external_linkage);
+  Lambda_ = rvsdg::LambdaNode::Create(
+      graph->GetRootRegion(),
+      llvm::LlvmLambdaOperation::Create(fcttype, "f", linkage::external_linkage));
   auto entryMemoryState = Lambda_->GetFunctionArguments()[0];
   auto deltaContextVar = Lambda_->AddContextVar(*Delta_->output()).inner;
   auto importContextVar = Lambda_->AddContextVar(*Import_).inner;
@@ -3569,8 +3572,9 @@ NAllocaNodesTest::SetupRvsdg()
   auto module = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto graph = &module->Rvsdg();
 
-  Function_ =
-      lambda::node::create(&graph->GetRootRegion(), fcttype, "f", linkage::external_linkage);
+  Function_ = rvsdg::LambdaNode::Create(
+      graph->GetRootRegion(),
+      llvm::LlvmLambdaOperation::Create(fcttype, "f", linkage::external_linkage));
 
   auto allocaSize = jlm::rvsdg::create_bitconstant(Function_->subregion(), 32, 1);
 
@@ -3623,11 +3627,9 @@ EscapingLocalFunctionTest::SetupRvsdg()
   const auto constantZero = rvsdg::create_bitconstant(Global_->subregion(), 32, 0);
   const auto deltaOutput = Global_->finalize(constantZero);
 
-  LocalFunc_ = lambda::node::create(
-      &graph->GetRootRegion(),
-      localFuncType,
-      "localFunction",
-      linkage::internal_linkage);
+  LocalFunc_ = rvsdg::LambdaNode::Create(
+      graph->GetRootRegion(),
+      llvm::LlvmLambdaOperation::Create(localFuncType, "localFunction", linkage::internal_linkage));
 
   LocalFuncParam_ = LocalFunc_->GetFunctionArguments()[0];
 
@@ -3653,11 +3655,12 @@ EscapingLocalFunctionTest::SetupRvsdg()
       rvsdg::CreateOpNode<FunctionToPointerOperation>({ LocalFunc_->output() }, localFuncType)
           .output(0);
 
-  ExportedFunc_ = lambda::node::create(
-      &graph->GetRootRegion(),
-      exportedFuncType,
-      "exportedFunc",
-      linkage::external_linkage);
+  ExportedFunc_ = rvsdg::LambdaNode::Create(
+      graph->GetRootRegion(),
+      llvm::LlvmLambdaOperation::Create(
+          exportedFuncType,
+          "exportedFunc",
+          linkage::external_linkage));
 
   const auto localFuncCtxVar = ExportedFunc_->AddContextVar(*LocalFuncRegister_).inner;
 
@@ -3681,11 +3684,9 @@ FreeNullTest::SetupRvsdg()
   auto module = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto graph = &module->Rvsdg();
 
-  LambdaMain_ = lambda::node::create(
-      &graph->GetRootRegion(),
-      functionType,
-      "main",
-      linkage::external_linkage);
+  LambdaMain_ = rvsdg::LambdaNode::Create(
+      graph->GetRootRegion(),
+      llvm::LlvmLambdaOperation::Create(functionType, "main", linkage::external_linkage));
   auto iOStateArgument = LambdaMain_->GetFunctionArguments()[0];
   auto memoryStateArgument = LambdaMain_->GetFunctionArguments()[1];
 
@@ -3726,8 +3727,9 @@ LambdaCallArgumentMismatch::SetupRvsdg()
     auto iOStateType = IOStateType::Create();
     auto memoryStateType = MemoryStateType::Create();
 
-    auto lambda =
-        lambda::node::create(&rvsdg.GetRootRegion(), functionType, "g", linkage::internal_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        rvsdg.GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionType, "g", linkage::internal_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -3745,11 +3747,9 @@ LambdaCallArgumentMismatch::SetupRvsdg()
         { IOStateType::Create(), MemoryStateType::Create() },
         { rvsdg::bittype::Create(32), IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda = lambda::node::create(
-        &rvsdg.GetRootRegion(),
-        functionTypeMain,
-        "main",
-        linkage::external_linkage);
+    auto lambda = rvsdg::LambdaNode::Create(
+        rvsdg.GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(functionTypeMain, "main", linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
     auto lambdaGArgument = lambda->AddContextVar(lambdaG).inner;
@@ -3781,7 +3781,7 @@ LambdaCallArgumentMismatch::SetupRvsdg()
     return std::make_tuple(lambdaOutput, &call);
   };
 
-  LambdaG_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*setupLambdaG());
+  LambdaG_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*setupLambdaG());
 
   // Formal arguments and call arguments do not match. Force conversion through pointer
   // to hide the mismatch, the call operator would complain otherwise.
@@ -3792,7 +3792,7 @@ LambdaCallArgumentMismatch::SetupRvsdg()
   auto fn =
       jlm::rvsdg::CreateOpNode<PointerToFunctionOperation>({ ptr }, functionTypeCall).output(0);
   auto [lambdaMainOutput, call] = setupLambdaMain(*fn);
-  LambdaMain_ = &rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaMainOutput);
+  LambdaMain_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaMainOutput);
   Call_ = call;
 
   return rvsdgModule;
@@ -3828,8 +3828,9 @@ VariadicFunctionTest1::SetupRvsdg()
 
   // Setup f()
   {
-    LambdaF_ =
-        lambda::node::create(&rvsdg.GetRootRegion(), lambdaFType, "f", linkage::internal_linkage);
+    LambdaF_ = rvsdg::LambdaNode::Create(
+        rvsdg.GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(lambdaFType, "f", linkage::internal_linkage));
     auto iArgument = LambdaF_->GetFunctionArguments()[0];
     auto iOStateArgument = LambdaF_->GetFunctionArguments()[1];
     auto memoryStateArgument = LambdaF_->GetFunctionArguments()[2];
@@ -3856,8 +3857,9 @@ VariadicFunctionTest1::SetupRvsdg()
 
   // Setup g()
   {
-    LambdaG_ =
-        lambda::node::create(&rvsdg.GetRootRegion(), lambdaGType, "g", linkage::external_linkage);
+    LambdaG_ = rvsdg::LambdaNode::Create(
+        rvsdg.GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(lambdaGType, "g", linkage::external_linkage));
     auto iOStateArgument = LambdaG_->GetFunctionArguments()[0];
     auto memoryStateArgument = LambdaG_->GetFunctionArguments()[1];
     auto lambdaFArgument = LambdaG_->AddContextVar(*LambdaF_->output()).inner;
@@ -3954,11 +3956,9 @@ VariadicFunctionTest2::SetupRvsdg()
 
   // Setup function fst()
   {
-    LambdaFst_ = lambda::node::create(
-        &rvsdg.GetRootRegion(),
-        lambdaFstType,
-        "fst",
-        linkage::internal_linkage);
+    LambdaFst_ = rvsdg::LambdaNode::Create(
+        rvsdg.GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(lambdaFstType, "fst", linkage::internal_linkage));
     auto iOStateArgument = LambdaFst_->GetFunctionArguments()[2];
     auto memoryStateArgument = LambdaFst_->GetFunctionArguments()[3];
     auto llvmLifetimeStartArgument = LambdaFst_->AddContextVar(*llvmLifetimeStart).inner;
@@ -4077,8 +4077,9 @@ VariadicFunctionTest2::SetupRvsdg()
 
   // Setup function g()
   {
-    LambdaG_ =
-        lambda::node::create(&rvsdg.GetRootRegion(), lambdaGType, "g", linkage::external_linkage);
+    LambdaG_ = rvsdg::LambdaNode::Create(
+        rvsdg.GetRootRegion(),
+        llvm::LlvmLambdaOperation::Create(lambdaGType, "g", linkage::external_linkage));
     auto iOStateArgument = LambdaG_->GetFunctionArguments()[0];
     auto memoryStateArgument = LambdaG_->GetFunctionArguments()[1];
     auto lambdaFstArgument = LambdaG_->AddContextVar(*LambdaFst_->output()).inner;

--- a/tests/TestRvsdgs.hpp
+++ b/tests/TestRvsdgs.hpp
@@ -81,7 +81,7 @@ private:
   SetupRvsdg() override;
 
 public:
-  jlm::llvm::lambda::node * lambda;
+  jlm::rvsdg::LambdaNode * lambda;
 
   rvsdg::Node * size;
 
@@ -119,7 +119,7 @@ private:
   SetupRvsdg() override;
 
 public:
-  jlm::llvm::lambda::node * lambda;
+  jlm::rvsdg::LambdaNode * lambda;
 
   rvsdg::Node * size;
 
@@ -153,7 +153,7 @@ private:
   SetupRvsdg() override;
 
 public:
-  jlm::llvm::lambda::node * lambda;
+  jlm::rvsdg::LambdaNode * lambda;
 
   rvsdg::Node * load_p;
   rvsdg::Node * load_x;
@@ -187,7 +187,7 @@ private:
   SetupRvsdg() override;
 
 public:
-  jlm::llvm::lambda::node * lambda;
+  jlm::rvsdg::LambdaNode * lambda;
 
   rvsdg::Node * size;
 
@@ -223,7 +223,7 @@ private:
   SetupRvsdg() override;
 
 public:
-  [[nodiscard]] const jlm::llvm::lambda::node &
+  [[nodiscard]] const jlm::rvsdg::LambdaNode &
   Lambda() const noexcept
   {
     return *Lambda_;
@@ -236,7 +236,7 @@ public:
   }
 
 private:
-  jlm::llvm::lambda::node * Lambda_;
+  jlm::rvsdg::LambdaNode * Lambda_;
   rvsdg::Node * UndefValueNode_;
 };
 
@@ -266,7 +266,7 @@ private:
   SetupRvsdg() override;
 
 public:
-  jlm::llvm::lambda::node * lambda;
+  jlm::rvsdg::LambdaNode * lambda;
 
   rvsdg::Node * getElementPtrX;
   rvsdg::Node * getElementPtrY;
@@ -290,7 +290,7 @@ private:
   SetupRvsdg() override;
 
 public:
-  jlm::llvm::lambda::node * lambda;
+  jlm::rvsdg::LambdaNode * lambda;
 
   rvsdg::Node * bitCast;
 };
@@ -318,13 +318,13 @@ public:
 class Bits2PtrTest final : public RvsdgTest
 {
 public:
-  [[nodiscard]] const jlm::llvm::lambda::node &
+  [[nodiscard]] const jlm::rvsdg::LambdaNode &
   GetLambdaBits2Ptr() const noexcept
   {
     return *LambdaBits2Ptr_;
   }
 
-  [[nodiscard]] const jlm::llvm::lambda::node &
+  [[nodiscard]] const jlm::rvsdg::LambdaNode &
   GetLambdaTest() const noexcept
   {
     return *LambdaTest_;
@@ -346,8 +346,8 @@ private:
   std::unique_ptr<jlm::llvm::RvsdgModule>
   SetupRvsdg() override;
 
-  jlm::llvm::lambda::node * LambdaBits2Ptr_;
-  jlm::llvm::lambda::node * LambdaTest_;
+  jlm::rvsdg::LambdaNode * LambdaBits2Ptr_;
+  jlm::rvsdg::LambdaNode * LambdaTest_;
 
   rvsdg::Node * BitsToPtrNode_;
 
@@ -372,7 +372,7 @@ private:
   SetupRvsdg() override;
 
 public:
-  jlm::llvm::lambda::node * lambda;
+  jlm::rvsdg::LambdaNode * lambda;
 
   rvsdg::Node * constantPointerNullNode;
 };
@@ -424,9 +424,9 @@ public:
     return *CallG_;
   }
 
-  jlm::llvm::lambda::node * lambda_f;
-  jlm::llvm::lambda::node * lambda_g;
-  jlm::llvm::lambda::node * lambda_h;
+  jlm::rvsdg::LambdaNode * lambda_f;
+  jlm::rvsdg::LambdaNode * lambda_g;
+  jlm::rvsdg::LambdaNode * lambda_h;
 
   rvsdg::Node * alloca_x;
   rvsdg::Node * alloca_y;
@@ -495,9 +495,9 @@ public:
     return *CallDestroy2_;
   }
 
-  jlm::llvm::lambda::node * lambda_create;
-  jlm::llvm::lambda::node * lambda_destroy;
-  jlm::llvm::lambda::node * lambda_test;
+  jlm::rvsdg::LambdaNode * lambda_create;
+  jlm::rvsdg::LambdaNode * lambda_destroy;
+  jlm::rvsdg::LambdaNode * lambda_test;
 
   rvsdg::Node * malloc;
   rvsdg::Node * free;
@@ -567,25 +567,25 @@ public:
     return *CallFour_;
   }
 
-  [[nodiscard]] const jlm::llvm::lambda::node &
+  [[nodiscard]] const jlm::rvsdg::LambdaNode &
   GetLambdaThree() const noexcept
   {
     return *LambdaThree_;
   }
 
-  [[nodiscard]] const jlm::llvm::lambda::node &
+  [[nodiscard]] const jlm::rvsdg::LambdaNode &
   GetLambdaFour() const noexcept
   {
     return *LambdaFour_;
   }
 
-  [[nodiscard]] const jlm::llvm::lambda::node &
+  [[nodiscard]] const jlm::rvsdg::LambdaNode &
   GetLambdaIndcall() const noexcept
   {
     return *LambdaIndcall_;
   }
 
-  [[nodiscard]] const jlm::llvm::lambda::node &
+  [[nodiscard]] const jlm::rvsdg::LambdaNode &
   GetLambdaTest() const noexcept
   {
     return *LambdaTest_;
@@ -599,10 +599,10 @@ private:
   jlm::llvm::CallNode * CallThree_;
   jlm::llvm::CallNode * CallFour_;
 
-  jlm::llvm::lambda::node * LambdaThree_;
-  jlm::llvm::lambda::node * LambdaFour_;
-  jlm::llvm::lambda::node * LambdaIndcall_;
-  jlm::llvm::lambda::node * LambdaTest_;
+  jlm::rvsdg::LambdaNode * LambdaThree_;
+  jlm::rvsdg::LambdaNode * LambdaFour_;
+  jlm::rvsdg::LambdaNode * LambdaIndcall_;
+  jlm::rvsdg::LambdaNode * LambdaTest_;
 };
 
 /** \brief IndirectCallTest2 class
@@ -682,43 +682,43 @@ public:
     return *DeltaG2_;
   }
 
-  [[nodiscard]] jlm::llvm::lambda::node &
+  [[nodiscard]] jlm::rvsdg::LambdaNode &
   GetLambdaThree() const noexcept
   {
     return *LambdaThree_;
   }
 
-  [[nodiscard]] jlm::llvm::lambda::node &
+  [[nodiscard]] jlm::rvsdg::LambdaNode &
   GetLambdaFour() const noexcept
   {
     return *LambdaFour_;
   }
 
-  [[nodiscard]] jlm::llvm::lambda::node &
+  [[nodiscard]] jlm::rvsdg::LambdaNode &
   GetLambdaI() const noexcept
   {
     return *LambdaI_;
   }
 
-  [[nodiscard]] jlm::llvm::lambda::node &
+  [[nodiscard]] jlm::rvsdg::LambdaNode &
   GetLambdaX() const noexcept
   {
     return *LambdaX_;
   }
 
-  [[nodiscard]] jlm::llvm::lambda::node &
+  [[nodiscard]] jlm::rvsdg::LambdaNode &
   GetLambdaY() const noexcept
   {
     return *LambdaY_;
   }
 
-  [[nodiscard]] jlm::llvm::lambda::node &
+  [[nodiscard]] jlm::rvsdg::LambdaNode &
   GetLambdaTest() const noexcept
   {
     return *LambdaTest_;
   }
 
-  [[nodiscard]] jlm::llvm::lambda::node &
+  [[nodiscard]] jlm::rvsdg::LambdaNode &
   GetLambdaTest2() const noexcept
   {
     return *LambdaTest2_;
@@ -785,13 +785,13 @@ private:
   jlm::llvm::delta::node * DeltaG1_;
   jlm::llvm::delta::node * DeltaG2_;
 
-  jlm::llvm::lambda::node * LambdaThree_;
-  jlm::llvm::lambda::node * LambdaFour_;
-  jlm::llvm::lambda::node * LambdaI_;
-  jlm::llvm::lambda::node * LambdaX_;
-  jlm::llvm::lambda::node * LambdaY_;
-  jlm::llvm::lambda::node * LambdaTest_;
-  jlm::llvm::lambda::node * LambdaTest2_;
+  jlm::rvsdg::LambdaNode * LambdaThree_;
+  jlm::rvsdg::LambdaNode * LambdaFour_;
+  jlm::rvsdg::LambdaNode * LambdaI_;
+  jlm::rvsdg::LambdaNode * LambdaX_;
+  jlm::rvsdg::LambdaNode * LambdaY_;
+  jlm::rvsdg::LambdaNode * LambdaTest_;
+  jlm::rvsdg::LambdaNode * LambdaTest2_;
 
   jlm::llvm::CallNode * IndirectCall_;
   jlm::llvm::CallNode * CallIWithThree_;
@@ -825,7 +825,7 @@ private:
 class ExternalCallTest1 final : public RvsdgTest
 {
 public:
-  [[nodiscard]] const jlm::llvm::lambda::node &
+  [[nodiscard]] const jlm::rvsdg::LambdaNode &
   LambdaF() const noexcept
   {
     return *LambdaF_;
@@ -847,7 +847,7 @@ private:
   std::unique_ptr<jlm::llvm::RvsdgModule>
   SetupRvsdg() override;
 
-  jlm::llvm::lambda::node * LambdaF_;
+  jlm::rvsdg::LambdaNode * LambdaF_;
 
   jlm::llvm::CallNode * CallG_;
 
@@ -887,7 +887,7 @@ private:
 class ExternalCallTest2 final : public RvsdgTest
 {
 public:
-  [[nodiscard]] jlm::llvm::lambda::node &
+  [[nodiscard]] jlm::rvsdg::LambdaNode &
   LambdaG()
   {
     JLM_ASSERT(LambdaG_ != nullptr);
@@ -912,7 +912,7 @@ private:
   std::unique_ptr<jlm::llvm::RvsdgModule>
   SetupRvsdg() override;
 
-  jlm::llvm::lambda::node * LambdaG_ = {};
+  jlm::rvsdg::LambdaNode * LambdaG_ = {};
 
   jlm::llvm::CallNode * CallF_ = {};
 
@@ -948,7 +948,7 @@ private:
   SetupRvsdg() override;
 
 public:
-  jlm::llvm::lambda::node * lambda;
+  jlm::rvsdg::LambdaNode * lambda;
 
   rvsdg::GammaNode * gamma;
 };
@@ -1002,19 +1002,19 @@ public:
 class GammaTest2 final : public RvsdgTest
 {
 public:
-  [[nodiscard]] llvm::lambda::node &
+  [[nodiscard]] rvsdg::LambdaNode &
   GetLambdaF() const noexcept
   {
     return *LambdaF_;
   }
 
-  [[nodiscard]] llvm::lambda::node &
+  [[nodiscard]] rvsdg::LambdaNode &
   GetLambdaG() const noexcept
   {
     return *LambdaG_;
   }
 
-  [[nodiscard]] llvm::lambda::node &
+  [[nodiscard]] rvsdg::LambdaNode &
   GetLambdaH() const noexcept
   {
     return *LambdaH_;
@@ -1072,9 +1072,9 @@ private:
   std::unique_ptr<llvm::RvsdgModule>
   SetupRvsdg() override;
 
-  llvm::lambda::node * LambdaF_;
-  llvm::lambda::node * LambdaG_;
-  llvm::lambda::node * LambdaH_;
+  rvsdg::LambdaNode * LambdaF_;
+  rvsdg::LambdaNode * LambdaG_;
+  rvsdg::LambdaNode * LambdaH_;
 
   rvsdg::GammaNode * Gamma_;
 
@@ -1112,7 +1112,7 @@ private:
   SetupRvsdg() override;
 
 public:
-  jlm::llvm::lambda::node * lambda;
+  jlm::rvsdg::LambdaNode * lambda;
   jlm::rvsdg::ThetaNode * theta;
   rvsdg::Node * gep;
 };
@@ -1150,8 +1150,8 @@ public:
     return *CallG_;
   }
 
-  jlm::llvm::lambda::node * lambda_g;
-  jlm::llvm::lambda::node * lambda_h;
+  jlm::rvsdg::LambdaNode * lambda_g;
+  jlm::rvsdg::LambdaNode * lambda_h;
 
   jlm::llvm::delta::node * delta_f;
 
@@ -1199,8 +1199,8 @@ public:
     return *CallF1_;
   }
 
-  jlm::llvm::lambda::node * lambda_f1;
-  jlm::llvm::lambda::node * lambda_f2;
+  jlm::rvsdg::LambdaNode * lambda_f1;
+  jlm::rvsdg::LambdaNode * lambda_f2;
 
   jlm::llvm::delta::node * delta_d1;
   jlm::llvm::delta::node * delta_d2;
@@ -1240,13 +1240,13 @@ private:
 class DeltaTest3 final : public RvsdgTest
 {
 public:
-  [[nodiscard]] const jlm::llvm::lambda::node &
+  [[nodiscard]] const jlm::rvsdg::LambdaNode &
   LambdaF() const noexcept
   {
     return *LambdaF_;
   }
 
-  [[nodiscard]] const jlm::llvm::lambda::node &
+  [[nodiscard]] const jlm::rvsdg::LambdaNode &
   LambdaTest() const noexcept
   {
     return *LambdaTest_;
@@ -1274,8 +1274,8 @@ private:
   std::unique_ptr<jlm::llvm::RvsdgModule>
   SetupRvsdg() override;
 
-  jlm::llvm::lambda::node * LambdaF_;
-  jlm::llvm::lambda::node * LambdaTest_;
+  jlm::rvsdg::LambdaNode * LambdaF_;
+  jlm::rvsdg::LambdaNode * LambdaTest_;
 
   jlm::llvm::delta::node * DeltaG1_;
   jlm::llvm::delta::node * DeltaG2_;
@@ -1318,8 +1318,8 @@ public:
     return *CallF1_;
   }
 
-  jlm::llvm::lambda::node * lambda_f1;
-  jlm::llvm::lambda::node * lambda_f2;
+  jlm::rvsdg::LambdaNode * lambda_f1;
+  jlm::rvsdg::LambdaNode * lambda_f2;
 
   jlm::rvsdg::RegionArgument * import_d1;
   jlm::rvsdg::RegionArgument * import_d2;
@@ -1383,8 +1383,8 @@ public:
     return *CallFibm2_;
   }
 
-  jlm::llvm::lambda::node * lambda_fib;
-  jlm::llvm::lambda::node * lambda_test;
+  jlm::rvsdg::LambdaNode * lambda_fib;
+  jlm::rvsdg::LambdaNode * lambda_test;
 
   rvsdg::GammaNode * gamma;
 
@@ -1476,43 +1476,43 @@ private:
 class PhiTest2 final : public RvsdgTest
 {
 public:
-  [[nodiscard]] jlm::llvm::lambda::node &
+  [[nodiscard]] jlm::rvsdg::LambdaNode &
   GetLambdaEight() const noexcept
   {
     return *LambdaEight_;
   }
 
-  [[nodiscard]] jlm::llvm::lambda::node &
+  [[nodiscard]] jlm::rvsdg::LambdaNode &
   GetLambdaI() const noexcept
   {
     return *LambdaI_;
   }
 
-  [[nodiscard]] jlm::llvm::lambda::node &
+  [[nodiscard]] jlm::rvsdg::LambdaNode &
   GetLambdaA() const noexcept
   {
     return *LambdaA_;
   }
 
-  [[nodiscard]] jlm::llvm::lambda::node &
+  [[nodiscard]] jlm::rvsdg::LambdaNode &
   GetLambdaB() const noexcept
   {
     return *LambdaB_;
   }
 
-  [[nodiscard]] jlm::llvm::lambda::node &
+  [[nodiscard]] jlm::rvsdg::LambdaNode &
   GetLambdaC() const noexcept
   {
     return *LambdaC_;
   }
 
-  [[nodiscard]] jlm::llvm::lambda::node &
+  [[nodiscard]] jlm::rvsdg::LambdaNode &
   GetLambdaD() const noexcept
   {
     return *LambdaD_;
   }
 
-  [[nodiscard]] jlm::llvm::lambda::node &
+  [[nodiscard]] jlm::rvsdg::LambdaNode &
   GetLambdaTest() const noexcept
   {
     return *LambdaTest_;
@@ -1600,13 +1600,13 @@ private:
   std::unique_ptr<jlm::llvm::RvsdgModule>
   SetupRvsdg() override;
 
-  jlm::llvm::lambda::node * LambdaEight_;
-  jlm::llvm::lambda::node * LambdaI_;
-  jlm::llvm::lambda::node * LambdaA_;
-  jlm::llvm::lambda::node * LambdaB_;
-  jlm::llvm::lambda::node * LambdaC_;
-  jlm::llvm::lambda::node * LambdaD_;
-  jlm::llvm::lambda::node * LambdaTest_;
+  jlm::rvsdg::LambdaNode * LambdaEight_;
+  jlm::rvsdg::LambdaNode * LambdaI_;
+  jlm::rvsdg::LambdaNode * LambdaA_;
+  jlm::rvsdg::LambdaNode * LambdaB_;
+  jlm::rvsdg::LambdaNode * LambdaC_;
+  jlm::rvsdg::LambdaNode * LambdaD_;
+  jlm::rvsdg::LambdaNode * LambdaTest_;
 
   jlm::llvm::CallNode * CallAFromTest_;
   jlm::llvm::CallNode * CallAFromC_;
@@ -1679,7 +1679,7 @@ private:
   SetupRvsdg() override;
 
 public:
-  jlm::llvm::lambda::node * LambdaF;
+  jlm::rvsdg::LambdaNode * LambdaF;
 };
 
 /** \brief EscapedMemoryTest1 class
@@ -1711,7 +1711,7 @@ private:
   SetupRvsdg() override;
 
 public:
-  jlm::llvm::lambda::node * LambdaTest;
+  jlm::rvsdg::LambdaNode * LambdaTest;
 
   jlm::llvm::delta::node * DeltaA;
   jlm::llvm::delta::node * DeltaB;
@@ -1760,9 +1760,9 @@ private:
   SetupRvsdg() override;
 
 public:
-  jlm::llvm::lambda::node * ReturnAddressFunction;
-  jlm::llvm::lambda::node * CallExternalFunction1;
-  jlm::llvm::lambda::node * CallExternalFunction2;
+  jlm::rvsdg::LambdaNode * ReturnAddressFunction;
+  jlm::rvsdg::LambdaNode * CallExternalFunction1;
+  jlm::rvsdg::LambdaNode * CallExternalFunction2;
 
   jlm::llvm::CallNode * ExternalFunction1Call;
   jlm::llvm::CallNode * ExternalFunction2Call;
@@ -1800,7 +1800,7 @@ private:
   SetupRvsdg() override;
 
 public:
-  jlm::llvm::lambda::node * LambdaTest;
+  jlm::rvsdg::LambdaNode * LambdaTest;
 
   jlm::llvm::delta::node * DeltaGlobal;
 
@@ -1841,13 +1841,13 @@ public:
 class MemcpyTest final : public RvsdgTest
 {
 public:
-  [[nodiscard]] const jlm::llvm::lambda::node &
+  [[nodiscard]] const jlm::rvsdg::LambdaNode &
   LambdaF() const noexcept
   {
     return *LambdaF_;
   }
 
-  [[nodiscard]] const jlm::llvm::lambda::node &
+  [[nodiscard]] const jlm::rvsdg::LambdaNode &
   LambdaG() const noexcept
   {
     return *LambdaG_;
@@ -1881,8 +1881,8 @@ private:
   std::unique_ptr<jlm::llvm::RvsdgModule>
   SetupRvsdg() override;
 
-  jlm::llvm::lambda::node * LambdaF_;
-  jlm::llvm::lambda::node * LambdaG_;
+  jlm::rvsdg::LambdaNode * LambdaF_;
+  jlm::rvsdg::LambdaNode * LambdaG_;
 
   jlm::llvm::delta::node * LocalArray_;
   jlm::llvm::delta::node * GlobalArray_;
@@ -1925,14 +1925,14 @@ private:
 class MemcpyTest2 final : public RvsdgTest
 {
 public:
-  [[nodiscard]] const jlm::llvm::lambda::node &
+  [[nodiscard]] const jlm::rvsdg::LambdaNode &
   LambdaF() const noexcept
   {
     JLM_ASSERT(LambdaF_ != nullptr);
     return *LambdaF_;
   }
 
-  [[nodiscard]] const jlm::llvm::lambda::node &
+  [[nodiscard]] const jlm::rvsdg::LambdaNode &
   LambdaG() const noexcept
   {
     JLM_ASSERT(LambdaG_ != nullptr);
@@ -1957,8 +1957,8 @@ private:
   std::unique_ptr<jlm::llvm::RvsdgModule>
   SetupRvsdg() override;
 
-  jlm::llvm::lambda::node * LambdaF_ = {};
-  jlm::llvm::lambda::node * LambdaG_ = {};
+  jlm::rvsdg::LambdaNode * LambdaF_ = {};
+  jlm::rvsdg::LambdaNode * LambdaG_ = {};
 
   jlm::llvm::CallNode * CallG_ = {};
 
@@ -1987,7 +1987,7 @@ private:
 class MemcpyTest3 final : public RvsdgTest
 {
 public:
-  [[nodiscard]] const jlm::llvm::lambda::node &
+  [[nodiscard]] const jlm::rvsdg::LambdaNode &
   Lambda() const noexcept
   {
     JLM_ASSERT(Lambda_ != nullptr);
@@ -2012,7 +2012,7 @@ private:
   std::unique_ptr<jlm::llvm::RvsdgModule>
   SetupRvsdg() override;
 
-  jlm::llvm::lambda::node * Lambda_ = {};
+  jlm::rvsdg::LambdaNode * Lambda_ = {};
 
   rvsdg::Node * Alloca_ = {};
 
@@ -2049,7 +2049,7 @@ public:
     return *Alloca_;
   }
 
-  [[nodiscard]] const jlm::llvm::lambda::node &
+  [[nodiscard]] const jlm::rvsdg::LambdaNode &
   GetLambdaNext() const noexcept
   {
     return *LambdaNext_;
@@ -2067,7 +2067,7 @@ private:
 
   jlm::llvm::delta::node * DeltaMyList_;
 
-  jlm::llvm::lambda::node * LambdaNext_;
+  jlm::rvsdg::LambdaNode * LambdaNext_;
 
   rvsdg::Node * Alloca_;
 };
@@ -2115,7 +2115,7 @@ public:
     return *Import_;
   }
 
-  [[nodiscard]] const jlm::llvm::lambda::node &
+  [[nodiscard]] const jlm::rvsdg::LambdaNode &
   GetLambdaNode() const noexcept
   {
     JLM_ASSERT(Lambda_);
@@ -2165,7 +2165,7 @@ private:
 
   jlm::llvm::GraphImport * Import_ = {};
 
-  jlm::llvm::lambda::node * Lambda_ = {};
+  jlm::rvsdg::LambdaNode * Lambda_ = {};
 
   rvsdg::Node * Alloca_ = {};
 
@@ -2215,7 +2215,7 @@ public:
     return *AllocaNodes_[index]->output(0);
   }
 
-  [[nodiscard]] const jlm::llvm::lambda::node &
+  [[nodiscard]] const jlm::rvsdg::LambdaNode &
   GetFunction() const noexcept
   {
     JLM_ASSERT(Function_);
@@ -2230,7 +2230,7 @@ private:
 
   std::vector<const rvsdg::Node *> AllocaNodes_ = {};
 
-  jlm::llvm::lambda::node * Function_;
+  jlm::rvsdg::LambdaNode * Function_;
 };
 
 /** \brief RVSDG module with a static function escaping through another function.
@@ -2265,7 +2265,7 @@ public:
     return *Global_;
   }
 
-  [[nodiscard]] const jlm::llvm::lambda::node &
+  [[nodiscard]] const jlm::rvsdg::LambdaNode &
   GetLocalFunction() const noexcept
   {
     JLM_ASSERT(LocalFunc_);
@@ -2293,7 +2293,7 @@ public:
     return *LocalFuncParamAllocaNode_;
   }
 
-  [[nodiscard]] const jlm::llvm::lambda::node &
+  [[nodiscard]] const jlm::rvsdg::LambdaNode &
   GetExportedFunction() const noexcept
   {
     JLM_ASSERT(ExportedFunc_);
@@ -2305,11 +2305,11 @@ private:
   SetupRvsdg() override;
 
   jlm::llvm::delta::node * Global_ = {};
-  jlm::llvm::lambda::node * LocalFunc_ = {};
+  jlm::rvsdg::LambdaNode * LocalFunc_ = {};
   jlm::rvsdg::output * LocalFuncParam_ = {};
   jlm::rvsdg::output * LocalFuncRegister_ = {};
   rvsdg::Node * LocalFuncParamAllocaNode_ = {};
-  jlm::llvm::lambda::node * ExportedFunc_ = {};
+  jlm::rvsdg::LambdaNode * ExportedFunc_ = {};
 };
 
 /** \brief RVSDG module containing a static function that is called with the wrong number of
@@ -2337,13 +2337,13 @@ private:
 class LambdaCallArgumentMismatch final : public RvsdgTest
 {
 public:
-  [[nodiscard]] const llvm::lambda::node &
+  [[nodiscard]] const rvsdg::LambdaNode &
   GetLambdaMain() const noexcept
   {
     return *LambdaMain_;
   }
 
-  [[nodiscard]] const llvm::lambda::node &
+  [[nodiscard]] const rvsdg::LambdaNode &
   GetLambdaG() const noexcept
   {
     return *LambdaG_;
@@ -2359,8 +2359,8 @@ private:
   std::unique_ptr<llvm::RvsdgModule>
   SetupRvsdg() override;
 
-  llvm::lambda::node * LambdaG_ = {};
-  llvm::lambda::node * LambdaMain_ = {};
+  rvsdg::LambdaNode * LambdaG_ = {};
+  rvsdg::LambdaNode * LambdaMain_ = {};
   llvm::CallNode * Call_ = {};
 };
 
@@ -2382,7 +2382,7 @@ private:
 class FreeNullTest final : public RvsdgTest
 {
 public:
-  [[nodiscard]] llvm::lambda::node &
+  [[nodiscard]] rvsdg::LambdaNode &
   LambdaMain() const noexcept
   {
     return *LambdaMain_;
@@ -2392,7 +2392,7 @@ private:
   std::unique_ptr<llvm::RvsdgModule>
   SetupRvsdg() override;
 
-  llvm::lambda::node * LambdaMain_;
+  rvsdg::LambdaNode * LambdaMain_;
 };
 
 /**
@@ -2424,14 +2424,14 @@ private:
 class VariadicFunctionTest1 final : public RvsdgTest
 {
 public:
-  [[nodiscard]] llvm::lambda::node &
+  [[nodiscard]] rvsdg::LambdaNode &
   GetLambdaF() const noexcept
   {
     JLM_ASSERT(LambdaF_ != nullptr);
     return *LambdaF_;
   }
 
-  [[nodiscard]] llvm::lambda::node &
+  [[nodiscard]] rvsdg::LambdaNode &
   GetLambdaG() const noexcept
   {
     JLM_ASSERT(LambdaG_ != nullptr);
@@ -2463,8 +2463,8 @@ private:
   std::unique_ptr<llvm::RvsdgModule>
   SetupRvsdg() override;
 
-  llvm::lambda::node * LambdaF_ = {};
-  llvm::lambda::node * LambdaG_ = {};
+  rvsdg::LambdaNode * LambdaF_ = {};
+  rvsdg::LambdaNode * LambdaG_ = {};
 
   rvsdg::RegionArgument * ImportH_ = {};
 
@@ -2506,14 +2506,14 @@ private:
 class VariadicFunctionTest2 final : public RvsdgTest
 {
 public:
-  [[nodiscard]] const jlm::llvm::lambda::node &
+  [[nodiscard]] const jlm::rvsdg::LambdaNode &
   GetLambdaFst() const noexcept
   {
     JLM_ASSERT(LambdaFst_ != nullptr);
     return *LambdaFst_;
   }
 
-  [[nodiscard]] const jlm::llvm::lambda::node &
+  [[nodiscard]] const jlm::rvsdg::LambdaNode &
   GetLambdaG() const noexcept
   {
     JLM_ASSERT(LambdaG_ != nullptr);
@@ -2531,8 +2531,8 @@ private:
   std::unique_ptr<jlm::llvm::RvsdgModule>
   SetupRvsdg() override;
 
-  jlm::llvm::lambda::node * LambdaFst_ = {};
-  jlm::llvm::lambda::node * LambdaG_ = {};
+  jlm::rvsdg::LambdaNode * LambdaFst_ = {};
+  jlm::rvsdg::LambdaNode * LambdaG_ = {};
 
   rvsdg::Node * AllocaNode_ = {};
 };

--- a/tests/jlm/hls/backend/rvsdg2rhls/DeadNodeEliminationTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/DeadNodeEliminationTests.cpp
@@ -23,11 +23,12 @@ TestDeadLoopNode()
   jlm::llvm::RvsdgModule rvsdgModule(jlm::util::filepath(""), "", "");
   auto & rvsdg = rvsdgModule.Rvsdg();
 
-  auto lambdaNode = jlm::llvm::lambda::node::create(
-      &rvsdg.GetRootRegion(),
-      functionType,
-      "f",
-      jlm::llvm::linkage::external_linkage);
+  auto lambdaNode = jlm::rvsdg::LambdaNode::Create(
+      rvsdg.GetRootRegion(),
+      jlm::llvm::LlvmLambdaOperation::Create(
+          functionType,
+          "f",
+          jlm::llvm::linkage::external_linkage));
 
   loop_node::create(lambdaNode->subregion());
 
@@ -54,11 +55,12 @@ TestDeadLoopNodeOutput()
   jlm::llvm::RvsdgModule rvsdgModule(jlm::util::filepath(""), "", "");
   auto & rvsdg = rvsdgModule.Rvsdg();
 
-  auto lambdaNode = jlm::llvm::lambda::node::create(
-      &rvsdg.GetRootRegion(),
-      functionType,
-      "f",
-      jlm::llvm::linkage::external_linkage);
+  auto lambdaNode = jlm::rvsdg::LambdaNode::Create(
+      rvsdg.GetRootRegion(),
+      jlm::llvm::LlvmLambdaOperation::Create(
+          functionType,
+          "f",
+          jlm::llvm::linkage::external_linkage));
 
   auto p = lambdaNode->GetFunctionArguments()[0];
   auto x = lambdaNode->GetFunctionArguments()[1];

--- a/tests/jlm/hls/backend/rvsdg2rhls/MemoryConverterTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/MemoryConverterTests.cpp
@@ -32,11 +32,9 @@ TestTraceArgument()
         MemoryStateType::Create() },
       { MemoryStateType::Create() });
 
-  auto lambda = lambda::node::create(
-      &rvsdgModule->Rvsdg().GetRootRegion(),
-      functionType,
-      "test",
-      linkage::external_linkage);
+  auto lambda = jlm::rvsdg::LambdaNode::Create(
+      rvsdgModule->Rvsdg().GetRootRegion(),
+      LlvmLambdaOperation::Create(functionType, "test", linkage::external_linkage));
 
   // Load followed by store
   auto loadAddress = lambda->GetFunctionArguments()[0];
@@ -87,11 +85,9 @@ TestLoad()
       { jlm::llvm::PointerType::Create(), MemoryStateType::Create() },
       { jlm::rvsdg::bittype::Create(32), MemoryStateType::Create() });
 
-  auto lambda = lambda::node::create(
-      &rvsdgModule->Rvsdg().GetRootRegion(),
-      functionType,
-      "test",
-      linkage::external_linkage);
+  auto lambda = jlm::rvsdg::LambdaNode::Create(
+      rvsdgModule->Rvsdg().GetRootRegion(),
+      LlvmLambdaOperation::Create(functionType, "test", linkage::external_linkage));
 
   // Single load
   auto loadAddress = lambda->GetFunctionArguments()[0];
@@ -113,7 +109,7 @@ TestLoad()
   // Memory Converter replaces the lambda so we start from the root of the graph
   auto region = &rvsdgModule->Rvsdg().GetRootRegion();
   assert(region->nnodes() == 1);
-  lambda = jlm::util::AssertedCast<lambda::node>(region->Nodes().begin().ptr());
+  lambda = jlm::util::AssertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
 
   // Assert
   auto lambdaRegion = lambda->subregion();
@@ -169,11 +165,9 @@ TestLoadStore()
         MemoryStateType::Create() },
       { MemoryStateType::Create() });
 
-  auto lambda = lambda::node::create(
-      &rvsdgModule->Rvsdg().GetRootRegion(),
-      functionType,
-      "test",
-      linkage::external_linkage);
+  auto lambda = jlm::rvsdg::LambdaNode::Create(
+      rvsdgModule->Rvsdg().GetRootRegion(),
+      LlvmLambdaOperation::Create(functionType, "test", linkage::external_linkage));
 
   // Load followed by store
   auto loadAddress = lambda->GetFunctionArguments()[0];
@@ -197,7 +191,7 @@ TestLoadStore()
   // Memory Converter replaces the lambda so we start from the root of the graph
   auto region = &rvsdgModule->Rvsdg().GetRootRegion();
   assert(region->nnodes() == 1);
-  lambda = jlm::util::AssertedCast<lambda::node>(region->Nodes().begin().ptr());
+  lambda = jlm::util::AssertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
 
   // Assert
   auto lambdaRegion = lambda->subregion();
@@ -256,11 +250,9 @@ TestThetaLoad()
         MemoryStateType::Create() },
       { jlm::llvm::PointerType::Create(), MemoryStateType::Create() });
 
-  auto lambda = lambda::node::create(
-      &rvsdgModule->Rvsdg().GetRootRegion(),
-      functionType,
-      "test",
-      linkage::external_linkage);
+  auto lambda = jlm::rvsdg::LambdaNode::Create(
+      rvsdgModule->Rvsdg().GetRootRegion(),
+      LlvmLambdaOperation::Create(functionType, "test", linkage::external_linkage));
 
   // Theta
   auto theta = jlm::rvsdg::ThetaNode::create(lambda->subregion());
@@ -330,7 +322,7 @@ TestThetaLoad()
   // Memory Converter replaces the lambda so we start from the root of the graph
   auto region = &rvsdgModule->Rvsdg().GetRootRegion();
   assert(region->nnodes() == 1);
-  lambda = jlm::util::AssertedCast<lambda::node>(region->Nodes().begin().ptr());
+  lambda = jlm::util::AssertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
   lambdaRegion = lambda->subregion();
 
   assert(jlm::rvsdg::Region::Contains<mem_resp_op>(*lambdaRegion, true));

--- a/tests/jlm/hls/backend/rvsdg2rhls/MemoryQueueTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/MemoryQueueTests.cpp
@@ -28,11 +28,9 @@ TestSingleLoad()
       { jlm::llvm::PointerType::Create(), MemoryStateType::Create() },
       { jlm::llvm::PointerType::Create(), MemoryStateType::Create() });
 
-  auto lambda = lambda::node::create(
-      &rvsdgModule->Rvsdg().GetRootRegion(),
-      functionType,
-      "test",
-      linkage::external_linkage);
+  auto lambda = jlm::rvsdg::LambdaNode::Create(
+      rvsdgModule->Rvsdg().GetRootRegion(),
+      LlvmLambdaOperation::Create(functionType, "test", linkage::external_linkage));
 
   // Theta
   auto theta = jlm::rvsdg::ThetaNode::create(lambda->subregion());
@@ -104,11 +102,9 @@ TestLoadStore()
         MemoryStateType::Create() },
       { jlm::llvm::PointerType::Create(), MemoryStateType::Create() });
 
-  auto lambda = lambda::node::create(
-      &rvsdgModule->Rvsdg().GetRootRegion(),
-      functionType,
-      "test",
-      linkage::external_linkage);
+  auto lambda = jlm::rvsdg::LambdaNode::Create(
+      rvsdgModule->Rvsdg().GetRootRegion(),
+      LlvmLambdaOperation::Create(functionType, "test", linkage::external_linkage));
 
   // Theta
   auto theta = jlm::rvsdg::ThetaNode::create(lambda->subregion());
@@ -185,11 +181,9 @@ TestAddrQueue()
       { jlm::llvm::PointerType::Create(), MemoryStateType::Create() },
       { jlm::llvm::PointerType::Create(), MemoryStateType::Create() });
 
-  auto lambda = lambda::node::create(
-      &rvsdgModule->Rvsdg().GetRootRegion(),
-      functionType,
-      "test",
-      linkage::external_linkage);
+  auto lambda = jlm::rvsdg::LambdaNode::Create(
+      rvsdgModule->Rvsdg().GetRootRegion(),
+      LlvmLambdaOperation::Create(functionType, "test", linkage::external_linkage));
 
   // Theta
   auto theta = jlm::rvsdg::ThetaNode::create(lambda->subregion());

--- a/tests/jlm/hls/backend/rvsdg2rhls/TestFork.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/TestFork.cpp
@@ -23,8 +23,9 @@ TestFork()
 
   RvsdgModule rm(util::filepath(""), "", "");
 
-  auto lambda =
-      lambda::node::create(&rm.Rvsdg().GetRootRegion(), ft, "f", linkage::external_linkage);
+  auto lambda = jlm::rvsdg::LambdaNode::Create(
+      rm.Rvsdg().GetRootRegion(),
+      LlvmLambdaOperation::Create(ft, "f", linkage::external_linkage));
 
   auto loop = hls::loop_node::create(lambda->subregion());
   rvsdg::output * idvBuffer;
@@ -53,8 +54,8 @@ TestFork()
   {
     auto omegaRegion = &rm.Rvsdg().GetRootRegion();
     assert(omegaRegion->nnodes() == 1);
-    auto lambda = util::AssertedCast<lambda::node>(omegaRegion->Nodes().begin().ptr());
-    assert(is<lambda::operation>(lambda));
+    auto lambda = util::AssertedCast<jlm::rvsdg::LambdaNode>(omegaRegion->Nodes().begin().ptr());
+    assert(is<jlm::rvsdg::LambdaOperation>(lambda));
 
     auto lambdaRegion = lambda->subregion();
     assert(lambdaRegion->nnodes() == 1);
@@ -86,8 +87,9 @@ TestConstantFork()
 
   RvsdgModule rm(util::filepath(""), "", "");
 
-  auto lambda =
-      lambda::node::create(&rm.Rvsdg().GetRootRegion(), ft, "f", linkage::external_linkage);
+  auto lambda = jlm::rvsdg::LambdaNode::Create(
+      rm.Rvsdg().GetRootRegion(),
+      LlvmLambdaOperation::Create(ft, "f", linkage::external_linkage));
   auto lambdaRegion = lambda->subregion();
 
   auto loop = hls::loop_node::create(lambdaRegion);
@@ -115,8 +117,8 @@ TestConstantFork()
   {
     auto omegaRegion = &rm.Rvsdg().GetRootRegion();
     assert(omegaRegion->nnodes() == 1);
-    auto lambda = util::AssertedCast<lambda::node>(omegaRegion->Nodes().begin().ptr());
-    assert(is<lambda::operation>(lambda));
+    auto lambda = util::AssertedCast<jlm::rvsdg::LambdaNode>(omegaRegion->Nodes().begin().ptr());
+    assert(is<jlm::rvsdg::LambdaOperation>(lambda));
 
     auto lambdaRegion = lambda->subregion();
     assert(lambdaRegion->nnodes() == 1);

--- a/tests/jlm/hls/backend/rvsdg2rhls/TestGamma.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/TestGamma.cpp
@@ -24,8 +24,9 @@ TestWithMatch()
 
   /* Setup graph */
 
-  auto lambda =
-      lambda::node::create(&rm.Rvsdg().GetRootRegion(), ft, "f", linkage::external_linkage);
+  auto lambda = jlm::rvsdg::LambdaNode::Create(
+      rm.Rvsdg().GetRootRegion(),
+      LlvmLambdaOperation::Create(ft, "f", linkage::external_linkage));
 
   auto match = jlm::rvsdg::match(1, { { 0, 0 } }, 1, 2, lambda->GetFunctionArguments()[0]);
   auto gamma = jlm::rvsdg::GammaNode::create(match, 2);
@@ -61,8 +62,9 @@ TestWithoutMatch()
 
   /* Setup graph */
 
-  auto lambda =
-      lambda::node::create(&rm.Rvsdg().GetRootRegion(), ft, "f", linkage::external_linkage);
+  auto lambda = jlm::rvsdg::LambdaNode::Create(
+      rm.Rvsdg().GetRootRegion(),
+      LlvmLambdaOperation::Create(ft, "f", linkage::external_linkage));
 
   auto gamma = jlm::rvsdg::GammaNode::create(lambda->GetFunctionArguments()[0], 2);
   auto ev1 = gamma->AddEntryVar(lambda->GetFunctionArguments()[1]);

--- a/tests/jlm/hls/backend/rvsdg2rhls/TestTheta.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/TestTheta.cpp
@@ -22,8 +22,9 @@ TestUnknownBoundaries()
 
   RvsdgModule rm(jlm::util::filepath(""), "", "");
 
-  auto lambda =
-      lambda::node::create(&rm.Rvsdg().GetRootRegion(), ft, "f", linkage::external_linkage);
+  auto lambda = jlm::rvsdg::LambdaNode::Create(
+      rm.Rvsdg().GetRootRegion(),
+      LlvmLambdaOperation::Create(ft, "f", linkage::external_linkage));
 
   auto theta = jlm::rvsdg::ThetaNode::create(lambda->subregion());
   auto idv = theta->AddLoopVar(lambda->GetFunctionArguments()[0]);

--- a/tests/jlm/hls/backend/rvsdg2rhls/UnusedStateRemovalTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/UnusedStateRemovalTests.cpp
@@ -136,8 +136,9 @@ TestLambda()
 
   auto x = &jlm::tests::GraphImport::Create(rvsdg, valueType, "x");
 
-  auto lambdaNode =
-      lambda::node::create(&rvsdg.GetRootRegion(), functionType, "f", linkage::external_linkage);
+  auto lambdaNode = jlm::rvsdg::LambdaNode::Create(
+      rvsdg.GetRootRegion(),
+      LlvmLambdaOperation::Create(functionType, "f", linkage::external_linkage));
   auto argument0 = lambdaNode->GetFunctionArguments()[0];
   auto argument1 = lambdaNode->GetFunctionArguments()[1];
   auto argument2 = lambdaNode->AddContextVar(*x).inner;
@@ -159,7 +160,8 @@ TestLambda()
 
   // Assert
   assert(rvsdg.GetRootRegion().nnodes() == 1);
-  auto & newLambdaNode = dynamic_cast<const lambda::node &>(*rvsdg.GetRootRegion().Nodes().begin());
+  auto & newLambdaNode =
+      dynamic_cast<const jlm::rvsdg::LambdaNode &>(*rvsdg.GetRootRegion().Nodes().begin());
   assert(newLambdaNode.ninputs() == 2);
   assert(newLambdaNode.subregion()->narguments() == 3);
   assert(newLambdaNode.subregion()->nresults() == 2);

--- a/tests/jlm/hls/backend/rvsdg2rhls/test-loop-passthrough.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/test-loop-passthrough.cpp
@@ -42,11 +42,9 @@ test()
 
   /* setup graph */
 
-  auto lambda = jlm::llvm::lambda::node::create(
-      &rm.Rvsdg().GetRootRegion(),
-      ft,
-      "f",
-      jlm::llvm::linkage::external_linkage);
+  auto lambda = jlm::rvsdg::LambdaNode::Create(
+      rm.Rvsdg().GetRootRegion(),
+      jlm::llvm::LlvmLambdaOperation::Create(ft, "f", jlm::llvm::linkage::external_linkage));
 
   auto loop = hls::loop_node::create(lambda->subregion());
 

--- a/tests/jlm/hls/util/ViewTests.cpp
+++ b/tests/jlm/hls/util/ViewTests.cpp
@@ -27,7 +27,9 @@ TestDumpDot()
 
   rvsdg::Graph graph;
 
-  auto lambda = lambda::node::create(&graph.GetRootRegion(), ft, "f", linkage::external_linkage);
+  auto lambda = rvsdg::LambdaNode::Create(
+      graph.GetRootRegion(),
+      LlvmLambdaOperation::Create(ft, "f", linkage::external_linkage));
 
   auto bitConstant = rvsdg::create_bitconstant(lambda->subregion(), 32, 0);
 
@@ -64,7 +66,9 @@ TestDumpDotTheta()
 
   rvsdg::Graph graph;
 
-  auto lambda = lambda::node::create(&graph.GetRootRegion(), ft, "f", linkage::external_linkage);
+  auto lambda = rvsdg::LambdaNode::Create(
+      graph.GetRootRegion(),
+      LlvmLambdaOperation::Create(ft, "f", linkage::external_linkage));
 
   auto theta = rvsdg::ThetaNode::create(lambda->subregion());
   auto idv = theta->AddLoopVar(lambda->GetFunctionArguments()[0]);

--- a/tests/jlm/llvm/backend/llvm/r2j/GammaTests.cpp
+++ b/tests/jlm/llvm/backend/llvm/r2j/GammaTests.cpp
@@ -31,11 +31,9 @@ GammaWithMatch()
 
   RvsdgModule rvsdgModule(filepath(""), "", "");
 
-  auto lambdaNode = lambda::node::create(
-      &rvsdgModule.Rvsdg().GetRootRegion(),
-      functionType,
-      "lambdaOutput",
-      linkage::external_linkage);
+  auto lambdaNode = jlm::rvsdg::LambdaNode::Create(
+      rvsdgModule.Rvsdg().GetRootRegion(),
+      LlvmLambdaOperation::Create(functionType, "lambdaOutput", linkage::external_linkage));
 
   auto match = jlm::rvsdg::match(1, { { 0, 0 } }, 1, 2, lambdaNode->GetFunctionArguments()[0]);
   auto gamma = jlm::rvsdg::GammaNode::create(match, 2);
@@ -84,11 +82,9 @@ GammaWithoutMatch()
 
   RvsdgModule rvsdgModule(filepath(""), "", "");
 
-  auto lambdaNode = lambda::node::create(
-      &rvsdgModule.Rvsdg().GetRootRegion(),
-      functionType,
-      "lambdaOutput",
-      linkage::external_linkage);
+  auto lambdaNode = jlm::rvsdg::LambdaNode::Create(
+      rvsdgModule.Rvsdg().GetRootRegion(),
+      LlvmLambdaOperation::Create(functionType, "lambdaOutput", linkage::external_linkage));
 
   auto gammaNode = jlm::rvsdg::GammaNode::create(lambdaNode->GetFunctionArguments()[0], 2);
   auto gammaInput1 = gammaNode->AddEntryVar(lambdaNode->GetFunctionArguments()[1]);
@@ -137,11 +133,9 @@ EmptyGammaWithThreeSubregions()
 
   RvsdgModule rvsdgModule(filepath(""), "", "");
 
-  auto lambdaNode = lambda::node::create(
-      &rvsdgModule.Rvsdg().GetRootRegion(),
-      functionType,
-      "lambdaOutput",
-      linkage::external_linkage);
+  auto lambdaNode = jlm::rvsdg::LambdaNode::Create(
+      rvsdgModule.Rvsdg().GetRootRegion(),
+      LlvmLambdaOperation::Create(functionType, "lambdaOutput", linkage::external_linkage));
 
   auto match =
       jlm::rvsdg::match(32, { { 0, 0 }, { 1, 1 } }, 2, 3, lambdaNode->GetFunctionArguments()[0]);
@@ -192,11 +186,9 @@ PartialEmptyGamma()
 
   RvsdgModule rvsdgModule(filepath(""), "", "");
 
-  auto lambdaNode = lambda::node::create(
-      &rvsdgModule.Rvsdg().GetRootRegion(),
-      functionType,
-      "lambdaOutput",
-      linkage::external_linkage);
+  auto lambdaNode = jlm::rvsdg::LambdaNode::Create(
+      rvsdgModule.Rvsdg().GetRootRegion(),
+      LlvmLambdaOperation::Create(functionType, "lambdaOutput", linkage::external_linkage));
 
   auto match = jlm::rvsdg::match(1, { { 0, 0 } }, 1, 2, lambdaNode->GetFunctionArguments()[0]);
   auto gammaNode = jlm::rvsdg::GammaNode::create(match, 2);

--- a/tests/jlm/llvm/frontend/llvm/ThreeAddressCodeConversionTests.cpp
+++ b/tests/jlm/llvm/frontend/llvm/ThreeAddressCodeConversionTests.cpp
@@ -97,7 +97,8 @@ LoadVolatileConversion()
 
   // Assert
   auto lambdaOutput = rvsdgModule->Rvsdg().GetRootRegion().result(0)->origin();
-  auto lambda = dynamic_cast<const lambda::node *>(jlm::rvsdg::output::GetNode(*lambdaOutput));
+  auto lambda =
+      dynamic_cast<const jlm::rvsdg::LambdaNode *>(jlm::rvsdg::output::GetNode(*lambdaOutput));
 
   auto loadVolatileNode = lambda->subregion()->Nodes().begin().ptr();
   assert(dynamic_cast<const LoadVolatileNode *>(loadVolatileNode));
@@ -126,7 +127,8 @@ StoreVolatileConversion()
 
   // Assert
   auto lambdaOutput = rvsdgModule->Rvsdg().GetRootRegion().result(0)->origin();
-  auto lambda = dynamic_cast<const lambda::node *>(jlm::rvsdg::output::GetNode(*lambdaOutput));
+  auto lambda =
+      dynamic_cast<const jlm::rvsdg::LambdaNode *>(jlm::rvsdg::output::GetNode(*lambdaOutput));
 
   auto storeVolatileNode = lambda->subregion()->Nodes().begin().ptr();
   assert(dynamic_cast<const StoreVolatileNode *>(storeVolatileNode));

--- a/tests/jlm/llvm/ir/TestCallSummary.cpp
+++ b/tests/jlm/llvm/ir/TestCallSummary.cpp
@@ -24,11 +24,12 @@ TestCallSummaryComputationDead()
   auto rvsdgModule = jlm::llvm::RvsdgModule::Create(util::filepath(""), "", "");
   auto & rvsdg = rvsdgModule->Rvsdg();
 
-  auto lambdaNode = jlm::llvm::lambda::node::create(
-      &rvsdg.GetRootRegion(),
-      functionType,
-      "f",
-      jlm::llvm::linkage::external_linkage);
+  auto lambdaNode = jlm::rvsdg::LambdaNode::Create(
+      rvsdg.GetRootRegion(),
+      jlm::llvm::LlvmLambdaOperation::Create(
+          functionType,
+          "f",
+          jlm::llvm::linkage::external_linkage));
 
   auto result = tests::create_testop(lambdaNode->subregion(), {}, { vt })[0];
 
@@ -58,11 +59,12 @@ TestCallSummaryComputationExport()
   auto rvsdgModule = jlm::llvm::RvsdgModule::Create(util::filepath(""), "", "");
   auto & rvsdg = rvsdgModule->Rvsdg();
 
-  auto lambdaNode = jlm::llvm::lambda::node::create(
-      &rvsdg.GetRootRegion(),
-      functionType,
-      "f",
-      jlm::llvm::linkage::external_linkage);
+  auto lambdaNode = jlm::rvsdg::LambdaNode::Create(
+      rvsdg.GetRootRegion(),
+      jlm::llvm::LlvmLambdaOperation::Create(
+          functionType,
+          "f",
+          jlm::llvm::linkage::external_linkage));
 
   auto result = tests::create_testop(lambdaNode->subregion(), {}, { vt })[0];
 
@@ -97,11 +99,12 @@ TestCallSummaryComputationDirectCalls()
 
   auto SetupLambdaX = [&]()
   {
-    auto lambdaNode = jlm::llvm::lambda::node::create(
-        &rvsdg.GetRootRegion(),
-        functionType,
-        "x",
-        jlm::llvm::linkage::external_linkage);
+    auto lambdaNode = jlm::rvsdg::LambdaNode::Create(
+        rvsdg.GetRootRegion(),
+        jlm::llvm::LlvmLambdaOperation::Create(
+            functionType,
+            "x",
+            jlm::llvm::linkage::external_linkage));
     auto iOStateArgument = lambdaNode->GetFunctionArguments()[0];
     auto memoryStateArgument = lambdaNode->GetFunctionArguments()[1];
 
@@ -112,11 +115,12 @@ TestCallSummaryComputationDirectCalls()
 
   auto SetupLambdaY = [&](rvsdg::output & lambdaX)
   {
-    auto lambdaNode = jlm::llvm::lambda::node::create(
-        &rvsdg.GetRootRegion(),
-        functionType,
-        "y",
-        jlm::llvm::linkage::external_linkage);
+    auto lambdaNode = jlm::rvsdg::LambdaNode::Create(
+        rvsdg.GetRootRegion(),
+        jlm::llvm::LlvmLambdaOperation::Create(
+            functionType,
+            "y",
+            jlm::llvm::linkage::external_linkage));
     auto iOStateArgument = lambdaNode->GetFunctionArguments()[0];
     auto memoryStateArgument = lambdaNode->GetFunctionArguments()[1];
     auto lambdaXCv = lambdaNode->AddContextVar(lambdaX).inner;
@@ -134,11 +138,12 @@ TestCallSummaryComputationDirectCalls()
 
   auto SetupLambdaZ = [&](rvsdg::output & lambdaX, rvsdg::output & lambdaY)
   {
-    auto lambdaNode = jlm::llvm::lambda::node::create(
-        &rvsdg.GetRootRegion(),
-        functionType,
-        "y",
-        jlm::llvm::linkage::external_linkage);
+    auto lambdaNode = jlm::rvsdg::LambdaNode::Create(
+        rvsdg.GetRootRegion(),
+        jlm::llvm::LlvmLambdaOperation::Create(
+            functionType,
+            "y",
+            jlm::llvm::linkage::external_linkage));
     auto iOStateArgument = lambdaNode->GetFunctionArguments()[0];
     auto memoryStateArgument = lambdaNode->GetFunctionArguments()[1];
     auto lambdaXCv = lambdaNode->AddContextVar(lambdaX).inner;
@@ -168,11 +173,11 @@ TestCallSummaryComputationDirectCalls()
 
   // Act
   auto lambdaXCallSummary =
-      jlm::llvm::ComputeCallSummary(rvsdg::AssertGetOwnerNode<jlm::llvm::lambda::node>(*lambdaX));
+      jlm::llvm::ComputeCallSummary(rvsdg::AssertGetOwnerNode<jlm::rvsdg::LambdaNode>(*lambdaX));
   auto lambdaYCallSummary =
-      jlm::llvm::ComputeCallSummary(rvsdg::AssertGetOwnerNode<jlm::llvm::lambda::node>(*lambdaY));
+      jlm::llvm::ComputeCallSummary(rvsdg::AssertGetOwnerNode<jlm::rvsdg::LambdaNode>(*lambdaY));
   auto lambdaZCallSummary =
-      jlm::llvm::ComputeCallSummary(rvsdg::AssertGetOwnerNode<jlm::llvm::lambda::node>(*lambdaZ));
+      jlm::llvm::ComputeCallSummary(rvsdg::AssertGetOwnerNode<jlm::rvsdg::LambdaNode>(*lambdaZ));
 
   // Assert
   assert(lambdaXCallSummary.HasOnlyDirectCalls());
@@ -249,8 +254,9 @@ TestCallSummaryComputationFunctionPointerInDelta()
   auto valueType = jlm::tests::valuetype::Create();
   auto functionType = jlm::rvsdg::FunctionType::Create({ valueType }, { valueType });
 
-  auto lambdaNode =
-      lambda::node::create(&rvsdg->GetRootRegion(), functionType, "f", linkage::external_linkage);
+  auto lambdaNode = jlm::rvsdg::LambdaNode::Create(
+      rvsdg->GetRootRegion(),
+      LlvmLambdaOperation::Create(functionType, "f", linkage::external_linkage));
   lambdaNode->finalize({ lambdaNode->GetFunctionArguments()[0] });
 
   auto deltaNode = delta::node::Create(
@@ -286,12 +292,14 @@ TestCallSummaryComputationLambdaResult()
   auto functionTypeG = jlm::rvsdg::FunctionType::Create({ valueType }, { valueType });
   auto functionTypeF = jlm::rvsdg::FunctionType::Create({ valueType }, { PointerType::Create() });
 
-  auto lambdaNodeG =
-      lambda::node::create(&rvsdg.GetRootRegion(), functionTypeG, "g", linkage::external_linkage);
+  auto lambdaNodeG = jlm::rvsdg::LambdaNode::Create(
+      rvsdg.GetRootRegion(),
+      jlm::llvm::LlvmLambdaOperation::Create(functionTypeG, "g", linkage::external_linkage));
   auto lambdaOutputG = lambdaNodeG->finalize({ lambdaNodeG->GetFunctionArguments()[0] });
 
-  auto lambdaNodeF =
-      lambda::node::create(&rvsdg.GetRootRegion(), functionTypeF, "f", linkage::external_linkage);
+  auto lambdaNodeF = jlm::rvsdg::LambdaNode::Create(
+      rvsdg.GetRootRegion(),
+      jlm::llvm::LlvmLambdaOperation::Create(functionTypeF, "f", linkage::external_linkage));
   auto lambdaGArgument = lambdaNodeF->AddContextVar(*lambdaOutputG).inner;
   auto ptr =
       jlm::rvsdg::CreateOpNode<FunctionToPointerOperation>({ lambdaGArgument }, functionTypeG)

--- a/tests/jlm/llvm/ir/operators/TestCall.cpp
+++ b/tests/jlm/llvm/ir/operators/TestCall.cpp
@@ -115,8 +115,9 @@ TestCallTypeClassifierIndirectCall()
 
   auto SetupFunction = [&]()
   {
-    auto lambda =
-        lambda::node::create(&graph->GetRootRegion(), fcttype2, "fct", linkage::external_linkage);
+    auto lambda = jlm::rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        LlvmLambdaOperation::Create(fcttype2, "fct", linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[1];
     auto memoryStateArgument = lambda->GetFunctionArguments()[2];
 
@@ -173,11 +174,9 @@ TestCallTypeClassifierNonRecursiveDirectCall()
 
   auto SetupFunctionG = [&]()
   {
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        functionTypeG,
-        "g",
-        linkage::external_linkage);
+    auto lambda = jlm::rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        LlvmLambdaOperation::Create(functionTypeG, "g", linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -218,8 +217,9 @@ TestCallTypeClassifierNonRecursiveDirectCall()
         { IOStateType::Create(), MemoryStateType::Create() },
         { vt, IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda =
-        lambda::node::create(&graph->GetRootRegion(), functionType, "f", linkage::external_linkage);
+    auto lambda = jlm::rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        LlvmLambdaOperation::Create(functionType, "f", linkage::external_linkage));
     auto functionGArgument = lambda->AddContextVar(*g).inner;
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
@@ -270,11 +270,9 @@ TestCallTypeClassifierNonRecursiveDirectCallTheta()
 
   auto SetupFunctionG = [&]()
   {
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        functionTypeG,
-        "g",
-        linkage::external_linkage);
+    auto lambda = jlm::rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        LlvmLambdaOperation::Create(functionTypeG, "g", linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -332,8 +330,9 @@ TestCallTypeClassifierNonRecursiveDirectCallTheta()
         { IOStateType::Create(), MemoryStateType::Create() },
         { vt, IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda =
-        lambda::node::create(&graph->GetRootRegion(), functionType, "f", linkage::external_linkage);
+    auto lambda = jlm::rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        LlvmLambdaOperation::Create(functionType, "f", linkage::external_linkage));
     auto functionG = lambda->AddContextVar(*g).inner;
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
@@ -392,8 +391,9 @@ TestCallTypeClassifierRecursiveDirectCall()
     pb.begin(&graph->GetRootRegion());
     auto fibrv = pb.add_recvar(functionType);
 
-    auto lambda =
-        lambda::node::create(pb.subregion(), functionType, "fib", linkage::external_linkage);
+    auto lambda = jlm::rvsdg::LambdaNode::Create(
+        *pb.subregion(),
+        LlvmLambdaOperation::Create(functionType, "fib", linkage::external_linkage));
     auto valueArgument = lambda->GetFunctionArguments()[0];
     auto pointerArgument = lambda->GetFunctionArguments()[1];
     auto iOStateArgument = lambda->GetFunctionArguments()[2];

--- a/tests/jlm/llvm/ir/operators/TestLambda.cpp
+++ b/tests/jlm/llvm/ir/operators/TestLambda.cpp
@@ -22,11 +22,9 @@ TestArgumentIterators()
   {
     auto functionType = jlm::rvsdg::FunctionType::Create({ vt }, { vt });
 
-    auto lambda = lambda::node::create(
-        &rvsdgModule.Rvsdg().GetRootRegion(),
-        functionType,
-        "f",
-        linkage::external_linkage);
+    auto lambda = jlm::rvsdg::LambdaNode::Create(
+        rvsdgModule.Rvsdg().GetRootRegion(),
+        LlvmLambdaOperation::Create(functionType, "f", linkage::external_linkage));
     lambda->finalize({ lambda->GetFunctionArguments()[0] });
 
     std::vector<const jlm::rvsdg::output *> functionArguments;
@@ -40,11 +38,9 @@ TestArgumentIterators()
   {
     auto functionType = jlm::rvsdg::FunctionType::Create({}, { vt });
 
-    auto lambda = lambda::node::create(
-        &rvsdgModule.Rvsdg().GetRootRegion(),
-        functionType,
-        "f",
-        linkage::external_linkage);
+    auto lambda = jlm::rvsdg::LambdaNode::Create(
+        rvsdgModule.Rvsdg().GetRootRegion(),
+        LlvmLambdaOperation::Create(functionType, "f", linkage::external_linkage));
 
     auto nullaryNode = jlm::tests::create_testop(lambda->subregion(), {}, { vt });
 
@@ -58,11 +54,9 @@ TestArgumentIterators()
 
     auto functionType = jlm::rvsdg::FunctionType::Create({ vt, vt, vt }, { vt, vt });
 
-    auto lambda = lambda::node::create(
-        &rvsdgModule.Rvsdg().GetRootRegion(),
-        functionType,
-        "f",
-        linkage::external_linkage);
+    auto lambda = jlm::rvsdg::LambdaNode::Create(
+        rvsdgModule.Rvsdg().GetRootRegion(),
+        LlvmLambdaOperation::Create(functionType, "f", linkage::external_linkage));
 
     auto cv = lambda->AddContextVar(*rvsdgImport).inner;
 
@@ -90,8 +84,9 @@ TestInvalidOperandRegion()
   auto rvsdgModule = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto rvsdg = &rvsdgModule->Rvsdg();
 
-  auto lambdaNode =
-      lambda::node::create(&rvsdg->GetRootRegion(), functionType, "f", linkage::external_linkage);
+  auto lambdaNode = jlm::rvsdg::LambdaNode::Create(
+      rvsdg->GetRootRegion(),
+      LlvmLambdaOperation::Create(functionType, "f", linkage::external_linkage));
   auto result = jlm::tests::create_testop(&rvsdg->GetRootRegion(), {}, { vt })[0];
 
   bool invalidRegionErrorCaught = false;
@@ -108,7 +103,7 @@ TestInvalidOperandRegion()
 }
 
 /**
- * Test lambda::node::RemoveLambdaInputsWhere()
+ * Test LambdaNode::RemoveLambdaInputsWhere()
  */
 static void
 TestRemoveLambdaInputsWhere()
@@ -124,8 +119,9 @@ TestRemoveLambdaInputsWhere()
 
   auto x = &jlm::tests::GraphImport::Create(rvsdg, valueType, "x");
 
-  auto lambdaNode =
-      lambda::node::create(&rvsdg.GetRootRegion(), functionType, "f", linkage::external_linkage);
+  auto lambdaNode = jlm::rvsdg::LambdaNode::Create(
+      rvsdg.GetRootRegion(),
+      LlvmLambdaOperation::Create(functionType, "f", linkage::external_linkage));
 
   auto lambdaBinder0 = lambdaNode->AddContextVar(*x);
   auto lambdaBinder1 = lambdaNode->AddContextVar(*x);
@@ -177,7 +173,7 @@ TestRemoveLambdaInputsWhere()
 }
 
 /**
- * Test lambda::node::PruneLambdaInputs()
+ * Test LambdaNode::PruneLambdaInputs()
  */
 static void
 TestPruneLambdaInputs()
@@ -193,8 +189,9 @@ TestPruneLambdaInputs()
 
   auto x = &jlm::tests::GraphImport::Create(rvsdg, valueType, "x");
 
-  auto lambdaNode =
-      lambda::node::create(&rvsdg.GetRootRegion(), functionType, "f", linkage::external_linkage);
+  auto lambdaNode = jlm::rvsdg::LambdaNode::Create(
+      rvsdg.GetRootRegion(),
+      LlvmLambdaOperation::Create(functionType, "f", linkage::external_linkage));
 
   lambdaNode->AddContextVar(*x);
   auto lambdaInput1 = lambdaNode->AddContextVar(*x);

--- a/tests/jlm/llvm/ir/operators/TestPhi.cpp
+++ b/tests/jlm/llvm/ir/operators/TestPhi.cpp
@@ -31,7 +31,9 @@ TestPhiCreation()
 
   auto SetupEmptyLambda = [&](jlm::rvsdg::Region * region, const std::string & name)
   {
-    auto lambda = lambda::node::create(region, f0type, name, linkage::external_linkage);
+    auto lambda = jlm::rvsdg::LambdaNode::Create(
+        *region,
+        LlvmLambdaOperation::Create(f0type, name, linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[1];
     auto memoryStateArgument = lambda->GetFunctionArguments()[2];
 
@@ -40,7 +42,9 @@ TestPhiCreation()
 
   auto SetupF2 = [&](jlm::rvsdg::Region * region, jlm::rvsdg::RegionArgument * f2)
   {
-    auto lambda = lambda::node::create(region, f1type, "f2", linkage::external_linkage);
+    auto lambda = jlm::rvsdg::LambdaNode::Create(
+        *region,
+        LlvmLambdaOperation::Create(f1type, "f2", linkage::external_linkage));
     auto ctxVarF2 = lambda->AddContextVar(*f2).inner;
     auto valueArgument = lambda->GetFunctionArguments()[0];
     auto iOStateArgument = lambda->GetFunctionArguments()[1];

--- a/tests/jlm/llvm/opt/InvariantValueRedirectionTests.cpp
+++ b/tests/jlm/llvm/opt/InvariantValueRedirectionTests.cpp
@@ -45,8 +45,9 @@ TestGamma()
   auto rvsdgModule = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto & rvsdg = rvsdgModule->Rvsdg();
 
-  auto lambdaNode =
-      lambda::node::create(&rvsdg.GetRootRegion(), functionType, "test", linkage::external_linkage);
+  auto lambdaNode = jlm::rvsdg::LambdaNode::Create(
+      rvsdg.GetRootRegion(),
+      jlm::llvm::LlvmLambdaOperation::Create(functionType, "test", linkage::external_linkage));
 
   auto c = lambdaNode->GetFunctionArguments()[0];
   auto x = lambdaNode->GetFunctionArguments()[1];
@@ -98,8 +99,9 @@ TestTheta()
   auto rvsdgModule = RvsdgModule::Create(jlm::util::filepath(""), "", "");
   auto & rvsdg = rvsdgModule->Rvsdg();
 
-  auto lambdaNode =
-      lambda::node::create(&rvsdg.GetRootRegion(), functionType, "test", linkage::external_linkage);
+  auto lambdaNode = jlm::rvsdg::LambdaNode::Create(
+      rvsdg.GetRootRegion(),
+      jlm::llvm::LlvmLambdaOperation::Create(functionType, "test", linkage::external_linkage));
 
   auto c = lambdaNode->GetFunctionArguments()[0];
   auto x = lambdaNode->GetFunctionArguments()[1];
@@ -156,11 +158,9 @@ TestCall()
 
   jlm::rvsdg::output * lambdaOutputTest1;
   {
-    auto lambdaNode = lambda::node::create(
-        &rvsdg.GetRootRegion(),
-        functionTypeTest1,
-        "test1",
-        linkage::external_linkage);
+    auto lambdaNode = jlm::rvsdg::LambdaNode::Create(
+        rvsdg.GetRootRegion(),
+        LlvmLambdaOperation::Create(functionTypeTest1, "test1", linkage::external_linkage));
 
     auto controlArgument = lambdaNode->GetFunctionArguments()[0];
     auto xArgument = lambdaNode->GetFunctionArguments()[1];
@@ -194,11 +194,9 @@ TestCall()
         { valueType, valueType, ioStateType, memoryStateType },
         { valueType, valueType, ioStateType, memoryStateType });
 
-    auto lambdaNode = lambda::node::create(
-        &rvsdg.GetRootRegion(),
-        functionType,
-        "test2",
-        linkage::external_linkage);
+    auto lambdaNode = jlm::rvsdg::LambdaNode::Create(
+        rvsdg.GetRootRegion(),
+        LlvmLambdaOperation::Create(functionType, "test2", linkage::external_linkage));
     auto xArgument = lambdaNode->GetFunctionArguments()[0];
     auto yArgument = lambdaNode->GetFunctionArguments()[1];
     auto ioStateArgument = lambdaNode->GetFunctionArguments()[2];
@@ -220,7 +218,7 @@ TestCall()
   RunInvariantValueRedirection(*rvsdgModule);
 
   // Assert
-  auto & lambdaNode = jlm::rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaOutputTest2);
+  auto & lambdaNode = jlm::rvsdg::AssertGetOwnerNode<jlm::rvsdg::LambdaNode>(*lambdaOutputTest2);
   assert(lambdaNode.GetFunctionResults().size() == 4);
   assert(lambdaNode.GetFunctionResults()[0]->origin() == lambdaNode.GetFunctionArguments()[1]);
   assert(lambdaNode.GetFunctionResults()[1]->origin() == lambdaNode.GetFunctionArguments()[0]);
@@ -251,11 +249,9 @@ TestCallWithMemoryStateNodes()
 
   jlm::rvsdg::output * lambdaOutputTest1;
   {
-    auto lambdaNode = lambda::node::create(
-        &rvsdg.GetRootRegion(),
-        functionTypeTest1,
-        "test1",
-        linkage::external_linkage);
+    auto lambdaNode = jlm::rvsdg::LambdaNode::Create(
+        rvsdg.GetRootRegion(),
+        LlvmLambdaOperation::Create(functionTypeTest1, "test1", linkage::external_linkage));
 
     auto controlArgument = lambdaNode->GetFunctionArguments()[0];
     auto xArgument = lambdaNode->GetFunctionArguments()[1];
@@ -289,11 +285,9 @@ TestCallWithMemoryStateNodes()
         { valueType, ioStateType, memoryStateType },
         { valueType, ioStateType, memoryStateType });
 
-    auto lambdaNode = lambda::node::create(
-        &rvsdg.GetRootRegion(),
-        functionType,
-        "test2",
-        linkage::external_linkage);
+    auto lambdaNode = jlm::rvsdg::LambdaNode::Create(
+        rvsdg.GetRootRegion(),
+        LlvmLambdaOperation::Create(functionType, "test2", linkage::external_linkage));
     auto xArgument = lambdaNode->GetFunctionArguments()[0];
     auto ioStateArgument = lambdaNode->GetFunctionArguments()[1];
     auto memoryStateArgument = lambdaNode->GetFunctionArguments()[2];
@@ -328,7 +322,7 @@ TestCallWithMemoryStateNodes()
   RunInvariantValueRedirection(*rvsdgModule);
 
   // Assert
-  auto & lambdaNode = jlm::rvsdg::AssertGetOwnerNode<lambda::node>(*lambdaOutputTest2);
+  auto & lambdaNode = jlm::rvsdg::AssertGetOwnerNode<jlm::rvsdg::LambdaNode>(*lambdaOutputTest2);
   assert(lambdaNode.GetFunctionResults().size() == 3);
   assert(lambdaNode.GetFunctionResults()[0]->origin() == lambdaNode.GetFunctionArguments()[0]);
   assert(lambdaNode.GetFunctionResults()[1]->origin() == lambdaNode.GetFunctionArguments()[1]);

--- a/tests/jlm/llvm/opt/RvsdgTreePrinterTests.cpp
+++ b/tests/jlm/llvm/opt/RvsdgTreePrinterTests.cpp
@@ -58,11 +58,9 @@ PrintRvsdgTree()
   auto functionType = jlm::rvsdg::FunctionType::Create(
       { MemoryStateType::Create() },
       { MemoryStateType::Create() });
-  auto lambda = lambda::node::create(
-      &rvsdgModule->Rvsdg().GetRootRegion(),
-      functionType,
-      "f",
-      linkage::external_linkage);
+  auto lambda = jlm::rvsdg::LambdaNode::Create(
+      rvsdgModule->Rvsdg().GetRootRegion(),
+      LlvmLambdaOperation::Create(functionType, "f", linkage::external_linkage));
   auto lambdaOutput = lambda->finalize({ lambda->GetFunctionArguments()[0] });
   jlm::tests::GraphExport::Create(*lambdaOutput, "f");
 

--- a/tests/jlm/llvm/opt/TestDeadNodeElimination.cpp
+++ b/tests/jlm/llvm/opt/TestDeadNodeElimination.cpp
@@ -252,11 +252,12 @@ TestLambda()
   auto x = &jlm::tests::GraphImport::Create(graph, vt, "x");
   auto y = &jlm::tests::GraphImport::Create(graph, vt, "y");
 
-  auto lambda = lambda::node::create(
-      &graph.GetRootRegion(),
-      jlm::rvsdg::FunctionType::Create({ vt }, { vt, vt }),
-      "f",
-      linkage::external_linkage);
+  auto lambda = jlm::rvsdg::LambdaNode::Create(
+      graph.GetRootRegion(),
+      LlvmLambdaOperation::Create(
+          jlm::rvsdg::FunctionType::Create({ vt }, { vt, vt }),
+          "f",
+          linkage::external_linkage));
 
   auto cv1 = lambda->AddContextVar(*x).inner;
   auto cv2 = lambda->AddContextVar(*y).inner;
@@ -295,7 +296,9 @@ TestPhi()
   auto setupF1 =
       [&](jlm::rvsdg::Region & region, phi::rvoutput & rv2, jlm::rvsdg::RegionArgument & dx)
   {
-    auto lambda1 = lambda::node::create(&region, functionType, "f1", linkage::external_linkage);
+    auto lambda1 = jlm::rvsdg::LambdaNode::Create(
+        region,
+        LlvmLambdaOperation::Create(functionType, "f1", linkage::external_linkage));
     auto f2Argument = lambda1->AddContextVar(*rv2.argument()).inner;
     auto xArgument = lambda1->AddContextVar(dx).inner;
 
@@ -311,7 +314,9 @@ TestPhi()
   auto setupF2 =
       [&](jlm::rvsdg::Region & region, phi::rvoutput & rv1, jlm::rvsdg::RegionArgument & dy)
   {
-    auto lambda2 = lambda::node::create(&region, functionType, "f2", linkage::external_linkage);
+    auto lambda2 = jlm::rvsdg::LambdaNode::Create(
+        region,
+        LlvmLambdaOperation::Create(functionType, "f2", linkage::external_linkage));
     auto f1Argument = lambda2->AddContextVar(*rv1.argument()).inner;
     lambda2->AddContextVar(dy);
 
@@ -326,7 +331,9 @@ TestPhi()
 
   auto setupF3 = [&](jlm::rvsdg::Region & region, jlm::rvsdg::RegionArgument & dz)
   {
-    auto lambda3 = lambda::node::create(&region, functionType, "f3", linkage::external_linkage);
+    auto lambda3 = jlm::rvsdg::LambdaNode::Create(
+        region,
+        LlvmLambdaOperation::Create(functionType, "f3", linkage::external_linkage));
     auto zArgument = lambda3->AddContextVar(dz).inner;
 
     auto result = jlm::tests::SimpleNode::Create(
@@ -340,7 +347,9 @@ TestPhi()
 
   auto setupF4 = [&](jlm::rvsdg::Region & region)
   {
-    auto lambda = lambda::node::create(&region, functionType, "f4", linkage::external_linkage);
+    auto lambda = jlm::rvsdg::LambdaNode::Create(
+        region,
+        LlvmLambdaOperation::Create(functionType, "f4", linkage::external_linkage));
     return lambda->finalize({ lambda->GetFunctionArguments()[0] });
   };
 

--- a/tests/jlm/llvm/opt/alias-analyses/TestPointsToGraph.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestPointsToGraph.cpp
@@ -72,7 +72,7 @@ private:
 
         AnalyzeRegion(*deltaNode->subregion());
       }
-      else if (auto lambdaNode = dynamic_cast<const lambda::node *>(&node))
+      else if (auto lambdaNode = dynamic_cast<const jlm::rvsdg::LambdaNode *>(&node))
       {
         auto & lambdaPtgNode = aa::PointsToGraph::LambdaNode::Create(*PointsToGraph_, *lambdaNode);
         auto & registerNode =

--- a/tests/jlm/llvm/opt/test-cne.cpp
+++ b/tests/jlm/llvm/opt/test-cne.cpp
@@ -384,7 +384,9 @@ test_lambda()
 
   auto x = &jlm::tests::GraphImport::Create(graph, vt, "x");
 
-  auto lambda = lambda::node::create(&graph.GetRootRegion(), ft, "f", linkage::external_linkage);
+  auto lambda = jlm::rvsdg::LambdaNode::Create(
+      graph.GetRootRegion(),
+      LlvmLambdaOperation::Create(ft, "f", linkage::external_linkage));
 
   auto d1 = lambda->AddContextVar(*x).inner;
   auto d2 = lambda->AddContextVar(*x).inner;
@@ -427,11 +429,15 @@ test_phi()
   auto r1 = pb.add_recvar(ft);
   auto r2 = pb.add_recvar(ft);
 
-  auto lambda1 = lambda::node::create(region, ft, "f", linkage::external_linkage);
+  auto lambda1 = jlm::rvsdg::LambdaNode::Create(
+      *region,
+      LlvmLambdaOperation::Create(ft, "f", linkage::external_linkage));
   auto cv1 = lambda1->AddContextVar(*d1).inner;
   auto f1 = lambda1->finalize({ cv1 });
 
-  auto lambda2 = lambda::node::create(region, ft, "f", linkage::external_linkage);
+  auto lambda2 = jlm::rvsdg::LambdaNode::Create(
+      *region,
+      LlvmLambdaOperation::Create(ft, "f", linkage::external_linkage));
   auto cv2 = lambda2->AddContextVar(*d2).inner;
   auto f2 = lambda2->finalize({ cv2 });
 
@@ -449,8 +455,8 @@ test_phi()
   //	jlm::rvsdg::view(graph.GetRootRegion(), stdout);
 
   assert(
-      jlm::rvsdg::AssertGetOwnerNode<lambda::node>(*f1).input(0)->origin()
-      == jlm::rvsdg::AssertGetOwnerNode<lambda::node>(*f2).input(0)->origin());
+      jlm::rvsdg::AssertGetOwnerNode<jlm::rvsdg::LambdaNode>(*f1).input(0)->origin()
+      == jlm::rvsdg::AssertGetOwnerNode<jlm::rvsdg::LambdaNode>(*f2).input(0)->origin());
 }
 
 static int

--- a/tests/jlm/llvm/opt/test-inlining.cpp
+++ b/tests/jlm/llvm/opt/test-inlining.cpp
@@ -37,8 +37,9 @@ test1()
         { vt, IOStateType::Create(), MemoryStateType::Create() },
         { vt, IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda =
-        lambda::node::create(&graph.GetRootRegion(), functionType, "f1", linkage::external_linkage);
+    auto lambda = jlm::rvsdg::LambdaNode::Create(
+        graph.GetRootRegion(),
+        LlvmLambdaOperation::Create(functionType, "f1", linkage::external_linkage));
     lambda->AddContextVar(*i);
 
     auto t = jlm::tests::test_op::create(
@@ -63,8 +64,9 @@ test1()
           MemoryStateType::Create() },
         { vt, IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda =
-        lambda::node::create(&graph.GetRootRegion(), functionType, "f1", linkage::external_linkage);
+    auto lambda = jlm::rvsdg::LambdaNode::Create(
+        graph.GetRootRegion(),
+        LlvmLambdaOperation::Create(functionType, "f1", linkage::external_linkage));
     auto d = lambda->AddContextVar(*f1).inner;
     auto controlArgument = lambda->GetFunctionArguments()[0];
     auto valueArgument = lambda->GetFunctionArguments()[1];
@@ -79,7 +81,7 @@ test1()
 
     auto callResults = CallNode::Create(
         gammaInputF1.branchArgument[0],
-        jlm::rvsdg::AssertGetOwnerNode<lambda::node>(*f1).GetOperation().Type(),
+        jlm::rvsdg::AssertGetOwnerNode<jlm::rvsdg::LambdaNode>(*f1).GetOperation().Type(),
         { gammaInputValue.branchArgument[0],
           gammaInputIoState.branchArgument[0],
           gammaInputMemoryState.branchArgument[0] });
@@ -136,8 +138,9 @@ test2()
 
   auto SetupF1 = [&](const std::shared_ptr<const jlm::rvsdg::FunctionType> & functionType)
   {
-    auto lambda =
-        lambda::node::create(&graph.GetRootRegion(), functionType, "f1", linkage::external_linkage);
+    auto lambda = jlm::rvsdg::LambdaNode::Create(
+        graph.GetRootRegion(),
+        LlvmLambdaOperation::Create(functionType, "f1", linkage::external_linkage));
     return lambda->finalize(
         { lambda->GetFunctionArguments()[1], lambda->GetFunctionArguments()[2] });
   };
@@ -150,8 +153,9 @@ test2()
         { IOStateType::Create(), MemoryStateType::Create() },
         { IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda =
-        lambda::node::create(&graph.GetRootRegion(), functionType, "f2", linkage::external_linkage);
+    auto lambda = jlm::rvsdg::LambdaNode::Create(
+        graph.GetRootRegion(),
+        LlvmLambdaOperation::Create(functionType, "f2", linkage::external_linkage));
     auto cvi = lambda->AddContextVar(*i).inner;
     auto cvf1 = lambda->AddContextVar(*f1).inner;
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
@@ -178,8 +182,10 @@ test2()
 
   // Assert
   // Function f1 should not have been inlined.
-  assert(is<CallOperation>(jlm::rvsdg::output::GetNode(
-      *jlm::rvsdg::AssertGetOwnerNode<lambda::node>(*f2).GetFunctionResults()[0]->origin())));
+  assert(is<CallOperation>(
+      jlm::rvsdg::output::GetNode(*jlm::rvsdg::AssertGetOwnerNode<jlm::rvsdg::LambdaNode>(*f2)
+                                       .GetFunctionResults()[0]
+                                       ->origin())));
 }
 
 static int

--- a/tests/jlm/mlir/backend/TestJlmToMlirConverter.cpp
+++ b/tests/jlm/mlir/backend/TestJlmToMlirConverter.cpp
@@ -28,11 +28,9 @@ TestLambda()
         { IOStateType::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        functionType,
-        "test",
-        linkage::external_linkage);
+    auto lambda = jlm::rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        LlvmLambdaOperation::Create(functionType, "test", linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -53,7 +51,7 @@ TestLambda()
     // Lamda + terminating operation
     assert(omegaBlock.getOperations().size() == 2);
     auto & mlirLambda = omegaBlock.front();
-    assert(mlirLambda.getName().getStringRef().equals(LambdaNode::getOperationName()));
+    assert(mlirLambda.getName().getStringRef().equals(mlir::rvsdg::LambdaNode::getOperationName()));
 
     // Verify function name
     std::cout << "Verify function name" << std::endl;
@@ -147,11 +145,9 @@ TestAddOperation()
         { IOStateType::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(32), IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        functionType,
-        "test",
-        linkage::external_linkage);
+    auto lambda = jlm::rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        LlvmLambdaOperation::Create(functionType, "test", linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -248,11 +244,9 @@ TestComZeroExt()
         { IOStateType::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::bittype::Create(1), IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        functionType,
-        "test",
-        linkage::external_linkage);
+    auto lambda = jlm::rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        LlvmLambdaOperation::Create(functionType, "test", linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 
@@ -390,11 +384,9 @@ TestMatch()
         { IOStateType::Create(), MemoryStateType::Create() },
         { jlm::rvsdg::ControlType::Create(2), IOStateType::Create(), MemoryStateType::Create() });
 
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        functionType,
-        "test",
-        linkage::external_linkage);
+    auto lambda = jlm::rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        LlvmLambdaOperation::Create(functionType, "test", linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments()[0];
     auto memoryStateArgument = lambda->GetFunctionArguments()[1];
 

--- a/tests/jlm/mlir/frontend/TestMlirToJlmConverter.cpp
+++ b/tests/jlm/mlir/frontend/TestMlirToJlmConverter.cpp
@@ -115,8 +115,8 @@ TestLambda()
 
       assert(region->nnodes() == 1);
       auto convertedLambda =
-          jlm::util::AssertedCast<jlm::llvm::lambda::node>(region->Nodes().begin().ptr());
-      assert(is<jlm::llvm::lambda::operation>(convertedLambda));
+          jlm::util::AssertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
+      assert(is<jlm::llvm::LlvmLambdaOperation>(convertedLambda));
 
       assert(convertedLambda->subregion()->nnodes() == 1);
       assert(is<bitconstant_op>(convertedLambda->subregion()->Nodes().begin().ptr()));
@@ -268,8 +268,8 @@ TestDivOperation()
 
       // Get the lambda block
       auto convertedLambda =
-          jlm::util::AssertedCast<jlm::llvm::lambda::node>(region->Nodes().begin().ptr());
-      assert(is<jlm::llvm::lambda::operation>(convertedLambda));
+          jlm::util::AssertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
+      assert(is<jlm::llvm::LlvmLambdaOperation>(convertedLambda));
 
       // 2 Constants + 1 DivUIOp
       assert(convertedLambda->subregion()->nnodes() == 3);
@@ -446,8 +446,8 @@ TestCompZeroExt()
 
       // Get the lambda block
       auto convertedLambda =
-          jlm::util::AssertedCast<jlm::llvm::lambda::node>(region->Nodes().begin().ptr());
-      assert(is<jlm::llvm::lambda::operation>(convertedLambda));
+          jlm::util::AssertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
+      assert(is<jlm::llvm::LlvmLambdaOperation>(convertedLambda));
 
       // 2 Constants + AddOp + CompOp + ZeroExtOp
       assert(convertedLambda->subregion()->nnodes() == 5);
@@ -659,8 +659,8 @@ TestMatchOp()
 
       // Get the lambda block
       auto convertedLambda =
-          jlm::util::AssertedCast<jlm::llvm::lambda::node>(region->Nodes().begin().ptr());
-      assert(is<jlm::llvm::lambda::operation>(convertedLambda));
+          jlm::util::AssertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
+      assert(is<jlm::llvm::LlvmLambdaOperation>(convertedLambda));
 
       auto lambdaRegion = convertedLambda->subregion();
 
@@ -832,8 +832,8 @@ TestGammaOp()
 
       // Get the lambda block
       auto convertedLambda =
-          jlm::util::AssertedCast<jlm::llvm::lambda::node>(region->Nodes().begin().ptr());
-      assert(is<jlm::llvm::lambda::operation>(convertedLambda));
+          jlm::util::AssertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
+      assert(is<jlm::llvm::LlvmLambdaOperation>(convertedLambda));
 
       auto lambdaRegion = convertedLambda->subregion();
 
@@ -981,8 +981,8 @@ TestThetaOp()
 
       // Get the lambda block
       auto convertedLambda =
-          jlm::util::AssertedCast<jlm::llvm::lambda::node>(region->Nodes().begin().ptr());
-      assert(is<jlm::llvm::lambda::operation>(convertedLambda));
+          jlm::util::AssertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
+      assert(is<jlm::llvm::LlvmLambdaOperation>(convertedLambda));
 
       auto lambdaRegion = convertedLambda->subregion();
 


### PR DESCRIPTION
Move lambda node to rvsdg, and rename it to LambdaNode / LambdaOperation. Provide "baseline" LambdaOperation and derived llvm-specific features. The name LambdaOperation is provisional and may later change to better capture its intent.