### PR TITLE
Simplify HLS merge gamma pass

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/merge-gamma.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/merge-gamma.cpp
@@ -242,20 +242,6 @@ eliminate_gamma_eol(rvsdg::GammaNode * gamma)
   return changed;
 }
 
-bool
-eliminate_dead_gamma(rvsdg::GammaNode * gamma)
-{
-  // eliminates gammas that have no used outputs - dne does not seem to do this and empty gammas
-  // make tginversion go mayham and duplicate loops
-  if (gamma->IsDead())
-  {
-    JLM_UNREACHABLE("Ah we reached this part here.");
-    remove(gamma);
-    return true;
-  }
-  return false;
-}
-
 void
 merge_gamma(rvsdg::Region * region)
 {
@@ -272,7 +258,7 @@ merge_gamma(rvsdg::Region * region)
         if (auto gamma = dynamic_cast<rvsdg::GammaNode *>(node))
         {
           if (fix_match_inversion(gamma) || eliminate_gamma_ctl(gamma) || eliminate_gamma_eol(gamma)
-              || merge_gamma(gamma) || bit_type_to_ctl_type(gamma) || eliminate_dead_gamma(gamma))
+              || merge_gamma(gamma) || bit_type_to_ctl_type(gamma))
           {
             changed = true;
             break;

--- a/jlm/hls/backend/rvsdg2rhls/merge-gamma.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/merge-gamma.cpp
@@ -249,6 +249,7 @@ eliminate_dead_gamma(rvsdg::GammaNode * gamma)
   // make tginversion go mayham and duplicate loops
   if (gamma->IsDead())
   {
+    JLM_UNREACHABLE("Ah we reached this part here.");
     remove(gamma);
     return true;
   }

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -449,6 +449,7 @@ rvsdg2rhls(llvm::RvsdgModule & rhls, util::StatisticsCollector & collector)
   RemoveUnusedStates(rhls);
 
   llvm::DeadNodeElimination llvmDne;
+  llvmDne.Run(rhls, collector);
   jlm::llvm::tginversion tgi;
   // simplify loops
   tgi.Run(rhls, collector);


### PR DESCRIPTION
Contrary to what the comment in the code says, DNE is perfectly capable to remove the dead gammas created by the merge gamma pass.