### PR TITLE
Fix select creation in RvsdgToIpGraphConverter

### DIFF
--- a/jlm/llvm/backend/RvsdgToIpGraphConverter.cpp
+++ b/jlm/llvm/backend/RvsdgToIpGraphConverter.cpp
@@ -284,6 +284,7 @@ RvsdgToIpGraphConverter::ConvertEmptyGammaNode(const rvsdg::GammaNode & gammaNod
       const auto matchOperation =
           util::AssertedCast<const rvsdg::match_op>(&matchNode->GetOperation());
       JLM_ASSERT(matchOperation->nalternatives() == 2);
+      JLM_ASSERT(std::distance(matchOperation->begin(), matchOperation->end()) == 1);
 
       const auto matchOrigin = Context_->GetVariable(matchNode->input(0)->origin());
       const auto caseValue = matchOperation->begin()->first;

--- a/jlm/llvm/backend/RvsdgToIpGraphConverter.cpp
+++ b/jlm/llvm/backend/RvsdgToIpGraphConverter.cpp
@@ -283,14 +283,14 @@ RvsdgToIpGraphConverter::ConvertEmptyGammaNode(const rvsdg::GammaNode & gammaNod
     {
       const auto matchOperation =
           util::AssertedCast<const rvsdg::match_op>(&matchNode->GetOperation());
-      assert(matchOperation->nalternatives() == 2);
+      JLM_ASSERT(matchOperation->nalternatives() == 2);
 
       const auto matchOrigin = Context_->GetVariable(matchNode->input(0)->origin());
       const auto caseValue = matchOperation->begin()->first;
       const auto caseSubregion = matchOperation->begin()->second;
       const auto defaultSubregion = matchOperation->default_alternative();
       const auto numMatchBits = matchOperation->nbits();
-      assert(caseSubregion != defaultSubregion);
+      JLM_ASSERT(caseSubregion != defaultSubregion);
 
       const variable * selectPredicate = nullptr;
       const variable * trueAlternative = nullptr;


### PR DESCRIPTION
The RvsdgToIpGraphConverter was not handling the conversion of empty gamma nodes with match nodes to select operations correctly. This PR fixes the problems with it by creating select predicate operations in case there is no identity mapping in the match operation.

Close #846 