### PR TITLE
Make BijectiveMap compile on more machines by avoiding const

### DIFF
--- a/jlm/util/BijectiveMap.hpp
+++ b/jlm/util/BijectiveMap.hpp
@@ -21,11 +21,11 @@ namespace jlm::util
 template<typename K, typename V>
 class BijectiveMap
 {
-  using ForwardMapType = std::unordered_map<K, const V>;
-  using ReverseMapType = std::unordered_map<V, const K>;
+  using ForwardMapType = std::unordered_map<K, V>;
+  using ReverseMapType = std::unordered_map<V, K>;
 
 public:
-  using ItemType = std::pair<const K, const V>;
+  using ItemType = std::pair<const K, V>;
 
   class ConstIterator final
   {
@@ -177,7 +177,6 @@ public:
   {
     static_assert(
         std::is_base_of_v<std::forward_iterator_tag, typename IteratorType::iterator_category>);
-    static_assert(std::is_base_of_v<ItemType, typename IteratorType::value_type>);
 
     size_t inserted = 0;
     while (begin != end)
@@ -212,7 +211,7 @@ public:
   [[nodiscard]] bool
   HasKey(const K & key) const noexcept
   {
-    return ForwardMap_.find(key) != ForwardMap_.end();
+    return ForwardMap_.count(key);
   }
 
   /**
@@ -223,7 +222,7 @@ public:
   [[nodiscard]] bool
   HasValue(const V & value) const noexcept
   {
-    return ReverseMap_.find(value) != ReverseMap_.end();
+    return ReverseMap_.count(value);
   }
 
   /**


### PR DESCRIPTION
When I originally wrote `BijectiveMap`, I wrote the iterator interface as a thin wrapper around the forward mapping's `cbegin()` and `cend()`.

The iterator you get from `cbegin()` has the reference type `const std::pair<const Key, Value> &`.
To achieve some symmetry, I added an additional `const` to get `const std::pair<const K, const V> &`.

Later it turned out that a `std::pair` or `std::unordered_map` with added `const` behaves very unergonomically. When the STL gives a `std::pair<const Key, Value>` it almost feels like an ugly hack to make only the `first` immutable. Trying to add additional `const` for symmetry only makes the assignment operator break in weird ways, and only on some systems.

In practice all I want is for the iterator to return `const std::pair<Key, Value> &`, but there is no subtyping of these ugly types, so the best I can do without extremely cursed and maybe illegal casting is `const std::pair<const Key, Value> &`.