### PR TITLE
Remove outdated Create() method from SimpleNode class

### DIFF
--- a/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
+++ b/jlm/llvm/frontend/InterProceduralGraphConversion.cpp
@@ -552,9 +552,8 @@ ConvertThreeAddressCode(
     for (size_t n = 0; n < threeAddressCode.noperands(); n++)
       operands.push_back(variableMap.lookup(threeAddressCode.operand(n)));
 
-    auto & simpleOperation =
-        static_cast<const rvsdg::SimpleOperation &>(threeAddressCode.operation());
-    auto results = outputs(&rvsdg::SimpleNode::Create(region, simpleOperation, operands));
+    auto results =
+        outputs(&rvsdg::SimpleNode::Create(region, threeAddressCode.operation().copy(), operands));
 
     JLM_ASSERT(results.size() == threeAddressCode.nresults());
     for (size_t n = 0; n < threeAddressCode.nresults(); n++)

--- a/jlm/llvm/opt/unroll.cpp
+++ b/jlm/llvm/opt/unroll.cpp
@@ -342,9 +342,14 @@ create_unrolled_gamma_predicate(const LoopUnrollInfo & ui, size_t factor)
 
   auto uf = jlm::rvsdg::create_bitconstant(region, nbits, factor);
   auto mul = jlm::rvsdg::bitmul_op::create(nbits, step, uf);
-  auto arm = rvsdg::SimpleNode::Create(*region, ui.armoperation(), { ui.init(), mul }).output(0);
+  std::unique_ptr<rvsdg::SimpleOperation> copiedArmOp(
+      util::AssertedCast<rvsdg::SimpleOperation>(ui.armoperation().copy().release()));
+  auto arm =
+      rvsdg::SimpleNode::Create(*region, std::move(copiedArmOp), { ui.init(), mul }).output(0);
   /* FIXME: order of operands */
-  auto cmp = rvsdg::SimpleNode::Create(*region, ui.cmpoperation(), { arm, end }).output(0);
+  std::unique_ptr<rvsdg::SimpleOperation> copiedCmpOp(
+      util::AssertedCast<rvsdg::SimpleOperation>(ui.cmpoperation().copy().release()));
+  auto cmp = rvsdg::SimpleNode::Create(*region, std::move(copiedCmpOp), { arm, end }).output(0);
   auto pred = jlm::rvsdg::match(1, { { 1, 1 } }, 0, 2, cmp);
 
   return pred;
@@ -372,9 +377,13 @@ create_unrolled_theta_predicate(
 
   auto uf = create_bitconstant(region, nbits, factor);
   auto mul = bitmul_op::create(nbits, step, uf);
-  auto arm = SimpleNode::Create(*region, ui.armoperation(), { idv->origin(), mul }).output(0);
+  std::unique_ptr<rvsdg::SimpleOperation> copiedArmOp(
+      util::AssertedCast<rvsdg::SimpleOperation>(ui.armoperation().copy().release()));
+  auto arm = SimpleNode::Create(*region, std::move(copiedArmOp), { idv->origin(), mul }).output(0);
   /* FIXME: order of operands */
-  auto cmp = SimpleNode::Create(*region, ui.cmpoperation(), { arm, iend->origin() }).output(0);
+  std::unique_ptr<rvsdg::SimpleOperation> copiedCmpOp(
+      util::AssertedCast<rvsdg::SimpleOperation>(ui.cmpoperation().copy().release()));
+  auto cmp = SimpleNode::Create(*region, std::move(copiedCmpOp), { arm, iend->origin() }).output(0);
   auto pred = match(1, { { 1, 1 } }, 0, 2, cmp);
 
   return pred;
@@ -388,7 +397,9 @@ create_residual_gamma_predicate(const rvsdg::SubstitutionMap & smap, const LoopU
   auto end = ui.theta()->MapPreLoopVar(*ui.end()).input->origin();
 
   /* FIXME: order of operands */
-  auto cmp = rvsdg::SimpleNode::Create(*region, ui.cmpoperation(), { idv, end }).output(0);
+  std::unique_ptr<rvsdg::SimpleOperation> copiedCmpOp(
+      util::AssertedCast<rvsdg::SimpleOperation>(ui.cmpoperation().copy().release()));
+  auto cmp = rvsdg::SimpleNode::Create(*region, std::move(copiedCmpOp), { idv, end }).output(0);
   auto pred = jlm::rvsdg::match(1, { { 1, 1 } }, 0, 2, cmp);
 
   return pred;

--- a/jlm/mlir/frontend/MlirToJlmConverter.cpp
+++ b/jlm/mlir/frontend/MlirToJlmConverter.cpp
@@ -364,94 +364,55 @@ MlirToJlmConverter::ConvertBitBinaryNode(
 
   if (::mlir::isa<::mlir::arith::AddIOp>(mlirOperation))
   {
-    return &rvsdg::SimpleNode::Create(
-        rvsdgRegion,
-        jlm::llvm::IntegerAddOperation(width),
-        { inputs[0], inputs[1] });
+    return &rvsdg::CreateOpNode<jlm::llvm::IntegerAddOperation>({ inputs[0], inputs[1] }, width);
   }
   else if (::mlir::isa<::mlir::arith::SubIOp>(mlirOperation))
   {
-    return &rvsdg::SimpleNode::Create(
-        rvsdgRegion,
-        jlm::llvm::IntegerSubOperation(width),
-        { inputs[0], inputs[1] });
+    return &rvsdg::CreateOpNode<jlm::llvm::IntegerSubOperation>({ inputs[0], inputs[1] }, width);
   }
   else if (::mlir::isa<::mlir::arith::MulIOp>(mlirOperation))
   {
-    return &rvsdg::SimpleNode::Create(
-        rvsdgRegion,
-        jlm::llvm::IntegerMulOperation(width),
-        { inputs[0], inputs[1] });
+    return &rvsdg::CreateOpNode<jlm::llvm::IntegerMulOperation>({ inputs[0], inputs[1] }, width);
   }
   else if (::mlir::isa<::mlir::arith::DivSIOp>(mlirOperation))
   {
-    return &rvsdg::SimpleNode::Create(
-        rvsdgRegion,
-        jlm::llvm::IntegerSDivOperation(width),
-        { inputs[0], inputs[1] });
+    return &rvsdg::CreateOpNode<jlm::llvm::IntegerSDivOperation>({ inputs[0], inputs[1] }, width);
   }
   else if (::mlir::isa<::mlir::arith::DivUIOp>(mlirOperation))
   {
-    return &rvsdg::SimpleNode::Create(
-        rvsdgRegion,
-        jlm::llvm::IntegerUDivOperation(width),
-        { inputs[0], inputs[1] });
+    return &rvsdg::CreateOpNode<jlm::llvm::IntegerUDivOperation>({ inputs[0], inputs[1] }, width);
   }
   else if (::mlir::isa<::mlir::arith::RemSIOp>(mlirOperation))
   {
-    return &rvsdg::SimpleNode::Create(
-        rvsdgRegion,
-        jlm::llvm::IntegerSRemOperation(width),
-        { inputs[0], inputs[1] });
+    return &rvsdg::CreateOpNode<jlm::llvm::IntegerSRemOperation>({ inputs[0], inputs[1] }, width);
   }
   else if (::mlir::isa<::mlir::arith::RemUIOp>(mlirOperation))
   {
-    return &rvsdg::SimpleNode::Create(
-        rvsdgRegion,
-        jlm::llvm::IntegerURemOperation(width),
-        { inputs[0], inputs[1] });
+    return &rvsdg::CreateOpNode<jlm::llvm::IntegerURemOperation>({ inputs[0], inputs[1] }, width);
   }
   else if (::mlir::isa<::mlir::LLVM::ShlOp>(mlirOperation))
   {
-    return &rvsdg::SimpleNode::Create(
-        rvsdgRegion,
-        jlm::llvm::IntegerShlOperation(width),
-        { inputs[0], inputs[1] });
+    return &rvsdg::CreateOpNode<jlm::llvm::IntegerShlOperation>({ inputs[0], inputs[1] }, width);
   }
   else if (::mlir::isa<::mlir::LLVM::AShrOp>(mlirOperation))
   {
-    return &rvsdg::SimpleNode::Create(
-        rvsdgRegion,
-        jlm::llvm::IntegerAShrOperation(width),
-        { inputs[0], inputs[1] });
+    return &rvsdg::CreateOpNode<jlm::llvm::IntegerAShrOperation>({ inputs[0], inputs[1] }, width);
   }
   else if (::mlir::isa<::mlir::LLVM::LShrOp>(mlirOperation))
   {
-    return &rvsdg::SimpleNode::Create(
-        rvsdgRegion,
-        jlm::llvm::IntegerLShrOperation(width),
-        { inputs[0], inputs[1] });
+    return &rvsdg::CreateOpNode<jlm::llvm::IntegerLShrOperation>({ inputs[0], inputs[1] }, width);
   }
   else if (::mlir::isa<::mlir::arith::AndIOp>(mlirOperation))
   {
-    return &rvsdg::SimpleNode::Create(
-        rvsdgRegion,
-        jlm::llvm::IntegerAndOperation(width),
-        { inputs[0], inputs[1] });
+    return &rvsdg::CreateOpNode<jlm::llvm::IntegerAndOperation>({ inputs[0], inputs[1] }, width);
   }
   else if (::mlir::isa<::mlir::arith::OrIOp>(mlirOperation))
   {
-    return &rvsdg::SimpleNode::Create(
-        rvsdgRegion,
-        jlm::llvm::IntegerOrOperation(width),
-        { inputs[0], inputs[1] });
+    return &rvsdg::CreateOpNode<jlm::llvm::IntegerOrOperation>({ inputs[0], inputs[1] }, width);
   }
   else if (::mlir::isa<::mlir::arith::XOrIOp>(mlirOperation))
   {
-    return &rvsdg::SimpleNode::Create(
-        rvsdgRegion,
-        jlm::llvm::IntegerXorOperation(width),
-        { inputs[0], inputs[1] });
+    return &rvsdg::CreateOpNode<jlm::llvm::IntegerXorOperation>({ inputs[0], inputs[1] }, width);
   }
   else
   {

--- a/jlm/mlir/frontend/MlirToJlmConverter.cpp
+++ b/jlm/mlir/frontend/MlirToJlmConverter.cpp
@@ -153,73 +153,43 @@ MlirToJlmConverter::ConvertCmpIOp(
 {
   if (CompOp.getPredicate() == ::mlir::arith::CmpIPredicate::eq)
   {
-    return &rvsdg::SimpleNode::Create(
-        rvsdgRegion,
-        jlm::llvm::IntegerEqOperation(nbits),
-        { inputs[0], inputs[1] });
+    return &rvsdg::CreateOpNode<jlm::llvm::IntegerEqOperation>({ inputs[0], inputs[1] }, nbits);
   }
   else if (CompOp.getPredicate() == ::mlir::arith::CmpIPredicate::ne)
   {
-    return &rvsdg::SimpleNode::Create(
-        rvsdgRegion,
-        jlm::llvm::IntegerNeOperation(nbits),
-        { inputs[0], inputs[1] });
+    return &rvsdg::CreateOpNode<jlm::llvm::IntegerNeOperation>({ inputs[0], inputs[1] }, nbits);
   }
   else if (CompOp.getPredicate() == ::mlir::arith::CmpIPredicate::sge)
   {
-    return &rvsdg::SimpleNode::Create(
-        rvsdgRegion,
-        jlm::llvm::IntegerSgeOperation(nbits),
-        { inputs[0], inputs[1] });
+    return &rvsdg::CreateOpNode<jlm::llvm::IntegerSgeOperation>({ inputs[0], inputs[1] }, nbits);
   }
   else if (CompOp.getPredicate() == ::mlir::arith::CmpIPredicate::sgt)
   {
-    return &rvsdg::SimpleNode::Create(
-        rvsdgRegion,
-        jlm::llvm::IntegerSgtOperation(nbits),
-        { inputs[0], inputs[1] });
+    return &rvsdg::CreateOpNode<jlm::llvm::IntegerSgtOperation>({ inputs[0], inputs[1] }, nbits);
   }
   else if (CompOp.getPredicate() == ::mlir::arith::CmpIPredicate::sle)
   {
-    return &rvsdg::SimpleNode::Create(
-        rvsdgRegion,
-        jlm::llvm::IntegerSleOperation(nbits),
-        { inputs[0], inputs[1] });
+    return &rvsdg::CreateOpNode<jlm::llvm::IntegerSleOperation>({ inputs[0], inputs[1] }, nbits);
   }
   else if (CompOp.getPredicate() == ::mlir::arith::CmpIPredicate::slt)
   {
-    return &rvsdg::SimpleNode::Create(
-        rvsdgRegion,
-        jlm::llvm::IntegerSltOperation(nbits),
-        { inputs[0], inputs[1] });
+    return &rvsdg::CreateOpNode<jlm::llvm::IntegerSltOperation>({ inputs[0], inputs[1] }, nbits);
   }
   else if (CompOp.getPredicate() == ::mlir::arith::CmpIPredicate::uge)
   {
-    return &rvsdg::SimpleNode::Create(
-        rvsdgRegion,
-        jlm::llvm::IntegerUgeOperation(nbits),
-        { inputs[0], inputs[1] });
+    return &rvsdg::CreateOpNode<jlm::llvm::IntegerUgeOperation>({ inputs[0], inputs[1] }, nbits);
   }
   else if (CompOp.getPredicate() == ::mlir::arith::CmpIPredicate::ugt)
   {
-    return &rvsdg::SimpleNode::Create(
-        rvsdgRegion,
-        jlm::llvm::IntegerUgtOperation(nbits),
-        { inputs[0], inputs[1] });
+    return &rvsdg::CreateOpNode<jlm::llvm::IntegerUgtOperation>({ inputs[0], inputs[1] }, nbits);
   }
   else if (CompOp.getPredicate() == ::mlir::arith::CmpIPredicate::ule)
   {
-    return &rvsdg::SimpleNode::Create(
-        rvsdgRegion,
-        jlm::llvm::IntegerUleOperation(nbits),
-        { inputs[0], inputs[1] });
+    return &rvsdg::CreateOpNode<jlm::llvm::IntegerUleOperation>({ inputs[0], inputs[1] }, nbits);
   }
   else if (CompOp.getPredicate() == ::mlir::arith::CmpIPredicate::ult)
   {
-    return &rvsdg::SimpleNode::Create(
-        rvsdgRegion,
-        jlm::llvm::IntegerUltOperation(nbits),
-        { inputs[0], inputs[1] });
+    return &rvsdg::CreateOpNode<jlm::llvm::IntegerUltOperation>({ inputs[0], inputs[1] }, nbits);
   }
   else
   {
@@ -332,10 +302,7 @@ MlirToJlmConverter::ConvertFPBinaryNode(
   {
     return nullptr;
   }
-  return &rvsdg::SimpleNode::Create(
-      rvsdgRegion,
-      llvm::FBinaryOperation(op, size),
-      { inputs[0], inputs[1] });
+  return &rvsdg::CreateOpNode<llvm::FBinaryOperation>({ inputs[0], inputs[1] }, op, size);
 }
 
 llvm::fpcmp

--- a/jlm/rvsdg/binary.cpp
+++ b/jlm/rvsdg/binary.cpp
@@ -96,7 +96,7 @@ FlattenAssociativeBinaryOperation(
   JLM_ASSERT(newOperands.size() > 2);
   auto flattenedBinaryOperation =
       std::make_unique<FlattenedBinaryOperation>(operation, newOperands.size());
-  return outputs(&SimpleNode::Create(*region, *flattenedBinaryOperation, newOperands));
+  return outputs(&SimpleNode::Create(*region, flattenedBinaryOperation, newOperands));
 }
 
 std::optional<std::vector<rvsdg::Output *>>
@@ -122,7 +122,7 @@ NormalizeBinaryOperation(
   }
 
   JLM_ASSERT(newOperands.size() == 2);
-  return outputs(&SimpleNode::Create(*region, operation, newOperands));
+  return outputs(&SimpleNode::Create(*region, operation.copy(), newOperands));
 }
 
 FlattenedBinaryOperation::~FlattenedBinaryOperation() noexcept = default;
@@ -166,7 +166,7 @@ reduce_parallel(const BinaryOperation & op, const std::vector<jlm::rvsdg::Output
     auto op2 = worklist.front();
     worklist.pop_front();
 
-    auto output = SimpleNode::Create(*region, op, { op1, op2 }).output(0);
+    auto output = SimpleNode::Create(*region, std::move(op.copy()), { op1, op2 }).output(0);
     worklist.push_back(output);
   }
 
@@ -188,7 +188,7 @@ reduce_linear(const BinaryOperation & op, const std::vector<jlm::rvsdg::Output *
     auto op2 = worklist.front();
     worklist.pop_front();
 
-    auto output = SimpleNode::Create(*region, op, { op1, op2 }).output(0);
+    auto output = SimpleNode::Create(*region, op.copy(), { op1, op2 }).output(0);
     worklist.push_front(output);
   }
 

--- a/jlm/rvsdg/binary.cpp
+++ b/jlm/rvsdg/binary.cpp
@@ -96,7 +96,7 @@ FlattenAssociativeBinaryOperation(
   JLM_ASSERT(newOperands.size() > 2);
   auto flattenedBinaryOperation =
       std::make_unique<FlattenedBinaryOperation>(operation, newOperands.size());
-  return outputs(&SimpleNode::Create(*region, flattenedBinaryOperation, newOperands));
+  return outputs(&SimpleNode::Create(*region, std::move(flattenedBinaryOperation), newOperands));
 }
 
 std::optional<std::vector<rvsdg::Output *>>
@@ -166,7 +166,7 @@ reduce_parallel(const BinaryOperation & op, const std::vector<jlm::rvsdg::Output
     auto op2 = worklist.front();
     worklist.pop_front();
 
-    auto output = SimpleNode::Create(*region, std::move(op.copy()), { op1, op2 }).output(0);
+    auto output = SimpleNode::Create(*region, op.copy(), { op1, op2 }).output(0);
     worklist.push_back(output);
   }
 

--- a/jlm/rvsdg/simple-node.hpp
+++ b/jlm/rvsdg/simple-node.hpp
@@ -47,20 +47,17 @@ public:
   DebugString() const override;
 
   static SimpleNode &
-  Create(Region & region, const SimpleOperation & op, const std::vector<rvsdg::Output *> & operands)
-  {
-    std::unique_ptr<SimpleOperation> newOp(
-        util::AssertedCast<SimpleOperation>(op.copy().release()));
-    return *(new SimpleNode(region, std::move(newOp), operands));
-  }
-
-  static SimpleNode &
   Create(
       Region & region,
-      std::unique_ptr<SimpleOperation> operation,
+      std::unique_ptr<Operation> operation,
       const std::vector<rvsdg::Output *> & operands)
   {
-    return *new SimpleNode(region, std::move(operation), operands);
+    if (!is<SimpleOperation>(*operation))
+      throw util::error("Expected operation derived from SimpleOperation");
+
+    std::unique_ptr<SimpleOperation> simpleOperation(
+        util::AssertedCast<SimpleOperation>(operation.release()));
+    return *new SimpleNode(region, std::move(simpleOperation), operands);
   }
 
 private:

--- a/tests/jlm/llvm/opt/test-unroll.cpp
+++ b/tests/jlm/llvm/opt/test-unroll.cpp
@@ -51,8 +51,8 @@ create_theta(
   auto lvs = theta->AddLoopVar(step);
   auto lve = theta->AddLoopVar(end);
 
-  auto arm = SimpleNode::Create(*subregion, aop, { idv.pre, lvs.pre }).output(0);
-  auto cmp = SimpleNode::Create(*subregion, cop, { arm, lve.pre }).output(0);
+  auto arm = SimpleNode::Create(*subregion, aop.copy(), { idv.pre, lvs.pre }).output(0);
+  auto cmp = SimpleNode::Create(*subregion, cop.copy(), { arm, lve.pre }).output(0);
   auto match = jlm::rvsdg::match(1, { { 1, 1 } }, 0, 2, cmp);
 
   idv.post->divert_to(arm);

--- a/tests/jlm/mlir/TestIntegerOperationsJlmToMlirToJlm.cpp
+++ b/tests/jlm/mlir/TestIntegerOperationsJlmToMlirToJlm.cpp
@@ -49,7 +49,7 @@ TestIntegerBinaryOperation()
     auto constOp1 = jlm::rvsdg::create_bitconstant(&graph->GetRootRegion(), nbits, val1);
     auto constOp2 = jlm::rvsdg::create_bitconstant(&graph->GetRootRegion(), nbits, val2);
     auto binaryOp = JlmOperation(nbits);
-    jlm::rvsdg::SimpleNode::Create(graph->GetRootRegion(), binaryOp, { constOp1, constOp2 });
+    jlm::rvsdg::SimpleNode::Create(graph->GetRootRegion(), binaryOp.copy(), { constOp1, constOp2 });
 
     // Convert the RVSDG to MLIR
     std::cout << "Convert to MLIR" << std::endl;
@@ -172,7 +172,7 @@ TestIntegerComparisonOperation(const IntegerComparisonOpTest<JlmOperation> & tes
     auto constOp1 = jlm::rvsdg::create_bitconstant(&graph->GetRootRegion(), nbits, val1);
     auto constOp2 = jlm::rvsdg::create_bitconstant(&graph->GetRootRegion(), nbits, val2);
     auto compOp = JlmOperation(nbits);
-    jlm::rvsdg::SimpleNode::Create(graph->GetRootRegion(), compOp, { constOp1, constOp2 });
+    jlm::rvsdg::SimpleNode::Create(graph->GetRootRegion(), compOp.copy(), { constOp1, constOp2 });
 
     // Convert the RVSDG to MLIR
     std::cout << "Convert to MLIR" << std::endl;

--- a/tests/jlm/mlir/TestJlmToMlirToJlm.cpp
+++ b/tests/jlm/mlir/TestJlmToMlirToJlm.cpp
@@ -90,9 +90,11 @@ TestAlloca()
 
     // Create alloca node
     std::cout << "Alloca Operation" << std::endl;
-    auto allocaOp =
-        AllocaOperation(jlm::rvsdg::bittype::Create(64), jlm::rvsdg::bittype::Create(32), 4);
-    jlm::rvsdg::SimpleNode::Create(graph->GetRootRegion(), allocaOp, { bits });
+    CreateOpNode<AllocaOperation>(
+        { bits },
+        jlm::rvsdg::bittype::Create(64),
+        jlm::rvsdg::bittype::Create(32),
+        4);
 
     // Convert the RVSDG to MLIR
     std::cout << "Convert to MLIR" << std::endl;
@@ -456,8 +458,7 @@ TestSitofp()
     auto bitsArgument = lambda->GetFunctionArguments().at(0);
 
     // Create sitofp operation
-    auto sitofpOp = SIToFPOperation(bitsType, floatType);
-    jlm::rvsdg::SimpleNode::Create(*lambda->subregion(), sitofpOp, { bitsArgument });
+    CreateOpNode<SIToFPOperation>({ bitsArgument }, bitType, floatType);
 
     lambda->finalize({});
 
@@ -523,8 +524,7 @@ TestConstantFP()
         LlvmLambdaOperation::Create(functionType, "test", linkage::external_linkage));
 
     // Create sitofp operation
-    auto constOp = ConstantFP(fpsize::dbl, ::llvm::APFloat(2.0));
-    jlm::rvsdg::SimpleNode::Create(*lambda->subregion(), constOp, {});
+    CreateOpNode<ConstantFP>(*lambda->subregion(), fpsize::dbl, ::llvm::APFloat(2.0));
 
     lambda->finalize({});
 
@@ -586,10 +586,7 @@ TestFpBinary()
       auto floatArgument1 = lambda->GetFunctionArguments().at(0);
       auto floatArgument2 = lambda->GetFunctionArguments().at(1);
 
-      jlm::rvsdg::SimpleNode::Create(
-          *lambda->subregion(),
-          FBinaryOperation(binOp, floatType),
-          { floatArgument1, floatArgument2 });
+      CreateOpNode<FBinaryOperation>({ floatArgument1, floatArgument2 }, binOp, floatType);
 
       lambda->finalize({});
 
@@ -1064,10 +1061,9 @@ TestFNeg()
 
   {
     auto floatType = jlm::llvm::FloatingPointType::Create(jlm::llvm::fpsize::flt);
-    auto constOp = ConstantFP(floatType, ::llvm::APFloat(2.0));
-    auto & constNode = jlm::rvsdg::SimpleNode::Create(graph->GetRootRegion(), constOp, {});
-    auto fnegOp = FNegOperation(jlm::llvm::fpsize::flt);
-    jlm::rvsdg::SimpleNode::Create(graph->GetRootRegion(), fnegOp, { constNode.output(0) });
+    auto & constNode =
+        CreateOpNode<ConstantFP>(graph->GetRootRegion(), floatType, ::llvm::APFloat(2.0));
+    CreateOpNode<FNegOperation>({ constNode.output(0) }, jlm::llvm::fpsize::flt);
 
     // Convert the RVSDG to MLIR
     std::cout << "Convert to MLIR" << std::endl;
@@ -1141,10 +1137,9 @@ TestFPExt()
   {
     auto floatType1 = jlm::llvm::FloatingPointType::Create(jlm::llvm::fpsize::flt);
     auto floatType2 = jlm::llvm::FloatingPointType::Create(jlm::llvm::fpsize::dbl);
-    auto constOp = ConstantFP(floatType1, ::llvm::APFloat(2.0));
-    auto & constNode = jlm::rvsdg::SimpleNode::Create(graph->GetRootRegion(), constOp, {});
-    auto fpextOp = FPExtOperation(floatType1, floatType2);
-    jlm::rvsdg::SimpleNode::Create(graph->GetRootRegion(), fpextOp, { constNode.output(0) });
+    auto & constNode =
+        CreateOpNode<ConstantFP>(graph->GetRootRegion(), floatType1, ::llvm::APFloat(2.0));
+    CreateOpNode<FPExtOperation>({ constNode.output(0) }, floatType1, floatType2);
 
     // Convert the RVSDG to MLIR
     std::cout << "Convert to MLIR" << std::endl;
@@ -1219,8 +1214,7 @@ TestTrunc()
     auto bitType1 = jlm::rvsdg::bittype::Create(64);
     auto bitType2 = jlm::rvsdg::bittype::Create(32);
     auto constOp = jlm::rvsdg::create_bitconstant(&graph->GetRootRegion(), 64, 2);
-    auto truncOp = TruncOperation(bitType1, bitType2);
-    jlm::rvsdg::SimpleNode::Create(graph->GetRootRegion(), truncOp, { constOp });
+    CreateOpNode<TruncOperation>({ constOp }, bitType1, bitType2);
 
     // Convert the RVSDG to MLIR
     std::cout << "Convert to MLIR" << std::endl;
@@ -1547,8 +1541,9 @@ TestIOBarrier()
     auto value = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 42);
 
     // Create the IOBarrier operation
-    auto ioBarrierOp = jlm::llvm::IOBarrierOperation(std::make_shared<jlm::rvsdg::bittype>(32));
-    jlm::rvsdg::SimpleNode::Create(*lambda->subregion(), ioBarrierOp, { value, ioStateArgument });
+    CreateOpNode<jlm::llvm::IOBarrierOperation>(
+        { value, ioStateArgument },
+        jlm::rvsdg::bittype::Create(32));
 
     // Finalize the lambda
     lambda->finalize({});

--- a/tests/jlm/mlir/TestJlmToMlirToJlm.cpp
+++ b/tests/jlm/mlir/TestJlmToMlirToJlm.cpp
@@ -6,17 +6,9 @@
 #include <test-registry.hpp>
 #include <TestRvsdgs.hpp>
 
-#include <jlm/llvm/ir/operators/delta.hpp>
 #include <jlm/llvm/ir/operators/IOBarrier.hpp>
-#include <jlm/llvm/ir/operators/lambda.hpp>
-#include <jlm/llvm/ir/RvsdgModule.hpp>
-#include <jlm/llvm/ir/types.hpp>
 #include <jlm/mlir/backend/JlmToMlirConverter.hpp>
 #include <jlm/mlir/frontend/MlirToJlmConverter.hpp>
-#include <jlm/rvsdg/bitstring/constant.hpp>
-#include <jlm/rvsdg/FunctionType.hpp>
-#include <jlm/rvsdg/nullary.hpp>
-#include <jlm/rvsdg/simple-node.hpp>
 #include <jlm/rvsdg/traverser.hpp>
 
 static void
@@ -90,7 +82,7 @@ TestAlloca()
 
     // Create alloca node
     std::cout << "Alloca Operation" << std::endl;
-    CreateOpNode<AllocaOperation>(
+    jlm::rvsdg::CreateOpNode<AllocaOperation>(
         { bits },
         jlm::rvsdg::bittype::Create(64),
         jlm::rvsdg::bittype::Create(32),
@@ -458,7 +450,7 @@ TestSitofp()
     auto bitsArgument = lambda->GetFunctionArguments().at(0);
 
     // Create sitofp operation
-    CreateOpNode<SIToFPOperation>({ bitsArgument }, bitType, floatType);
+    jlm::rvsdg::CreateOpNode<SIToFPOperation>({ bitsArgument }, bitsType, floatType);
 
     lambda->finalize({});
 
@@ -524,7 +516,7 @@ TestConstantFP()
         LlvmLambdaOperation::Create(functionType, "test", linkage::external_linkage));
 
     // Create sitofp operation
-    CreateOpNode<ConstantFP>(*lambda->subregion(), fpsize::dbl, ::llvm::APFloat(2.0));
+    jlm::rvsdg::CreateOpNode<ConstantFP>(*lambda->subregion(), fpsize::dbl, ::llvm::APFloat(2.0));
 
     lambda->finalize({});
 
@@ -586,7 +578,10 @@ TestFpBinary()
       auto floatArgument1 = lambda->GetFunctionArguments().at(0);
       auto floatArgument2 = lambda->GetFunctionArguments().at(1);
 
-      CreateOpNode<FBinaryOperation>({ floatArgument1, floatArgument2 }, binOp, floatType);
+      jlm::rvsdg::CreateOpNode<FBinaryOperation>(
+          { floatArgument1, floatArgument2 },
+          binOp,
+          floatType);
 
       lambda->finalize({});
 
@@ -1061,9 +1056,11 @@ TestFNeg()
 
   {
     auto floatType = jlm::llvm::FloatingPointType::Create(jlm::llvm::fpsize::flt);
-    auto & constNode =
-        CreateOpNode<ConstantFP>(graph->GetRootRegion(), floatType, ::llvm::APFloat(2.0));
-    CreateOpNode<FNegOperation>({ constNode.output(0) }, jlm::llvm::fpsize::flt);
+    auto & constNode = jlm::rvsdg::CreateOpNode<ConstantFP>(
+        graph->GetRootRegion(),
+        floatType,
+        ::llvm::APFloat(2.0));
+    jlm::rvsdg::CreateOpNode<FNegOperation>({ constNode.output(0) }, jlm::llvm::fpsize::flt);
 
     // Convert the RVSDG to MLIR
     std::cout << "Convert to MLIR" << std::endl;
@@ -1137,9 +1134,11 @@ TestFPExt()
   {
     auto floatType1 = jlm::llvm::FloatingPointType::Create(jlm::llvm::fpsize::flt);
     auto floatType2 = jlm::llvm::FloatingPointType::Create(jlm::llvm::fpsize::dbl);
-    auto & constNode =
-        CreateOpNode<ConstantFP>(graph->GetRootRegion(), floatType1, ::llvm::APFloat(2.0));
-    CreateOpNode<FPExtOperation>({ constNode.output(0) }, floatType1, floatType2);
+    auto & constNode = jlm::rvsdg::CreateOpNode<ConstantFP>(
+        graph->GetRootRegion(),
+        floatType1,
+        ::llvm::APFloat(2.0));
+    jlm::rvsdg::CreateOpNode<FPExtOperation>({ constNode.output(0) }, floatType1, floatType2);
 
     // Convert the RVSDG to MLIR
     std::cout << "Convert to MLIR" << std::endl;
@@ -1214,7 +1213,7 @@ TestTrunc()
     auto bitType1 = jlm::rvsdg::bittype::Create(64);
     auto bitType2 = jlm::rvsdg::bittype::Create(32);
     auto constOp = jlm::rvsdg::create_bitconstant(&graph->GetRootRegion(), 64, 2);
-    CreateOpNode<TruncOperation>({ constOp }, bitType1, bitType2);
+    jlm::rvsdg::CreateOpNode<TruncOperation>({ constOp }, bitType1, bitType2);
 
     // Convert the RVSDG to MLIR
     std::cout << "Convert to MLIR" << std::endl;
@@ -1541,7 +1540,7 @@ TestIOBarrier()
     auto value = jlm::rvsdg::create_bitconstant(lambda->subregion(), 32, 42);
 
     // Create the IOBarrier operation
-    CreateOpNode<jlm::llvm::IOBarrierOperation>(
+    jlm::rvsdg::CreateOpNode<jlm::llvm::IOBarrierOperation>(
         { value, ioStateArgument },
         jlm::rvsdg::bittype::Create(32));
 

--- a/tests/jlm/rvsdg/UnaryOperationTests.cpp
+++ b/tests/jlm/rvsdg/UnaryOperationTests.cpp
@@ -74,12 +74,11 @@ NormalizeUnaryOperation_Success()
   Graph graph;
   const auto valueType = jlm::tests::ValueType::Create();
 
-  const jlm::tests::NullaryOperation nullaryOperation(valueType);
-  const auto nullaryNode = &SimpleNode::Create(graph.GetRootRegion(), nullaryOperation, {});
+  const auto nullaryNode =
+      &CreateOpNode<jlm::tests::NullaryOperation>(graph.GetRootRegion(), valueType);
 
-  const ::UnaryOperation unaryOperation(valueType, valueType);
   const auto unaryNode =
-      &SimpleNode::Create(graph.GetRootRegion(), unaryOperation, { nullaryNode->output(0) });
+      &CreateOpNode<::UnaryOperation>({ nullaryNode->output(0) }, valueType, valueType);
 
   auto & ex = jlm::tests::GraphExport::Create(*unaryNode->output(0), "o2");
 
@@ -114,8 +113,7 @@ NormalizeUnaryOperation_Failure()
   Graph graph;
   auto i0 = &jlm::tests::GraphImport::Create(graph, valueType, "i0");
 
-  const ::UnaryOperation unaryOperation(valueType, valueType);
-  const auto unaryNode = &SimpleNode::Create(graph.GetRootRegion(), unaryOperation, { i0 });
+  const auto unaryNode = &CreateOpNode<::UnaryOperation>({ i0 }, valueType, valueType);
 
   auto & ex = jlm::tests::GraphExport::Create(*unaryNode->output(0), "o2");
 

--- a/tests/jlm/rvsdg/test-binary.cpp
+++ b/tests/jlm/rvsdg/test-binary.cpp
@@ -186,12 +186,16 @@ FlattenAssociativeBinaryOperation_NotAssociativeBinary()
   auto i1 = &jlm::tests::GraphImport::Create(graph, valueType, "i1");
   auto i2 = &jlm::tests::GraphImport::Create(graph, valueType, "i2");
 
-  jlm::tests::TestBinaryOperation binaryOperation(
+  auto o1 = &CreateOpNode<jlm::tests::TestBinaryOperation>(
+      { i0, i1 },
       valueType,
       valueType,
       jlm::rvsdg::BinaryOperation::flags::none);
-  auto o1 = &SimpleNode::Create(graph.GetRootRegion(), binaryOperation, { i0, i1 });
-  auto o2 = &SimpleNode::Create(graph.GetRootRegion(), binaryOperation, { o1->output(0), i2 });
+  auto o2 = &CreateOpNode<jlm::tests::TestBinaryOperation>(
+      { o1->output(0), i2 },
+      valueType,
+      valueType,
+      jlm::rvsdg::BinaryOperation::flags::none);
 
   auto & ex = jlm::tests::GraphExport::Create(*o2->output(0), "o2");
 
@@ -225,15 +229,13 @@ FlattenAssociativeBinaryOperation_NoNewOperands()
   auto i0 = &jlm::tests::GraphImport::Create(graph, valueType, "i0");
   auto i1 = &jlm::tests::GraphImport::Create(graph, valueType, "i1");
 
-  jlm::tests::TestUnaryOperation unaryOperation(valueType, valueType);
-  jlm::tests::TestBinaryOperation binaryOperation(
+  auto u1 = &CreateOpNode<jlm::tests::TestUnaryOperation>({ i0 }, valueType, valueType);
+  auto u2 = &CreateOpNode<jlm::tests::TestUnaryOperation>({ i1 }, valueType, valueType);
+  auto b2 = &CreateOpNode<jlm::tests::TestBinaryOperation>(
+      { u1->output(0), u2->output(0) },
       valueType,
       valueType,
       jlm::rvsdg::BinaryOperation::flags::associative);
-  auto u1 = &SimpleNode::Create(graph.GetRootRegion(), unaryOperation, { i0 });
-  auto u2 = &SimpleNode::Create(graph.GetRootRegion(), unaryOperation, { i1 });
-  auto b2 =
-      &SimpleNode::Create(graph.GetRootRegion(), binaryOperation, { u1->output(0), u2->output(0) });
 
   auto & ex = jlm::tests::GraphExport::Create(*b2->output(0), "o2");
 
@@ -268,12 +270,16 @@ FlattenAssociativeBinaryOperation_Success()
   auto i1 = &jlm::tests::GraphImport::Create(graph, valueType, "i1");
   auto i2 = &jlm::tests::GraphImport::Create(graph, valueType, "i2");
 
-  jlm::tests::TestBinaryOperation binaryOperation(
+  auto o1 = &CreateOpNode<jlm::tests::TestBinaryOperation>(
+      { i0, i1 },
       valueType,
       valueType,
       jlm::rvsdg::BinaryOperation::flags::associative);
-  auto o1 = &SimpleNode::Create(graph.GetRootRegion(), binaryOperation, { i0, i1 });
-  auto o2 = &SimpleNode::Create(graph.GetRootRegion(), binaryOperation, { o1->output(0), i2 });
+  auto o2 = &CreateOpNode<jlm::tests::TestBinaryOperation>(
+      { o1->output(0), i2 },
+      valueType,
+      valueType,
+      jlm::rvsdg::BinaryOperation::flags::associative);
 
   auto & ex = jlm::tests::GraphExport::Create(*o2->output(0), "o2");
 
@@ -309,11 +315,11 @@ NormalizeBinaryOperation_NoNewOperands()
   auto i0 = &jlm::tests::GraphImport::Create(graph, valueType, "i0");
   auto i1 = &jlm::tests::GraphImport::Create(graph, valueType, "i1");
 
-  jlm::tests::TestBinaryOperation binaryOperation(
+  auto o1 = &CreateOpNode<jlm::tests::TestBinaryOperation>(
+      { i0, i1 },
       valueType,
       valueType,
       jlm::rvsdg::BinaryOperation::flags::associative);
-  auto o1 = &SimpleNode::Create(graph.GetRootRegion(), binaryOperation, { i0, i1 });
 
   auto & ex = jlm::tests::GraphExport::Create(*o1->output(0), "o2");
 
@@ -341,18 +347,18 @@ NormalizeBinaryOperation_SingleOperand()
   // Arrange
   auto valueType = jlm::tests::ValueType::Create();
 
-  jlm::tests::TestUnaryOperation unaryOperation(valueType, valueType);
-  ::BinaryOperation binaryOperation(valueType, valueType, jlm::rvsdg::BinaryOperation::flags::none);
-
   Graph graph;
   auto s0 = &jlm::tests::GraphImport::Create(graph, valueType, "s0");
   auto s1 = &jlm::tests::GraphImport::Create(graph, valueType, "s1");
 
-  auto u1 = &SimpleNode::Create(graph.GetRootRegion(), unaryOperation, { s0 });
-  auto u2 = &SimpleNode::Create(graph.GetRootRegion(), unaryOperation, { s1 });
+  auto u1 = &CreateOpNode<jlm::tests::TestUnaryOperation>({ s0 }, valueType, valueType);
+  auto u2 = &CreateOpNode<jlm::tests::TestUnaryOperation>({ s1 }, valueType, valueType);
 
-  auto o1 =
-      &SimpleNode::Create(graph.GetRootRegion(), binaryOperation, { u1->output(0), u2->output(0) });
+  auto o1 = &CreateOpNode<::BinaryOperation>(
+      { u1->output(0), u2->output(0) },
+      valueType,
+      valueType,
+      jlm::rvsdg::BinaryOperation::flags::none);
 
   auto & ex = jlm::tests::GraphExport::Create(*o1->output(0), "ex");
 

--- a/tests/test-operation.hpp
+++ b/tests/test-operation.hpp
@@ -201,7 +201,7 @@ public:
       rvsdg::Output * op1,
       rvsdg::Output * op2)
   {
-    return &CreateOpNode<TestBinaryOperation>(
+    return &rvsdg::CreateOpNode<TestBinaryOperation>(
         { op1, op2 },
         srctype,
         std::move(dsttype),
@@ -439,11 +439,11 @@ public:
       const std::vector<rvsdg::Output *> & operands,
       std::vector<std::shared_ptr<const rvsdg::Type>> resultTypes)
   {
-    return operands.empty() ? &CreateOpNode<TestOperation>(
+    return operands.empty() ? &rvsdg::CreateOpNode<TestOperation>(
                                   *region,
                                   std::move(operandTypes),
                                   std::move(resultTypes))
-                            : &CreateOpNode<TestOperation>(
+                            : &rvsdg::CreateOpNode<TestOperation>(
                                   { operands },
                                   std::move(operandTypes),
                                   std::move(resultTypes));

--- a/tests/test-operation.hpp
+++ b/tests/test-operation.hpp
@@ -201,8 +201,11 @@ public:
       rvsdg::Output * op1,
       rvsdg::Output * op2)
   {
-    TestBinaryOperation op(srctype, std::move(dsttype), BinaryOperation::flags::none);
-    return &rvsdg::SimpleNode::Create(*op1->region(), op, { op1, op2 });
+    return &CreateOpNode<TestBinaryOperation>(
+        { op1, op2 },
+        srctype,
+        std::move(dsttype),
+        BinaryOperation::flags::none);
   }
 
   static inline rvsdg::Output *
@@ -426,8 +429,7 @@ public:
     for (const auto & operand : operands)
       operand_types.push_back(operand->Type());
 
-    TestOperation op(std::move(operand_types), std::move(result_types));
-    return &rvsdg::SimpleNode::Create(*region, op, { operands });
+    return Create(region, operand_types, operands, result_types);
   }
 
   static rvsdg::SimpleNode *
@@ -437,8 +439,14 @@ public:
       const std::vector<rvsdg::Output *> & operands,
       std::vector<std::shared_ptr<const rvsdg::Type>> resultTypes)
   {
-    TestOperation op(std::move(operandTypes), std::move(resultTypes));
-    return &rvsdg::SimpleNode::Create(*region, op, { operands });
+    return operands.empty() ? &CreateOpNode<TestOperation>(
+                                  *region,
+                                  std::move(operandTypes),
+                                  std::move(resultTypes))
+                            : &CreateOpNode<TestOperation>(
+                                  { operands },
+                                  std::move(operandTypes),
+                                  std::move(resultTypes));
   }
 };
 


### PR DESCRIPTION
The PR does the following:

1. Remove a Create() method from SimpleNode class. The method lead to a lot of unnecessary additional operation allocation and copies. Remove it such that it can not be misused any longer.
2. Extend the second Create() method of the SimpleNode class to also take a Operation instead of just a SimpleOperation. This leads to a more usable interface for the user and allows to combine the method easily with the copy() method of the Operation class.