### PR TITLE
Add normalization to NodeReduction pass

### DIFF
--- a/jlm/llvm/opt/reduction.cpp
+++ b/jlm/llvm/opt/reduction.cpp
@@ -251,7 +251,8 @@ NodeReduction::NormalizeLoadNode(
         LoadNonVolatileOperation::NormalizeLoadAlloca,
         LoadNonVolatileOperation::NormalizeDuplicateStates,
         LoadNonVolatileOperation::NormalizeLoadStoreState,
-        LoadNonVolatileOperation::NormalizeLoadLoadState });
+        LoadNonVolatileOperation::NormalizeLoadLoadState,
+        LoadNonVolatileOperation::NormalizeIOBarrierAllocaAddress });
 
   return rvsdg::NormalizeSequence<LoadNonVolatileOperation>(
       loadNodeNormalizations,


### PR DESCRIPTION
The LoadNonVolatileOperation::NormalizeIOBarrierAllocaAddress was not part of the NodeReduction pass.