### PR TITLE
Separate SimpleOperation / StructuralOperation

### DIFF
--- a/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.cpp
+++ b/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.cpp
@@ -1153,10 +1153,10 @@ RhlsToFirrtlConverter::MlirGenHlsLocalMem(const jlm::rvsdg::SimpleNode * node)
 {
   auto lmem_op = dynamic_cast<const local_mem_op *>(&(node->GetOperation()));
   JLM_ASSERT(lmem_op);
-  auto res_node = rvsdg::TryGetOwnerNode<rvsdg::Node>(**node->output(0)->begin());
+  auto res_node = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(**node->output(0)->begin());
   auto res_op = dynamic_cast<const local_mem_resp_op *>(&res_node->GetOperation());
   JLM_ASSERT(res_op);
-  auto req_node = rvsdg::TryGetOwnerNode<rvsdg::Node>(**node->output(1)->begin());
+  auto req_node = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(**node->output(1)->begin());
   auto req_op = dynamic_cast<const local_mem_req_op *>(&req_node->GetOperation());
   JLM_ASSERT(req_op);
   // Create the module and its input/output ports - we use a non-standard way here
@@ -2788,8 +2788,8 @@ RhlsToFirrtlConverter::createInstances(
   {
     if (auto sn = dynamic_cast<jlm::rvsdg::SimpleNode *>(node))
     {
-      if (dynamic_cast<const local_mem_req_op *>(&(node->GetOperation()))
-          || dynamic_cast<const local_mem_resp_op *>(&(node->GetOperation())))
+      if (dynamic_cast<const local_mem_req_op *>(&(sn->GetOperation()))
+          || dynamic_cast<const local_mem_resp_op *>(&(sn->GetOperation())))
       {
         // these are virtual - connections go to local_mem instead
         continue;
@@ -3993,7 +3993,7 @@ RhlsToFirrtlConverter::GetFirrtlType(const jlm::rvsdg::Type * type)
 }
 
 std::string
-RhlsToFirrtlConverter::GetModuleName(const rvsdg::Node * node)
+RhlsToFirrtlConverter::GetModuleName(const rvsdg::SimpleNode * node)
 {
 
   std::string append = "";
@@ -4085,7 +4085,7 @@ RhlsToFirrtlConverter::IsIdentityMapping(const jlm::rvsdg::match_op & op)
 void
 RhlsToFirrtlConverter::WriteModuleToFile(
     const circt::firrtl::FModuleOp fModuleOp,
-    const rvsdg::Node * node)
+    const rvsdg::SimpleNode * node)
 {
   if (!fModuleOp)
     return;

--- a/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.hpp
+++ b/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.hpp
@@ -68,7 +68,7 @@ public:
   MlirGen(const rvsdg::LambdaNode * lamdaNode);
 
   void
-  WriteModuleToFile(const circt::firrtl::FModuleOp fModuleOp, const rvsdg::Node * node);
+  WriteModuleToFile(const circt::firrtl::FModuleOp fModuleOp, const rvsdg::SimpleNode * node);
 
   void
   WriteCircuitToFile(const circt::firrtl::CircuitOp circuit, std::string name);
@@ -283,7 +283,7 @@ private:
   circt::firrtl::FIRRTLBaseType
   GetFirrtlType(const jlm::rvsdg::Type * type);
   std::string
-  GetModuleName(const rvsdg::Node * node);
+  GetModuleName(const rvsdg::SimpleNode * node);
   bool
   IsIdentityMapping(const jlm::rvsdg::match_op & op);
 

--- a/jlm/hls/backend/rhls2firrtl/dot-hls.cpp
+++ b/jlm/hls/backend/rhls2firrtl/dot-hls.cpp
@@ -248,8 +248,10 @@ DotHLS::loop_to_dot(hls::loop_node * ln)
   dot << "{rank=same ";
   for (auto node : rvsdg::TopDownTraverser(sr))
   {
-    auto mx = dynamic_cast<const hls::mux_op *>(&node->GetOperation());
-    auto lc = dynamic_cast<const hls::loop_constant_buffer_op *>(&node->GetOperation());
+    auto simpleNode = dynamic_cast<const rvsdg::SimpleNode *>(node);
+    auto mx = dynamic_cast<const hls::mux_op *>(simpleNode ? &simpleNode->GetOperation() : nullptr);
+    auto lc = dynamic_cast<const hls::loop_constant_buffer_op *>(
+        simpleNode ? &simpleNode->GetOperation() : nullptr);
     if ((mx && !mx->discarding && mx->loop) || lc)
     {
       dot << get_node_name(node) << " ";
@@ -260,7 +262,9 @@ DotHLS::loop_to_dot(hls::loop_node * ln)
   dot << "{rank=same ";
   for (auto node : rvsdg::TopDownTraverser(sr))
   {
-    auto br = dynamic_cast<const hls::branch_op *>(&node->GetOperation());
+    auto simpleNode = dynamic_cast<const rvsdg::SimpleNode *>(node);
+    auto br =
+        dynamic_cast<const hls::branch_op *>(simpleNode ? &simpleNode->GetOperation() : nullptr);
     if (br && br->loop)
     {
       dot << get_node_name(node) << " ";
@@ -272,9 +276,9 @@ DotHLS::loop_to_dot(hls::loop_node * ln)
   // do edges outside in order not to pull other nodes into the cluster
   for (auto node : rvsdg::TopDownTraverser(sr))
   {
-    if (dynamic_cast<jlm::rvsdg::SimpleNode *>(node))
+    if (auto simpleNode = dynamic_cast<jlm::rvsdg::SimpleNode *>(node))
     {
-      auto mx = dynamic_cast<const hls::mux_op *>(&node->GetOperation());
+      auto mx = dynamic_cast<const hls::mux_op *>(&simpleNode->GetOperation());
       auto node_name = get_node_name(node);
       for (size_t i = 0; i < node->ninputs(); ++i)
       {

--- a/jlm/hls/backend/rvsdg2rhls/mem-queue.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-queue.cpp
@@ -507,7 +507,7 @@ jlm::hls::mem_queue(jlm::rvsdg::Region * region)
   // Check if there exists a memory state splitter
   if (state_arg->nusers() == 1)
   {
-    auto entryNode = rvsdg::TryGetOwnerNode<rvsdg::Node>(**state_arg->begin());
+    auto entryNode = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(**state_arg->begin());
     if (jlm::rvsdg::is<const jlm::llvm::LambdaEntryMemoryStateSplitOperation>(
             entryNode->GetOperation()))
     {

--- a/jlm/hls/backend/rvsdg2rhls/remove-redundant-buf.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/remove-redundant-buf.cpp
@@ -58,9 +58,9 @@ remove_redundant_buf(rvsdg::Region * region)
         remove_redundant_buf(structnode->subregion(n));
       }
     }
-    else if (dynamic_cast<jlm::rvsdg::SimpleNode *>(node))
+    else if (auto simplenode = dynamic_cast<jlm::rvsdg::SimpleNode *>(node))
     {
-      if (auto buf = dynamic_cast<const buffer_op *>(&node->GetOperation()))
+      if (auto buf = dynamic_cast<const buffer_op *>(&simplenode->GetOperation()))
       {
         if (std::dynamic_pointer_cast<const jlm::llvm::MemoryStateType>(buf->argument(0)))
         {

--- a/jlm/hls/ir/hls.cpp
+++ b/jlm/hls/ir/hls.cpp
@@ -95,7 +95,7 @@ loop_node::AddLoopVar(jlm::rvsdg::output * origin, jlm::rvsdg::output ** buffer)
   return output;
 }
 
-[[nodiscard]] const rvsdg::Operation &
+[[nodiscard]] const rvsdg::StructuralOperation &
 loop_node::GetOperation() const noexcept
 {
   static const loop_op singleton;

--- a/jlm/hls/ir/hls.hpp
+++ b/jlm/hls/ir/hls.hpp
@@ -755,7 +755,7 @@ private:
   jlm::rvsdg::node_output * _predicate_buffer;
 
 public:
-  [[nodiscard]] const rvsdg::Operation &
+  [[nodiscard]] const rvsdg::StructuralOperation &
   GetOperation() const noexcept override;
 
   static loop_node *

--- a/jlm/hls/opt/IOBarrierRemoval.cpp
+++ b/jlm/hls/opt/IOBarrierRemoval.cpp
@@ -7,6 +7,7 @@
 #include <jlm/llvm/ir/operators/IOBarrier.hpp>
 #include <jlm/rvsdg/region.hpp>
 #include <jlm/rvsdg/RvsdgModule.hpp>
+#include <jlm/rvsdg/simple-node.hpp>
 #include <jlm/rvsdg/structural-node.hpp>
 
 namespace jlm::hls
@@ -33,11 +34,13 @@ IOBarrierRemoval::RemoveIOBarrierFromRegion(rvsdg::Region & region)
         RemoveIOBarrierFromRegion(*structuralNode->subregion(n));
       }
     }
-
-    // Render all IOBarrier nodes dead
-    if (rvsdg::is<llvm::IOBarrierOperation>(&node))
+    else if (auto simpleNode = dynamic_cast<const rvsdg::SimpleNode *>(&node))
     {
-      node.output(0)->divert_users(node.input(0)->origin());
+      // Render all IOBarrier nodes dead
+      if (rvsdg::is<llvm::IOBarrierOperation>(simpleNode))
+      {
+        node.output(0)->divert_users(node.input(0)->origin());
+      }
     }
   }
 

--- a/jlm/llvm/backend/RvsdgToIpGraphConverter.cpp
+++ b/jlm/llvm/backend/RvsdgToIpGraphConverter.cpp
@@ -162,7 +162,7 @@ RvsdgToIpGraphConverter::CreateInitialization(const delta::node & deltaNode)
       operands.push_back(Context_->GetVariable(node->input(n)->origin()));
 
     // convert node to tac
-    auto & op = *static_cast<const rvsdg::SimpleOperation *>(&node->GetOperation());
+    auto & op = util::AssertedCast<rvsdg::SimpleNode>(node)->GetOperation();
     tacs.push_back(tac::create(op, operands));
     Context_->InsertVariable(output, tacs.back()->result(0));
   }

--- a/jlm/llvm/ir/operators/operators.cpp
+++ b/jlm/llvm/ir/operators/operators.cpp
@@ -408,7 +408,8 @@ ZExtOperation::reduce_operand(rvsdg::unop_reduction_path_t path, rvsdg::output *
 {
   if (path == rvsdg::unop_reduction_constant)
   {
-    auto c = static_cast<const rvsdg::bitconstant_op *>(&producer(operand)->GetOperation());
+    auto c = util::AssertedCast<const rvsdg::bitconstant_op>(
+        &util::AssertedCast<rvsdg::SimpleNode>(producer(operand))->GetOperation());
     return create_bitconstant(
         rvsdg::TryGetOwnerNode<rvsdg::Node>(*operand)->region(),
         c->value().zext(ndstbits() - nsrcbits()));

--- a/jlm/llvm/ir/operators/sext.cpp
+++ b/jlm/llvm/ir/operators/sext.cpp
@@ -118,7 +118,8 @@ sext_op::reduce_operand(rvsdg::unop_reduction_path_t path, rvsdg::output * opera
 {
   if (path == rvsdg::unop_reduction_constant)
   {
-    auto c = static_cast<const rvsdg::bitconstant_op *>(&producer(operand)->GetOperation());
+    auto c = util::AssertedCast<const rvsdg::bitconstant_op>(
+        &util::AssertedCast<rvsdg::SimpleNode>(producer(operand))->GetOperation());
     return create_bitconstant(operand->region(), c->value().sext(ndstbits() - nsrcbits()));
   }
 

--- a/jlm/llvm/opt/InvariantValueRedirection.cpp
+++ b/jlm/llvm/opt/InvariantValueRedirection.cpp
@@ -86,11 +86,17 @@ InvariantValueRedirection::RedirectInRootRegion(rvsdg::Graph & rvsdg)
       // Nothing needs to be done.
       // Delta nodes are irrelevant for invariant value redirection.
     }
-    else if (
-        is<FunctionToPointerOperation>(node->GetOperation())
-        || is<PointerToFunctionOperation>(node->GetOperation()))
+    else if (auto simpleNode = dynamic_cast<const rvsdg::SimpleNode *>(node))
     {
-      // Nothing needs to be done.
+      if (is<FunctionToPointerOperation>(simpleNode->GetOperation())
+          || is<PointerToFunctionOperation>(simpleNode->GetOperation()))
+      {
+        // Nothing needs to be done.
+      }
+      else
+      {
+        JLM_UNREACHABLE("Unhandled node type.");
+      }
     }
     else
     {
@@ -125,9 +131,12 @@ InvariantValueRedirection::RedirectInRegion(rvsdg::Region & region)
       RedirectInSubregions(*thetaNode);
       RedirectThetaOutputs(*thetaNode);
     }
-    else if (is<CallOperation>(&node))
+    else if (auto simpleNode = dynamic_cast<rvsdg::SimpleNode *>(&node))
     {
-      RedirectCallOutputs(*util::AssertedCast<rvsdg::SimpleNode>(&node));
+      if (is<CallOperation>(simpleNode))
+      {
+        RedirectCallOutputs(*util::AssertedCast<rvsdg::SimpleNode>(&node));
+      }
     }
   }
 }

--- a/jlm/llvm/opt/alias-analyses/TopDownModRefEliminator.cpp
+++ b/jlm/llvm/opt/alias-analyses/TopDownModRefEliminator.cpp
@@ -504,11 +504,18 @@ TopDownModRefEliminator::EliminateTopDownRootRegion(rvsdg::Region & region)
     {
       // Nothing needs to be done.
     }
-    else if (
-        is<FunctionToPointerOperation>(node->GetOperation())
-        || is<PointerToFunctionOperation>(node->GetOperation()))
+    else if (auto simpleNode = dynamic_cast<const rvsdg::SimpleNode *>(node))
     {
-      // Nothing needs to be done.
+      if (is<FunctionToPointerOperation>(simpleNode->GetOperation())
+          || is<PointerToFunctionOperation>(simpleNode->GetOperation()))
+
+      {
+        // Nothing needs to be done.
+      }
+      else
+      {
+        JLM_UNREACHABLE("Unhandled node type!");
+      }
     }
     else
     {

--- a/jlm/llvm/opt/push.cpp
+++ b/jlm/llvm/opt/push.cpp
@@ -322,7 +322,7 @@ is_movable_store(rvsdg::Node * node)
 }
 
 static void
-pushout_store(rvsdg::Node * storenode)
+pushout_store(rvsdg::SimpleNode * storenode)
 {
   JLM_ASSERT(dynamic_cast<const rvsdg::ThetaNode *>(storenode->region()->node()));
   JLM_ASSERT(jlm::rvsdg::is<StoreNonVolatileOperation>(storenode) && is_movable_store(storenode));

--- a/jlm/llvm/opt/reduction.cpp
+++ b/jlm/llvm/opt/reduction.cpp
@@ -84,9 +84,9 @@ NodeReduction::ReduceNodesInRegion(rvsdg::Region & region)
       {
         reductionPerformed |= ReduceStructuralNode(*structuralNode);
       }
-      else if (rvsdg::is<rvsdg::SimpleOperation>(node))
+      else if (const auto simpleNode = dynamic_cast<rvsdg::SimpleNode *>(node))
       {
-        reductionPerformed |= ReduceSimpleNode(*node);
+        reductionPerformed |= ReduceSimpleNode(*simpleNode);
       }
       else
       {
@@ -144,7 +144,7 @@ NodeReduction::ReduceGammaNode(rvsdg::StructuralNode & gammaNode)
 }
 
 bool
-NodeReduction::ReduceSimpleNode(rvsdg::Node & simpleNode)
+NodeReduction::ReduceSimpleNode(rvsdg::SimpleNode & simpleNode)
 {
   if (is<LoadNonVolatileOperation>(&simpleNode))
   {
@@ -169,7 +169,7 @@ NodeReduction::ReduceSimpleNode(rvsdg::Node & simpleNode)
 }
 
 bool
-NodeReduction::ReduceLoadNode(rvsdg::Node & simpleNode)
+NodeReduction::ReduceLoadNode(rvsdg::SimpleNode & simpleNode)
 {
   JLM_ASSERT(is<LoadNonVolatileOperation>(&simpleNode));
 
@@ -177,7 +177,7 @@ NodeReduction::ReduceLoadNode(rvsdg::Node & simpleNode)
 }
 
 bool
-NodeReduction::ReduceStoreNode(rvsdg::Node & simpleNode)
+NodeReduction::ReduceStoreNode(rvsdg::SimpleNode & simpleNode)
 {
   JLM_ASSERT(is<StoreNonVolatileOperation>(&simpleNode));
 
@@ -185,7 +185,7 @@ NodeReduction::ReduceStoreNode(rvsdg::Node & simpleNode)
 }
 
 bool
-NodeReduction::ReduceBinaryNode(rvsdg::Node & simpleNode)
+NodeReduction::ReduceBinaryNode(rvsdg::SimpleNode & simpleNode)
 {
   JLM_ASSERT(is<rvsdg::BinaryOperation>(&simpleNode));
 

--- a/jlm/llvm/opt/reduction.hpp
+++ b/jlm/llvm/opt/reduction.hpp
@@ -6,6 +6,7 @@
 #ifndef JLM_LLVM_OPT_REDUCTION_HPP
 #define JLM_LLVM_OPT_REDUCTION_HPP
 
+#include <jlm/rvsdg/simple-node.hpp>
 #include <jlm/rvsdg/Transformation.hpp>
 #include <jlm/util/Statistics.hpp>
 
@@ -73,16 +74,16 @@ private:
   ReduceGammaNode(rvsdg::StructuralNode & gammaNode);
 
   [[nodiscard]] static bool
-  ReduceSimpleNode(rvsdg::Node & simpleNode);
+  ReduceSimpleNode(rvsdg::SimpleNode & simpleNode);
 
   [[nodiscard]] static bool
-  ReduceLoadNode(rvsdg::Node & simpleNode);
+  ReduceLoadNode(rvsdg::SimpleNode & simpleNode);
 
   [[nodiscard]] static bool
-  ReduceStoreNode(rvsdg::Node & simpleNode);
+  ReduceStoreNode(rvsdg::SimpleNode & simpleNode);
 
   [[nodiscard]] static bool
-  ReduceBinaryNode(rvsdg::Node & simpleNode);
+  ReduceBinaryNode(rvsdg::SimpleNode & simpleNode);
 
   static std::optional<std::vector<rvsdg::output *>>
   NormalizeLoadNode(

--- a/jlm/llvm/opt/unroll.hpp
+++ b/jlm/llvm/opt/unroll.hpp
@@ -51,8 +51,8 @@ public:
 
 private:
   inline unrollinfo(
-      rvsdg::Node * cmpnode,
-      rvsdg::Node * armnode,
+      rvsdg::SimpleNode * cmpnode,
+      rvsdg::SimpleNode * armnode,
       rvsdg::output * idv,
       rvsdg::output * step,
       rvsdg::output * end)
@@ -108,7 +108,7 @@ public:
   std::unique_ptr<jlm::rvsdg::bitvalue_repr>
   niterations() const noexcept;
 
-  rvsdg::Node *
+  rvsdg::SimpleNode *
   cmpnode() const noexcept
   {
     return cmpnode_;
@@ -117,10 +117,10 @@ public:
   [[nodiscard]] const rvsdg::SimpleOperation &
   cmpoperation() const noexcept
   {
-    return *static_cast<const rvsdg::SimpleOperation *>(&cmpnode()->GetOperation());
+    return cmpnode()->GetOperation();
   }
 
-  inline rvsdg::Node *
+  inline rvsdg::SimpleNode *
   armnode() const noexcept
   {
     return armnode_;
@@ -129,7 +129,7 @@ public:
   [[nodiscard]] const rvsdg::SimpleOperation &
   armoperation() const noexcept
   {
-    return *static_cast<const rvsdg::SimpleOperation *>(&armnode()->GetOperation());
+    return armnode()->GetOperation();
   }
 
   inline rvsdg::output *
@@ -206,10 +206,9 @@ private:
   inline bool
   is_known(jlm::rvsdg::output * output) const noexcept
   {
-    auto p = producer(output);
+    auto p = dynamic_cast<const rvsdg::SimpleNode *>(producer(output));
     if (!p)
       return false;
-
     auto op = dynamic_cast<const rvsdg::bitconstant_op *>(&p->GetOperation());
     return op && op->value().is_known();
   }
@@ -220,14 +219,14 @@ private:
     if (!is_known(output))
       return nullptr;
 
-    auto p = producer(output);
-    return &static_cast<const rvsdg::bitconstant_op *>(&p->GetOperation())->value();
+    auto p = util::AssertedCast<const rvsdg::SimpleNode>(producer(output));
+    return &util::AssertedCast<const rvsdg::bitconstant_op>(&p->GetOperation())->value();
   }
 
   rvsdg::output * end_;
   rvsdg::output * step_;
-  rvsdg::Node * cmpnode_;
-  rvsdg::Node * armnode_;
+  rvsdg::SimpleNode * cmpnode_;
+  rvsdg::SimpleNode * armnode_;
   rvsdg::output * idv_;
 };
 

--- a/jlm/rvsdg/NodeNormalization.hpp
+++ b/jlm/rvsdg/NodeNormalization.hpp
@@ -43,7 +43,7 @@ NormalizeSequence(
 
 template<class TOperation>
 bool
-ReduceNode(const NodeNormalization<TOperation> & nodeNormalization, Node & node)
+ReduceNode(const NodeNormalization<TOperation> & nodeNormalization, SimpleNode & node)
 {
   auto operation = util::AssertedCast<const TOperation>(&node.GetOperation());
   auto operands = rvsdg::operands(&node);

--- a/jlm/rvsdg/bitstring/bitoperation-classes.cpp
+++ b/jlm/rvsdg/bitstring/bitoperation-classes.cpp
@@ -27,7 +27,7 @@ bitunary_op::reduce_operand(unop_reduction_path_t path, jlm::rvsdg::output * arg
 {
   if (path == unop_reduction_constant)
   {
-    auto p = producer(arg);
+    auto p = static_cast<const SimpleNode *>(producer(arg));
     auto & c = static_cast<const bitconstant_op &>(p->GetOperation());
     return create_bitconstant(p->region(), reduce_constant(c.value()));
   }
@@ -57,8 +57,10 @@ bitbinary_op::reduce_operand_pair(
 {
   if (path == binop_reduction_constants)
   {
-    auto & c1 = static_cast<const bitconstant_op &>(producer(arg1)->GetOperation());
-    auto & c2 = static_cast<const bitconstant_op &>(producer(arg2)->GetOperation());
+    auto & c1 = static_cast<const bitconstant_op &>(
+        static_cast<const SimpleNode *>(producer(arg1))->GetOperation());
+    auto & c2 = static_cast<const bitconstant_op &>(
+        static_cast<const SimpleNode *>(producer(arg2))->GetOperation());
     return create_bitconstant(arg1->region(), reduce_constants(c1.value(), c2.value()));
   }
 
@@ -73,12 +75,12 @@ bitcompare_op::can_reduce_operand_pair(
     const jlm::rvsdg::output * arg1,
     const jlm::rvsdg::output * arg2) const noexcept
 {
-  auto p = producer(arg1);
+  auto p = dynamic_cast<const SimpleNode *>(producer(arg1));
   const bitconstant_op * c1_op = nullptr;
   if (p)
     c1_op = dynamic_cast<const bitconstant_op *>(&p->GetOperation());
 
-  p = producer(arg2);
+  p = dynamic_cast<const SimpleNode *>(producer(arg2));
   const bitconstant_op * c2_op = nullptr;
   if (p)
     c2_op = dynamic_cast<const bitconstant_op *>(&p->GetOperation());

--- a/jlm/rvsdg/bitstring/concat.cpp
+++ b/jlm/rvsdg/bitstring/concat.cpp
@@ -58,8 +58,8 @@ bitconcat_op::can_reduce_operand_pair(
     const jlm::rvsdg::output * arg1,
     const jlm::rvsdg::output * arg2) const noexcept
 {
-  auto node1 = TryGetOwnerNode<Node>(*arg1);
-  auto node2 = TryGetOwnerNode<Node>(*arg2);
+  auto node1 = TryGetOwnerNode<SimpleNode>(*arg1);
+  auto node2 = TryGetOwnerNode<SimpleNode>(*arg2);
 
   if (!node1 || !node2)
     return binop_reduction_none;
@@ -97,13 +97,13 @@ bitconcat_op::reduce_operand_pair(
     jlm::rvsdg::output * arg1,
     jlm::rvsdg::output * arg2) const
 {
-  auto node1 = static_cast<node_output *>(arg1)->node();
-  auto node2 = static_cast<node_output *>(arg2)->node();
+  auto & node1 = AssertGetOwnerNode<SimpleNode>(*arg1);
+  auto & node2 = AssertGetOwnerNode<SimpleNode>(*arg2);
 
   if (path == binop_reduction_constants)
   {
-    auto & arg1_constant = static_cast<const bitconstant_op &>(node1->GetOperation());
-    auto & arg2_constant = static_cast<const bitconstant_op &>(node2->GetOperation());
+    auto & arg1_constant = static_cast<const bitconstant_op &>(node1.GetOperation());
+    auto & arg2_constant = static_cast<const bitconstant_op &>(node2.GetOperation());
 
     bitvalue_repr bits(arg1_constant.value());
     bits.Append(arg2_constant.value());
@@ -112,9 +112,9 @@ bitconcat_op::reduce_operand_pair(
 
   if (path == binop_reduction_merge)
   {
-    auto arg1_slice = static_cast<const bitslice_op *>(&node1->GetOperation());
-    auto arg2_slice = static_cast<const bitslice_op *>(&node2->GetOperation());
-    return jlm::rvsdg::bitslice(node1->input(0)->origin(), arg1_slice->low(), arg2_slice->high());
+    auto arg1_slice = static_cast<const bitslice_op *>(&node1.GetOperation());
+    auto arg2_slice = static_cast<const bitslice_op *>(&node2.GetOperation());
+    return jlm::rvsdg::bitslice(node1.input(0)->origin(), arg1_slice->low(), arg2_slice->high());
 
     /* FIXME: support sign bit */
   }

--- a/jlm/rvsdg/bitstring/slice.cpp
+++ b/jlm/rvsdg/bitstring/slice.cpp
@@ -57,17 +57,17 @@ bitslice_op::reduce_operand(unop_reduction_path_t path, jlm::rvsdg::output * arg
     return arg;
   }
 
-  auto node = static_cast<node_output *>(arg)->node();
+  auto & node = AssertGetOwnerNode<SimpleNode>(*arg);
 
   if (path == unop_reduction_narrow)
   {
-    auto op = static_cast<const bitslice_op &>(node->GetOperation());
-    return jlm::rvsdg::bitslice(node->input(0)->origin(), low() + op.low(), high() + op.low());
+    auto op = static_cast<const bitslice_op &>(node.GetOperation());
+    return jlm::rvsdg::bitslice(node.input(0)->origin(), low() + op.low(), high() + op.low());
   }
 
   if (path == unop_reduction_constant)
   {
-    auto op = static_cast<const bitconstant_op &>(node->GetOperation());
+    auto op = static_cast<const bitconstant_op &>(node.GetOperation());
     std::string s(&op.value()[0] + low(), high() - low());
     return create_bitconstant(arg->region(), s.c_str());
   }
@@ -76,9 +76,9 @@ bitslice_op::reduce_operand(unop_reduction_path_t path, jlm::rvsdg::output * arg
   {
     size_t pos = 0, n;
     std::vector<jlm::rvsdg::output *> arguments;
-    for (n = 0; n < node->ninputs(); n++)
+    for (n = 0; n < node.ninputs(); n++)
     {
-      auto argument = node->input(n)->origin();
+      auto argument = node.input(n)->origin();
       size_t base = pos;
       size_t nbits = std::static_pointer_cast<const bittype>(argument->Type())->nbits();
       pos = pos + nbits;

--- a/jlm/rvsdg/control.cpp
+++ b/jlm/rvsdg/control.cpp
@@ -119,7 +119,8 @@ match_op::reduce_operand(unop_reduction_path_t path, jlm::rvsdg::output * arg) c
 {
   if (path == unop_reduction_constant)
   {
-    auto op = static_cast<const bitconstant_op &>(producer(arg)->GetOperation());
+    auto op = static_cast<const bitconstant_op &>(
+        static_cast<const SimpleNode *>(producer(arg))->GetOperation());
     return jlm::rvsdg::control_constant(
         arg->region(),
         nalternatives(),

--- a/jlm/rvsdg/node.hpp
+++ b/jlm/rvsdg/node.hpp
@@ -588,9 +588,6 @@ public:
 
   explicit Node(Region * region);
 
-  [[nodiscard]] virtual const Operation &
-  GetOperation() const noexcept = 0;
-
   inline bool
   has_users() const noexcept
   {
@@ -1028,16 +1025,6 @@ divert_users(Node * node, const std::vector<output *> & outputs)
 
   for (size_t n = 0; n < outputs.size(); n++)
     node->output(n)->divert_users(outputs[n]);
-}
-
-template<class T>
-static inline bool
-is(const Node * node) noexcept
-{
-  if (!node)
-    return false;
-
-  return is<T>(node->GetOperation());
 }
 
 Node *

--- a/jlm/rvsdg/simple-node.cpp
+++ b/jlm/rvsdg/simple-node.cpp
@@ -121,9 +121,9 @@ NormalizeSimpleOperationCommonNodeElimination(
 {
   auto isCongruent = [&](const Node & node)
   {
-    auto & nodeOperation = node.GetOperation();
-    return nodeOperation == operation && operands == rvsdg::operands(&node)
-        && &nodeOperation != &operation;
+    auto simpleNode = dynamic_cast<const SimpleNode *>(&node);
+    return simpleNode && simpleNode->GetOperation() == operation
+        && operands == rvsdg::operands(&node) && &simpleNode->GetOperation() != &operation;
   };
 
   if (operands.empty())

--- a/jlm/rvsdg/simple-node.hpp
+++ b/jlm/rvsdg/simple-node.hpp
@@ -36,7 +36,7 @@ public:
   output(size_t index) const noexcept;
 
   [[nodiscard]] const SimpleOperation &
-  GetOperation() const noexcept override;
+  GetOperation() const noexcept;
 
   Node *
   copy(rvsdg::Region * region, const std::vector<jlm::rvsdg::output *> & operands) const override;
@@ -215,6 +215,17 @@ CreateOpNode(Region & region, OperatorArguments... operatorArguments)
       region,
       std::make_unique<OperatorType>(std::move(operatorArguments)...),
       {});
+}
+
+template<class T>
+static inline bool
+is(const Node * node) noexcept
+{
+  if (!node)
+    return false;
+
+  auto simple_node = dynamic_cast<const SimpleNode *>(node);
+  return simple_node && dynamic_cast<const T *>(&simple_node->GetOperation());
 }
 
 }

--- a/jlm/rvsdg/structural-node.hpp
+++ b/jlm/rvsdg/structural-node.hpp
@@ -31,6 +31,9 @@ public:
   std::string
   DebugString() const override;
 
+  [[nodiscard]] virtual const StructuralOperation &
+  GetOperation() const noexcept = 0;
+
   inline size_t
   nsubregions() const noexcept
   {

--- a/tests/jlm/hls/opt/InvariantLambdaMemoryStateRemovalTests.cpp
+++ b/tests/jlm/hls/opt/InvariantLambdaMemoryStateRemovalTests.cpp
@@ -63,7 +63,7 @@ TestEliminateSplitAndMergeNodes()
   assert(lambdaSubregion->nresults() == 1);
   assert(is<MemoryStateType>(lambdaSubregion->result(0)->Type()));
   auto loadNode =
-      jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*lambdaSubregion->result(0)->origin());
+      jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*lambdaSubregion->result(0)->origin());
   assert(is<LoadNonVolatileOperation>(loadNode->GetOperation()));
   jlm::util::AssertedCast<jlm::rvsdg::RegionArgument>(loadNode->input(1)->origin());
 
@@ -136,14 +136,15 @@ TestInvariantMemoryState()
   assert(is<MemoryStateType>(lambdaSubregion->result(0)->Type()));
   // Since there is more than one invariant memory state edge, the MemoryStateMerge node should
   // still exists
-  auto node = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*lambdaSubregion->result(0)->origin());
+  auto node =
+      jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*lambdaSubregion->result(0)->origin());
   assert(is<LambdaExitMemoryStateMergeOperation>(node->GetOperation()));
   assert(node->ninputs() == 2);
   // Need to pass a load node to reach the MemoryStateSplit node
-  node = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*node->input(1)->origin());
+  node = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*node->input(1)->origin());
   assert(is<LoadNonVolatileOperation>(node->GetOperation()));
   // Check that the MemoryStateSplit node is still present
-  node = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*node->input(1)->origin());
+  node = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*node->input(1)->origin());
   assert(is<LambdaEntryMemoryStateSplitOperation>(node->GetOperation()));
 
   return 0;

--- a/tests/jlm/llvm/ir/operators/LoadTests.cpp
+++ b/tests/jlm/llvm/ir/operators/LoadTests.cpp
@@ -66,12 +66,14 @@ TestCopy()
   auto loadResults = LoadNonVolatileOperation::Create(address1, { memoryState1 }, valueType, 4);
 
   // Act
-  auto node = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*loadResults[0]);
+  auto node = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*loadResults[0]);
   assert(is<LoadNonVolatileOperation>(node));
   auto copiedNode = node->copy(&graph.GetRootRegion(), { address2, memoryState2 });
 
   // Assert
-  assert(node->GetOperation() == copiedNode->GetOperation());
+  assert(
+      node->GetOperation()
+      == jlm::util::AssertedCast<jlm::rvsdg::SimpleNode>(copiedNode)->GetOperation());
 
   return 0;
 }
@@ -638,7 +640,8 @@ NodeCopy()
   auto copiedNode = loadNode.copy(&graph.GetRootRegion(), { &address2, &iOState2, &memoryState2 });
 
   // Assert
-  auto copiedOperation = dynamic_cast<const LoadVolatileOperation *>(&copiedNode->GetOperation());
+  auto copiedOperation = dynamic_cast<const LoadVolatileOperation *>(
+      &jlm::util::AssertedCast<SimpleNode>(copiedNode)->GetOperation());
   assert(copiedOperation != nullptr);
   assert(LoadOperation::AddressInput(*copiedNode).origin() == &address2);
   assert(LoadVolatileOperation::IOStateInput(*copiedNode).origin() == &iOState2);

--- a/tests/jlm/llvm/ir/operators/StoreTests.cpp
+++ b/tests/jlm/llvm/ir/operators/StoreTests.cpp
@@ -194,11 +194,13 @@ TestCopy()
   auto storeResults = StoreNonVolatileOperation::Create(address1, value1, { memoryState1 }, 4);
 
   // Act
-  auto node = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*storeResults[0]);
+  auto node = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*storeResults[0]);
   auto copiedNode = node->copy(&graph.GetRootRegion(), { address2, value2, memoryState2 });
 
   // Assert
-  assert(node->GetOperation() == copiedNode->GetOperation());
+  assert(
+      node->GetOperation()
+      == jlm::util::AssertedCast<jlm::rvsdg::SimpleNode>(copiedNode)->GetOperation());
 
   return 0;
 }
@@ -240,9 +242,9 @@ TestStoreMuxNormalization()
   auto muxNode = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*ex.origin());
   assert(is<MemoryStateMergeOperation>(muxNode));
   assert(muxNode->ninputs() == 3);
-  auto n0 = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*muxNode->input(0)->origin());
-  auto n1 = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*muxNode->input(1)->origin());
-  auto n2 = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*muxNode->input(2)->origin());
+  auto n0 = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*muxNode->input(0)->origin());
+  auto n1 = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*muxNode->input(1)->origin());
+  auto n2 = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*muxNode->input(2)->origin());
   assert(jlm::rvsdg::is<StoreNonVolatileOperation>(n0->GetOperation()));
   assert(jlm::rvsdg::is<StoreNonVolatileOperation>(n1->GetOperation()));
   assert(jlm::rvsdg::is<StoreNonVolatileOperation>(n2->GetOperation()));

--- a/tests/jlm/llvm/ir/operators/TestCall.cpp
+++ b/tests/jlm/llvm/ir/operators/TestCall.cpp
@@ -41,12 +41,14 @@ TestCopy()
       CallOperation::Create(function1, functionType, { value1, iOState1, memoryState1 });
 
   // Act
-  auto node = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*callResults[0]);
+  auto node = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*callResults[0]);
   auto copiedNode =
       node->copy(&rvsdg.GetRootRegion(), { function2, value2, iOState2, memoryState2 });
 
   // Assert
-  assert(node->GetOperation() == copiedNode->GetOperation());
+  assert(
+      node->GetOperation()
+      == jlm::util::AssertedCast<jlm::rvsdg::SimpleNode>(copiedNode)->GetOperation());
 }
 
 static void

--- a/tests/jlm/llvm/ir/operators/test-sext.cpp
+++ b/tests/jlm/llvm/ir/operators/test-sext.cpp
@@ -36,7 +36,7 @@ test_bitunary_reduction()
   // Act
   ReduceNode<sext_op>(
       NormalizeUnaryOperation,
-      *jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*ex.origin()));
+      *jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*ex.origin()));
   graph.PruneNodes();
 
   view(graph, stdout);
@@ -68,7 +68,7 @@ test_bitbinary_reduction()
   // Act
   ReduceNode<sext_op>(
       NormalizeUnaryOperation,
-      *jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*ex.origin()));
+      *jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*ex.origin()));
   graph.PruneNodes();
 
   view(graph, stdout);
@@ -97,7 +97,9 @@ test_inverse_reduction()
   view(graph, stdout);
 
   // Act
-  ReduceNode<sext_op>(NormalizeUnaryOperation, *jlm::rvsdg::TryGetOwnerNode<Node>(*ex.origin()));
+  ReduceNode<sext_op>(
+      NormalizeUnaryOperation,
+      *jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*ex.origin()));
   graph.PruneNodes();
 
   view(graph, stdout);

--- a/tests/jlm/llvm/opt/IfConversionTests.cpp
+++ b/tests/jlm/llvm/opt/IfConversionTests.cpp
@@ -127,10 +127,11 @@ EmptyGammaWithTwoSubregionsAndMatch()
   assert(selectNode->input(2)->origin() == falseValue);
 
   const auto eqNode =
-      jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*selectNode->input(0)->origin());
+      jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*selectNode->input(0)->origin());
   assert(eqNode && is<IntegerEqOperation>(eqNode));
 
-  auto constantNode = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*eqNode->input(0)->origin());
+  auto constantNode =
+      jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*eqNode->input(0)->origin());
   if (constantNode)
   {
     assert(eqNode->input(1)->origin() == conditionValue);
@@ -142,7 +143,7 @@ EmptyGammaWithTwoSubregionsAndMatch()
   else
   {
     assert(eqNode->input(0)->origin() == conditionValue);
-    constantNode = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*eqNode->input(1)->origin());
+    constantNode = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*eqNode->input(1)->origin());
     auto constantOperation =
         dynamic_cast<const IntegerConstantOperation *>(&constantNode->GetOperation());
     assert(constantOperation);

