### PR TITLE
Allow the HLS cycle count changed comment on PRs to fail

### DIFF
--- a/.github/workflows/hls.yml
+++ b/.github/workflows/hls.yml
@@ -34,6 +34,7 @@ jobs:
         script: |
           const fs = require("fs");
           const comment = fs.readFileSync("./usr/hls-test-suite/build/cycle-diff.log", { encoding: "utf8" });
+          console.log("Writing comment on PR: \n" + comment);
           github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,

--- a/.github/workflows/hls.yml
+++ b/.github/workflows/hls.yml
@@ -12,12 +12,6 @@ jobs:
 
   hls-test-suite:
     runs-on: ubuntu-22.04
-
-    # To enable commenting on the pull request
-    permissions:
-      issues: write
-      pull-requests: write
-
     steps:
     - uses: actions/checkout@v4
       with:
@@ -46,3 +40,4 @@ jobs:
             repo: context.repo.repo,
             body: "```\n" + comment + "```"
           });
+      continue-on-error: true


### PR DESCRIPTION
It turns out that specifying permissions directly did not help.
The `GITHUB_TOKEN` created for a `pull_request` workflow only has permissions inside the source repository. Since @halvorlinder's PR #803 is from his own fork, the workflow can not comment on the PR in this repository.

I found one workaround on [stack overflow](https://stackoverflow.com/a/71683208) that uploads the comment as an artifact, and uses a second workflow triggered by the completion of the first workflow to comment.

However, for an informative comment like this, I think it makes more sense to just allow the commenting to fail silently.