### PR TITLE
add PrecisionEvaluation to alias analysis

### DIFF
--- a/jlm/llvm/Makefile.sub
+++ b/jlm/llvm/Makefile.sub
@@ -52,6 +52,7 @@ libllvm_SOURCES = \
     jlm/llvm/opt/alias-analyses/Optimization.cpp \
     jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp \
     jlm/llvm/opt/alias-analyses/PointsToGraph.cpp \
+    jlm/llvm/opt/alias-analyses/PrecisionEvaluator.cpp \
     jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.cpp \
     jlm/llvm/opt/alias-analyses/Steensgaard.cpp \
     jlm/llvm/opt/alias-analyses/TopDownMemoryNodeEliminator.cpp \
@@ -88,6 +89,7 @@ libllvm_HEADERS = \
 	jlm/llvm/opt/alias-analyses/AgnosticMemoryNodeProvider.hpp \
 	jlm/llvm/opt/alias-analyses/RegionAwareMemoryNodeProvider.hpp \
 	jlm/llvm/opt/alias-analyses/PointsToGraph.hpp \
+	jlm/llvm/opt/alias-analyses/PrecisionEvaluator.hpp \
 	jlm/llvm/opt/alias-analyses/AliasAnalysis.hpp \
 	jlm/llvm/opt/pull.hpp \
 	jlm/llvm/opt/reduction.hpp \