--- a/tests/jlm/mlir/TestIntegerOperationsJlmToMlirToJlm.cpp
+++ b/tests/jlm/mlir/TestIntegerOperationsJlmToMlirToJlm.cpp
@@ -97,7 +97,9 @@ TestIntegerBinaryOperation()
       bool foundBinaryOp = false;
       for (auto & node : region->Nodes())
       {
-        auto convertedBinaryOp = dynamic_cast<const JlmOperation *>(&node.GetOperation());
+        auto simpleNode = dynamic_cast<const jlm::rvsdg::SimpleNode *>(&node);
+        auto convertedBinaryOp =
+            dynamic_cast<const JlmOperation *>(simpleNode ? &simpleNode->GetOperation() : nullptr);
         if (convertedBinaryOp)
         {
           assert(convertedBinaryOp->nresults() == 1);
@@ -225,7 +227,9 @@ TestIntegerComparisonOperation(const IntegerComparisonOpTest<JlmOperation> & tes
       bool foundCompOp = false;
       for (auto & node : region->Nodes())
       {
-        auto convertedCompOp = dynamic_cast<const JlmOperation *>(&node.GetOperation());
+        auto simpleNode = dynamic_cast<const jlm::rvsdg::SimpleNode *>(&node);
+        auto convertedCompOp =
+            dynamic_cast<const JlmOperation *>(simpleNode ? &simpleNode->GetOperation() : nullptr);
         if (convertedCompOp)
         {
           assert(convertedCompOp->nresults() == 1);

--- a/tests/jlm/mlir/frontend/TestMlirToJlmConverter.cpp
+++ b/tests/jlm/mlir/frontend/TestMlirToJlmConverter.cpp
@@ -267,17 +267,15 @@ TestDivOperation()
       // Get the lambda block
       auto convertedLambda =
           jlm::util::AssertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
-      assert(is<jlm::llvm::LlvmLambdaOperation>(convertedLambda));
+      assert(is<jlm::llvm::LlvmLambdaOperation>(convertedLambda->GetOperation()));
 
       // 2 Constants + 1 DivUIOp
       assert(convertedLambda->subregion()->nnodes() == 3);
 
       // Traverse the rvsgd graph upwards to check connections
-      jlm::rvsdg::node_output * lambdaResultOriginNodeOuput;
-      assert(
-          lambdaResultOriginNodeOuput = dynamic_cast<jlm::rvsdg::node_output *>(
-              convertedLambda->subregion()->result(0)->origin()));
-      Node * lambdaResultOriginNode = lambdaResultOriginNodeOuput->node();
+      auto lambdaResultOriginNode = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(
+          *convertedLambda->subregion()->result(0)->origin());
+      assert(lambdaResultOriginNode);
       assert(is<jlm::llvm::IntegerUDivOperation>(lambdaResultOriginNode->GetOperation()));
       assert(lambdaResultOriginNode->ninputs() == 2);
 
@@ -441,7 +439,7 @@ TestCompZeroExt()
       // Get the lambda block
       auto convertedLambda =
           jlm::util::AssertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
-      assert(is<jlm::llvm::LlvmLambdaOperation>(convertedLambda));
+      assert(is<jlm::llvm::LlvmLambdaOperation>(convertedLambda->GetOperation()));
 
       // 2 Constants + AddOp + CompOp + ZeroExtOp
       assert(convertedLambda->subregion()->nnodes() == 5);
@@ -646,7 +644,7 @@ TestMatchOp()
       // Get the lambda block
       auto convertedLambda =
           jlm::util::AssertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
-      assert(is<jlm::llvm::LlvmLambdaOperation>(convertedLambda));
+      assert(is<jlm::llvm::LlvmLambdaOperation>(convertedLambda->GetOperation()));
 
       auto lambdaRegion = convertedLambda->subregion();
 

--- a/tests/jlm/rvsdg/SimpleOperationTests.cpp
+++ b/tests/jlm/rvsdg/SimpleOperationTests.cpp
@@ -51,10 +51,18 @@ NormalizeSimpleOperationCne_NodesWithoutOperands()
   };
 
   // Act
-  ReduceNode<SimpleOperation>(NormalizeCne, *TryGetOwnerNode<Node>(*exNullaryValueNode1.origin()));
-  ReduceNode<SimpleOperation>(NormalizeCne, *TryGetOwnerNode<Node>(*exNullaryValueNode2.origin()));
-  ReduceNode<SimpleOperation>(NormalizeCne, *TryGetOwnerNode<Node>(*exNullaryStateNode1.origin()));
-  ReduceNode<SimpleOperation>(NormalizeCne, *TryGetOwnerNode<Node>(*exNullaryStateNode2.origin()));
+  ReduceNode<SimpleOperation>(
+      NormalizeCne,
+      *TryGetOwnerNode<SimpleNode>(*exNullaryValueNode1.origin()));
+  ReduceNode<SimpleOperation>(
+      NormalizeCne,
+      *TryGetOwnerNode<SimpleNode>(*exNullaryValueNode2.origin()));
+  ReduceNode<SimpleOperation>(
+      NormalizeCne,
+      *TryGetOwnerNode<SimpleNode>(*exNullaryStateNode1.origin()));
+  ReduceNode<SimpleOperation>(
+      NormalizeCne,
+      *TryGetOwnerNode<SimpleNode>(*exNullaryStateNode2.origin()));
   graph.PruneNodes();
 
   view(graph, stdout);
@@ -106,10 +114,10 @@ NormalizeSimpleOperationCne_NodesWithOperands()
   };
 
   // Act
-  ReduceNode<SimpleOperation>(NormalizeCne, *TryGetOwnerNode<Node>(*exValueNode1.origin()));
-  ReduceNode<SimpleOperation>(NormalizeCne, *TryGetOwnerNode<Node>(*exValueNode2.origin()));
-  ReduceNode<SimpleOperation>(NormalizeCne, *TryGetOwnerNode<Node>(*exStateNode1.origin()));
-  ReduceNode<SimpleOperation>(NormalizeCne, *TryGetOwnerNode<Node>(*exStateNode2.origin()));
+  ReduceNode<SimpleOperation>(NormalizeCne, *TryGetOwnerNode<SimpleNode>(*exValueNode1.origin()));
+  ReduceNode<SimpleOperation>(NormalizeCne, *TryGetOwnerNode<SimpleNode>(*exValueNode2.origin()));
+  ReduceNode<SimpleOperation>(NormalizeCne, *TryGetOwnerNode<SimpleNode>(*exStateNode1.origin()));
+  ReduceNode<SimpleOperation>(NormalizeCne, *TryGetOwnerNode<SimpleNode>(*exStateNode2.origin()));
   graph.PruneNodes();
 
   view(graph, stdout);
@@ -163,10 +171,18 @@ NormalizeSimpleOperationCne_Failure()
   };
 
   // Act
-  ReduceNode<SimpleOperation>(NormalizeCne, *TryGetOwnerNode<Node>(*exNullaryValueNode.origin()));
-  ReduceNode<SimpleOperation>(NormalizeCne, *TryGetOwnerNode<Node>(*exNullaryStateNode.origin()));
-  ReduceNode<SimpleOperation>(NormalizeCne, *TryGetOwnerNode<Node>(*exUnaryValueNode.origin()));
-  ReduceNode<SimpleOperation>(NormalizeCne, *TryGetOwnerNode<Node>(*exUnaryStateNode.origin()));
+  ReduceNode<SimpleOperation>(
+      NormalizeCne,
+      *TryGetOwnerNode<SimpleNode>(*exNullaryValueNode.origin()));
+  ReduceNode<SimpleOperation>(
+      NormalizeCne,
+      *TryGetOwnerNode<SimpleNode>(*exNullaryStateNode.origin()));
+  ReduceNode<SimpleOperation>(
+      NormalizeCne,
+      *TryGetOwnerNode<SimpleNode>(*exUnaryValueNode.origin()));
+  ReduceNode<SimpleOperation>(
+      NormalizeCne,
+      *TryGetOwnerNode<SimpleNode>(*exUnaryStateNode.origin()));
   graph.PruneNodes();
 
   view(graph, stdout);

--- a/tests/jlm/rvsdg/bitstring/bitstring.cpp
+++ b/tests/jlm/rvsdg/bitstring/bitstring.cpp
@@ -40,8 +40,8 @@ types_bitstring_arithmetic_test_bitand()
   view(&graph.GetRootRegion(), stdout);
 
   // Assert
-  assert(TryGetOwnerNode<Node>(*ex0.origin())->GetOperation() == bitand_op(32));
-  assert(TryGetOwnerNode<Node>(*ex1.origin())->GetOperation() == int_constant_op(32, +1));
+  assert(TryGetOwnerNode<SimpleNode>(*ex0.origin())->GetOperation() == bitand_op(32));
+  assert(TryGetOwnerNode<SimpleNode>(*ex1.origin())->GetOperation() == int_constant_op(32, +1));
 
   return 0;
 }
@@ -86,11 +86,11 @@ types_bitstring_arithmetic_test_bitashr()
   view(&graph.GetRootRegion(), stdout);
 
   // Assert
-  assert(TryGetOwnerNode<Node>(*ex0.origin())->GetOperation() == bitashr_op(32));
-  assert(TryGetOwnerNode<Node>(*ex1.origin())->GetOperation() == int_constant_op(32, 4));
-  assert(TryGetOwnerNode<Node>(*ex2.origin())->GetOperation() == int_constant_op(32, 0));
-  assert(TryGetOwnerNode<Node>(*ex3.origin())->GetOperation() == int_constant_op(32, -4));
-  assert(TryGetOwnerNode<Node>(*ex4.origin())->GetOperation() == int_constant_op(32, -1));
+  assert(TryGetOwnerNode<SimpleNode>(*ex0.origin())->GetOperation() == bitashr_op(32));
+  assert(TryGetOwnerNode<SimpleNode>(*ex1.origin())->GetOperation() == int_constant_op(32, 4));
+  assert(TryGetOwnerNode<SimpleNode>(*ex2.origin())->GetOperation() == int_constant_op(32, 0));
+  assert(TryGetOwnerNode<SimpleNode>(*ex3.origin())->GetOperation() == int_constant_op(32, -4));
+  assert(TryGetOwnerNode<SimpleNode>(*ex4.origin())->GetOperation() == int_constant_op(32, -1));
 
   return 0;
 }
