### PR TITLE
delta: revise API for context variables

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -276,11 +276,11 @@ rename_delta(llvm::DeltaNode * odn)
       odn->constant());
   /* add dependencies */
   rvsdg::SubstitutionMap rmap;
-  for (size_t i = 0; i < odn->ncvarguments(); i++)
+  for (auto ctxVar : odn->GetContextVars())
   {
-    auto input = odn->input(i);
+    auto input = ctxVar.input;
     auto nd = db->AddContextVar(*input->origin()).inner;
-    rmap.insert(input->argument(), nd);
+    rmap.insert(ctxVar.inner, nd);
   }
 
   /* copy subregion */

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -279,7 +279,7 @@ rename_delta(llvm::DeltaNode * odn)
   for (size_t i = 0; i < odn->ncvarguments(); i++)
   {
     auto input = odn->input(i);
-    auto nd = db->add_ctxvar(input->origin());
+    auto nd = db->AddContextVar(*input->origin()).inner;
     rmap.insert(input->argument(), nd);
   }
 

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -226,7 +226,7 @@ convert_alloca(rvsdg::Region * region)
       {
         cout = llvm::ConstantAggregateZeroOperation::Create(*db->subregion(), po->ValueType());
       }
-      auto delta = db->finalize(cout);
+      auto delta = &db->finalize(cout);
       jlm::llvm::GraphExport::Create(*delta, delta_name);
       auto delta_local = route_to_region_rvsdg(delta, region);
       node->output(0)->divert_users(delta_local);
@@ -287,9 +287,9 @@ rename_delta(llvm::DeltaNode * odn)
   odn->subregion()->copy(db->subregion(), rmap, false, false);
 
   auto result = rmap.lookup(odn->subregion()->result(0)->origin());
-  auto data = db->finalize(result);
+  auto data = &db->finalize(result);
 
-  odn->output()->divert_users(data);
+  odn->output().divert_users(data);
   jlm::rvsdg::remove(odn);
   return rvsdg::TryGetOwnerNode<llvm::DeltaNode>(*data);
 }
@@ -398,7 +398,7 @@ split_hls_function(llvm::RvsdgModule & rm, const std::string & function_name)
           smap.insert(ln->input(i)->origin(), &graphImport);
           // add export for delta to rm
           // TODO: check if not already exported and maybe adjust linkage?
-          jlm::llvm::GraphExport::Create(*odn->output(), odn->name());
+          jlm::llvm::GraphExport::Create(odn->output(), odn->name());
         }
         else
         {

--- a/jlm/llvm/backend/RvsdgToIpGraphConverter.cpp
+++ b/jlm/llvm/backend/RvsdgToIpGraphConverter.cpp
@@ -482,7 +482,7 @@ RvsdgToIpGraphConverter::ConvertPhiNode(const rvsdg::PhiNode & phiNode)
       const auto variable =
           util::AssertedCast<const GlobalValue>(Context_->GetVariable(subregion->argument(n)));
       variable->node()->set_initialization(CreateInitialization(*deltaNode));
-      Context_->InsertVariable(deltaNode->output(), variable);
+      Context_->InsertVariable(&deltaNode->output(), variable);
     }
     else
     {
@@ -515,7 +515,7 @@ RvsdgToIpGraphConverter::ConvertDeltaNode(const DeltaNode & deltaNode)
       deltaNode.constant());
   dataNode->set_initialization(CreateInitialization(deltaNode));
   const auto variable = ipGraphModule.create_global_value(dataNode);
-  Context_->InsertVariable(deltaNode.output(), variable);
+  Context_->InsertVariable(&deltaNode.output(), variable);
 }
 
 void

--- a/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
+++ b/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
@@ -1060,7 +1060,7 @@ ConvertDataNode(
         *dataNodeInitialization,
         *deltaNode->subregion(),
         regionalizedVariableMap);
-    auto deltaOutput = deltaNode->finalize(initOutput);
+    auto deltaOutput = &deltaNode->finalize(initOutput);
     regionalizedVariableMap.PopRegion();
 
     return deltaOutput;

--- a/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
+++ b/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
@@ -1052,8 +1052,8 @@ ConvertDataNode(
     for (const auto & dependency : dataNode)
     {
       auto dependencyVariable = interProceduralGraphModule.variable(dependency);
-      auto argument = deltaNode->add_ctxvar(outerVariableMap.lookup(dependencyVariable));
-      regionalizedVariableMap.GetTopVariableMap().insert(dependencyVariable, argument);
+      auto ctxVar = deltaNode->AddContextVar(*outerVariableMap.lookup(dependencyVariable));
+      regionalizedVariableMap.GetTopVariableMap().insert(dependencyVariable, ctxVar.inner);
     }
 
     auto initOutput = ConvertDataNodeInitialization(

--- a/jlm/llvm/ir/CallSummary.cpp
+++ b/jlm/llvm/ir/CallSummary.cpp
@@ -103,9 +103,9 @@ ComputeCallSummary(const rvsdg::LambdaNode & lambdaNode)
       continue;
     }
 
-    if (auto deltaResult = dynamic_cast<delta::result *>(input))
+    if (rvsdg::TryGetRegionParentNode<DeltaNode>(*input))
     {
-      otherUsers.emplace_back(deltaResult);
+      otherUsers.emplace_back(input);
       continue;
     }
 

--- a/jlm/llvm/ir/CallSummary.cpp
+++ b/jlm/llvm/ir/CallSummary.cpp
@@ -96,10 +96,10 @@ ComputeCallSummary(const rvsdg::LambdaNode & lambdaNode)
       continue;
     }
 
-    if (auto cvinput = dynamic_cast<delta::cvinput *>(input))
+    if (auto deltaNode = rvsdg::TryGetOwnerNode<DeltaNode>(*input))
     {
-      auto argument = cvinput->arguments.first();
-      worklist.insert(worklist.end(), argument->begin(), argument->end());
+      auto ctxVar = deltaNode->MapInputContextVar(*input);
+      worklist.insert(worklist.end(), ctxVar.inner->begin(), ctxVar.inner->end());
       continue;
     }
 

--- a/jlm/llvm/ir/operators/delta.cpp
+++ b/jlm/llvm/ir/operators/delta.cpp
@@ -85,11 +85,11 @@ DeltaNode::copy(rvsdg::Region * region, rvsdg::SubstitutionMap & smap) const
 
   // add context variables
   rvsdg::SubstitutionMap subregionmap;
-  for (auto & cv : ctxvars())
+  for (auto & cv : GetContextVars())
   {
-    auto origin = smap.lookup(cv.origin());
+    auto origin = smap.lookup(cv.input->origin());
     auto newCtxVar = delta->AddContextVar(*origin);
-    subregionmap.insert(cv.argument(), newCtxVar.inner);
+    subregionmap.insert(cv.inner, newCtxVar.inner);
   }
 
   // copy subregion
@@ -101,42 +101,6 @@ DeltaNode::copy(rvsdg::Region * region, rvsdg::SubstitutionMap & smap) const
   smap.insert(&output(), o);
 
   return delta;
