### PR TITLE
Add TryGetSimpleNodeAndOp() methods

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/decouple-mem-state.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/decouple-mem-state.cpp
@@ -3,7 +3,6 @@
  * See COPYING for terms of redistribution.
  */
 
-#include "../../../rvsdg/simple-node.hpp"
 #include <jlm/hls/backend/rvsdg2rhls/decouple-mem-state.hpp>
 #include <jlm/hls/backend/rvsdg2rhls/hls-function-util.hpp>
 #include <jlm/hls/backend/rvsdg2rhls/mem-conv.hpp>

--- a/jlm/hls/backend/rvsdg2rhls/hls-function-util.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/hls-function-util.hpp
@@ -48,35 +48,6 @@ trace_call_rhls(const rvsdg::output * output);
 std::string
 get_function_name(jlm::rvsdg::input * input);
 
-// this might already exist somewhere
-template<typename OpType>
-inline const OpType *
-TryGetOwnerOp(const rvsdg::input & input) noexcept
-{
-  if (const auto node = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(input))
-  {
-    return dynamic_cast<const OpType *>(&node->GetOperation());
-  }
-  else
-  {
-    return nullptr;
-  }
-}
-
-template<typename OpType>
-inline const OpType *
-TryGetOwnerOp(const rvsdg::output & output) noexcept
-{
-  if (const auto node = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(output))
-  {
-    return dynamic_cast<const OpType *>(&node->GetOperation());
-  }
-  else
-  {
-    return nullptr;
-  }
-}
-
 bool
 is_dec_req(rvsdg::SimpleNode * node);
 

--- a/jlm/rvsdg/simple-node.hpp
+++ b/jlm/rvsdg/simple-node.hpp
@@ -217,6 +217,82 @@ CreateOpNode(Region & region, OperatorArguments... operatorArguments)
       {});
 }
 
+/**
+ * \brief Checks if this is an input to a \ref SimpleNode and of specified operation type.
+ *
+ * \tparam TOperation
+ *   The operation type to be matched against.
+ *
+ * \param input
+ *   Input to be checked.
+ *
+ * \returns
+ *   A pair of the owning simple node and requested operation. If the owner of \p input is not a
+ *   \ref SimpleNode, then <nullptr, nullptr> is returned. If the owner of \p input is a \ref
+ * SimpleNode but not of the correct operation type, then <SimpleNode*, nullptr> are returned.
+ * Otherwise, <SimpleNode*, TOperation*> are returned.
+ *
+ * Checks if the specified input belongs to a \ref SimpleNode of requested operation type.
+ * If this is the case, returns a pair of pointers to the node and operation of matched type.
+ *
+ * See \ref def_use_inspection.
+ */
+template<typename TOperation>
+std::pair<SimpleNode *, const TOperation *>
+TryGetSimpleNodeAndOp(const rvsdg::input & input) noexcept
+{
+  const auto simpleNode = TryGetOwnerNode<SimpleNode>(input);
+  if (!simpleNode)
+  {
+    return std::make_pair(nullptr, nullptr);
+  }
+
+  if (auto operation = dynamic_cast<const TOperation *>(simpleNode->GetOperation()))
+  {
+    return std::make_pair(simpleNode, operation);
+  }
+
+  return std::make_pair(simpleNode, nullptr);
+}
+
+/**
+ * \brief Checks if this is an output to a \ref SimpleNode and of specified operation type.
+ *
+ * \tparam TOperation
+ *   The operation type to be matched against.
+ *
+ * \param output
+ *   Output to be checked.
+ *
+ * \returns
+ *   A pair of the owning simple node and requested operation. If the owner of \p output is not a
+ *   \ref SimpleNode, then <nullptr, nullptr> is returned. If the owner of \p output is a \ref
+ *   SimpleNode but not of the correct operation type, then <SimpleNode*, nullptr> are returned.
+ *   Otherwise, <SimpleNode*, TOperation*> are returned.
+ *
+ * Checks if the specified output belongs to a \ref SimpleNode of requested operation type.
+ * If this is the case, returns a pair of pointers to the node and operation of matched type.
+ *
+ * See \ref def_use_inspection.
+ */
+template<typename TOperation>
+std::pair<SimpleNode *, const TOperation *>
+TryGetSimpleNodeAndOp(const rvsdg::output & output) noexcept
+{
+  const auto simpleNode = TryGetOwnerNode<SimpleNode>(output);
+  if (!simpleNode)
+  {
+    return std::make_pair(nullptr, nullptr);
+  }
+
+  if (auto operation = dynamic_cast<const TOperation *>(&simpleNode->GetOperation()))
+  {
+    return std::make_pair(simpleNode, operation);
+  }
+
+  return std::make_pair(simpleNode, nullptr);
+}
+
 }
 
 #endif

--- a/jlm/rvsdg/simple-node.hpp
+++ b/jlm/rvsdg/simple-node.hpp
@@ -247,7 +247,7 @@ TryGetSimpleNodeAndOp(const rvsdg::input & input) noexcept
     return std::make_pair(nullptr, nullptr);
   }
 
-  if (auto operation = dynamic_cast<const TOperation *>(simpleNode->GetOperation()))
+  if (auto operation = dynamic_cast<const TOperation *>(&simpleNode->GetOperation()))
   {
     return std::make_pair(simpleNode, operation);
   }


### PR DESCRIPTION
A lot of transformation in the code simply have to check whether the owners of inputs/outputs are SimpleNode of a specific operation type. Those methods simplify these checks.