### PR TITLE
Add LambdaExitMemoryStateMergeOperation normalizations

### DIFF
--- a/jlm/llvm/ir/operators/Load.hpp
+++ b/jlm/llvm/ir/operators/Load.hpp
@@ -149,6 +149,9 @@ public:
              MemoryStateOutputIterator(nullptr) };
   }
 
+  /**
+   * Maps a memory state output of a load operation to its corresponding memory state input.
+   */
   [[nodiscard]] static rvsdg::Input &
   MapMemoryStateOutputToInput(const rvsdg::Output & output)
   {

--- a/jlm/llvm/ir/operators/Load.hpp
+++ b/jlm/llvm/ir/operators/Load.hpp
@@ -149,6 +149,18 @@ public:
              MemoryStateOutputIterator(nullptr) };
   }
 
+  [[nodiscard]] static rvsdg::Input &
+  MapMemoryStateOutputToInput(const rvsdg::Output & output)
+  {
+    JLM_ASSERT(is<MemoryStateType>(output.Type()));
+    auto [loadNode, loadOperation] = rvsdg::TryGetSimpleNodeAndOp<LoadOperation>(output);
+    JLM_ASSERT(loadOperation);
+    JLM_ASSERT(loadNode->ninputs() == loadNode->noutputs());
+    const auto input = loadNode->input(output.index());
+    JLM_ASSERT(is<MemoryStateType>(input->Type()));
+    return *input;
+  }
+
 private:
   size_t NumMemoryStates_;
   size_t Alignment_;

--- a/jlm/llvm/ir/operators/MemoryStateOperations.cpp
+++ b/jlm/llvm/ir/operators/MemoryStateOperations.cpp
@@ -233,7 +233,7 @@ LambdaExitMemoryStateMergeOperation::copy() const
 }
 
 std::optional<std::vector<rvsdg::Output *>>