-}
-
-DeltaNode::ctxvar_range
-DeltaNode::ctxvars()
-{
-  cviterator end(nullptr);
-
-  if (ncvarguments() == 0)
-    return ctxvar_range(end, end);
-
-  cviterator begin(input(0));
-  return ctxvar_range(begin, end);
-}
-
-DeltaNode::ctxvar_constrange
-DeltaNode::ctxvars() const
-{
-  cvconstiterator end(nullptr);
-
-  if (ncvarguments() == 0)
-    return ctxvar_constrange(end, end);
-
-  cvconstiterator begin(input(0));
-  return ctxvar_constrange(begin, end);
-}
-
-delta::cvinput *
-DeltaNode::input(size_t n) const noexcept
-{
-  return static_cast<delta::cvinput *>(StructuralNode::input(n));
-}
-
-delta::cvargument *
-DeltaNode::cvargument(size_t n) const noexcept
-{
-  return util::AssertedCast<delta::cvargument>(subregion()->argument(n));
 }
 
 rvsdg::Output &
@@ -174,29 +138,4 @@ DeltaNode::finalize(jlm::rvsdg::Output * origin)
   return *append_output(std::make_unique<rvsdg::StructuralOutput>(this, PointerType::Create()));
 }
 
-namespace delta
-{
-
-cvinput::~cvinput()
-{}
-
-cvargument *
-cvinput::argument() const noexcept
-{
-  return static_cast<cvargument *>(arguments.first());
-}
-
-/* delta context variable argument class */
-
-cvargument::~cvargument()
-{}
-
-cvargument &
-cvargument::Copy(rvsdg::Region & region, rvsdg::StructuralInput * input)
-{
-  auto deltaInput = util::AssertedCast<delta::cvinput>(input);
-  return *cvargument::create(&region, deltaInput);
-}
-
-}
 }

--- a/jlm/llvm/ir/operators/delta.cpp
+++ b/jlm/llvm/ir/operators/delta.cpp
@@ -50,7 +50,7 @@ DeltaNode::copy(rvsdg::Region * region, rvsdg::SubstitutionMap & smap) const
 {
   auto delta = Create(region, Type(), name(), linkage(), Section(), constant());
 
-  /* add context variables */
+  // add context variables
   rvsdg::SubstitutionMap subregionmap;
   for (auto & cv : ctxvars())
   {
@@ -59,13 +59,13 @@ DeltaNode::copy(rvsdg::Region * region, rvsdg::SubstitutionMap & smap) const
     subregionmap.insert(cv.argument(), newcv);
   }
 
-  /* copy subregion */
+  // copy subregion
   subregion()->copy(delta->subregion(), subregionmap, false, false);
 
-  /* finalize delta */
+  // finalize delta
   auto result = subregionmap.lookup(delta->result()->origin());
-  auto o = delta->finalize(result);
-  smap.insert(output(), o);
+  auto o = &delta->finalize(result);
+  smap.insert(&output(), o);
 
   return delta;
 }
@@ -113,10 +113,10 @@ DeltaNode::cvargument(size_t n) const noexcept
   return util::AssertedCast<delta::cvargument>(subregion()->argument(n));
 }
 
-delta::output *
+rvsdg::Output &
 DeltaNode::output() const noexcept
 {
-  return static_cast<delta::output *>(StructuralNode::output(0));
+  return *StructuralNode::output(0);
 }
 
 delta::result *
@@ -125,10 +125,10 @@ DeltaNode::result() const noexcept
   return static_cast<delta::result *>(subregion()->result(0));
 }
 
-delta::output *
+rvsdg::Output &
 DeltaNode::finalize(jlm::rvsdg::Output * origin)
 {
-  /* check if finalized was already called */
+  // check if finalized was already called
   if (noutputs() > 0)
   {
     JLM_ASSERT(noutputs() == 1);
@@ -145,7 +145,7 @@ DeltaNode::finalize(jlm::rvsdg::Output * origin)
 
   delta::result::create(origin);
 
-  return delta::output::create(this, PointerType::Create());
+  return *append_output(std::make_unique<rvsdg::StructuralOutput>(this, PointerType::Create()));
 }
 
 namespace delta
@@ -159,11 +159,6 @@ cvinput::argument() const noexcept
 {
   return static_cast<cvargument *>(arguments.first());
 }
-
-/* delta output class */
-
-output::~output()
-{}
 
 /* delta context variable argument class */
 

--- a/jlm/llvm/ir/operators/delta.cpp
+++ b/jlm/llvm/ir/operators/delta.cpp
@@ -63,7 +63,7 @@ DeltaNode::copy(rvsdg::Region * region, rvsdg::SubstitutionMap & smap) const
   subregion()->copy(delta->subregion(), subregionmap, false, false);
 
   // finalize delta
-  auto result = subregionmap.lookup(delta->result()->origin());
+  auto result = subregionmap.lookup(delta->result().origin());
   auto o = &delta->finalize(result);
   smap.insert(&output(), o);
 
@@ -119,10 +119,10 @@ DeltaNode::output() const noexcept
   return *StructuralNode::output(0);
 }
 
-delta::result *
+rvsdg::Input &
 DeltaNode::result() const noexcept
 {
-  return static_cast<delta::result *>(subregion()->result(0));
+  return *subregion()->result(0);
 }
 
 rvsdg::Output &
@@ -143,7 +143,7 @@ DeltaNode::finalize(jlm::rvsdg::Output * origin)
   if (origin->region() != subregion())
     throw util::error("Invalid operand region.");
 
-  delta::result::create(origin);
+  rvsdg::RegionResult::Create(*origin->region(), *origin, nullptr, origin->Type());
 
   return *append_output(std::make_unique<rvsdg::StructuralOutput>(this, PointerType::Create()));
 }
@@ -170,18 +170,6 @@ cvargument::Copy(rvsdg::Region & region, rvsdg::StructuralInput * input)
 {
   auto deltaInput = util::AssertedCast<delta::cvinput>(input);
   return *cvargument::create(&region, deltaInput);
-}
-
-/* delta result class */
-
-result::~result()
-{}
-
-result &
-result::Copy(rvsdg::Output & origin, rvsdg::StructuralOutput * output)
-{
-  JLM_ASSERT(output == nullptr);
-  return *result::create(&origin);
 }
 
 }

--- a/jlm/llvm/ir/operators/delta.hpp
+++ b/jlm/llvm/ir/operators/delta.hpp
@@ -145,6 +145,99 @@ private:
   {}
 
 public:
