### PR TITLE
Fix support for no operands in CallEntryMemoryStateMergeOperation creation

### DIFF
--- a/jlm/llvm/ir/operators/MemoryStateOperations.hpp
+++ b/jlm/llvm/ir/operators/MemoryStateOperations.hpp
@@ -208,10 +208,13 @@ public:
   copy() const override;
 
   static rvsdg::output &
-  Create(rvsdg::Region &, const std::vector<rvsdg::output *> & operands)
+  Create(rvsdg::Region & region, const std::vector<rvsdg::output *> & operands)
   {
-    return *rvsdg::CreateOpNode<CallEntryMemoryStateMergeOperation>(operands, operands.size())
-                .output(0);
+    return operands.empty()
+             ? *rvsdg::CreateOpNode<CallEntryMemoryStateMergeOperation>(region, operands.size())
+                    .output(0)
+             : *rvsdg::CreateOpNode<CallEntryMemoryStateMergeOperation>(operands, operands.size())
+                    .output(0);
   }
 };
 


### PR DESCRIPTION
The CallEntryMemoryStateMergeOperation should support no operands. This was lost during refactoring in this [PR](https://github.com/phate/jlm/commit/86f1970e48e3a8d71d9e7b8e799b975f43c1fdf1).