### PR TITLE
Move GraphWriter classes to namespace and add some extra attributes to the RVSDG DotWriter

### DIFF
--- a/jlm/llvm/backend/dot/DotWriter.cpp
+++ b/jlm/llvm/backend/dot/DotWriter.cpp
@@ -99,8 +99,8 @@ AttachNodeInput(util::graph::Port & inputPort, const rvsdg::Input & rvsdgInput)
   inputPort.SetProgramObject(rvsdgInput);
 
   // nodes are visited in topological order, so if the origin is an output, it will already exist
-  if (auto originPort =
-          reinterpret_cast<util::graph::Port *>(graph.GetElementFromProgramObject(*rvsdgInput.origin())))
+  if (auto originPort = reinterpret_cast<util::graph::Port *>(
+          graph.GetElementFromProgramObject(*rvsdgInput.origin())))
   {
     auto & edge = graph.CreateDirectedEdge(*originPort, inputPort);
     if (rvsdg::is<MemoryStateType>(rvsdgInput.Type()))

--- a/jlm/llvm/backend/dot/DotWriter.hpp
+++ b/jlm/llvm/backend/dot/DotWriter.hpp
@@ -22,8 +22,8 @@ namespace jlm::llvm::dot
  * @param emitTypeGraph if true, an additional graph containing nodes for all types is emitted
  * @return a reference to the top-level graph corresponding to the region
  */
-util::Graph &
-WriteGraphs(util::GraphWriter & writer, rvsdg::Region & region, bool emitTypeGraph);
+util::graph::Graph &
+WriteGraphs(util::graph::Writer & writer, rvsdg::Region & region, bool emitTypeGraph);
 }
 
 #endif // JLM_LLVM_BACKEND_DOT_DOTWRITER_HPP