+  /**
+   * \brief Bound context variable
+   *
+   * Context variables may be bound at the point of creation of a
+   * delta abstraction. These are represented as inputs to the
+   * delta node itself, and made accessible to the body of the
+   * delta in the form of an initial argument to the subregion.
+   */
+  struct ContextVar
+  {
+    /**
+     * \brief Input variable bound into delta node
+     *
+     * The input port into the delta node that supplies the value
+     * of the context variable bound into the delta at the
+     * time the delta abstraction is built.
+     */
+    rvsdg::Input * input;
+
+    /**
+     * \brief Access to bound object in subregion.
+     *
+     * Supplies access to the value bound into the delta abstraction
+     * from inside the region contained in the delta node. This
+     * evaluates to the value bound into the delta.
+     */
+    rvsdg::Output * inner;
+  };
+
+  /**
+   * \brief Adds a context/free variable to the delta node.
+   *
+   * \param origin
+   *   The value to be bound into the delta node.
+   *
+   * \pre
+   *   \p origin must be from the same region as the delta node.
+   *
+   * \return The context variable argument of the delta abstraction.
+   */
+  ContextVar
+  AddContextVar(jlm::rvsdg::Output & origin);
+
+  /**
+   * \brief Maps input to context variable.
+   *
+   * \param input
+   *   Input to the delta node.
+   *
+   * \returns
+   *   The context variable description corresponding to the input.
+   *
+   * \pre
+   *   \p input must be input to this node.
+   *
+   * Returns the context variable description corresponding
+   * to this input of the delta node. All inputs to the delta
+   * node are by definition bound context variables that are
+   * accessible in the subregion through the corresponding
+   * argument.
+   */
+  [[nodiscard]] ContextVar
+  MapInputContextVar(const rvsdg::Input & input) const noexcept;
+
+  /**
+   * \brief Maps bound variable reference to context variable
+   *
+   * \param output
+   *   Region argument to delta subregion
+   *
+   * \returns
+   *   The context variable description corresponding to the argument
+   *
+   * \pre
+   *   \p output must be an argument to the subregion of this node
+   *
+   * Returns the context variable description corresponding
+   * to this bound variable reference in the delta node region.
+   */
+  [[nodiscard]] std::optional<ContextVar>
+  MapBinderContextVar(const rvsdg::Output & output) const noexcept;
+
+  /**
+   * \brief Gets all bound context variables
+   *
+   * \returns
+   *   The context variable descriptions.
+   *
+   * Returns all context variable descriptions.
+   */
+  [[nodiscard]] std::vector<ContextVar>
+  GetContextVars() const noexcept;
+
   ctxvar_range
   ctxvars();
 
@@ -201,15 +294,6 @@ public:
   {
     return ninputs();
   }
-
-  /**
-   * Adds a context/free variable to the delta node. The \p origin must be from the same region
-   * as the delta node.
-   *
-   * \return The context variable argument from the delta region.
-   */
-  delta::cvargument *
-  add_ctxvar(rvsdg::Output * origin);
 
   /**
    * Remove delta inputs and their respective arguments.

--- a/jlm/llvm/ir/operators/delta.hpp
+++ b/jlm/llvm/ir/operators/delta.hpp
@@ -103,7 +103,6 @@ namespace delta
 
 class cvargument;
 class cvinput;
-class result;
 
 }
 
@@ -254,7 +253,7 @@ public:
   [[nodiscard]] rvsdg::Output &
   output() const noexcept;
 
-  delta::result *
+  [[nodiscard]] rvsdg::Input &
   result() const noexcept;
 
   virtual DeltaNode *
@@ -420,39 +419,6 @@ public:
   input() const noexcept
   {
     return static_cast<cvinput *>(rvsdg::RegionArgument::input());
-  }
-};
-
-/** \brief Delta result
- */
-class result final : public rvsdg::RegionResult
-{
-  friend ::jlm::llvm::DeltaNode;
-
-public:
-  ~result() override;
-
-  result &
-  Copy(rvsdg::Output & origin, rvsdg::StructuralOutput * output) override;
-
-private:
-  explicit result(rvsdg::Output * origin)
-      : rvsdg::RegionResult(origin->region(), origin, nullptr, origin->Type())
-  {}
-
-  static result *
-  create(rvsdg::Output * origin)
-  {
-    auto result = new delta::result(origin);
-    origin->region()->append_result(result);
-    return result;
-  }
-
-public:
-  rvsdg::Output *
-  output() const noexcept
-  {
-    return rvsdg::RegionResult::output();
   }
 };
 

--- a/jlm/llvm/ir/operators/delta.hpp
+++ b/jlm/llvm/ir/operators/delta.hpp
@@ -103,7 +103,6 @@ namespace delta
 
 class cvargument;
 class cvinput;
-class output;
 class result;
 
 }
@@ -252,7 +251,7 @@ public:
   delta::cvargument *
   cvargument(size_t n) const noexcept;
 
-  delta::output *
+  [[nodiscard]] rvsdg::Output &
   output() const noexcept;
 
   delta::result *
@@ -304,7 +303,7 @@ public:
    *
    * \return The output of the delta node.
    */
-  delta::output *
+  rvsdg::Output &
   finalize(rvsdg::Output * result);
 
 private:
@@ -391,35 +390,6 @@ class DeltaNode::cvconstiterator final : public rvsdg::Input::constiterator<delt
 namespace delta
 {
 
-/** \brief Delta output
- */
-class output final : public rvsdg::StructuralOutput
-{
-  friend ::jlm::llvm::DeltaNode;
-
-public:
-  ~output() override;
-
-  output(DeltaNode * node, std::shared_ptr<const rvsdg::Type> type)
-      : StructuralOutput(node, std::move(type))
-  {}
-
-private:
-  static output *
-  create(DeltaNode * node, std::shared_ptr<const rvsdg::Type> type)
-  {
-    auto output = std::make_unique<delta::output>(node, std::move(type));
-    return static_cast<delta::output *>(node->append_output(std::move(output)));
-  }
-
-public:
-  DeltaNode *
-  node() const noexcept
-  {
-    return static_cast<DeltaNode *>(StructuralOutput::node());
-  }
-};
-
 /** \brief Delta context variable argument
  */
 class cvargument final : public rvsdg::RegionArgument
@@ -479,10 +449,10 @@ private:
   }
 
 public:
-  delta::output *
+  rvsdg::Output *
   output() const noexcept
   {
-    return static_cast<delta::output *>(rvsdg::RegionResult::output());
+    return rvsdg::RegionResult::output();
   }
 };
 

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -1073,7 +1073,7 @@ Andersen::AnalyzeDelta(const DeltaNode & delta)
   AnalyzeRegion(*delta.subregion());
 
   // Get the result register from the subregion
-  auto & resultRegister = *delta.result()->origin();
+  auto & resultRegister = *delta.result().origin();
 
   // If the type of the delta can point, the analysis should track its set of possible pointees
   bool canPoint = IsOrContainsPointerType(delta.type());

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -1059,13 +1059,13 @@ void
 Andersen::AnalyzeDelta(const DeltaNode & delta)
 {
   // Handle context variables
-  for (auto & cv : delta.ctxvars())
+  for (auto & cv : delta.GetContextVars())
   {
-    if (!IsOrContainsPointerType(*cv.Type()))
+    if (!IsOrContainsPointerType(*cv.input->Type()))
       continue;
 
-    auto & inputRegister = *cv.origin();
-    auto & argumentRegister = *cv.argument();
+    auto & inputRegister = *cv.input->origin();
+    auto & argumentRegister = *cv.inner;
     const auto inputRegisterPO = Set_->GetRegisterPointerObject(inputRegister);
     Set_->MapRegisterToExistingPointerObject(argumentRegister, inputRegisterPO);
   }

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -1089,7 +1089,7 @@ Andersen::AnalyzeDelta(const DeltaNode & delta)
   }
 
   // Finally create a Register PointerObject for the delta's output, pointing to the memory object
-  auto & outputRegister = *delta.output();
+  auto & outputRegister = delta.output();
   const auto outputRegisterPO = Set_->CreateRegisterPointerObject(outputRegister);
   Constraints_->AddPointerPointeeConstraint(outputRegisterPO, globalPO);
 }

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -1618,7 +1618,7 @@ Steensgaard::AnalyzeDelta(const DeltaNode & delta)
   auto & deltaLocation = Context_->InsertDeltaLocation(delta);
   deltaOutputLocation.SetPointsTo(deltaLocation);
 
