### PR TITLE
Fix includes of standard library headers

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/UnusedStateRemoval.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/UnusedStateRemoval.cpp
@@ -11,6 +11,8 @@
 #include <jlm/rvsdg/theta.hpp>
 #include <jlm/rvsdg/traverser.hpp>
 
+#include <algorithm>
+
 namespace jlm::hls
 {
 

--- a/jlm/hls/backend/rvsdg2rhls/decouple-mem-state.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/decouple-mem-state.cpp
@@ -21,6 +21,7 @@
 #include <jlm/rvsdg/traverser.hpp>
 #include <jlm/rvsdg/view.hpp>
 
+#include <algorithm>
 #include <deque>
 
 namespace jlm::hls


### PR DESCRIPTION
On my system these files do not compile, despite CI passing fine. I assume Ubuntu has slightly different headers causing the added headers to already be transitively included.