### PR TITLE
MLIR roundtrip of Alloca, Load and Store operations (Non-volatile)

### DIFF
--- a/scripts/build-mlir.sh
+++ b/scripts/build-mlir.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu
 
-GIT_COMMIT=50fca6b034e909087c3bf24f4edb8ede59f8cd0b
+GIT_COMMIT=e8cf79403b9a24ae71b3d286cc87f547e107f811
 
 # Get the absolute path to this script and set default build and install paths
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"

--- a/tests/jlm/mlir/TestJlmToMlirToJlm.cpp
+++ b/tests/jlm/mlir/TestJlmToMlirToJlm.cpp
@@ -11,6 +11,8 @@
 #include <jlm/llvm/ir/types.hpp>
 #include <jlm/mlir/backend/JlmToMlirConverter.hpp>
 #include <jlm/mlir/frontend/MlirToJlmConverter.hpp>
+#include <jlm/rvsdg/nullary.hpp>
+#include <jlm/rvsdg/FunctionType.hpp>
 
 static int
 TestUndef()
@@ -67,4 +69,294 @@ TestUndef()
   return 0;
 }
 
+static int
+TestAlloca()
+{
+  using namespace jlm::llvm;
+  using namespace mlir::rvsdg;
+
+  auto rvsdgModule = RvsdgModule::Create(jlm::util::filepath(""), "", "");
+  auto graph = &rvsdgModule->Rvsdg();
+
+  {
+    // Create a bits node for alloc size
+    std::cout << "Bit Constanr" << std::endl;
+    auto bits = jlm::rvsdg::create_bitconstant(&graph->GetRootRegion(), 32, 1);
+
+    // Create alloca node
+    std::cout << "Alloca Operation" << std::endl;
+    auto allocaOp = alloca_op(jlm::rvsdg::bittype::Create(64), jlm::rvsdg::bittype::Create(32), 4);
+    jlm::rvsdg::SimpleNode::Create(graph->GetRootRegion(), allocaOp, { bits });
+
+    // Convert the RVSDG to MLIR
+    std::cout << "Convert to MLIR" << std::endl;
+    jlm::mlir::JlmToMlirConverter mlirgen;
+    auto omega = mlirgen.ConvertModule(*rvsdgModule);
+
+    std::cout << "Checking blocks and operations count" << std::endl;
+    auto & omegaRegion = omega.getRegion();
+    assert(omegaRegion.getBlocks().size() == 1);
+    auto & omegaBlock = omegaRegion.front();
+
+    // Bit-contant + alloca + omegaResult
+    assert(omegaBlock.getOperations().size() == 3);
+
+    bool foundAlloca = false;
+    for (auto & op : omegaBlock)
+    {
+      if (mlir::isa<mlir::jlm::Alloca>(op))
+      {
+        auto mlirAllocaOp = mlir::cast<mlir::jlm::Alloca>(op);
+        assert(mlirAllocaOp.getAlignment() == 4);
+        assert(mlirAllocaOp.getNumResults() == 2);
+
+        auto valueType = mlir::cast<mlir::IntegerType>(mlirAllocaOp.getValueType());
+        assert(valueType);
+        assert(valueType.getWidth() == 64);
+        foundAlloca = true;
+      }
+    }
+    if (!foundAlloca)
+    {
+      return 1;
+    }
+
+    // // Convert the MLIR to RVSDG and check the result
+    std::cout << "Converting MLIR to RVSDG" << std::endl;
+    std::unique_ptr<mlir::Block> rootBlock = std::make_unique<mlir::Block>();
+    rootBlock->push_back(omega);
+    auto rvsdgModule = jlm::mlir::MlirToJlmConverter::CreateAndConvert(rootBlock);
+    auto region = &rvsdgModule->Rvsdg().GetRootRegion();
+
+    {
+      using namespace jlm::llvm;
+
+      assert(region->nnodes() == 2);
+
+      bool foundAlloca = false;
+      for (auto & node : region->Nodes())
+      {
+        if (auto allocaOp = dynamic_cast<const alloca_op *>(&node.GetOperation()))
+        {
+          assert(allocaOp->alignment() == 4);
+
+          assert(jlm::rvsdg::is<jlm::rvsdg::bittype>(allocaOp->ValueType()));
+          auto valueBitType =
+              dynamic_cast<const jlm::rvsdg::bittype *>(allocaOp->ValueType().get());
+          assert(valueBitType->nbits() == 64);
+
+          assert(allocaOp->narguments() == 1);
+
+          assert(jlm::rvsdg::is<jlm::rvsdg::bittype>(allocaOp->argument(0)));
+          auto inputBitType =
+              dynamic_cast<const jlm::rvsdg::bittype *>(allocaOp->argument(0).get());
+          assert(inputBitType->nbits() == 32);
+
+          assert(allocaOp->nresults() == 2);
+
+          assert(jlm::rvsdg::is<PointerType>(allocaOp->result(0)));
+          assert(jlm::rvsdg::is<jlm::llvm::MemoryStateType>(allocaOp->result(1)));
+
+          foundAlloca = true;
+        }
+      }
+      if (!foundAlloca)
+      {
+        return 1;
+      }
+    }
+  }
+  return 0;
+}
+
+static int
+TestLoad()
+{
+  using namespace jlm::llvm;
+  using namespace mlir::rvsdg;
+
+  auto rvsdgModule = RvsdgModule::Create(jlm::util::filepath(""), "", "");
+  auto graph = &rvsdgModule->Rvsdg();
+
+  {
+    auto functionType = jlm::rvsdg::FunctionType::Create(
+        { IOStateType::Create(), MemoryStateType::Create(), PointerType::Create() },
+        { IOStateType::Create(), MemoryStateType::Create() });
+    auto lambda =
+        lambda::node::create(&graph->GetRootRegion(), functionType, "test", linkage::external_linkage);
+    auto iOStateArgument = lambda->GetFunctionArguments().at(0);
+    auto memoryStateArgument = lambda->GetFunctionArguments().at(1);
+    auto pointerArgument = lambda->GetFunctionArguments().at(2);
+
+    // Create load operation
+    auto loadType = jlm::rvsdg::bittype::Create(32);
+    auto loadOp = jlm::llvm::LoadNonVolatileOperation(loadType, 1, 4);
+    auto& subregion = *(lambda->subregion());
+    jlm::llvm::LoadNonVolatileNode::Create(
+        subregion,
+        std::make_unique<LoadNonVolatileOperation>(loadOp),
+        { pointerArgument, memoryStateArgument });
+
+    lambda->finalize({ iOStateArgument, memoryStateArgument });
+
+    // Convert the RVSDG to MLIR
+    std::cout << "Convert to MLIR" << std::endl;
+    jlm::mlir::JlmToMlirConverter mlirgen;
+    auto omega = mlirgen.ConvertModule(*rvsdgModule);
+
+    // Validate the generated MLIR
+    std::cout << "Validate MLIR" << std::endl;
+    auto & omegaRegion = omega.getRegion();
+    auto & omegaBlock = omegaRegion.front();
+    auto & mlirLambda = omegaBlock.front();
+    auto & mlirLambdaRegion = mlirLambda.getRegion(0);
+    auto & mlirLambdaBlock = mlirLambdaRegion.front();
+    auto & mlirOp = mlirLambdaBlock.front();
+
+    if (!mlir::isa<mlir::jlm::Load>(mlirOp))
+      return 1;
+
+    auto mlirLoad = mlir::cast<mlir::jlm::Load>(mlirOp);
+    assert(mlirLoad.getAlignment() == 4);
+    assert(mlirLoad.getInputMemStates().size() == 1);
+    assert(mlirLoad.getNumOperands() == 2);
+    assert(mlirLoad.getNumResults() == 2);
+
+    auto outputType = mlirLoad.getOutput().getType();
+    assert(mlir::isa<mlir::IntegerType>(outputType));
+    auto integerType = mlir::cast<mlir::IntegerType>(outputType);
+    assert(integerType.getWidth() == 32);
+
+    // // Convert the MLIR to RVSDG and check the result
+    std::cout << "Converting MLIR to RVSDG" << std::endl;
+    std::unique_ptr<mlir::Block> rootBlock = std::make_unique<mlir::Block>();
+    rootBlock->push_back(omega);
+    auto rvsdgModule = jlm::mlir::MlirToJlmConverter::CreateAndConvert(rootBlock);
+    auto region = &rvsdgModule->Rvsdg().GetRootRegion();
+
+    {
+      using namespace jlm::llvm;
+
+      assert(region->nnodes() == 1);
+      auto convertedLambda = jlm::util::AssertedCast<lambda::node>(region->Nodes().begin().ptr());
+      assert(is<lambda::operation>(convertedLambda));
+
+      assert(convertedLambda->subregion()->nnodes() == 1);
+      assert(is<LoadNonVolatileOperation>(convertedLambda->subregion()->Nodes().begin()->GetOperation()));
+      auto convertedLoad =
+          dynamic_cast<const LoadNonVolatileNode *>(convertedLambda->subregion()->Nodes().begin().ptr());
+
+      assert(convertedLoad->GetAlignment() == 4);
+      assert(convertedLoad->NumMemoryStates() == 1);
+
+      assert(is<jlm::llvm::PointerType>(convertedLoad->input(0)->type()));
+      assert(is<jlm::llvm::MemoryStateType>(convertedLoad->input(1)->type()));
+
+      assert(is<jlm::rvsdg::bittype>(convertedLoad->output(0)->type()));
+      assert(is<jlm::llvm::MemoryStateType>(convertedLoad->output(1)->type()));
+
+      auto outputBitType =
+          dynamic_cast<const jlm::rvsdg::bittype *>(&convertedLoad->output(0)->type());
+      assert(outputBitType->nbits() == 32);
+    }
+  }
+  return 0;
+}
+
+static int
+TestStore()
+{
+  using namespace jlm::llvm;
+  using namespace mlir::rvsdg;
+
+  auto rvsdgModule = RvsdgModule::Create(jlm::util::filepath(""), "", "");
+  auto graph = &rvsdgModule->Rvsdg();
+
+  {
+    auto bitsType = jlm::rvsdg::bittype::Create(32);
+    auto functionType = jlm::rvsdg::FunctionType::Create(
+        { IOStateType::Create(), MemoryStateType::Create(), PointerType::Create(), bitsType },
+        { IOStateType::Create(), MemoryStateType::Create() });
+    auto lambda =
+        lambda::node::create(&graph->GetRootRegion(), functionType, "test", linkage::external_linkage);
+    auto iOStateArgument = lambda->GetFunctionArguments().at(0);
+    auto memoryStateArgument = lambda->GetFunctionArguments().at(1);
+    auto pointerArgument = lambda->GetFunctionArguments().at(2);
+    auto bitsArgument = lambda->GetFunctionArguments().at(3);
+
+    // Create store operation
+    auto storeOp = jlm::llvm::StoreNonVolatileOperation(bitsType, 1, 4);
+    jlm::llvm::StoreNonVolatileNode::Create(
+        *lambda->subregion(),
+        std::make_unique<StoreNonVolatileOperation>(storeOp),
+        { pointerArgument, bitsArgument, memoryStateArgument });
+
+    lambda->finalize({ iOStateArgument, memoryStateArgument });
+
+    // Convert the RVSDG to MLIR
+    std::cout << "Convert to MLIR" << std::endl;
+    jlm::mlir::JlmToMlirConverter mlirgen;
+    auto omega = mlirgen.ConvertModule(*rvsdgModule);
+
+    // Validate the generated MLIR
+    std::cout << "Validate MLIR" << std::endl;
+    auto & omegaRegion = omega.getRegion();
+    auto & omegaBlock = omegaRegion.front();
+    auto & mlirLambda = omegaBlock.front();
+    auto & mlirLambdaRegion = mlirLambda.getRegion(0);
+    auto & mlirLambdaBlock = mlirLambdaRegion.front();
+    auto & mlirOp = mlirLambdaBlock.front();
+
+    if (!mlir::isa<mlir::jlm::Store>(mlirOp))
+      return 1;
+
+    auto mlirStore = mlir::cast<mlir::jlm::Store>(mlirOp);
+    assert(mlirStore.getAlignment() == 4);
+    assert(mlirStore.getInputMemStates().size() == 1);
+    assert(mlirStore.getNumOperands() == 3);
+
+    auto inputType = mlirStore.getValue().getType();
+    assert(mlir::isa<mlir::IntegerType>(inputType));
+    auto integerType = mlir::cast<mlir::IntegerType>(inputType);
+    assert(integerType.getWidth() == 32);
+
+    // // Convert the MLIR to RVSDG and check the result
+    std::cout << "Converting MLIR to RVSDG" << std::endl;
+    std::unique_ptr<mlir::Block> rootBlock = std::make_unique<mlir::Block>();
+    rootBlock->push_back(omega);
+    auto rvsdgModule = jlm::mlir::MlirToJlmConverter::CreateAndConvert(rootBlock);
+    auto region = &rvsdgModule->Rvsdg().GetRootRegion();
+
+    {
+      using namespace jlm::llvm;
+
+      assert(region->nnodes() == 1);
+      auto convertedLambda = jlm::util::AssertedCast<lambda::node>(region->Nodes().begin().ptr());
+      assert(is<lambda::operation>(convertedLambda));
+
+      assert(convertedLambda->subregion()->nnodes() == 1);
+      assert(is<StoreNonVolatileOperation>(convertedLambda->subregion()->Nodes().begin()->GetOperation()));
+      auto convertedStore =
+          dynamic_cast<const StoreNonVolatileNode *>(convertedLambda->subregion()->Nodes().begin().ptr());
+
+      assert(convertedStore->GetAlignment() == 4);
+      assert(convertedStore->NumMemoryStates() == 1);
+
+      assert(is<jlm::llvm::PointerType>(convertedStore->input(0)->type()));
+      assert(is<jlm::rvsdg::bittype>(convertedStore->input(1)->type()));
+      assert(is<jlm::llvm::MemoryStateType>(convertedStore->input(2)->type()));
+
+      assert(is<jlm::llvm::MemoryStateType>(convertedStore->output(0)->type()));
+
+      auto inputBitType =
+          dynamic_cast<const jlm::rvsdg::bittype *>(&convertedStore->input(1)->type());
+      assert(inputBitType->nbits() == 32);
+    }
+  }
+  return 0;
+}
+
 JLM_UNIT_TEST_REGISTER("jlm/mlir/TestMlirUndefGen", TestUndef)