-  auto & origin = *delta.result()->origin();
+  auto & origin = *delta.result().origin();
   if (HasOrContainsPointerType(origin))
   {
     auto & originLocation = Context_->GetLocation(origin);

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -226,7 +226,7 @@ public:
       }
     }
 
-    if (is<delta::cvargument>(Output_))
+    if (rvsdg::TryGetRegionParentNode<DeltaNode>(*Output_))
     {
       auto dbgstr = Output_->region()->node()->DebugString();
       return jlm::util::strfmt(dbgstr, ":cv:", index);
@@ -1600,14 +1600,14 @@ void
 Steensgaard::AnalyzeDelta(const DeltaNode & delta)
 {
   // Handle context variables
-  for (auto & input : delta.ctxvars())
+  for (auto & ctxVar : delta.GetContextVars())
   {
-    auto & origin = *input.origin();
+    auto & origin = *ctxVar.input->origin();
 
     if (HasOrContainsPointerType(origin))
     {
       auto & originLocation = Context_->GetLocation(origin);
-      auto & argumentLocation = Context_->GetOrInsertRegisterLocation(*input.arguments.first());
+      auto & argumentLocation = Context_->GetOrInsertRegisterLocation(*ctxVar.inner);
       Context_->Join(originLocation, argumentLocation);
     }
   }

--- a/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
+++ b/jlm/llvm/opt/alias-analyses/Steensgaard.cpp
@@ -1614,7 +1614,7 @@ Steensgaard::AnalyzeDelta(const DeltaNode & delta)
 
   AnalyzeRegion(*delta.subregion());
 
-  auto & deltaOutputLocation = Context_->GetOrInsertRegisterLocation(*delta.output());
+  auto & deltaOutputLocation = Context_->GetOrInsertRegisterLocation(delta.output());
   auto & deltaLocation = Context_->InsertDeltaLocation(delta);
   deltaOutputLocation.SetPointsTo(deltaLocation);
 

--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -1919,9 +1919,9 @@ DeltaTest3::SetupRvsdg()
         "",
         false);
 
-    auto g1Argument = delta->add_ctxvar(&g1);
+    auto ctxVar = delta->AddContextVar(g1);
 
-    return &delta->finalize(g1Argument);
+    return &delta->finalize(ctxVar.inner);
   };
 
   auto SetupF = [&](rvsdg::Output & g1, rvsdg::Output & g2)
@@ -2663,7 +2663,7 @@ PhiWithDeltaTest::SetupRvsdg()
 
   auto delta =
       DeltaNode::Create(pb.subregion(), arrayType, "myArray", linkage::external_linkage, "", false);
-  auto myArrayArgument = delta->add_ctxvar(myArrayRecVar.recref);
+  auto myArrayArgument = delta->AddContextVar(*myArrayRecVar.recref).inner;
 
   auto aggregateZero = ConstantAggregateZeroOperation::Create(*delta->subregion(), structType);
   auto & constantStruct =
@@ -2766,7 +2766,7 @@ EscapedMemoryTest1::SetupRvsdg()
         "",
         false);
 
-    auto contextVariableA = deltaNode->add_ctxvar(&deltaA);
+    auto contextVariableA = deltaNode->AddContextVar(deltaA).inner;
 
     return &deltaNode->finalize(contextVariableA);
   };
@@ -2783,7 +2783,7 @@ EscapedMemoryTest1::SetupRvsdg()
         "",
         false);
 
-    auto contextVariableX = deltaNode->add_ctxvar(&deltaX);
+    auto contextVariableX = deltaNode->AddContextVar(deltaX).inner;
 
     auto deltaOutput = &deltaNode->finalize(contextVariableX);
     GraphExport::Create(*deltaOutput, "y");

--- a/tests/TestRvsdgs.cpp
+++ b/tests/TestRvsdgs.cpp
@@ -913,7 +913,7 @@ IndirectCallTest2::SetupRvsdg()
 
     auto constant = jlm::rvsdg::create_bitconstant(delta->subregion(), 32, 1);
 
-    return delta->finalize(constant);
+    return &delta->finalize(constant);
   };
 
   auto SetupG2 = [&]()
@@ -928,7 +928,7 @@ IndirectCallTest2::SetupRvsdg()
 
     auto constant = jlm::rvsdg::create_bitconstant(delta->subregion(), 32, 2);
 
-    return delta->finalize(constant);
+    return &delta->finalize(constant);
   };
 
   auto SetupConstantFunction = [&](ssize_t n, const std::string & name)
@@ -1012,8 +1012,8 @@ IndirectCallTest2::SetupRvsdg()
 
   auto SetupTestFunction = [&](rvsdg::Output & functionX,
                                rvsdg::Output & functionY,
-                               delta::output & globalG1,
-                               delta::output & globalG2)
+                               rvsdg::Output & globalG1,
+                               rvsdg::Output & globalG2)
   {
     auto functionType = rvsdg::FunctionType::Create(
         { IOStateType::Create(), MemoryStateType::Create() },
@@ -1131,8 +1131,8 @@ IndirectCallTest2::SetupRvsdg()
   /*
    * Assign
    */
-  this->DeltaG1_ = deltaG1->node();
-  this->DeltaG2_ = deltaG2->node();
+  this->DeltaG1_ = &rvsdg::AssertGetOwnerNode<llvm::DeltaNode>(*deltaG1);
+  this->DeltaG2_ = &rvsdg::AssertGetOwnerNode<llvm::DeltaNode>(*deltaG2);
   this->LambdaThree_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaThree);
   this->LambdaFour_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaFour);
   this->LambdaI_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaI);
@@ -1695,7 +1695,7 @@ DeltaTest1::SetupRvsdg()
 
     auto constant = jlm::rvsdg::create_bitconstant(dfNode->subregion(), 32, 0);
 
-    return dfNode->finalize(constant);
+    return &dfNode->finalize(constant);
   };
 
   auto SetupFunctionG = [&]()
@@ -1723,7 +1723,7 @@ DeltaTest1::SetupRvsdg()
     return lambda->finalize({ ld[0], iOStateArgument, ld[1] });
   };
 
-  auto SetupFunctionH = [&](delta::output * f, rvsdg::Output * g)
+  auto SetupFunctionH = [&](rvsdg::Output * f, rvsdg::Output * g)
   {
     auto iOStateType = IOStateType::Create();
     auto memoryStateType = MemoryStateType::Create();
@@ -1763,7 +1763,7 @@ DeltaTest1::SetupRvsdg()
   this->lambda_g = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*g);
   this->lambda_h = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*h);
 
-  this->delta_f = f->node();
+  this->delta_f = &rvsdg::AssertGetOwnerNode<llvm::DeltaNode>(*f);
 
   this->CallG_ = callFunctionG;
   this->constantFive = constantFive;
@@ -1791,7 +1791,7 @@ DeltaTest2::SetupRvsdg()
 
     auto constant = jlm::rvsdg::create_bitconstant(delta->subregion(), 32, 0);
 
