### PR TITLE
Add LLVM-specific integer comparison operations

### DIFF
--- a/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.cpp
+++ b/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.cpp
@@ -147,7 +147,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::SimpleNode * node)
     auto uIntOp = AddAsUIntOp(body, remOp);
     Connect(body, outData, uIntOp);
   }
-  else if (dynamic_cast<const jlm::rvsdg::biteq_op *>(&(node->GetOperation())))
+  else if (rvsdg::is<llvm::IntegerEqOperation>(node))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     auto input1 = GetSubfield(body, inBundles[1], "data");
@@ -155,7 +155,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::SimpleNode * node)
     // Connect the op to the output data
     Connect(body, outData, op);
   }
-  else if (dynamic_cast<const jlm::rvsdg::bitne_op *>(&(node->GetOperation())))
+  else if (rvsdg::is<llvm::IntegerNeOperation>(node))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     auto input1 = GetSubfield(body, inBundles[1], "data");
@@ -163,7 +163,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::SimpleNode * node)
     // Connect the op to the output data
     Connect(body, outData, op);
   }
-  else if (dynamic_cast<const jlm::rvsdg::bitsgt_op *>(&(node->GetOperation())))
+  else if (rvsdg::is<llvm::IntegerSgtOperation>(node))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     auto input1 = GetSubfield(body, inBundles[1], "data");
@@ -173,7 +173,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::SimpleNode * node)
     // Connect the op to the output data
     Connect(body, outData, op);
   }
-  else if (dynamic_cast<const jlm::rvsdg::bitult_op *>(&(node->GetOperation())))
+  else if (rvsdg::is<llvm::IntegerUltOperation>(node))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     auto input1 = GetSubfield(body, inBundles[1], "data");
@@ -181,7 +181,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::SimpleNode * node)
     // Connect the op to the output data
     Connect(body, outData, op);
   }
-  else if (dynamic_cast<const jlm::rvsdg::bitule_op *>(&(node->GetOperation())))
+  else if (rvsdg::is<llvm::IntegerUleOperation>(node))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     auto input1 = GetSubfield(body, inBundles[1], "data");
@@ -189,7 +189,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::SimpleNode * node)
     // Connect the op to the output data
     Connect(body, outData, op);
   }
-  else if (dynamic_cast<const jlm::rvsdg::bitugt_op *>(&(node->GetOperation())))
+  else if (rvsdg::is<llvm::IntegerUgtOperation>(node))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     auto input1 = GetSubfield(body, inBundles[1], "data");
@@ -197,7 +197,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::SimpleNode * node)
     // Connect the op to the output data
     Connect(body, outData, op);
   }
-  else if (dynamic_cast<const jlm::rvsdg::bitsge_op *>(&(node->GetOperation())))
+  else if (rvsdg::is<llvm::IntegerSgeOperation>(node))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     auto input1 = GetSubfield(body, inBundles[1], "data");
@@ -207,7 +207,7 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::SimpleNode * node)
     // Connect the op to the output data
     Connect(body, outData, op);
   }
-  else if (dynamic_cast<const jlm::rvsdg::bitsle_op *>(&(node->GetOperation())))
+  else if (rvsdg::is<llvm::IntegerSleOperation>(node))
   {
     auto input0 = GetSubfield(body, inBundles[0], "data");
     auto input1 = GetSubfield(body, inBundles[1], "data");
@@ -215,6 +215,15 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::SimpleNode * node)
     auto sIntOp1 = AddAsSIntOp(body, input1);
     auto op = AddLeqOp(body, sIntOp0, sIntOp1);
     // Connect the op to the output data
+    Connect(body, outData, op);
+  }
+  else if (rvsdg::is<llvm::IntegerSltOperation>(node))
+  {
+    auto input0 = GetSubfield(body, inBundles[0], "data");
+    auto input1 = GetSubfield(body, inBundles[1], "data");
+    auto sInt0 = AddAsSIntOp(body, input0);
+    auto sInt1 = AddAsSIntOp(body, input1);
+    auto op = AddLtOp(body, sInt0, sInt1);
     Connect(body, outData, op);
   }
   else if (dynamic_cast<const llvm::zext_op *>(&(node->GetOperation())))
@@ -260,15 +269,6 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::SimpleNode * node)
     auto size = ceil(log2(op->value().nalternatives()));
     auto constant = GetConstant(body, size, value);
     Connect(body, outData, constant);
