### PR TITLE
Add functions for getting size and alignment of types

### DIFF
--- a/jlm/llvm/ir/types.hpp
+++ b/jlm/llvm/ir/types.hpp
@@ -195,6 +195,15 @@ public:
   StructType &
   operator=(StructType &&) = delete;
 
+  bool
+  operator==(const jlm::rvsdg::Type & other) const noexcept override;
+
+  [[nodiscard]] std::size_t
+  ComputeHash() const noexcept override;
+
+  [[nodiscard]] std::string
+  debug_string() const override;
+
   [[nodiscard]] bool
   HasName() const noexcept
   {
@@ -219,14 +228,15 @@ public:
     return Declaration_;
   }
 
-  bool
-  operator==(const jlm::rvsdg::Type & other) const noexcept override;
-
-  [[nodiscard]] std::size_t
-  ComputeHash() const noexcept override;
-
-  [[nodiscard]] std::string
-  debug_string() const override;
+  /**
+   * Gets the position of the given field, as a byte offset from the start of the struct.
+   * Non-packed structs use padding to respect the alignment of each field, just like in C.
+   * Packed structs have no padding, and no alignment.
+   * @param fieldIndex the index of the field, must be valid
+   * @return the byte offset of the given field
+   */
+  [[nodiscard]] size_t
+  GetFieldOffset(size_t fieldIndex) const;
 
   static std::shared_ptr<const StructType>
   Create(const std::string & name, bool isPacked, const Declaration & declaration)
@@ -507,16 +517,6 @@ GetTypeSize(const rvsdg::ValueType & type);
  */
 [[nodiscard]] size_t
 GetTypeAlignment(const rvsdg::ValueType & type);
-
-/**
- * Gets the offset at which the given field is located in memory.
- * Respects alignment of each field, just like in C. Supports packed structs.
- * @param structType the struct type
- * @param fieldIndex the index of the field, must be a valid field
- * @return the byte offset of the field, relative to the beginning of the struct.
- */
-[[nodiscard]] size_t
-GetStructFieldOffset(const StructType & structType, size_t fieldIndex);
 
 }
 

--- a/jlm/llvm/ir/types.hpp
+++ b/jlm/llvm/ir/types.hpp
@@ -487,6 +487,37 @@ IsAggregateType(const jlm::rvsdg::Type & type)
   return jlm::rvsdg::is<ArrayType>(type) || jlm::rvsdg::is<StructType>(type);
 }
 
+/**
+ * Returns the size of the given type's representation, in bytes.
+ * The size is always a multiple of the alignment, just like the C operator sizeof().
+ * This means the size includes any padding at the end.
+ * @param type the ValueType
+ * @return the byte size of the type
+ */
+[[nodiscard]] size_t
+GetTypeSize(const rvsdg::ValueType & type);
+
+/**
+ * Returns the natural alignment of the given type, in bytes.
+ * Types are not guaranteed to be stored at their natural alignment,
+ * so instead check the alignment of the store and load operations.
+ * A non-packed struct will add padding to maintain alignment.
+ * @param type the ValueType
+ * @return the byte alignment of the type
+ */
+[[nodiscard]] size_t
+GetTypeAlignment(const rvsdg::ValueType & type);
+
+/**
+ * Gets the offset at which the given field is located in memory.
+ * Respects alignment of each field, just like in C. Supports packed structs.
+ * @param structType the struct type
+ * @param fieldIndex the index of the field, must be a valid field
+ * @return the byte offset of the field, relative to the beginning of the struct.
+ */
+[[nodiscard]] size_t
+GetStructFieldOffset(const StructType & structType, size_t fieldIndex);
+
 }
 
 #endif

--- a/tests/jlm/llvm/ir/TestTypes.cpp
+++ b/tests/jlm/llvm/ir/TestTypes.cpp
@@ -115,20 +115,20 @@ TestGetTypeSizeAndAlignment()
   structDeclaration->Append(bits32);
 
   auto structType = StructType::Create("myStruct", false, *structDeclaration);
-  assert(GetStructFieldOffset(*structType, 0) == 0);
-  assert(GetStructFieldOffset(*structType, 1) == 8); // Due to 4 bytes of padding after i32
-  assert(GetStructFieldOffset(*structType, 2) == 16);
-  assert(GetStructFieldOffset(*structType, 3) == 48); // 12 bytes of padding after array
-  assert(GetStructFieldOffset(*structType, 4) == 64);
+  assert(structType->GetFieldOffset(0) == 0);
+  assert(structType->GetFieldOffset(1) == 8); // Due to 4 bytes of padding after i32
+  assert(structType->GetFieldOffset(2) == 16);
+  assert(structType->GetFieldOffset(3) == 48); // 12 bytes of padding after array
+  assert(structType->GetFieldOffset(4) == 64);
   assert(GetTypeSize(*structType) == 80); // Struct ends with 12 bytes of padding
   assert(GetTypeAlignment(*structType) == 16);
 
   auto packedStructType = StructType::Create("myPackedStruct", true, *structDeclaration);