--- a/jlm/llvm/opt/alias-analyses/Andersen.cpp
+++ b/jlm/llvm/opt/alias-analyses/Andersen.cpp
@@ -1381,7 +1381,7 @@ Andersen::Analyze(
   const bool doubleCheck = std::getenv(ENV_DOUBLE_CHECK);
 
   const bool dumpGraphs = std::getenv(ENV_DUMP_SUBSET_GRAPH);
-  util::GraphWriter writer;
+  util::graph::Writer writer;
 
   AnalyzeModule(module, *statistics);
 
@@ -1408,7 +1408,7 @@ Andersen::Analyze(
   {
     auto & graph = Constraints_->DrawSubsetGraph(writer);
     graph.AppendToLabel("After Solving with " + config.ToString());
-    writer.OutputAllGraphs(std::cout, util::GraphOutputFormat::Dot);
+    writer.OutputAllGraphs(std::cout, util::graph::OutputFormat::Dot);
   }
 
   auto result = ConstructPointsToGraphFromPointerObjectSet(*Set_, *statistics);

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp
@@ -1081,7 +1081,7 @@ CreateSubsetGraphNodeLabel(PointerObjectSet & set, PointerObjectIndex index)
  * Helper function used by DrawSubsetGraph.
  */
 static void
-CreateSubsetGraphNodes(PointerObjectSet & set, util::Graph & graph)
+CreateSubsetGraphNodes(PointerObjectSet & set, util::graph::Graph & graph)
 {
   // Ensure the index of nodes line up with the index of the corresponding PointerObject
   JLM_ASSERT(graph.NumNodes() == 0);
@@ -1093,9 +1093,9 @@ CreateSubsetGraphNodes(PointerObjectSet & set, util::Graph & graph)
     node.SetLabel(CreateSubsetGraphNodeLabel(set, i));
 
     if (set.IsPointerObjectRegister(i))
-      node.SetShape(util::Node::Shape::Oval);
+      node.SetShape(util::graph::Node::Shape::Oval);
     else
-      node.SetShape(util::Node::Shape::Rectangle);
+      node.SetShape(util::graph::Node::Shape::Rectangle);
 
     if (set.HasEscaped(i))
       node.SetFillColor("#FFFF99");
@@ -1137,7 +1137,7 @@ static void
 CreateSubsetGraphEdges(
     const PointerObjectSet & set,
     const std::vector<PointerObjectConstraintSet::ConstraintVariant> & constraints,
-    util::Graph & graph)
+    util::graph::Graph & graph)
 {
   // Draw edges for constraints
   size_t nextCallConstraintIndex = 0;
@@ -1154,7 +1154,7 @@ CreateSubsetGraphEdges(
       auto & edge = graph.CreateDirectedEdge(
           graph.GetNode(storeConstraint->GetValue()),
           graph.GetNode(storeConstraint->GetPointer()));
-      edge.SetStyle(util::Edge::Style::Dashed);
+      edge.SetStyle(util::graph::Edge::Style::Dashed);
       edge.SetArrowHead("normalodot");
     }
     else if (auto * loadConstraint = std::get_if<LoadConstraint>(&constraint))
@@ -1162,7 +1162,7 @@ CreateSubsetGraphEdges(
       auto & edge = graph.CreateDirectedEdge(
           graph.GetNode(loadConstraint->GetPointer()),
           graph.GetNode(loadConstraint->GetValue()));
-      edge.SetStyle(util::Edge::Style::Dashed);
+      edge.SetStyle(util::graph::Edge::Style::Dashed);
       edge.SetArrowTail("odot");
     }
     else if (auto * callConstraint = std::get_if<FunctionCallConstraint>(&constraint))
@@ -1206,7 +1206,7 @@ CreateSubsetGraphEdges(
  * Helper function used by DrawSubsetGraph.
  */
 static void
-LabelFunctionsArgumentsAndReturnValues(PointerObjectSet & set, util::Graph & graph)
+LabelFunctionsArgumentsAndReturnValues(PointerObjectSet & set, util::graph::Graph & graph)
 {
   size_t nextFunctionIndex = 0;
   for (auto [function, pointerObject] : set.GetFunctionMap())
@@ -1237,8 +1237,8 @@ LabelFunctionsArgumentsAndReturnValues(PointerObjectSet & set, util::Graph & gra
   }
 }
 
-util::Graph &
-PointerObjectConstraintSet::DrawSubsetGraph(util::GraphWriter & writer) const
+util::graph::Graph &
+PointerObjectConstraintSet::DrawSubsetGraph(util::graph::Writer & writer) const
 {
   auto & graph = writer.CreateGraph();
   graph.SetLabel("Andersen subset graph");

--- a/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointerObjectSet.hpp
@@ -1036,8 +1036,8 @@ public:
    * Creates a subset graph containing all PointerObjects, their current points-to sets,
    * and edges representing the current set of constraints.
    */
-  util::Graph &
-  DrawSubsetGraph(util::GraphWriter & writer) const;
+  util::graph::Graph &
+  DrawSubsetGraph(util::graph::Writer & writer) const;
 
   /**
    * Performs off-line detection of PointerObjects that can be shown to always contain

--- a/jlm/tooling/Command.cpp
+++ b/jlm/tooling/Command.cpp
@@ -603,18 +603,18 @@ JlmOptCommand::PrintAsDot(
 {
   auto & rootRegion = rvsdgModule.Rvsdg().GetRootRegion();
 
-  util::GraphWriter writer;
-  jlm::llvm::dot::WriteGraphs(writer, rootRegion, true);
+  util::graph::Writer writer;
+  llvm::dot::WriteGraphs(writer, rootRegion, true);
 
   if (outputFile == "")
   {
-    writer.OutputAllGraphs(std::cout, util::GraphOutputFormat::Dot);
+    writer.OutputAllGraphs(std::cout, util::graph::OutputFormat::Dot);
   }
   else
   {
     std::ofstream fs;
     fs.open(outputFile.to_str());
-    writer.OutputAllGraphs(fs, util::GraphOutputFormat::Dot);
+    writer.OutputAllGraphs(fs, util::graph::OutputFormat::Dot);
     fs.close();
   }
 }

--- a/jlm/util/GraphWriter.hpp
+++ b/jlm/util/GraphWriter.hpp
@@ -8,16 +8,17 @@
 
 #include <jlm/util/common.hpp>
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <unordered_map>
 #include <variant>
 #include <vector>
 
-namespace jlm::util
+namespace jlm::util::graph
 {
 
-enum class GraphOutputFormat
+enum class OutputFormat
 {
   Dot,   // prints
   ASCII, // output format that makes edges implicit when possible
@@ -29,7 +30,7 @@ enum class AttributeOutputFormat
   HTMLAttributes      // adds extra restrictions on attribute names
 };
 
-class GraphWriter;
+class Writer;
 class Node;
 class Edge;
 class Port;
@@ -414,7 +415,7 @@ public:
    * Depending on output format, this function may also recurse and print sub graphs.
    */
   void
-  Output(std::ostream & out, GraphOutputFormat format, size_t indent) const;
+  Output(std::ostream & out, OutputFormat format, size_t indent) const;
 
   /**
    * Prints all sub graphs of the node, to the given ostream \p out, in the given \p format.
@@ -422,7 +423,7 @@ public:
    * This function is recursive, as sub graphs may have nodes with sub graphs of their own.
    */
   virtual void
-  OutputSubgraphs(std::ostream & out, GraphOutputFormat format, size_t indent) const;
+  OutputSubgraphs(std::ostream & out, OutputFormat format, size_t indent) const;
 
 protected:
   /**
@@ -584,7 +585,7 @@ public:
   Finalize() override;
 
   void
-  OutputSubgraphs(std::ostream & out, GraphOutputFormat format, size_t indent) const override;
+  OutputSubgraphs(std::ostream & out, OutputFormat format, size_t indent) const override;
 
 protected:
   void
@@ -766,12 +767,12 @@ private:
 
 class Graph : public GraphElement
 {
-  friend GraphWriter;
+  friend Writer;
   friend GraphElement;
 
-  explicit Graph(GraphWriter & writer);
+  explicit Graph(Writer & writer);
 
-  Graph(GraphWriter & writer, Node & parentNode);
+  Graph(Writer & writer, Node & parentNode);
 
 public:
   ~Graph() override = default;
@@ -782,11 +783,11 @@ public:
   Graph &
   GetGraph() override;
 
-  [[nodiscard]] GraphWriter &
-  GetGraphWriter();
+  [[nodiscard]] Writer &
+  GetWriter();
 
-  [[nodiscard]] const GraphWriter &
-  GetGraphWriter() const;
+  [[nodiscard]] const Writer &
+  GetWriter() const;
 
   /**
    * @return true if this graph is a subgraph of another graph, false if it is top-level
@@ -972,7 +973,7 @@ public:
    * @param indent the amount of indentation levels the graph should be printed with
    */
   void
-  Output(std::ostream & out, GraphOutputFormat format, size_t indent = 0) const;
+  Output(std::ostream & out, OutputFormat format, size_t indent = 0) const;
 
 private:
   void
@@ -997,7 +998,7 @@ private:
   RemoveProgramObjectMapping(uintptr_t object);
 
   // The GraphWriter this graph was created by, and belongs to
-  GraphWriter & Writer_;
+  Writer & Writer_;
 
   // If this graph is a subgraph, this is its parent node in the parent graph.
   // For top level graphs, this field is nullptr
@@ -1020,22 +1021,22 @@ private:
  * Utility class for creating graphs in memory, and printing them to a human or machine readable
  * format.
  */
-class GraphWriter
+class Writer
 {
 public:
-  ~GraphWriter() = default;
+  ~Writer() = default;
 
-  GraphWriter() = default;
+  Writer() = default;
 
-  GraphWriter(const GraphWriter & other) = delete;
+  Writer(const Writer & other) = delete;
 
-  GraphWriter(GraphWriter && other) = delete;
+  Writer(Writer && other) = delete;
 
-  GraphWriter &
-  operator=(const GraphWriter & other) = delete;
+  Writer &
+  operator=(const Writer & other) = delete;
 
-  GraphWriter &
-  operator=(GraphWriter && other) = delete;
+  Writer &
+  operator=(Writer && other) = delete;
 
   /**
    * Creates a new graph and appends it to the GraphWriter's list of graphs.
@@ -1086,7 +1087,7 @@ public:
    * @param format the format to emit the graphs in
    */
   void
-  OutputAllGraphs(std::ostream & out, GraphOutputFormat format);
+  OutputAllGraphs(std::ostream & out, OutputFormat format);
 
 private:
   [[nodiscard]] Graph &

--- a/tests/jlm/llvm/backend/dot/DotWriterTests.cpp
+++ b/tests/jlm/llvm/backend/dot/DotWriterTests.cpp
@@ -17,15 +17,16 @@ TestWriteGraphs()
 {
   using namespace jlm::llvm;
   using namespace jlm::util;
+  using namespace jlm::util::graph;
 
   // Arrange
   jlm::tests::GammaTest gammaTest;
 
   // Act
-  GraphWriter writer;
+  Writer writer;
   dot::WriteGraphs(writer, gammaTest.graph().GetRootRegion(), false);
 
-  writer.OutputAllGraphs(std::cout, GraphOutputFormat::Dot);
+  writer.OutputAllGraphs(std::cout, OutputFormat::Dot);
 
   // Assert
   auto & rootGraph = writer.GetGraph(0);
@@ -82,6 +83,7 @@ TestTypeGraph()
 {
   using namespace jlm::llvm;
   using namespace jlm::util;
+  using namespace jlm::util::graph;
 
   // Arrange
   jlm::tests::GammaTest gammaTest;
@@ -90,11 +92,11 @@ TestTypeGraph()
   auto memType = MemoryStateType::Create();
 
   // Act
-  GraphWriter writer;
+  Writer writer;
   dot::WriteGraphs(writer, gammaTest.graph().GetRootRegion(), true);
 
   writer.Finalize();
-  writer.OutputAllGraphs(std::cout, GraphOutputFormat::Dot);
+  writer.OutputAllGraphs(std::cout, OutputFormat::Dot);
 
   // Assert
   auto & typeGraph = writer.GetGraph(0);

--- a/tests/jlm/llvm/opt/alias-analyses/TestPointerObjectSet.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestPointerObjectSet.cpp
@@ -772,7 +772,7 @@ TestDrawSubsetGraph()
   constraints.AddConstraint(LoadConstraint(loadValue, loadPointer));
 
   // Act
-  GraphWriter writer;
+  graph::Writer writer;
   auto & graph = constraints.DrawSubsetGraph(writer);
 
   // Assert
@@ -798,14 +798,14 @@ TestDrawSubsetGraph()
   auto * storeEdge = graph.GetEdgeBetween(graph.GetNode(storeValue), graph.GetNode(storePointer));
   assert(storeEdge);
   assert(storeEdge->IsDirected());
-  assert(storeEdge->GetAttributeString("style") == Edge::Style::Dashed);
+  assert(storeEdge->GetAttributeString("style") == graph::Edge::Style::Dashed);
   assert(StringContains(storeEdge->GetAttributeString("arrowhead").value(), "dot"));
 
   // Check that a load edge connects loadPointer to loadValue
   auto * loadEdge = graph.GetEdgeBetween(graph.GetNode(loadPointer), graph.GetNode(loadValue));
   assert(loadEdge);
   assert(loadEdge->IsDirected());
-  assert(loadEdge->GetAttributeString("style") == Edge::Style::Dashed);
+  assert(loadEdge->GetAttributeString("style") == graph::Edge::Style::Dashed);
   assert(StringContains(loadEdge->GetAttributeString("arrowtail").value(), "dot"));
 
   // Check that the function contains the word "function0"

--- a/tests/jlm/util/TestGraphWriter.cpp
+++ b/tests/jlm/util/TestGraphWriter.cpp
@@ -21,7 +21,8 @@ static void
 TestGraphElement()
 {
   using namespace jlm::util;
-  GraphWriter writer;
+  using namespace jlm::util::graph;
+  Writer writer;
   auto & graph = writer.CreateGraph();
 
   // Test labels
@@ -91,7 +92,8 @@ static void
 TestNode()
 {
   using namespace jlm::util;
-  GraphWriter writer;
+  using namespace jlm::util::graph;
+  Writer writer;
   auto & graph = writer.CreateGraph();
 
   auto & node = graph.CreateNode();
@@ -106,12 +108,12 @@ TestNode()
   node.Finalize();
 
   std::ostringstream out;
-  node.Output(out, GraphOutputFormat::ASCII, 0);
+  node.Output(out, OutputFormat::ASCII, 0);
   auto string = out.str();
   assert(StringContains(string, "MyNode"));
 
   std::ostringstream out2;
-  node.Output(out2, GraphOutputFormat::Dot, 0);
+  node.Output(out2, OutputFormat::Dot, 0);
   auto string2 = out2.str();
   assert(StringContains(string2, "label=MyNode"));
   assert(StringContains(string2, "shape=rect"));
@@ -121,7 +123,8 @@ static void
 TestASCIIEdges()
 {
   using namespace jlm::util;
-  GraphWriter writer;
+  using namespace jlm::util::graph;
+  Writer writer;
   auto & graph = writer.CreateGraph();
 
   auto & node0 = graph.CreateNode();
@@ -139,9 +142,9 @@ TestASCIIEdges()
   graph.Finalize();
 
   std::ostringstream out;
-  node0.Output(out, GraphOutputFormat::ASCII, 0);
-  node1.Output(out, GraphOutputFormat::ASCII, 0);
-  node2.Output(out, GraphOutputFormat::ASCII, 0);
+  node0.Output(out, OutputFormat::ASCII, 0);
+  node1.Output(out, OutputFormat::ASCII, 0);
+  node2.Output(out, OutputFormat::ASCII, 0);
 
   auto string = out.str();
   assert(StringContains(string, "node0:NODE0"));
@@ -153,7 +156,8 @@ static void
 TestInOutNode()
 {
   using namespace jlm::util;
-  GraphWriter writer;
+  using namespace jlm::util::graph;
+  Writer writer;
   auto & graph = writer.CreateGraph();
 
   auto & node = graph.CreateInOutNode(2, 3);
@@ -182,7 +186,7 @@ TestInOutNode()
   assert(subgraph.IsFinalized());
 
   std::ostringstream out;
-  node.Output(out, GraphOutputFormat::ASCII, 0);
+  node.Output(out, OutputFormat::ASCII, 0);
   auto string = out.str();
   assert(StringContains(string, "out0, out1, out2 := \"My\\nInOutNode\" out2, []"));
 
@@ -192,7 +196,7 @@ TestInOutNode()
 
   // Check that HTML labels with newlines turn into <BR/>
   std::ostringstream out2;
-  node.Output(out2, GraphOutputFormat::Dot, 0);
+  node.Output(out2, OutputFormat::Dot, 0);
   auto string0 = out2.str();
   assert(StringContains(string0, "My<BR/>InOutNode"));
 }
@@ -201,7 +205,8 @@ static void
 TestEdge()
 {
   using namespace jlm::util;
-  GraphWriter writer;
+  using namespace jlm::util::graph;
+  Writer writer;
   auto & graph = writer.CreateGraph();
 
   auto & node0 = graph.CreateNode();
@@ -263,7 +268,8 @@ static void
 TestGraphCreateNodes()
 {
   using namespace jlm::util;
-  GraphWriter writer;
+  using namespace jlm::util::graph;
+  Writer writer;
   auto & graph = writer.CreateGraph();
 
   // Test node creation and count
@@ -301,11 +307,12 @@ static void
 TestGraphAttributes()
 {
   using namespace jlm::util;
-  GraphWriter writer;
+  using namespace jlm::util::graph;
+  Writer writer;
   auto & graph = writer.CreateGraph();
   graph.SetLabel("My Graph");
 
-  assert(&graph.GetGraphWriter() == &writer);
+  assert(&graph.GetWriter() == &writer);
   auto & node = graph.CreateNode();
 
   // Test associating a GraphElement with a pointer, and retrieving it
@@ -321,7 +328,7 @@ TestGraphAttributes()
 
   // Test that the Dot output of the graph contains everything specified
   std::ostringstream out;
-  graph.Output(out, jlm::util::GraphOutputFormat::Dot, 0);
+  graph.Output(out, OutputFormat::Dot, 0);
   auto string = out.str();
 
   assert(StringContains(string, "label=\"My Graph\""));
@@ -335,7 +342,8 @@ static void
 TestGraphWriterClass()
 {
   using namespace jlm::util;
-  GraphWriter writer;
+  using namespace jlm::util::graph;
+  Writer writer;
 
   auto & graph0 = writer.CreateGraph();
   auto & graph1 = writer.CreateGraph();
@@ -355,7 +363,7 @@ TestGraphWriterClass()
 
   // Render all the graphs to dot, which first finalizes the graphs to assign unique IDs
   std::ostringstream out;
-  writer.OutputAllGraphs(out, GraphOutputFormat::Dot);
+  writer.OutputAllGraphs(out, OutputFormat::Dot);
   auto string = out.str();
 
   assert(graph0.IsFinalized());


### PR DESCRIPTION
I did not like how the GraphWriter-related classes were all in the `jlm::util` namespace, with very general names like `Node` and `Edge`.

This PR hides them away in `jlm::util::graph`.

Also, in the `DotWriter.cpp` backend, some extra attributes are added to preserve type info and linkage info.