@@ -118,7 +118,7 @@ types_bitstring_arithmetic_test_bitdifference()
   view(&graph.GetRootRegion(), stdout);
 
   // Act
-  assert(TryGetOwnerNode<Node>(*ex0.origin())->GetOperation() == bitsub_op(32));
+  assert(TryGetOwnerNode<SimpleNode>(*ex0.origin())->GetOperation() == bitsub_op(32));
 
   return 0;
 }
@@ -152,9 +152,9 @@ types_bitstring_arithmetic_test_bitnegate()
   view(&graph.GetRootRegion(), stdout);
 
   // Assert
-  assert(TryGetOwnerNode<Node>(*ex0.origin())->GetOperation() == bitneg_op(32));
-  assert(TryGetOwnerNode<Node>(*ex1.origin())->GetOperation() == int_constant_op(32, -3));
-  assert(TryGetOwnerNode<Node>(*ex2.origin())->GetOperation() == int_constant_op(32, 3));
+  assert(TryGetOwnerNode<SimpleNode>(*ex0.origin())->GetOperation() == bitneg_op(32));
+  assert(TryGetOwnerNode<SimpleNode>(*ex1.origin())->GetOperation() == int_constant_op(32, -3));
+  assert(TryGetOwnerNode<SimpleNode>(*ex2.origin())->GetOperation() == int_constant_op(32, 3));
 
   return 0;
 }