-    return delta->finalize(constant);
+    return &delta->finalize(constant);
   };
 
   auto SetupD2 = [&]()
@@ -1806,10 +1806,10 @@ DeltaTest2::SetupRvsdg()
 
     auto constant = jlm::rvsdg::create_bitconstant(delta->subregion(), 32, 0);
 
-    return delta->finalize(constant);
+    return &delta->finalize(constant);
   };
 
-  auto SetupF1 = [&](delta::output * d1)
+  auto SetupF1 = [&](rvsdg::Output * d1)
   {
     auto iOStateType = IOStateType::Create();
     auto memoryStateType = MemoryStateType::Create();
@@ -1830,7 +1830,7 @@ DeltaTest2::SetupRvsdg()
     return lambda->finalize({ iOStateArgument, st[0] });
   };
 
-  auto SetupF2 = [&](rvsdg::Output * f1, delta::output * d1, delta::output * d2)
+  auto SetupF2 = [&](rvsdg::Output * f1, rvsdg::Output * d1, rvsdg::Output * d2)
   {
     auto iOStateType = IOStateType::Create();
     auto memoryStateType = MemoryStateType::Create();
@@ -1876,8 +1876,8 @@ DeltaTest2::SetupRvsdg()
   this->lambda_f1 = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*f1);
   this->lambda_f2 = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*f2);
 
-  this->delta_d1 = d1->node();
-  this->delta_d2 = d2->node();
+  this->delta_d1 = &rvsdg::AssertGetOwnerNode<llvm::DeltaNode>(*d1);
+  this->delta_d2 = &rvsdg::AssertGetOwnerNode<llvm::DeltaNode>(*d2);
 
   this->CallF1_ = callF1;
 
@@ -1904,10 +1904,10 @@ DeltaTest3::SetupRvsdg()
 
     auto constant = jlm::rvsdg::create_bitconstant(delta->subregion(), 32, 1);
 
-    return delta->finalize(constant);
+    return &delta->finalize(constant);
   };
 
-  auto SetupG2 = [&](delta::output & g1)
+  auto SetupG2 = [&](rvsdg::Output & g1)
   {
     auto pointerType = PointerType::Create();
 
@@ -1921,10 +1921,10 @@ DeltaTest3::SetupRvsdg()
 
     auto g1Argument = delta->add_ctxvar(&g1);
 
-    return delta->finalize(g1Argument);
+    return &delta->finalize(g1Argument);
   };
 
-  auto SetupF = [&](delta::output & g1, delta::output & g2)
+  auto SetupF = [&](rvsdg::Output & g1, rvsdg::Output & g2)
   {
     auto iOStateType = IOStateType::Create();
     auto memoryStateType = MemoryStateType::Create();
@@ -1997,8 +1997,8 @@ DeltaTest3::SetupRvsdg()
   this->LambdaF_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*f);
   this->LambdaTest_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*test);
 
-  this->DeltaG1_ = g1->node();
-  this->DeltaG2_ = g2->node();
+  this->DeltaG1_ = &rvsdg::AssertGetOwnerNode<llvm::DeltaNode>(*g1);
+  this->DeltaG2_ = &rvsdg::AssertGetOwnerNode<llvm::DeltaNode>(*g2);
 
   this->CallF_ = callF;
 
@@ -2670,8 +2670,8 @@ PhiWithDeltaTest::SetupRvsdg()
       ConstantStruct::Create(*delta->subregion(), { myArrayArgument }, structType);
   auto constantArray = ConstantArrayOperation::Create({ aggregateZero, &constantStruct });
 
-  auto deltaOutput = delta->finalize(constantArray);
-  Delta_ = deltaOutput->node();
+  auto deltaOutput = &delta->finalize(constantArray);
+  Delta_ = &rvsdg::AssertGetOwnerNode<llvm::DeltaNode>(*deltaOutput);
   myArrayRecVar.result->divert_to(deltaOutput);
 
   auto phiNode = pb.end();
@@ -2736,7 +2736,7 @@ EscapedMemoryTest1::SetupRvsdg()
 
     auto constant = jlm::rvsdg::create_bitconstant(deltaNode->subregion(), 32, 1);
 
-    return deltaNode->finalize(constant);
+    return &deltaNode->finalize(constant);
   };
 
   auto SetupDeltaB = [&]()
@@ -2751,10 +2751,10 @@ EscapedMemoryTest1::SetupRvsdg()
 
     auto constant = jlm::rvsdg::create_bitconstant(deltaNode->subregion(), 32, 2);
 
-    return deltaNode->finalize(constant);
+    return &deltaNode->finalize(constant);
   };
 
-  auto SetupDeltaX = [&](delta::output & deltaA)
+  auto SetupDeltaX = [&](rvsdg::Output & deltaA)
   {
     auto pointerType = PointerType::Create();
 
@@ -2768,10 +2768,10 @@ EscapedMemoryTest1::SetupRvsdg()
 
     auto contextVariableA = deltaNode->add_ctxvar(&deltaA);
 
-    return deltaNode->finalize(contextVariableA);
+    return &deltaNode->finalize(contextVariableA);
   };
 
-  auto SetupDeltaY = [&](delta::output & deltaX)
+  auto SetupDeltaY = [&](rvsdg::Output & deltaX)
   {
     auto pointerType = PointerType::Create();
 
@@ -2785,13 +2785,13 @@ EscapedMemoryTest1::SetupRvsdg()
 
     auto contextVariableX = deltaNode->add_ctxvar(&deltaX);
 
-    auto deltaOutput = deltaNode->finalize(contextVariableX);
+    auto deltaOutput = &deltaNode->finalize(contextVariableX);
     GraphExport::Create(*deltaOutput, "y");
 
     return deltaOutput;
   };
 
-  auto SetupLambdaTest = [&](delta::output & deltaB)
+  auto SetupLambdaTest = [&](rvsdg::Output & deltaB)
   {
     auto pointerType = PointerType::Create();
     auto iOStateType = IOStateType::Create();
@@ -2842,10 +2842,10 @@ EscapedMemoryTest1::SetupRvsdg()
    */
   this->LambdaTest = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaTest);
 
-  this->DeltaA = deltaA->node();
-  this->DeltaB = deltaB->node();
-  this->DeltaX = deltaX->node();
-  this->DeltaY = deltaY->node();
+  this->DeltaA = &rvsdg::AssertGetOwnerNode<llvm::DeltaNode>(*deltaA);
+  this->DeltaB = &rvsdg::AssertGetOwnerNode<llvm::DeltaNode>(*deltaB);
+  this->DeltaX = &rvsdg::AssertGetOwnerNode<llvm::DeltaNode>(*deltaX);
+  this->DeltaY = &rvsdg::AssertGetOwnerNode<llvm::DeltaNode>(*deltaY);
 
   this->LoadNode1 = loadNode1;
 
@@ -3074,7 +3074,7 @@ EscapedMemoryTest3::SetupRvsdg()
 
     auto constant = jlm::rvsdg::create_bitconstant(delta->subregion(), 32, 4);
 
-    auto deltaOutput = delta->finalize(constant);
+    auto deltaOutput = &delta->finalize(constant);
 
     GraphExport::Create(*deltaOutput, "global");
 
@@ -3126,7 +3126,7 @@ EscapedMemoryTest3::SetupRvsdg()
 
   // Assign nodes
   this->LambdaTest = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaTest);