-  }
-  else if (dynamic_cast<const jlm::rvsdg::bitslt_op *>(&(node->GetOperation())))
-  {
-    auto input0 = GetSubfield(body, inBundles[0], "data");
-    auto input1 = GetSubfield(body, inBundles[1], "data");
-    auto sInt0 = AddAsSIntOp(body, input0);
-    auto sInt1 = AddAsSIntOp(body, input1);
-    auto op = AddLtOp(body, sInt0, sInt1);
-    Connect(body, outData, op);
   }
   else if (dynamic_cast<const llvm::bitcast_op *>(&(node->GetOperation())))
   {

--- a/jlm/llvm/backend/jlm2llvm/instruction.cpp
+++ b/jlm/llvm/backend/jlm2llvm/instruction.cpp
@@ -1106,43 +1106,43 @@ convert_operation(
   {
     return CreateBinOpInstruction(::llvm::Instruction::Mul, arguments, builder, ctx);
   }
-  if (is<rvsdg::biteq_op>(op))
+  if (is<IntegerEqOperation>(op))
   {
     return CreateICmpInstruction(::llvm::CmpInst::ICMP_EQ, arguments, builder, ctx);
   }
-  if (is<rvsdg::bitne_op>(op))
+  if (is<IntegerNeOperation>(op))
   {
     return CreateICmpInstruction(::llvm::CmpInst::ICMP_NE, arguments, builder, ctx);
   }
-  if (is<rvsdg::bitugt_op>(op))
+  if (is<IntegerUgtOperation>(op))
   {
     return CreateICmpInstruction(::llvm::CmpInst::ICMP_UGT, arguments, builder, ctx);
   }
-  if (is<rvsdg::bituge_op>(op))
+  if (is<IntegerUgeOperation>(op))
   {
     return CreateICmpInstruction(::llvm::CmpInst::ICMP_UGE, arguments, builder, ctx);
   }
-  if (is<rvsdg::bitult_op>(op))
+  if (is<IntegerUltOperation>(op))
   {
     return CreateICmpInstruction(::llvm::CmpInst::ICMP_ULT, arguments, builder, ctx);
   }
-  if (is<rvsdg::bitule_op>(op))
+  if (is<IntegerUleOperation>(op))
   {
     return CreateICmpInstruction(::llvm::CmpInst::ICMP_ULE, arguments, builder, ctx);
   }
-  if (is<rvsdg::bitsgt_op>(op))
+  if (is<IntegerSgtOperation>(op))
   {
     return CreateICmpInstruction(::llvm::CmpInst::ICMP_SGT, arguments, builder, ctx);
   }
-  if (is<rvsdg::bitsge_op>(op))
+  if (is<IntegerSgeOperation>(op))
   {
     return CreateICmpInstruction(::llvm::CmpInst::ICMP_SGE, arguments, builder, ctx);
   }
-  if (is<rvsdg::bitslt_op>(op))
+  if (is<IntegerSltOperation>(op))
   {
     return CreateICmpInstruction(::llvm::CmpInst::ICMP_SLT, arguments, builder, ctx);
   }
-  if (is<rvsdg::bitsle_op>(op))
+  if (is<IntegerSleOperation>(op))
   {
     return CreateICmpInstruction(::llvm::CmpInst::ICMP_SLE, arguments, builder, ctx);
   }

--- a/jlm/llvm/frontend/LlvmInstructionConversion.cpp
+++ b/jlm/llvm/frontend/LlvmInstructionConversion.cpp
@@ -463,25 +463,25 @@ ConvertIntegerIcmpPredicate(const ::llvm::CmpInst::Predicate predicate, const st
   switch (predicate)
   {
   case ::llvm::CmpInst::ICMP_SLT:
-    return std::make_unique<rvsdg::bitslt_op>(numBits);
+    return std::make_unique<IntegerSltOperation>(numBits);
   case ::llvm::CmpInst::ICMP_ULT:
-    return std::make_unique<rvsdg::bitult_op>(numBits);
+    return std::make_unique<IntegerUltOperation>(numBits);
   case ::llvm::CmpInst::ICMP_SLE:
-    return std::make_unique<rvsdg::bitsle_op>(numBits);
+    return std::make_unique<IntegerSleOperation>(numBits);
   case ::llvm::CmpInst::ICMP_ULE:
-    return std::make_unique<rvsdg::bitule_op>(numBits);
+    return std::make_unique<IntegerUleOperation>(numBits);
   case ::llvm::CmpInst::ICMP_EQ:
-    return std::make_unique<rvsdg::biteq_op>(numBits);
+    return std::make_unique<IntegerEqOperation>(numBits);
   case ::llvm::CmpInst::ICMP_NE:
-    return std::make_unique<rvsdg::bitne_op>(numBits);
+    return std::make_unique<IntegerNeOperation>(numBits);
   case ::llvm::CmpInst::ICMP_SGE:
-    return std::make_unique<rvsdg::bitsge_op>(numBits);
+    return std::make_unique<IntegerSgeOperation>(numBits);
   case ::llvm::CmpInst::ICMP_UGE:
-    return std::make_unique<rvsdg::bituge_op>(numBits);
+    return std::make_unique<IntegerUgeOperation>(numBits);
   case ::llvm::CmpInst::ICMP_SGT:
-    return std::make_unique<rvsdg::bitsgt_op>(numBits);
+    return std::make_unique<IntegerSgtOperation>(numBits);
   case ::llvm::CmpInst::ICMP_UGT:
-    return std::make_unique<rvsdg::bitugt_op>(numBits);
+    return std::make_unique<IntegerUgtOperation>(numBits);
   default:
     JLM_UNREACHABLE("ConvertIntegerIcmpPredicate: Unsupported icmp predicate.");
   }

--- a/jlm/llvm/ir/operators/IntegerOperations.cpp
+++ b/jlm/llvm/ir/operators/IntegerOperations.cpp
@@ -569,4 +569,434 @@ IntegerXorOperation::flags() const noexcept
   return flags::associative | flags::commutative;
 }
 
+IntegerEqOperation::~IntegerEqOperation() noexcept = default;
+
+bool
+IntegerEqOperation::operator==(const Operation & other) const noexcept
+{
+  const auto eqOperation = dynamic_cast<const IntegerEqOperation *>(&other);
+  return eqOperation && eqOperation->result(0) == result(0);
+}
+
+std::string
+IntegerEqOperation::debug_string() const
+{
+  return "IEq";
+}
+
+std::unique_ptr<rvsdg::Operation>
+IntegerEqOperation::copy() const
+{
+  return std::make_unique<IntegerEqOperation>(*this);
+}
+
+rvsdg::binop_reduction_path_t
+IntegerEqOperation::can_reduce_operand_pair(const rvsdg::output *, const rvsdg::output *)
+    const noexcept
+{
+  return rvsdg::binop_reduction_none;
+}
+
+rvsdg::output *
+IntegerEqOperation::reduce_operand_pair(
+    rvsdg::binop_reduction_path_t,
+    rvsdg::output *,
+    rvsdg::output *) const
+{
+  return nullptr;
+}
+
+enum rvsdg::BinaryOperation::flags
+IntegerEqOperation::flags() const noexcept
+{
+  return flags::none;
+}
+
+IntegerNeOperation::~IntegerNeOperation() noexcept = default;
+
+bool
+IntegerNeOperation::operator==(const Operation & other) const noexcept
+{
+  const auto neOperation = dynamic_cast<const IntegerNeOperation *>(&other);
+  return neOperation && neOperation->result(0) == result(0);
+}
+
+std::string
+IntegerNeOperation::debug_string() const
+{
+  return "INe";
+}
+
+std::unique_ptr<rvsdg::Operation>
+IntegerNeOperation::copy() const
+{
+  return std::make_unique<IntegerNeOperation>(*this);
+}
+
+rvsdg::binop_reduction_path_t
+IntegerNeOperation::can_reduce_operand_pair(const rvsdg::output *, const rvsdg::output *)
+    const noexcept
+{
+  return rvsdg::binop_reduction_none;
+}
+
+rvsdg::output *
+IntegerNeOperation::reduce_operand_pair(
+    rvsdg::binop_reduction_path_t,
+    rvsdg::output *,
+    rvsdg::output *) const
+{
+  return nullptr;
+}
+
+enum rvsdg::BinaryOperation::flags
+IntegerNeOperation::flags() const noexcept
+{
+  return flags::none;
+}
+
+IntegerSgeOperation::~IntegerSgeOperation() noexcept = default;
+
+bool
+IntegerSgeOperation::operator==(const Operation & other) const noexcept
+{
+  const auto sgeOperation = dynamic_cast<const IntegerSgeOperation *>(&other);
+  return sgeOperation && sgeOperation->result(0) == result(0);
+}
+
+std::string
+IntegerSgeOperation::debug_string() const
+{
+  return "ISge";
+}
+
+std::unique_ptr<rvsdg::Operation>
+IntegerSgeOperation::copy() const
+{
+  return std::make_unique<IntegerSgeOperation>(*this);
+}
+
+rvsdg::binop_reduction_path_t
+IntegerSgeOperation::can_reduce_operand_pair(const rvsdg::output *, const rvsdg::output *)
+    const noexcept
+{
+  return rvsdg::binop_reduction_none;
+}
+
+rvsdg::output *
+IntegerSgeOperation::reduce_operand_pair(
+    rvsdg::binop_reduction_path_t,
+    rvsdg::output *,
+    rvsdg::output *) const
+{
+  return nullptr;
+}
+
+enum rvsdg::BinaryOperation::flags
+IntegerSgeOperation::flags() const noexcept
+{
+  return flags::none;
+}
+
+IntegerSgtOperation::~IntegerSgtOperation() noexcept = default;
+
+bool
+IntegerSgtOperation::operator==(const Operation & other) const noexcept
+{
+  const auto sgtOperation = dynamic_cast<const IntegerSgtOperation *>(&other);
+  return sgtOperation && sgtOperation->result(0) == result(0);
+}
+
+std::string
+IntegerSgtOperation::debug_string() const
+{
+  return "ISgt";
+}
+
+std::unique_ptr<rvsdg::Operation>
+IntegerSgtOperation::copy() const
+{
+  return std::make_unique<IntegerSgtOperation>(*this);
+}
+
+rvsdg::binop_reduction_path_t
+IntegerSgtOperation::can_reduce_operand_pair(const rvsdg::output *, const rvsdg::output *)
+    const noexcept
+{
+  return rvsdg::binop_reduction_none;
+}
+
+rvsdg::output *
+IntegerSgtOperation::reduce_operand_pair(
+    rvsdg::binop_reduction_path_t,
+    rvsdg::output *,
+    rvsdg::output *) const
+{
+  return nullptr;
+}
+
+enum rvsdg::BinaryOperation::flags
+IntegerSgtOperation::flags() const noexcept
+{
+  return flags::none;
+}
+
+IntegerSleOperation::~IntegerSleOperation() noexcept = default;
+
+bool
+IntegerSleOperation::operator==(const Operation & other) const noexcept
+{
+  const auto sleOperation = dynamic_cast<const IntegerSleOperation *>(&other);
+  return sleOperation && sleOperation->result(0) == result(0);
+}
+
+std::string
+IntegerSleOperation::debug_string() const
+{
+  return "ISle";
+}
+
+std::unique_ptr<rvsdg::Operation>
+IntegerSleOperation::copy() const
+{
+  return std::make_unique<IntegerSleOperation>(*this);
+}
+
+rvsdg::binop_reduction_path_t
+IntegerSleOperation::can_reduce_operand_pair(const rvsdg::output *, const rvsdg::output *)
+    const noexcept
+{
+  return rvsdg::binop_reduction_none;
+}
+
+rvsdg::output *
+IntegerSleOperation::reduce_operand_pair(
+    rvsdg::binop_reduction_path_t,
+    rvsdg::output *,
+    rvsdg::output *) const
+{
+  return nullptr;
+}
+
+enum rvsdg::BinaryOperation::flags
+IntegerSleOperation::flags() const noexcept
+{
+  return flags::none;
+}
+
+IntegerSltOperation::~IntegerSltOperation() noexcept = default;
+
+bool
+IntegerSltOperation::operator==(const Operation & other) const noexcept
+{
+  const auto sltOperation = dynamic_cast<const IntegerSltOperation *>(&other);
+  return sltOperation && sltOperation->result(0) == result(0);
+}
+
+std::string
+IntegerSltOperation::debug_string() const
+{
+  return "ISlt";
+}
+
+std::unique_ptr<rvsdg::Operation>
+IntegerSltOperation::copy() const
+{
+  return std::make_unique<IntegerSltOperation>(*this);
+}
+
+rvsdg::binop_reduction_path_t
+IntegerSltOperation::can_reduce_operand_pair(const rvsdg::output *, const rvsdg::output *)
+    const noexcept
+{
+  return rvsdg::binop_reduction_none;
+}
+
+rvsdg::output *
+IntegerSltOperation::reduce_operand_pair(
+    rvsdg::binop_reduction_path_t,
+    rvsdg::output *,
+    rvsdg::output *) const
+{
+  return nullptr;
+}
+
+enum rvsdg::BinaryOperation::flags
+IntegerSltOperation::flags() const noexcept
+{
+  return flags::none;
+}
+
+IntegerUgeOperation::~IntegerUgeOperation() noexcept = default;
+
+bool
+IntegerUgeOperation::operator==(const Operation & other) const noexcept
+{
+  const auto ugeOperation = dynamic_cast<const IntegerUgeOperation *>(&other);
+  return ugeOperation && ugeOperation->result(0) == result(0);
+}
+
+std::string
+IntegerUgeOperation::debug_string() const
+{
+  return "IUge";
+}
+
+std::unique_ptr<rvsdg::Operation>
+IntegerUgeOperation::copy() const
+{
+  return std::make_unique<IntegerUgeOperation>(*this);
+}
+
+rvsdg::binop_reduction_path_t
+IntegerUgeOperation::can_reduce_operand_pair(const rvsdg::output *, const rvsdg::output *)
+    const noexcept
+{
+  return rvsdg::binop_reduction_none;
+}
+
+rvsdg::output *
+IntegerUgeOperation::reduce_operand_pair(
+    rvsdg::binop_reduction_path_t,
+    rvsdg::output *,
+    rvsdg::output *) const
+{
+  return nullptr;
+}
+
+enum rvsdg::BinaryOperation::flags
+IntegerUgeOperation::flags() const noexcept
+{
+  return flags::none;
+}
+
+IntegerUgtOperation::~IntegerUgtOperation() noexcept = default;
+
+bool
+IntegerUgtOperation::operator==(const Operation & other) const noexcept
+{
+  const auto ugtOperation = dynamic_cast<const IntegerUgtOperation *>(&other);
+  return ugtOperation && ugtOperation->result(0) == result(0);
+}
+
+std::string
+IntegerUgtOperation::debug_string() const
+{
+  return "IUgt";
+}
+
+std::unique_ptr<rvsdg::Operation>
+IntegerUgtOperation::copy() const
+{
+  return std::make_unique<IntegerUgtOperation>(*this);
+}
+
+rvsdg::binop_reduction_path_t
+IntegerUgtOperation::can_reduce_operand_pair(const rvsdg::output *, const rvsdg::output *)
+    const noexcept
+{
+  return rvsdg::binop_reduction_none;
+}
+
+rvsdg::output *
+IntegerUgtOperation::reduce_operand_pair(
+    rvsdg::binop_reduction_path_t,
+    rvsdg::output *,
+    rvsdg::output *) const
+{
+  return nullptr;
+}
+
+enum rvsdg::BinaryOperation::flags
+IntegerUgtOperation::flags() const noexcept
+{
+  return flags::none;
+}
+
+IntegerUleOperation::~IntegerUleOperation() noexcept = default;
+
+bool
+IntegerUleOperation::operator==(const Operation & other) const noexcept
+{
+  const auto uleOperation = dynamic_cast<const IntegerUleOperation *>(&other);
+  return uleOperation && uleOperation->result(0) == result(0);
+}
+
+std::string
+IntegerUleOperation::debug_string() const
+{
+  return "IUle";
+}
+
+std::unique_ptr<rvsdg::Operation>
+IntegerUleOperation::copy() const
+{
+  return std::make_unique<IntegerUleOperation>(*this);
+}
+
+rvsdg::binop_reduction_path_t
+IntegerUleOperation::can_reduce_operand_pair(const rvsdg::output *, const rvsdg::output *)
+    const noexcept
+{
+  return rvsdg::binop_reduction_none;
+}
+
+rvsdg::output *
+IntegerUleOperation::reduce_operand_pair(
+    rvsdg::binop_reduction_path_t,
+    rvsdg::output *,
+    rvsdg::output *) const
+{
+  return nullptr;
+}
+
+enum rvsdg::BinaryOperation::flags
+IntegerUleOperation::flags() const noexcept
+{
+  return flags::none;
+}
+
+IntegerUltOperation::~IntegerUltOperation() noexcept = default;
+
+bool
+IntegerUltOperation::operator==(const Operation & other) const noexcept
+{
+  const auto ultOperation = dynamic_cast<const IntegerUltOperation *>(&other);
+  return ultOperation && ultOperation->result(0) == result(0);
+}
+
+std::string
+IntegerUltOperation::debug_string() const
+{
+  return "IUlt";
+}
+
+std::unique_ptr<rvsdg::Operation>
+IntegerUltOperation::copy() const
+{
+  return std::make_unique<IntegerUltOperation>(*this);
+}
+
+rvsdg::binop_reduction_path_t
+IntegerUltOperation::can_reduce_operand_pair(const rvsdg::output *, const rvsdg::output *)
+    const noexcept
+{
+  return rvsdg::binop_reduction_none;
+}
+
+rvsdg::output *
+IntegerUltOperation::reduce_operand_pair(
+    rvsdg::binop_reduction_path_t,
+    rvsdg::output *,
+    rvsdg::output *) const
+{
+  return nullptr;
+}
+
+enum rvsdg::BinaryOperation::flags
+IntegerUltOperation::flags() const noexcept
+{
+  return flags::none;
+}
+
 }

--- a/jlm/llvm/ir/operators/IntegerOperations.cpp
+++ b/jlm/llvm/ir/operators/IntegerOperations.cpp
@@ -609,7 +609,7 @@ IntegerEqOperation::reduce_operand_pair(
 enum rvsdg::BinaryOperation::flags
 IntegerEqOperation::flags() const noexcept
 {
-  return flags::none;
+  return flags::commutative;
 }
 
 IntegerNeOperation::~IntegerNeOperation() noexcept = default;
@@ -652,7 +652,7 @@ IntegerNeOperation::reduce_operand_pair(
 enum rvsdg::BinaryOperation::flags
 IntegerNeOperation::flags() const noexcept
 {
-  return flags::none;
+  return flags::commutative;
 }
 
 IntegerSgeOperation::~IntegerSgeOperation() noexcept = default;

--- a/jlm/llvm/ir/operators/IntegerOperations.hpp
+++ b/jlm/llvm/ir/operators/IntegerOperations.hpp
@@ -486,7 +486,11 @@ public:
   flags() const noexcept override;
 };
 
-// FIXME: add documentation
+/**
+ * This operation is equivalent to LLVM's 'icmp' instruction with condition 'eq' for integer
+ * operands. See [LLVM Language Reference
+ * Manual](https://llvm.org/docs/LangRef.html#icmp-instruction) for more details.
+ */
 class IntegerEqOperation final : public rvsdg::BinaryOperation
 {
 public:
@@ -494,8 +498,8 @@ public:
 
   explicit IntegerEqOperation(const std::size_t numBits)
       : BinaryOperation(
-            { IntegerType::Create(numBits), IntegerType::Create(numBits) },
-            IntegerType::Create(numBits))
+            { rvsdg::bittype::Create(numBits), rvsdg::bittype::Create(numBits) },
+            rvsdg::bittype::Create(1))
   {}
 
   bool
@@ -519,7 +523,11 @@ public:
   flags() const noexcept override;
 };
 
-// FIXME: add documentation
+/**
+ * This operation is equivalent to LLVM's 'icmp' instruction with condition 'ne' for integer
+ * operands. See [LLVM Language Reference
+ * Manual](https://llvm.org/docs/LangRef.html#icmp-instruction) for more details.
+ */
 class IntegerNeOperation final : public rvsdg::BinaryOperation
 {
 public:
@@ -527,8 +535,8 @@ public:
 
   explicit IntegerNeOperation(const std::size_t numBits)
       : BinaryOperation(
-            { IntegerType::Create(numBits), IntegerType::Create(numBits) },
-            IntegerType::Create(numBits))
+            { rvsdg::bittype::Create(numBits), rvsdg::bittype::Create(numBits) },
+            rvsdg::bittype::Create(1))
   {}
 
   bool
@@ -552,7 +560,11 @@ public:
   flags() const noexcept override;
 };
 