@@ -188,9 +188,9 @@ types_bitstring_arithmetic_test_bitnot()
   view(&graph.GetRootRegion(), stdout);
 
   // Assert
-  assert(TryGetOwnerNode<Node>(*ex0.origin())->GetOperation() == bitnot_op(32));
-  assert(TryGetOwnerNode<Node>(*ex1.origin())->GetOperation() == int_constant_op(32, -4));
-  assert(TryGetOwnerNode<Node>(*ex2.origin())->GetOperation() == int_constant_op(32, 3));
+  assert(TryGetOwnerNode<SimpleNode>(*ex0.origin())->GetOperation() == bitnot_op(32));
+  assert(TryGetOwnerNode<SimpleNode>(*ex1.origin())->GetOperation() == int_constant_op(32, -4));
+  assert(TryGetOwnerNode<SimpleNode>(*ex2.origin())->GetOperation() == int_constant_op(32, 3));
 
   return 0;
 }
@@ -224,8 +224,8 @@ types_bitstring_arithmetic_test_bitor()
   view(&graph.GetRootRegion(), stdout);
 
   // Assert
-  assert(TryGetOwnerNode<Node>(*ex0.origin())->GetOperation() == bitor_op(32));
-  assert(TryGetOwnerNode<Node>(*ex1.origin())->GetOperation() == uint_constant_op(32, 7));
+  assert(TryGetOwnerNode<SimpleNode>(*ex0.origin())->GetOperation() == bitor_op(32));
+  assert(TryGetOwnerNode<SimpleNode>(*ex1.origin())->GetOperation() == uint_constant_op(32, 7));
 
   return 0;
 }