+JLM_UNIT_TEST_REGISTER("jlm/mlir/TestMlirAllocaGen", TestAlloca)
+JLM_UNIT_TEST_REGISTER("jlm/mlir/TestMlirLoadGen", TestLoad)
+JLM_UNIT_TEST_REGISTER("jlm/mlir/TestMlirStoreGen", TestStore)

--- a/tests/jlm/mlir/TestJlmToMlirToJlm.cpp
+++ b/tests/jlm/mlir/TestJlmToMlirToJlm.cpp
@@ -182,11 +182,9 @@ TestLoad()
     auto functionType = jlm::rvsdg::FunctionType::Create(
         { IOStateType::Create(), MemoryStateType::Create(), PointerType::Create() },
         { IOStateType::Create(), MemoryStateType::Create() });
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        functionType,
-        "test",
-        linkage::external_linkage);
+    auto lambda = jlm::rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        LlvmLambdaOperation::Create(functionType, "test", linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments().at(0);
     auto memoryStateArgument = lambda->GetFunctionArguments().at(1);
     auto pointerArgument = lambda->GetFunctionArguments().at(2);
@@ -241,8 +239,9 @@ TestLoad()
       using namespace jlm::llvm;
 
       assert(region->nnodes() == 1);
-      auto convertedLambda = jlm::util::AssertedCast<lambda::node>(region->Nodes().begin().ptr());
-      assert(is<lambda::operation>(convertedLambda));
+      auto convertedLambda =
+          jlm::util::AssertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
+      assert(is<jlm::rvsdg::LambdaOperation>(convertedLambda));
 
       assert(convertedLambda->subregion()->nnodes() == 1);
       assert(is<LoadNonVolatileOperation>(
@@ -281,11 +280,9 @@ TestStore()
     auto functionType = jlm::rvsdg::FunctionType::Create(
         { IOStateType::Create(), MemoryStateType::Create(), PointerType::Create(), bitsType },
         { IOStateType::Create(), MemoryStateType::Create() });
-    auto lambda = lambda::node::create(
-        &graph->GetRootRegion(),
-        functionType,
-        "test",
-        linkage::external_linkage);
+    auto lambda = jlm::rvsdg::LambdaNode::Create(
+        graph->GetRootRegion(),
+        LlvmLambdaOperation::Create(functionType, "test", linkage::external_linkage));
     auto iOStateArgument = lambda->GetFunctionArguments().at(0);
     auto memoryStateArgument = lambda->GetFunctionArguments().at(1);
     auto pointerArgument = lambda->GetFunctionArguments().at(2);
@@ -338,8 +335,9 @@ TestStore()
       using namespace jlm::llvm;
 
       assert(region->nnodes() == 1);
-      auto convertedLambda = jlm::util::AssertedCast<lambda::node>(region->Nodes().begin().ptr());
-      assert(is<lambda::operation>(convertedLambda));
+      auto convertedLambda =
+          jlm::util::AssertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
+      assert(is<jlm::rvsdg::LambdaOperation>(convertedLambda));
 
       assert(convertedLambda->subregion()->nnodes() == 1);
       assert(is<StoreNonVolatileOperation>(

--- a/tests/jlm/mlir/TestJlmToMlirToJlm.cpp
+++ b/tests/jlm/mlir/TestJlmToMlirToJlm.cpp
@@ -68,6 +68,7 @@ TestUndef()
   }
   return 0;
 }
+JLM_UNIT_TEST_REGISTER("jlm/mlir/TestMlirUndefGen", TestUndef)
 
 static int
 TestAlloca()
@@ -116,10 +117,7 @@ TestAlloca()
         foundAlloca = true;
       }
     }
-    if (!foundAlloca)
-    {
-      return 1;
-    }
+    assert(foundAlloca);
 
     // // Convert the MLIR to RVSDG and check the result
     std::cout << "Converting MLIR to RVSDG" << std::endl;
@@ -160,14 +158,12 @@ TestAlloca()
           foundAlloca = true;
         }
       }