--- a/jlm/llvm/opt/alias-analyses/PrecisionEvaluator.cpp
+++ b/jlm/llvm/opt/alias-analyses/PrecisionEvaluator.cpp
@@ -1,0 +1,368 @@
+/*
+ * Copyright 2025 Håvard Krogstie <krogstie.havard@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include "MemoryStateEncoder.hpp"
+#include <jlm/llvm/opt/alias-analyses/PrecisionEvaluator.hpp>
+#include <jlm/rvsdg/RvsdgModule.hpp>
+
+#include <fstream>
+
+namespace jlm::llvm::aa
+{
+PairwiseAliasAnalysis::PairwiseAliasAnalysis() = default;
+
+PairwiseAliasAnalysis::~PairwiseAliasAnalysis() = default;
+
+bool
+PairwiseAliasAnalysis::MayAlias(const rvsdg::output & p1, const rvsdg::output & p2)
+{
+  if (!MayAliasImpl(p1, p2))
+    return false;
+
+  // This analysis was unable to determine that p1 and p2 do not alias, do we have a backup?
+  if (Backup_)
+    return Backup_->MayAlias(p1, p2);
+
+  return true;
+}
+
+std::string
+PairwiseAliasAnalysis::ToString() const
+{
+  std::string result = ToStringImpl();
+  if (Backup_)
+    result = util::strfmt(result, "(", Backup_->ToString(), ")");
+  return result;
+}
+
+PointsToGraphAliasAnalysis::PointsToGraphAliasAnalysis(PointsToGraph & pointsToGraph)
+    : PointsToGraph_(pointsToGraph)
+{}
+
+PointsToGraphAliasAnalysis::~PointsToGraphAliasAnalysis() = default;
+
+bool
+PointsToGraphAliasAnalysis::MayAliasImpl(const rvsdg::output & p1, const rvsdg::output & p2)
+{
+  // Assume that all pointers actually exist in the PointsToGraph
+  auto & p1RegisterNode = PointsToGraph_.GetRegisterNode(p1);
+  auto & p2RegisterNode = PointsToGraph_.GetRegisterNode(p2);
+
+  // If the registers are represented by the same node, they may alias
+  if (&p1RegisterNode == &p2RegisterNode)
+    return true;
+
+  // Check if both pointers may target the external node, to avoid iterating over large sets
+  const auto & externalNode = PointsToGraph_.GetExternalMemoryNode();
+  if (p1RegisterNode.HasTarget(externalNode) && p2RegisterNode.HasTarget(externalNode))
+    return true;
+
+  // Check if p1 and p2 share any target memory nodes
+  for (auto & target : p1RegisterNode.Targets())
+  {
+    if (p2RegisterNode.HasTarget(target))
+      return true;
+  }
+
+  return false;
+}
+
+std::string
+PointsToGraphAliasAnalysis::ToStringImpl() const
+{
+  return "PointsToGraphAliasAnalysis";
+}
+
+std::string_view
+PrecisionEvaluationModeToString(PrecisionEvaluationMode mode)
+{
+  switch (mode)
+  {
+  case PrecisionEvaluationMode::ClobberingStores:
+    return "ClobberingStores";
+  case PrecisionEvaluationMode::AllPointerPairs:
+    return "AllPointerPairs";
+  default:
+    JLM_UNREACHABLE("Unknown precision evaluation mode");
+  }
+}
+
+class PrecisionEvaluator::PrecisionStatistics final : public util::Statistics
+{
+  // This statistic places additional information in a separate file. This is the path of the file.
+  static constexpr auto PrecisionEvaluationMode_ = "PrecisionEvaluationMode";
+  static constexpr auto PairwiseAliasAnalysisType_ = "PairwiseAliasAnalysisType";
+  static constexpr auto NumMayAliasQueries_ = "#MayAliasQueries";
+  static constexpr auto PrecisionDumpFile_ = "DumpFile";
+  static constexpr auto ModuleAverageMayAliasRate_ = "ModuleAverageMayAliasRate";
+  static constexpr auto PrecisionEvaluationTimer_ = "PrecisionEvaluationTimer";
+
+public:
+  ~PrecisionStatistics() override = default;
+
+  explicit PrecisionStatistics(const util::filepath & sourceFile)
+      : Statistics(Id::AliasAnalysisPrecisionEvaluation, sourceFile)
+  {}
+
+  void
+  StartEvaluatingPrecision(PrecisionEvaluationMode mode, PairwiseAliasAnalysis & aliasAnalysis)
+  {
+    AddTimer(PrecisionEvaluationTimer_).start();
+    AddMeasurement(PrecisionEvaluationMode_, std::string(PrecisionEvaluationModeToString(mode)));
+    AddMeasurement(PairwiseAliasAnalysisType_, aliasAnalysis.ToString());
+  }
+
+  void
+  StopEvaluatingPrecision(uint64_t numMayAliasQueries)
+  {
+    GetTimer(PrecisionEvaluationTimer_).stop();
+    AddMeasurement(NumMayAliasQueries_, numMayAliasQueries);
+  }
+
+  void
+  AddPrecisionSummaryStatistics(const util::filepath & outputFile, double moduleAverageMayAliasRate)
+  {
+    AddMeasurement(PrecisionDumpFile_, outputFile.to_str());
+    AddMeasurement(ModuleAverageMayAliasRate_, moduleAverageMayAliasRate);
+  }
+
+  static std::unique_ptr<PrecisionStatistics>
+  Create(const util::filepath & sourceFile)
+  {
+    return std::make_unique<PrecisionStatistics>(sourceFile);
+  }
+};
+
+void
+PrecisionEvaluator::EvaluateAliasAnalysisClient(
+    const rvsdg::RvsdgModule & rvsdgModule,
+    PairwiseAliasAnalysis & aliasAnalysis,
+    util::StatisticsCollector & statisticsCollector)
+{
+  auto statistics = PrecisionStatistics::Create(rvsdgModule.SourceFilePath().value());
+
+  // If a precision evaluation is not demanded, skip doing it
+  if (!statisticsCollector.IsDemanded(*statistics))
+    return;
+
+  Context_ = Context{};
+
+  statistics->StartEvaluatingPrecision(Mode_, aliasAnalysis);
+
+  EvaluateAllFunctions(rvsdgModule.Rvsdg().GetRootRegion(), aliasAnalysis);
+
+  statistics->StopEvaluatingPrecision(Context_.NumMayAliasQueries);
+
+  // Calculate average precision in functions and for the whole module, and print to output
+  const auto outputFile = statisticsCollector.CreateOutputFile("AAPrecisionEvaluation.log", true);
+  CalculateAverageMayAliasRate(outputFile, *statistics);
+
+  statisticsCollector.CollectDemandedStatistics(std::move(statistics));
+}
+
+void
+PrecisionEvaluator::EvaluateAllFunctions(
+    const rvsdg::Region & region,
+    PairwiseAliasAnalysis & aliasAnalysis)
+{
+  for (auto & node : region.Nodes())
+  {
+    if (auto lambda = dynamic_cast<const rvsdg::LambdaNode *>(&node))
+    {
+      EvaluateFunction(*lambda, aliasAnalysis);
+    }
+    else if (auto structural = dynamic_cast<const rvsdg::StructuralNode *>(&node))
+    {
+      for (size_t n = 0; n < structural->nsubregions(); n++)
+      {
+        EvaluateAllFunctions(*structural->subregion(n), aliasAnalysis);
+      }
+    }
+  }
+}
+
+void
+PrecisionEvaluator::EvaluateFunction(
+    const rvsdg::LambdaNode & function,
+    PairwiseAliasAnalysis & aliasAnalysis)
+{
+  // Reset collected pointer uses and pointer clobbers
+  Context_.PointerUses.clear();
+  Context_.PointerClobbers.clear();
+
+  // Collect all pointer uses and clobbers from this function
+  CollectPointersFromFunctionArguments(function);
+  CollectPointersFromRegion(*function.subregion());
+
+  // Create a PrecisionInfo instance for this function
+  auto & precisionEvaluation = Context_.PerFunctionPrecision[&function];
+  precisionEvaluation.NumClobberingPointers = Context_.PointerClobbers.size();
+
+  // Go over all pointer usages, find the ratio of clobbering points that may alias with it
+  for (auto [usedPointer, useIsClobber] : Context_.PointerUses)
+  {
+    uint64_t mayAliasClobbers = 0;
+    for (auto clobberedPointer : Context_.PointerClobbers)
+    {
+      Context_.NumMayAliasQueries++;
+      mayAliasClobbers += aliasAnalysis.MayAlias(*usedPointer, *clobberedPointer);
+    }
+    precisionEvaluation.AddPointerUse(useIsClobber, mayAliasClobbers);
+  }
+}
+
+void
+PrecisionEvaluator::CollectPointersFromFunctionArguments(const rvsdg::LambdaNode & function)
+{
+  // In this mode, only loads and stores constitute uses and clobbers, so ignore function arguments
+  if (Mode_ == PrecisionEvaluationMode::ClobberingStores)
+    return;
+
+  JLM_ASSERT(Mode_ == PrecisionEvaluationMode::AllPointerPairs);
+  for (const auto arg : function.GetFunctionArguments())
+  {
+    if (IsPointerCompatible(arg))
+      CollectPointer(arg, true, true);
+  }
+}
+
+void
+PrecisionEvaluator::CollectPointersFromRegion(const rvsdg::Region & region)
+{
+  for (auto & node : region.Nodes())
+  {
+    if (auto simpleNode = dynamic_cast<const rvsdg::SimpleNode *>(&node))
+    {
+      CollectPointersFromSimpleNode(*simpleNode);
+    }
+    else if (auto structuralNode = dynamic_cast<const rvsdg::StructuralNode *>(&node))
+    {
+      CollectPointersFromStructuralNode(*structuralNode);
+    }
+    else
+    {
+      JLM_UNREACHABLE("Unknown node type");
+    }
+  }
+}
+
+void
+PrecisionEvaluator::CollectPointersFromSimpleNode(const rvsdg::SimpleNode & node)
+{
+  if (Mode_ == PrecisionEvaluationMode::ClobberingStores)
+  {
+    // In this mode, only (volatile) load and store operations count as uses and clobbers
+    if (auto load = dynamic_cast<const LoadNode *>(&node))
+    {
+      CollectPointer(load->GetAddressInput().origin(), true, false);
+    }
+    else if (auto store = dynamic_cast<const StoreNode *>(&node))
+    {
+      CollectPointer(store->GetAddressInput().origin(), true, true);
+    }
+  }
+  else if (Mode_ == PrecisionEvaluationMode::AllPointerPairs)
+  {
+    // In this mode, all pointer compatible outputs are regarded as both uses and clobbers
+    for (size_t n = 0; n < node.noutputs(); n++)
+    {
+      if (const auto output = node.output(n); IsPointerCompatible(output))
+        CollectPointer(output, true, true);
+    }
+  }
+  else
+  {
+    JLM_UNREACHABLE("Unknown precision evaluation mode");
+  }
+}
+
+void
+PrecisionEvaluator::CollectPointersFromStructuralNode(const rvsdg::StructuralNode & node)
+{
+  for (size_t n = 0; n < node.nsubregions(); n++)
+  {
+    CollectPointersFromRegion(*node.subregion(n));
+  }
+
+  if (Mode_ == PrecisionEvaluationMode::AllPointerPairs)
+  {
+    // In this mode, pointer compatible outputs from structural nodes represent new pointers.
+    // This is to mimic LLVM phi nodes more closely
+    // If the output has no users, such as a theta loop variable only used in the loop, it is
+    // skipped
+    for (size_t n = 0; n < node.noutputs(); n++)
+    {
+      const auto output = node.output(n);
+      if (IsPointerCompatible(output) && output->nusers() > 0)
+        CollectPointer(output, true, true);
+    }
+  }
+}
+
+bool
+PrecisionEvaluator::IsPointerCompatible(const rvsdg::output * value)
+{
+  // We omit including function types as pointers, as we otherwise risk including a bunch of trivial
+  // direct calls.
+  const auto & type = value->type();
+  return IsOrContains<PointerType>(type);
+}
+
+void
+PrecisionEvaluator::CollectPointer(const rvsdg::output * value, bool isUse, bool isClobber)
+{
+  JLM_ASSERT(IsPointerCompatible(value));
+
+  if (isUse)
+    Context_.PointerUses.push_back({ value, isClobber });
+
+  if (isClobber)
+    Context_.PointerClobbers.push_back(value);
+}
+
+void
+PrecisionEvaluator::CalculateAverageMayAliasRate(
+    const util::file & outputFile,
+    PrecisionStatistics & statistics) const
+{
+  // Create one average alias analysis precision for the whole module
+  size_t moduleNumUsages = 0;
+  double moduleUseMayAliasTotal = 0.0;
+
+  // Write precision info about each function to an output file
+  std::ofstream out(outputFile.path().to_str());
+  for (auto [function, precision] : Context_.PerFunctionPrecision)
+  {
+    // Calculate the average alias analysis precision rate for this function
+    auto functionNumUsages = precision.UsedPointerMayAlias.size();
+    double functionUseMayAliasTotal = 0.0;
+    for (double mayAlias : precision.UsedPointerMayAlias)
+      functionUseMayAliasTotal += mayAlias;
+
+    // Also include the pointer uses in the module average
+    moduleNumUsages += functionNumUsages;
+    moduleUseMayAliasTotal += functionUseMayAliasTotal;
+
+    const auto functionAverageMayAlias = functionUseMayAliasTotal / functionNumUsages;
+
+    out << function->GetOperation().debug_string() << " [";
+    out << precision.UsedPointerMayAlias.size() << " used pointers, ";
+    out << precision.NumClobberingPointers << " clobbering pointers]: ";
+    out << functionAverageMayAlias;
+    out << std::endl;
+  }
+
+  // Calculate the module-wide average precision for each pointer use
+  const auto moduleAverageMayAlias = moduleUseMayAliasTotal / moduleNumUsages;
+  out << std::endl; // Empty line before the final result
+  out << "Total: " << moduleNumUsages << " used pointers. ";
+  out << "Average use may alias clobber rate: " << moduleAverageMayAlias << std::endl;
+
+  out.close();
+
+  statistics.AddPrecisionSummaryStatistics(outputFile.path(), moduleAverageMayAlias);
+}
+
+}

--- a/jlm/llvm/opt/alias-analyses/PrecisionEvaluator.hpp
+++ b/jlm/llvm/opt/alias-analyses/PrecisionEvaluator.hpp
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2025 Håvard Krogstie <krogstie.havard@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#ifndef JLM_LLVM_OPT_ALIAS_ANALYSES_PRECISIONEVALUATOR_HPP
+#define JLM_LLVM_OPT_ALIAS_ANALYSES_PRECISIONEVALUATOR_HPP
+
+#include <jlm/llvm/opt/alias-analyses/PointsToGraph.hpp>
+#include <jlm/rvsdg/RvsdgModule.hpp>
+#include <jlm/util/Statistics.hpp>
+
+#include <unordered_map>
+
+namespace jlm::llvm::aa
+{
+
+/**
+ * Interface for making alias analysis queries about pairs of pointers
+ */
+class PairwiseAliasAnalysis
+{
+public:
+  PairwiseAliasAnalysis();
+  virtual ~PairwiseAliasAnalysis();
+
+  /**
+   * If this alias analysis is unable to determine NoAlias, it queries the optional backup analysis.
+   * @param backup the PairwiseAliasAnalysis instance to use as backup
+   */
+  void
+  SetBackup(PairwiseAliasAnalysis * backup) noexcept
+  {
+    Backup_ = backup;
+  }
+
+  PairwiseAliasAnalysis *
+  GetBackup() const noexcept
+  {
+    return Backup_;
+  }
+
+  /**
+   * Checks if the pointers represented by p1 and p2 may alias.
+   * If this analysis is unable to prove No Alias, and a backup is provided, the backup is asked.
+   * @param p1 the first pointer value
+   * @param p2 the second pointer value
+   * @return false if the analysis is able to prove that they do not alias, true otherwise
+   */
+  bool
+  MayAlias(const rvsdg::output & p1, const rvsdg::output & p2);
+
+  /**
+   * @return a string description of the pairwise alias analysis, including any backup instances
+   */
+  [[nodiscard]] std::string
+  ToString() const;
+
+protected:
+  virtual bool
+  MayAliasImpl(const rvsdg::output & p1, const rvsdg::output & p2) = 0;
+
+  virtual std::string
+  ToStringImpl() const = 0;
+
+private:
+  // Another instance of PairwiseAliasAnalysis, queried if the current analysis says "May Alias"
+  PairwiseAliasAnalysis * Backup_ = nullptr;
+};
+
+/**
+ * Interface for making alias pairwise analysis queries to a PointsToGraph
+ */
+class PointsToGraphAliasAnalysis final : public PairwiseAliasAnalysis
+{
+public:
+  explicit PointsToGraphAliasAnalysis(PointsToGraph & pointsToGraph);
+  ~PointsToGraphAliasAnalysis() override;
+
+protected:
+  bool
+  MayAliasImpl(const rvsdg::output & p1, const rvsdg::output & p2) override;
+
+  std::string
+  ToStringImpl() const override;
+
+private:
+  // The PointsToGraph used to answer alias queries
+  PointsToGraph & PointsToGraph_;
+};
+
+/**
+ * Option configuring how pointers are collected and evaluated for may-alias precision
+ */
+enum class PrecisionEvaluationMode
+{
+  // In this mode, a pointer use is a store / load, and a clobber is a store
+  ClobberingStores,
+
+  // In this mode, all pointer outputs are both used, and considered to clobber.
+  // This is equivalent to checking all pairs of pointers in each function.
+  // Temporary pointers, such as the result of a pointer offset, are counted as separate pointers.
+  // This is consistent with Lattner's 2007 DSA paper.
+  AllPointerPairs
+};
+
+/**
+ * Class for evaluating the precision of a PointsToGraph on an RVSDG module.
+ * Uses a pairwise alias analysis to ask MayAlias queries on relevant pairs of pointers.
+ */
+class PrecisionEvaluator
+{
+  class PrecisionStatistics;
+
+public:
+  explicit PrecisionEvaluator(PrecisionEvaluationMode mode)
+      : Mode_(mode)
+  {}
+
+  void
+  SetMode(PrecisionEvaluationMode mode)
+  {
+    Mode_ = mode;
+  }
+
+  PrecisionEvaluationMode
+  GetMode() const noexcept
+  {
+    return Mode_;
+  }
+
+  void
+  EvaluateAliasAnalysisClient(
+      const rvsdg::RvsdgModule & rvsdgModule,
+      PairwiseAliasAnalysis & aliasAnalysis,
+      util::StatisticsCollector & statisticsCollector);
+
+private:
+  void
+  EvaluateAllFunctions(const rvsdg::Region & region, PairwiseAliasAnalysis & aliasAnalysis);
+
+  void
+  EvaluateFunction(const rvsdg::LambdaNode & function, PairwiseAliasAnalysis & aliasAnalysis);
+
+  void
+  CollectPointersFromFunctionArguments(const rvsdg::LambdaNode & function);
+
+  void
+  CollectPointersFromRegion(const rvsdg::Region & region);
+
+  void
+  CollectPointersFromSimpleNode(const rvsdg::SimpleNode & node);
+
+  void
+  CollectPointersFromStructuralNode(const rvsdg::StructuralNode & node);
+
+  // Determines if the given value is regarded as representing a pointer
+  bool
+  IsPointerCompatible(const rvsdg::output * value);
+
+  // Adds a value to the list of pointer uses and/or clobbers in the function being evaluated
+  // currently
+  void
+  CollectPointer(const rvsdg::output * value, bool isUse, bool isClobber);
+
+  // Called once all functions have been evaluated, to calculate and print averages
+  void
+  CalculateAverageMayAliasRate(const util::file & outputFile, PrecisionStatistics & statistics)
+      const;
+
+  // How pointers are counted in the precision evaluation
+  PrecisionEvaluationMode Mode_;
+
+  // Alias analysis precision info for a set of pointer usages
+  struct PrecisionInfo
+  {
+    // The number of points in the function that are considered to be pointer clobbering
+    uint64_t NumClobberingPointers;
+
+    /**
+     * When a pointer is used, how many of the clobbering pointers in the function may it alias?
+     * Each value is a double between 0 and 1, where 1 means it may alias with every clobber.
+     * If the use is itself a clobber, it only considers all other clobbers.
+     */
+    std::vector<double> UsedPointerMayAlias;
+
+    /**
+     * Adds a pointer use to the statistics.
+     * Calculates the ratio:
+     *  other clobbers I may alias / number of other clobbers in function
+     * @param useIsClobber true if the pointer use is also a clobber
+     * @param numClobbersMayAlias the number of clobber operations in the function the use may alias
+     */
+    void
+    AddPointerUse(bool useIsClobber, uint64_t numClobbersMayAlias)
+    {
+      // If this use is itself a clobber, omit it from the ratio calculation
+      numClobbersMayAlias -= useIsClobber;
+      auto numOtherClobbers = NumClobberingPointers - useIsClobber;
+      auto ratio = numClobbersMayAlias / static_cast<double>(numOtherClobbers);
+      UsedPointerMayAlias.push_back(ratio);
+    }
+  };
+
+  struct Context
+  {
+    // Precision info per function in the evaluated module
+    std::unordered_map<const rvsdg::LambdaNode *, PrecisionInfo> PerFunctionPrecision;
+
+    /**
+     * During traversal of the current function, which pointers are used.
+     * The use consists of a pointer value, and a bool that is true if the use is also a clobber.
+     * How pointers are counted depends on the configured mode.
+     * The same pointer can also be used multiple times.
+     * @see PrecisionEvaluationMode
+     */
+    std::vector<std::pair<const rvsdg::output *, bool>> PointerUses;
+    std::vector<const rvsdg::output *> PointerClobbers;
+
+    // Keeps count of the number of MayAlias queries made
+    uint64_t NumMayAliasQueries = 0;
+  };
+
+  Context Context_;
+};
+
+}
+
+#endif // JLM_LLVM_OPT_ALIAS_ANALYSES_PRECISIONEVALUATOR_HPP

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -220,6 +220,7 @@ const util::BijectiveMap<util::Statistics::Id, std::string_view> &
 JlmOptCommandLineOptions::GetStatisticsIdCommandLineArguments()
 {
   static util::BijectiveMap<util::Statistics::Id, std::string_view> mapping = {
+    { util::Statistics::Id::AliasAnalysisPrecisionEvaluation, "print-aa-precision-evaluation" },
     { util::Statistics::Id::Aggregation, "print-aggregation-time" },
     { util::Statistics::Id::AgnosticMemoryNodeProvisioning,
       "print-agnostic-memory-node-provisioning" },
@@ -700,6 +701,9 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, const char * const 
 
   cl::list<util::Statistics::Id> printStatistics(
       cl::values(
+          CreateStatisticsOption(
+              util::Statistics::Id::AliasAnalysisPrecisionEvaluation,
+              "Evaluate alias analysis precision and store to file"),
           CreateStatisticsOption(
               util::Statistics::Id::Aggregation,
               "Write aggregation statistics to file."),

--- a/jlm/util/Statistics.cpp
+++ b/jlm/util/Statistics.cpp
@@ -18,6 +18,7 @@ static const util::BijectiveMap<Statistics::Id, std::string_view> &
 GetStatisticsIdNames()
 {
   static util::BijectiveMap<Statistics::Id, std::string_view> mapping = {
+    { Statistics::Id::AliasAnalysisPrecisionEvaluation, "AliasAnalysisPrecisionEvaluation" },
     { Statistics::Id::Aggregation, "Aggregation" },
     { Statistics::Id::AgnosticMemoryNodeProvisioning, "AgnosticMemoryNodeProvider" },
     { Statistics::Id::AndersenAnalysis, "AndersenAnalysis" },

--- a/jlm/util/Statistics.hpp
+++ b/jlm/util/Statistics.hpp
@@ -34,6 +34,7 @@ public:
   {
     FirstEnumValue, // must always be the first enum value, used for iteration
 
+    AliasAnalysisPrecisionEvaluation,
     Aggregation,
     AgnosticMemoryNodeProvisioning,
     AndersenAnalysis,


### PR DESCRIPTION
It uses a new `PairwiseAliasAnalysis` interface to check pairs of pointers.

Depending on mode, it either checks all pairs of pointers in each function, or it only checks clobbering between loads and stores. In the latter mode, all loads and stores are regarded as uses, while only stores are regarded as clobbers.

We might want to move some logic out of the `PrecisionAnalysis` file, as I later plan to write a different `PairwiseAliasAnalysis` that is not based on a PointsToGraph, for comparison.

The name `PairwiseAliasAnalysis`could also possibly be changed. The problem is that the current `AliasAnalysis` is actually a points-to-analysis, so we could juggle the names a bit to make it more clear.

The output looks like
```
AliasAnalysisPrecisionEvaluation spotsFilled.c PrecisionEvaluationMode:ClobberingStores PairwiseAliasAnalysisType:PointsToGraphAliasAnalysis #MayAliasQueries:18 DumpFile:./jlm-out/spotsFilled-JDT40v-AAPrecisionEvaluation-1.log ModuleAverageMayAliasRate:0.444444 PrecisionEvaluationTimer[ns]:27849
```

and function-wise numbers are written to a separate file (one line per function)

```
LAMBDA[takeSpot] [6 used pointers, 3 clobbering pointers]: 0.444444
```

@phate