### PR TITLE
Keep names when generating Verilog

### DIFF
--- a/jlm/hls/backend/firrtl2verilog/FirrtlToVerilogConverter.cpp
+++ b/jlm/hls/backend/firrtl2verilog/FirrtlToVerilogConverter.cpp
@@ -56,7 +56,7 @@ FirrtlToVerilogConverter::Convert(
   firtool::FirtoolOptions firtoolOptions;
   firtoolOptions.setOutputFilename(outputVerilogFile.to_str());
   firtoolOptions.setPreserveAggregate(firrtl::PreserveAggregate::PreserveMode::None);
-  firtoolOptions.setPreserveValues(firrtl::PreserveValues::PreserveMode::None);
+  firtoolOptions.setPreserveValues(firrtl::PreserveValues::PreserveMode::Named);
   firtoolOptions.setBuildMode(firtool::FirtoolOptions::BuildModeDefault);
   firtoolOptions.setChiselInterfaceOutDirectory("");
   firtoolOptions.setDisableHoistingHWPassthrough(true);


### PR DESCRIPTION
This simplifies debugging