-      if (!foundAlloca)
-      {
-        return 1;
-      }
+      assert(foundAlloca);
     }
   }
   return 0;
 }
+JLM_UNIT_TEST_REGISTER("jlm/mlir/TestMlirAllocaGen", TestAlloca)
 
 static int
 TestLoad()
@@ -214,8 +210,7 @@ TestLoad()
     auto & mlirLambdaBlock = mlirLambdaRegion.front();
     auto & mlirOp = mlirLambdaBlock.front();
 
-    if (!mlir::isa<mlir::jlm::Load>(mlirOp))
-      return 1;
+    assert(mlir::isa<mlir::jlm::Load>(mlirOp));
 
     auto mlirLoad = mlir::cast<mlir::jlm::Load>(mlirOp);
     assert(mlirLoad.getAlignment() == 4);
@@ -265,6 +260,7 @@ TestLoad()
   }
   return 0;
 }
+JLM_UNIT_TEST_REGISTER("jlm/mlir/TestMlirLoadGen", TestLoad)
 
 static int
 TestStore()
@@ -311,8 +307,7 @@ TestStore()
     auto & mlirLambdaBlock = mlirLambdaRegion.front();
     auto & mlirOp = mlirLambdaBlock.front();
 
-    if (!mlir::isa<mlir::jlm::Store>(mlirOp))
-      return 1;
+    assert(mlir::isa<mlir::jlm::Store>(mlirOp));
 
     auto mlirStore = mlir::cast<mlir::jlm::Store>(mlirOp);
     assert(mlirStore.getAlignment() == 4);
