### PR TITLE
Add Alloca/Load/Store printing support to RvsdgTreePrinter

### DIFF
--- a/jlm/llvm/opt/RvsdgTreePrinter.hpp
+++ b/jlm/llvm/opt/RvsdgTreePrinter.hpp
@@ -13,6 +13,7 @@
 namespace jlm::rvsdg
 {
 class Graph;
+class Node;
 class Input;
 class Output;
 }
@@ -51,6 +52,21 @@ public:
        * Annotate regions and structural nodes with the number of RVSDG nodes.
        */
       NumRvsdgNodes,
+
+      /**
+       * Annotate regions and structural nodes with the number of AllocaOperation nodes.
+       */
+      NumAllocaNodes,
+
+      /**
+       * Annotate regions and structural nodes with the number of LoadOperation nodes.
+       */
+      NumLoadNodes,
+
+      /**
+       * Annotate regions and structural nodes with the number of StoreOperation nodes.
+       */
+      NumStoreNodes,
 
       /**
        * Annotate region and structural nodes with the number of inputs/outputs of type
@@ -116,12 +132,18 @@ private:
    * and structural nodes.
    *
    * @param rvsdg The RVSDG for which to compute the annotation.
+   * @param match Returns true if a node should be counted, otherwise false.
+   * @param label The label used for annotating the region tree.
    * @param annotationMap The annotation map in which the annotation is inserted.
    *
    * @see NumRvsdgNodes
    */
   static void
-  AnnotateNumRvsdgNodes(const rvsdg::Graph & rvsdg, util::AnnotationMap & annotationMap);
+  AnnotateNumNodes(
+      const rvsdg::Graph & rvsdg,
+      const std::function<bool(const rvsdg::Node &)> & match,
+      const std::string_view & label,
+      util::AnnotationMap & annotationMap);
 
   /**
    * Adds an annotation to \p annotationMap that indicates the number of inputs/outputs of type

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -912,13 +912,25 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, const char * const 
   cl::list<llvm::RvsdgTreePrinter::Configuration::Annotation> rvsdgTreePrinterAnnotations(
       "annotations",
       cl::values(::clEnumValN(
-          llvm::RvsdgTreePrinter::Configuration::Annotation::NumRvsdgNodes,
-          "NumRvsdgNodes",
-          "Annotate number of RVSDG nodes")),
+          llvm::RvsdgTreePrinter::Configuration::Annotation::NumAllocaNodes,
+          "NumAllocaNodes",
+          "Annotate number of AllocaOperation nodes")),
+      cl::values(::clEnumValN(
+          llvm::RvsdgTreePrinter::Configuration::Annotation::NumLoadNodes,
+          "NumLoadNodes",
+          "Annotate number of LoadOperation nodes")),
       cl::values(::clEnumValN(
           llvm::RvsdgTreePrinter::Configuration::Annotation::NumMemoryStateInputsOutputs,
           "NumMemoryStateInputsOutputs",
           "Annotate number of inputs/outputs with memory state type")),
+      cl::values(::clEnumValN(
+          llvm::RvsdgTreePrinter::Configuration::Annotation::NumRvsdgNodes,
+          "NumRvsdgNodes",
+          "Annotate number of RVSDG nodes")),
+      cl::values(::clEnumValN(
+          llvm::RvsdgTreePrinter::Configuration::Annotation::NumStoreNodes,
+          "NumStoreNodes",
+          "Annotate number of StoreOperation nodes")),
       cl::CommaSeparated,
       cl::desc("Comma separated list of RVSDG tree printer annotations"));
 

--- a/tests/jlm/llvm/opt/RvsdgTreePrinterTests.cpp
+++ b/tests/jlm/llvm/opt/RvsdgTreePrinterTests.cpp
@@ -8,6 +8,7 @@
 #include <test-types.hpp>
 
 #include <jlm/llvm/ir/operators/lambda.hpp>
+#include <jlm/llvm/ir/operators/Load.hpp>
 #include <jlm/llvm/opt/RvsdgTreePrinter.hpp>
 #include <jlm/util/Statistics.hpp>
 
@@ -121,6 +122,65 @@ PrintNumRvsdgNodesAnnotation()
 JLM_UNIT_TEST_REGISTER(
     "jlm/llvm/opt/RvsdgTreePrinterTests-PrintNumRvsdgNodesAnnotation",
     PrintNumRvsdgNodesAnnotation)
+
+static int
+PrintNumLoadNodesAnnotation()
+{
+  using namespace jlm::llvm;
+  using namespace jlm::util;
+
+  // Arrange
+  const auto pointerType = PointerType::Create();
+  const auto memoryStateType = MemoryStateType::Create();
+  const auto valueType = jlm::tests::valuetype::Create();
+
+  auto rvsdgModule = RvsdgModule::Create(FilePath(""), "", "");
+  auto & rvsdg = rvsdgModule->Rvsdg();
+  auto rootRegion = &rvsdg.GetRootRegion();
+
+  auto & address = jlm::tests::GraphImport::Create(rvsdg, pointerType, "a");
+  auto & memoryState = jlm::tests::GraphImport::Create(rvsdg, memoryStateType, "m");
+
+  auto structuralNode = jlm::tests::structural_node::create(rootRegion, 3);
+  auto & addressInput = structuralNode->AddInputWithArguments(address);
+  auto & memoryStateInput = structuralNode->AddInputWithArguments(memoryState);
+  LoadNonVolatileOperation::Create(
+      &addressInput.Argument(0),
+      { &memoryStateInput.Argument(0) },
+      valueType,
+      4);
+  jlm::tests::test_op::create(structuralNode->subregion(1), {}, {});
+  LoadNonVolatileOperation::Create(
+      &addressInput.Argument(2),
+      { &memoryStateInput.Argument(2) },
+      valueType,
+      4);
+
+  jlm::tests::test_op::create(rootRegion, {}, {});
+
+  RvsdgTreePrinter::Configuration configuration(
+      { RvsdgTreePrinter::Configuration::Annotation::NumLoadNodes });
+  RvsdgTreePrinter printer(configuration);
+
+  // Act
+  auto tree = RunAndExtractFile(*rvsdgModule, printer);
+  std::cout << tree;
+
+  // Assert
+  auto expectedTree = "RootRegion NumLoadNodes:0\n"
+                      "-STRUCTURAL_TEST_NODE NumLoadNodes:2\n"
+                      "--Region[0] NumLoadNodes:1\n"
+                      "--Region[1] NumLoadNodes:0\n"
+                      "--Region[2] NumLoadNodes:1\n\n";
+
+  assert(tree == expectedTree);
+
+  return 0;
+}
+
+JLM_UNIT_TEST_REGISTER(
+    "jlm/llvm/opt/RvsdgTreePrinterTests-PrintNumLoadNodesAnnotation",
+    PrintNumLoadNodesAnnotation)
 
 static int
 PrintNumMemoryStateInputsOutputsAnnotation()


### PR DESCRIPTION
Add support for printing the number of Alloca, Load, and Store nodes in the RvsdgTreePrinter pass.