@@ -259,8 +259,8 @@ types_bitstring_arithmetic_test_bitproduct()
   view(&graph.GetRootRegion(), stdout);
 
   // Assert
-  assert(TryGetOwnerNode<Node>(*ex0.origin())->GetOperation() == bitmul_op(32));
-  assert(TryGetOwnerNode<Node>(*ex1.origin())->GetOperation() == uint_constant_op(32, 15));
+  assert(TryGetOwnerNode<SimpleNode>(*ex0.origin())->GetOperation() == bitmul_op(32));
+  assert(TryGetOwnerNode<SimpleNode>(*ex1.origin())->GetOperation() == uint_constant_op(32, 15));
 
   return 0;
 }
@@ -288,7 +288,7 @@ types_bitstring_arithmetic_test_bitshiproduct()
   view(&graph.GetRootRegion(), stdout);
 
   // Assert
-  assert(TryGetOwnerNode<Node>(*ex0.origin())->GetOperation() == bitsmulh_op(32));
+  assert(TryGetOwnerNode<SimpleNode>(*ex0.origin())->GetOperation() == bitsmulh_op(32));
 
   return 0;
 }
@@ -326,9 +326,9 @@ types_bitstring_arithmetic_test_bitshl()
   view(&graph.GetRootRegion(), stdout);
 
   // Assert