-  this->DeltaGlobal = deltaGlobal->node();
+  this->DeltaGlobal = &rvsdg::AssertGetOwnerNode<llvm::DeltaNode>(*deltaGlobal);
   this->ImportExternalFunction = importExternalFunction;
   this->CallExternalFunction = callExternalFunction;
   this->LoadNode = loadNode;
@@ -3162,7 +3162,7 @@ MemcpyTest::SetupRvsdg()
 
     auto constantDataArray = ConstantDataArray::Create({ zero, one, two, three, four });
 
-    auto deltaOutput = delta->finalize(constantDataArray);
+    auto deltaOutput = &delta->finalize(constantDataArray);
 
     GraphExport::Create(*deltaOutput, "localArray");
 
@@ -3182,14 +3182,14 @@ MemcpyTest::SetupRvsdg()
     auto constantAggregateZero =
         ConstantAggregateZeroOperation::Create(*delta->subregion(), arrayType);
 
-    auto deltaOutput = delta->finalize(constantAggregateZero);
+    auto deltaOutput = &delta->finalize(constantAggregateZero);
 
     GraphExport::Create(*deltaOutput, "globalArray");
 
     return deltaOutput;
   };
 
-  auto SetupFunctionF = [&](delta::output & globalArray)
+  auto SetupFunctionF = [&](rvsdg::Output & globalArray)
   {
     auto iOStateType = IOStateType::Create();
     auto memoryStateType = MemoryStateType::Create();
@@ -3231,7 +3231,7 @@ MemcpyTest::SetupRvsdg()
   };
 
   auto SetupFunctionG =
-      [&](delta::output & localArray, delta::output & globalArray, rvsdg::Output & lambdaF)
+      [&](rvsdg::Output & localArray, rvsdg::Output & globalArray, rvsdg::Output & lambdaF)
   {
     auto iOStateType = IOStateType::Create();
     auto memoryStateType = MemoryStateType::Create();
@@ -3285,8 +3285,8 @@ MemcpyTest::SetupRvsdg()
    */
   this->LambdaF_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaF);
   this->LambdaG_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaG);
-  this->LocalArray_ = localArray->node();
-  this->GlobalArray_ = globalArray->node();
+  this->LocalArray_ = &rvsdg::AssertGetOwnerNode<llvm::DeltaNode>(*localArray);
+  this->GlobalArray_ = &rvsdg::AssertGetOwnerNode<llvm::DeltaNode>(*globalArray);
   this->CallF_ = callF;
   this->Memcpy_ = memcpyNode;
 
@@ -3479,13 +3479,13 @@ LinkedListTest::SetupRvsdg()
     auto constantPointerNullResult =
         ConstantPointerNullOperation::Create(delta->subregion(), pointerType);
 
-    auto deltaOutput = delta->finalize(constantPointerNullResult);
+    auto deltaOutput = &delta->finalize(constantPointerNullResult);
     GraphExport::Create(*deltaOutput, "myList");
 
     return deltaOutput;
   };
 
-  auto SetupFunctionNext = [&](delta::output & myList)
+  auto SetupFunctionNext = [&](rvsdg::Output & myList)
   {
     auto iOStateType = IOStateType::Create();
     auto memoryStateType = MemoryStateType::Create();
@@ -3532,7 +3532,7 @@ LinkedListTest::SetupRvsdg()
   /*
    * Assign nodes
    */
-  this->DeltaMyList_ = deltaMyList->node();
+  this->DeltaMyList_ = &rvsdg::AssertGetOwnerNode<llvm::DeltaNode>(*deltaMyList);
   this->LambdaNext_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaNext);
   this->Alloca_ = alloca;
 
@@ -3577,7 +3577,7 @@ AllMemoryNodesTest::SetupRvsdg()
       graph->GetRootRegion(),
       llvm::LlvmLambdaOperation::Create(fcttype, "f", linkage::external_linkage));
   auto entryMemoryState = Lambda_->GetFunctionArguments()[0];
-  auto deltaContextVar = Lambda_->AddContextVar(*Delta_->output()).inner;
+  auto deltaContextVar = Lambda_->AddContextVar(Delta_->output()).inner;
   auto importContextVar = Lambda_->AddContextVar(*Import_).inner;
 
   // Create alloca node
@@ -3631,7 +3631,7 @@ AllMemoryNodesTest::SetupRvsdg()
 
   Lambda_->finalize({ storeOutputs[0] });
 
-  GraphExport::Create(*Delta_->output(), "global");
+  GraphExport::Create(Delta_->output(), "global");
   GraphExport::Create(*Lambda_->output(), "f");
 
   return module;
@@ -3703,7 +3703,7 @@ EscapingLocalFunctionTest::SetupRvsdg()
       "",
       false);
   const auto constantZero = rvsdg::create_bitconstant(Global_->subregion(), 32, 0);
-  const auto deltaOutput = Global_->finalize(constantZero);
+  const auto deltaOutput = &Global_->finalize(constantZero);
 
   LocalFunc_ = rvsdg::LambdaNode::Create(
       graph->GetRootRegion(),

--- a/tests/TestRvsdgs.hpp
+++ b/tests/TestRvsdgs.hpp
@@ -2101,11 +2101,11 @@ public:
     return *Delta_;
   }
 
-  [[nodiscard]] const jlm::llvm::delta::output &
+  [[nodiscard]] const rvsdg::Output &
   GetDeltaOutput() const noexcept
   {
     JLM_ASSERT(Delta_);
-    return *Delta_->output();
+    return Delta_->output();
   }
 
   [[nodiscard]] const llvm::GraphImport &

--- a/tests/jlm/llvm/backend/RvsdgToIpGraphConverterTests.cpp
+++ b/tests/jlm/llvm/backend/RvsdgToIpGraphConverterTests.cpp
@@ -351,16 +351,16 @@ RecursiveData()
   jlm::rvsdg::Output *delta1 = nullptr, *delta2 = nullptr;
   {
     auto delta = DeltaNode::Create(region, vt, "test-delta1", linkage::external_linkage, "", false);
-    auto dep1 = delta->add_ctxvar(r2.recref);
-    auto dep2 = delta->add_ctxvar(dep.inner);
+    auto dep1 = delta->AddContextVar(*r2.recref).inner;
+    auto dep2 = delta->AddContextVar(*dep.inner).inner;
     delta1 =
         &delta->finalize(jlm::tests::create_testop(delta->subregion(), { dep1, dep2 }, { vt })[0]);
   }
 
   {
     auto delta = DeltaNode::Create(region, vt, "test-delta2", linkage::external_linkage, "", false);
-    auto dep1 = delta->add_ctxvar(r1.recref);
-    auto dep2 = delta->add_ctxvar(dep.inner);
+    auto dep1 = delta->AddContextVar(*r1.recref).inner;
+    auto dep2 = delta->AddContextVar(*dep.inner).inner;
     delta2 =
         &delta->finalize(jlm::tests::create_testop(delta->subregion(), { dep1, dep2 }, { vt })[0]);
   }

