### PR TITLE
Refactor SimpleOutput dispatching

### DIFF
--- a/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.cpp
+++ b/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.cpp
@@ -2693,7 +2693,7 @@ RhlsToFirrtlConverter::MlirGen(rvsdg::Region * subRegion, mlir::Block * circuitB
 
 // Trace a structural output back to the "node" generating the value
 // Returns the output of the node
-rvsdg::SimpleOutput *
+rvsdg::Output *
 RhlsToFirrtlConverter::TraceStructuralOutput(rvsdg::StructuralOutput * output)
 {
   auto node = output->node();
@@ -2711,10 +2711,10 @@ RhlsToFirrtlConverter::TraceStructuralOutput(rvsdg::StructuralOutput * output)
     return TraceStructuralOutput(o);
   }
 
-  if (auto o = dynamic_cast<rvsdg::SimpleOutput *>(origin))
+  if (rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(*origin))
   {
     // Found the source node
-    return o;
+    return origin;
   }
   else if (dynamic_cast<rvsdg::RegionArgument *>(origin))
   {

--- a/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.hpp
+++ b/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.hpp
@@ -263,7 +263,7 @@ private:
   jlm::rvsdg::Output *
   TraceArgument(rvsdg::RegionArgument * arg);
 
-  rvsdg::SimpleOutput *
+  rvsdg::Output *
   TraceStructuralOutput(rvsdg::StructuralOutput * out);
 
   void

--- a/jlm/hls/backend/rvsdg2rhls/distribute-constants.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/distribute-constants.cpp
@@ -15,9 +15,10 @@ namespace jlm
 {
 
 void
-distribute_constant(const rvsdg::SimpleOperation & op, rvsdg::SimpleOutput * out)
+distribute_constant(const rvsdg::SimpleOperation & op, rvsdg::Output * out)
 {
-  JLM_ASSERT(jlm::hls::is_constant(out->node()));
+  JLM_ASSERT(hls::is_constant(rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(*out)));
+
   bool changed = true;
   while (changed)
   {

--- a/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
@@ -616,20 +616,22 @@ ConnectRequestResponseMemPorts(
   std::vector<std::shared_ptr<const rvsdg::Type>> responseTypes;
   for (auto loadNode : originalLoadNodes)
   {
-    JLM_ASSERT(smap.contains(*loadNode->output(0)));
-    auto loadOutput = dynamic_cast<rvsdg::SimpleOutput *>(smap.lookup(loadNode->output(0)));
-    loadNodes.push_back(loadOutput->node());
-    auto loadOp = util::AssertedCast<const llvm::LoadNonVolatileOperation>(
-        &loadOutput->node()->GetOperation());
+    auto oldLoadedValue = loadNode->output(0);
+    JLM_ASSERT(smap.contains(*oldLoadedValue));
+    auto & newLoadNode = rvsdg::AssertGetOwnerNode<rvsdg::SimpleNode>(*smap.lookup(oldLoadedValue));
+    loadNodes.push_back(&newLoadNode);
+    auto loadOp =
+        util::AssertedCast<const llvm::LoadNonVolatileOperation>(&newLoadNode.GetOperation());
     responseTypes.push_back(loadOp->GetLoadedType());
   }
   std::vector<rvsdg::SimpleNode *> decoupledNodes;
   for (auto decoupleRequest : originalDecoupledNodes)
   {
-    JLM_ASSERT(smap.contains(*decoupleRequest->output(0)));
-    auto decoupledOutput =
-        dynamic_cast<rvsdg::SimpleOutput *>(smap.lookup(decoupleRequest->output(0)));
-    decoupledNodes.push_back(decoupledOutput->node());
+    auto oldOutput = decoupleRequest->output(0);
+    JLM_ASSERT(smap.contains(*oldOutput));
+    auto & decoupledRequestNode =
+        rvsdg::AssertGetOwnerNode<rvsdg::SimpleNode>(*smap.lookup(oldOutput));
+    decoupledNodes.push_back(&decoupledRequestNode);
     // get load type from response output
     auto channel = decoupleRequest->input(1)->origin();
     auto channelConstant = trace_constant(channel);
@@ -640,9 +642,10 @@ ConnectRequestResponseMemPorts(
   std::vector<rvsdg::SimpleNode *> storeNodes;
   for (auto storeNode : originalStoreNodes)
   {
-    JLM_ASSERT(smap.contains(*storeNode->output(0)));
-    auto storeOutput = dynamic_cast<rvsdg::SimpleOutput *>(smap.lookup(storeNode->output(0)));
-    storeNodes.push_back(storeOutput->node());
+    auto oldOutput = storeNode->output(0);
+    JLM_ASSERT(smap.contains(*oldOutput));
+    auto & newStoreNode = rvsdg::AssertGetOwnerNode<rvsdg::SimpleNode>(*smap.lookup(oldOutput));
+    storeNodes.push_back(&newStoreNode);
     // use memory state type as response for stores
     auto vt = std::make_shared<llvm::MemoryStateType>();
     responseTypes.push_back(vt);
@@ -725,7 +728,7 @@ ReplaceLoad(
   // We need the load in the new lambda such that we can replace it with a load node with explicit
   // memory ports
   auto replacedLoad =
-      static_cast<rvsdg::SimpleOutput *>(smap.lookup(originalLoad->output(0)))->node();
+      &rvsdg::AssertGetOwnerNode<rvsdg::SimpleNode>(*smap.lookup(originalLoad->output(0)));
 
   auto loadAddress = replacedLoad->input(0)->origin();
   std::vector<rvsdg::Output *> states;
@@ -767,7 +770,7 @@ ReplaceStore(
   // We need the store in the new lambda such that we can replace it with a store node with explicit
   // memory ports
   auto replacedStore =
-      static_cast<rvsdg::SimpleOutput *>(smap.lookup(originalStore->output(0)))->node();
+      &rvsdg::AssertGetOwnerNode<rvsdg::SimpleNode>(*smap.lookup(originalStore->output(0)));
 
   auto addr = replacedStore->input(0)->origin();
   JLM_ASSERT(rvsdg::is<llvm::PointerType>(addr->Type()));

--- a/jlm/hls/backend/rvsdg2rhls/mem-queue.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-queue.cpp
@@ -105,20 +105,18 @@ find_loop_output(jlm::rvsdg::StructuralInput * sti)
     {
       auto res = ba->result();
       JLM_ASSERT(res);
-      auto buffer_out = dynamic_cast<jlm::rvsdg::SimpleOutput *>(res->origin());
-      JLM_ASSERT(buffer_out);
-      JLM_ASSERT(jlm::rvsdg::is<jlm::hls::BufferOperation>(buffer_out->node()));
-      auto branch_out =
-          dynamic_cast<jlm::rvsdg::SimpleOutput *>(buffer_out->node()->input(0)->origin());
-      JLM_ASSERT(branch_out);
-      JLM_ASSERT(
-          dynamic_cast<const jlm::hls::BranchOperation *>(&branch_out->node()->GetOperation()));
-      // branch
+      auto [bufferNode, bufferOperation] =
+          jlm::rvsdg::TryGetSimpleNodeAndOp<jlm::hls::BufferOperation>(*res->origin());
+      JLM_ASSERT(bufferNode && bufferOperation);
+      auto [branchNode, branchOperation] =
+          jlm::rvsdg::TryGetSimpleNodeAndOp<jlm::hls::BranchOperation>(
+              *bufferNode->input(0)->origin());
+      JLM_ASSERT(branchNode && branchOperation);
       for (size_t j = 0; j < 2; ++j)
       {
-        JLM_ASSERT(branch_out->node()->output(j)->nusers() == 1);
-        auto result = dynamic_cast<jlm::rvsdg::RegionResult *>(
-            &*branch_out->node()->output(j)->Users().begin());
+        JLM_ASSERT(branchNode->output(j)->nusers() == 1);
+        auto result =
+            dynamic_cast<jlm::rvsdg::RegionResult *>(&*branchNode->output(j)->Users().begin());
         if (result)
         {
           return result->output();
@@ -324,7 +322,7 @@ separate_load_edge(
           user->divert_to(addr_edge);
           sn->output(1)->divert_users(mem_edge);
           remove(sn);
-          *load = dynamic_cast<jlm::rvsdg::SimpleOutput *>(new_load_outputs[0])->node();
+          *load = &jlm::rvsdg::AssertGetOwnerNode<jlm::rvsdg::SimpleNode>(*new_load_outputs[0]);
           *load_encountered = true;
         }
         else
@@ -459,7 +457,8 @@ process_loops(jlm::rvsdg::Output * state_edge)
         JLM_ASSERT(store_nodes.size() == store_addresses.size());
         JLM_ASSERT(store_nodes.size() == store_dequeues.size());
         auto state_gate_addr_in =
-            dynamic_cast<jlm::rvsdg::SimpleOutput *>(load->input(0)->origin())->node()->input(0);
+            jlm::rvsdg::AssertGetOwnerNode<jlm::rvsdg::SimpleNode>(*load->input(0)->origin())
+                .input(0);
         for (size_t j = 0; j < store_nodes.size(); ++j)
         {
           JLM_ASSERT(state_gate_addr_in->origin()->region() == store_addresses[j]->region());

--- a/jlm/hls/backend/rvsdg2rhls/merge-gamma.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/merge-gamma.cpp
@@ -38,9 +38,9 @@ eliminate_gamma_ctl(rvsdg::GammaNode * gamma)
       for (size_t j = 0; j < gamma->nsubregions(); ++j)
       {
         auto r = gamma->subregion(j)->result(i);
-        if (auto so = dynamic_cast<rvsdg::SimpleOutput *>(r->origin()))
+        if (auto simpleNode = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(*r->origin()))
         {
-          if (auto ctl = dynamic_cast<const rvsdg::ctlconstant_op *>(&so->node()->GetOperation()))
+          if (auto ctl = dynamic_cast<const rvsdg::ctlconstant_op *>(&simpleNode->GetOperation()))
           {
             if (j == ctl->value().alternative())
             {
@@ -134,9 +134,9 @@ fix_match_inversion(rvsdg::GammaNode * old_gamma)
       for (size_t j = 0; j < old_gamma->nsubregions(); ++j)
       {
         auto r = old_gamma->subregion(j)->result(i);
-        if (auto so = dynamic_cast<rvsdg::SimpleOutput *>(r->origin()))
+        if (auto simpleNode = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(*r->origin()))
         {
-          if (auto ctl = dynamic_cast<const rvsdg::ctlconstant_op *>(&so->node()->GetOperation()))
+          if (auto ctl = dynamic_cast<const rvsdg::ctlconstant_op *>(&simpleNode->GetOperation()))
           {
             if (j != ctl->value().alternative())
             {

--- a/jlm/hls/util/view.cpp
+++ b/jlm/hls/util/view.cpp
@@ -63,9 +63,9 @@ GetDotName(rvsdg::Output * output)
     return util::strfmt("a", hex((intptr_t)output), ":", "default");
   }
 
-  if (auto no = dynamic_cast<rvsdg::SimpleOutput *>(output))
+  if (auto simpleNode = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(*output))
   {
-    return util::strfmt(GetDotName(no->node()), ":", "o", hex((intptr_t)output));
+    return util::strfmt(GetDotName(simpleNode), ":", "o", hex((intptr_t)output));
   }
   else if (dynamic_cast<rvsdg::StructuralOutput *>(output))
   {

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -39,9 +39,9 @@ public:
   void
   MarkAlive(const jlm::rvsdg::Output & output)
   {
-    if (auto simpleOutput = dynamic_cast<const rvsdg::SimpleOutput *>(&output))
+    if (auto simpleNode = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(output))
     {
-      SimpleNodes_.Insert(simpleOutput->node());
+      SimpleNodes_.Insert(simpleNode);
       return;
     }
 
@@ -51,9 +51,9 @@ public:
   bool
   IsAlive(const jlm::rvsdg::Output & output) const noexcept
   {
-    if (auto simpleOutput = dynamic_cast<const rvsdg::SimpleOutput *>(&output))
+    if (auto simpleNode = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(output))
     {
-      return SimpleNodes_.Contains(simpleOutput->node());
+      return SimpleNodes_.Contains(simpleNode);
     }
 
     return Outputs_.Contains(&output);


### PR DESCRIPTION
We would like to remove the SimpleOutput subclass, but before we can do
this we need to refactor all the dispatching that is based on it.