### PR TITLE
Add support for IOBarrier [AndersenAgnostic][SteensgaardAgnostic]

### DIFF
--- a/jlm/hls/Makefile.sub
+++ b/jlm/hls/Makefile.sub
@@ -37,6 +37,7 @@ libhls_SOURCES = \
     jlm/hls/ir/hls.cpp \
     \
     jlm/hls/opt/cne.cpp \
+    jlm/hls/opt/IOBarrierRemoval.cpp \
     \
     jlm/hls/util/view.cpp \
 
@@ -76,6 +77,7 @@ libhls_HEADERS = \
 	jlm/hls/ir/hls.hpp \
 	\
 	jlm/hls/opt/cne.hpp \
+	jlm/hls/opt/IOBarrierRemoval.hpp \
 	\
 	jlm/hls/util/view.hpp \
 
@@ -88,6 +90,7 @@ libhls_TESTS += \
 	tests/jlm/hls/backend/rvsdg2rhls/TestTheta \
 	tests/jlm/hls/backend/rvsdg2rhls/UnusedStateRemovalTests \
 	tests/jlm/hls/backend/rvsdg2rhls/test-loop-passthrough \
+	tests/jlm/hls/opt/IOBarrierRemovalTests \
 	tests/jlm/hls/util/ViewTests \
 
 libhls_TEST_LIBS += \

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -47,6 +47,7 @@
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Support/SourceMgr.h>
 
+#include <jlm/hls/opt/IOBarrierRemoval.hpp>
 #include <regex>
 
 namespace jlm::hls