-// FIXME: add documentation
+/**
+ * This operation is equivalent to LLVM's 'icmp' instruction with condition 'sge' for integer
+ * operands. See [LLVM Language Reference
+ * Manual](https://llvm.org/docs/LangRef.html#icmp-instruction) for more details.
+ */
 class IntegerSgeOperation final : public rvsdg::BinaryOperation
 {
 public:
@@ -560,8 +572,8 @@ public:
 
   explicit IntegerSgeOperation(const std::size_t numBits)
       : BinaryOperation(
-            { IntegerType::Create(numBits), IntegerType::Create(numBits) },
-            IntegerType::Create(numBits))
+            { rvsdg::bittype::Create(numBits), rvsdg::bittype::Create(numBits) },
+            rvsdg::bittype::Create(1))
   {}
 
   bool
@@ -585,7 +597,11 @@ public:
   flags() const noexcept override;
 };
 
-// FIXME: add documentation
+/**
+ * This operation is equivalent to LLVM's 'icmp' instruction with condition 'sgt' for integer
+ * operands. See [LLVM Language Reference
+ * Manual](https://llvm.org/docs/LangRef.html#icmp-instruction) for more details.
+ */
 class IntegerSgtOperation final : public rvsdg::BinaryOperation
 {
 public:
@@ -593,8 +609,8 @@ public:
 
   explicit IntegerSgtOperation(const std::size_t numBits)
       : BinaryOperation(
-            { IntegerType::Create(numBits), IntegerType::Create(numBits) },
-            IntegerType::Create(numBits))
+            { rvsdg::bittype::Create(numBits), rvsdg::bittype::Create(numBits) },
+            rvsdg::bittype::Create(1))
   {}
 
   bool
