### PR TITLE
Fix bug in InvariantValueRedirection pass

### DIFF
--- a/jlm/llvm/opt/InvariantValueRedirection.cpp
+++ b/jlm/llvm/opt/InvariantValueRedirection.cpp
@@ -3,6 +3,9 @@
  * See COPYING for terms of redistribution.
  */
 
+#include "jlm/llvm/backend/dot/DotWriter.hpp"
+#include "jlm/util/GraphWriter.hpp"
+#include <fstream>
 #include <jlm/llvm/ir/LambdaMemoryState.hpp>
 #include <jlm/llvm/ir/operators/call.hpp>
 #include <jlm/llvm/ir/operators/delta.hpp>
@@ -53,6 +56,14 @@ InvariantValueRedirection::Run(
     util::StatisticsCollector & statisticsCollector)
 {
   auto statistics = Statistics::Create(module.SourceFilePath().value());
+
+  util::GraphWriter writer;
+  dot::WriteGraphs(writer, module.Rvsdg().GetRootRegion(), false);
+
+  std::ofstream fs;
+  fs.open("/tmp/output.dot");
+  writer.OutputAllGraphs(fs, util::GraphOutputFormat::Dot);
+  fs.close();
 
   statistics->Start();
   RedirectInRootRegion(module.Rvsdg());

--- a/jlm/llvm/opt/InvariantValueRedirection.cpp
+++ b/jlm/llvm/opt/InvariantValueRedirection.cpp
@@ -3,9 +3,6 @@
  * See COPYING for terms of redistribution.
  */
 
-#include "jlm/llvm/backend/dot/DotWriter.hpp"
-#include "jlm/util/GraphWriter.hpp"
-#include <fstream>
 #include <jlm/llvm/ir/LambdaMemoryState.hpp>
 #include <jlm/llvm/ir/operators/call.hpp>
 #include <jlm/llvm/ir/operators/delta.hpp>

--- a/tests/jlm/llvm/opt/InvariantValueRedirectionTests.cpp
+++ b/tests/jlm/llvm/opt/InvariantValueRedirectionTests.cpp
@@ -3,7 +3,6 @@
  * See COPYING for terms of redistribution.
  */
 
-#include "jlm/llvm/ir/operators/IntegerOperations.hpp"
 #include <test-registry.hpp>
 #include <test-types.hpp>
 #include <TestRvsdgs.hpp>
@@ -15,6 +14,7 @@
 
 #include <jlm/llvm/ir/LambdaMemoryState.hpp>
 #include <jlm/llvm/ir/operators/call.hpp>
+#include <jlm/llvm/ir/operators/IntegerOperations.hpp>
 #include <jlm/llvm/ir/RvsdgModule.hpp>
 #include <jlm/llvm/opt/InvariantValueRedirection.hpp>
 #include <jlm/util/Statistics.hpp>


### PR DESCRIPTION
The pass falsely assumed that if the CallMemoryStateExitSplit node is present for a call, then all the other memory state nodes (i.e., CallMemoryStateEntryMerge,  LambdaMemoryStateEntrySplit, LambdaMemoryStateExitMerge) are present as well. This does not have to be the case in general. For example, it might be that after region-aware state encoding, the LambdaMemoryStateEntrySplit node is missing, while all other nodes are present.

Close #937 