### PR TITLE
Fix bug in RegionAwareModRefSummarizer [AndersenRegionAware]

### DIFF
--- a/jlm/llvm/opt/alias-analyses/RegionAwareModRefSummarizer.cpp
+++ b/jlm/llvm/opt/alias-analyses/RegionAwareModRefSummarizer.cpp
@@ -800,6 +800,7 @@ RegionAwareModRefSummarizer::AnnotateLoad(
     RegionSummary & regionSummary)
 {
   const auto origin = LoadOperation::AddressInput(loadNode).origin();
+
   const auto memoryNodes = ModRefSummary_->GetOutputNodes(*origin);
   regionSummary.AddMemoryNodes(memoryNodes);
 }

--- a/jlm/llvm/opt/alias-analyses/RegionAwareModRefSummarizer.cpp
+++ b/jlm/llvm/opt/alias-analyses/RegionAwareModRefSummarizer.cpp
@@ -800,7 +800,6 @@ RegionAwareModRefSummarizer::AnnotateLoad(
     RegionSummary & regionSummary)
 {
   const auto origin = LoadOperation::AddressInput(loadNode).origin();
-
   const auto memoryNodes = ModRefSummary_->GetOutputNodes(*origin);
   regionSummary.AddMemoryNodes(memoryNodes);
 }

--- a/jlm/llvm/opt/alias-analyses/RegionAwareModRefSummarizer.cpp
+++ b/jlm/llvm/opt/alias-analyses/RegionAwareModRefSummarizer.cpp
@@ -764,9 +764,9 @@ RegionAwareModRefSummarizer::AnnotateSimpleNode(
     const rvsdg::SimpleNode & simpleNode,
     RegionSummary & regionSummary)
 {
-  if (auto loadNode = dynamic_cast<const LoadNode *>(&simpleNode))
+  if (is<LoadOperation>(&simpleNode))
   {
-    AnnotateLoad(*loadNode, regionSummary);
+    AnnotateLoad(simpleNode, regionSummary);
   }
   else if (auto storeNode = dynamic_cast<const StoreNode *>(&simpleNode))
   {
@@ -795,9 +795,12 @@ RegionAwareModRefSummarizer::AnnotateSimpleNode(
 }
 
 void
-RegionAwareModRefSummarizer::AnnotateLoad(const LoadNode & loadNode, RegionSummary & regionSummary)
+RegionAwareModRefSummarizer::AnnotateLoad(
+    const rvsdg::SimpleNode & loadNode,
+    RegionSummary & regionSummary)
 {
-  auto memoryNodes = ModRefSummary_->GetOutputNodes(*loadNode.GetAddressInput().origin());
+  const auto origin = LoadOperation::AddressInput(loadNode).origin();
+  const auto memoryNodes = ModRefSummary_->GetOutputNodes(*origin);
   regionSummary.AddMemoryNodes(memoryNodes);
 }
 

--- a/jlm/llvm/opt/alias-analyses/RegionAwareModRefSummarizer.hpp
+++ b/jlm/llvm/opt/alias-analyses/RegionAwareModRefSummarizer.hpp
@@ -138,7 +138,7 @@ private:
   AnnotateSimpleNode(const rvsdg::SimpleNode & simpleNode, RegionSummary & regionSummary);
 
   void
-  AnnotateLoad(const LoadNode & loadNode, RegionSummary & regionSummary);
+  AnnotateLoad(const rvsdg::SimpleNode & loadNode, RegionSummary & regionSummary);
 
   void
   AnnotateStore(const StoreNode & storeNode, RegionSummary & regionSummary);


### PR DESCRIPTION
The last PR removed LoadVolatileNodes, but forgot to change some lines in the RegionAwareModRefSummarizer. This should fix this problem.