### PR TITLE
Add LLVM-specific integer constant operation

### DIFF
--- a/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.cpp
+++ b/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.cpp
@@ -255,9 +255,9 @@ RhlsToFirrtlConverter::MlirGenSimpleNode(const jlm::rvsdg::SimpleNode * node)
     auto uintOp = AddAsUIntOp(body, padOp);
     Connect(body, outData, uintOp);
   }
-  else if (auto op = dynamic_cast<const jlm::rvsdg::bitconstant_op *>(&(node->GetOperation())))
+  else if (auto op = dynamic_cast<const llvm::IntegerConstantOperation *>(&(node->GetOperation())))
   {
-    auto value = op->value();
+    auto & value = op->Representation();
     auto size = value.nbits();
     // Create a constant of UInt<size>(value) and connect to output data
     auto constant = GetConstant(body, size, value.to_uint());

--- a/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.hpp
+++ b/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.hpp
@@ -13,8 +13,6 @@
 #include <jlm/llvm/ir/operators/operators.hpp>
 #include <jlm/llvm/ir/operators/sext.hpp>
 #include <jlm/llvm/ir/operators/Store.hpp>
-#include <jlm/rvsdg/bitstring/comparison.hpp>
-#include <jlm/rvsdg/bitstring/type.hpp>
 #include <jlm/rvsdg/traverser.hpp>
 
 #include <mlir/IR/Builders.h>

--- a/jlm/hls/backend/rvsdg2rhls/add-prints.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-prints.cpp
@@ -6,6 +6,7 @@
 #include <jlm/hls/backend/rvsdg2rhls/add-prints.hpp>
 #include <jlm/hls/ir/hls.hpp>
 #include <jlm/llvm/ir/operators.hpp>
+#include <jlm/llvm/ir/operators/IntegerOperations.hpp>
 #include <jlm/rvsdg/gamma.hpp>
 #include <jlm/rvsdg/theta.hpp>
 #include <jlm/rvsdg/traverser.hpp>
@@ -116,7 +117,7 @@ convert_prints(
     else if (auto po = dynamic_cast<const print_op *>(&(node->GetOperation())))
     {
       auto printf_local = route_to_region(printf, region); // TODO: prevent repetition?
-      auto bc = jlm::rvsdg::create_bitconstant(region, 64, po->id());
+      auto & constantNode = llvm::IntegerConstantOperation::Create(*region, 64, po->id());
       jlm::rvsdg::output * val = node->input(0)->origin();
       if (val->type() != *jlm::rvsdg::bittype::Create(64))
       {
@@ -124,7 +125,7 @@ convert_prints(
         JLM_ASSERT(bt);
         val = &llvm::zext_op::Create(*val, rvsdg::bittype::Create(64));
       }
-      llvm::CallNode::Create(printf_local, functionType, { bc, val });
+      llvm::CallNode::Create(printf_local, functionType, { constantNode.output(0), val });
       node->output(0)->divert_users(node->input(0)->origin());
       jlm::rvsdg::remove(node);
     }

--- a/jlm/hls/backend/rvsdg2rhls/alloca-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/alloca-conv.cpp
@@ -9,6 +9,7 @@
 #include <jlm/llvm/ir/operators/alloca.hpp>
 #include <jlm/llvm/ir/operators/call.hpp>
 #include <jlm/llvm/ir/operators/GetElementPtr.hpp>
+#include <jlm/llvm/ir/operators/IntegerOperations.hpp>
 #include <jlm/llvm/ir/operators/Load.hpp>
 #include <jlm/llvm/ir/operators/MemoryStateOperations.hpp>
 #include <jlm/llvm/ir/operators/operators.hpp>
@@ -133,10 +134,10 @@ alloca_conv(rvsdg::Region * region)
       JLM_ASSERT(node->ninputs() == 1);
       auto constant_output = dynamic_cast<jlm::rvsdg::node_output *>(node->input(0)->origin());
       JLM_ASSERT(constant_output);
-      auto constant_operation = dynamic_cast<const jlm::rvsdg::bitconstant_op *>(
+      auto constant_operation = dynamic_cast<const llvm::IntegerConstantOperation *>(
           &constant_output->node()->GetOperation());
       JLM_ASSERT(constant_operation);
-      JLM_ASSERT(constant_operation->value().to_uint() == 1);
+      JLM_ASSERT(constant_operation->Representation().to_uint() == 1);
       // ensure that the alloca is an array type
       auto at = std::dynamic_pointer_cast<const llvm::ArrayType>(po->ValueType());
       JLM_ASSERT(at);

--- a/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
@@ -11,6 +11,7 @@
 #include <jlm/hls/ir/hls.hpp>
 #include <jlm/llvm/ir/CallSummary.hpp>
 #include <jlm/llvm/ir/operators/call.hpp>
+#include <jlm/llvm/ir/operators/IntegerOperations.hpp>
 #include <jlm/llvm/ir/operators/lambda.hpp>
 #include <jlm/llvm/ir/operators/Load.hpp>
 #include <jlm/llvm/ir/operators/Store.hpp>
@@ -82,7 +83,7 @@ replace_load(jlm::rvsdg::SimpleNode * orig, jlm::rvsdg::output * resp)
   return dynamic_cast<jlm::rvsdg::SimpleNode *>(nn);
 }
 
-const jlm::rvsdg::bitconstant_op *
+const jlm::llvm::IntegerConstantOperation *
 trace_channel(const jlm::rvsdg::output * dst)
 {
   if (auto arg = dynamic_cast<const jlm::rvsdg::RegionArgument *>(dst))
@@ -92,7 +93,8 @@ trace_channel(const jlm::rvsdg::output * dst)
 
   if (auto so = dynamic_cast<const jlm::rvsdg::SimpleOutput *>(dst))
   {
-    if (auto co = dynamic_cast<const jlm::rvsdg::bitconstant_op *>(&so->node()->GetOperation()))
+    if (auto co =
+            dynamic_cast<const jlm::llvm::IntegerConstantOperation *>(&so->node()->GetOperation()))
     {
       return co;
     }
@@ -235,7 +237,7 @@ trace_function_calls(
 jlm::rvsdg::SimpleNode *
 find_decouple_response(
     const jlm::rvsdg::LambdaNode * lambda,
-    const jlm::rvsdg::bitconstant_op * request_constant)
+    const jlm::llvm::IntegerConstantOperation * request_constant)
 {
   jlm::rvsdg::output * response_function = nullptr;
   for (const auto & ctxvar : lambda->GetContextVars())

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -48,6 +48,7 @@
 #include <llvm/Support/SourceMgr.h>
 
 #include <jlm/hls/opt/IOBarrierRemoval.hpp>
+#include <jlm/llvm/ir/operators/IntegerOperations.hpp>
 #include <regex>
 
 namespace jlm::hls
@@ -206,9 +207,13 @@ convert_alloca(rvsdg::Region * region)
           false);
       // create zero constant of allocated type
       jlm::rvsdg::output * cout;
-      if (auto bt = dynamic_cast<const jlm::rvsdg::bittype *>(&po->value_type()))
+      if (auto bt = dynamic_cast<const llvm::IntegerConstantOperation *>(&po->value_type()))
       {
-        cout = jlm::rvsdg::create_bitconstant(db->subregion(), bt->nbits(), 0);
+        cout = llvm::IntegerConstantOperation::Create(
+                   *db->subregion(),
+                   bt->Representation().nbits(),
+                   0)
+                   .output(0);
       }
       else
       {

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.hpp
@@ -6,9 +6,9 @@
 #ifndef JLM_HLS_BACKEND_RVSDG2RHLS_RVSDG2RHLS_HPP
 #define JLM_HLS_BACKEND_RVSDG2RHLS_RVSDG2RHLS_HPP
 
+#include <jlm/llvm/ir/operators/IntegerOperations.hpp>
 #include <jlm/llvm/ir/operators/operators.hpp>
 #include <jlm/llvm/ir/RvsdgModule.hpp>
-#include <jlm/rvsdg/bitstring/constant.hpp>
 #include <jlm/rvsdg/node.hpp>
 #include <jlm/util/Statistics.hpp>
 
@@ -18,7 +18,7 @@ namespace jlm::hls
 static inline bool
 is_constant(const rvsdg::Node * node)
 {
-  return jlm::rvsdg::is<jlm::rvsdg::bitconstant_op>(node)
+  return jlm::rvsdg::is<llvm::IntegerConstantOperation>(node)
       || jlm::rvsdg::is<llvm::UndefValueOperation>(node)
       || jlm::rvsdg::is<jlm::rvsdg::ctlconstant_op>(node);
 }

--- a/jlm/llvm/backend/jlm2llvm/instruction.cpp
+++ b/jlm/llvm/backend/jlm2llvm/instruction.cpp
@@ -88,7 +88,7 @@ ConverterIntegerConstant(
     ::llvm::IRBuilder<> & builder,
     context &)
 {
-  const auto representation =
+  const auto & representation =
       util::AssertedCast<const IntegerConstantOperation>(&op)->Representation();
   const auto type = ::llvm::IntegerType::get(builder.getContext(), representation.nbits());
 

--- a/jlm/llvm/backend/jlm2llvm/instruction.cpp
+++ b/jlm/llvm/backend/jlm2llvm/instruction.cpp
@@ -82,19 +82,18 @@ convert_bitvalue_repr(const rvsdg::bitvalue_repr & vr)
 }
 
 static inline ::llvm::Value *
-convert_bitconstant(
+ConverterIntegerConstant(
     const rvsdg::SimpleOperation & op,
     const std::vector<const variable *> &,
     ::llvm::IRBuilder<> & builder,
     context &)
 {
-  JLM_ASSERT(dynamic_cast<const rvsdg::bitconstant_op *>(&op));
-  auto value = static_cast<const rvsdg::bitconstant_op *>(&op)->value();
+  const auto representation =
+      util::AssertedCast<const IntegerConstantOperation>(&op)->Representation();
+  const auto type = ::llvm::IntegerType::get(builder.getContext(), representation.nbits());
 
-  auto type = ::llvm::IntegerType::get(builder.getContext(), value.nbits());
-
-  if (value.is_defined())
-    return ::llvm::ConstantInt::get(type, convert_bitvalue_repr(value));
+  if (representation.is_defined())
+    return ::llvm::ConstantInt::get(type, convert_bitvalue_repr(representation));
 
   return ::llvm::UndefValue::get(type);
 }
@@ -1150,6 +1149,10 @@ convert_operation(
   {
     return ctx.value(arguments[0]);
   }
+  if (is<IntegerConstantOperation>(op))
+  {
+    return ConverterIntegerConstant(op, arguments, builder, ctx);
+  }
 
   static std::unordered_map<
       std::type_index,
@@ -1157,8 +1160,7 @@ convert_operation(
                           const std::vector<const variable *> &,
                           ::llvm::IRBuilder<> &,
                           context & ctx)>
-      map({ { typeid(rvsdg::bitconstant_op), convert_bitconstant },
-            { typeid(rvsdg::ctlconstant_op), convert_ctlconstant },
+      map({ { typeid(rvsdg::ctlconstant_op), convert_ctlconstant },
             { typeid(ConstantFP), convert<ConstantFP> },
             { typeid(UndefValueOperation), convert_undef },
             { typeid(PoisonValueOperation), convert<PoisonValueOperation> },

--- a/jlm/llvm/frontend/LlvmInstructionConversion.cpp
+++ b/jlm/llvm/frontend/LlvmInstructionConversion.cpp
@@ -84,16 +84,13 @@ convert_apint(const ::llvm::APInt & value)
 }
 
 static const variable *
-convert_int_constant(
-    ::llvm::Constant * c,
-    std::vector<std::unique_ptr<llvm::tac>> & tacs,
-    context &)
+convert_int_constant(::llvm::Constant * c, std::vector<std::unique_ptr<tac>> & tacs, context &)
 {
   JLM_ASSERT(c->getValueID() == ::llvm::Value::ConstantIntVal);
-  const ::llvm::ConstantInt * constant = static_cast<const ::llvm::ConstantInt *>(c);
+  const auto constant = ::llvm::cast<const ::llvm::ConstantInt>(c);
 
-  rvsdg::bitvalue_repr v = convert_apint(constant->getValue());
-  tacs.push_back(tac::create(rvsdg::bitconstant_op(v), {}));
+  const auto v = convert_apint(constant->getValue());
+  tacs.push_back(tac::create(IntegerConstantOperation(std::move(v)), {}));
 
   return tacs.back()->result(0);
 }

--- a/jlm/llvm/ir/operators/IntegerOperations.cpp
+++ b/jlm/llvm/ir/operators/IntegerOperations.cpp
@@ -8,7 +8,31 @@
 namespace jlm::llvm
 {
 
-IntegerBinaryOperation::~IntegerBinaryOperation() = default;
+IntegerConstantOperation::~IntegerConstantOperation() = default;
+
+std::unique_ptr<rvsdg::Operation>
+IntegerConstantOperation::copy() const
+{
+  return std::make_unique<IntegerConstantOperation>(*this);
+}
+
+std::string
+IntegerConstantOperation::debug_string() const
+{
+  if (Representation().is_known() && Representation().nbits() <= 64)
+    return util::strfmt("I", Representation().nbits(), "(", Representation().to_uint(), ")");
+
+  return Representation().str();
+}
+
+bool
+IntegerConstantOperation::operator==(const Operation & other) const noexcept
+{
+  const auto constant = dynamic_cast<const IntegerConstantOperation *>(&other);
+  return constant && constant->Representation() == Representation();
+}
+
+IntegerBinaryOperation::~IntegerBinaryOperation() noexcept = default;
 
 IntegerAddOperation::~IntegerAddOperation() noexcept = default;
 

--- a/jlm/llvm/ir/operators/IntegerOperations.hpp
+++ b/jlm/llvm/ir/operators/IntegerOperations.hpp
@@ -82,7 +82,7 @@ public:
   Type() const noexcept
   {
     return *util::AssertedCast<const rvsdg::bittype>(argument(0).get());
-    }
+  }
 };
 
 /**

--- a/jlm/llvm/ir/operators/IntegerOperations.hpp
+++ b/jlm/llvm/ir/operators/IntegerOperations.hpp
@@ -10,7 +10,6 @@
 #include <jlm/rvsdg/bitstring/type.hpp>
 #include <jlm/rvsdg/bitstring/value-representation.hpp>
 #include <jlm/rvsdg/nullary.hpp>
-#include <jlm/rvsdg/unary.hpp>
 
 namespace jlm::llvm
 {
@@ -75,13 +74,13 @@ public:
       const std::size_t numArgumentBits,
       const std::size_t numResultBits) noexcept
       : BinaryOperation(
-              { rvsdg::bittype::Create(numArgumentBits), rvsdg::bittype::Create(numArgumentBits) },
-              rvsdg::bittype::Create(numResultBits))
-    {}
+            { rvsdg::bittype::Create(numArgumentBits), rvsdg::bittype::Create(numArgumentBits) },
+            rvsdg::bittype::Create(numResultBits))
+  {}
 
-    [[nodiscard]] const rvsdg::bittype &
-    Type() const noexcept
-    {
+  [[nodiscard]] const rvsdg::bittype &
+  Type() const noexcept
+  {
       return *util::AssertedCast<const rvsdg::bittype>(argument(0).get());
     }
 };

--- a/jlm/llvm/ir/operators/IntegerOperations.hpp
+++ b/jlm/llvm/ir/operators/IntegerOperations.hpp
@@ -25,42 +25,42 @@ using IntegerValueRepresentation = rvsdg::bitvalue_repr;
 class IntegerConstantOperation final : public rvsdg::NullaryOperation
 {
 public:
-    ~IntegerConstantOperation() override;
+  ~IntegerConstantOperation() override;
 
-    explicit IntegerConstantOperation(IntegerValueRepresentation representation)
-        : NullaryOperation(rvsdg::bittype::Create(representation.nbits())),
-          Representation_(std::move(representation))
-    {}
+  explicit IntegerConstantOperation(IntegerValueRepresentation representation)
+      : NullaryOperation(rvsdg::bittype::Create(representation.nbits())),
+        Representation_(std::move(representation))
+  {}
 
-    std::unique_ptr<Operation>
-    copy() const override;
+  std::unique_ptr<Operation>
+  copy() const override;
 
-    std::string
-    debug_string() const override;
+  std::string
+  debug_string() const override;
 
-    bool
-    operator==(const Operation & other) const noexcept override;
+  bool
+  operator==(const Operation & other) const noexcept override;
 
-    [[nodiscard]] const IntegerValueRepresentation &
-    Representation() const noexcept
-    {
-        return Representation_;
-    }
+  [[nodiscard]] const IntegerValueRepresentation &
+  Representation() const noexcept
+  {
+    return Representation_;
+  }
 
-    static rvsdg::Node &
-    Create(rvsdg::Region & region, IntegerValueRepresentation representation)
-    {
-        return rvsdg::CreateOpNode<IntegerConstantOperation>(region, std::move(representation));
-    }
+  static rvsdg::Node &
+  Create(rvsdg::Region & region, IntegerValueRepresentation representation)
+  {
+    return rvsdg::CreateOpNode<IntegerConstantOperation>(region, std::move(representation));
+  }
 
-    static rvsdg::Node &
-    Create(rvsdg::Region & region, std::size_t numBits, std::int64_t value)
-    {
-        return Create(region, { numBits, value });
-    }
+  static rvsdg::Node &
+  Create(rvsdg::Region & region, std::size_t numBits, std::int64_t value)
+  {
+    return Create(region, { numBits, value });
+  }
 
 private:
-    IntegerValueRepresentation Representation_;
+  IntegerValueRepresentation Representation_;
 };
 
 /**
@@ -80,7 +80,7 @@ public:
     [[nodiscard]] const rvsdg::bittype &
     Type() const noexcept
     {
-        return *util::AssertedCast<const rvsdg::bittype>(argument(0).get());
+      return *util::AssertedCast<const rvsdg::bittype>(argument(0).get());
     }
 };
 

--- a/jlm/llvm/ir/operators/IntegerOperations.hpp
+++ b/jlm/llvm/ir/operators/IntegerOperations.hpp
@@ -69,10 +69,12 @@ private:
 class IntegerBinaryOperation : public rvsdg::BinaryOperation
 {
 public:
-    ~IntegerBinaryOperation() override;
+  ~IntegerBinaryOperation() noexcept override;
 
-    IntegerBinaryOperation(std::size_t numArgumentBits, std::size_t numResultBits) noexcept
-        : BinaryOperation(
+  IntegerBinaryOperation(
+      const std::size_t numArgumentBits,
+      const std::size_t numResultBits) noexcept
+      : BinaryOperation(
               { rvsdg::bittype::Create(numArgumentBits), rvsdg::bittype::Create(numArgumentBits) },
               rvsdg::bittype::Create(numResultBits))
     {}

--- a/jlm/llvm/ir/operators/IntegerOperations.hpp
+++ b/jlm/llvm/ir/operators/IntegerOperations.hpp
@@ -81,7 +81,7 @@ public:
   [[nodiscard]] const rvsdg::bittype &
   Type() const noexcept
   {
-      return *util::AssertedCast<const rvsdg::bittype>(argument(0).get());
+    return *util::AssertedCast<const rvsdg::bittype>(argument(0).get());
     }
 };
 

--- a/tests/jlm/llvm/backend/llvm/jlm-llvm/test-bitconstant.cpp
+++ b/tests/jlm/llvm/backend/llvm/jlm-llvm/test-bitconstant.cpp
@@ -9,6 +9,7 @@
 #include <jlm/llvm/backend/jlm2llvm/jlm2llvm.hpp>
 #include <jlm/llvm/ir/ipgraph-module.hpp>
 #include <jlm/llvm/ir/operators.hpp>
+#include <jlm/llvm/ir/operators/IntegerOperations.hpp>
 #include <jlm/llvm/ir/print.hpp>
 
 #include <llvm/IR/LLVMContext.h>
@@ -34,7 +35,7 @@ test()
 
   auto cfg = cfg::create(im);
   auto bb = basic_block::create(*cfg);
-  bb->append_last(tac::create(jlm::rvsdg::bitconstant_op(vr), {}));
+  bb->append_last(tac::create(IntegerConstantOperation(vr), {}));
   auto c = bb->last()->result(0);
 
   cfg->exit()->divert_inedges(bb);

--- a/tests/jlm/llvm/frontend/llvm/LlvmPhiConversionTests.cpp
+++ b/tests/jlm/llvm/frontend/llvm/LlvmPhiConversionTests.cpp
@@ -8,6 +8,7 @@
 
 #include <jlm/llvm/frontend/LlvmModuleConversion.hpp>
 #include <jlm/llvm/ir/operators/call.hpp>
+#include <jlm/llvm/ir/operators/IntegerOperations.hpp>
 #include <jlm/llvm/ir/operators/operators.hpp>
 #include <jlm/llvm/ir/print.hpp>
 #include <jlm/rvsdg/bitstring/constant.hpp>
@@ -17,7 +18,6 @@
 #include <llvm/IRReader/IRReader.h>
 #include <llvm/Support/SourceMgr.h>
 
-#include <jlm/llvm/ir/operators/IntegerOperations.hpp>
 #include <string>
 
 /**

--- a/tests/jlm/llvm/frontend/llvm/LlvmPhiConversionTests.cpp
+++ b/tests/jlm/llvm/frontend/llvm/LlvmPhiConversionTests.cpp
@@ -17,6 +17,7 @@
 #include <llvm/IRReader/IRReader.h>
 #include <llvm/Support/SourceMgr.h>
 
+#include <jlm/llvm/ir/operators/IntegerOperations.hpp>
 #include <string>
 
 /**
@@ -145,9 +146,9 @@ TestPhiConversion()
   // The first operand of the phi node is the constant integer 0
   auto constant0variable =
       jlm::util::AssertedCast<const jlm::llvm::tacvariable>(phiPopcnt->operand(0));
-  auto constant0op = jlm::util::AssertedCast<const jlm::rvsdg::bitconstant_op>(
+  auto constant0op = jlm::util::AssertedCast<const jlm::llvm::IntegerConstantOperation>(
       &constant0variable->tac()->operation());
-  assert(constant0op->value() == 0);
+  assert(constant0op->Representation() == 0);
   // The last operand of the popcnt phi is the result of the phi itself
   assert(phiPopcnt->operand(2) == phiPopcnt->result(0));
 
@@ -262,9 +263,9 @@ TestPhiOperandElision()
   // The first phi operand should be a constant 0
   auto constant0variable =
       jlm::util::AssertedCast<const jlm::llvm::tacvariable>(phiTac->operand(0));
-  auto constant0op = jlm::util::AssertedCast<const jlm::rvsdg::bitconstant_op>(
+  auto constant0op = jlm::util::AssertedCast<const jlm::llvm::IntegerConstantOperation>(
       &constant0variable->tac()->operation());
-  assert(constant0op->value() == 0);
+  assert(constant0op->Representation() == 0);
 
   return 0;
 }


### PR DESCRIPTION
This PR replaces the old bitstring constant operation with a new LLVM specific integer constant operation.