@@ -426,6 +427,10 @@ void
 rvsdg2rhls(llvm::RvsdgModule & rhls, util::StatisticsCollector & collector)
 {
   pre_opt(rhls);
+
+  IOBarrierRemoval ioBarrierRemoval;
+  ioBarrierRemoval.Run(rhls, collector);
+
   merge_gamma(rhls);
 
   llvm::DeadNodeElimination llvmDne;

--- a/jlm/hls/opt/IOBarrierRemoval.cpp
+++ b/jlm/hls/opt/IOBarrierRemoval.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <jlm/hls/opt/IOBarrierRemoval.hpp>
+#include <jlm/llvm/ir/operators/IOBarrier.hpp>
+#include <jlm/rvsdg/region.hpp>
+#include <jlm/rvsdg/RvsdgModule.hpp>
+#include <jlm/rvsdg/structural-node.hpp>
+
+namespace jlm::hls
+{
+
+IOBarrierRemoval::~IOBarrierRemoval() noexcept = default;
+
+void
+IOBarrierRemoval::Run(rvsdg::RvsdgModule & module, util::StatisticsCollector &)
+{
+  RemoveIOBarrierFromRegion(module.Rvsdg().GetRootRegion());
+}
+
+void
+IOBarrierRemoval::RemoveIOBarrierFromRegion(rvsdg::Region & region)
+{
+  for (auto & node : region.Nodes())
+  {
+    // Handle subregions first
+    if (const auto structuralNode = dynamic_cast<const rvsdg::StructuralNode *>(&node))
+    {
+      for (size_t n = 0; n < structuralNode->nsubregions(); n++)
+      {
+        RemoveIOBarrierFromRegion(*structuralNode->subregion(n));
+      }
+    }
+
+    // Render all IOBarrier nodes dead
+    if (rvsdg::is<llvm::IOBarrierOperation>(&node))
+    {
+      node.output(0)->divert_users(node.input(0)->origin());
+    }
+  }
+
+  // Remove all dead IOBarrier nodes
+  region.prune(false);
+}
+
+}

--- a/jlm/hls/opt/IOBarrierRemoval.hpp
+++ b/jlm/hls/opt/IOBarrierRemoval.hpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#ifndef JLM_HLS_OPT_IOBARRIERREMOVAL_HPP
+#define JLM_HLS_OPT_IOBARRIERREMOVAL_HPP
+
+#include <jlm/rvsdg/Transformation.hpp>
+
+namespace jlm::rvsdg
+{
+class Region;
+}
+
+namespace jlm::hls
+{
+
+/**
+ * \brief Removes all IOBarrier nodes from the RVSDG.
+ *
+ * In HLS, we can safely assume that we will not encounter any undefined behavior. However, this
+ * means also that we can relax the sequentialization restrictions on certain operations, such as
+ * division or modulo operations, with respect to each other. Ultimately, it means that we can
+ * remove IOBarrier nodes from the RVSDG when performing HLS.
+ *
+ * @see IOBarrierOperation
+ */
+class IOBarrierRemoval final : public rvsdg::Transformation
+{
+public:
+  ~IOBarrierRemoval() noexcept override;
+
+  void
+  Run(rvsdg::RvsdgModule & module, util::StatisticsCollector & statisticsCollector) override;
+
+private:
+  static void
+  RemoveIOBarrierFromRegion(rvsdg::Region & region);
+};
+
+}
+
+#endif // JLM_HLS_OPT_IOBARRIERREMOVAL_HPP

--- a/jlm/llvm/Makefile.sub
+++ b/jlm/llvm/Makefile.sub
@@ -31,6 +31,7 @@ libllvm_SOURCES = \
     jlm/llvm/ir/operators/FunctionPointer.cpp \
     jlm/llvm/ir/operators/GetElementPtr.cpp \
     jlm/llvm/ir/operators/IntegerOperations.cpp \
+    jlm/llvm/ir/operators/IOBarrier.cpp \
     jlm/llvm/ir/operators/lambda.cpp \
     jlm/llvm/ir/operators/Load.cpp \
     jlm/llvm/ir/operators/MemCpy.cpp \
@@ -127,6 +128,7 @@ libllvm_HEADERS = \
 	jlm/llvm/ir/operators/FunctionPointer.hpp \
 	jlm/llvm/ir/operators/GetElementPtr.hpp \
 	jlm/llvm/ir/operators/IntegerOperations.hpp \
+	jlm/llvm/ir/operators/IOBarrier.hpp \
 	jlm/llvm/ir/operators/delta.hpp \
 	jlm/llvm/ir/operators/Store.hpp \
 	jlm/llvm/ir/operators/alloca.hpp \

--- a/jlm/llvm/backend/jlm2llvm/instruction.cpp
+++ b/jlm/llvm/backend/jlm2llvm/instruction.cpp
@@ -19,6 +19,7 @@
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Module.h>
 
+#include <jlm/llvm/ir/operators/IOBarrier.hpp>
 #include <typeindex>
 
 namespace jlm::llvm
@@ -1145,6 +1146,10 @@ convert_operation(
   if (is<rvsdg::bitsle_op>(op))
   {
     return CreateICmpInstruction(::llvm::CmpInst::ICMP_SLE, arguments, builder, ctx);
+  }
+  if (is<IOBarrierOperation>(op))
+  {
+    return ctx.value(arguments[0]);
   }
 
   static std::unordered_map<

--- a/jlm/llvm/backend/jlm2llvm/instruction.cpp
+++ b/jlm/llvm/backend/jlm2llvm/instruction.cpp
@@ -11,6 +11,7 @@
 #include <jlm/llvm/ir/operators.hpp>
 #include <jlm/llvm/ir/operators/FunctionPointer.hpp>
 #include <jlm/llvm/ir/operators/IntegerOperations.hpp>
+#include <jlm/llvm/ir/operators/IOBarrier.hpp>
 #include <jlm/llvm/ir/operators/MemoryStateOperations.hpp>
 
 #include <jlm/llvm/backend/jlm2llvm/context.hpp>
@@ -19,7 +20,6 @@
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Module.h>
 
-#include <jlm/llvm/ir/operators/IOBarrier.hpp>
 #include <typeindex>
 
 namespace jlm::llvm

--- a/jlm/llvm/ir/operators/IOBarrier.cpp
+++ b/jlm/llvm/ir/operators/IOBarrier.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <jlm/llvm/ir/operators/IOBarrier.hpp>
+
+namespace jlm::llvm
+{
+
+IOBarrierOperation::~IOBarrierOperation() noexcept = default;
+
+bool
+IOBarrierOperation::operator==(const Operation & other) const noexcept
+{
+  const auto ioBarrier = dynamic_cast<const IOBarrierOperation *>(&other);
+  return ioBarrier && ioBarrier->Type() == Type();
+}
+
+std::string
+IOBarrierOperation::debug_string() const
+{
+  return "IOBarrier";
+}
+
+std::unique_ptr<rvsdg::Operation>
+IOBarrierOperation::copy() const
+{
+  return std::make_unique<IOBarrierOperation>(*this);
+}
+
+}

--- a/jlm/llvm/ir/operators/IOBarrier.hpp
+++ b/jlm/llvm/ir/operators/IOBarrier.hpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#ifndef JLM_LLVM_IR_OPERATORS_IOBARRIER_HPP
+#define JLM_LLVM_IR_OPERATORS_IOBARRIER_HPP
+
+#include <jlm/llvm/ir/types.hpp>
+#include <jlm/rvsdg/operation.hpp>
+
+namespace jlm::llvm
+{
+
+/**
+ * An IOBarrier operation is used to sequentialize other operations after other IO state operations.
+ * It has no equivalent in LLVM.
+ *
+ * Example:
+ *
+ * \code{.c}
+ * int f(int x)
+ * {
+ *   opaque(); //calls internally exit(0)
+ *   return x / 0;
+ * }
+ * \endcode
+ *
+ * The above code is valid C code and not undefined even though there is a division by zero present.
+ * The reason for this is that the function opaque() invokes exit(0), and the division by zero is
+ * never performed at runtime. In the RVSDG, the division operation has no dependency on the
+ * function call to opaque() and therefore it can happen that it is sequentialized before the call
+ * operation, transforming the valid program to an undefined program.
+ *
+ * The IOBarrier operation ensures a sequentialization of these two operations by routing one of the
+ * division operands through it along with an I/O state as additional operand. The division
+ * operation consumes then the result value of the IOBarrier operation, effectively seuqentializing
+ * the division after the barrier and with that after the call operation:
+ *
+ * ... io = Call opaque ....
+ * xo = IOBarrier x io
+ * ... = ISDiv xo 0
+ */
+class IOBarrierOperation final : public rvsdg::SimpleOperation
+{
+public:
+  ~IOBarrierOperation() noexcept override;
+
+  explicit IOBarrierOperation(const std::shared_ptr<const rvsdg::Type> & type)
+      : SimpleOperation({ type, IOStateType::Create() }, { type })
+  {}
+
+  [[nodiscard]] const std::shared_ptr<const rvsdg::Type> &
+  Type() const noexcept
+  {
+    return result(0);
+  }
+
+  bool
+  operator==(const Operation & other) const noexcept override;
+
+  std::string
+  debug_string() const override;
+
+  std::unique_ptr<Operation>
+  copy() const override;
+};
+
+}
+
+#endif // JLM_LLVM_IR_OPERATORS_IOBARRIER_HPP

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -989,8 +989,10 @@ Andersen::AnalyzeFunctionToPointer(const rvsdg::SimpleNode & node)
 void
 Andersen::AnalyzeIOBarrier(const rvsdg::SimpleNode & node)
 {
-  const auto ioBarrierNode = util::AssertedCast<IOBarrierOperation>(&node);
-  if (!IsOrContainsPointerType(*ioBarrierNode->Type()))
+  JLM_ASSERT(is<IOBarrierOperation>(&node));
+
+  const auto operation = util::AssertedCast<const IOBarrierOperation>(&node.GetOperation());
+  if (!IsOrContainsPointerType(*operation->Type()))
     return;
 
   const auto & inputRegister = *node.input(0)->origin();

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -989,7 +989,9 @@ Andersen::AnalyzeFunctionToPointer(const rvsdg::SimpleNode & node)
 void
 Andersen::AnalyzeIOBarrier(const rvsdg::SimpleNode & node)
 {
-  JLM_ASSERT(is<IOBarrierOperation>(&node));
+  const auto ioBarrierNode = util::AssertedCast<IOBarrierOperation>(&node);
+  if (!IsOrContainsPointerType(*ioBarrierNode->Type()))
+    return;
 
   const auto & inputRegister = *node.input(0)->origin();
   const auto inputRegisterPO = Set_->GetRegisterPointerObject(inputRegister);

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -3,6 +3,7 @@
  * See COPYING for terms of redistribution.
  */
 
+#include <jlm/llvm/ir/operators/IOBarrier.hpp>
 #include <jlm/llvm/opt/alias-analyses/Andersen.hpp>
 #include <jlm/llvm/opt/alias-analyses/PointsToGraph.hpp>
 #include <jlm/rvsdg/traverser.hpp>
@@ -650,6 +651,8 @@ Andersen::AnalyzeSimpleNode(const rvsdg::SimpleNode & node)
     AnalyzePointerToFunction(node);
   else if (is<FunctionToPointerOperation>(op))
     AnalyzeFunctionToPointer(node);
+  else if (is<IOBarrierOperation>(op))
+    AnalyzeIOBarrier(node);
   else if (is<FreeOperation>(op) || is<ptrcmp_op>(op))
   {
     // These operations take pointers as input, but do not affect any points-to sets
@@ -981,6 +984,17 @@ Andersen::AnalyzeFunctionToPointer(const rvsdg::SimpleNode & node)
   const auto baseRegisterPO = Set_->GetRegisterPointerObject(baseRegister);
   const auto & outputRegister = *node.output(0);
   Set_->MapRegisterToExistingPointerObject(outputRegister, baseRegisterPO);
+}
+
+void
+Andersen::AnalyzeIOBarrier(const rvsdg::SimpleNode & node)
+{
+  JLM_ASSERT(is<IOBarrierOperation>(&node));
+
+  const auto & inputRegister = *node.input(0)->origin();
+  const auto inputRegisterPO = Set_->GetRegisterPointerObject(inputRegister);
+  const auto & outputRegister = *node.output(0);
+  Set_->MapRegisterToExistingPointerObject(outputRegister, inputRegisterPO);
 }
 
 void

--- a/jlm/llvm/opt/alias-analyses/Andersen.hpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.hpp
@@ -409,6 +409,9 @@ private:
   AnalyzeFunctionToPointer(const rvsdg::SimpleNode & node);
 
   void
+  AnalyzeIOBarrier(const rvsdg::SimpleNode & node);
+
+  void
   AnalyzeStructuralNode(const rvsdg::StructuralNode & node);
 
   void

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.hpp
@@ -187,6 +187,9 @@ private:
   AnalyzePointerToFunction(const rvsdg::SimpleNode & node);
 
   void
+  AnalyzeIOBarrier(const rvsdg::SimpleNode & node);
+
+  void
   AnalyzeFunctionToPointer(const rvsdg::SimpleNode & node);
 
   /**

--- a/tests/jlm/hls/opt/IOBarrierRemovalTests.cpp
+++ b/tests/jlm/hls/opt/IOBarrierRemovalTests.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <test-registry.hpp>
+
+#include <jlm/hls/opt/IOBarrierRemoval.hpp>
+#include <jlm/llvm/ir/operators/IntegerOperations.hpp>
+#include <jlm/llvm/ir/operators/IOBarrier.hpp>
+#include <jlm/llvm/ir/operators/lambda.hpp>
+#include <jlm/rvsdg/bitstring/type.hpp>
+#include <jlm/rvsdg/simple-node.hpp>
+
+static int
+IOBarrierRemoval()
+{
+  using namespace jlm::hls;
+  using namespace jlm::llvm;
+  using namespace jlm::rvsdg;
+
+  // Arrange
+  auto i32Type = bittype::Create(32);
+  auto ioStateType = IOStateType::Create();
+  const auto functionType =
+      FunctionType::Create({ i32Type, i32Type, ioStateType }, { i32Type, ioStateType });
+
+  jlm::llvm::RvsdgModule rvsdgModule(jlm::util::filepath(""), "", "");
+  const auto & rvsdg = rvsdgModule.Rvsdg();
+
+  const auto lambdaNode = LambdaNode::Create(
+      rvsdg.GetRootRegion(),
+      LlvmLambdaOperation::Create(functionType, "f", linkage::external_linkage));
+
+  auto x = lambdaNode->GetFunctionArguments()[0];
+  auto y = lambdaNode->GetFunctionArguments()[1];
+  auto ioState = lambdaNode->GetFunctionArguments()[2];
+
+  auto & ioBarrierNode = jlm::rvsdg::CreateOpNode<IOBarrierOperation>({ x, ioState }, i32Type);
+
+  auto & sdivNode =
+      jlm::rvsdg::CreateOpNode<IntegerSDivOperation>({ ioBarrierNode.output(0), y }, 32);
+
+  const auto lambdaOutput = lambdaNode->finalize({ sdivNode.output(0), ioState });
+
+  jlm::llvm::GraphExport::Create(*lambdaOutput, "f");
+
+  // Act
+  jlm::hls::IOBarrierRemoval ioBarrierRemoval;
+  jlm::util::StatisticsCollector statisticsCollector;
+  ioBarrierRemoval.Run(rvsdgModule, statisticsCollector);
+
+  // Assert
+  assert(!Region::Contains<IOBarrierOperation>(rvsdg.GetRootRegion(), true));
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER("jlm/hls/opt/IOBarrierRemoval", IOBarrierRemoval)


### PR DESCRIPTION
This PR introduces the IOBarrier operation and adds support for it to the LLVM and HLS dialect. The IOBarrier operation is necessary to sequentialize operations with potentially undefined behavior, such as division and modulo by zero as well as load and store operations from null pointers, to ensure correct program semantics. For example, the following code requires a IOBarrier to avoid unwanted undefined behavior:

```
int f(int x, int y)
{
   opaque(); // calls internally exit(0)
   return x / y;
}
```
The program is a valid C program under all circumstances, even if y equals zero. In order to capture this semantic, it is necessary to sequentialize the division operation below the call to opaque in the RVSDG. This is accomplished using the IOBarrier operation. If it can be proven that an operation can never exhibit undefined behavior, then the respective IOBarrier can be removed.

Close #750 