### PR TITLE
Avoid compilation error

### DIFF
--- a/tests/jlm/rvsdg/test-nodes.cpp
+++ b/tests/jlm/rvsdg/test-nodes.cpp
@@ -275,7 +275,7 @@ NodeInputConstIteration()
   Graph rvsdg;
   auto i = &jlm::tests::GraphImport::Create(rvsdg, valueType, "i");
 
-  const auto & node = CreateOpNode<jlm::tests::TestOperation>(
+  auto & node = CreateOpNode<jlm::tests::TestOperation>(
       { i, i, i, i, i },
       std::vector<std::shared_ptr<const Type>>(5, valueType),
       std::vector<std::shared_ptr<const Type>>{ valueType });


### PR DESCRIPTION
My local compiler things this leads to a dangling pointer. Avoid the problem by removing `const`