-  assert(GetStructFieldOffset(*packedStructType, 0) == 0);
-  assert(GetStructFieldOffset(*packedStructType, 1) == 4);
-  assert(GetStructFieldOffset(*packedStructType, 2) == 12);
-  assert(GetStructFieldOffset(*packedStructType, 3) == 32); // array is 20 bytes
-  assert(GetStructFieldOffset(*packedStructType, 4) == 48); // vector is 16 bytes
+  assert(packedStructType->GetFieldOffset(0) == 0);
+  assert(packedStructType->GetFieldOffset(1) == 4);
+  assert(packedStructType->GetFieldOffset(2) == 12);
+  assert(packedStructType->GetFieldOffset(3) == 32); // array is 20 bytes
+  assert(packedStructType->GetFieldOffset(4) == 48); // vector is 16 bytes
   assert(GetTypeSize(*packedStructType) == 52);
   assert(GetTypeAlignment(*packedStructType) == 1);
 

--- a/tests/jlm/llvm/ir/TestTypes.cpp
+++ b/tests/jlm/llvm/ir/TestTypes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Håvard Krogstie <krogstie.havard@gmail.com>
+ * Copyright 2024, 2025 Håvard Krogstie <krogstie.havard@gmail.com>
  * See COPYING for terms of redistribution.
  */
 
@@ -71,5 +71,69 @@ TestIsOrContains()
 
   return 0;
 }
+JLM_UNIT_TEST_REGISTER("jlm/llvm/ir/TestTypes-TestIsOrContains", TestIsOrContains)
 
-JLM_UNIT_TEST_REGISTER("jlm/llvm/ir/TestTypes-TestIsOrContains", TestIsOrContains);
+static int
+TestGetTypeSizeAndAlignment()
+{
+  using namespace jlm::llvm;
+
+  auto pointerType = PointerType::Create();
+  assert(GetTypeSize(*pointerType) == 8);
+  assert(GetTypeAlignment(*pointerType) == 8);
+
+  auto bits32 = jlm::rvsdg::bittype::Create(32);
+  auto bits50 = jlm::rvsdg::bittype::Create(50);
+  assert(GetTypeSize(*bits32) == 4);
+  assert(GetTypeAlignment(*bits32) == 4);
+
+  assert(GetTypeSize(*bits50) == 8);
+  assert(GetTypeAlignment(*bits50) == 8);
+
+  auto floatType = FloatingPointType::Create(fpsize::fp128);
+  assert(GetTypeSize(*floatType) == 16);
+  assert(GetTypeAlignment(*floatType) == 16);
+  floatType = FloatingPointType::Create(fpsize::half);
+  assert(GetTypeSize(*floatType) == 2);
+  assert(GetTypeAlignment(*floatType) == 2);
+
+  auto arrayType = ArrayType::Create(bits32, 5);
+  assert(GetTypeSize(*arrayType) == 4 * 5);
+  assert(GetTypeAlignment(*arrayType) == 4);
+
+  // Vectors are always aligned up, so a <3 x i32> is 12 bytes of data and 4 bytes of padding.
+  // Vectors are also very aligned
+  auto vectorType = FixedVectorType::Create(bits32, 3);
+  assert(GetTypeSize(*vectorType) == 16);
+  assert(GetTypeAlignment(*vectorType) == 16);
+
+  auto structDeclaration = StructType::Declaration::Create();
+  structDeclaration->Append(bits32);
+  structDeclaration->Append(pointerType);
+  structDeclaration->Append(arrayType);
+  structDeclaration->Append(vectorType); // The most aligned type, 16 byte alignment
+  structDeclaration->Append(bits32);
+
+  auto structType = StructType::Create("myStruct", false, *structDeclaration);
+  assert(GetStructFieldOffset(*structType, 0) == 0);
+  assert(GetStructFieldOffset(*structType, 1) == 8); // Due to 4 bytes of padding after i32
+  assert(GetStructFieldOffset(*structType, 2) == 16);
+  assert(GetStructFieldOffset(*structType, 3) == 48); // 12 bytes of padding after array
+  assert(GetStructFieldOffset(*structType, 4) == 64);
+  assert(GetTypeSize(*structType) == 80); // Struct ends with 12 bytes of padding
+  assert(GetTypeAlignment(*structType) == 16);
+
+  auto packedStructType = StructType::Create("myPackedStruct", true, *structDeclaration);
+  assert(GetStructFieldOffset(*packedStructType, 0) == 0);
+  assert(GetStructFieldOffset(*packedStructType, 1) == 4);
+  assert(GetStructFieldOffset(*packedStructType, 2) == 12);
+  assert(GetStructFieldOffset(*packedStructType, 3) == 32); // array is 20 bytes
+  assert(GetStructFieldOffset(*packedStructType, 4) == 48); // vector is 16 bytes
+  assert(GetTypeSize(*packedStructType) == 52);
+  assert(GetTypeAlignment(*packedStructType) == 1);
+
+  return 0;
+}
+JLM_UNIT_TEST_REGISTER(
+    "jlm/llvm/ir/TestTypes-TestGetTypeSizeAndAlignment",
+    TestGetTypeSizeAndAlignment)


### PR DESCRIPTION
The logic surrounding alignment was based on opening up Compiler Explorer and testing with `sizeof()` and `alignof()`