### PR TITLE
Make DeadNodeEliminiation extensible

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -58,7 +58,7 @@ void
 split_opt(llvm::RvsdgModule & rm)
 {
   // TODO: figure out which optimizations to use here
-  jlm::llvm::DeadNodeElimination dne;
+  jlm::llvm::DeadNodeElimination dne({ llvm::DNEGammaNodeHandler::GetInstance() });
   jlm::hls::cne cne;
   jlm::llvm::InvariantValueRedirection ivr;
   jlm::llvm::tginversion tgi;
@@ -76,7 +76,7 @@ void
 pre_opt(jlm::llvm::RvsdgModule & rm)
 {
   // TODO: figure out which optimizations to use here
-  jlm::llvm::DeadNodeElimination dne;
+  jlm::llvm::DeadNodeElimination dne({ llvm::DNEGammaNodeHandler::GetInstance() });
   jlm::hls::cne cne;
   jlm::llvm::InvariantValueRedirection ivr;
   jlm::llvm::tginversion tgi;
@@ -438,7 +438,7 @@ rvsdg2rhls(llvm::RvsdgModule & rhls, util::StatisticsCollector & collector)
 
   merge_gamma(rhls);
 
-  llvm::DeadNodeElimination llvmDne;
+  llvm::DeadNodeElimination llvmDne({ llvm::DNEGammaNodeHandler::GetInstance() });
   llvmDne.Run(rhls, collector);
 
   mem_sep_argument(rhls);

--- a/jlm/llvm/opt/DeadNodeElimination.hpp
+++ b/jlm/llvm/opt/DeadNodeElimination.hpp
@@ -34,6 +34,15 @@ namespace phi
 class node;
 }
 
+class DNEStructuralNodeHandler
+{
+public:
+  virtual ~DNEStructuralNodeHandler();
+
+  virtual void
+  SweepNode(rvsdg::StructuralNode & structuralNode) = 0;
+};
+
 /** \brief Dead Node Elimination Optimization
  *
  * Dead Node Elimination removes all nodes that do not contribute to the result of a computation. A

--- a/jlm/llvm/opt/DeadNodeElimination.hpp
+++ b/jlm/llvm/opt/DeadNodeElimination.hpp
@@ -177,7 +177,7 @@ class DeadNodeElimination final : public rvsdg::Transformation
 public:
   ~DeadNodeElimination() noexcept override;
 
-  explicit DeadNodeElimination(std::vector<const DNEStructuralNodeHandler *> handlers);
+  explicit DeadNodeElimination(const std::vector<const DNEStructuralNodeHandler *> & handlers);
 
   DeadNodeElimination(const DeadNodeElimination &) = delete;
 
@@ -224,7 +224,7 @@ private:
   SweepDelta(delta::node & deltaNode);
 
   DNEContext Context_;
-  std::vector<const DNEStructuralNodeHandler *> Handlers_;
+  std::unordered_map<std::type_index, const DNEStructuralNodeHandler *> Handlers_;
 };
 
 }

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
@@ -480,7 +480,7 @@ MemoryStateEncoder::Encode(
   Context_.reset();
 
   // Remove all nodes that became dead throughout the encoding.
-  DeadNodeElimination deadNodeElimination;
+  DeadNodeElimination deadNodeElimination({ DNEGammaNodeHandler::GetInstance() });
   deadNodeElimination.Run(rvsdgModule, statisticsCollector);
 }
 

--- a/jlm/tooling/Command.cpp
+++ b/jlm/tooling/Command.cpp
@@ -407,7 +407,8 @@ JlmOptCommand::CreateTransformation(
   case JlmOptCommandLineOptions::OptimizationId::CommonNodeElimination:
     return std::make_unique<llvm::cne>();
   case JlmOptCommandLineOptions::OptimizationId::DeadNodeElimination:
-    return std::make_unique<llvm::DeadNodeElimination>();
+    return std::unique_ptr<llvm::DeadNodeElimination>(
+        new llvm::DeadNodeElimination({ llvm::DNEGammaNodeHandler::GetInstance() }));
   case JlmOptCommandLineOptions::OptimizationId::FunctionInlining:
     return std::make_unique<llvm::fctinline>();
   case JlmOptCommandLineOptions::OptimizationId::IfConversion:

--- a/tests/jlm/llvm/opt/TestDeadNodeElimination.cpp
+++ b/tests/jlm/llvm/opt/TestDeadNodeElimination.cpp
@@ -21,8 +21,9 @@
 static void
 RunDeadNodeElimination(jlm::llvm::RvsdgModule & rvsdgModule)
 {
+  using namespace jlm::llvm;
   jlm::util::StatisticsCollector statisticsCollector;
-  jlm::llvm::DeadNodeElimination deadNodeElimination;
+  DeadNodeElimination deadNodeElimination({ DNEGammaNodeHandler::GetInstance() });
   deadNodeElimination.Run(rvsdgModule, statisticsCollector);
 }
 

--- a/tests/jlm/llvm/opt/test-unroll.cpp
+++ b/tests/jlm/llvm/opt/test-unroll.cpp
@@ -257,7 +257,7 @@ test_unknown_boundaries()
   assert(jlm::rvsdg::is<jlm::rvsdg::GammaOperation>(node));
 
   /* Create cleaner output */
-  DeadNodeElimination dne;
+  DeadNodeElimination dne({ DNEGammaNodeHandler::GetInstance() });
   dne.Run(rm, statisticsCollector);
   //	jlm::rvsdg::view(graph, stdout);
 }


### PR DESCRIPTION
We currently have two DNE transformations in the code base: one for LLVM dialect and one for HLS dialect. The reason why we duplicated them in the first place was because the HLS dialect required to handle additional structural nodes (loop node) that was not handle in the LLVM DNE.

This PR introduces a way to extend DNE for custom structural nodes such that the two transformations can be unified and we can remove the duplicated code. This PR  is meant as a POC and only shows the idea for the gamma node. For the other node, it would be possible to refactor it in a similar fashion. However, I would like to get some feedback to ensure that this is on the right track before I invest the time to convert the rest of the transformation.