@@ -618,7 +634,11 @@ public:
   flags() const noexcept override;
 };
 
-// FIXME: add documentation
+/**
+ * This operation is equivalent to LLVM's 'icmp' instruction with condition 'sle' for integer
+ * operands. See [LLVM Language Reference
+ * Manual](https://llvm.org/docs/LangRef.html#icmp-instruction) for more details.
+ */
 class IntegerSleOperation final : public rvsdg::BinaryOperation
 {
 public:
@@ -626,8 +646,8 @@ public:
 
   explicit IntegerSleOperation(const std::size_t numBits)
       : BinaryOperation(
-            { IntegerType::Create(numBits), IntegerType::Create(numBits) },
-            IntegerType::Create(numBits))
+            { rvsdg::bittype::Create(numBits), rvsdg::bittype::Create(numBits) },
+            rvsdg::bittype::Create(1))
   {}
 
   bool
@@ -651,7 +671,11 @@ public:
   flags() const noexcept override;
 };
 
-// FIXME: add documentation
+/**
+ * This operation is equivalent to LLVM's 'icmp' instruction with condition 'slt' for integer
+ * operands. See [LLVM Language Reference
+ * Manual](https://llvm.org/docs/LangRef.html#icmp-instruction) for more details.
+ */
 class IntegerSltOperation final : public rvsdg::BinaryOperation
 {
 public:
@@ -659,8 +683,8 @@ public:
 
   explicit IntegerSltOperation(const std::size_t numBits)
       : BinaryOperation(
-            { IntegerType::Create(numBits), IntegerType::Create(numBits) },
-            IntegerType::Create(numBits))
+            { rvsdg::bittype::Create(numBits), rvsdg::bittype::Create(numBits) },
+            rvsdg::bittype::Create(1))
   {}
 
   bool