-  assert(TryGetOwnerNode<Node>(*ex0.origin())->GetOperation() == bitshl_op(32));
-  assert(TryGetOwnerNode<Node>(*ex1.origin())->GetOperation() == uint_constant_op(32, 64));
-  assert(TryGetOwnerNode<Node>(*ex2.origin())->GetOperation() == uint_constant_op(32, 0));
+  assert(TryGetOwnerNode<SimpleNode>(*ex0.origin())->GetOperation() == bitshl_op(32));
+  assert(TryGetOwnerNode<SimpleNode>(*ex1.origin())->GetOperation() == uint_constant_op(32, 64));
+  assert(TryGetOwnerNode<SimpleNode>(*ex2.origin())->GetOperation() == uint_constant_op(32, 0));
 
   return 0;
 }
@@ -366,9 +366,9 @@ types_bitstring_arithmetic_test_bitshr()
   view(&graph.GetRootRegion(), stdout);
 
   // Assert
-  assert(TryGetOwnerNode<Node>(*ex0.origin())->GetOperation() == bitshr_op(32));
-  assert(TryGetOwnerNode<Node>(*ex1.origin())->GetOperation() == uint_constant_op(32, 4));
-  assert(TryGetOwnerNode<Node>(*ex2.origin())->GetOperation() == uint_constant_op(32, 0));
+  assert(TryGetOwnerNode<SimpleNode>(*ex0.origin())->GetOperation() == bitshr_op(32));
+  assert(TryGetOwnerNode<SimpleNode>(*ex1.origin())->GetOperation() == uint_constant_op(32, 4));
+  assert(TryGetOwnerNode<SimpleNode>(*ex2.origin())->GetOperation() == uint_constant_op(32, 0));
 
   return 0;
 }
@@ -402,8 +402,8 @@ types_bitstring_arithmetic_test_bitsmod()
   view(&graph.GetRootRegion(), stdout);
 
   // Assert
-  assert(TryGetOwnerNode<Node>(*ex0.origin())->GetOperation() == bitsmod_op(32));
-  assert(TryGetOwnerNode<Node>(*ex1.origin())->GetOperation() == int_constant_op(32, -1));
+  assert(TryGetOwnerNode<SimpleNode>(*ex0.origin())->GetOperation() == bitsmod_op(32));
+  assert(TryGetOwnerNode<SimpleNode>(*ex1.origin())->GetOperation() == int_constant_op(32, -1));
 
   return 0;
 }
@@ -437,8 +437,8 @@ types_bitstring_arithmetic_test_bitsquotient()
   view(&graph.GetRootRegion(), stdout);
 
   // Assert
-  assert(TryGetOwnerNode<Node>(*ex0.origin())->GetOperation() == bitsdiv_op(32));
-  assert(TryGetOwnerNode<Node>(*ex1.origin())->GetOperation() == int_constant_op(32, -2));
+  assert(TryGetOwnerNode<SimpleNode>(*ex0.origin())->GetOperation() == bitsdiv_op(32));
+  assert(TryGetOwnerNode<SimpleNode>(*ex1.origin())->GetOperation() == int_constant_op(32, -2));
 
   return 0;
 }
@@ -472,8 +472,8 @@ types_bitstring_arithmetic_test_bitsum()
   view(&graph.GetRootRegion(), stdout);
 
   // Assert
-  assert(TryGetOwnerNode<Node>(*ex0.origin())->GetOperation() == bitadd_op(32));
-  assert(TryGetOwnerNode<Node>(*ex1.origin())->GetOperation() == int_constant_op(32, 8));
+  assert(TryGetOwnerNode<SimpleNode>(*ex0.origin())->GetOperation() == bitadd_op(32));
+  assert(TryGetOwnerNode<SimpleNode>(*ex1.origin())->GetOperation() == int_constant_op(32, 8));
 
   return 0;
 }
@@ -501,7 +501,7 @@ types_bitstring_arithmetic_test_bituhiproduct()
   view(&graph.GetRootRegion(), stdout);
 
   // Assert
-  assert(TryGetOwnerNode<Node>(*ex0.origin())->GetOperation() == bitumulh_op(32));
+  assert(TryGetOwnerNode<SimpleNode>(*ex0.origin())->GetOperation() == bitumulh_op(32));
 
   return 0;
 }
@@ -535,8 +535,8 @@ types_bitstring_arithmetic_test_bitumod()
   view(&graph.GetRootRegion(), stdout);
 
   // Assert
-  assert(TryGetOwnerNode<Node>(*ex0.origin())->GetOperation() == bitumod_op(32));
-  assert(TryGetOwnerNode<Node>(*ex1.origin())->GetOperation() == int_constant_op(32, 1));
+  assert(TryGetOwnerNode<SimpleNode>(*ex0.origin())->GetOperation() == bitumod_op(32));
+  assert(TryGetOwnerNode<SimpleNode>(*ex1.origin())->GetOperation() == int_constant_op(32, 1));
 
   return 0;
 }
@@ -570,8 +570,8 @@ types_bitstring_arithmetic_test_bituquotient()
   view(&graph.GetRootRegion(), stdout);
 
   // Assert
-  assert(TryGetOwnerNode<Node>(*ex0.origin())->GetOperation() == bitudiv_op(32));
-  assert(TryGetOwnerNode<Node>(*ex1.origin())->GetOperation() == int_constant_op(32, 2));
+  assert(TryGetOwnerNode<SimpleNode>(*ex0.origin())->GetOperation() == bitudiv_op(32));
+  assert(TryGetOwnerNode<SimpleNode>(*ex1.origin())->GetOperation() == int_constant_op(32, 2));
 
   return 0;
 }
@@ -605,8 +605,8 @@ types_bitstring_arithmetic_test_bitxor()
   view(&graph.GetRootRegion(), stdout);
 
   // Arrange
-  assert(TryGetOwnerNode<Node>(*ex0.origin())->GetOperation() == bitxor_op(32));
-  assert(TryGetOwnerNode<Node>(*ex1.origin())->GetOperation() == int_constant_op(32, 6));
+  assert(TryGetOwnerNode<SimpleNode>(*ex0.origin())->GetOperation() == bitxor_op(32));
+  assert(TryGetOwnerNode<SimpleNode>(*ex1.origin())->GetOperation() == int_constant_op(32, 6));
 
   return 0;
 }
