### PR TITLE
Fix incorrect cache key of MLIR Dialect built in CI

### DIFF
--- a/.github/actions/BuildJlm/action.yml
+++ b/.github/actions/BuildJlm/action.yml
@@ -65,7 +65,7 @@ runs:
           JLM_CONFIGURE_ARGUMENTS="$JLM_CONFIGURE_ARGUMENTS --enable-hls=${{ github.workspace }}/build-circt/circt"
         fi
         if [[ "${{inputs.enable-mlir}}" == "true" ]]; then
-          JLM_CONFIGURE_ARGUMENTS="$JLM_CONFIGURE_ARGUMENTS --enable-mlir=${{ github.workspace }}/lib/mlir-rvsdg"
+          JLM_CONFIGURE_ARGUMENTS="$JLM_CONFIGURE_ARGUMENTS --enable-mlir=${{ github.workspace }}/build-mlir/usr"
         fi
         if [[ "${{inputs.enable-coverage}}" == "true" ]]; then
           JLM_CONFIGURE_ARGUMENTS="$JLM_CONFIGURE_ARGUMENTS --enable-coverage"

--- a/.github/actions/BuildMlirDialect/action.yml
+++ b/.github/actions/BuildMlirDialect/action.yml
@@ -29,7 +29,7 @@ runs:
       if: steps.restore-cache-mlir.outputs.cache-hit != 'true'
       run: |
         ./scripts/build-mlir.sh \
-          --build-path ${{ github.workspace }}/build-mlir
+          --build-path ${{ github.workspace }}/build-mlir \
           --install-path ${{ github.workspace }}/build-mlir/usr
       shell: bash
 

--- a/.github/actions/BuildMlirDialect/action.yml
+++ b/.github/actions/BuildMlirDialect/action.yml
@@ -4,44 +4,40 @@ description: "Restore MLIR RVSDG Dialect from cache and build if it's not in the
 runs:
   using: "composite"
   steps:
-    - name: "Clone MLIR RVSDG dialect"
-      run: git clone https://github.com/EECS-NTNU/mlir_rvsdg.git ${{ github.workspace }}/mlir-rvsdg
-      shell: bash
-
-    - name: "Extract the hash for latest commit for use in the cache key"
-      id: get-mlir-hash
-      run: |
-        cd ${{ github.workspace }}/mlir-rvsdg
-        echo "hash=$(git rev-parse main)" >> $GITHUB_OUTPUT
-      shell: bash
-
-    - name: "Try to fetch Dialect from the cache"
-      id: cache-mlir
-      uses: actions/cache@v4
-      with:
-        path: |
-          ${{ github.workspace }}/lib/mlir-rvsdg
-        key: ${{ runner.os }}-mlir-${{ steps.get-mlir-hash.outputs.hash }}
-
-    - name: "Install LLVM and Clang"
+    - name: "Install LLVM, MLIR and Ninja"
       uses: ./.github/actions/InstallPackages
       with:
         install-llvm: true
         install-mlir: true
         install-ninja: true
 
+    - name: "Extract the commit hash for building the MLIR Dialect"
+      id: get-mlir-hash
+      run: |
+        echo "hash=$(./scripts/build-mlir.sh --get-commit-hash)" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: "Try to fetch Dialect from the cache"
+      id: restore-cache-mlir
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{ github.workspace }}/build-mlir/usr
+        key: ${{ runner.os }}-mlir-${{ steps.get-mlir-hash.outputs.hash }}
+
     - name: "Build MLIR RVSDG Dialect if we didn't hit in the cache"
-      if: steps.cache-mlir.outputs.cache-hit != 'true'
+      if: steps.restore-cache-mlir.outputs.cache-hit != 'true'
       run: |
         ./scripts/build-mlir.sh \
-          --install-path ${{ github.workspace }}/lib/mlir-rvsdg
+          --build-path ${{ github.workspace }}/build-mlir
+          --install-path ${{ github.workspace }}/build-mlir/usr
       shell: bash
 
     - name: "Save MLIR to the cache"
-      if: steps.cache-mlir.outputs.cache-hit != 'true'
-      id: save-cache-circt
+      if: steps.rstore-cache-mlir.outputs.cache-hit != 'true'
+      id: save-cache-mlir
       uses: actions/cache/save@v4
       with:
         path: |
-          ${{ github.workspace }}/lib/mlir-rvsdg
+          ${{ github.workspace }}/build-mlir/usr
         key: ${{ runner.os }}-mlir-${{ steps.get-mlir-hash.outputs.hash }}

--- a/.github/workflows/ClangTidy.yml
+++ b/.github/workflows/ClangTidy.yml
@@ -26,7 +26,7 @@ jobs:
         uses: ./.github/actions/BuildMlirDialect
 
       - name: "Configure jlm with HLS and MLIR enabled"
-        run: ./configure.sh --enable-mlir=${{ github.workspace }}/lib/mlir-rvsdg --enable-hls=${{ github.workspace }}/build-circt/circt
+        run: ./configure.sh --enable-mlir=${{ github.workspace }}/build-mlir/usr --enable-hls=${{ github.workspace }}/build-circt/circt
 
       - name: "Run clang tidy"
         run: make tidy

--- a/scripts/build-mlir.sh
+++ b/scripts/build-mlir.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -eu
 
+GIT_REPOSITORY=https://github.com/EECS-NTNU/mlir_rvsdg.git
 GIT_COMMIT=50fca6b034e909087c3bf24f4edb8ede59f8cd0b
 
 # Get the absolute path to this script and set default build and install paths
@@ -67,7 +68,7 @@ MLIR_BUILD_DIR=${MLIR_BUILD}/build
 
 if [ ! -d "$MLIR_GIT_DIR" ] ;
 then
-	git clone https://github.com/EECS-NTNU/mlir_rvsdg.git ${MLIR_GIT_DIR}
+	git clone ${GIT_REPOSITORY} ${MLIR_GIT_DIR}
 fi
 
 git -C ${MLIR_GIT_DIR} checkout ${GIT_COMMIT}


### PR DESCRIPTION
Takes a lot of inspiration from the existing action `BuildCirct/action.yml`

Also changes the installation directory from `JLM_ROOT/lib/mlir-rvsdg` into `JLM_ROOT/build-mlir/usr`, which is closer to what CIRCT uses (`JLM_ROOT/build-circt/circt`).