@@ -684,7 +708,11 @@ public:
   flags() const noexcept override;
 };
 
-// FIXME: add documentation
+/**
+ * This operation is equivalent to LLVM's 'icmp' instruction with condition 'uge' for integer
+ * operands. See [LLVM Language Reference
+ * Manual](https://llvm.org/docs/LangRef.html#icmp-instruction) for more details.
+ */
 class IntegerUgeOperation final : public rvsdg::BinaryOperation
 {
 public:
@@ -692,8 +720,8 @@ public:
 
   explicit IntegerUgeOperation(const std::size_t numBits)
       : BinaryOperation(
-            { IntegerType::Create(numBits), IntegerType::Create(numBits) },
-            IntegerType::Create(numBits))
+            { rvsdg::bittype::Create(numBits), rvsdg::bittype::Create(numBits) },
+            rvsdg::bittype::Create(1))
   {}
 
   bool
@@ -717,7 +745,11 @@ public:
   flags() const noexcept override;
 };
 
-// FIXME: add documentation
+/**
+ * This operation is equivalent to LLVM's 'icmp' instruction with condition 'ugt' for integer
+ * operands. See [LLVM Language Reference
+ * Manual](https://llvm.org/docs/LangRef.html#icmp-instruction) for more details.
+ */
 class IntegerUgtOperation final : public rvsdg::BinaryOperation
 {
 public:
@@ -725,8 +757,8 @@ public:
 
   explicit IntegerUgtOperation(const std::size_t numBits)
       : BinaryOperation(
-            { IntegerType::Create(numBits), IntegerType::Create(numBits) },
-            IntegerType::Create(numBits))
+            { rvsdg::bittype::Create(numBits), rvsdg::bittype::Create(numBits) },
+            rvsdg::bittype::Create(1))
   {}
 
   bool
@@ -750,7 +782,11 @@ public:
   flags() const noexcept override;
 };
 
-// FIXME: add documentation
+/**
+ * This operation is equivalent to LLVM's 'icmp' instruction with condition 'ule' for integer
+ * operands. See [LLVM Language Reference
+ * Manual](https://llvm.org/docs/LangRef.html#icmp-instruction) for more details.
+ */
 class IntegerUleOperation final : public rvsdg::BinaryOperation
 {
 public:
@@ -758,8 +794,8 @@ public:
 
   explicit IntegerUleOperation(const std::size_t numBits)
       : BinaryOperation(
-            { IntegerType::Create(numBits), IntegerType::Create(numBits) },
-            IntegerType::Create(numBits))
+            { rvsdg::bittype::Create(numBits), rvsdg::bittype::Create(numBits) },
+            rvsdg::bittype::Create(1))
   {}
 
   bool
@@ -783,7 +819,11 @@ public:
   flags() const noexcept override;
 };
 
-// FIXME: add documentation
+/**
+ * This operation is equivalent to LLVM's 'icmp' instruction with condition 'ult' for integer
+ * operands. See [LLVM Language Reference
+ * Manual](https://llvm.org/docs/LangRef.html#icmp-instruction) for more details.
+ */
 class IntegerUltOperation final : public rvsdg::BinaryOperation
 {
 public:
@@ -791,8 +831,8 @@ public:
 
   explicit IntegerUltOperation(const std::size_t numBits)
       : BinaryOperation(
-            { IntegerType::Create(numBits), IntegerType::Create(numBits) },
-            IntegerType::Create(numBits))
+            { rvsdg::bittype::Create(numBits), rvsdg::bittype::Create(numBits) },
+            rvsdg::bittype::Create(1))
   {}
 
   bool

--- a/jlm/llvm/ir/operators/IntegerOperations.hpp
+++ b/jlm/llvm/ir/operators/IntegerOperations.hpp
@@ -20,8 +20,10 @@ class IntegerBinaryOperation : public rvsdg::BinaryOperation
 public:
   ~IntegerBinaryOperation() override;
 
-  explicit IntegerBinaryOperation(const std::shared_ptr<const rvsdg::bittype> & type) noexcept
-      : BinaryOperation({ type, type }, type)
+  IntegerBinaryOperation(std::size_t numArgumentBits, std::size_t numResultBits) noexcept
+      : BinaryOperation(
+            { rvsdg::bittype::Create(numArgumentBits), rvsdg::bittype::Create(numArgumentBits) },
+            rvsdg::bittype::Create(numResultBits))
   {}
 
   [[nodiscard]] const rvsdg::bittype &
@@ -42,7 +44,7 @@ public:
   ~IntegerAddOperation() noexcept override;
 
   explicit IntegerAddOperation(const std::size_t numBits)
-      : IntegerBinaryOperation(rvsdg::bittype::Create(numBits))
+      : IntegerBinaryOperation(numBits, numBits)
   {}
 
   bool
@@ -77,7 +79,7 @@ public:
   ~IntegerSubOperation() noexcept override;
 
   explicit IntegerSubOperation(const std::size_t numBits)
-      : IntegerBinaryOperation(rvsdg::bittype::Create(numBits))
+      : IntegerBinaryOperation(numBits, numBits)
   {}
 
   bool
@@ -112,7 +114,7 @@ public:
   ~IntegerMulOperation() noexcept override;
 
   explicit IntegerMulOperation(const std::size_t numBits)
-      : IntegerBinaryOperation(rvsdg::bittype::Create(numBits))
+      : IntegerBinaryOperation(numBits, numBits)
   {}
 
   bool
@@ -147,7 +149,7 @@ public:
   ~IntegerSDivOperation() noexcept override;
 
   explicit IntegerSDivOperation(const std::size_t numBits)
-      : IntegerBinaryOperation(rvsdg::bittype::Create(numBits))
+      : IntegerBinaryOperation(numBits, numBits)
   {}
 
   bool
@@ -182,7 +184,7 @@ public:
   ~IntegerUDivOperation() noexcept override;
 
   explicit IntegerUDivOperation(const std::size_t numBits)
-      : IntegerBinaryOperation(rvsdg::bittype::Create(numBits))
+      : IntegerBinaryOperation(numBits, numBits)
   {}
 
   bool
