### PR TITLE
GammaNode: EntryVar/ExitVar removal API, and consistent usage of safe…

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/UnusedStateRemoval.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/UnusedStateRemoval.cpp
@@ -129,48 +129,53 @@ RemovePassthroughArgument(const rvsdg::RegionArgument & argument)
   region->node()->RemoveOutput(outputIndex);
 }
 
+// If this output has a single user and that single user happens to be
+// the exit variable of this gamma node, then return it.
+static std::optional<rvsdg::GammaNode::ExitVar>
+TryGetSingleUserExitVar(rvsdg::GammaNode & gammaNode, rvsdg::output & argument)
+{
+  if (argument.nusers() == 1)
+  {
+    rvsdg::input * user = *argument.begin();
+    if (rvsdg::TryGetRegionParentNode<rvsdg::GammaNode>(*user) == &gammaNode)
+    {
+      return gammaNode.MapBranchResultExitVar(*user);
+    }
+  }
+  return std::nullopt;
+}
+
 static void
 RemoveUnusedStatesFromGammaNode(rvsdg::GammaNode & gammaNode)
 {
-  auto entryvars = gammaNode.GetEntryVars();
-  for (int i = entryvars.size() - 1; i >= 0; --i)
-  {
-    size_t resultIndex = 0;
-    auto argument = entryvars[i].branchArgument[0];
-    if (argument->nusers() == 1)
-    {
-      auto result = dynamic_cast<rvsdg::RegionResult *>(*argument->begin());
-      resultIndex = result ? result->index() : resultIndex;
-    }
+  std::vector<rvsdg::GammaNode::EntryVar> deadEntryVars;
+  std::vector<rvsdg::GammaNode::ExitVar> deadExitVars;
 
-    bool shouldRemove = true;
-    for (size_t n = 0; n < gammaNode.nsubregions(); n++)
-    {
-      auto subregion = gammaNode.subregion(n);
-      shouldRemove &=
-          IsPassthroughArgument(*subregion->argument(i))
-          && dynamic_cast<jlm::rvsdg::RegionResult *>(*subregion->argument(i)->begin())->index()
-                 == resultIndex;
-    }
+  for (const auto & entryvar : gammaNode.GetEntryVars())
+  {
+    std::optional<rvsdg::GammaNode::ExitVar> exitvar0 =
+        TryGetSingleUserExitVar(gammaNode, *entryvar.branchArgument[0]);
+
+    bool shouldRemove = exitvar0
+                     && std::all_of(
+                            entryvar.branchArgument.begin(),
+                            entryvar.branchArgument.end(),
+                            [&gammaNode, &exitvar0](rvsdg::output * argument) -> bool
+                            {
+                              auto exitvar = TryGetSingleUserExitVar(gammaNode, *argument);
+                              return exitvar && exitvar->output == exitvar0->output;
+                            });
 
     if (shouldRemove)
     {
-      auto origin = entryvars[i].input->origin();
-      gammaNode.output(resultIndex)->divert_users(origin);
-
-      for (size_t r = 0; r < gammaNode.nsubregions(); r++)
-      {
-        gammaNode.subregion(r)->RemoveResult(resultIndex);
-      }
-      gammaNode.RemoveOutput(resultIndex);
-
-      for (size_t r = 0; r < gammaNode.nsubregions(); r++)
-      {
-        gammaNode.subregion(r)->RemoveArgument(i);
-      }
-      gammaNode.RemoveInput(i + 1);
+      exitvar0->output->divert_users(entryvar.input->origin());
+      deadEntryVars.push_back(entryvar);
+      deadExitVars.push_back(*exitvar0);
     }
   }
+
+  gammaNode.RemoveExitVars(deadExitVars);
+  gammaNode.RemoveEntryVars(deadEntryVars);
 }
 
 static void

--- a/jlm/llvm/backend/RvsdgToIpGraphConverter.cpp
+++ b/jlm/llvm/backend/RvsdgToIpGraphConverter.cpp
@@ -261,15 +261,18 @@ RvsdgToIpGraphConverter::ConvertGammaNode(const rvsdg::GammaNode & gammaNode)
   // convert gamma regions
   std::vector<cfg_node *> phi_nodes;
   entryBlock->append_last(BranchOperation::create(numSubregions, Context_->GetVariable(predicate)));
+  auto entryvars = gammaNode.GetEntryVars();
   for (size_t n = 0; n < gammaNode.nsubregions(); n++)
   {
     const auto subregion = gammaNode.subregion(n);
 
     // add arguments to context
-    for (size_t i = 0; i < subregion->narguments(); i++)
+    for (size_t i = 0; i < entryvars.size(); i++)
     {
-      const auto argument = subregion->argument(i);
-      Context_->InsertVariable(argument, Context_->GetVariable(argument->input()->origin()));
+      auto & entryvar = entryvars[i];
+      Context_->InsertVariable(
+          entryvar.branchArgument[n],
+          Context_->GetVariable(entryvar.input->origin()));
     }
 
     // convert subregion

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -399,20 +399,16 @@ DeadNodeElimination::SweepStructuralNode(rvsdg::StructuralNode & node) const
 void
 DeadNodeElimination::SweepGamma(rvsdg::GammaNode & gammaNode) const
 {
-  // Remove dead outputs and results
-  for (size_t n = gammaNode.noutputs() - 1; n != static_cast<size_t>(-1); n--)
+  // Remove dead exit vars.
+  std::vector<rvsdg::GammaNode::ExitVar> deadExitVars;
+  for (const auto & exitvar : gammaNode.GetExitVars())
   {
-    if (Context_->IsAlive(*gammaNode.output(n)))
+    if (!Context_->IsAlive(*exitvar.output))
     {
-      continue;
+      deadExitVars.push_back(exitvar);
     }
-
-    for (size_t r = 0; r < gammaNode.nsubregions(); r++)
-    {
-      gammaNode.subregion(r)->RemoveResult(n);
-    }
-    gammaNode.RemoveOutput(n);
   }
+  gammaNode.RemoveExitVars(deadExitVars);
 
   // Sweep gamma subregions
   for (size_t r = 0; r < gammaNode.nsubregions(); r++)
@@ -420,29 +416,23 @@ DeadNodeElimination::SweepGamma(rvsdg::GammaNode & gammaNode) const
     SweepRegion(*gammaNode.subregion(r));
   }
 
-  // Remove dead arguments and inputs
-  for (size_t n = gammaNode.ninputs() - 1; n >= 1; n--)
+  // Remove dead entry vars.
+  std::vector<rvsdg::GammaNode::EntryVar> deadEntryVars;
+  for (const auto & entryvar : gammaNode.GetEntryVars())
   {
-    auto input = gammaNode.input(n);
-
-    bool alive = false;
-    for (auto & argument : input->arguments)
-    {
-      if (Context_->IsAlive(argument))
-      {
-        alive = true;
-        break;
-      }
-    }
+    bool alive = std::any_of(
+        entryvar.branchArgument.begin(),
+        entryvar.branchArgument.end(),
+        [this](const rvsdg::output * arg)
+        {
+          return Context_->IsAlive(*arg);
+        });
     if (!alive)
     {
-      for (size_t r = 0; r < gammaNode.nsubregions(); r++)
-      {
-        gammaNode.subregion(r)->RemoveArgument(n - 1);
-      }
-      gammaNode.RemoveInput(n);
+      deadEntryVars.push_back(entryvar);
     }
   }
+  gammaNode.RemoveEntryVars(deadEntryVars);
 }
 
 void

--- a/jlm/rvsdg/gamma.hpp
+++ b/jlm/rvsdg/gamma.hpp
@@ -234,6 +234,30 @@ public:
   MapBranchResultExitVar(const rvsdg::input & input) const;
 
   /**
+   * \brief Removes the given exit variables.
+   *
+   * \pre
+   *   All exit variables must be unused (= the corresponding gamma outputs
+   *   must not have any users).
+   *
+   * Removes the variables as exit variables from this gamma.
+   */
+  void
+  RemoveExitVars(const std::vector<ExitVar> & exitvars);
+
+  /**
+   * \brief Removes the given entry variables
+   *
+   * \pre
+   *   All entry variables must be unused in the gamma branch subregions
+   *   (= the corresponding region arguments must not have any users).
+   *
+   * Removes the variables as entry variables from this gamma.
+   */
+  void
+  RemoveEntryVars(const std::vector<EntryVar> & entryvars);
+
+  /**
    * Removes all gamma outputs and their respective results. The outputs must have no users and
    * match the condition specified by \p match.
    *

--- a/tests/jlm/llvm/opt/alias-analyses/TestAndersen.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestAndersen.cpp
@@ -560,9 +560,10 @@ TestGamma()
     assert(TargetsExactly(lambdaArgument, { &lambda, &ptg->GetExternalMemoryNode() }));
   }
 
-  for (size_t n = 0; n < 4; n++)
+  auto entryvars = test.gamma->GetEntryVars();
+  assert(entryvars.size() == 4);
+  for (const auto & entryvar : entryvars)
   {
-    auto entryvar = test.gamma->GetEntryVar(n);
     auto & argument0 = ptg->GetRegisterNode(*entryvar.branchArgument[0]);
     auto & argument1 = ptg->GetRegisterNode(*entryvar.branchArgument[1]);
 
@@ -758,8 +759,8 @@ TestPhi1()
   auto & phi_rv = ptg->GetRegisterNode(*test.phi->GetFixVars()[0].output);
   auto & phi_rv_arg = ptg->GetRegisterNode(*test.phi->GetFixVars()[0].recref);
 
-  auto & gamma_result = ptg->GetRegisterNode(*test.gamma->subregion(0)->argument(1));
-  auto & gamma_fib = ptg->GetRegisterNode(*test.gamma->subregion(0)->argument(2));
+  auto & gamma_result = ptg->GetRegisterNode(*test.gamma->GetEntryVars()[1].branchArgument[0]);
+  auto & gamma_fib = ptg->GetRegisterNode(*test.gamma->GetEntryVars()[2].branchArgument[0]);
 
   auto & alloca = ptg->GetAllocaNode(*test.alloca);
   auto & alloca_out = ptg->GetRegisterNode(*test.alloca->output(0));

--- a/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
@@ -651,9 +651,10 @@ TestGamma()
       assertTargets(lambdaArgument, { &lambda, &pointsToGraph.GetExternalMemoryNode() });
     }
 
-    for (size_t n = 0; n < 4; n++)
+    auto entryvars = test.gamma->GetEntryVars();
+    assert(entryvars.size() == 4);
+    for (const auto & entryvar : entryvars)
     {
-      auto entryvar = test.gamma->GetEntryVar(n);
       auto & argument0 = pointsToGraph.GetRegisterNode(*entryvar.branchArgument[0]);
       auto & argument1 = pointsToGraph.GetRegisterNode(*entryvar.branchArgument[1]);
 
@@ -874,8 +875,8 @@ TestPhi1()
     auto & phi_rv = ptg.GetRegisterNode(*test.phi->GetFixVars()[0].output);
     auto & phi_rv_arg = ptg.GetRegisterNode(*test.phi->GetFixVars()[0].recref);
 
-    auto & gamma_result = ptg.GetRegisterNode(*test.gamma->subregion(0)->argument(1));
-    auto & gamma_fib = ptg.GetRegisterNode(*test.gamma->subregion(0)->argument(2));
+    auto & gamma_result = ptg.GetRegisterNode(*test.gamma->GetEntryVars()[1].branchArgument[0]);
+    auto & gamma_fib = ptg.GetRegisterNode(*test.gamma->GetEntryVars()[2].branchArgument[0]);
 
     auto & alloca = ptg.GetAllocaNode(*test.alloca);
     auto & alloca_out = ptg.GetRegisterNode(*test.alloca->output(0));


### PR DESCRIPTION
Add methods that allow safe removal of entryvars / exitvars, and generally make use of the safe EntryVar/ExitVar API in all places that need to map between inputs/arguments and results/outputs. This is in preparation to changes how gamma arguments are allocated when generalizing gamma to support pattern matching.