-LambdaExitMemoryStateMergeOperation::NormalizeLoad(
+LambdaExitMemoryStateMergeOperation::NormalizeLoadFromAlloca(
     const LambdaExitMemoryStateMergeOperation &,
     const std::vector<rvsdg::Output *> & operands)
 {
@@ -270,7 +270,7 @@ LambdaExitMemoryStateMergeOperation::NormalizeLoad(
 }
 
 std::optional<std::vector<rvsdg::Output *>>
-LambdaExitMemoryStateMergeOperation::NormalizeStore(
+LambdaExitMemoryStateMergeOperation::NormalizeStoreToAlloca(
     const LambdaExitMemoryStateMergeOperation &,
     const std::vector<rvsdg::Output *> & operands)
 {

--- a/jlm/llvm/ir/operators/MemoryStateOperations.cpp
+++ b/jlm/llvm/ir/operators/MemoryStateOperations.cpp
@@ -237,7 +237,8 @@ LambdaExitMemoryStateMergeOperation::NormalizeLoadFromAlloca(
     const LambdaExitMemoryStateMergeOperation &,
     const std::vector<rvsdg::Output *> & operands)
 {
-  JLM_ASSERT(!operands.empty());
+  if (operands.empty())
+    return std::nullopt;
 
   bool replacedOperands = false;
   std::vector<rvsdg::Output *> newOperands;
@@ -274,7 +275,8 @@ LambdaExitMemoryStateMergeOperation::NormalizeStoreToAlloca(
     const LambdaExitMemoryStateMergeOperation &,
     const std::vector<rvsdg::Output *> & operands)
 {
-  JLM_ASSERT(!operands.empty());
+  if (operands.empty())
+    return std::nullopt;
 
   bool replacedOperands = false;
   std::vector<rvsdg::Output *> newOperands;
@@ -311,7 +313,8 @@ LambdaExitMemoryStateMergeOperation::NormalizeAlloca(
     const LambdaExitMemoryStateMergeOperation &,
     const std::vector<rvsdg::Output *> & operands)
 {
-  JLM_ASSERT(!operands.empty());
+  if (operands.empty())
+    return std::nullopt;
 
   bool replacedOperands = false;
   std::vector<rvsdg::Output *> newOperands;

--- a/jlm/llvm/ir/operators/MemoryStateOperations.hpp
+++ b/jlm/llvm/ir/operators/MemoryStateOperations.hpp
@@ -266,14 +266,36 @@ public:
   [[nodiscard]] std::unique_ptr<Operation>
   copy() const override;
 
-  static rvsdg::Output &
-  Create(rvsdg::Region & region, const std::vector<jlm::rvsdg::Output *> & operands)
+  // FIXME: documentation
+  static std::optional<std::vector<rvsdg::Output *>>
+  NormalizeLoad(
+      const LambdaExitMemoryStateMergeOperation & operation,
+      const std::vector<rvsdg::Output *> & operands);
+
+  // FIXME: documentation
+  static std::optional<std::vector<rvsdg::Output *>>
+  NormalizeStore(
+      const LambdaExitMemoryStateMergeOperation & operation,
+      const std::vector<rvsdg::Output *> & operands);
+
+  // FIXME: documentation
+  static std::optional<std::vector<rvsdg::Output *>>
+  NormalizeAlloca(
+      const LambdaExitMemoryStateMergeOperation & operation,
+      const std::vector<rvsdg::Output *> & operands);
+
+  static rvsdg::Node &
+  CreateNode(rvsdg::Region & region, const std::vector<rvsdg::Output *> & operands)
   {
     return operands.empty()
-             ? *rvsdg::CreateOpNode<LambdaExitMemoryStateMergeOperation>(region, operands.size())
-                    .output(0)
-             : *rvsdg::CreateOpNode<LambdaExitMemoryStateMergeOperation>(operands, operands.size())
-                    .output(0);
+             ? rvsdg::CreateOpNode<LambdaExitMemoryStateMergeOperation>(region, operands.size())
+             : rvsdg::CreateOpNode<LambdaExitMemoryStateMergeOperation>(operands, operands.size());
+  }
+
+  static rvsdg::Output &
+  Create(rvsdg::Region & region, const std::vector<rvsdg::Output *> & operands)
+  {
+    return *CreateNode(region, operands).output(0);
   }
 };
 

--- a/jlm/llvm/ir/operators/MemoryStateOperations.hpp
+++ b/jlm/llvm/ir/operators/MemoryStateOperations.hpp
@@ -266,19 +266,48 @@ public:
   [[nodiscard]] std::unique_ptr<Operation>
   copy() const override;
 
-  // FIXME: documentation
+  /**
+   * Performs the following transformation:
+   *
+   * a, s1 = AllocaOperation ...
+   * v, s2 = LoadOperation a s1
+   * ... = LambdaExitMemoryStateMergeOperation s2 ... sn
+   * =>
+   * a, s1 = AllocaOperation ...
+   * v, s2 = LoadOperation a s1
+   * ... = LambdaExitMemoryStateMergeOperation s1 ... sn
+   */
   static std::optional<std::vector<rvsdg::Output *>>
-  NormalizeLoad(
+  NormalizeLoadFromAlloca(
       const LambdaExitMemoryStateMergeOperation & operation,
       const std::vector<rvsdg::Output *> & operands);
 
-  // FIXME: documentation
+  /**
+   * Performs the following transformation:
+   *
+   * a, s1 = AllocaOperation ...
+   * s2 = StoreOperation a v s1
+   * ... = LambdaExitMemoryStateMergeOperation s2 ... sn
+   * =>
+   * a, s1 = AllocaOperation ...
+   * s2 = StoreOperation a v s1
+   * ... = LambdaExitMemoryStateMergeOperation s1 ... sn
+   */
   static std::optional<std::vector<rvsdg::Output *>>
-  NormalizeStore(
+  NormalizeStoreToAlloca(
       const LambdaExitMemoryStateMergeOperation & operation,
       const std::vector<rvsdg::Output *> & operands);
 
-  // FIXME: documentation
+  /**
+   * Performs the following transformation:
+   *
+   * a, s1 = AllocaOperation ...
+   * ... = LambdaExitMemoryStateMergeOperation s1 ... sn
+   * =>
+   * a, s1 = AllocaOperation ...
+   * s2 = UndefValueOperation
+   * ... = LambdaExitMemoryStateMergeOperation s2 ... sn
+   */
   static std::optional<std::vector<rvsdg::Output *>>
   NormalizeAlloca(
       const LambdaExitMemoryStateMergeOperation & operation,

--- a/jlm/llvm/ir/operators/Store.hpp
+++ b/jlm/llvm/ir/operators/Store.hpp
@@ -126,6 +126,18 @@ public:
              MemoryStateOutputIterator(nullptr) };
   }
 
+  [[nodiscard]] static rvsdg::Input &
+  MapMemoryStateOutputToInput(const rvsdg::Output & output)
+  {
+    JLM_ASSERT(is<MemoryStateType>(output.Type()));
+    auto [storeNode, storeOperation] = rvsdg::TryGetSimpleNodeAndOp<StoreOperation>(output);
+    JLM_ASSERT(storeOperation);
+    JLM_ASSERT(storeNode->ninputs() - 2 == storeNode->noutputs());
+    const auto input = storeNode->input(output.index() + 2);
+    JLM_ASSERT(is<MemoryStateType>(input->Type()));
+    return *input;
+  }
+
 private:
   size_t NumMemoryStates_;
   size_t Alignment_;

--- a/jlm/llvm/ir/operators/Store.hpp
+++ b/jlm/llvm/ir/operators/Store.hpp
@@ -126,6 +126,9 @@ public:
              MemoryStateOutputIterator(nullptr) };
   }
 
+  /**
+   * Maps a memory state output to a store operation to its corresponding memory state input.
+   */
   [[nodiscard]] static rvsdg::Input &
   MapMemoryStateOutputToInput(const rvsdg::Output & output)
   {

--- a/jlm/llvm/opt/reduction.cpp
+++ b/jlm/llvm/opt/reduction.cpp
@@ -162,6 +162,10 @@ NodeReduction::ReduceSimpleNode(rvsdg::Node & simpleNode)
   {
     return ReduceMemoryStateSplitNode(simpleNode);
   }
+  if (is<LambdaExitMemoryStateMergeOperation>(&simpleNode))
+  {
+    return ReduceLambdaExitMemoryStateMergeNode(simpleNode);
+  }
   if (is<rvsdg::UnaryOperation>(&simpleNode))
   {
     // FIXME: handle the unary node
@@ -214,6 +218,15 @@ NodeReduction::ReduceMemoryStateSplitNode(rvsdg::Node & simpleNode)
   JLM_ASSERT(is<MemoryStateSplitOperation>(&simpleNode));
 
   return rvsdg::ReduceNode<MemoryStateSplitOperation>(NormalizeMemoryStateSplitNode, simpleNode);
+}
+
+bool
+NodeReduction::ReduceLambdaExitMemoryStateMergeNode(rvsdg::Node & simpleNode)
+{
+  JLM_ASSERT(is<LambdaExitMemoryStateMergeOperation>(&simpleNode));
+  return rvsdg::ReduceNode<LambdaExitMemoryStateMergeOperation>(
+      NormalizeLambdaExitMemoryStateMergeNode,
+      simpleNode);
 }
 
 std::optional<std::vector<rvsdg::Output *>>
@@ -277,6 +290,22 @@ NodeReduction::NormalizeMemoryStateSplitNode(
         MemoryStateSplitOperation::NormalizeSplitMerge });
 
   return rvsdg::NormalizeSequence<MemoryStateSplitOperation>(normalizations, operation, operands);
+}
+
+std::optional<std::vector<rvsdg::Output *>>
+NodeReduction::NormalizeLambdaExitMemoryStateMergeNode(
+    const LambdaExitMemoryStateMergeOperation & operation,
+    const std::vector<rvsdg::Output *> & operands)
+{
+  static std::vector<rvsdg::NodeNormalization<LambdaExitMemoryStateMergeOperation>> normalizations(
+      { LambdaExitMemoryStateMergeOperation::NormalizeLoadFromAlloca,
+        LambdaExitMemoryStateMergeOperation::NormalizeStoreToAlloca,
+        LambdaExitMemoryStateMergeOperation::NormalizeAlloca });
+
+  return rvsdg::NormalizeSequence<LambdaExitMemoryStateMergeOperation>(
+      normalizations,
+      operation,
+      operands);
 }
 
 }

--- a/jlm/llvm/opt/reduction.hpp
+++ b/jlm/llvm/opt/reduction.hpp
@@ -23,6 +23,7 @@ class StructuralNode;
 namespace jlm::llvm
 {
 
+class LambdaExitMemoryStateMergeOperation;
 class LoadNonVolatileOperation;
 class MemoryStateMergeOperation;
 class MemoryStateSplitOperation;

--- a/jlm/llvm/opt/reduction.hpp
+++ b/jlm/llvm/opt/reduction.hpp
@@ -90,6 +90,9 @@ private:
   ReduceMemoryStateSplitNode(rvsdg::Node & simpleNode);
 
   [[nodiscard]] static bool
+  ReduceLambdaExitMemoryStateMergeNode(rvsdg::Node & simpleNode);
+
+  [[nodiscard]] static bool
   ReduceBinaryNode(rvsdg::Node & simpleNode);
 
   static std::optional<std::vector<rvsdg::Output *>>
@@ -110,6 +113,11 @@ private:
   static std::optional<std::vector<rvsdg::Output *>>
   NormalizeMemoryStateSplitNode(
       const MemoryStateSplitOperation & operation,
+      const std::vector<rvsdg::Output *> & operands);
+
+  static std::optional<std::vector<rvsdg::Output *>>
+  NormalizeLambdaExitMemoryStateMergeNode(
+      const LambdaExitMemoryStateMergeOperation & operation,
       const std::vector<rvsdg::Output *> & operands);
 
   std::unique_ptr<Statistics> Statistics_;

--- a/tests/jlm/llvm/ir/operators/MemoryStateOperationTests.cpp
+++ b/tests/jlm/llvm/ir/operators/MemoryStateOperationTests.cpp
@@ -453,7 +453,7 @@ LambdaExitMemoryStateMergeNormalizeLoad()
 
   // Act
   const auto success = jlm::rvsdg::ReduceNode<LambdaExitMemoryStateMergeOperation>(
-      LambdaExitMemoryStateMergeOperation::NormalizeLoad,
+      LambdaExitMemoryStateMergeOperation::NormalizeLoadFromAlloca,
       lambdaExitMergeNode1);
   graph.PruneNodes();
 
@@ -516,7 +516,7 @@ LambdaExitMemoryStateMergeNormalizeStore()
 
   // Act
   const auto success = jlm::rvsdg::ReduceNode<LambdaExitMemoryStateMergeOperation>(
-      LambdaExitMemoryStateMergeOperation::NormalizeStore,
+      LambdaExitMemoryStateMergeOperation::NormalizeStoreToAlloca,
       lambdaExitMergeNode1);
   graph.PruneNodes();
 


### PR DESCRIPTION
Adds three LambdaExitMemoryStateMergeOperation normalizations that together render load, store, and alloca operations independent from the lambda node, leading to them potentially becoming dead code. This should be able to remove a significant amount of load, stores, and allocas that are normally eliminated by mem2reg.