### PR TITLE
Introduce UnitType

### DIFF
--- a/jlm/llvm/backend/dot/DotWriter.cpp
+++ b/jlm/llvm/backend/dot/DotWriter.cpp
@@ -12,6 +12,7 @@
 #include <jlm/rvsdg/structural-node.hpp>
 #include <jlm/rvsdg/traverser.hpp>
 #include <jlm/rvsdg/type.hpp>
+#include <jlm/rvsdg/UnitType.hpp>
 
 namespace jlm::llvm::dot
 {
@@ -38,7 +39,7 @@ GetOrCreateTypeGraphNode(const rvsdg::Type & type, util::Graph & typeGraph)
   // Some types get special handling, such as adding incoming edges from aggregate types
   if (rvsdg::is<rvsdg::StateType>(type) || rvsdg::is<rvsdg::bittype>(type)
       || rvsdg::is<PointerType>(type) || rvsdg::is<FloatingPointType>(type)
-      || rvsdg::is<VariableArgumentType>(type))
+      || rvsdg::is<VariableArgumentType>(type) || rvsdg::is<rvsdg::UnitType>(type))
   {
     // No need to provide any information beyond the debug string
   }

--- a/jlm/mlir/backend/JlmToMlirConverter.cpp
+++ b/jlm/mlir/backend/JlmToMlirConverter.cpp
@@ -17,6 +17,7 @@
 #include <jlm/rvsdg/bitstring/constant.hpp>
 #include <jlm/rvsdg/node.hpp>
 #include <jlm/rvsdg/traverser.hpp>
+#include <jlm/rvsdg/UnitType.hpp>
 
 #include <llvm/Support/raw_os_ostream.h>
 
@@ -85,6 +86,11 @@ JlmToMlirConverter::ConvertRegion(rvsdg::Region & region, ::mlir::Block & block,
   for (size_t i = 0; i < region.narguments(); ++i)
   {
     auto arg = region.argument(i);
+    // Ignore unit type.
+    if (*arg->Type() == *rvsdg::UnitType::Create())
+    {
+      continue;
+    }
     if (isRoot) // Omega arguments are treated separately
     {
       auto imp = util::AssertedCast<llvm::GraphImport>(arg);

--- a/jlm/rvsdg/Makefile.sub
+++ b/jlm/rvsdg/Makefile.sub
@@ -19,6 +19,7 @@ librvsdg_SOURCES = \
 	jlm/rvsdg/traverser.cpp \
 	jlm/rvsdg/type.cpp \
 	jlm/rvsdg/unary.cpp \
+	jlm/rvsdg/UnitType.cpp \
 	jlm/rvsdg/view.cpp \
 	\
 	jlm/rvsdg/bitstring/arithmetic.cpp \
@@ -51,6 +52,7 @@ librvsdg_HEADERS = \
 	jlm/rvsdg/lambda.hpp \
 	jlm/rvsdg/substitution.hpp \
 	jlm/rvsdg/unary.hpp \
+	jlm/rvsdg/UnitType.hpp \
 	jlm/rvsdg/tracker.hpp \
 	jlm/rvsdg/simple-node.hpp \
 	jlm/rvsdg/type.hpp \

--- a/jlm/rvsdg/UnitType.cpp
+++ b/jlm/rvsdg/UnitType.cpp
@@ -1,0 +1,33 @@
+#include <jlm/rvsdg/UnitType.hpp>
+
+namespace jlm::rvsdg
+{
+
+UnitType::~UnitType() noexcept = default;
+
+std::string
+UnitType::debug_string() const
+{
+  return "Unit";
+}
+
+bool
+UnitType::operator==(const Type & other) const noexcept
+{
+  return dynamic_cast<const UnitType *>(&other) != nullptr;
+}
+
+std::size_t
+UnitType::ComputeHash() const noexcept
+{
+  return typeid(UnitType).hash_code();
+}
+
+std::shared_ptr<const UnitType>
+UnitType::Create()
+{
+  static const UnitType instance;
+  return std::shared_ptr<const UnitType>(std::shared_ptr<void>(), &instance);
+}
+
+}

--- a/jlm/rvsdg/UnitType.hpp
+++ b/jlm/rvsdg/UnitType.hpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 Helge Bahmann <hcb@chaoticmind.net>
+ * See COPYING for terms of redistribution.
+ */
+
+#ifndef JLM_RVSDG_UNITTYPE_HPP
+#define JLM_RVSDG_UNITTYPE_HPP
+
+#include <jlm/rvsdg/type.hpp>
+
+namespace jlm::rvsdg
+{
+
+/**
+ * \brief Unit type (type carrying no information)
+ *
+ * Represents the "unit" type: A type which has only a single inhabitant
+ * without content and carries no information. This is used in places where
+ * a formal argument or result is needed, but no information is carried.
+ *
+ * This roughly corresponds to the "void" type in C/C++.
+ */
+class UnitType final : public ValueType
+{
+public:
+  ~UnitType() noexcept override;
+
+  std::string
+  debug_string() const override;
+
+  bool
+  operator==(const Type & other) const noexcept override;
+
+  std::size_t
+  ComputeHash() const noexcept override;
+
+  static std::shared_ptr<const UnitType>
+  Create();
+};
+
+}
+
+#endif


### PR DESCRIPTION
Introduce the UnitType to allow representing a type that holds no data (akin to the C "void" type). This can formally be used in places where "something" must be produced, but it has no content -- this will later be used in pattern matching over types without a content in generalized gamma constructs.

Prepare places that currently balk on existency of this type so its usage can be introduced without breakage later.