### PR TITLE
Give the cfg_node iterators for outedges and inedges

### DIFF
--- a/jlm/llvm/frontend/ControlFlowRestructuring.cpp
+++ b/jlm/llvm/frontend/ControlFlowRestructuring.cpp
@@ -30,15 +30,15 @@ struct tcloop
 static inline tcloop
 extract_tcloop(cfg_node * ne, cfg_node * nx)
 {
-  JLM_ASSERT(nx->noutedges() == 2);
+  JLM_ASSERT(nx->NumOutEdges() == 2);
   auto & cfg = ne->cfg();
 
-  auto er = nx->outedge(0);
-  auto ex = nx->outedge(1);
+  auto er = nx->OutEdge(0);
+  auto ex = nx->OutEdge(1);
   if (er->sink() != ne)
   {
-    er = nx->outedge(1);
-    ex = nx->outedge(0);
+    er = nx->OutEdge(1);
+    ex = nx->OutEdge(0);
   }
   JLM_ASSERT(er->sink() == ne);
 
@@ -55,12 +55,12 @@ extract_tcloop(cfg_node * ne, cfg_node * nx)
 static inline void
 reinsert_tcloop(const tcloop & l)
 {
-  JLM_ASSERT(l.insert->ninedges() == 1);
-  JLM_ASSERT(l.replacement->noutedges() == 1);
+  JLM_ASSERT(l.insert->NumInEdges() == 1);
+  JLM_ASSERT(l.replacement->NumOutEdges() == 1);
   auto & cfg = l.ne->cfg();
 
   l.replacement->divert_inedges(l.ne);
-  l.insert->divert_inedges(l.replacement->outedge(0)->sink());
+  l.insert->divert_inedges(l.replacement->OutEdge(0)->sink());
 
   cfg.remove_node(l.insert);
   cfg.remove_node(l.replacement);
@@ -220,7 +220,7 @@ find_tvariable_bb(cfg_node * node)
   if (auto bb = dynamic_cast<basic_block *>(node))
     return bb;
 
-  auto sink = node->outedge(0)->sink();
+  auto sink = node->OutEdge(0)->sink();
   JLM_ASSERT(is<basic_block>(sink));
 
   return static_cast<basic_block *>(sink);
@@ -289,7 +289,7 @@ find_head_branch(cfg_node * start, cfg_node * end)
     if (start->is_branch() || start == end)
       break;
 
-    start = start->outedge(0)->sink();
+    start = start->OutEdge(0)->sink();
   } while (1);
 
   return start;
@@ -310,7 +310,7 @@ find_dominator_graph(const cfg_edge * edge)
       continue;
 
     bool accept = true;
-    for (auto & inedge : node->inedges())
+    for (auto & inedge : node->InEdges())
     {
       if (edges.find(&inedge) == edges.end())
       {
@@ -322,7 +322,7 @@ find_dominator_graph(const cfg_edge * edge)
     if (accept)
     {
       nodes.insert(node);
-      for (auto & outedge : node->outedges())
+      for (auto & outedge : node->OutEdges())
       {
         edges.insert(&outedge);
         to_visit.push_back(outedge.sink());
@@ -342,14 +342,14 @@ struct continuation
 static inline continuation
 compute_continuation(cfg_node * hb)
 {
-  JLM_ASSERT(hb->noutedges() > 1);
+  JLM_ASSERT(hb->NumOutEdges() > 1);
 
   std::unordered_map<cfg_edge *, std::unordered_set<cfg_node *>> dgraphs;
-  for (auto & outedge : hb->outedges())
+  for (auto & outedge : hb->OutEdges())
     dgraphs[&outedge] = find_dominator_graph(&outedge);
 
   continuation c;
-  for (auto & outedge : hb->outedges())
+  for (auto & outedge : hb->OutEdges())
   {
     auto & dgraph = dgraphs[&outedge];
     if (dgraph.empty())
@@ -361,7 +361,7 @@ compute_continuation(cfg_node * hb)
 
     for (const auto & node : dgraph)
     {
-      for (auto & outedge2 : node->outedges())
+      for (auto & outedge2 : node->OutEdges())
       {
         if (dgraph.find(outedge2.sink()) == dgraph.end())
         {
@@ -393,7 +393,7 @@ restructure_branches(cfg_node * entry, cfg_node * exit)
   if (c.points.size() == 1)
   {
     auto cpoint = *c.points.begin();
-    for (auto & outedge : hb->outedges())
+    for (auto & outedge : hb->OutEdges())
     {
       auto cedges = c.edges[&outedge];
 
@@ -438,7 +438,7 @@ restructure_branches(cfg_node * entry, cfg_node * exit)
   }
 
   /* restructure branch subgraphs */
-  for (auto & outedge : hb->outedges())
+  for (auto & outedge : hb->OutEdges())
   {
     auto cedges = c.edges[&outedge];
 

--- a/jlm/llvm/frontend/LlvmModuleConversion.cpp
+++ b/jlm/llvm/frontend/LlvmModuleConversion.cpp
@@ -288,7 +288,7 @@ EnsureSingleInEdgeToExitNode(llvm::cfg & cfg)
 {
   auto exitNode = cfg.exit();
 
-  if (exitNode->ninedges() == 0)
+  if (exitNode->NumInEdges() == 0)
   {
     /*
       LLVM can produce CFGs that have no incoming edge to the exit node. This can happen if
@@ -334,7 +334,7 @@ EnsureSingleInEdgeToExitNode(llvm::cfg & cfg)
     }
   }
 
-  if (exitNode->ninedges() == 1)
+  if (exitNode->NumInEdges() == 1)
     return;
 
   /*

--- a/jlm/llvm/ir/aggregation.cpp
+++ b/jlm/llvm/ir/aggregation.cpp
@@ -193,38 +193,38 @@ private:
 static bool
 is_sese_basic_block(const cfg_node * node) noexcept
 {
-  return node->ninedges() == 1 && node->noutedges() == 1;
+  return node->NumInEdges() == 1 && node->NumOutEdges() == 1;
 }
 
 static bool
 is_branch_split(const cfg_node * node) noexcept
 {
-  return node->noutedges() > 1;
+  return node->NumOutEdges() > 1;
 }
 
 static bool
 is_branch_join(const cfg_node * node) noexcept
 {
-  return node->ninedges() > 1;
+  return node->NumInEdges() > 1;
 }
 
 static bool
 is_branch(const cfg_node * split) noexcept
 {
-  if (split->noutedges() < 2)
+  if (split->NumOutEdges() < 2)
     return false;
 
-  if (split->outedge(0)->sink()->noutedges() != 1)
+  if (split->OutEdge(0)->sink()->NumOutEdges() != 1)
     return false;
 
-  auto join = split->outedge(0)->sink()->outedge(0)->sink();
-  for (auto & edge : split->outedges())
+  auto join = split->OutEdge(0)->sink()->OutEdge(0)->sink();
+  for (auto & edge : split->OutEdges())
   {
-    if (edge.sink()->ninedges() != 1)
+    if (edge.sink()->NumInEdges() != 1)
       return false;
-    if (edge.sink()->noutedges() != 1)
+    if (edge.sink()->NumOutEdges() != 1)
       return false;
-    if (edge.sink()->outedge(0)->sink() != join)
+    if (edge.sink()->OutEdge(0)->sink() != join)
       return false;
   }
 
@@ -234,11 +234,11 @@ is_branch(const cfg_node * split) noexcept
 static bool
 is_linear(const cfg_node * node) noexcept
 {
-  if (node->noutedges() != 1)
+  if (node->NumOutEdges() != 1)
     return false;
 
-  auto exit = node->outedge(0)->sink();
-  if (exit->ninedges() != 1)
+  auto exit = node->OutEdge(0)->sink();
+  if (exit->NumInEdges() != 1)
     return false;
 
   return true;
@@ -298,17 +298,17 @@ static cfg_node *
 reduce_branch(cfg_node * split, cfg_node ** entry, aggregation_map & map)
 {
   /* sanity checks */
-  JLM_ASSERT(split->noutedges() > 1);
-  JLM_ASSERT(split->outedge(0)->sink()->noutedges() == 1);
+  JLM_ASSERT(split->NumOutEdges() > 1);
+  JLM_ASSERT(split->OutEdge(0)->sink()->NumOutEdges() == 1);
   JLM_ASSERT(map.contains(split));
 
-  auto join = split->outedge(0)->sink()->outedge(0)->sink();
-  for (auto & edge : split->outedges())
+  auto join = split->OutEdge(0)->sink()->OutEdge(0)->sink();
+  for (auto & edge : split->OutEdges())
   {
-    JLM_ASSERT(edge.sink()->ninedges() == 1);
+    JLM_ASSERT(edge.sink()->NumInEdges() == 1);
     JLM_ASSERT(map.contains(edge.sink()));
-    JLM_ASSERT(edge.sink()->noutedges() == 1);
-    JLM_ASSERT(edge.sink()->outedge(0)->sink() == join);
+    JLM_ASSERT(edge.sink()->NumOutEdges() == 1);
+    JLM_ASSERT(edge.sink()->OutEdge(0)->sink() == join);
   }
 
   /* perform reduction */
@@ -317,7 +317,7 @@ reduce_branch(cfg_node * split, cfg_node ** entry, aggregation_map & map)
   sese->add_outedge(join);
 
   auto branch = branchaggnode::create();
-  for (auto & edge : split->outedges())
+  for (auto & edge : split->OutEdges())
   {
     edge.sink()->remove_outedge(0);
     branch->add_child(std::move(map.lookup(edge.sink())));
@@ -358,11 +358,11 @@ static cfg_node *
 reduce_linear(cfg_node * source, cfg_node ** entry, cfg_node ** exit, aggregation_map & map)
 {
   JLM_ASSERT(is_linear(source));
-  auto sink = source->outedge(0)->sink();
+  auto sink = source->OutEdge(0)->sink();
 
   auto sese = basic_block::create(source->cfg());
   source->divert_inedges(sese);
-  for (auto & edge : sink->outedges())
+  for (auto & edge : sink->OutEdges())
     sese->add_outedge(edge.sink());
   sink->remove_outedges();
 
@@ -439,7 +439,7 @@ aggregate_acyclic_sese(cfg_node * node, cfg_node ** entry, cfg_node ** exit, agg
     /*
       First, greedily reduce all branches of the branch subgraph...
     */
-    for (auto & edge : node->outedges())
+    for (auto & edge : node->OutEdges())
       aggregate_acyclic_sese(edge.sink(), entry, exit, map);
 
     /*
@@ -460,7 +460,7 @@ aggregate_acyclic_sese(cfg_node * node, cfg_node ** entry, cfg_node ** exit, agg
   */
   if (is_sese_basic_block(node))
   {
-    aggregate_acyclic_sese(node->outedge(0)->sink(), entry, exit, map);
+    aggregate_acyclic_sese(node->OutEdge(0)->sink(), entry, exit, map);
     return;
   }
 

--- a/jlm/llvm/ir/cfg-node.cpp
+++ b/jlm/llvm/ir/cfg-node.cpp
@@ -101,10 +101,10 @@ cfg_node::single_successor() const noexcept
   if (noutedges() == 0)
     return false;
 
-  for (auto it = begin_outedges(); it != end_outedges(); it++)
+  for (auto & edge : outedges())
   {
-    JLM_ASSERT(it->source() == this);
-    if (it->sink() != begin_outedges()->sink())
+    JLM_ASSERT(edge.source() == this);
+    if (edge.sink() != outedge(0)->sink())
       return false;
   }
 
@@ -114,9 +114,9 @@ cfg_node::single_successor() const noexcept
 bool
 cfg_node::has_selfloop_edge() const noexcept
 {
-  for (auto it = begin_outedges(); it != end_outedges(); it++)
+  for (auto & edge : outedges())
   {
-    if (it->is_selfloop())
+    if (edge.is_selfloop())
       return true;
   }
 

--- a/jlm/llvm/ir/cfg-node.cpp
+++ b/jlm/llvm/ir/cfg-node.cpp
@@ -45,7 +45,7 @@ cfg_node::~cfg_node()
 {}
 
 size_t
-cfg_node::noutedges() const noexcept
+cfg_node::NumOutEdges() const noexcept
 {
   return outedges_.size();
 }
@@ -62,7 +62,7 @@ cfg_node::remove_inedges()
 }
 
 size_t
-cfg_node::ninedges() const noexcept
+cfg_node::NumInEdges() const noexcept
 {
   return inedges_.size();
 }
@@ -70,13 +70,13 @@ cfg_node::ninedges() const noexcept
 bool
 cfg_node::no_predecessor() const noexcept
 {
-  return ninedges() == 0;
+  return NumInEdges() == 0;
 }
 
 bool
 cfg_node::single_predecessor() const noexcept
 {
-  if (ninedges() == 0)
+  if (NumInEdges() == 0)
     return false;
 
   for (auto i = inedges_.begin(); i != inedges_.end(); i++)
@@ -92,19 +92,19 @@ cfg_node::single_predecessor() const noexcept
 bool
 cfg_node::no_successor() const noexcept
 {
-  return noutedges() == 0;
+  return NumOutEdges() == 0;
 }
 
 bool
 cfg_node::single_successor() const noexcept
 {
-  if (noutedges() == 0)
+  if (NumOutEdges() == 0)
     return false;
 
-  for (auto & edge : outedges())
+  for (auto & edge : OutEdges())
   {
     JLM_ASSERT(edge.source() == this);
-    if (edge.sink() != outedge(0)->sink())
+    if (edge.sink() != OutEdge(0)->sink())
       return false;
   }
 
@@ -114,7 +114,7 @@ cfg_node::single_successor() const noexcept
 bool
 cfg_node::has_selfloop_edge() const noexcept
 {
-  for (auto & edge : outedges())
+  for (auto & edge : OutEdges())
   {
     if (edge.is_selfloop())
       return true;

--- a/jlm/llvm/ir/cfg-node.hpp
+++ b/jlm/llvm/ir/cfg-node.hpp
@@ -8,9 +8,9 @@
 
 #include <jlm/util/common.hpp>
 #include <jlm/util/iterator_range.hpp>
+#include <jlm/util/PtrIterator.hpp>
 
 #include <memory>
-#include <string>
 #include <unordered_set>
 #include <vector>
 
@@ -24,9 +24,18 @@ class cfg_node;
 class cfg_edge final
 {
 public:
-  ~cfg_edge() noexcept {};
+  ~cfg_edge() noexcept
+  {}
 
   cfg_edge(cfg_node * source, cfg_node * sink, size_t index) noexcept;
+
+  cfg_edge(const cfg_edge & other) = delete;
+  cfg_edge(cfg_edge && other) = default;
+
+  cfg_edge &
+  operator=(const cfg_edge & other) = delete;
+  cfg_edge &
+  operator=(cfg_edge && other) = default;
 
   void
   divert(cfg_node * new_sink);
@@ -34,25 +43,28 @@ public:
   basic_block *
   split();
 
-  inline cfg_node *
+  cfg_node *
   source() const noexcept
   {
     return source_;
   }
 
-  inline cfg_node *
+  cfg_node *
   sink() const noexcept
   {
     return sink_;
   }
 
-  inline size_t
+  /**
+   * @return the index of this edge among the source's out edges
+   */
+  size_t
   index() const noexcept
   {
     return index_;
   }
 
-  inline bool
+  bool
   is_selfloop() const noexcept
   {
     return source_ == sink_;
@@ -68,61 +80,13 @@ private:
 
 class cfg_node
 {
-  typedef std::unordered_set<cfg_edge *>::iterator inedge_iterator;
-  typedef std::unordered_set<cfg_edge *>::const_iterator const_inedge_iterator;
-
+  using inedge_iterator =
+      util::PtrIterator<cfg_edge, std::unordered_set<cfg_edge *>::const_iterator>;
   using inedge_iterator_range = util::IteratorRange<inedge_iterator>;
-  using constinedge_iterator_range = util::IteratorRange<const_inedge_iterator>;
 
-  class const_outedge_iterator final
-  {
-  public:
-    inline const_outedge_iterator(const std::vector<std::unique_ptr<cfg_edge>>::const_iterator & it)
-        : it_(it)
-    {}
-
-    inline const const_outedge_iterator &
-    operator++() noexcept
-    {
-      ++it_;
-      return *this;
-    }
-
-    inline const_outedge_iterator
-    operator++(int) noexcept
-    {
-      auto tmp = *this;
-      ++*this;
-      return tmp;
-    }
-
-    inline bool
-    operator==(const const_outedge_iterator & other) const noexcept
-    {
-      return it_ == other.it_;
-    }
-
-    inline bool
-    operator!=(const const_outedge_iterator & other) const noexcept
-    {
-      return !(other == *this);
-    }
-
-    inline cfg_edge *
-    operator->() const noexcept
-    {
-      return edge();
-    }
-
-    inline cfg_edge *
-    edge() const noexcept
-    {
-      return it_->get();
-    }
-
-  private:
-    std::vector<std::unique_ptr<cfg_edge>>::const_iterator it_;
-  };
+  using outedge_iterator =
+      util::PtrIterator<cfg_edge, std::vector<std::unique_ptr<cfg_edge>>::const_iterator>;
+  using outedge_iterator_range = util::IteratorRange<outedge_iterator>;
 
 public:
   virtual ~cfg_node();
@@ -139,6 +103,24 @@ public:
     return cfg_;
   }
 
+  size_t
+  noutedges() const noexcept;
+
+  cfg_edge *
+  outedge(size_t n) const
+  {
+    JLM_ASSERT(n < noutedges());
+    return outedges_[n].get();
+  }
+
+  outedge_iterator_range
+  outedges() const
+  {
+    return outedge_iterator_range(
+        outedge_iterator(outedges_.begin()),
+        outedge_iterator(outedges_.end()));
+  }
+
   cfg_edge *
   add_outedge(cfg_node * sink)
   {
@@ -147,7 +129,7 @@ public:
     return outedges_.back().get();
   }
 
-  inline void
+  void
   remove_outedge(size_t n)
   {
     JLM_ASSERT(n < noutedges());
@@ -162,45 +144,22 @@ public:
     outedges_.resize(noutedges() - 1);
   }
 
-  inline void
+  void
   remove_outedges()
   {
     while (noutedges() != 0)
       remove_outedge(noutedges() - 1);
   }
 
-  inline cfg_edge *
-  outedge(size_t n) const
-  {
-    JLM_ASSERT(n < noutedges());
-    return outedges_[n].get();
-  }
-
   size_t
-  noutedges() const noexcept;
-
-  inline const_outedge_iterator
-  begin_outedges() const
-  {
-    return const_outedge_iterator(outedges_.begin());
-  }
-
-  inline const_outedge_iterator
-  end_outedges() const
-  {
-    return const_outedge_iterator(outedges_.end());
-  }
+  ninedges() const noexcept;
 
   inedge_iterator_range
-  inedges()
-  {
-    return inedge_iterator_range(inedges_.begin(), inedges_.end());
-  }
-
-  constinedge_iterator_range
   inedges() const
   {
-    return constinedge_iterator_range(inedges_.begin(), inedges_.end());
+    return inedge_iterator_range(
+        inedge_iterator(inedges_.begin()),
+        inedge_iterator(inedges_.end()));
   }
 
   inline void
@@ -210,14 +169,11 @@ public:
       return;
 
     while (ninedges())
-      (*inedges().begin())->divert(new_successor);
+      inedges().begin()->divert(new_successor);
   }
 
   void
   remove_inedges();
-
-  size_t
-  ninedges() const noexcept;
 
   bool
   no_predecessor() const noexcept;
@@ -231,7 +187,7 @@ public:
   bool
   single_successor() const noexcept;
 
-  inline bool
+  bool
   is_branch() const noexcept
   {
     return noutedges() > 1;

--- a/jlm/llvm/ir/cfg-node.hpp
+++ b/jlm/llvm/ir/cfg-node.hpp
@@ -104,17 +104,17 @@ public:
   }
 
   size_t
-  noutedges() const noexcept;
+  NumOutEdges() const noexcept;
 
   cfg_edge *
-  outedge(size_t n) const
+  OutEdge(size_t n) const
   {
-    JLM_ASSERT(n < noutedges());
+    JLM_ASSERT(n < NumOutEdges());
     return outedges_[n].get();
   }
 
   outedge_iterator_range
-  outedges() const
+  OutEdges() const
   {
     return outedge_iterator_range(
         outedge_iterator(outedges_.begin()),
@@ -124,7 +124,7 @@ public:
   cfg_edge *
   add_outedge(cfg_node * sink)
   {
-    outedges_.push_back(std::make_unique<cfg_edge>(this, sink, noutedges()));
+    outedges_.push_back(std::make_unique<cfg_edge>(this, sink, NumOutEdges()));
     sink->inedges_.insert(outedges_.back().get());
     return outedges_.back().get();
   }
@@ -132,30 +132,30 @@ public:
   void
   remove_outedge(size_t n)
   {
-    JLM_ASSERT(n < noutedges());
+    JLM_ASSERT(n < NumOutEdges());
     auto edge = outedges_[n].get();
 
     edge->sink()->inedges_.erase(edge);
-    for (size_t i = n + 1; i < noutedges(); i++)
+    for (size_t i = n + 1; i < NumOutEdges(); i++)
     {
       outedges_[i - 1] = std::move(outedges_[i]);
       outedges_[i - 1]->index_ = outedges_[i - 1]->index_ - 1;
     }
-    outedges_.resize(noutedges() - 1);
+    outedges_.resize(NumOutEdges() - 1);
   }
 
   void
   remove_outedges()
   {
-    while (noutedges() != 0)
-      remove_outedge(noutedges() - 1);
+    while (NumOutEdges() != 0)
+      remove_outedge(NumOutEdges() - 1);
   }
 
   size_t
-  ninedges() const noexcept;
+  NumInEdges() const noexcept;
 
   inedge_iterator_range
-  inedges() const
+  InEdges() const
   {
     return inedge_iterator_range(
         inedge_iterator(inedges_.begin()),
@@ -168,8 +168,8 @@ public:
     if (this == new_successor)
       return;
 
-    while (ninedges())
-      inedges().begin()->divert(new_successor);
+    while (NumInEdges())
+      InEdges().begin()->divert(new_successor);
   }
 
   void
@@ -190,7 +190,7 @@ public:
   bool
   is_branch() const noexcept
   {
-    return noutedges() > 1;
+    return NumOutEdges() > 1;
   }
 
   bool

--- a/jlm/llvm/ir/cfg.cpp
+++ b/jlm/llvm/ir/cfg.cpp
@@ -46,7 +46,7 @@ cfg::remove_node(cfg::iterator & nodeit)
 {
   auto & cfg = nodeit->cfg();
 
-  for (auto & inedge : nodeit->inedges())
+  for (auto & inedge : nodeit->InEdges())
   {
     if (inedge.source() != nodeit.node())
       throw util::error("cannot remove node. It has still incoming edges.");
@@ -162,10 +162,10 @@ cfg::CreateTargets(
 {
   size_t n = 0;
   std::string str("[");
-  for (auto & outedge : node.outedges())
+  for (auto & outedge : node.OutEdges())
   {
     str += labels.at(outedge.sink());
-    if (n != node.noutedges() - 1)
+    if (n != node.NumOutEdges() - 1)
       str += ", ";
   }
   str += "]";
@@ -214,9 +214,9 @@ postorder(const llvm::cfg & cfg)
                      std::vector<cfg_node *> & nodes)
   {
     visited.insert(node);
-    for (size_t n = 0; n < node->noutedges(); n++)
+    for (size_t n = 0; n < node->NumOutEdges(); n++)
     {
-      auto edge = node->outedge(n);
+      auto edge = node->OutEdge(n);
       if (visited.find(edge->sink()) == visited.end())
         traverse(edge->sink(), visited, nodes);
     }
@@ -250,7 +250,7 @@ breadth_first(const llvm::cfg & cfg)
     auto node = next.front();
     next.pop_front();
 
-    for (auto & outedge : node->outedges())
+    for (auto & outedge : node->OutEdges())
     {
       if (visited.find(outedge.sink()) == visited.end())
       {

--- a/jlm/llvm/ir/cfg.cpp
+++ b/jlm/llvm/ir/cfg.cpp
@@ -48,7 +48,7 @@ cfg::remove_node(cfg::iterator & nodeit)
 
   for (auto & inedge : nodeit->inedges())
   {
-    if (inedge->source() != nodeit.node())
+    if (inedge.source() != nodeit.node())
       throw util::error("cannot remove node. It has still incoming edges.");
   }
 
@@ -162,9 +162,9 @@ cfg::CreateTargets(
 {
   size_t n = 0;
   std::string str("[");
-  for (auto it = node.begin_outedges(); it != node.end_outedges(); it++, n++)
+  for (auto & outedge : node.outedges())
   {
-    str += labels.at(it->sink());
+    str += labels.at(outedge.sink());
     if (n != node.noutedges() - 1)
       str += ", ";
   }
@@ -250,13 +250,13 @@ breadth_first(const llvm::cfg & cfg)
     auto node = next.front();
     next.pop_front();
 
-    for (auto it = node->begin_outedges(); it != node->end_outedges(); it++)
+    for (auto & outedge : node->outedges())
     {
-      if (visited.find(it->sink()) == visited.end())
+      if (visited.find(outedge.sink()) == visited.end())
       {
-        visited.insert(it->sink());
-        next.push_back(it->sink());
-        nodes.push_back(it->sink());
+        visited.insert(outedge.sink());
+        next.push_back(outedge.sink());
+        nodes.push_back(outedge.sink());
       }
     }
   }

--- a/jlm/llvm/ir/domtree.cpp
+++ b/jlm/llvm/ir/domtree.cpp
@@ -114,7 +114,7 @@ domtree(llvm::cfg & cfg)
       cfg_node * newidom = nullptr;
       for (auto & inedge : node->inedges())
       {
-        auto p = inedge->source();
+        auto p = inedge.source();
         if (doms[p] != nullptr)
         {
           newidom = p;
@@ -126,7 +126,7 @@ domtree(llvm::cfg & cfg)
       auto pred = newidom;
       for (auto & inedge : node->inedges())
       {
-        auto p = inedge->source();
+        auto p = inedge.source();
         if (p == pred)
           continue;
 

--- a/jlm/llvm/ir/domtree.cpp
+++ b/jlm/llvm/ir/domtree.cpp
@@ -112,7 +112,7 @@ domtree(llvm::cfg & cfg)
 
       /* find first processed predecessor */
       cfg_node * newidom = nullptr;
-      for (auto & inedge : node->inedges())
+      for (auto & inedge : node->InEdges())
       {
         auto p = inedge.source();
         if (doms[p] != nullptr)
@@ -124,7 +124,7 @@ domtree(llvm::cfg & cfg)
       JLM_ASSERT(newidom != nullptr);
 
       auto pred = newidom;
-      for (auto & inedge : node->inedges())
+      for (auto & inedge : node->InEdges())
       {
         auto p = inedge.source();
         if (p == pred)

--- a/jlm/llvm/ir/print.cpp
+++ b/jlm/llvm/ir/print.cpp
@@ -200,10 +200,10 @@ to_dot(const llvm::cfg & cfg)
   {
     dot += util::strfmt("{", (intptr_t)&node);
     dot += util::strfmt("[shape = box, label = \"", emit_node(node), "\"]; }\n");
-    for (auto it = node.begin_outedges(); it != node.end_outedges(); it++)
+    for (auto & edge : node.outedges())
     {
-      dot += util::strfmt((intptr_t)it->source(), " -> ", (intptr_t)it->sink());
-      dot += util::strfmt("[label = \"", it->index(), "\"];\n");
+      dot += util::strfmt((intptr_t)edge.source(), " -> ", (intptr_t)edge.sink());
+      dot += util::strfmt("[label = \"", edge.index(), "\"];\n");
     }
   }
   dot += "}\n";

--- a/jlm/llvm/ir/print.cpp
+++ b/jlm/llvm/ir/print.cpp
@@ -185,7 +185,7 @@ to_dot(const llvm::cfg & cfg)
   dot += util::strfmt(
       (intptr_t)entry,
       " -> ",
-      (intptr_t)entry->outedge(0)->sink(),
+      (intptr_t)entry->OutEdge(0)->sink(),
       "[label=\"0\"];\n");
 
   /* emit exit node */
@@ -200,7 +200,7 @@ to_dot(const llvm::cfg & cfg)
   {
     dot += util::strfmt("{", (intptr_t)&node);
     dot += util::strfmt("[shape = box, label = \"", emit_node(node), "\"]; }\n");
-    for (auto & edge : node.outedges())
+    for (auto & edge : node.OutEdges())
     {
       dot += util::strfmt((intptr_t)edge.source(), " -> ", (intptr_t)edge.sink());
       dot += util::strfmt("[label = \"", edge.index(), "\"];\n");

--- a/jlm/llvm/ir/ssa.cpp
+++ b/jlm/llvm/ir/ssa.cpp
@@ -47,8 +47,8 @@ destruct_ssa(llvm::cfg & cfg)
       std::unordered_map<cfg_node *, cfg_edge *> edges;
       for (auto & inedge : phi_block->inedges())
       {
-        JLM_ASSERT(edges.find(inedge->source()) == edges.end());
-        edges[inedge->source()] = inedge;
+        JLM_ASSERT(edges.find(inedge.source()) == edges.end());
+        edges[inedge.source()] = &inedge;
       }
 
       while (tacs.first())

--- a/jlm/llvm/ir/ssa.cpp
+++ b/jlm/llvm/ir/ssa.cpp
@@ -36,7 +36,7 @@ destruct_ssa(llvm::cfg & cfg)
     if (phi_blocks.empty())
       return;
 
-    auto firstbb = static_cast<basic_block *>(cfg.entry()->outedge(0)->sink());
+    auto firstbb = static_cast<basic_block *>(cfg.entry()->OutEdge(0)->sink());
 
     for (auto phi_block : phi_blocks)
     {
@@ -45,7 +45,7 @@ destruct_ssa(llvm::cfg & cfg)
 
       /* collect inedges of phi block */
       std::unordered_map<cfg_node *, cfg_edge *> edges;
-      for (auto & inedge : phi_block->inedges())
+      for (auto & inedge : phi_block->InEdges())
       {
         JLM_ASSERT(edges.find(inedge.source()) == edges.end());
         edges[inedge.source()] = &inedge;

--- a/jlm/util/Makefile.sub
+++ b/jlm/util/Makefile.sub
@@ -19,6 +19,7 @@ libutil_HEADERS = \
     jlm/util/intrusive-list.hpp \
     jlm/util/iterator_range.hpp \
     jlm/util/Math.hpp \
+    jlm/util/PtrIterator.hpp \
     jlm/util/Statistics.hpp \
     jlm/util/strfmt.hpp \
     jlm/util/TarjanScc.hpp \

--- a/jlm/util/Makefile.sub
+++ b/jlm/util/Makefile.sub
@@ -35,6 +35,7 @@ libutil_TESTS += \
 	tests/jlm/util/TestGraphWriter \
 	tests/jlm/util/TestHashSet \
 	tests/jlm/util/TestMath \
+	tests/jlm/util/TestPtrIterator \
 	tests/jlm/util/TestStatistics \
 	tests/jlm/util/TestTarjanScc \
 	tests/jlm/util/TestTimer \

--- a/jlm/util/PtrIterator.hpp
+++ b/jlm/util/PtrIterator.hpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2025 Håvard Krogstie <krogstie.havard@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#ifndef JLM_UTIL_UNIQUEPTRITERATOR_HPP
+#define JLM_UTIL_UNIQUEPTRITERATOR_HPP
+
+#include <vector>
+
+namespace jlm::util
+{
+
+/**
+ * Helper class for providing iterators over lists of pointers and/or smart pointers.
+ * The iterator does one level of pointer dereferencing when yielding elements.
+ * This means the user may not modify the pointers, but may modify the elements.
+ * To get a const interator, let T be a const type.
+ * This iterator should not be used if any element may be a null pointer.
+ *
+ * @tparam T the underlying type.
+ * @tparam BaseIterator the type of the base iterator, can always be a const iterator.
+ */
+template<typename T, typename BaseIterator>
+class PtrIterator final
+{
+public:
+  using difference_type = std::ptrdiff_t;
+  using value_type = T;
+  using pointer = T *;
+  using reference = T &;
+  using iterator_category = std::forward_iterator_tag;
+
+  explicit PtrIterator(BaseIterator it)
+      : it_(it)
+  {}
+
+  PtrIterator &
+  operator++() noexcept
+  {
+    ++it_;
+    return *this;
+  }
+
+  PtrIterator
+  operator++(int) noexcept
+  {
+    auto tmp = *this;
+    ++*this;
+    return tmp;
+  }
+
+  bool
+  operator==(const PtrIterator & other) const noexcept
+  {
+    return it_ == other.it_;
+  }
+
+  bool
+  operator!=(const PtrIterator & other) const noexcept
+  {
+    return !(other == *this);
+  }
+
+  reference
+  operator*() const noexcept
+  {
+    return *(*it_);
+  }
+
+  pointer
+  operator->() const noexcept
+  {
+    return &(*(*it_));
+  }
+
+private:
+  BaseIterator it_;
+};
+}
+
+#endif // JLM_UTIL_UNIQUEPTRITERATOR_HPP

--- a/jlm/util/PtrIterator.hpp
+++ b/jlm/util/PtrIterator.hpp
@@ -3,8 +3,8 @@
  * See COPYING for terms of redistribution.
  */
 
-#ifndef JLM_UTIL_UNIQUEPTRITERATOR_HPP
-#define JLM_UTIL_UNIQUEPTRITERATOR_HPP
+#ifndef JLM_UTIL_PTRITERATOR_HPP
+#define JLM_UTIL_PTRITERATOR_HPP
 
 #include <vector>
 
@@ -32,13 +32,13 @@ public:
   using iterator_category = std::forward_iterator_tag;
 
   explicit PtrIterator(BaseIterator it)
-      : it_(it)
+      : Iterator_(it)
   {}
 
   PtrIterator &
   operator++() noexcept
   {
-    ++it_;
+    ++Iterator_;
     return *this;
   }
 
@@ -53,7 +53,7 @@ public:
   bool
   operator==(const PtrIterator & other) const noexcept
   {
-    return it_ == other.it_;
+    return Iterator_ == other.Iterator_;
   }
 
   bool
@@ -65,18 +65,18 @@ public:
   reference
   operator*() const noexcept
   {
-    return *(*it_);
+    return *(*Iterator_);
   }
 
   pointer
   operator->() const noexcept
   {
-    return &(*(*it_));
+    return &(*(*Iterator_));
   }
 
 private:
-  BaseIterator it_;
+  BaseIterator Iterator_;
 };
 }
 
-#endif // JLM_UTIL_UNIQUEPTRITERATOR_HPP
+#endif // JLM_UTIL_PTRITERATOR_HPP

--- a/tests/jlm/llvm/backend/llvm/r2j/GammaTests.cpp
+++ b/tests/jlm/llvm/backend/llvm/r2j/GammaTests.cpp
@@ -58,7 +58,7 @@ GammaWithMatch()
 
   auto cfg = dynamic_cast<const function_node &>(*ipg.begin()).cfg();
   assert(cfg->nnodes() == 1);
-  auto node = cfg->entry()->outedge(0)->sink();
+  auto node = cfg->entry()->OutEdge(0)->sink();
   auto bb = dynamic_cast<const basic_block *>(node);
   assert(is<select_op>(bb->tacs().last()->operation()));
 
@@ -108,7 +108,7 @@ GammaWithoutMatch()
 
   auto cfg = dynamic_cast<const function_node &>(*ipg.begin()).cfg();
   assert(cfg->nnodes() == 1);
-  auto node = cfg->entry()->outedge(0)->sink();
+  auto node = cfg->entry()->OutEdge(0)->sink();
   auto bb = dynamic_cast<const basic_block *>(node);
   assert(is<ctl2bits_op>(bb->tacs().first()->operation()));
   assert(is<select_op>(bb->tacs().last()->operation()));

--- a/tests/jlm/llvm/frontend/llvm/LlvmPhiConversionTests.cpp
+++ b/tests/jlm/llvm/frontend/llvm/LlvmPhiConversionTests.cpp
@@ -119,9 +119,9 @@ TestPhiConversion()
       jlm::util::AssertedCast<const jlm::llvm::function_node>(ipgmod->ipgraph().find("popcount"));
   auto entry_node = popcount->cfg()->entry();
   assert(entry_node->single_successor());
-  auto bb1_node = entry_node->outedge(0)->sink();
+  auto bb1_node = entry_node->OutEdge(0)->sink();
   assert(bb1_node->single_successor());
-  auto bb2_node = bb1_node->outedge(0)->sink();
+  auto bb2_node = bb1_node->OutEdge(0)->sink();
   auto bb2 = jlm::util::AssertedCast<jlm::llvm::basic_block>(bb2_node);
 
   // The first two tac instructions should be the phi representing x and popcnt respectively

--- a/tests/jlm/llvm/frontend/llvm/LoadTests.cpp
+++ b/tests/jlm/llvm/frontend/llvm/LoadTests.cpp
@@ -54,7 +54,7 @@ LoadConversion()
     auto controlFlowGraph =
         dynamic_cast<const function_node *>(ipgModule->ipgraph().find("f"))->cfg();
     auto basicBlock =
-        dynamic_cast<const basic_block *>(controlFlowGraph->entry()->outedge(0)->sink());
+        dynamic_cast<const basic_block *>(controlFlowGraph->entry()->OutEdge(0)->sink());
 
     size_t numLoadThreeAddressCodes = 0;
     size_t numLoadVolatileThreeAddressCodes = 0;

--- a/tests/jlm/llvm/frontend/llvm/MemCpyTests.cpp
+++ b/tests/jlm/llvm/frontend/llvm/MemCpyTests.cpp
@@ -57,7 +57,7 @@ MemCpyConversion()
     auto controlFlowGraph =
         dynamic_cast<const function_node *>(ipgModule->ipgraph().find("f"))->cfg();
     auto basicBlock =
-        dynamic_cast<const basic_block *>(controlFlowGraph->entry()->outedge(0)->sink());
+        dynamic_cast<const basic_block *>(controlFlowGraph->entry()->OutEdge(0)->sink());
 
     size_t numMemCpyThreeAddressCodes = 0;
     size_t numMemCpyVolatileThreeAddressCodes = 0;

--- a/tests/jlm/llvm/frontend/llvm/StoreTests.cpp
+++ b/tests/jlm/llvm/frontend/llvm/StoreTests.cpp
@@ -56,7 +56,7 @@ StoreConversion()
     auto controlFlowGraph =
         dynamic_cast<const function_node *>(ipgModule->ipgraph().find("f"))->cfg();
     auto basicBlock =
-        dynamic_cast<const basic_block *>(controlFlowGraph->entry()->outedge(0)->sink());
+        dynamic_cast<const basic_block *>(controlFlowGraph->entry()->OutEdge(0)->sink());
 
     size_t numStoreThreeAddressCodes = 0;
     size_t numStoreVolatileThreeAddressCodes = 0;

--- a/tests/jlm/llvm/frontend/llvm/TestFNeg.cpp
+++ b/tests/jlm/llvm/frontend/llvm/TestFNeg.cpp
@@ -25,7 +25,7 @@ Contains(const jlm::llvm::ipgraph_module & module, const std::string &)
   auto controlFlowGraph =
       dynamic_cast<const jlm::llvm::function_node *>(module.ipgraph().find("f"))->cfg();
   auto basicBlock =
-      dynamic_cast<const jlm::llvm::basic_block *>(controlFlowGraph->entry()->outedge(0)->sink());
+      dynamic_cast<const jlm::llvm::basic_block *>(controlFlowGraph->entry()->OutEdge(0)->sink());
   for (auto threeAddressCode : *basicBlock)
     hasInstruction = hasInstruction || jlm::llvm::is<OP>(threeAddressCode);
 

--- a/tests/jlm/llvm/frontend/llvm/test-function-call.cpp
+++ b/tests/jlm/llvm/frontend/llvm/test-function-call.cpp
@@ -56,7 +56,7 @@ test_function_call()
       }
     }
 
-    auto bb = dynamic_cast<const basic_block *>(cfg->entry()->outedge(0)->sink());
+    auto bb = dynamic_cast<const basic_block *>(cfg->entry()->OutEdge(0)->sink());
     assert(is<CallOperation>(*std::next(bb->rbegin(), 2)));
   };
 
@@ -113,7 +113,7 @@ test_malloc_call()
       }
     }
 
-    auto bb = dynamic_cast<const basic_block *>(cfg->entry()->outedge(0)->sink());
+    auto bb = dynamic_cast<const basic_block *>(cfg->entry()->OutEdge(0)->sink());
     assert(is<MemoryStateMergeOperation>(*std::next(bb->rbegin())));
     assert(is<malloc_op>((*std::next(bb->rbegin(), 2))));
   };
@@ -169,7 +169,7 @@ test_free_call()
       }
     }
 
-    auto bb = dynamic_cast<const basic_block *>(cfg->entry()->outedge(0)->sink());
+    auto bb = dynamic_cast<const basic_block *>(cfg->entry()->OutEdge(0)->sink());
     assert(is<AssignmentOperation>(*bb->rbegin()));
     assert(is<AssignmentOperation>(*std::next(bb->rbegin())));
     assert(is<FreeOperation>(*std::next(bb->rbegin(), 2)));

--- a/tests/jlm/llvm/frontend/llvm/test-restructuring.cpp
+++ b/tests/jlm/llvm/frontend/llvm/test-restructuring.cpp
@@ -97,8 +97,8 @@ test_dowhile()
   //	jlm::view_ascii(cfg, stdout);
 
   assert(nnodes == cfg.nnodes());
-  assert(bb2->outedge(0)->sink() == bb2);
-  assert(bb3->outedge(0)->sink() == bb1);
+  assert(bb2->OutEdge(0)->sink() == bb2);
+  assert(bb3->OutEdge(0)->sink() == bb1);
 }
 
 static inline void

--- a/tests/jlm/llvm/frontend/llvm/test-select.cpp
+++ b/tests/jlm/llvm/frontend/llvm/test-select.cpp
@@ -23,7 +23,7 @@ contains(const jlm::llvm::ipgraph_module & module, const std::string & fctname)
 
   bool has_select = false;
   auto cfg = dynamic_cast<const function_node *>(module.ipgraph().find(fctname))->cfg();
-  auto bb = dynamic_cast<const basic_block *>(cfg->entry()->outedge(0)->sink());
+  auto bb = dynamic_cast<const basic_block *>(cfg->entry()->OutEdge(0)->sink());
   for (auto tac : *bb)
     has_select = has_select || is<OP>(tac);
 

--- a/tests/jlm/llvm/ir/test-cfg-structure.cpp
+++ b/tests/jlm/llvm/ir/test-cfg-structure.cpp
@@ -39,7 +39,7 @@ test_straightening()
   straighten(cfg);
 
   assert(cfg.nnodes() == 1);
-  auto node = cfg.entry()->outedge(0)->sink();
+  auto node = cfg.entry()->OutEdge(0)->sink();
 
   assert(is<basic_block>(node));
   auto & tacs = static_cast<const basic_block *>(node)->tacs();

--- a/tests/jlm/util/TestPtrIterator.cpp
+++ b/tests/jlm/util/TestPtrIterator.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2025 Håvard Krogstie <krogstie.havard@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <test-registry.hpp>
+#include <test-util.hpp>
+
+#include <jlm/util/iterator_range.hpp>
+#include <jlm/util/PtrIterator.hpp>
+
+#include <cassert>
+#include <memory>
+#include <unordered_set>
+#include <vector>
+
+static int
+TestPtrVector()
+{
+  int a = 10;
+  int b = 20;
+  int c = 30;
+
+  std::vector<int *> ints = { &a, &b, &c };
+  using ItType = jlm::util::PtrIterator<int, decltype(ints)::iterator>;
+
+  // Act 1 + Assert 1 - iterate manually using operator ++
+  ItType it(ints.begin());
+  assert(*it == 10);
+  it++;
+  assert(*it == 20);
+  it++;
+  assert(it != ItType(ints.end()));
+  it++;
+  assert(it == ItType(ints.end()));
+
+  // Act 2 - modify targets through range based for loop
+  jlm::util::IteratorRange range(ItType(ints.begin()), ItType(ints.end()));
+  for (auto & i : range)
+  {
+    i++;
+  }
+
+  // Assert 2
+  assert(a == 11);
+  assert(b == 21);
+  assert(c == 31);
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER("jlm/util/TestPtrIterator-TestPtrVector", TestPtrVector);
+
+static int
+TestPtrUnorderedSet()
+{
+  int a = 10;
+  int b = 20;
+  int c = 30;
+
+  std::unordered_set<int *> set = { &a, &b, &c };
+  using ItType = jlm::util::PtrIterator<int, decltype(set)::iterator>;
+
+  // Act - modify targets through range based for loop
+  jlm::util::IteratorRange range(ItType(set.begin()), ItType(set.end()));
+  for (auto & i : range)
+  {
+    i++;
+  }
+
+  // Assert
+  assert(a == 11);
+  assert(b == 21);
+  assert(c == 31);
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER("jlm/util/TestPtrIterator-TestPtrUnorderedSet", TestPtrUnorderedSet);
+
+static int
+TestUniquePtrVector()
+{
+
+  // Arrange
+  std::vector<std::unique_ptr<int>> vector;
+  vector.emplace_back(std::make_unique<int>(10));
+  vector.emplace_back(std::make_unique<int>(20));
+  vector.emplace_back(std::make_unique<int>(30));
+
+  // The iterator still works with a const_iterator, as the pointer itself is not const
+  using ItType = jlm::util::PtrIterator<int, decltype(vector)::const_iterator>;
+
+  // Act
+  jlm::util::IteratorRange range(ItType(vector.begin()), ItType(vector.end()));
+  for (auto & i : range)
+  {
+    i++;
+  }
+
+  // Assert
+  assert(*vector[0] == 11);
+  assert(*vector[1] == 21);
+  assert(*vector[2] == 31);
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER("jlm/util/TestPtrIterator-TestUniquePtrVector", TestUniquePtrVector);


### PR DESCRIPTION
While doing other things, I was annoyed with the iterator interfaces for accessing in-edges and out-edges on cfg nodes not implementing everything needed to be regarded as real iterators.

I added a helper class for wrapping iterators to pointers, to become an iterator to the pointees instead. It works for both raw pointers and smart pointers. See the test for examples.

I also removed some unnecessary `inline` keywords when I was touching functions.
