### PR TITLE
Remove weird and unused llvm include

### DIFF
--- a/tests/jlm/llvm/ir/operators/MemoryStateOperationTests.cpp
+++ b/tests/jlm/llvm/ir/operators/MemoryStateOperationTests.cpp
@@ -10,7 +10,6 @@
 #include <jlm/llvm/ir/RvsdgModule.hpp>
 #include <jlm/rvsdg/NodeNormalization.hpp>
 #include <jlm/rvsdg/view.hpp>
-#include <llvm-18/llvm/ADT/StringExtras.h>
 
 static int
 MemoryStateSplitEquality()


### PR DESCRIPTION
I assume this was added by CLion accidentally. It does not do anything, and causes compilation to fail when not on Ubuntu