@@ -614,7 +614,7 @@ types_bitstring_arithmetic_test_bitxor()
 static inline void
 expect_static_true(jlm::rvsdg::output * port)
 {
-  auto node = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*port);
+  auto node = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*port);
   auto op = dynamic_cast<const jlm::rvsdg::bitconstant_op *>(&node->GetOperation());
   assert(op && op->value().nbits() == 1 && op->value().str() == "1");
 }
@@ -622,7 +622,7 @@ expect_static_true(jlm::rvsdg::output * port)
 static inline void
 expect_static_false(jlm::rvsdg::output * port)
 {
-  auto node = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*port);
+  auto node = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*port);
   auto op = dynamic_cast<const jlm::rvsdg::bitconstant_op *>(&node->GetOperation());
   assert(op && op->value().nbits() == 1 && op->value().str() == "0");
 }
@@ -662,10 +662,10 @@ types_bitstring_comparison_test_bitequal()
   view(&graph.GetRootRegion(), stdout);
 
   // Assert
-  assert(TryGetOwnerNode<Node>(*ex0.origin())->GetOperation() == biteq_op(32));
+  assert(TryGetOwnerNode<SimpleNode>(*ex0.origin())->GetOperation() == biteq_op(32));
   expect_static_true(ex1.origin());
   expect_static_false(ex2.origin());
-  assert(TryGetOwnerNode<Node>(*ex3.origin())->GetOperation() == biteq_op(32));
+  assert(TryGetOwnerNode<SimpleNode>(*ex3.origin())->GetOperation() == biteq_op(32));
 
   return 0;
 }
@@ -705,10 +705,10 @@ types_bitstring_comparison_test_bitnotequal()
   view(&graph.GetRootRegion(), stdout);
 
   // Assert
-  assert(TryGetOwnerNode<Node>(*ex0.origin())->GetOperation() == bitne_op(32));
+  assert(TryGetOwnerNode<SimpleNode>(*ex0.origin())->GetOperation() == bitne_op(32));
   expect_static_false(ex1.origin());
   expect_static_true(ex2.origin());
-  assert(TryGetOwnerNode<Node>(*ex3.origin())->GetOperation() == bitne_op(32));
+  assert(TryGetOwnerNode<SimpleNode>(*ex3.origin())->GetOperation() == bitne_op(32));
 
   return 0;
 }
@@ -753,7 +753,7 @@ types_bitstring_comparison_test_bitsgreater()
   view(&graph.GetRootRegion(), stdout);
 
   // Assert
-  assert(TryGetOwnerNode<Node>(*ex0.origin())->GetOperation() == bitsgt_op(32));
+  assert(TryGetOwnerNode<SimpleNode>(*ex0.origin())->GetOperation() == bitsgt_op(32));
   expect_static_false(ex1.origin());
   expect_static_true(ex2.origin());
   expect_static_false(ex3.origin());
@@ -804,7 +804,7 @@ types_bitstring_comparison_test_bitsgreatereq()
   view(&graph.GetRootRegion(), stdout);
 
   // Arrange
-  assert(TryGetOwnerNode<Node>(*ex0.origin())->GetOperation() == bitsge_op(32));
+  assert(TryGetOwnerNode<SimpleNode>(*ex0.origin())->GetOperation() == bitsge_op(32));
   expect_static_false(ex1.origin());
   expect_static_true(ex2.origin());
   expect_static_true(ex3.origin());
@@ -854,7 +854,7 @@ types_bitstring_comparison_test_bitsless()
   view(&graph.GetRootRegion(), stdout);
 
   // Arrange
-  assert(TryGetOwnerNode<Node>(*ex0.origin())->GetOperation() == bitslt_op(32));
+  assert(TryGetOwnerNode<SimpleNode>(*ex0.origin())->GetOperation() == bitslt_op(32));
   expect_static_true(ex1.origin());
   expect_static_false(ex2.origin());
   expect_static_false(ex3.origin());
@@ -906,7 +906,7 @@ types_bitstring_comparison_test_bitslesseq()
   view(&graph.GetRootRegion(), stdout);
 
   // Assert
-  assert(TryGetOwnerNode<Node>(*ex0.origin())->GetOperation() == bitsle_op(32));
+  assert(TryGetOwnerNode<SimpleNode>(*ex0.origin())->GetOperation() == bitsle_op(32));
   expect_static_true(ex1.origin());
   expect_static_true(ex2.origin());
   expect_static_false(ex3.origin());
@@ -955,7 +955,7 @@ types_bitstring_comparison_test_bitugreater()
   view(&graph.GetRootRegion(), stdout);
 
   // Assert
-  assert(TryGetOwnerNode<Node>(*ex0.origin())->GetOperation() == bitugt_op(32));
+  assert(TryGetOwnerNode<SimpleNode>(*ex0.origin())->GetOperation() == bitugt_op(32));
   expect_static_false(ex1.origin());
   expect_static_true(ex2.origin());
   expect_static_false(ex3.origin());
@@ -1006,7 +1006,7 @@ types_bitstring_comparison_test_bitugreatereq()
   view(&graph.GetRootRegion(), stdout);
 
   // Assert
-  assert(TryGetOwnerNode<Node>(*ex0.origin())->GetOperation() == bituge_op(32));
+  assert(TryGetOwnerNode<SimpleNode>(*ex0.origin())->GetOperation() == bituge_op(32));
   expect_static_false(ex1.origin());
   expect_static_true(ex2.origin());
   expect_static_true(ex3.origin());
@@ -1056,7 +1056,7 @@ types_bitstring_comparison_test_bituless()
   view(&graph.GetRootRegion(), stdout);
 
   // Assert
-  assert(TryGetOwnerNode<Node>(*ex0.origin())->GetOperation() == bitult_op(32));
+  assert(TryGetOwnerNode<SimpleNode>(*ex0.origin())->GetOperation() == bitult_op(32));
   expect_static_true(ex1.origin());
   expect_static_false(ex2.origin());
   expect_static_false(ex3.origin());
@@ -1108,7 +1108,7 @@ types_bitstring_comparison_test_bitulesseq()
   view(&graph.GetRootRegion(), stdout);
 
   // Assert
-  assert(TryGetOwnerNode<Node>(*ex0.origin())->GetOperation() == bitule_op(32));
+  assert(TryGetOwnerNode<SimpleNode>(*ex0.origin())->GetOperation() == bitule_op(32));
   expect_static_true(ex1.origin());
   expect_static_true(ex2.origin());
   expect_static_false(ex3.origin());
@@ -1179,19 +1179,19 @@ types_bitstring_test_constant()
   assert(b1.GetOperation() == uint_constant_op(8, 204));
   assert(b1.GetOperation() == int_constant_op(8, -52));
 
-  ReduceNode<bitconstant_op>(NormalizeCne, *TryGetOwnerNode<Node>(*ex1.origin()));
-  ReduceNode<bitconstant_op>(NormalizeCne, *TryGetOwnerNode<Node>(*ex2.origin()));
-  ReduceNode<bitconstant_op>(NormalizeCne, *TryGetOwnerNode<Node>(*ex3.origin()));
-  ReduceNode<bitconstant_op>(NormalizeCne, *TryGetOwnerNode<Node>(*ex4.origin()));
+  ReduceNode<bitconstant_op>(NormalizeCne, *TryGetOwnerNode<SimpleNode>(*ex1.origin()));
+  ReduceNode<bitconstant_op>(NormalizeCne, *TryGetOwnerNode<SimpleNode>(*ex2.origin()));
+  ReduceNode<bitconstant_op>(NormalizeCne, *TryGetOwnerNode<SimpleNode>(*ex3.origin()));
+  ReduceNode<bitconstant_op>(NormalizeCne, *TryGetOwnerNode<SimpleNode>(*ex4.origin()));
 
   assert(ex1.origin() == ex2.origin());
   assert(ex1.origin() == ex3.origin());
 
-  const auto node1 = TryGetOwnerNode<Node>(*ex1.origin());
+  const auto node1 = TryGetOwnerNode<SimpleNode>(*ex1.origin());
   assert(node1->GetOperation() == uint_constant_op(8, 204));
   assert(node1->GetOperation() == int_constant_op(8, -52));
 
-  const auto node4 = TryGetOwnerNode<Node>(*ex4.origin());
+  const auto node4 = TryGetOwnerNode<SimpleNode>(*ex4.origin());
   assert(node4->GetOperation() == uint_constant_op(9, 204));
   assert(node4->GetOperation() == int_constant_op(9, 204));
 
@@ -1230,14 +1230,14 @@ types_bitstring_test_normalize()
 
   // Act
   ReduceNode<bitadd_op>(FlattenAssociativeBinaryOperation, sum1);
-  auto & flattenedBinaryNode = *TryGetOwnerNode<Node>(*ex.origin());
+  auto & flattenedBinaryNode = *TryGetOwnerNode<SimpleNode>(*ex.origin());
   ReduceNode<FlattenedBinaryOperation>(NormalizeFlattenedBinaryOperation, flattenedBinaryNode);
   graph.PruneNodes();
 
   view(&graph.GetRootRegion(), stdout);
 
   // Assert
-  auto node = TryGetOwnerNode<Node>(*ex.origin());
+  auto node = TryGetOwnerNode<SimpleNode>(*ex.origin());
   assert(node->GetOperation() == bitadd_op(32));
   assert(node->ninputs() == 2);
   auto op1 = node->input(0)->origin();
@@ -1249,7 +1249,7 @@ types_bitstring_test_normalize()
     op2 = tmp;
   }
   /* FIXME: the graph traversers are currently broken, that is why it won't normalize */
-  assert(TryGetOwnerNode<Node>(*op1)->GetOperation() == int_constant_op(32, 3 + 4));
+  assert(TryGetOwnerNode<SimpleNode>(*op1)->GetOperation() == int_constant_op(32, 3 + 4));
   assert(op2 == imp);
 
   view(&graph.GetRootRegion(), stdout);
