### PR TITLE
add HashSet::DifferenceWith method

### DIFF
--- a/jlm/util/HashSet.hpp
+++ b/jlm/util/HashSet.hpp
@@ -294,6 +294,35 @@ public:
   }
 
   /**
+   * Modifies this HashSet object by removing any elements that are present in \p other.
+   *
+   * @param other the HashSet used as the negative side of the set difference.
+   */
+  void
+  DifferenceWith(const HashSet<ItemType> & other)
+  {
+    // If this HashSet is smaller, loop over it and remove elements in other.
+    // If other is smaller, loop over it and remove elements from this.
+
+    if (Size() <= other.Size())
+    {
+      // This branch also handles the unlikely case where this and other are the same set.
+
+      auto inOther = [&](const ItemType item)
+      {
+        return other.Contains(item);
+      };
+
+      RemoveWhere(inOther);
+    }
+    else
+    {
+      for (auto & item : other.Set_)
+        Remove(item);
+    }
+  }
+
+  /**
    * Removes the specified item from a HashSet object.
    *
    * @param item The item to remove.

--- a/jlm/util/HashSet.hpp
+++ b/jlm/util/HashSet.hpp
@@ -268,7 +268,7 @@ public:
   void
   IntersectWith(const HashSet<ItemType> & other)
   {
-    auto isContained = [&](const ItemType item)
+    auto isContained = [&](const ItemType & item)
     {
       return !other.Contains(item);
     };
@@ -308,7 +308,7 @@ public:
     {
       // This branch also handles the unlikely case where this and other are the same set.
 
-      auto inOther = [&](const ItemType item)
+      auto inOther = [&](const ItemType & item)
       {
         return other.Contains(item);
       };

--- a/jlm/util/HashSet.hpp
+++ b/jlm/util/HashSet.hpp
@@ -308,12 +308,12 @@ public:
     {
       // This branch also handles the unlikely case where this and other are the same set.
 
-      auto inOther = [&](const ItemType & item)
+      auto isInOther = [&](const ItemType & item)
       {
         return other.Contains(item);
       };
 
-      RemoveWhere(inOther);
+      RemoveWhere(isInOther);
     }
     else
     {

--- a/tests/jlm/util/TestHashSet.cpp
+++ b/tests/jlm/util/TestHashSet.cpp
@@ -180,3 +180,41 @@ TestIntersectWith()
 }
 
 JLM_UNIT_TEST_REGISTER("jlm/util/TestHashSet-TestIntersectWith", TestIntersectWith)
+
+static int
+TestDifferenceWith()
+{
+  using namespace jlm::util;
+
+  HashSet<int> set12({ 1, 2 });
+  HashSet<int> set123({ 1, 2, 3 });
+  HashSet<int> set45({ 4, 5 });
+
+  set123.DifferenceWith(set12); // {1, 2, 3} - {1, 2}
+  assert(set123.Size() == 1);
+  assert(set123.Contains(3));
+
+  // set12 was not touched
+  assert(set12.Size() == 2);
+
+  // Create the set {0, 1, 3}
+  set123.Insert(0);
+  set123.Insert(1);
+
+  set12.DifferenceWith(set123); // {1, 2} - {0, 1, 3}
+  assert(set12.Size() == 1);
+  assert(set12.Contains(2));
+
+  // Difference with other sets becomes empty
+  set45.DifferenceWith(set123);
+  set45.DifferenceWith(set12);
+  assert(set45.Size() == 2);
+
+  // We handle the case where both sets are the same set without crashing
+  set45.DifferenceWith(set45);
+  assert(set45.IsEmpty());
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER("jlm/util/TestHashSet-TestDifferenceWith", TestDifferenceWith)

--- a/tests/jlm/util/TestHashSet.cpp
+++ b/tests/jlm/util/TestHashSet.cpp
@@ -190,12 +190,14 @@ TestDifferenceWith()
   HashSet<int> set123({ 1, 2, 3 });
   HashSet<int> set45({ 4, 5 });
 
+  const auto set12Copy = set12;
+
   set123.DifferenceWith(set12); // {1, 2, 3} - {1, 2}
   assert(set123.Size() == 1);
   assert(set123.Contains(3));
 
   // set12 was not touched
-  assert(set12.Size() == 2);
+  assert(set12 == set12Copy);
 
   // Create the set {0, 1, 3}
   set123.Insert(0);


### PR DESCRIPTION
I had a use for this method in the Andersen-work, and thought I would backport it as I am likely to want to use it again.

With this operation, there are two possible implementations. I try to pick the one that should be the fastest, but I have not done benchmarking to figure out exactly where one implementation becomes faster than the other.