### PR TITLE
GammaNode: Add pattern matching support to gamma

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/distribute-constants.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/distribute-constants.cpp
@@ -61,23 +61,33 @@ distribute_constant(const rvsdg::SimpleOperation & op, rvsdg::SimpleOutput * out
       }
       if (auto gammaNode = rvsdg::TryGetOwnerNode<rvsdg::GammaNode>(*user))
       {
-        if (gammaNode->predicate() == user)
+        auto rolevar = gammaNode->MapInput(*user);
+        if (std::get_if<rvsdg::GammaNode::MatchVar>(&rolevar))
         {
+          // ignore predicate
           continue;
         }
-        for (auto argument : gammaNode->MapInputEntryVar(*user).branchArgument)
+        else if (auto entryvar = std::get_if<rvsdg::GammaNode::EntryVar>(&rolevar))
         {
-          if (argument->nusers())
+          for (auto argument : entryvar->branchArgument)
           {
-            auto arg_replacement = rvsdg::SimpleNode::Create(*argument->region(), op, {}).output(0);
-            argument->divert_users(arg_replacement);
-            distribute_constant(op, arg_replacement);
+            if (argument->nusers())
+            {
+              auto arg_replacement =
+                  rvsdg::SimpleNode::Create(*argument->region(), op, {}).output(0);
+              argument->divert_users(arg_replacement);
+              distribute_constant(op, arg_replacement);
+            }
+            argument->region()->RemoveArgument(argument->index());
           }
-          argument->region()->RemoveArgument(argument->index());
+          gammaNode->RemoveInput(user->index());
+          changed = true;
+          break;
         }
-        gammaNode->RemoveInput(user->index());
-        changed = true;
-        break;
+        else
+        {
+          JLM_UNREACHABLE("Gamma input must either by MatchVar or EntryVar");
+        }
       }
     }
   }

--- a/jlm/hls/backend/rvsdg2rhls/mem-sep.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-sep.cpp
@@ -195,16 +195,20 @@ trace_edge(
       new_edge = gammaNode->AddExitVar(ip.branchArgument).output;
       new_next->divert_to(new_edge);
 
-      auto entryvar = gammaNode->MapInputEntryVar(*user);
-      for (size_t i = 0; i < gammaNode->nsubregions(); ++i)
+      auto rolevar = gammaNode->MapInput(*user);
+
+      if (auto entryvar = std::get_if<rvsdg::GammaNode::EntryVar>(&rolevar))
       {
-        auto subres = trace_edge(
-            entryvar.branchArgument[i],
-            ip.branchArgument[i],
-            load_nodes,
-            store_nodes,
-            decouple_nodes);
-        common_edge = subres->output();
+        for (size_t i = 0; i < gammaNode->nsubregions(); ++i)
+        {
+          auto subres = trace_edge(
+              entryvar->branchArgument[i],
+              ip.branchArgument[i],
+              load_nodes,
+              store_nodes,
+              decouple_nodes);
+          common_edge = subres->output();
+        }
       }
     }
     else if (auto theta = rvsdg::TryGetOwnerNode<rvsdg::ThetaNode>(*user))

--- a/jlm/hls/backend/rvsdg2rhls/merge-gamma.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/merge-gamma.cpp
@@ -253,7 +253,11 @@ get_entryvar(jlm::rvsdg::output * origin, rvsdg::GammaNode * gamma)
   {
     if (rvsdg::TryGetOwnerNode<rvsdg::GammaNode>(*user) == gamma)
     {
-      return gamma->MapInputEntryVar(*user);
+      auto rolevar = gamma->MapInput(*user);
+      if (auto entryvar = std::get_if<rvsdg::GammaNode::EntryVar>(&rolevar))
+      {
+        return *entryvar;
+      }
     }
   }
   return gamma->AddEntryVar(origin);

