### PR TITLE
Overhaul Input::iterator class

### DIFF
--- a/jlm/rvsdg/Makefile.sub
+++ b/jlm/rvsdg/Makefile.sub
@@ -73,6 +73,7 @@ librvsdg_HEADERS = \
 librvsdg_TESTS = \
     tests/jlm/rvsdg/bitstring/bitstring \
     tests/jlm/rvsdg/ArgumentTests \
+    tests/jlm/rvsdg/InputTests \
     tests/jlm/rvsdg/RegionTests \
     tests/jlm/rvsdg/ResultTests \
     tests/jlm/rvsdg/SimpleOperationTests \

--- a/jlm/rvsdg/node.cpp
+++ b/jlm/rvsdg/node.cpp
@@ -102,7 +102,7 @@ Input::Iterator::ComputeNext() const
 {
   if (Input_ == nullptr)
     return nullptr;
-  
+
   const auto index = Input_->index();
   auto owner = Input_->GetOwner();
 

--- a/jlm/rvsdg/node.cpp
+++ b/jlm/rvsdg/node.cpp
@@ -97,6 +97,28 @@ Input::region() const noexcept
   }
 }
 
+Input *
+Input::Iterator::ComputeNext() const
+{
+  if (Input_ == nullptr)
+    return nullptr;
+  
+  const auto index = Input_->index();
+  auto owner = Input_->GetOwner();
+
+  if (auto node = std::get_if<Node *>(&owner))
+  {
+    return index + 1 < (*node)->ninputs() ? (*node)->input(index + 1) : nullptr;
+  }
+
+  if (auto region = std::get_if<Region *>(&owner))
+  {
+    return index + 1 < (*region)->nresults() ? (*region)->result(index + 1) : nullptr;
+  }
+
+  JLM_UNREACHABLE("Unhandled owner case.");
+}
+
 Output::~Output() noexcept
 {
   JLM_ASSERT(nusers() == 0);

--- a/jlm/rvsdg/node.hpp
+++ b/jlm/rvsdg/node.hpp
@@ -84,84 +84,70 @@ public:
     return Owner_;
   }
 
-  template<class T>
-  class iterator
+  class Iterator final
   {
   public:
     using iterator_category = std::forward_iterator_tag;
-    using value_type = T *;
+    using value_type = Input *;
     using difference_type = std::ptrdiff_t;
-    using pointer = T **;
-    using reference = T *&;
+    using pointer = Input **;
+    using reference = Input *&;
 
-    static_assert(
-        std::is_base_of<jlm::rvsdg::Input, T>::value,
-        "Template parameter T must be derived from jlm::rvsdg::input.");
-
-  protected:
-    constexpr iterator(T * value)
-        : value_(value)
+    constexpr explicit Iterator(Input * value)
+        : Input_(value)
     {}
 
-    virtual T *
-    next() const
+    [[nodiscard]] Input *
+    GetInput() const noexcept
     {
-      /*
-        I cannot make this method abstract due to the return value of operator++(int).
-        This is the best I could come up with as a workaround.
-      */
-      throw jlm::util::error("This method must be overloaded.");
+      return Input_;
     }
 
-  public:
-    T *
-    value() const noexcept
-    {
-      return value_;
-    }
-
-    T &
+    Input &
     operator*()
     {
-      JLM_ASSERT(value_ != nullptr);
-      return *value_;
+      JLM_ASSERT(Input_ != nullptr);
+      return *Input_;
     }
 
-    T *
+    Input *
     operator->() const
     {
-      return value_;
+      return Input_;
     }
 
-    iterator<T> &
+    Iterator &
     operator++()
     {
-      value_ = next();
+      Input_ = ComputeNext();
       return *this;
     }
 
-    iterator<T>
+    Iterator
     operator++(int)
     {
-      iterator<T> tmp = *this;
+      Iterator tmp = *this;
       ++*this;
       return tmp;
     }
 
     virtual bool
-    operator==(const iterator<T> & other) const
+    operator==(const Iterator & other) const
     {
-      return value_ == other.value_;
+      return Input_ == other.Input_;
     }
 
     bool
-    operator!=(const iterator<T> & other) const
+    operator!=(const Iterator & other) const
     {
       return !operator==(other);
     }
 
   private:
-    T * value_;
+    [[nodiscard]] Input *
+    ComputeNext() const;
+
+    Input * Input_;
   };
 
   template<class T>

--- a/tests/jlm/rvsdg/InputTests.cpp
+++ b/tests/jlm/rvsdg/InputTests.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include "test-operation.hpp"
+#include "test-registry.hpp"
+#include "test-types.hpp"
+
+static void
+TestInputIterator()
+{
+  using namespace jlm::rvsdg;
+
+  // Arrange
+  auto valueType = jlm::tests::ValueType::Create();
+
+  Graph rvsdg;
+  auto & rootRegion = rvsdg.GetRootRegion();
+  auto i = &jlm::tests::GraphImport::Create(rvsdg, valueType, "i");
+
+  auto & node = CreateOpNode<jlm::tests::TestOperation>(
+      { i, i, i, i, i },
+      std::vector<std::shared_ptr<const Type>>(5, valueType),
+      std::vector<std::shared_ptr<const Type>>{ valueType });
+
+  jlm::tests::GraphExport::Create(*node.output(0), "x0");
+  jlm::tests::GraphExport::Create(*node.output(0), "x1");
+  jlm::tests::GraphExport::Create(*node.output(0), "x2");
+
+  // Act & Assert
+  auto nodeIt = Input::Iterator(node.input(0));
+  assert(nodeIt.GetInput() == node.input(0));
+  assert(nodeIt->index() == node.input(0)->index());
+  assert((*nodeIt).index() == node.input(0)->index());
+  assert(nodeIt == Input::Iterator(node.input(0)));
+  assert(nodeIt != Input::Iterator(node.input(1)));
+
+  nodeIt++;
+  assert(nodeIt.GetInput() == node.input(1));
+
+  ++nodeIt;
+  assert(nodeIt.GetInput() == node.input(2));
+
+  ++nodeIt;
+  ++nodeIt;
+  assert(nodeIt.GetInput() == node.input(4));
+
+  ++nodeIt;
+  assert(nodeIt.GetInput() == nullptr);
+
+  auto regionIt = Input::Iterator(rootRegion.result(0));
+  assert(regionIt.GetInput() == rootRegion.result(0));
+  assert(regionIt->index() == rootRegion.result(0)->index());
+  assert((*regionIt).index() == rootRegion.result(0)->index());
+  assert(regionIt == Input::Iterator(rootRegion.result(0)));
+  assert(regionIt != Input::Iterator(rootRegion.result(1)));
+
+  regionIt++;
+  regionIt++;
+  assert(regionIt.GetInput() == rootRegion.result(2));
+
+  regionIt++;
+  assert(regionIt.GetInput() == nullptr);
+
+  auto it = Input::Iterator(nullptr);
+  it++;
+  ++it;
+  assert(it.GetInput() == nullptr);
+}
+
+JLM_UNIT_TEST_REGISTER("jlm/rvsdg/InputTests", TestInputIterator)


### PR DESCRIPTION
The GetOwner() method of the Input class allows us to compute the next input directly in the iterator, simplifying all the iterator code a lot.