### PR TITLE
Fix operand order in select creation in RvsdgToIpGraphConverter

### DIFF
--- a/jlm/llvm/backend/RvsdgToIpGraphConverter.cpp
+++ b/jlm/llvm/backend/RvsdgToIpGraphConverter.cpp
@@ -296,7 +296,7 @@ RvsdgToIpGraphConverter::ConvertEmptyGammaNode(const rvsdg::GammaNode & gammaNod
       const auto vo1 = Context_->GetVariable(output1);
       basicBlock->append_last(
           ctl2bits_op::create(Context_->GetVariable(predicate), rvsdg::bittype::Create(1)));
-      basicBlock->append_last(SelectOperation::create(basicBlock->last()->result(0), vo0, vo1));
+      basicBlock->append_last(SelectOperation::create(basicBlock->last()->result(0), vo1, vo0));
     }
 
     Context_->InsertVariable(output, basicBlock->last()->result(0));

--- a/jlm/llvm/backend/RvsdgToIpGraphConverter.cpp
+++ b/jlm/llvm/backend/RvsdgToIpGraphConverter.cpp
@@ -292,11 +292,14 @@ RvsdgToIpGraphConverter::ConvertEmptyGammaNode(const rvsdg::GammaNode & gammaNod
     }
     else
     {
-      const auto vo0 = Context_->GetVariable(output0);
-      const auto vo1 = Context_->GetVariable(output1);
+      const auto falseAlternative = Context_->GetVariable(output0);
+      const auto trueAlternative = Context_->GetVariable(output1);
       basicBlock->append_last(
           ctl2bits_op::create(Context_->GetVariable(predicate), rvsdg::bittype::Create(1)));
-      basicBlock->append_last(SelectOperation::create(basicBlock->last()->result(0), vo1, vo0));
+      basicBlock->append_last(SelectOperation::create(
+          basicBlock->last()->result(0),
+          trueAlternative,
+          falseAlternative));
     }
 
     Context_->InsertVariable(output, basicBlock->last()->result(0));


### PR DESCRIPTION
When handling an empty gamma node with 2 subregions, then the RvsdgToIpGraphConverter can create select operations instead of basic blocks. However, the operands of the select operations were switched. This PR fixes this problem.

Close #836
Close #586