### PR TITLE
Match on node type for structural nodes

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/GammaConversion.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/GammaConversion.cpp
@@ -105,7 +105,8 @@ CanGammaNodeBeSpeculative(const rvsdg::GammaNode & gammaNode)
   {
     for (auto & node : gammaNode.subregion(i)->Nodes())
     {
-      if (rvsdg::is<rvsdg::ThetaOperation>(&node) || rvsdg::is<hls::loop_op>(&node))
+      if (dynamic_cast<const rvsdg::ThetaNode *>(&node)
+          || dynamic_cast<const hls::loop_node *>(&node))
       {
         // don't allow thetas or loops since they could potentially block forever
         return false;

--- a/jlm/hls/backend/rvsdg2rhls/decouple-mem-state.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/decouple-mem-state.cpp
@@ -78,7 +78,7 @@ trace_edge(
         new_edge = new_out;
         convert_loop_state_to_lcb(new_in);
       }
-      JLM_ASSERT(TryGetOwnerOp<loop_op>(*out));
+      JLM_ASSERT(rvsdg::TryGetOwnerNode<loop_node>(*out));
       JLM_ASSERT(out->region() == state_edge->region());
       state_edge = get_mem_state_user(out);
       continue;

--- a/jlm/hls/backend/rvsdg2rhls/hls-function-util.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/hls-function-util.hpp
@@ -53,10 +53,9 @@ template<typename OpType>
 inline const OpType *
 TryGetOwnerOp(const rvsdg::input & input) noexcept
 {
-  auto owner = input.GetOwner();
-  if (const auto node = std::get_if<rvsdg::Node *>(&owner))
+  if (const auto node = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(input))
   {
-    return dynamic_cast<const OpType *>(&(*node)->GetOperation());
+    return dynamic_cast<const OpType *>(&node->GetOperation());
   }
   else
   {
@@ -68,10 +67,9 @@ template<typename OpType>
 inline const OpType *
 TryGetOwnerOp(const rvsdg::output & output) noexcept
 {
-  auto owner = output.GetOwner();
-  if (const auto node = std::get_if<rvsdg::Node *>(&owner))
+  if (const auto node = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(output))
   {
-    return dynamic_cast<const OpType *>(&(*node)->GetOperation());
+    return dynamic_cast<const OpType *>(&node->GetOperation());
   }
   else
   {

--- a/jlm/hls/backend/rvsdg2rhls/mem-queue.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-queue.cpp
@@ -420,7 +420,7 @@ process_loops(jlm::rvsdg::output * state_edge)
     }
     else if (auto sti = dynamic_cast<jlm::rvsdg::StructuralInput *>(user))
     {
-      JLM_ASSERT(jlm::rvsdg::is<jlm::hls::loop_op>(sti->node()));
+      JLM_ASSERT(dynamic_cast<const jlm::hls::loop_node *>(sti->node()));
       // update to output of loop
       auto mem_edge_after_loop = find_loop_output(sti);
       JLM_ASSERT(mem_edge_after_loop->nusers() == 1);

--- a/jlm/hls/ir/hls.cpp
+++ b/jlm/hls/ir/hls.cpp
@@ -60,6 +60,12 @@ backedge_result::Copy(rvsdg::output & origin, rvsdg::StructuralOutput * output)
 
 ExitResult::~ExitResult() noexcept = default;
 
+ExitResult::ExitResult(rvsdg::output & origin, rvsdg::StructuralOutput & output)
+    : rvsdg::RegionResult(origin.region(), &origin, &output, origin.Type())
+{
+  JLM_ASSERT(dynamic_cast<const loop_node *>(origin.region()->node()));
+}
+
 ExitResult &
 ExitResult::Copy(rvsdg::output & origin, rvsdg::StructuralOutput * output)
 {

--- a/jlm/hls/ir/hls.hpp
+++ b/jlm/hls/ir/hls.hpp
@@ -724,11 +724,7 @@ public:
   ~ExitResult() noexcept override;
 
 private:
-  ExitResult(rvsdg::output & origin, rvsdg::StructuralOutput & output)
-      : rvsdg::RegionResult(origin.region(), &origin, &output, origin.Type())
-  {
-    JLM_ASSERT(rvsdg::is<loop_op>(origin.region()->node()));
-  }
+  ExitResult(rvsdg::output & origin, rvsdg::StructuralOutput & output);
 
 public:
   ExitResult &

--- a/jlm/hls/opt/InvariantLambdaMemoryStateRemoval.cpp
+++ b/jlm/hls/opt/InvariantLambdaMemoryStateRemoval.cpp
@@ -101,7 +101,7 @@ InvariantLambdaMemoryStateRemoval::RemoveInvariantLambdaMemoryStateEdges(
   {
     if (auto lambda = dynamic_cast<const rvsdg::LambdaNode *>(node))
     {
-      if (rvsdg::is<const llvm::LlvmLambdaOperation>(node->GetOperation())
+      if (rvsdg::is<const llvm::LlvmLambdaOperation>(lambda->GetOperation())
           && lambda->output()->nusers() == 1
           && dynamic_cast<const jlm::rvsdg::GraphExport *>(*lambda->output()->begin()))
       {

--- a/jlm/hls/opt/cne.cpp
+++ b/jlm/hls/opt/cne.cpp
@@ -224,7 +224,8 @@ congruent(jlm::rvsdg::output * o1, jlm::rvsdg::output * o2, vset & vs, cnectx & 
 
   auto a1 = dynamic_cast<rvsdg::RegionArgument *>(o1);
   auto a2 = dynamic_cast<rvsdg::RegionArgument *>(o2);
-  if (a1 && is<hls::loop_op>(a1->region()->node()) && a2 && is<hls::loop_op>(a2->region()->node()))
+  if (a1 && dynamic_cast<const hls::loop_node *>(a1->region()->node()) && a2
+      && dynamic_cast<const hls::loop_node *>(a2->region()->node()))
   {
     JLM_ASSERT(o1->region()->node() == o2->region()->node());
     if (a1->input() && a2->input())
@@ -235,7 +236,7 @@ congruent(jlm::rvsdg::output * o1, jlm::rvsdg::output * o2, vset & vs, cnectx & 
     }
   }
 
-  if (rvsdg::is<rvsdg::GammaOperation>(n1) && n1 == n2)
+  if (dynamic_cast<const rvsdg::GammaNode *>(n1) && n1 == n2)
   {
     auto so1 = static_cast<StructuralOutput *>(o1);
     auto so2 = static_cast<StructuralOutput *>(o2);
@@ -317,7 +318,7 @@ mark(jlm::rvsdg::Region *, cnectx &);
 static void
 mark_gamma(const rvsdg::StructuralNode * node, cnectx & ctx)
 {
-  JLM_ASSERT(rvsdg::is<rvsdg::GammaOperation>(node->GetOperation()));
+  JLM_ASSERT(dynamic_cast<const rvsdg::GammaNode *>(node));
 
   /* mark entry variables */
   for (size_t i1 = 1; i1 < node->ninputs(); i1++)
@@ -343,7 +344,7 @@ mark_gamma(const rvsdg::StructuralNode * node, cnectx & ctx)
 static void
 mark_theta(const rvsdg::StructuralNode * node, cnectx & ctx)
 {
-  JLM_ASSERT(is<jlm::rvsdg::ThetaOperation>(node));
+  JLM_ASSERT(dynamic_cast<const jlm::rvsdg::ThetaNode *>(node));
   auto theta = static_cast<const rvsdg::ThetaNode *>(node);
 
   /* mark loop variables */
@@ -369,7 +370,7 @@ mark_theta(const rvsdg::StructuralNode * node, cnectx & ctx)
 static void
 mark_loop(const rvsdg::StructuralNode * node, cnectx & ctx)
 {
-  JLM_ASSERT(rvsdg::is<hls::loop_op>(node));
+  JLM_ASSERT(dynamic_cast<const hls::loop_node *>(node));
   auto loop = static_cast<const jlm::hls::loop_node *>(node);
 
   /* mark loop variables */
@@ -391,7 +392,7 @@ mark_loop(const rvsdg::StructuralNode * node, cnectx & ctx)
 static void
 mark_lambda(const rvsdg::StructuralNode * node, cnectx & ctx)
 {
-  JLM_ASSERT(jlm::rvsdg::is<rvsdg::LambdaOperation>(node));
+  JLM_ASSERT(dynamic_cast<const rvsdg::LambdaNode *>(node));
 
   /* mark dependencies */
   for (size_t i1 = 0; i1 < node->ninputs(); i1++)
@@ -533,7 +534,7 @@ divert(rvsdg::Region *, cnectx &);
 static void
 divert_gamma(rvsdg::StructuralNode * node, cnectx & ctx)
 {
-  JLM_ASSERT(rvsdg::is<rvsdg::GammaOperation>(node));
+  JLM_ASSERT(dynamic_cast<const rvsdg::GammaNode *>(node));
   auto gamma = static_cast<GammaNode *>(node);
 
   for (const auto & ev : gamma->GetEntryVars())
@@ -551,7 +552,7 @@ divert_gamma(rvsdg::StructuralNode * node, cnectx & ctx)
 static void
 divert_theta(rvsdg::StructuralNode * node, cnectx & ctx)
 {
-  JLM_ASSERT(is<jlm::rvsdg::ThetaOperation>(node));
+  JLM_ASSERT(dynamic_cast<const rvsdg::ThetaNode *>(node));
   auto theta = static_cast<rvsdg::ThetaNode *>(node);
   auto subregion = node->subregion(0);
 
@@ -568,7 +569,7 @@ divert_theta(rvsdg::StructuralNode * node, cnectx & ctx)
 static void
 divert_loop(rvsdg::StructuralNode * node, cnectx & ctx)
 {
-  JLM_ASSERT(rvsdg::is<hls::loop_op>(node));
+  JLM_ASSERT(dynamic_cast<const hls::loop_node *>(node));
   auto subregion = node->subregion(0);
   divert(subregion, ctx);
 }
@@ -576,7 +577,7 @@ divert_loop(rvsdg::StructuralNode * node, cnectx & ctx)
 static void
 divert_lambda(rvsdg::StructuralNode * node, cnectx & ctx)
 {
-  JLM_ASSERT(jlm::rvsdg::is<rvsdg::LambdaOperation>(node));
+  JLM_ASSERT(dynamic_cast<const rvsdg::LambdaNode *>(node));
 
   divert_arguments(node->subregion(0), ctx);
   divert(node->subregion(0), ctx);

--- a/jlm/llvm/opt/InvariantValueRedirection.cpp
+++ b/jlm/llvm/opt/InvariantValueRedirection.cpp
@@ -81,7 +81,7 @@ InvariantValueRedirection::RedirectInRootRegion(rvsdg::Graph & rvsdg)
         RedirectInRegion(*phiLambdaNode->subregion());
       }
     }
-    else if (is<delta::operation>(node))
+    else if (dynamic_cast<const delta::node *>(node))
     {
       // Nothing needs to be done.
       // Delta nodes are irrelevant for invariant value redirection.
@@ -102,9 +102,9 @@ InvariantValueRedirection::RedirectInRootRegion(rvsdg::Graph & rvsdg)
 void
 InvariantValueRedirection::RedirectInRegion(rvsdg::Region & region)
 {
-  auto isGammaNode = is<rvsdg::GammaOperation>(region.node());
-  auto isThetaNode = is<rvsdg::ThetaOperation>(region.node());
-  auto isLambdaNode = is<rvsdg::LambdaOperation>(region.node());
+  auto isGammaNode = !!dynamic_cast<rvsdg::GammaNode *>(region.node());
+  auto isThetaNode = !!dynamic_cast<rvsdg::ThetaNode *>(region.node());
+  auto isLambdaNode = !!dynamic_cast<rvsdg::LambdaNode *>(region.node());
   JLM_ASSERT(isGammaNode || isThetaNode || isLambdaNode);
 
   // We do not need a traverser here and can just iterate through all the nodes of a region as
@@ -135,8 +135,8 @@ InvariantValueRedirection::RedirectInRegion(rvsdg::Region & region)
 void
 InvariantValueRedirection::RedirectInSubregions(rvsdg::StructuralNode & structuralNode)
 {
-  auto isGammaNode = is<rvsdg::GammaOperation>(&structuralNode);
-  auto isThetaNode = is<rvsdg::ThetaOperation>(&structuralNode);
+  auto isGammaNode = !!dynamic_cast<rvsdg::GammaNode *>(&structuralNode);
+  auto isThetaNode = !!dynamic_cast<rvsdg::ThetaNode *>(&structuralNode);
   JLM_ASSERT(isGammaNode || isThetaNode);
 
   for (size_t n = 0; n < structuralNode.nsubregions(); n++)

--- a/jlm/llvm/opt/alias-analyses/PointsToGraph.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraph.hpp
@@ -655,9 +655,7 @@ private:
   DeltaNode(PointsToGraph & pointsToGraph, const delta::node & deltaNode)
       : MemoryNode(pointsToGraph),
         DeltaNode_(&deltaNode)
-  {
-    JLM_ASSERT(is<delta::operation>(&deltaNode));
-  }
+  {}
 
 public:
   const delta::node &
@@ -730,7 +728,7 @@ private:
       : MemoryNode(pointsToGraph),
         LambdaNode_(&lambdaNode)
   {
-    JLM_ASSERT(is<llvm::LlvmLambdaOperation>(&lambdaNode));
+    JLM_ASSERT(dynamic_cast<const llvm::LlvmLambdaOperation *>(&lambdaNode.GetOperation()));
   }
 
 public:

--- a/jlm/llvm/opt/alias-analyses/TopDownModRefEliminator.cpp
+++ b/jlm/llvm/opt/alias-analyses/TopDownModRefEliminator.cpp
@@ -483,7 +483,7 @@ TopDownModRefEliminator::EliminateTopDown(const rvsdg::RvsdgModule & rvsdgModule
 void
 TopDownModRefEliminator::EliminateTopDownRootRegion(rvsdg::Region & region)
 {
-  JLM_ASSERT(region.IsRootRegion() || rvsdg::is<rvsdg::PhiOperation>(region.node()));
+  JLM_ASSERT(region.IsRootRegion() || dynamic_cast<const rvsdg::PhiNode *>(region.node()));
 
   // Process the lambda, phi, and delta nodes bottom-up.
   // This ensures that we visit all the call nodes before we visit the respective lambda nodes.
@@ -520,9 +520,9 @@ TopDownModRefEliminator::EliminateTopDownRootRegion(rvsdg::Region & region)
 void
 TopDownModRefEliminator::EliminateTopDownRegion(rvsdg::Region & region)
 {
-  auto isLambdaSubregion = rvsdg::is<rvsdg::LambdaOperation>(region.node());
-  auto isThetaSubregion = rvsdg::is<rvsdg::ThetaOperation>(region.node());
-  auto isGammaSubregion = rvsdg::is<rvsdg::GammaOperation>(region.node());
+  auto isLambdaSubregion = dynamic_cast<const rvsdg::LambdaNode *>(region.node());
+  auto isThetaSubregion = dynamic_cast<const rvsdg::ThetaNode *>(region.node());
+  auto isGammaSubregion = dynamic_cast<const rvsdg::GammaNode *>(region.node());
   JLM_ASSERT(isLambdaSubregion || isThetaSubregion || isGammaSubregion);
 
   // Process the intra-procedural nodes top-down.
@@ -648,7 +648,7 @@ TopDownModRefEliminator::EliminateTopDownPhi(const rvsdg::PhiNode & phiNode)
         auto & lambdaLiveNodes = Context_->GetLiveNodes(lambdaSubregion);
         liveNodes.UnionWith(lambdaLiveNodes);
       }
-      else if (is<delta::operation>(&node))
+      else if (dynamic_cast<const delta::node *>(&node))
       {
         // Nothing needs to be done.
       }

--- a/jlm/llvm/opt/inversion.cpp
+++ b/jlm/llvm/opt/inversion.cpp
@@ -111,8 +111,8 @@ pullin(rvsdg::GammaNode * gamma, rvsdg::ThetaNode * theta)
 static std::vector<std::vector<rvsdg::Node *>>
 collect_condition_nodes(rvsdg::StructuralNode * tnode, jlm::rvsdg::StructuralNode * gnode)
 {
-  JLM_ASSERT(is<rvsdg::ThetaOperation>(tnode));
-  JLM_ASSERT(rvsdg::is<rvsdg::GammaOperation>(gnode));
+  JLM_ASSERT(dynamic_cast<const rvsdg::ThetaNode *>(tnode));
+  JLM_ASSERT(dynamic_cast<const rvsdg::GammaNode *>(gnode));
   JLM_ASSERT(gnode->region()->node() == tnode);
 
   std::vector<std::vector<rvsdg::Node *>> nodes;

--- a/jlm/llvm/opt/push.cpp
+++ b/jlm/llvm/opt/push.cpp
@@ -97,7 +97,7 @@ has_side_effects(const rvsdg::Node * node)
 static std::vector<rvsdg::RegionArgument *>
 copy_from_gamma(rvsdg::Node * node, size_t r)
 {
-  JLM_ASSERT(jlm::rvsdg::is<rvsdg::GammaOperation>(node->region()->node()));
+  JLM_ASSERT(dynamic_cast<rvsdg::GammaNode *>(node->region()->node()));
   JLM_ASSERT(node->depth() == 0);
 
   auto target = node->region()->node()->region();
@@ -126,7 +126,7 @@ copy_from_gamma(rvsdg::Node * node, size_t r)
 static std::vector<rvsdg::output *>
 copy_from_theta(rvsdg::Node * node)
 {
-  JLM_ASSERT(is<rvsdg::ThetaOperation>(node->region()->node()));
+  JLM_ASSERT(dynamic_cast<const rvsdg::ThetaNode *>(node->region()->node()));
   JLM_ASSERT(node->depth() == 0);
 
   auto target = node->region()->node()->region();
@@ -212,7 +212,7 @@ push(rvsdg::GammaNode * gamma)
 static bool
 is_theta_invariant(const rvsdg::Node * node, const std::unordered_set<rvsdg::output *> & invariants)
 {
-  JLM_ASSERT(is<rvsdg::ThetaOperation>(node->region()->node()));
+  JLM_ASSERT(dynamic_cast<const rvsdg::ThetaNode *>(node->region()->node()));
   JLM_ASSERT(node->depth() == 0);
 
   for (size_t n = 0; n < node->ninputs(); n++)
@@ -287,14 +287,14 @@ push_top(rvsdg::ThetaNode * theta)
 static bool
 is_invariant(const rvsdg::RegionArgument * argument)
 {
-  JLM_ASSERT(is<rvsdg::ThetaOperation>(argument->region()->node()));
+  JLM_ASSERT(dynamic_cast<const rvsdg::ThetaNode *>(argument->region()->node()));
   return argument->region()->result(argument->index() + 1)->origin() == argument;
 }
 
 static bool
 is_movable_store(rvsdg::Node * node)
 {
-  JLM_ASSERT(is<rvsdg::ThetaOperation>(node->region()->node()));
+  JLM_ASSERT(dynamic_cast<const rvsdg::ThetaNode *>(node->region()->node()));
   JLM_ASSERT(jlm::rvsdg::is<StoreNonVolatileOperation>(node));
 
   auto address = dynamic_cast<rvsdg::RegionArgument *>(node->input(0)->origin());
@@ -324,7 +324,7 @@ is_movable_store(rvsdg::Node * node)
 static void
 pushout_store(rvsdg::Node * storenode)
 {
-  JLM_ASSERT(is<rvsdg::ThetaOperation>(storenode->region()->node()));
+  JLM_ASSERT(dynamic_cast<const rvsdg::ThetaNode *>(storenode->region()->node()));
   JLM_ASSERT(jlm::rvsdg::is<StoreNonVolatileOperation>(storenode) && is_movable_store(storenode));
   auto theta = static_cast<rvsdg::ThetaNode *>(storenode->region()->node());
   auto storeop = static_cast<const StoreNonVolatileOperation *>(&storenode->GetOperation());

--- a/jlm/llvm/opt/reduction.cpp
+++ b/jlm/llvm/opt/reduction.cpp
@@ -111,7 +111,7 @@ NodeReduction::ReduceStructuralNode(rvsdg::StructuralNode & structuralNode)
   bool reductionPerformed = false;
 
   // Reduce structural nodes
-  if (is<rvsdg::GammaOperation>(&structuralNode))
+  if (dynamic_cast<const rvsdg::GammaNode *>(&structuralNode))
   {
     reductionPerformed |= ReduceGammaNode(structuralNode);
   }
@@ -135,7 +135,7 @@ NodeReduction::ReduceStructuralNode(rvsdg::StructuralNode & structuralNode)
 bool
 NodeReduction::ReduceGammaNode(rvsdg::StructuralNode & gammaNode)
 {
-  JLM_ASSERT(is<rvsdg::GammaOperation>(&gammaNode));
+  JLM_ASSERT(dynamic_cast<const rvsdg::GammaNode *>(&gammaNode));
 
   // FIXME: We can not apply the reduction below due to a bug. See github issue #303
   // rvsdg::ReduceGammaControlConstant

--- a/jlm/llvm/opt/unroll.cpp
+++ b/jlm/llvm/opt/unroll.cpp
@@ -60,7 +60,7 @@ is_eqcmp(const rvsdg::Operation & op)
 static bool
 is_theta_invariant(const jlm::rvsdg::output * output)
 {
-  JLM_ASSERT(is<rvsdg::ThetaOperation>(output->region()->node()));
+  JLM_ASSERT(dynamic_cast<const rvsdg::ThetaNode *>(output->region()->node()));
 
   if (jlm::rvsdg::is<rvsdg::bitconstant_op>(rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(*output)))
     return true;
@@ -82,7 +82,7 @@ push_from_theta(jlm::rvsdg::output * output)
 
   auto tmp = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(*output);
   JLM_ASSERT(jlm::rvsdg::is<jlm::rvsdg::bitconstant_op>(tmp));
-  JLM_ASSERT(is<rvsdg::ThetaOperation>(tmp->region()->node()));
+  JLM_ASSERT(dynamic_cast<const rvsdg::ThetaNode *>(tmp->region()->node()));
   auto theta = static_cast<rvsdg::ThetaNode *>(tmp->region()->node());
 
   auto node = tmp->copy(theta->region(), {});

--- a/jlm/rvsdg/view.cpp
+++ b/jlm/rvsdg/view.cpp
@@ -262,10 +262,10 @@ edge_tag(const std::string & srcid, const std::string & dstid)
 static inline std::string
 type(const Node * n)
 {
-  if (dynamic_cast<const GammaOperation *>(&n->GetOperation()))
+  if (dynamic_cast<const GammaNode *>(n))
     return "gamma";
 
-  if (dynamic_cast<const ThetaOperation *>(&n->GetOperation()))
+  if (dynamic_cast<const ThetaNode *>(n))
     return "theta";
 
   return "";

--- a/tests/jlm/hls/backend/rvsdg2rhls/MemoryConverterTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/MemoryConverterTests.cpp
@@ -406,7 +406,7 @@ TestThetaLoad()
   auto loopOutput =
       jlm::util::AssertedCast<const jlm::rvsdg::StructuralOutput>(requestNode->input(0)->origin());
   auto loopNode = jlm::util::AssertedCast<const jlm::rvsdg::StructuralNode>(loopOutput->node());
-  assert(is<loop_op>(loopNode));
+  assert(dynamic_cast<const loop_node *>(loopNode));
   // Loop Result
   auto & thetaResult = loopOutput->results;
   assert(thetaResult.size() == 1);
@@ -532,7 +532,7 @@ TestThetaStore()
   auto loopOutput =
       jlm::util::AssertedCast<const jlm::rvsdg::StructuralOutput>(requestNode->input(0)->origin());
   auto loopNode = jlm::util::AssertedCast<const jlm::rvsdg::StructuralNode>(loopOutput->node());
-  assert(is<loop_op>(loopNode));
+  assert(dynamic_cast<const loop_node *>(loopNode));
   // Loop Result
   auto & thetaResult = loopOutput->results;
   assert(thetaResult.size() == 1);

--- a/tests/jlm/hls/backend/rvsdg2rhls/TestFork.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/TestFork.cpp
@@ -55,12 +55,12 @@ TestFork()
     auto omegaRegion = &rm.Rvsdg().GetRootRegion();
     assert(omegaRegion->nnodes() == 1);
     auto lambda = util::AssertedCast<jlm::rvsdg::LambdaNode>(omegaRegion->Nodes().begin().ptr());
-    assert(is<jlm::rvsdg::LambdaOperation>(lambda));
+    assert(dynamic_cast<const jlm::rvsdg::LambdaNode *>(lambda));
 
     auto lambdaRegion = lambda->subregion();
     assert(lambdaRegion->nnodes() == 1);
     auto loop = util::AssertedCast<hls::loop_node>(lambdaRegion->Nodes().begin().ptr());
-    assert(is<hls::loop_op>(loop));
+    assert(dynamic_cast<const hls::loop_node *>(loop));
 
     // Traverse the rvsgd graph upwards to check connections
     rvsdg::node_output * forkNodeOutput;
@@ -118,7 +118,7 @@ TestConstantFork()
     auto omegaRegion = &rm.Rvsdg().GetRootRegion();
     assert(omegaRegion->nnodes() == 1);
     auto lambda = util::AssertedCast<jlm::rvsdg::LambdaNode>(omegaRegion->Nodes().begin().ptr());
-    assert(is<jlm::rvsdg::LambdaOperation>(lambda));
+    assert(dynamic_cast<const jlm::rvsdg::LambdaNode *>(lambda));
 
     auto lambdaRegion = lambda->subregion();
     assert(lambdaRegion->nnodes() == 1);
@@ -126,7 +126,7 @@ TestConstantFork()
     rvsdg::node_output * loopOutput;
     assert(loopOutput = dynamic_cast<jlm::rvsdg::node_output *>(lambdaRegion->result(0)->origin()));
     auto loopNode = loopOutput->node();
-    assert(is<hls::loop_op>(loopNode));
+    assert(dynamic_cast<const hls::loop_node *>(loopNode));
     auto loop = util::AssertedCast<hls::loop_node>(loopNode);
 
     // Traverse the rvsgd graph upwards to check connections

--- a/tests/jlm/hls/opt/InvariantLambdaMemoryStateRemovalTests.cpp
+++ b/tests/jlm/hls/opt/InvariantLambdaMemoryStateRemovalTests.cpp
@@ -127,16 +127,16 @@ TestInvariantMemoryState()
   InvariantLambdaMemoryStateRemoval memStateRemoval;
   memStateRemoval.Run(*rvsdgModule, collector);
   // Assert
-  auto * node = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(
+  auto * lambdaNode = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::LambdaNode>(
       *rvsdgModule->Rvsdg().GetRootRegion().result(0)->origin());
-  auto lambdaSubregion = jlm::util::AssertedCast<jlm::rvsdg::LambdaNode>(node)->subregion();
+  auto lambdaSubregion = lambdaNode->subregion();
   jlm::rvsdg::view(rvsdgModule->Rvsdg(), stdout);
   assert(lambdaSubregion->narguments() == 2);
   assert(lambdaSubregion->nresults() == 1);
   assert(is<MemoryStateType>(lambdaSubregion->result(0)->Type()));
   // Since there is more than one invariant memory state edge, the MemoryStateMerge node should
   // still exists
-  node = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*lambdaSubregion->result(0)->origin());
+  auto node = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*lambdaSubregion->result(0)->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(node->GetOperation()));
   assert(node->ninputs() == 2);
   // Need to pass a load node to reach the MemoryStateSplit node

--- a/tests/jlm/llvm/opt/test-inversion.cpp
+++ b/tests/jlm/llvm/opt/test-inversion.cpp
@@ -70,12 +70,9 @@ test1()
   tginversion.Run(rm, statisticsCollector);
   //	jlm::rvsdg::view(graph.GetRootRegion(), stdout);
 
-  assert(jlm::rvsdg::is<jlm::rvsdg::GammaOperation>(
-      jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*ex1.origin())));
-  assert(jlm::rvsdg::is<jlm::rvsdg::GammaOperation>(
-      jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*ex2.origin())));
-  assert(jlm::rvsdg::is<jlm::rvsdg::GammaOperation>(
-      jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*ex3.origin())));
+  assert(jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::GammaNode>(*ex1.origin()));
+  assert(jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::GammaNode>(*ex2.origin()));
+  assert(jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::GammaNode>(*ex3.origin()));
 }
 
 static inline void
@@ -120,8 +117,7 @@ test2()
   tginversion.Run(rm, statisticsCollector);
   //	jlm::rvsdg::view(graph.GetRootRegion(), stdout);
 
-  assert(jlm::rvsdg::is<jlm::rvsdg::GammaOperation>(
-      jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*ex.origin())));
+  assert(jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::GammaNode>(*ex.origin()));
 }
 
 static int

--- a/tests/jlm/llvm/opt/test-push.cpp
+++ b/tests/jlm/llvm/opt/test-push.cpp
@@ -137,10 +137,8 @@ test_push_theta_bottom()
   auto storenode = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*ex.origin());
   assert(jlm::rvsdg::is<StoreNonVolatileOperation>(storenode));
   assert(storenode->input(0)->origin() == a);
-  assert(jlm::rvsdg::is<jlm::rvsdg::ThetaOperation>(
-      jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*storenode->input(1)->origin())));
-  assert(jlm::rvsdg::is<jlm::rvsdg::ThetaOperation>(
-      jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*storenode->input(2)->origin())));
+  assert(jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::ThetaNode>(*storenode->input(1)->origin()));
+  assert(jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::ThetaNode>(*storenode->input(2)->origin()));
 }
 
 static int

--- a/tests/jlm/llvm/opt/test-unroll.cpp
+++ b/tests/jlm/llvm/opt/test-unroll.cpp
@@ -26,7 +26,7 @@ nthetas(jlm::rvsdg::Region * region)
   size_t n = 0;
   for (const auto & node : region->Nodes())
   {
-    if (jlm::rvsdg::is<jlm::rvsdg::ThetaOperation>(&node))
+    if (dynamic_cast<const jlm::rvsdg::ThetaNode *>(&node))
       n++;
   }
 
@@ -251,10 +251,10 @@ test_unknown_boundaries()
   loopunroll.Run(rm, statisticsCollector);
   //	jlm::rvsdg::view(graph, stdout);
 
-  auto node = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*ex1.origin());
-  assert(jlm::rvsdg::is<jlm::rvsdg::GammaOperation>(node));
-  node = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*node->input(1)->origin());
-  assert(jlm::rvsdg::is<jlm::rvsdg::GammaOperation>(node));
+  auto node = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::GammaNode>(*ex1.origin());
+  assert(node);
+  node = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::GammaNode>(*node->input(1)->origin());
+  assert(node);
 
   /* Create cleaner output */
   DeadNodeElimination dne;

--- a/tests/jlm/mlir/frontend/TestMlirToJlmConverter.cpp
+++ b/tests/jlm/mlir/frontend/TestMlirToJlmConverter.cpp
@@ -115,7 +115,7 @@ TestLambda()
       assert(region->nnodes() == 1);
       auto convertedLambda =
           jlm::util::AssertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
-      assert(is<jlm::llvm::LlvmLambdaOperation>(convertedLambda));
+      assert(is<jlm::llvm::LlvmLambdaOperation>(convertedLambda->GetOperation()));
 
       assert(convertedLambda->subregion()->nnodes() == 1);
       assert(is<jlm::llvm::IntegerConstantOperation>(
@@ -825,18 +825,15 @@ TestGammaOp()
       // Get the lambda block
       auto convertedLambda =
           jlm::util::AssertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
-      assert(is<jlm::llvm::LlvmLambdaOperation>(convertedLambda));
+      assert(is<jlm::llvm::LlvmLambdaOperation>(convertedLambda->GetOperation()));
 
       auto lambdaRegion = convertedLambda->subregion();
 
       // 2 constants + gamma
       assert(lambdaRegion->nnodes() == 3);
 
-      jlm::rvsdg::node_output * gammaOutput;
-      assert(
-          gammaOutput = dynamic_cast<jlm::rvsdg::node_output *>(lambdaRegion->result(0)->origin()));
-      Node * gammaNode = gammaOutput->node();
-      assert(is<GammaOperation>(gammaNode->GetOperation()));
+      auto gammaNode = &jlm::rvsdg::AssertGetOwnerNode<jlm::rvsdg::GammaNode>(
+          *lambdaRegion->result(0)->origin());
 
       std::cout << "Checking gamma operation" << std::endl;
       auto gammaOp = dynamic_cast<const GammaOperation *>(&gammaNode->GetOperation());
@@ -954,19 +951,15 @@ TestThetaOp()
       // Get the lambda block
       auto convertedLambda =
           jlm::util::AssertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
-      assert(is<jlm::llvm::LlvmLambdaOperation>(convertedLambda));
+      assert(is<jlm::llvm::LlvmLambdaOperation>(convertedLambda->GetOperation()));
 
       auto lambdaRegion = convertedLambda->subregion();
 
       // Just the theta node
       assert(lambdaRegion->nnodes() == 1);
 
-      jlm::rvsdg::node_output * thetaOutput;
-      assert(
-          thetaOutput = dynamic_cast<jlm::rvsdg::node_output *>(lambdaRegion->result(0)->origin()));
-      Node * node = thetaOutput->node();
-      assert(is<ThetaOperation>(node->GetOperation()));
-      auto thetaNode = dynamic_cast<const jlm::rvsdg::ThetaNode *>(node);
+      auto thetaNode = &jlm::rvsdg::AssertGetOwnerNode<jlm::rvsdg::ThetaNode>(
+          *lambdaRegion->result(0)->origin());
 
       std::cout << "Checking theta node" << std::endl;
       assert(thetaNode->ninputs() == 2);

--- a/tests/jlm/rvsdg/test-gamma.cpp
+++ b/tests/jlm/rvsdg/test-gamma.cpp
@@ -40,7 +40,7 @@ test_gamma()
   auto gamma2 =
       static_cast<StructuralNode *>(gamma)->copy(&graph.GetRootRegion(), { pred, v0, v1, v2 });
   view(&graph.GetRootRegion(), stdout);
-  assert(is<GammaOperation>(gamma2));
+  assert(dynamic_cast<const GammaNode *>(gamma2));
 
   /* test entry and exit variable iterators */
 


### PR DESCRIPTION
Ensure to consistently match on node type instead of operation for all structural nodes. This is a necessary prerequisite for reworking operations eventually.