--- a/tests/jlm/llvm/backend/RvsdgToIpGraphConverterTests.cpp
+++ b/tests/jlm/llvm/backend/RvsdgToIpGraphConverterTests.cpp
@@ -354,7 +354,7 @@ RecursiveData()
     auto dep1 = delta->add_ctxvar(r2.recref);
     auto dep2 = delta->add_ctxvar(dep.inner);
     delta1 =
-        delta->finalize(jlm::tests::create_testop(delta->subregion(), { dep1, dep2 }, { vt })[0]);
+        &delta->finalize(jlm::tests::create_testop(delta->subregion(), { dep1, dep2 }, { vt })[0]);
   }
 
   {
@@ -362,7 +362,7 @@ RecursiveData()
     auto dep1 = delta->add_ctxvar(r1.recref);
     auto dep2 = delta->add_ctxvar(dep.inner);
     delta2 =
-        delta->finalize(jlm::tests::create_testop(delta->subregion(), { dep1, dep2 }, { vt })[0]);
+        &delta->finalize(jlm::tests::create_testop(delta->subregion(), { dep1, dep2 }, { vt })[0]);
   }
 
   r1.result->divert_to(delta1);

--- a/tests/jlm/llvm/ir/TestCallSummary.cpp
+++ b/tests/jlm/llvm/ir/TestCallSummary.cpp
@@ -268,7 +268,7 @@ TestCallSummaryComputationFunctionPointerInDelta()
       linkage::external_linkage,
       "",
       false);
-  auto argument = deltaNode->add_ctxvar(lambdaNode->output());
+  auto argument = deltaNode->AddContextVar(*lambdaNode->output()).inner;
   deltaNode->finalize(argument);
 
   GraphExport::Create(deltaNode->output(), "fp");

--- a/tests/jlm/llvm/ir/TestCallSummary.cpp
+++ b/tests/jlm/llvm/ir/TestCallSummary.cpp
@@ -271,7 +271,7 @@ TestCallSummaryComputationFunctionPointerInDelta()
   auto argument = deltaNode->add_ctxvar(lambdaNode->output());
   deltaNode->finalize(argument);
 
-  GraphExport::Create(*deltaNode->output(), "fp");
+  GraphExport::Create(deltaNode->output(), "fp");
 
   // Act
   auto callSummary = jlm::llvm::ComputeCallSummary(*lambdaNode);

--- a/tests/jlm/llvm/ir/operators/test-delta.cpp
+++ b/tests/jlm/llvm/ir/operators/test-delta.cpp
@@ -33,7 +33,7 @@ TestDeltaCreation()
       true);
   auto dep = delta1->add_ctxvar(imp);
   auto d1 =
-      delta1->finalize(jlm::tests::create_testop(delta1->subregion(), { dep }, { valueType })[0]);
+      &delta1->finalize(jlm::tests::create_testop(delta1->subregion(), { dep }, { valueType })[0]);
 
   auto delta2 = DeltaNode::Create(
       &rvsdgModule.Rvsdg().GetRootRegion(),
@@ -42,7 +42,7 @@ TestDeltaCreation()
       linkage::internal_linkage,
       "",
       false);
-  auto d2 = delta2->finalize(jlm::tests::create_testop(delta2->subregion(), {}, { valueType })[0]);
+  auto d2 = &delta2->finalize(jlm::tests::create_testop(delta2->subregion(), {}, { valueType })[0]);
 
   GraphExport::Create(*d1, "");
   GraphExport::Create(*d2, "");

--- a/tests/jlm/llvm/ir/operators/test-delta.cpp
+++ b/tests/jlm/llvm/ir/operators/test-delta.cpp
@@ -95,35 +95,35 @@ TestRemoveDeltaInputsWhere()
   // Act & Assert
   // Try to remove deltaInput1 even though it is used
   auto numRemovedInputs = deltaNode->RemoveDeltaInputsWhere(
-      [&](const delta::cvinput & input)
+      [&](const jlm::rvsdg::Input & input)
       {
         return input.index() == deltaInput1->index();
       });
   assert(numRemovedInputs == 0);
   assert(deltaNode->ninputs() == 3);
-  assert(deltaNode->ncvarguments() == 3);
+  assert(deltaNode->GetContextVars().size() == 3);
 
   // Remove deltaInput2
   numRemovedInputs = deltaNode->RemoveDeltaInputsWhere(
-      [&](const delta::cvinput & input)
+      [&](const jlm::rvsdg::Input & input)
       {
         return input.index() == 2;
       });
   assert(numRemovedInputs == 1);
   assert(deltaNode->ninputs() == 2);
-  assert(deltaNode->ncvarguments() == 2);
+  assert(deltaNode->GetContextVars().size() == 2);
   assert(deltaNode->input(0) == deltaInput0);
   assert(deltaNode->input(1) == deltaInput1);
 
   // Remove deltaInput0
   numRemovedInputs = deltaNode->RemoveDeltaInputsWhere(
-      [&](const delta::cvinput & input)
+      [&](const jlm::rvsdg::Input & input)
       {
         return input.index() == 0;
       });
   assert(numRemovedInputs == 1);
   assert(deltaNode->ninputs() == 1);
-  assert(deltaNode->ncvarguments() == 1);
+  assert(deltaNode->GetContextVars().size() == 1);
   assert(deltaNode->input(0) == deltaInput1);
   assert(deltaInput1->index() == 0);
   assert(deltaNode->MapInputContextVar(*deltaInput1).inner->index() == 0);
@@ -167,7 +167,7 @@ TestPruneDeltaInputs()
   // Assert
   assert(numRemovedInputs == 2);
   assert(deltaNode->ninputs() == 1);
-  assert(deltaNode->ncvarguments() == 1);
+  assert(deltaNode->GetContextVars().size() == 1);
   assert(deltaNode->input(0) == deltaInput1);
   assert(deltaNode->subregion()->argument(0) == deltaNode->MapInputContextVar(*deltaInput1).inner);
   assert(deltaInput1->index() == 0);

--- a/tests/jlm/llvm/ir/operators/test-delta.cpp
+++ b/tests/jlm/llvm/ir/operators/test-delta.cpp
@@ -31,7 +31,7 @@ TestDeltaCreation()
       linkage::external_linkage,
       "",
       true);
-  auto dep = delta1->add_ctxvar(imp);
+  auto dep = delta1->AddContextVar(*imp).inner;
   auto d1 =
       &delta1->finalize(jlm::tests::create_testop(delta1->subregion(), { dep }, { valueType })[0]);
 
@@ -80,12 +80,12 @@ TestRemoveDeltaInputsWhere()
       linkage::external_linkage,
       "",
       true);
-  auto deltaInput0 = deltaNode->add_ctxvar(x)->input();
-  auto deltaInput1 = deltaNode->add_ctxvar(x)->input();
-  deltaNode->add_ctxvar(x)->input();
+  auto deltaInput0 = deltaNode->AddContextVar(*x).input;
+  auto deltaInput1 = deltaNode->AddContextVar(*x).input;
+  deltaNode->AddContextVar(*x);
 
   auto result = jlm::rvsdg::CreateOpNode<jlm::tests::TestOperation>(
-                    { deltaInput1->argument() },
+                    { deltaNode->MapInputContextVar(*deltaInput1).inner },
                     std::vector<std::shared_ptr<const Type>>{ valueType },
                     std::vector<std::shared_ptr<const Type>>{ valueType })
                     .output(0);