@@ -361,8 +356,4 @@ TestStore()
   }
   return 0;
 }
-
-JLM_UNIT_TEST_REGISTER("jlm/mlir/TestMlirUndefGen", TestUndef)
-JLM_UNIT_TEST_REGISTER("jlm/mlir/TestMlirAllocaGen", TestAlloca)
-JLM_UNIT_TEST_REGISTER("jlm/mlir/TestMlirLoadGen", TestLoad)
 JLM_UNIT_TEST_REGISTER("jlm/mlir/TestMlirStoreGen", TestStore)

--- a/tests/jlm/mlir/TestJlmToMlirToJlm.cpp
+++ b/tests/jlm/mlir/TestJlmToMlirToJlm.cpp
@@ -11,8 +11,8 @@
 #include <jlm/llvm/ir/types.hpp>
 #include <jlm/mlir/backend/JlmToMlirConverter.hpp>
 #include <jlm/mlir/frontend/MlirToJlmConverter.hpp>
-#include <jlm/rvsdg/nullary.hpp>
 #include <jlm/rvsdg/FunctionType.hpp>
+#include <jlm/rvsdg/nullary.hpp>
 
 static int
 TestUndef()
@@ -182,8 +182,11 @@ TestLoad()
     auto functionType = jlm::rvsdg::FunctionType::Create(
         { IOStateType::Create(), MemoryStateType::Create(), PointerType::Create() },
         { IOStateType::Create(), MemoryStateType::Create() });