@@ -1260,7 +1260,7 @@ types_bitstring_test_normalize()
 static void
 assert_constant(jlm::rvsdg::output * bitstr, size_t nbits, const char bits[])
 {
-  auto node = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*bitstr);
+  auto node = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*bitstr);
   auto op = dynamic_cast<const jlm::rvsdg::bitconstant_op &>(node->GetOperation());
   assert(op.value() == jlm::rvsdg::bitvalue_repr(std::string(bits, nbits).c_str()));
 }
@@ -1402,7 +1402,7 @@ ConcatOfSliceReduction()
   view(&graph.GetRootRegion(), stdout);
 
   // Assert
-  const auto sliceNode = TryGetOwnerNode<Node>(*ex.origin());
+  const auto sliceNode = TryGetOwnerNode<SimpleNode>(*ex.origin());
   assert(sliceNode->GetOperation() == bitslice_op(bit16Type, 0, 16));
   assert(sliceNode->input(0)->origin() == x);
 
@@ -1435,7 +1435,7 @@ SliceOfConstant()
   view(graph, stdout);
 
   // Assert
-  const auto node = TryGetOwnerNode<Node>(*ex.origin());
+  const auto node = TryGetOwnerNode<SimpleNode>(*ex.origin());
   auto & operation = dynamic_cast<const bitconstant_op &>(node->GetOperation());
   assert(operation.value() == bitvalue_repr("1101"));
 
@@ -1468,7 +1468,7 @@ SliceOfSlice()
   view(graph, stdout);
 
   // Assert
-  const auto node = TryGetOwnerNode<Node>(*ex.origin());
+  const auto node = TryGetOwnerNode<SimpleNode>(*ex.origin());
   const auto operation = dynamic_cast<const bitslice_op *>(&node->GetOperation());
   assert(operation->low() == 3 && operation->high() == 5);
 
@@ -1527,11 +1527,11 @@ SliceOfConcat()
 
   // Act
   ReduceNode<bitslice_op>(NormalizeUnaryOperation, sliceNode);
-  auto concatNode = TryGetOwnerNode<Node>(*ex.origin());
+  auto concatNode = TryGetOwnerNode<SimpleNode>(*ex.origin());
   ReduceNode<bitslice_op>(
       NormalizeUnaryOperation,
-      *TryGetOwnerNode<Node>(*concatNode->input(0)->origin()));
-  concatNode = TryGetOwnerNode<Node>(*ex.origin());
+      *TryGetOwnerNode<SimpleNode>(*concatNode->input(0)->origin()));
+  concatNode = TryGetOwnerNode<SimpleNode>(*ex.origin());
   ReduceNode<bitconcat_op>(NormalizeBinaryOperation, *concatNode);
   graph.PruneNodes();
 
@@ -1565,13 +1565,13 @@ ConcatFlattening()
   view(graph, stdout);
 
   // Act
-  const auto concatNode = TryGetOwnerNode<Node>(*ex.origin());
+  const auto concatNode = TryGetOwnerNode<SimpleNode>(*ex.origin());
   ReduceNode<bitconcat_op>(FlattenBitConcatOperation, *concatNode);
 
   view(graph, stdout);
 
   // Assert
-  auto node = TryGetOwnerNode<Node>(*ex.origin());
+  auto node = TryGetOwnerNode<SimpleNode>(*ex.origin());
   assert(dynamic_cast<const bitconcat_op *>(&node->GetOperation()));
   assert(node->ninputs() == 3);
   assert(node->input(0)->origin() == x);
@@ -1637,7 +1637,7 @@ ConcatOfSlices()
 
   // Act
   ReduceNode<bitconcat_op>(NormalizeBinaryOperation, concatNode);
-  ReduceNode<bitslice_op>(NormalizeUnaryOperation, *TryGetOwnerNode<Node>(*ex.origin()));
+  ReduceNode<bitslice_op>(NormalizeUnaryOperation, *TryGetOwnerNode<SimpleNode>(*ex.origin()));
   graph.PruneNodes();
 
   view(graph, stdout);
@@ -1666,10 +1666,10 @@ ConcatOfConstants()
   view(graph, stdout);
 
   // Act
-  ReduceNode<bitconcat_op>(NormalizeBinaryOperation, *TryGetOwnerNode<Node>(*ex.origin()));
+  ReduceNode<bitconcat_op>(NormalizeBinaryOperation, *TryGetOwnerNode<SimpleNode>(*ex.origin()));
 
   // Assert
-  auto node = TryGetOwnerNode<Node>(*ex.origin());
+  auto node = TryGetOwnerNode<SimpleNode>(*ex.origin());
   auto operation = dynamic_cast<const bitconstant_op &>(node->GetOperation());
   assert(operation.value() == bitvalue_repr("0011011111001000"));
 
@@ -1709,8 +1709,8 @@ ConcatCne()
   view(graph, stdout);
 
   // Act
-  ReduceNode<bitconcat_op>(NormalizeCne, *TryGetOwnerNode<Node>(*ex1.origin()));
-  ReduceNode<bitconcat_op>(NormalizeCne, *TryGetOwnerNode<Node>(*ex2.origin()));
+  ReduceNode<bitconcat_op>(NormalizeCne, *TryGetOwnerNode<SimpleNode>(*ex1.origin()));
+  ReduceNode<bitconcat_op>(NormalizeCne, *TryGetOwnerNode<SimpleNode>(*ex2.origin()));
   graph.PruneNodes();
 
   view(graph, stdout);
@@ -1752,8 +1752,8 @@ SliceCne()
   view(graph, stdout);
 
   // Act
-  ReduceNode<bitslice_op>(NormalizeCne, *TryGetOwnerNode<Node>(*ex1.origin()));
-  ReduceNode<bitslice_op>(NormalizeCne, *TryGetOwnerNode<Node>(*ex2.origin()));
+  ReduceNode<bitslice_op>(NormalizeCne, *TryGetOwnerNode<SimpleNode>(*ex1.origin()));
+  ReduceNode<bitslice_op>(NormalizeCne, *TryGetOwnerNode<SimpleNode>(*ex2.origin()));
   graph.PruneNodes();
   view(graph, stdout);
 

--- a/tests/jlm/rvsdg/test-cse.cpp
+++ b/tests/jlm/rvsdg/test-cse.cpp
@@ -41,29 +41,29 @@ test_main()
   auto & e4 = jlm::tests::GraphExport::Create(*o4, "o4");
 
   // Act & Assert
-  ReduceNode<jlm::tests::test_op>(NormalizeCne, *TryGetOwnerNode<Node>(*e1.origin()));
-  ReduceNode<jlm::tests::test_op>(NormalizeCne, *TryGetOwnerNode<Node>(*e2.origin()));
-  ReduceNode<jlm::tests::test_op>(NormalizeCne, *TryGetOwnerNode<Node>(*e3.origin()));
-  ReduceNode<jlm::tests::test_op>(NormalizeCne, *TryGetOwnerNode<Node>(*e4.origin()));
+  ReduceNode<jlm::tests::test_op>(NormalizeCne, *TryGetOwnerNode<SimpleNode>(*e1.origin()));
+  ReduceNode<jlm::tests::test_op>(NormalizeCne, *TryGetOwnerNode<SimpleNode>(*e2.origin()));
+  ReduceNode<jlm::tests::test_op>(NormalizeCne, *TryGetOwnerNode<SimpleNode>(*e3.origin()));
+  ReduceNode<jlm::tests::test_op>(NormalizeCne, *TryGetOwnerNode<SimpleNode>(*e4.origin()));
 
   assert(e1.origin() == e3.origin());
   assert(e2.origin() == e4.origin());
 
   auto o5 = jlm::tests::create_testop(&graph.GetRootRegion(), {}, { valueType })[0];
   auto & e5 = jlm::tests::GraphExport::Create(*o5, "o5");
-  ReduceNode<jlm::tests::test_op>(NormalizeCne, *TryGetOwnerNode<Node>(*e5.origin()));
+  ReduceNode<jlm::tests::test_op>(NormalizeCne, *TryGetOwnerNode<SimpleNode>(*e5.origin()));
   assert(e5.origin() == e1.origin());
 
   auto o6 = jlm::tests::create_testop(&graph.GetRootRegion(), { i }, { valueType })[0];
   auto & e6 = jlm::tests::GraphExport::Create(*o6, "o6");
-  ReduceNode<jlm::tests::test_op>(NormalizeCne, *TryGetOwnerNode<Node>(*e6.origin()));
+  ReduceNode<jlm::tests::test_op>(NormalizeCne, *TryGetOwnerNode<SimpleNode>(*e6.origin()));
   assert(e6.origin() == e2.origin());
 
   auto o7 = jlm::tests::create_testop(&graph.GetRootRegion(), {}, { valueType })[0];
   auto & e7 = jlm::tests::GraphExport::Create(*o7, "o7");
   assert(e7.origin() != e1.origin());
 
-  ReduceNode<jlm::tests::test_op>(NormalizeCne, *TryGetOwnerNode<Node>(*e7.origin()));
+  ReduceNode<jlm::tests::test_op>(NormalizeCne, *TryGetOwnerNode<SimpleNode>(*e7.origin()));
   assert(e7.origin() == e1.origin());
 
   return 0;

--- a/tests/jlm/rvsdg/test-gamma.cpp
+++ b/tests/jlm/rvsdg/test-gamma.cpp
@@ -152,7 +152,7 @@ test_control_constant_reduction()
   view(&graph.GetRootRegion(), stdout);
 
   // Assert
-  auto match = TryGetOwnerNode<Node>(*ex1.origin());
+  auto match = TryGetOwnerNode<SimpleNode>(*ex1.origin());
   assert(match && is<match_op>(match->GetOperation()));
   auto & match_op = to_match_op(match->GetOperation());
   assert(match_op.default_alternative() == 0);


### PR DESCRIPTION
Separate the inheritance hierarchies of SimpleOperation / StructuralOperation. This makes "SimpleOperation" the root class for all operational nodes. The inheritance hierarchy for StructuralOperation is kept for the moment, eventually the "contents" of structural operations can be entirely disassociated. They should evolve into something that can carry information specific to the structure, particularly backend-specific customizations of structural nodes.