@@ -126,7 +126,7 @@ TestRemoveDeltaInputsWhere()
   assert(deltaNode->ncvarguments() == 1);
   assert(deltaNode->input(0) == deltaInput1);
   assert(deltaInput1->index() == 0);
-  assert(deltaInput1->argument()->index() == 0);
+  assert(deltaNode->MapInputContextVar(*deltaInput1).inner->index() == 0);
 }
 
 static void
@@ -149,12 +149,12 @@ TestPruneDeltaInputs()
       "",
       true);
 
-  deltaNode->add_ctxvar(x);
-  auto deltaInput1 = deltaNode->add_ctxvar(x)->input();
-  deltaNode->add_ctxvar(x);
+  deltaNode->AddContextVar(*x);
+  auto deltaInput1 = deltaNode->AddContextVar(*x).input;
+  deltaNode->AddContextVar(*x);
 
   auto result = jlm::rvsdg::CreateOpNode<jlm::tests::TestOperation>(
-                    { deltaInput1->argument() },
+                    { deltaNode->MapInputContextVar(*deltaInput1).inner },
                     std::vector<std::shared_ptr<const Type>>{ valueType },
                     std::vector<std::shared_ptr<const Type>>{ valueType })
                     .output(0);
@@ -169,9 +169,9 @@ TestPruneDeltaInputs()
   assert(deltaNode->ninputs() == 1);
   assert(deltaNode->ncvarguments() == 1);
   assert(deltaNode->input(0) == deltaInput1);
-  assert(deltaNode->cvargument(0) == deltaInput1->argument());
+  assert(deltaNode->subregion()->argument(0) == deltaNode->MapInputContextVar(*deltaInput1).inner);
   assert(deltaInput1->index() == 0);
-  assert(deltaInput1->argument()->index() == 0);
+  assert(deltaNode->MapInputContextVar(*deltaInput1).inner->index() == 0);
 }
 
 static void

--- a/tests/jlm/llvm/opt/DeadNodeEliminationTests.cpp
+++ b/tests/jlm/llvm/opt/DeadNodeEliminationTests.cpp
@@ -466,9 +466,9 @@ Delta()
       "",
       false);
 
-  auto xArgument = deltaNode->add_ctxvar(x);
-  deltaNode->add_ctxvar(y);
-  auto zArgument = deltaNode->add_ctxvar(z);
+  auto xArgument = deltaNode->AddContextVar(*x).inner;
+  deltaNode->AddContextVar(*y);
+  auto zArgument = deltaNode->AddContextVar(*z).inner;
 
   auto result = jlm::rvsdg::CreateOpNode<jlm::tests::TestOperation>(
                     { xArgument },

--- a/tests/jlm/llvm/opt/DeadNodeEliminationTests.cpp
+++ b/tests/jlm/llvm/opt/DeadNodeEliminationTests.cpp
@@ -481,7 +481,7 @@ Delta()
       std::vector<std::shared_ptr<const Type>>{ valueType },
       std::vector<std::shared_ptr<const Type>>{ valueType });
 
-  auto deltaOutput = deltaNode->finalize(result);
+  auto deltaOutput = &deltaNode->finalize(result);
   jlm::tests::GraphExport::Create(*deltaOutput, "");
   view(rvsdg, stdout);
 

--- a/tests/jlm/llvm/opt/alias-analyses/TestAndersen.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestAndersen.cpp
@@ -594,7 +594,7 @@ TestDelta1()
   assert(ptg->NumMappedRegisters() == 6);
 
   auto & delta_f = ptg->GetDeltaNode(*test.delta_f);
-  auto & pdelta_f = ptg->GetRegisterNode(*test.delta_f->output());
+  auto & pdelta_f = ptg->GetRegisterNode(test.delta_f->output());
 
   auto & lambda_g = ptg->GetLambdaNode(*test.lambda_g);
   auto & plambda_g = ptg->GetRegisterNode(*test.lambda_g->output());
@@ -630,10 +630,10 @@ TestDelta2()
   assert(ptg->NumMappedRegisters() == 8);
 
   auto & delta_d1 = ptg->GetDeltaNode(*test.delta_d1);
-  auto & delta_d1_out = ptg->GetRegisterNode(*test.delta_d1->output());
+  auto & delta_d1_out = ptg->GetRegisterNode(test.delta_d1->output());
 
   auto & delta_d2 = ptg->GetDeltaNode(*test.delta_d2);
-  auto & delta_d2_out = ptg->GetRegisterNode(*test.delta_d2->output());
+  auto & delta_d2_out = ptg->GetRegisterNode(test.delta_d2->output());
 
   auto & lambda_f1 = ptg->GetLambdaNode(*test.lambda_f1);
   auto & lambda_f1_out = ptg->GetRegisterNode(*test.lambda_f1->output());

--- a/tests/jlm/llvm/opt/alias-analyses/TestPointsToGraph.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestPointsToGraph.cpp
@@ -67,7 +67,7 @@ private:
       {
         auto & deltaPtgNode = aa::PointsToGraph::DeltaNode::Create(*PointsToGraph_, *deltaNode);
         auto & registerNode =
-            aa::PointsToGraph::RegisterNode::Create(*PointsToGraph_, { deltaNode->output() });
+            aa::PointsToGraph::RegisterNode::Create(*PointsToGraph_, { &deltaNode->output() });
         registerNode.AddEdge(deltaPtgNode);
 
         AnalyzeRegion(*deltaNode->subregion());

--- a/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestSteensgaard.cpp
@@ -727,7 +727,7 @@ TestDelta1()
     assert(ptg.NumRegisterNodes() == 3);
 
     auto & delta_f = ptg.GetDeltaNode(*test.delta_f);
-    auto & pdelta_f = ptg.GetRegisterNode(*test.delta_f->output());
+    auto & pdelta_f = ptg.GetRegisterNode(test.delta_f->output());
 
     auto & lambda_g = ptg.GetLambdaNode(*test.lambda_g);
     auto & plambda_g = ptg.GetRegisterNode(*test.lambda_g->output());
@@ -770,10 +770,10 @@ TestDelta2()
     assert(ptg.NumRegisterNodes() == 4);
 
     auto & delta_d1 = ptg.GetDeltaNode(*test.delta_d1);
-    auto & delta_d1_out = ptg.GetRegisterNode(*test.delta_d1->output());
+    auto & delta_d1_out = ptg.GetRegisterNode(test.delta_d1->output());
 
     auto & delta_d2 = ptg.GetDeltaNode(*test.delta_d2);
-    auto & delta_d2_out = ptg.GetRegisterNode(*test.delta_d2->output());
+    auto & delta_d2_out = ptg.GetRegisterNode(test.delta_d2->output());
 
     auto & lambda_f1 = ptg.GetLambdaNode(*test.lambda_f1);
     auto & lambda_f1_out = ptg.GetRegisterNode(*test.lambda_f1->output());


### PR DESCRIPTION
Remove all auxiliary input/output/argument/result classes for delta nodes. Provide new API for adding, retrieving, and mapping pieces to context variables. Change all dispatch to be based on checking for "delta node/subregion" instead of subclassed inputs/outputs.

This leads to:
- making the delta abstraction a generic rvsdg concept
- removing all needs to implement subclasses of argument, result, input and output
- dispatching purely based on node kind