--- a/jlm/hls/opt/cne.cpp
+++ b/jlm/hls/opt/cne.cpp
@@ -255,8 +255,18 @@ congruent(jlm::rvsdg::output * o1, jlm::rvsdg::output * o2, vset & vs, cnectx & 
     if (auto g2 = rvsdg::TryGetRegionParentNode<rvsdg::GammaNode>(*o2))
     {
       JLM_ASSERT(g1 == g2);
-      auto origin1 = g1->MapBranchArgumentEntryVar(*o1).input->origin();
-      auto origin2 = g2->MapBranchArgumentEntryVar(*o2).input->origin();
+      auto origin1 = std::visit(
+          [](const auto & rolevar) -> rvsdg::output *
+          {
+            return rolevar.input->origin();
+          },
+          g1->MapBranchArgument(*o1));
+      auto origin2 = std::visit(
+          [](const auto & rolevar) -> rvsdg::output *
+          {
+            return rolevar.input->origin();
+          },
+          g2->MapBranchArgument(*o2));
       return congruent(origin1, origin2, vs, ctx);
     }
   }

--- a/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
+++ b/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
@@ -698,9 +698,13 @@ Convert(
   {
     regionalizedVariableMap.PushRegion(*gamma->subregion(n));
     for (const auto & pair : gammaInputMap)
-      regionalizedVariableMap.GetTopVariableMap().insert(
-          pair.first,
-          gamma->MapInputEntryVar(*pair.second).branchArgument[n]);
+    {
+      auto rolevar = gamma->MapInput(*pair.second);
+      if (auto entryvar = std::get_if<rvsdg::GammaNode::EntryVar>(&rolevar))
+      {
+        regionalizedVariableMap.GetTopVariableMap().insert(pair.first, entryvar->branchArgument[n]);
+      }
+    }
 
     ConvertAggregationNode(
         *branchAggregationNode.child(n),

--- a/jlm/llvm/ir/CallSummary.cpp
+++ b/jlm/llvm/ir/CallSummary.cpp
@@ -47,9 +47,13 @@ ComputeCallSummary(const rvsdg::LambdaNode & lambdaNode)
 
     if (auto gammaNode = rvsdg::TryGetOwnerNode<rvsdg::GammaNode>(*input))
     {
-      for (auto & argument : gammaNode->MapInputEntryVar(*input).branchArgument)
+      auto rolevar = gammaNode->MapInput(*input);
+      if (auto entryvar = std::get_if<rvsdg::GammaNode::EntryVar>(&rolevar))
       {
-        worklist.insert(worklist.end(), argument->begin(), argument->end());
+        for (auto & argument : entryvar->branchArgument)
+        {
+          worklist.insert(worklist.end(), argument->begin(), argument->end());
+        }
       }
       continue;
     }

--- a/jlm/llvm/ir/operators/call.cpp
+++ b/jlm/llvm/ir/operators/call.cpp
@@ -196,7 +196,12 @@ CallOperation::TraceFunctionInput(const rvsdg::SimpleNode & callNode)
 
     if (auto gamma = rvsdg::TryGetRegionParentNode<rvsdg::GammaNode>(*origin))
     {
-      origin = gamma->MapBranchArgumentEntryVar(*origin).input->origin();
+      origin = std::visit(
+          [](const auto & rolevar) -> rvsdg::output *
+          {
+            return rolevar.input->origin();
+          },
+          gamma->MapBranchArgument(*origin));
       continue;
     }
 

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -214,7 +214,13 @@ DeadNodeElimination::MarkOutput(const jlm::rvsdg::output & output)
 
   if (auto gamma = rvsdg::TryGetRegionParentNode<rvsdg::GammaNode>(output))
   {
-    MarkOutput(*gamma->MapBranchArgumentEntryVar(output).input->origin());
+    auto external_origin = std::visit(
+        [](const auto & rolevar) -> rvsdg::output *
+        {
+          return rolevar.input->origin();
+        },
+        gamma->MapBranchArgument(output));
+    MarkOutput(*external_origin);
     return;
   }
 

--- a/jlm/llvm/opt/cne.cpp
+++ b/jlm/llvm/opt/cne.cpp
@@ -236,8 +236,18 @@ congruent(jlm::rvsdg::output * o1, jlm::rvsdg::output * o2, vset & vs, cnectx & 
     if (auto g2 = rvsdg::TryGetRegionParentNode<rvsdg::GammaNode>(*o2))
     {
       JLM_ASSERT(g1 == g2);
-      auto origin1 = g1->MapBranchArgumentEntryVar(*o1).input->origin();
-      auto origin2 = g2->MapBranchArgumentEntryVar(*o2).input->origin();
+      auto origin1 = std::visit(
+          [](const auto & rolevar) -> rvsdg::output *
+          {
+            return rolevar.input->origin();
+          },
+          g1->MapBranchArgument(*o1));
+      auto origin2 = std::visit(
+          [](const auto & rolevar) -> rvsdg::output *
+          {
+            return rolevar.input->origin();
+          },
+          g2->MapBranchArgument(*o2));
       return congruent(origin1, origin2, vs, ctx);
     }
   }

--- a/jlm/llvm/opt/pull.cpp
+++ b/jlm/llvm/opt/pull.cpp
@@ -92,7 +92,7 @@ pullin_node(rvsdg::GammaNode * gamma, rvsdg::Node * node)
     {
       for (const auto & user : *node->output(o))
       {
-        auto entryvar = gamma->MapInputEntryVar(*user);
+        auto entryvar = std::get<rvsdg::GammaNode::EntryVar>(gamma->MapInput(*user));
         entryvar.branchArgument[r]->divert_users(copy->output(o));
       }
     }
@@ -110,7 +110,7 @@ cleanup(rvsdg::GammaNode * gamma, rvsdg::Node * node)
   {
     for (auto user : *node->output(n))
     {
-      entryvars.push_back(gamma->MapInputEntryVar(*user));
+      entryvars.push_back(std::get<rvsdg::GammaNode::EntryVar>(gamma->MapInput(*user)));
     }
   }
   gamma->RemoveEntryVars(entryvars);
@@ -227,11 +227,33 @@ is_used_in_nsubregions(const rvsdg::GammaNode * gamma, const rvsdg::Node * node)
   std::unordered_set<rvsdg::Region *> subregions;
   for (const auto & input : inputs)
   {
-    for (const auto & argument : gamma->MapInputEntryVar(*input).branchArgument)
-    {
-      if (argument->nusers() != 0)
-        subregions.insert(argument->region());
-    }
+    std::visit(
+        [&subregions](const auto & rolevar)
+        {
+          if constexpr (std::is_same<std::decay_t<decltype(rolevar)>, rvsdg::GammaNode::EntryVar>())
+          {
+            for (const auto & argument : rolevar.branchArgument)
+            {
+              if (argument->nusers() != 0)
+                subregions.insert(argument->region());
+            }
+          }
+          else if constexpr (std::is_same<
+                                 std::decay_t<decltype(rolevar)>,
+                                 rvsdg::GammaNode::MatchVar>())
+          {
+            for (const auto & argument : rolevar.matchContent)
+            {
+              if (argument->nusers() != 0)
+                subregions.insert(argument->region());
+            }
+          }
+          else
+          {
+            JLM_UNREACHABLE("A gamma input must either be the match variable or an entry variable");
+          }
+        },
+        gamma->MapInput(*input));
   }
 
   return subregions.size();

--- a/jlm/mlir/backend/JlmToMlirConverter.cpp
+++ b/jlm/mlir/backend/JlmToMlirConverter.cpp
@@ -83,10 +83,12 @@ JlmToMlirConverter::ConvertModule(const llvm::RvsdgModule & rvsdgModule)
 JlmToMlirConverter::ConvertRegion(rvsdg::Region & region, ::mlir::Block & block, bool isRoot)
 {
   std::unordered_map<rvsdg::output *, ::mlir::Value> valueMap;
+  size_t argIndex = 0;
   for (size_t i = 0; i < region.narguments(); ++i)
   {
     auto arg = region.argument(i);
-    // Ignore unit type.
+    // Ignore unit type -- this is the first argument in gamma subregions
+    // and does not have a representation in MLIR.
     if (*arg->Type() == *rvsdg::UnitType::Create())
     {
       continue;
@@ -105,7 +107,8 @@ JlmToMlirConverter::ConvertRegion(rvsdg::Region & region, ::mlir::Block & block,
     else
     {
       block.addArgument(ConvertType(arg->type()), Builder_->getUnknownLoc());
-      valueMap[arg] = block.getArgument(i);
+      valueMap[arg] = block.getArgument(argIndex);
+      ++argIndex;
     }
   }
 

--- a/jlm/rvsdg/gamma.cpp
+++ b/jlm/rvsdg/gamma.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 2011 2012 2013 2014 2025 Helge Bahmann <hcb@chaoticmind.net>
+ * Copyright 2010 2011 2012 2013 2014 Helge Bahmann <hcb@chaoticmind.net>
  * Copyright 2013 2014 2015 2016 Nico Reißmann <nico.reissmann@gmail.com>
  * See COPYING for terms of redistribution.
  */
@@ -9,6 +9,7 @@
 #include <jlm/rvsdg/control.hpp>
 #include <jlm/rvsdg/gamma.hpp>
 #include <jlm/rvsdg/substitution.hpp>
+#include <jlm/rvsdg/UnitType.hpp>
 
 namespace jlm::rvsdg
 {
@@ -208,19 +209,33 @@ bool
 GammaOperation::operator==(const Operation & other) const noexcept
 {
   auto op = dynamic_cast<const GammaOperation *>(&other);
-  return op && op->nalternatives_ == nalternatives_;
+  return op && op->numAlternatives_ == numAlternatives_;
+}
+
+std::shared_ptr<const Type>
+GammaOperation::GetMatchContentType(std::size_t alternative) const
+{
+  return alternative < MatchContentTypes_.size() ? MatchContentTypes_[alternative]
+                                                 : UnitType::Create();
 }
 
 /* gamma node */
 
 GammaNode::~GammaNode() noexcept = default;
 
-GammaNode::GammaNode(rvsdg::output * predicate, size_t nalternatives)
+GammaNode::GammaNode(
+    rvsdg::output * predicate,
+    size_t nalternatives,
+    std::vector<std::shared_ptr<const Type>> match_content_types)
     : StructuralNode(predicate->region(), nalternatives),
-      Operation_(nalternatives)
+      Operation_(nalternatives, std::move(match_content_types))
 {
   add_input(std::unique_ptr<node_input>(
       new StructuralInput(this, predicate, ControlType::Create(nalternatives))));
+  for (std::size_t n = 0; n < nalternatives; ++n)
+  {
+    RegionArgument::Create(*subregion(n), nullptr, Operation_.GetMatchContentType(n));
+  }
 }
 
 [[nodiscard]] const GammaOperation &
@@ -255,9 +270,21 @@ GammaNode::GetEntryVar(std::size_t index) const
   ev.input = input(index + 1);
   for (size_t n = 0; n < nsubregions(); ++n)
   {
-    ev.branchArgument.push_back(subregion(n)->argument(index));
+    ev.branchArgument.push_back(subregion(n)->argument(index + 1));
   }
   return ev;
+}
+
+GammaNode::MatchVar
+GammaNode::GetMatchVar() const
+{
+  MatchVar mv;
+  mv.input = input(0);
+  for (size_t n = 0; n < nsubregions(); ++n)
+  {
+    mv.matchContent.push_back(subregion(n)->argument(0));
+  }
+  return mv;
 }
 
 std::vector<GammaNode::EntryVar>
@@ -271,19 +298,32 @@ GammaNode::GetEntryVars() const
   return vars;
 }
 
-GammaNode::EntryVar
-GammaNode::MapInputEntryVar(const rvsdg::input & input) const
+std::variant<GammaNode::MatchVar, GammaNode::EntryVar>
+GammaNode::MapInput(const rvsdg::input & input) const
 {
   JLM_ASSERT(rvsdg::TryGetOwnerNode<GammaNode>(input) == this);
-  JLM_ASSERT(input.index() != 0);
-  return GetEntryVar(input.index() - 1);
+  if (input.index() == 0)
+  {
+    return GetMatchVar();
+  }
+  else
+  {
+    return GetEntryVar(input.index() - 1);
+  }
 }
 
-GammaNode::EntryVar
-GammaNode::MapBranchArgumentEntryVar(const rvsdg::output & output) const
+std::variant<GammaNode::MatchVar, GammaNode::EntryVar>
+GammaNode::MapBranchArgument(const rvsdg::output & output) const
 {
   JLM_ASSERT(rvsdg::TryGetRegionParentNode<GammaNode>(output) == this);
-  return GetEntryVar(output.index());
+  if (output.index() == 0)
+  {
+    return GetMatchVar();
+  }
+  else
+  {
+    return GetEntryVar(output.index() - 1);
+  }
 }
 
 GammaNode::ExitVar
@@ -394,7 +434,7 @@ GammaNode::RemoveEntryVars(const std::vector<EntryVar> & entryvars)
   {
     for (std::size_t r = 0; r < nsubregions(); ++r)
     {
-      subregion(r)->RemoveArgument(index - 1);
+      subregion(r)->RemoveArgument(index);
     }
     RemoveInput(index);
   }
@@ -446,7 +486,15 @@ GetGammaInvariantOrigin(const GammaNode & gamma, const GammaNode::ExitVar & exit
     {
       return std::nullopt;
     }
-    return gamma.MapBranchArgumentEntryVar(*def).input->origin();
+    auto rolevar = gamma.MapBranchArgument(*def);
+    if (auto entryvar = std::get_if<GammaNode::EntryVar>(&rolevar))
+    {
+      return entryvar->input->origin();
+    }
+    else
+    {
+      return std::nullopt;
+    }
   };
 
   auto firstOrigin = GetExternalOriginOf(exitvar.branchResult[0]);

--- a/jlm/rvsdg/gamma.hpp
+++ b/jlm/rvsdg/gamma.hpp
@@ -23,15 +23,22 @@ class GammaOperation final : public StructuralOperation
 public:
   ~GammaOperation() noexcept override;
 
-  explicit constexpr GammaOperation(size_t nalternatives) noexcept
+  explicit GammaOperation(size_t numAlternatives) noexcept
+      : GammaOperation(numAlternatives, {})
+  {}
+
+  GammaOperation(
+      size_t numAlternatives,
+      std::vector<std::shared_ptr<const Type>> matchContentTypes) noexcept
       : StructuralOperation(),
-        nalternatives_(nalternatives)
+        numAlternatives_(numAlternatives),
+        MatchContentTypes_(std::move(matchContentTypes))
   {}
 
   inline size_t
   nalternatives() const noexcept
   {
-    return nalternatives_;
+    return numAlternatives_;
   }
 
   virtual std::string
@@ -43,21 +50,78 @@ public:
   virtual bool
   operator==(const Operation & other) const noexcept override;
 
+  /**
+   * \brief Returns the type of pattern matching content produced in a branch
+   */
+  std::shared_ptr<const Type>
+  GetMatchContentType(std::size_t alternative) const;
+
 private:
-  size_t nalternatives_;
+  size_t numAlternatives_;
+  std::vector<std::shared_ptr<const Type>> MatchContentTypes_;
 };
 
-/* gamma node */
-
+/**
+ * \brief Conditional operator / pattern matching
+ *
+ * Gamma nodes discriminate over a given value and conditionally
+ * select one of its subregions. In its simplest form, they
+ * correspond to an if/else statement:
+ *
+ * \code
+ *   if (pred) { branch1(); } else { branch0(); }
+ * \endcode
+ *
+ * More generically, they perform pattern-matching over a finitely-
+ * constructed type:
+ *
+ * \code
+ *   match shape with
+ *     | Circle x y r => ...
+ *     | Rect x1 y1 x2 y2 => ...
+ *     | Poly points => ...
+ *   end
+ * \endcode
+ *
+ * where the "contents" of the match is made available in its corresponding
+ * branch. Simple types such as booleans do not have any content and
+ * thus produce the content-less UnitType as placeholder for the
+ * destructured content -- so effectively Gamma then corresponds to:
+ *
+ * \code
+ *   match pred with
+ *     | false => branch1
+ *     | true => branch0
+ *   end
+ * \endcode
+ */
 class GammaNode : public StructuralNode
 {
 public:
   ~GammaNode() noexcept override;
 
 private:
-  GammaNode(rvsdg::output * predicate, size_t nalternatives);
+  GammaNode(
+      rvsdg::output * predicate,
+      size_t nalternatives,
+      std::vector<std::shared_ptr<const Type>> match_content_types);
 
 public:
+  /**
+   * \brief The match/discriminator variable of this gamma node
+   */
+  struct MatchVar
+  {
+    /**
+     * \brief The variable matched over (i.e. the "selector" of the gamma branch).
+     */
+    rvsdg::input * input;
+    /**
+     * \brief The content of the match per branch.
+     */
+    std::vector<rvsdg::output *> matchContent;
+  };
+
   /**
    * \brief A variable routed into all gamma regions.
    */
@@ -94,7 +158,16 @@ public:
   static GammaNode *
   create(jlm::rvsdg::output * predicate, size_t nalternatives)
   {
-    return new GammaNode(predicate, nalternatives);
+    return new GammaNode(predicate, nalternatives, {});
+  }
+
+  static GammaNode &
+  Create(
+      jlm::rvsdg::output * predicate,
+      size_t numAlternatives,
+      std::vector<std::shared_ptr<const Type>> matchContentTypes)
+  {
+    return *new GammaNode(predicate, numAlternatives, std::move(matchContentTypes));
   }
 
   inline rvsdg::input *
@@ -115,20 +188,8 @@ public:
   EntryVar
   AddEntryVar(rvsdg::output * origin);
 
-  /**
-   * \brief Gets entry variable by index.
-   *
-   * \param index
-   *   Index of entry variable
-   *
-   * \returns
-   *   Description of entry variable.
-   *
-   * Looks up the \p index 'th entry variable into the gamma
-   * node and returns its description.
-   */
-  EntryVar
-  GetEntryVar(std::size_t index) const;
+  MatchVar
+  GetMatchVar() const;
 
   /**
    * \brief Gets all entry variables for this gamma.
@@ -137,26 +198,27 @@ public:
   GetEntryVars() const;
 
   /**
-   * \brief Maps gamma input to entry variable.
+   * \brief Maps gamma input to its role (match variable or entry variable).
    *
    * \param input
    *   Input to be mapped.
    *
    * \returns
-   *   The entry variable description corresponding to this input
+   *   The variable description corresponding to this input
    *
    * \pre
-   *   \p input must be an input of this node and must not be the predicate
+   *   \p input must be an input of this node
    *
-   * Maps the gamma input to the entry variable description corresponding
-   * to it. This allows to trace the value through to users in the
-   * gamma subregions.
+   * Maps the gamma input to the variable description corresponding
+   * to it. This is either the "match" or "predicate" of the gamma, or
+   * an entry variable for values used inside the region. This allows to trace
+   * the value through to users in the gamma subregions.
    */
-  EntryVar
-  MapInputEntryVar(const rvsdg::input & input) const;
+  std::variant<MatchVar, EntryVar>
+  MapInput(const rvsdg::input & input) const;
 
   /**
-   * \brief Maps branch subregion entry argument to gamma entry variable.
+   * \brief Maps branch subregion entry argument to its role (pattern match or  entry variable).
    *
    * \param output
    *   The branch argument to be mapped.
@@ -167,12 +229,13 @@ public:
    * \pre
    *   \p output must be the entry argument to a subregion of this gamma nade.
    *
-   * Maps the subregion entry argument to the entry variable description
-   * corresponding to it. This allows to trace the value to users in other
+   * Maps the subregion entry argument to the variable description
+   * corresponding to it (the predicate + pattern matches, or an entry variable
+   * into this branch). This allows to trace the value to users in other
    * branches as well as its def site preceding the gamma node:
    */
-  EntryVar
-  MapBranchArgumentEntryVar(const rvsdg::output & output) const;
+  std::variant<MatchVar, EntryVar>
+  MapBranchArgument(const rvsdg::output & output) const;
 
   /**
    * \brief Routes per-branch result of gamma to output
@@ -286,6 +349,21 @@ public:
   copy(jlm::rvsdg::Region * region, SubstitutionMap & smap) const override;
 
 private:
+  /**
+   * \brief Gets entry variable by index.
+   *
+   * \param index
+   *   Index of entry variable
+   *
+   * \returns
+   *   Description of entry variable.
+   *
+   * Looks up the \p index 'th entry variable into the gamma
+   * node and returns its description.
+   */
+  EntryVar
+  GetEntryVar(std::size_t index) const;
+
   GammaOperation Operation_;
 };
 

--- a/tests/jlm/llvm/backend/dot/DotWriterTests.cpp
+++ b/tests/jlm/llvm/backend/dot/DotWriterTests.cpp
@@ -55,12 +55,12 @@ TestWriteGraphs()
   assert(gammaNode.NumOutputPorts() == 2);
   assert(gammaNode.NumSubgraphs() == 2);
 
-  // The first argument of the first region of the gamma references the second gamma input
-  auto & argument = gammaNode.GetSubgraph(0).GetArgumentNode(0);
+  // The second argument of the first region of the gamma references the second gamma input
+  auto & argument = gammaNode.GetSubgraph(0).GetArgumentNode(1);
   auto & input = gammaNode.GetInputPort(1);
   assert(argument.GetAttributeGraphElement("input") == &input);
   // The label also includes the attribute index and input index
-  assert(argument.GetLabel() == "a0 <- i1");
+  assert(argument.GetLabel() == "a1 <- i1");
   auto & result = argument.GetConnections().front()->GetOtherEnd(argument);
   assert(result.GetLabel() == "r0 -> o0");
 

--- a/tests/jlm/llvm/opt/TestDeadNodeElimination.cpp
+++ b/tests/jlm/llvm/opt/TestDeadNodeElimination.cpp
@@ -79,7 +79,7 @@ TestGamma()
 
   assert(gamma->noutputs() == 2);
   assert(gamma->subregion(1)->nnodes() == 0);
-  assert(gamma->subregion(1)->narguments() == 2);
+  assert(gamma->subregion(1)->narguments() == 3);
   assert(gamma->ninputs() == 3);
   assert(graph.GetRootRegion().narguments() == 2);
 }


### PR DESCRIPTION
Add an argument to gamma branch subregions that represents the "content" of the discriminator object that gamma is matching over. For booleans/control decisions, they do not have a content (although one could argue that they carry an "assertion" that a certain proposition holds that in turn some operations in the contained region may be dependent on -- e.g. a divisor not being zero, a pointer being non-null etc.) -- so use UnitType here by default.

This allows Gamma to serve as general pattern matching operator which makes the contents of e.g. an algebraic type being matched over available in its sub branches.

Adapt all places using Gamma API to deal with the fact that there is another argument now not corresponding to any EntryVar.