### PR TITLE
Give the hls workflow permission to comment on the PR

### DIFF
--- a/.github/workflows/hls.yml
+++ b/.github/workflows/hls.yml
@@ -18,7 +18,7 @@ jobs:
       issues: write
       pull-requests: write
 
-      steps:
+    steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: '0'

--- a/.github/workflows/hls.yml
+++ b/.github/workflows/hls.yml
@@ -12,7 +12,13 @@ jobs:
 
   hls-test-suite:
     runs-on: ubuntu-22.04
-    steps:
+
+    # To enable commenting on the pull request
+    permissions:
+      issues: write
+      pull-requests: write
+
+      steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: '0'


### PR DESCRIPTION
I am not entirely sure why, but the HLS workflow on #803 fails when it tries to write a comment about changed cycle count.

This has never been an issue before, but it might be because the creator of the PR, or the last committer, is @halvorlinder who has fewer permissions.

I am hoping this change might help with this, but the permission documentation is not very clear