@@ -217,7 +219,7 @@ public:
   ~IntegerSRemOperation() noexcept override;
 
   explicit IntegerSRemOperation(const std::size_t numBits)
-      : IntegerBinaryOperation(rvsdg::bittype::Create(numBits))
+      : IntegerBinaryOperation(numBits, numBits)
   {}
 
   bool
@@ -252,7 +254,7 @@ public:
   ~IntegerURemOperation() noexcept override;
 
   explicit IntegerURemOperation(const std::size_t numBits)
-      : IntegerBinaryOperation(rvsdg::bittype::Create(numBits))
+      : IntegerBinaryOperation(numBits, numBits)
   {}
 
   bool
@@ -287,7 +289,7 @@ public:
   ~IntegerAShrOperation() noexcept override;
 
   explicit IntegerAShrOperation(const std::size_t numBits)
-      : IntegerBinaryOperation(rvsdg::bittype::Create(numBits))
+      : IntegerBinaryOperation(numBits, numBits)
   {}
 
   bool
@@ -322,7 +324,7 @@ public:
   ~IntegerShlOperation() noexcept override;
 
   explicit IntegerShlOperation(const std::size_t numBits)
-      : IntegerBinaryOperation(rvsdg::bittype::Create(numBits))
+      : IntegerBinaryOperation(numBits, numBits)
   {}
 
   bool
@@ -357,7 +359,7 @@ public:
   ~IntegerLShrOperation() noexcept override;
 
   explicit IntegerLShrOperation(const std::size_t numBits)
-      : IntegerBinaryOperation(rvsdg::bittype::Create(numBits))
+      : IntegerBinaryOperation(numBits, numBits)
   {}
 
   bool
@@ -392,7 +394,7 @@ public:
   ~IntegerAndOperation() noexcept override;
 
   explicit IntegerAndOperation(const std::size_t numBits)
-      : IntegerBinaryOperation(rvsdg::bittype::Create(numBits))
+      : IntegerBinaryOperation(numBits, numBits)
   {}
 
   bool
@@ -427,7 +429,7 @@ public:
   ~IntegerOrOperation() noexcept override;
 
   explicit IntegerOrOperation(const std::size_t numBits)
-      : IntegerBinaryOperation(rvsdg::bittype::Create(numBits))
+      : IntegerBinaryOperation(numBits, numBits)
   {}
 
   bool
@@ -462,7 +464,7 @@ public:
   ~IntegerXorOperation() noexcept override;
 
   explicit IntegerXorOperation(const std::size_t numBits)
-      : IntegerBinaryOperation(rvsdg::bittype::Create(numBits))
+      : IntegerBinaryOperation(numBits, numBits)
   {}
 
   bool