-    auto lambda =
-        lambda::node::create(&graph->GetRootRegion(), functionType, "test", linkage::external_linkage);
+    auto lambda = lambda::node::create(
+        &graph->GetRootRegion(),
+        functionType,
+        "test",
+        linkage::external_linkage);
     auto iOStateArgument = lambda->GetFunctionArguments().at(0);
     auto memoryStateArgument = lambda->GetFunctionArguments().at(1);
     auto pointerArgument = lambda->GetFunctionArguments().at(2);
@@ -191,7 +194,7 @@ TestLoad()
     // Create load operation
     auto loadType = jlm::rvsdg::bittype::Create(32);
     auto loadOp = jlm::llvm::LoadNonVolatileOperation(loadType, 1, 4);
-    auto& subregion = *(lambda->subregion());
+    auto & subregion = *(lambda->subregion());
     jlm::llvm::LoadNonVolatileNode::Create(
         subregion,
         std::make_unique<LoadNonVolatileOperation>(loadOp),
@@ -242,9 +245,10 @@ TestLoad()
       assert(is<lambda::operation>(convertedLambda));
 
       assert(convertedLambda->subregion()->nnodes() == 1);
-      assert(is<LoadNonVolatileOperation>(convertedLambda->subregion()->Nodes().begin()->GetOperation()));
-      auto convertedLoad =
-          dynamic_cast<const LoadNonVolatileNode *>(convertedLambda->subregion()->Nodes().begin().ptr());
+      assert(is<LoadNonVolatileOperation>(
+          convertedLambda->subregion()->Nodes().begin()->GetOperation()));
+      auto convertedLoad = dynamic_cast<const LoadNonVolatileNode *>(
+          convertedLambda->subregion()->Nodes().begin().ptr());
 
       assert(convertedLoad->GetAlignment() == 4);
       assert(convertedLoad->NumMemoryStates() == 1);
@@ -277,8 +281,11 @@ TestStore()
     auto functionType = jlm::rvsdg::FunctionType::Create(
         { IOStateType::Create(), MemoryStateType::Create(), PointerType::Create(), bitsType },
         { IOStateType::Create(), MemoryStateType::Create() });
-    auto lambda =
-        lambda::node::create(&graph->GetRootRegion(), functionType, "test", linkage::external_linkage);
+    auto lambda = lambda::node::create(
+        &graph->GetRootRegion(),
+        functionType,
+        "test",
+        linkage::external_linkage);
     auto iOStateArgument = lambda->GetFunctionArguments().at(0);
     auto memoryStateArgument = lambda->GetFunctionArguments().at(1);
     auto pointerArgument = lambda->GetFunctionArguments().at(2);
@@ -335,9 +342,10 @@ TestStore()
       assert(is<lambda::operation>(convertedLambda));
 
       assert(convertedLambda->subregion()->nnodes() == 1);
-      assert(is<StoreNonVolatileOperation>(convertedLambda->subregion()->Nodes().begin()->GetOperation()));
-      auto convertedStore =
-          dynamic_cast<const StoreNonVolatileNode *>(convertedLambda->subregion()->Nodes().begin().ptr());
+      assert(is<StoreNonVolatileOperation>(
+          convertedLambda->subregion()->Nodes().begin()->GetOperation()));
+      auto convertedStore = dynamic_cast<const StoreNonVolatileNode *>(
+          convertedLambda->subregion()->Nodes().begin().ptr());
 
       assert(convertedStore->GetAlignment() == 4);
       assert(convertedStore->NumMemoryStates() == 1);


### PR DESCRIPTION
This PR adds roundtripping of the mentioned nodes together with tests for this functionality. 
Depends changes to the [dialect](https://github.com/EECS-NTNU/mlir_rvsdg/pull/4/commits/51889684abf9f64dac8d051ee6a71a0a78827860).