### PR TITLE
Prefer TryGetOwnerNode instead of casting input / output types

### DIFF
--- a/jlm/hls/backend/rhls2firrtl/base-hls.cpp
+++ b/jlm/hls/backend/rhls2firrtl/base-hls.cpp
@@ -62,11 +62,11 @@ std::string
 BaseHLS::get_port_name(jlm::rvsdg::input * port)
 {
   std::string result;
-  if (dynamic_cast<const jlm::rvsdg::node_input *>(port))
+  if (jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*port))
   {
     result += "i";
   }
-  else if (dynamic_cast<const rvsdg::RegionResult *>(port))
+  else if (jlm::rvsdg::TryGetOwnerRegion(*port))
   {
     result += "r";
   }

--- a/jlm/hls/backend/rhls2firrtl/dot-hls.cpp
+++ b/jlm/hls/backend/rhls2firrtl/dot-hls.cpp
@@ -284,9 +284,9 @@ DotHLS::loop_to_dot(hls::loop_node * ln)
         // implement edge as back edge when it produces a cycle
         bool back = mx && !mx->discarding && mx->loop
                  && (/*i==0||*/ i == 2); // back_outputs.count(node->input(i)->origin());
-        auto origin_out = dynamic_cast<jlm::rvsdg::node_output *>(node->input(i)->origin());
-        if (origin_out
-            && dynamic_cast<const predicate_buffer_op *>(&origin_out->node()->GetOperation()))
+        auto origin_out_node = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(*node->input(i)->origin());
+        if (origin_out_node
+            && dynamic_cast<const predicate_buffer_op *>(&origin_out_node->GetOperation()))
         {
           //
           back = true;

--- a/jlm/hls/backend/rvsdg2rhls/add-buffers.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-buffers.cpp
@@ -29,9 +29,9 @@ add_buffers(rvsdg::Region * region, bool pass_through)
       {
         auto out = node->output(0);
         JLM_ASSERT(out->nusers() == 1);
-        if (auto ni = dynamic_cast<jlm::rvsdg::node_input *>(*out->begin()))
+        if (auto simpleNode = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(**out->begin()))
         {
-          auto buf = dynamic_cast<const hls::buffer_op *>(&ni->node()->GetOperation());
+          auto buf = dynamic_cast<const hls::buffer_op *>(&simpleNode->GetOperation());
           if (buf && (buf->pass_through || !pass_through))
           {
             continue;
@@ -58,9 +58,9 @@ add_buffers(rvsdg::Region * region, bool pass_through)
         {
           auto out = node->output(i);
           JLM_ASSERT(out->nusers() == 1);
-          if (auto ni = dynamic_cast<jlm::rvsdg::node_input *>(*out->begin()))
+          if (auto simpleNode = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(**out->begin()))
           {
-            auto buf = dynamic_cast<const hls::buffer_op *>(&ni->node()->GetOperation());
+            auto buf = dynamic_cast<const hls::buffer_op *>(&simpleNode->GetOperation());
             if (buf && (buf->pass_through || !pass_through))
             {
               continue;

--- a/jlm/hls/backend/rvsdg2rhls/alloca-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/alloca-conv.cpp
@@ -107,14 +107,12 @@ jlm::rvsdg::output *
 gep_to_index(jlm::rvsdg::output * o)
 {
   // TODO: handle geps that are not direct predecessors
-  auto no = dynamic_cast<jlm::rvsdg::node_output *>(o);
-  JLM_ASSERT(no);
-  auto gep = dynamic_cast<const jlm::llvm::GetElementPtrOperation *>(&no->node()->GetOperation());
-  JLM_ASSERT(gep);
+  auto & node = rvsdg::AssertGetOwnerNode<rvsdg::SimpleNode>(*o);
+  util::AssertedCast<const jlm::llvm::GetElementPtrOperation>(&node.GetOperation());
   // pointer to array, i.e. first index is zero
   // TODO: check
-  JLM_ASSERT(no->node()->ninputs() == 3);
-  return no->node()->input(2)->origin();
+  JLM_ASSERT(node.ninputs() == 3);
+  return node.input(2)->origin();
 }
 
 void

--- a/jlm/hls/backend/rvsdg2rhls/merge-gamma.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/merge-gamma.cpp
@@ -98,19 +98,19 @@ fix_match_inversion(rvsdg::GammaNode * old_gamma)
   {
     return false;
   }
-  if (auto no = dynamic_cast<rvsdg::node_output *>(old_gamma->predicate()->origin()))
+  if (auto pred_node = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(*old_gamma->predicate()->origin()))
   {
-    if (no->nusers() != 1)
+    if (old_gamma->predicate()->origin()->nusers() != 1)
     {
       return false;
     }
-    if (auto match = dynamic_cast<const rvsdg::match_op *>(&no->node()->GetOperation()))
+    if (auto match = dynamic_cast<const rvsdg::match_op *>(&pred_node->GetOperation()))
     {
       if (match->nalternatives() == 2)
       {
         uint64_t default_alternative = match->default_alternative() ? 0 : 1;
         auto new_match = rvsdg::match_op::Create(
-            *no->node()->input(0)->origin(),
+            *pred_node->input(0)->origin(),
             { { 0, match->alternative(1) }, { 1, match->alternative(0) } },
             default_alternative,
             match->nalternatives());
@@ -136,7 +136,7 @@ fix_match_inversion(rvsdg::GammaNode * old_gamma)
           oex.output->divert_users(nex);
         }
         remove(old_gamma);
-        remove(no->node());
+        remove(pred_node);
         return true;
       }
     }

--- a/jlm/hls/backend/rvsdg2rhls/rhls-dne.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rhls-dne.cpp
@@ -162,16 +162,17 @@ dead_nonspec_gamma(rvsdg::Node * ndmux_node)
   rvsdg::Node * origin_branch = nullptr;
   for (size_t i = 1; i < ndmux_node->ninputs(); ++i)
   {
-    if (auto no = dynamic_cast<jlm::rvsdg::node_output *>(ndmux_node->input(i)->origin()))
+    if (auto node = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(*ndmux_node->input(i)->origin()))
     {
-      if (dynamic_cast<const branch_op *>(&no->node()->GetOperation()) && no->nusers() == 1)
+      if (dynamic_cast<const branch_op *>(&node->GetOperation())
+          && ndmux_node->input(i)->origin()->nusers() == 1)
       {
         if (i == 1)
         {
-          origin_branch = no->node();
+          origin_branch = node;
           continue;
         }
-        else if (origin_branch == no->node())
+        else if (origin_branch == node)
         {
           continue;
         }
@@ -209,43 +210,45 @@ dead_loop(rvsdg::Node * ndmux_node)
   {
     return false;
   }
-  auto branch_in = dynamic_cast<jlm::rvsdg::node_input *>(*ndmux_node->output(0)->begin());
-  if (!branch_in || !dynamic_cast<const branch_op *>(&branch_in->node()->GetOperation()))
+  auto branch_in_node = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(**ndmux_node->output(0)->begin());
+  if (!branch_in_node || !dynamic_cast<const branch_op *>(&branch_in_node->GetOperation()))
   {
     return false;
   }
   // one buffer
-  if (branch_in->node()->output(1)->nusers() != 1)
+  if (branch_in_node->output(1)->nusers() != 1)
   {
     return false;
   }
-  auto buf_in = dynamic_cast<jlm::rvsdg::node_input *>(*branch_in->node()->output(1)->begin());
-  if (!buf_in || !dynamic_cast<const buffer_op *>(&buf_in->node()->GetOperation()))
+  auto buf_in_node =
+      rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(**branch_in_node->output(1)->begin());
+  if (!buf_in_node || !dynamic_cast<const buffer_op *>(&buf_in_node->GetOperation()))
   {
     return false;
   }
-  auto buf_out = buf_in->node()->output(0);
+  auto buf_out = buf_in_node->output(0);
   if (buf_out != backedge_arg->result()->origin())
   {
     // no connection back up
     return false;
   }
   // depend on same control
-  auto branch_cond_origin = branch_in->node()->input(0)->origin();
-  auto pred_buf_out = dynamic_cast<jlm::rvsdg::node_output *>(ndmux_node->input(0)->origin());
-  if (!pred_buf_out
-      || !dynamic_cast<const predicate_buffer_op *>(&pred_buf_out->node()->GetOperation()))
+  auto branch_cond_origin = branch_in_node->input(0)->origin();
+  auto pred_buf_out_node =
+      rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(*ndmux_node->input(0)->origin());
+  if (!pred_buf_out_node
+      || !dynamic_cast<const predicate_buffer_op *>(&pred_buf_out_node->GetOperation()))
   {
     return false;
   }
-  auto pred_buf_cond_origin = pred_buf_out->node()->input(0)->origin();
+  auto pred_buf_cond_origin = pred_buf_out_node->input(0)->origin();
   // TODO: remove this once predicate buffers decouple combinatorial loops
-  auto extra_buf_out = dynamic_cast<jlm::rvsdg::node_output *>(pred_buf_cond_origin);
-  if (!extra_buf_out || !dynamic_cast<const buffer_op *>(&extra_buf_out->node()->GetOperation()))
+  auto extra_buf_out_node = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(*pred_buf_cond_origin);
+  if (!extra_buf_out_node || !dynamic_cast<const buffer_op *>(&extra_buf_out_node->GetOperation()))
   {
     return false;
   }
-  auto extra_buf_cond_origin = extra_buf_out->node()->input(0)->origin();
+  auto extra_buf_cond_origin = extra_buf_out_node->input(0)->origin();
 
   if (auto pred_be = dynamic_cast<backedge_argument *>(extra_buf_cond_origin))
   {
@@ -256,10 +259,10 @@ dead_loop(rvsdg::Node * ndmux_node)
     return false;
   }
   // divert users
-  branch_in->node()->output(0)->divert_users(ndmux_node->input(1)->origin());
+  branch_in_node->output(0)->divert_users(ndmux_node->input(1)->origin());
   buf_out->divert_users(backedge_arg);
-  remove(buf_in->node());
-  remove(branch_in->node());
+  remove(buf_in_node);
+  remove(branch_in_node);
   auto region = ndmux_node->region();
   remove(ndmux_node);
   region->RemoveResult(backedge_arg->result()->index());

--- a/jlm/rvsdg/node.cpp
+++ b/jlm/rvsdg/node.cpp
@@ -61,8 +61,8 @@ input::divert_to(jlm::rvsdg::output * new_origin)
   this->origin_ = new_origin;
   new_origin->add_user(this);
 
-  if (is<node_input>(*this))
-    static_cast<node_input *>(this)->node()->recompute_depth();
+  if (auto node = TryGetOwnerNode<Node>(*this))
+    node->recompute_depth();
 
   on_input_change(this, old_origin, new_origin);
 }
@@ -270,11 +270,10 @@ Node::recompute_depth() noexcept
   {
     for (auto user : *(output(n)))
     {
-      if (!is<node_input>(*user))
-        continue;
-
-      auto node = static_cast<node_input *>(user)->node();
-      node->recompute_depth();
+      if (auto node = TryGetOwnerNode<Node>(*user))
+      {
+        node->recompute_depth();
+      }
     }
   }
 }

--- a/jlm/rvsdg/traverser.cpp
+++ b/jlm/rvsdg/traverser.cpp
@@ -29,14 +29,13 @@ TopDownTraverser::TopDownTraverser(Region * region)
     auto argument = region->argument(n);
     for (const auto & user : *argument)
     {
-      if (!is<node_input>(*user))
-        continue;
+      if (auto node = TryGetOwnerNode<Node>(*user))
+      {
+        if (!predecessors_visited(node))
+          continue;
 
-      auto node = static_cast<node_input *>(user)->node();
-      if (!predecessors_visited(node))
-        continue;
-
-      tracker_.set_nodestate(node, traversal_nodestate::frontier);
+        tracker_.set_nodestate(node, traversal_nodestate::frontier);
+      }
     }
   }
 
@@ -73,12 +72,11 @@ TopDownTraverser::next()
   {
     for (const auto & user : *node->output(n))
     {
-      if (!is<node_input>(*user))
-        continue;
-
-      auto node = static_cast<node_input *>(user)->node();
-      if (tracker_.get_nodestate(node) == traversal_nodestate::ahead)
-        tracker_.set_nodestate(node, traversal_nodestate::frontier);
+      if (auto node = TryGetOwnerNode<Node>(*user))
+      {
+        if (tracker_.get_nodestate(node) == traversal_nodestate::ahead)
+          tracker_.set_nodestate(node, traversal_nodestate::frontier);
+      }
     }
   }
 
@@ -100,10 +98,13 @@ TopDownTraverser::node_create(Node * node)
 void
 TopDownTraverser::input_change(input * in, output *, output *)
 {
-  if (in->region() != region() || !is<node_input>(*in))
+  if (in->region() != region())
     return;
 
-  auto node = static_cast<node_input *>(in)->node();
+  auto node = TryGetOwnerNode<Node>(*in);
+  if (!node)
+    return;
+
   auto state = tracker_.get_nodestate(node);
 
   /* ignore nodes that have been traversed already, or that are already
@@ -188,10 +189,16 @@ BottomUpTraverser::node_destroy(Node * node)
 void
 BottomUpTraverser::input_change(input * in, output * old_origin, output *)
 {
-  if (in->region() != region() || !is<node_input>(*in) || !is<node_output>(old_origin))
+  if (in->region() != region())
+    return;
+
+  if (!TryGetOwnerNode<Node>(*in))
     return;
 
   auto node = TryGetOwnerNode<Node>(*old_origin);
+  if (!node)
+    return;
+
   traversal_nodestate state = tracker_.get_nodestate(node);
 
   /* ignore nodes that have been traversed already, or that are already

--- a/tests/jlm/hls/backend/rvsdg2rhls/MemoryQueueTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/MemoryQueueTests.cpp
@@ -66,7 +66,7 @@ TestSingleLoad()
   jlm::util::AssertedCast<const LambdaEntryMemoryStateSplitOperation>(
       &entryMemoryStateSplitNode->GetOperation());
   auto exitMemoryStateMergeNode =
-      jlm::util::AssertedCast<jlm::rvsdg::node_output>(lambdaRegion->result(1)->origin())->node();
+      jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*lambdaRegion->result(1)->origin());
   jlm::util::AssertedCast<const LambdaExitMemoryStateMergeOperation>(
       &exitMemoryStateMergeNode->GetOperation());
 
@@ -148,7 +148,7 @@ TestLoadStore()
   jlm::util::AssertedCast<const LambdaEntryMemoryStateSplitOperation>(
       &entryMemoryStateSplitNode->GetOperation());
   auto exitMemoryStateMergeNode =
-      jlm::util::AssertedCast<jlm::rvsdg::node_output>(lambdaRegion->result(1)->origin())->node();
+      jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*lambdaRegion->result(1)->origin());
   jlm::util::AssertedCast<const LambdaExitMemoryStateMergeOperation>(
       &exitMemoryStateMergeNode->GetOperation());
 
@@ -224,7 +224,7 @@ TestAddrQueue()
   jlm::util::AssertedCast<const LambdaEntryMemoryStateSplitOperation>(
       &entryMemoryStateSplitNode->GetOperation());
   auto exitMemoryStateMergeNode =
-      jlm::util::AssertedCast<jlm::rvsdg::node_output>(lambdaRegion->result(1)->origin())->node();
+      jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*lambdaRegion->result(1)->origin());
   jlm::util::AssertedCast<const LambdaExitMemoryStateMergeOperation>(
       &exitMemoryStateMergeNode->GetOperation());
 
@@ -250,15 +250,13 @@ TestAddrQueue()
         if (is<StoreNonVolatileOperation>(node))
         {
           auto loadNode =
-              jlm::util::AssertedCast<jlm::rvsdg::node_output>(node->input(1)->origin())->node();
+              jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*node->input(1)->origin());
           jlm::util::AssertedCast<const LoadOperation>(&loadNode->GetOperation());
           auto stateGate =
-              jlm::util::AssertedCast<jlm::rvsdg::node_output>(loadNode->input(0)->origin())
-                  ->node();
+              jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*loadNode->input(0)->origin());
           jlm::util::AssertedCast<const state_gate_op>(&stateGate->GetOperation());
           auto addrQueue =
-              jlm::util::AssertedCast<jlm::rvsdg::node_output>(stateGate->input(0)->origin())
-                  ->node();
+              jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*stateGate->input(0)->origin());
           jlm::util::AssertedCast<const addr_queue_op>(&addrQueue->GetOperation());
           return 0;
         }

--- a/tests/jlm/hls/backend/rvsdg2rhls/TestFork.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/TestFork.cpp
@@ -63,11 +63,9 @@ TestFork()
     assert(dynamic_cast<const hls::loop_node *>(loop));
 
     // Traverse the rvsgd graph upwards to check connections
-    rvsdg::node_output * forkNodeOutput;
-    assert(
-        forkNodeOutput =
-            dynamic_cast<rvsdg::node_output *>(loop->subregion()->result(0)->origin()));
-    auto forkNode = forkNodeOutput->node();
+    auto forkNode =
+        jlm::rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(*loop->subregion()->result(0)->origin());
+    assert(forkNode);
     auto forkOp = util::AssertedCast<const hls::fork_op>(&forkNode->GetOperation());
     assert(forkNode->ninputs() == 1);
     assert(forkNode->noutputs() == 4);
@@ -130,21 +128,16 @@ TestConstantFork()
     auto loop = util::AssertedCast<hls::loop_node>(loopNode);
 
     // Traverse the rvsgd graph upwards to check connections
-    rvsdg::node_output * forkNodeOutput;
-    assert(
-        forkNodeOutput =
-            dynamic_cast<rvsdg::node_output *>(loop->subregion()->result(0)->origin()));
-    auto forkNode = forkNodeOutput->node();
+    auto forkNode =
+        rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(*loop->subregion()->result(0)->origin());
+    assert(forkNode);
     auto forkOp = util::AssertedCast<const hls::fork_op>(&forkNode->GetOperation());
     assert(forkNode->ninputs() == 1);
     assert(forkNode->noutputs() == 2);
     assert(forkOp->IsConstant() == false);
-    auto matchNodeOutput = dynamic_cast<rvsdg::node_output *>(forkNode->input(0)->origin());
-    auto matchNode = matchNodeOutput->node();
-    auto bitsUltNodeOutput = dynamic_cast<rvsdg::node_output *>(matchNode->input(0)->origin());
-    auto bitsUltNode = bitsUltNodeOutput->node();
-    auto cforkNodeOutput = dynamic_cast<rvsdg::node_output *>(bitsUltNode->input(1)->origin());
-    auto cforkNode = cforkNodeOutput->node();
+    auto matchNode = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(*forkNode->input(0)->origin());
+    auto bitsUltNode = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(*matchNode->input(0)->origin());
+    auto cforkNode = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(*bitsUltNode->input(1)->origin());
     auto cforkOp = util::AssertedCast<const hls::fork_op>(&cforkNode->GetOperation());
     assert(cforkNode->ninputs() == 1);
     assert(cforkNode->noutputs() == 2);

--- a/tests/jlm/mlir/frontend/TestMlirToJlmConverter.cpp
+++ b/tests/jlm/mlir/frontend/TestMlirToJlmConverter.cpp
@@ -290,11 +290,9 @@ TestDivOperation()
       assert(std::dynamic_pointer_cast<const bittype>(DivInput0->Type())->nbits() == 32);
 
       // Check second input
-      jlm::rvsdg::node_output * DivInput1NodeOuput;
-      assert(
-          DivInput1NodeOuput =
-              dynamic_cast<jlm::rvsdg::node_output *>(lambdaResultOriginNode->input(1)->origin()));
-      Node * DivInput1Node = DivInput1NodeOuput->node();
+      auto DivInput1Node = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(
+          *lambdaResultOriginNode->input(1)->origin());
+      assert(DivInput1Node);
       assert(is<jlm::llvm::IntegerConstantOperation>(DivInput1Node->GetOperation()));
       auto DivInput1Constant =
           dynamic_cast<const jlm::llvm::IntegerConstantOperation *>(&DivInput1Node->GetOperation());
@@ -450,11 +448,9 @@ TestCompZeroExt()
 
       // Traverse the rvsgd graph upwards to check connections
       std::cout << "Testing lambdaResultOriginNodeOuput\n";
-      jlm::rvsdg::node_output * lambdaResultOriginNodeOuput;
-      assert(
-          lambdaResultOriginNodeOuput = dynamic_cast<jlm::rvsdg::node_output *>(
-              convertedLambda->subregion()->result(0)->origin()));
-      Node * ZExtNode = lambdaResultOriginNodeOuput->node();
+      auto ZExtNode = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(
+          *convertedLambda->subregion()->result(0)->origin());
+      assert(ZExtNode);
       assert(is<jlm::llvm::ZExtOperation>(ZExtNode->GetOperation()));
       assert(ZExtNode->ninputs() == 1);
 
@@ -465,9 +461,8 @@ TestCompZeroExt()
 
       // Check ZExt input
       std::cout << "Testing input 0\n";
-      jlm::rvsdg::node_output * ZExtInput0;
-      assert(ZExtInput0 = dynamic_cast<jlm::rvsdg::node_output *>(ZExtNode->input(0)->origin()));
-      Node * BitEqNode = ZExtInput0->node();
+      auto BitEqNode =
+          jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*ZExtNode->input(0)->origin());
       assert(is<jlm::llvm::IntegerEqOperation>(BitEqNode->GetOperation()));
 
       // Check BitEq
@@ -479,16 +474,14 @@ TestCompZeroExt()
       assert(BitEqNode->ninputs() == 2);
 
       // Check BitEq input 0
-      jlm::rvsdg::node_output * AddOuput;
-      assert(AddOuput = dynamic_cast<jlm::rvsdg::node_output *>(BitEqNode->input(0)->origin()));
-      Node * AddNode = AddOuput->node();
+      auto AddNode =
+          jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*BitEqNode->input(0)->origin());
       assert(is<jlm::llvm::IntegerAddOperation>(AddNode->GetOperation()));
       assert(AddNode->ninputs() == 2);
 
       // Check BitEq input 1
-      jlm::rvsdg::node_output * Const2Ouput;
-      assert(Const2Ouput = dynamic_cast<jlm::rvsdg::node_output *>(BitEqNode->input(1)->origin()));
-      Node * Const2Node = Const2Ouput->node();
+      auto Const2Node =
+          jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*BitEqNode->input(1)->origin());
       assert(is<jlm::llvm::IntegerConstantOperation>(Const2Node->GetOperation()));
 
       // Check Const2
@@ -509,9 +502,8 @@ TestCompZeroExt()
       assert(std::dynamic_pointer_cast<const bittype>(AddInput0->Type())->nbits() == 32);
 
       // Check add input1
-      jlm::rvsdg::node_output * Const1Output;
-      assert(Const1Output = dynamic_cast<jlm::rvsdg::node_output *>(AddNode->input(1)->origin()));
-      Node * Const1Node = Const1Output->node();
+      auto Const1Node =
+          jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*AddNode->input(1)->origin());
       assert(is<jlm::llvm::IntegerConstantOperation>(Const1Node->GetOperation()));
 
       // Check Const1
@@ -658,10 +650,8 @@ TestMatchOp()
 
       auto lambdaRegion = convertedLambda->subregion();
 
-      jlm::rvsdg::node_output * matchOutput;
-      assert(
-          matchOutput = dynamic_cast<jlm::rvsdg::node_output *>(lambdaRegion->result(0)->origin()));
-      Node * matchNode = matchOutput->node();
+      auto matchNode =
+          jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*lambdaRegion->result(0)->origin());
       assert(is<match_op>(matchNode->GetOperation()));
 
       auto matchOp = dynamic_cast<const match_op *>(&matchNode->GetOperation());

--- a/tests/jlm/rvsdg/bitstring/bitstring.cpp
+++ b/tests/jlm/rvsdg/bitstring/bitstring.cpp
@@ -1351,21 +1351,21 @@ SliceOfConcatReduction()
   view(&graph.GetRootRegion(), stdout);
 
   // Assert
-  const auto node = TryGetOwnerNode<Node>(*ex.origin());
-  const auto o0 = dynamic_cast<node_output *>(node->input(0)->origin());
-  const auto o1 = dynamic_cast<node_output *>(node->input(1)->origin());
+  const auto node = TryGetOwnerNode<SimpleNode>(*ex.origin());
+  const auto o0_node = TryGetOwnerNode<SimpleNode>(*node->input(0)->origin());
+  const auto o1_node = TryGetOwnerNode<SimpleNode>(*node->input(1)->origin());
   assert(dynamic_cast<const bitconcat_op *>(&node->GetOperation()));
   assert(node->ninputs() == 2);
-  assert(dynamic_cast<const bitslice_op *>(&o0->node()->GetOperation()));
-  assert(dynamic_cast<const bitslice_op *>(&o1->node()->GetOperation()));
+  assert(dynamic_cast<const bitslice_op *>(&o0_node->GetOperation()));
+  assert(dynamic_cast<const bitslice_op *>(&o1_node->GetOperation()));
 
-  auto attrs = dynamic_cast<const bitslice_op *>(&o0->node()->GetOperation());
+  auto attrs = dynamic_cast<const bitslice_op *>(&o0_node->GetOperation());
   assert((attrs->low() == 8) && (attrs->high() == 16));
-  attrs = dynamic_cast<const bitslice_op *>(&o1->node()->GetOperation());
+  attrs = dynamic_cast<const bitslice_op *>(&o1_node->GetOperation());
   assert((attrs->low() == 0) && (attrs->high() == 8));
 
-  assert(o0->node()->input(0)->origin() == x);
-  assert(o1->node()->input(0)->origin() == y);
+  assert(o0_node->input(0)->origin() == x);
+  assert(o1_node->input(0)->origin() == y);
 
   return 0;
 }


### PR DESCRIPTION
Some places in code still cast input / output to node_input / node_output in order to determine ownership. Replace this with the TryGetOwnerNode API.