@@ -491,15 +493,13 @@ public:
  * operands. See [LLVM Language Reference
  * Manual](https://llvm.org/docs/LangRef.html#icmp-instruction) for more details.
  */
-class IntegerEqOperation final : public rvsdg::BinaryOperation
+class IntegerEqOperation final : public IntegerBinaryOperation
 {
 public:
   ~IntegerEqOperation() noexcept override;
 
   explicit IntegerEqOperation(const std::size_t numBits)
-      : BinaryOperation(
-            { rvsdg::bittype::Create(numBits), rvsdg::bittype::Create(numBits) },
-            rvsdg::bittype::Create(1))
+      : IntegerBinaryOperation(numBits, 1)
   {}
 
   bool
@@ -528,15 +528,13 @@ public:
  * operands. See [LLVM Language Reference
  * Manual](https://llvm.org/docs/LangRef.html#icmp-instruction) for more details.
  */
-class IntegerNeOperation final : public rvsdg::BinaryOperation
+class IntegerNeOperation final : public IntegerBinaryOperation
 {
 public:
   ~IntegerNeOperation() noexcept override;
 
   explicit IntegerNeOperation(const std::size_t numBits)
-      : BinaryOperation(
-            { rvsdg::bittype::Create(numBits), rvsdg::bittype::Create(numBits) },
-            rvsdg::bittype::Create(1))
+      : IntegerBinaryOperation(numBits, 1)
   {}
 
   bool
@@ -565,15 +563,13 @@ public:
  * operands. See [LLVM Language Reference
  * Manual](https://llvm.org/docs/LangRef.html#icmp-instruction) for more details.
  */
-class IntegerSgeOperation final : public rvsdg::BinaryOperation
+class IntegerSgeOperation final : public IntegerBinaryOperation
 {
 public:
   ~IntegerSgeOperation() noexcept override;
 
   explicit IntegerSgeOperation(const std::size_t numBits)
-      : BinaryOperation(
-            { rvsdg::bittype::Create(numBits), rvsdg::bittype::Create(numBits) },
-            rvsdg::bittype::Create(1))
+      : IntegerBinaryOperation(numBits, 1)
   {}
 
   bool
@@ -602,15 +598,13 @@ public:
  * operands. See [LLVM Language Reference
  * Manual](https://llvm.org/docs/LangRef.html#icmp-instruction) for more details.
  */
-class IntegerSgtOperation final : public rvsdg::BinaryOperation
+class IntegerSgtOperation final : public IntegerBinaryOperation
 {
 public:
   ~IntegerSgtOperation() noexcept override;
 
   explicit IntegerSgtOperation(const std::size_t numBits)
-      : BinaryOperation(
-            { rvsdg::bittype::Create(numBits), rvsdg::bittype::Create(numBits) },
-            rvsdg::bittype::Create(1))
+      : IntegerBinaryOperation(numBits, 1)
   {}
 
   bool
@@ -639,15 +633,13 @@ public:
  * operands. See [LLVM Language Reference
  * Manual](https://llvm.org/docs/LangRef.html#icmp-instruction) for more details.
  */
-class IntegerSleOperation final : public rvsdg::BinaryOperation
+class IntegerSleOperation final : public IntegerBinaryOperation
 {
 public:
   ~IntegerSleOperation() noexcept override;
 
   explicit IntegerSleOperation(const std::size_t numBits)
-      : BinaryOperation(
-            { rvsdg::bittype::Create(numBits), rvsdg::bittype::Create(numBits) },
-            rvsdg::bittype::Create(1))
+      : IntegerBinaryOperation(numBits, 1)
   {}
 
   bool
@@ -676,15 +668,13 @@ public:
  * operands. See [LLVM Language Reference
  * Manual](https://llvm.org/docs/LangRef.html#icmp-instruction) for more details.
  */
-class IntegerSltOperation final : public rvsdg::BinaryOperation
+class IntegerSltOperation final : public IntegerBinaryOperation
 {
 public:
   ~IntegerSltOperation() noexcept override;
 
   explicit IntegerSltOperation(const std::size_t numBits)
-      : BinaryOperation(
-            { rvsdg::bittype::Create(numBits), rvsdg::bittype::Create(numBits) },
-            rvsdg::bittype::Create(1))
+      : IntegerBinaryOperation(numBits, 1)
   {}
 
   bool
@@ -713,15 +703,13 @@ public:
  * operands. See [LLVM Language Reference
  * Manual](https://llvm.org/docs/LangRef.html#icmp-instruction) for more details.
  */
-class IntegerUgeOperation final : public rvsdg::BinaryOperation
+class IntegerUgeOperation final : public IntegerBinaryOperation
 {
 public:
   ~IntegerUgeOperation() noexcept override;
 
   explicit IntegerUgeOperation(const std::size_t numBits)
-      : BinaryOperation(
-            { rvsdg::bittype::Create(numBits), rvsdg::bittype::Create(numBits) },
-            rvsdg::bittype::Create(1))
+      : IntegerBinaryOperation(numBits, 1)
   {}
 
   bool
@@ -750,15 +738,13 @@ public:
  * operands. See [LLVM Language Reference
  * Manual](https://llvm.org/docs/LangRef.html#icmp-instruction) for more details.
  */
-class IntegerUgtOperation final : public rvsdg::BinaryOperation
+class IntegerUgtOperation final : public IntegerBinaryOperation
 {
 public:
   ~IntegerUgtOperation() noexcept override;
 
   explicit IntegerUgtOperation(const std::size_t numBits)
-      : BinaryOperation(
-            { rvsdg::bittype::Create(numBits), rvsdg::bittype::Create(numBits) },
-            rvsdg::bittype::Create(1))
+      : IntegerBinaryOperation(numBits, 1)
   {}
 
   bool
@@ -787,15 +773,13 @@ public:
  * operands. See [LLVM Language Reference
  * Manual](https://llvm.org/docs/LangRef.html#icmp-instruction) for more details.
  */
-class IntegerUleOperation final : public rvsdg::BinaryOperation
+class IntegerUleOperation final : public IntegerBinaryOperation
 {
 public:
   ~IntegerUleOperation() noexcept override;
 
   explicit IntegerUleOperation(const std::size_t numBits)
-      : BinaryOperation(
-            { rvsdg::bittype::Create(numBits), rvsdg::bittype::Create(numBits) },
-            rvsdg::bittype::Create(1))
+      : IntegerBinaryOperation(numBits, 1)
   {}
 
   bool
@@ -824,15 +808,13 @@ public:
  * operands. See [LLVM Language Reference
  * Manual](https://llvm.org/docs/LangRef.html#icmp-instruction) for more details.
  */
-class IntegerUltOperation final : public rvsdg::BinaryOperation
+class IntegerUltOperation final : public IntegerBinaryOperation
 {
 public:
   ~IntegerUltOperation() noexcept override;
 
   explicit IntegerUltOperation(const std::size_t numBits)
-      : BinaryOperation(
-            { rvsdg::bittype::Create(numBits), rvsdg::bittype::Create(numBits) },
-            rvsdg::bittype::Create(1))
+      : IntegerBinaryOperation(numBits, 1)
   {}
 
   bool

--- a/jlm/llvm/ir/operators/IntegerOperations.hpp
+++ b/jlm/llvm/ir/operators/IntegerOperations.hpp
@@ -486,6 +486,336 @@ public:
   flags() const noexcept override;
 };
 
+// FIXME: add documentation
+class IntegerEqOperation final : public rvsdg::BinaryOperation
+{
+public:
+  ~IntegerEqOperation() noexcept override;
+
+  explicit IntegerEqOperation(const std::size_t numBits)
+      : BinaryOperation(
+            { IntegerType::Create(numBits), IntegerType::Create(numBits) },
+            IntegerType::Create(numBits))
+  {}
+
+  bool
+  operator==(const Operation & other) const noexcept override;
+
+  std::string
+  debug_string() const override;
+
+  [[nodiscard]] std::unique_ptr<Operation>
+  copy() const override;
+
+  rvsdg::binop_reduction_path_t
+  can_reduce_operand_pair(const rvsdg::output * op1, const rvsdg::output * op2)
+      const noexcept override;
+
+  rvsdg::output *
+  reduce_operand_pair(rvsdg::binop_reduction_path_t path, rvsdg::output * op1, rvsdg::output * op2)
+      const override;
+
+  enum flags
+  flags() const noexcept override;
+};
+
+// FIXME: add documentation
+class IntegerNeOperation final : public rvsdg::BinaryOperation
+{
+public:
+  ~IntegerNeOperation() noexcept override;
+
+  explicit IntegerNeOperation(const std::size_t numBits)
+      : BinaryOperation(
+            { IntegerType::Create(numBits), IntegerType::Create(numBits) },
+            IntegerType::Create(numBits))
+  {}
+
+  bool
+  operator==(const Operation & other) const noexcept override;
+
+  std::string
+  debug_string() const override;
+
+  [[nodiscard]] std::unique_ptr<Operation>
+  copy() const override;
+
+  rvsdg::binop_reduction_path_t
+  can_reduce_operand_pair(const rvsdg::output * op1, const rvsdg::output * op2)
+      const noexcept override;
+
+  rvsdg::output *
+  reduce_operand_pair(rvsdg::binop_reduction_path_t path, rvsdg::output * op1, rvsdg::output * op2)
+      const override;
+
+  enum flags
+  flags() const noexcept override;
+};
+
+// FIXME: add documentation
+class IntegerSgeOperation final : public rvsdg::BinaryOperation
+{
+public:
+  ~IntegerSgeOperation() noexcept override;
+
+  explicit IntegerSgeOperation(const std::size_t numBits)
+      : BinaryOperation(
+            { IntegerType::Create(numBits), IntegerType::Create(numBits) },
+            IntegerType::Create(numBits))
+  {}
+
+  bool
+  operator==(const Operation & other) const noexcept override;
+
+  std::string
+  debug_string() const override;
+
+  [[nodiscard]] std::unique_ptr<Operation>
+  copy() const override;
+
+  rvsdg::binop_reduction_path_t
+  can_reduce_operand_pair(const rvsdg::output * op1, const rvsdg::output * op2)
+      const noexcept override;
+
+  rvsdg::output *
+  reduce_operand_pair(rvsdg::binop_reduction_path_t path, rvsdg::output * op1, rvsdg::output * op2)
+      const override;
+
+  enum flags
+  flags() const noexcept override;
+};
+
+// FIXME: add documentation
+class IntegerSgtOperation final : public rvsdg::BinaryOperation
+{
+public:
+  ~IntegerSgtOperation() noexcept override;
+
+  explicit IntegerSgtOperation(const std::size_t numBits)
+      : BinaryOperation(
+            { IntegerType::Create(numBits), IntegerType::Create(numBits) },
+            IntegerType::Create(numBits))
+  {}
+
+  bool
+  operator==(const Operation & other) const noexcept override;
+
+  std::string
+  debug_string() const override;
+
+  [[nodiscard]] std::unique_ptr<Operation>
+  copy() const override;
+
+  rvsdg::binop_reduction_path_t
+  can_reduce_operand_pair(const rvsdg::output * op1, const rvsdg::output * op2)
+      const noexcept override;
+
+  rvsdg::output *
+  reduce_operand_pair(rvsdg::binop_reduction_path_t path, rvsdg::output * op1, rvsdg::output * op2)
+      const override;
+
+  enum flags
+  flags() const noexcept override;
+};
+
+// FIXME: add documentation
+class IntegerSleOperation final : public rvsdg::BinaryOperation
+{
+public:
+  ~IntegerSleOperation() noexcept override;
+
+  explicit IntegerSleOperation(const std::size_t numBits)
+      : BinaryOperation(
+            { IntegerType::Create(numBits), IntegerType::Create(numBits) },
+            IntegerType::Create(numBits))
+  {}
+
+  bool
+  operator==(const Operation & other) const noexcept override;
+
+  std::string
+  debug_string() const override;
+
+  [[nodiscard]] std::unique_ptr<Operation>
+  copy() const override;
+
+  rvsdg::binop_reduction_path_t
+  can_reduce_operand_pair(const rvsdg::output * op1, const rvsdg::output * op2)
+      const noexcept override;
+
+  rvsdg::output *
+  reduce_operand_pair(rvsdg::binop_reduction_path_t path, rvsdg::output * op1, rvsdg::output * op2)
+      const override;
+
+  enum flags
+  flags() const noexcept override;
+};
+
+// FIXME: add documentation
+class IntegerSltOperation final : public rvsdg::BinaryOperation
+{
+public:
+  ~IntegerSltOperation() noexcept override;
+
+  explicit IntegerSltOperation(const std::size_t numBits)
+      : BinaryOperation(
+            { IntegerType::Create(numBits), IntegerType::Create(numBits) },
+            IntegerType::Create(numBits))
+  {}
+
+  bool
+  operator==(const Operation & other) const noexcept override;
+
+  std::string
+  debug_string() const override;
+
+  [[nodiscard]] std::unique_ptr<Operation>
+  copy() const override;
+
+  rvsdg::binop_reduction_path_t
+  can_reduce_operand_pair(const rvsdg::output * op1, const rvsdg::output * op2)
+      const noexcept override;
+
+  rvsdg::output *
+  reduce_operand_pair(rvsdg::binop_reduction_path_t path, rvsdg::output * op1, rvsdg::output * op2)
+      const override;
+
+  enum flags
+  flags() const noexcept override;
+};
+
+// FIXME: add documentation
+class IntegerUgeOperation final : public rvsdg::BinaryOperation
+{
+public:
+  ~IntegerUgeOperation() noexcept override;
+
+  explicit IntegerUgeOperation(const std::size_t numBits)
+      : BinaryOperation(
+            { IntegerType::Create(numBits), IntegerType::Create(numBits) },
+            IntegerType::Create(numBits))
+  {}
+
+  bool
+  operator==(const Operation & other) const noexcept override;
+
+  std::string
+  debug_string() const override;
+
+  [[nodiscard]] std::unique_ptr<Operation>
+  copy() const override;
+
+  rvsdg::binop_reduction_path_t
+  can_reduce_operand_pair(const rvsdg::output * op1, const rvsdg::output * op2)
+      const noexcept override;
+
+  rvsdg::output *
+  reduce_operand_pair(rvsdg::binop_reduction_path_t path, rvsdg::output * op1, rvsdg::output * op2)
+      const override;
+
+  enum flags
+  flags() const noexcept override;
+};
+
+// FIXME: add documentation
+class IntegerUgtOperation final : public rvsdg::BinaryOperation
+{
+public:
+  ~IntegerUgtOperation() noexcept override;
+
+  explicit IntegerUgtOperation(const std::size_t numBits)
+      : BinaryOperation(
+            { IntegerType::Create(numBits), IntegerType::Create(numBits) },
+            IntegerType::Create(numBits))
+  {}
+
+  bool
+  operator==(const Operation & other) const noexcept override;
+
+  std::string
+  debug_string() const override;
+
+  [[nodiscard]] std::unique_ptr<Operation>
+  copy() const override;
+
+  rvsdg::binop_reduction_path_t
+  can_reduce_operand_pair(const rvsdg::output * op1, const rvsdg::output * op2)
+      const noexcept override;
+
+  rvsdg::output *
+  reduce_operand_pair(rvsdg::binop_reduction_path_t path, rvsdg::output * op1, rvsdg::output * op2)
+      const override;
+
+  enum flags
+  flags() const noexcept override;
+};
+
+// FIXME: add documentation
+class IntegerUleOperation final : public rvsdg::BinaryOperation
+{
+public:
+  ~IntegerUleOperation() noexcept override;
+
+  explicit IntegerUleOperation(const std::size_t numBits)
+      : BinaryOperation(
+            { IntegerType::Create(numBits), IntegerType::Create(numBits) },
+            IntegerType::Create(numBits))
+  {}
+
+  bool
+  operator==(const Operation & other) const noexcept override;
+
+  std::string
+  debug_string() const override;
+
+  [[nodiscard]] std::unique_ptr<Operation>
+  copy() const override;
+
+  rvsdg::binop_reduction_path_t
+  can_reduce_operand_pair(const rvsdg::output * op1, const rvsdg::output * op2)
+      const noexcept override;
+
+  rvsdg::output *
+  reduce_operand_pair(rvsdg::binop_reduction_path_t path, rvsdg::output * op1, rvsdg::output * op2)
+      const override;
+
+  enum flags
+  flags() const noexcept override;
+};
+
+// FIXME: add documentation
+class IntegerUltOperation final : public rvsdg::BinaryOperation
+{
+public:
+  ~IntegerUltOperation() noexcept override;
+
+  explicit IntegerUltOperation(const std::size_t numBits)
+      : BinaryOperation(
+            { IntegerType::Create(numBits), IntegerType::Create(numBits) },
+            IntegerType::Create(numBits))
+  {}
+
+  bool
+  operator==(const Operation & other) const noexcept override;
+
+  std::string
+  debug_string() const override;
+
+  [[nodiscard]] std::unique_ptr<Operation>
+  copy() const override;
+
+  rvsdg::binop_reduction_path_t
+  can_reduce_operand_pair(const rvsdg::output * op1, const rvsdg::output * op2)
+      const noexcept override;
+
+  rvsdg::output *
+  reduce_operand_pair(rvsdg::binop_reduction_path_t path, rvsdg::output * op1, rvsdg::output * op2)
+      const override;
+
+  enum flags
+  flags() const noexcept override;
+};
+
 }
 
 #endif // JLM_LLVM_IR_OPERATORS_INTEGEROPERATIONS_HPP


### PR DESCRIPTION
This PR replaces the old bitstring comparison operations with new LLVM specific
integer comparison operations. The implementations have currently still
the following limitations:

1. The operations still use the bistring type. The type will potentially be
later replaced by an LLVM specific type.
2. No operation specific reductions have been implemented yet. This will
also happen in a follow-up PR.

At this point, the implementation only tries to get on par with the
respective bitstring operations (minus the reductions). More LLVM
specific semantics are going to be introduced in a future PR.