### PR TITLE
Align TestStructuralNode API for adding inputs and outputs

### DIFF
--- a/tests/jlm/hls/backend/rvsdg2rhls/MemoryStateSplitConversionTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/MemoryStateSplitConversionTests.cpp
@@ -30,19 +30,19 @@ SplitConversion()
   auto & importY = jlm::tests::GraphImport::Create(rvsdg, memoryStateType, "y");
 
   auto structuralNode = jlm::tests::TestStructuralNode::create(&rvsdg.GetRootRegion(), 1);
-  auto & i0 = structuralNode->AddInputWithArguments(importX);
+  const auto inputVar = structuralNode->AddInputWithArguments(importX);
 
-  auto entrySplitResults = LambdaEntryMemoryStateSplitOperation::Create(i0.Argument(0), 3);
+  auto entrySplitResults = LambdaEntryMemoryStateSplitOperation::Create(*inputVar.argument[0], 3);
 
-  auto & o0 = structuralNode->AddOutputWithResults({ entrySplitResults[0] });
-  auto & o1 = structuralNode->AddOutputWithResults({ entrySplitResults[1] });
-  auto & o2 = structuralNode->AddOutputWithResults({ entrySplitResults[2] });
+  const auto outputVar0 = structuralNode->AddOutputWithResults({ entrySplitResults[0] });
+  const auto outputVar1 = structuralNode->AddOutputWithResults({ entrySplitResults[1] });
+  const auto outputVar2 = structuralNode->AddOutputWithResults({ entrySplitResults[2] });
 
   auto splitResults = MemoryStateSplitOperation::Create(importY, 2);
 
-  jlm::tests::GraphExport::Create(o0, "o0");
-  jlm::tests::GraphExport::Create(o1, "o1");
-  jlm::tests::GraphExport::Create(o2, "o2");
+  jlm::tests::GraphExport::Create(*outputVar0.output, "o0");
+  jlm::tests::GraphExport::Create(*outputVar1.output, "o1");
+  jlm::tests::GraphExport::Create(*outputVar2.output, "o2");
 
   jlm::tests::GraphExport::Create(*splitResults[0], "o3");
   jlm::tests::GraphExport::Create(*splitResults[1], "o4");
@@ -61,9 +61,9 @@ SplitConversion()
   // The memory state split conversion pass should have replaced the
   // LambdaEntryMemoryStateSplitOperation node with a ForkOperation node
   {
-    assert(o0.nusers() == 1);
+    assert(outputVar0.output->nusers() == 1);
     auto [forkNode, forkOperation] =
-        TryGetSimpleNodeAndOp<ForkOperation>(*i0.Argument(0).Users().begin());
+        TryGetSimpleNodeAndOp<ForkOperation>(*inputVar.argument[0]->Users().begin());
     assert(forkNode && forkOperation);
   }
 

--- a/tests/jlm/hls/backend/rvsdg2rhls/SinkInsertionTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/SinkInsertionTests.cpp
@@ -35,13 +35,13 @@ SinkInsertion()
   auto argument = lambdaNode->GetFunctionArguments()[0];
 
   auto structuralNode = jlm::tests::TestStructuralNode::create(lambdaNode->subregion(), 1);
-  auto & i0 = structuralNode->AddInputWithArguments(*argument);
-  auto & i1 = structuralNode->AddInputWithArguments(*argument);
+  const auto inputVar0 = structuralNode->AddInputWithArguments(*argument);
+  const auto inputVar1 = structuralNode->AddInputWithArguments(*argument);
 
-  auto & o0 = structuralNode->AddOutputWithResults({ &i1.Argument(0) });
-  auto & o1 = structuralNode->AddOutputWithResults({ &i1.Argument(0) });
+  const auto outputVar0 = structuralNode->AddOutputWithResults({ inputVar1.argument[0] });
+  const auto outputVar1 = structuralNode->AddOutputWithResults({ inputVar1.argument[0] });
 
-  auto lambdaOutput = lambdaNode->finalize({ &o1 });
+  auto lambdaOutput = lambdaNode->finalize({ outputVar1.output });
 
   jlm::tests::GraphExport::Create(*lambdaOutput, "");
 
@@ -58,14 +58,15 @@ SinkInsertion()
 
   // The sink insertion pass should have inserted a SinkOperation node at output o0
   {
-    assert(o0.nusers() == 1);
-    auto [sinkNode, sinkOperation] = TryGetSimpleNodeAndOp<SinkOperation>(*o0.Users().begin());
+    assert(outputVar0.output->nusers() == 1);
+    auto [sinkNode, sinkOperation] =
+        TryGetSimpleNodeAndOp<SinkOperation>(*outputVar0.output->Users().begin());
     assert(sinkNode && sinkOperation);
   }
 
   // The sink insertion pass should have inserted a SinkOperation node at the argument of i0
   {
-    auto & i0Argument = i0.Argument(0);
+    auto & i0Argument = *inputVar0.argument[0];
     assert(i0Argument.nusers() == 1);
     auto [sinkNode, sinkOperation] =
         TryGetSimpleNodeAndOp<SinkOperation>(*i0Argument.Users().begin());

--- a/tests/jlm/llvm/opt/RvsdgTreePrinterTests.cpp
+++ b/tests/jlm/llvm/opt/RvsdgTreePrinterTests.cpp
@@ -138,17 +138,17 @@ PrintNumLoadNodesAnnotation()
   auto & memoryState = jlm::tests::GraphImport::Create(rvsdg, memoryStateType, "m");
 
   auto structuralNode = jlm::tests::TestStructuralNode::create(rootRegion, 3);
-  auto & addressInput = structuralNode->AddInputWithArguments(address);
-  auto & memoryStateInput = structuralNode->AddInputWithArguments(memoryState);
+  const auto addressInput = structuralNode->AddInputWithArguments(address);
+  const auto memoryStateInput = structuralNode->AddInputWithArguments(memoryState);
   LoadNonVolatileOperation::Create(
-      &addressInput.Argument(0),
-      { &memoryStateInput.Argument(0) },
+      addressInput.argument[0],
+      { memoryStateInput.argument[0] },
       valueType,
       4);
   jlm::tests::TestOperation::create(structuralNode->subregion(1), {}, {});
   LoadNonVolatileOperation::Create(
-      &addressInput.Argument(2),
-      { &memoryStateInput.Argument(2) },
+      addressInput.argument[2],
+      { memoryStateInput.argument[2] },
       valueType,
       4);
 
@@ -193,14 +193,14 @@ PrintNumMemoryStateInputsOutputsAnnotation()
   auto & y = jlm::tests::GraphImport::Create(rvsdg, valueType, "y");
 
   auto structuralNode = jlm::tests::TestStructuralNode::create(&rvsdg.GetRootRegion(), 2);
-  auto & ix = structuralNode->AddInputWithArguments(x);
-  auto & iy = structuralNode->AddInputWithArguments(y);
+  const auto inputVarX = structuralNode->AddInputWithArguments(x);
+  const auto inputVarY = structuralNode->AddInputWithArguments(y);
 
-  auto & ox = structuralNode->AddOutputWithResults({ &ix.Argument(0), &ix.Argument(1) });
-  auto & oy = structuralNode->AddOutputWithResults({ &iy.Argument(0), &iy.Argument(1) });
+  auto outputVarX = structuralNode->AddOutputWithResults({ inputVarX.argument[0], inputVarX.argument[1] });
+  auto outputVarY = structuralNode->AddOutputWithResults({ inputVarY.argument[0], inputVarY.argument[1] });
 
-  jlm::tests::GraphExport::Create(ox, "x");
-  jlm::tests::GraphExport::Create(oy, "y");
+  jlm::tests::GraphExport::Create(*outputVarX.output, "x");
+  jlm::tests::GraphExport::Create(*outputVarY.output, "y");
 
   RvsdgTreePrinter::Configuration configuration(
       { RvsdgTreePrinter::Configuration::Annotation::NumMemoryStateInputsOutputs });

--- a/tests/jlm/rvsdg/RegionTests.cpp
+++ b/tests/jlm/rvsdg/RegionTests.cpp
@@ -446,8 +446,8 @@ BottomNodeTests()
   assert(&*(rvsdg.GetRootRegion().BottomNodes().begin()) == structuralNode);
 
   // The node cedes to be dead
-  auto & output = structuralNode->AddOutput(valueType);
-  jlm::tests::GraphExport::Create(output, "x");
+  auto [output, _] = structuralNode->AddOutput(valueType);
+  jlm::tests::GraphExport::Create(*output, "x");
   assert(structuralNode->IsDead() == false);
   assert(rvsdg.GetRootRegion().NumBottomNodes() == 0);
   assert(rvsdg.GetRootRegion().BottomNodes().begin() == rvsdg.GetRootRegion().BottomNodes().end());

--- a/tests/test-operation.hpp
+++ b/tests/test-operation.hpp
@@ -254,20 +254,79 @@ private:
   {}
 
 public:
-  [[nodiscard]] const TestStructuralOperation &
-  GetOperation() const noexcept override;
+  /**
+   * \brief A variable routed in a \ref TestStructuralNode
+   */
+  struct InputVar
+  {
+    rvsdg::Input * input{};
+    std::vector<rvsdg::Output *> argument{};
+  };
 
-  StructuralNodeInput &
+  /**
+   * \brief A variable routed out of a \ref TestStructuralNode
+   */
+  struct OutputVar
+  {
+    rvsdg::Output * output{};
+    std::vector<rvsdg::Input *> result{};
+  };
+
+  /**
+   * Add an input WITHOUT subregion arguments to a \ref TestStructuralNode.
+   *
+   * @param origin Value to be routed in.
+   * @return Description of input variable.
+   */
+  InputVar
   AddInput(rvsdg::Output & origin);
 
-  StructuralNodeInput &
+  /**
+   * Add an input WITH subregion arguments to a \ref TestStructuralNode.
+   *
+   * @param origin Value to be routed in.
+   * @return Description of input variable.
+   */
+  InputVar
   AddInputWithArguments(rvsdg::Output & origin);
 
-  StructuralNodeOutput &
+  /**
+   * Add subregion arguments WITHOUT an input to a \ref TestStructuralNode.
+   * @param type The argument type
+   * @return Description of input variable
+   */
+  InputVar
+  AddArguments(std::shared_ptr<const rvsdg::Type> type);
+
+  /**
+   * Add an output WITHOUT subregion results to a \ref TestStructuralNode.
+   *
+   * @param type The output type
+   * @return Description of output variable.
+   */
+  OutputVar
   AddOutput(std::shared_ptr<const rvsdg::Type> type);
 
-  StructuralNodeOutput &
+  /**
+   * Add an output WITH subregion results to a \ref TestStructuralNode.
+   *
+   * @param origins The values to be routed out.
+   * @return Description of output variable.
+   */
+  OutputVar
   AddOutputWithResults(const std::vector<rvsdg::Output *> & origins);
+
+  /**
+   * Add subregion results WITHOUT output to a \ref TestStructuralNode.
+   *
+   * @param origins The values to be routed out.
+   * @return Description of output variable.
+   */
+  OutputVar
+  AddResults(const std::vector<rvsdg::Output *> & origins);
+
+  [[nodiscard]] const TestStructuralOperation &
+  GetOperation() const noexcept override;
 
   static TestStructuralNode *
   create(rvsdg::Region * parent, size_t nsubregions)


### PR DESCRIPTION
Aligns the TestStructuralNode API for adding inputs, outputs, arguments, and results with the API of all other structural nodes in the code base. The consequence is that we can remove all TestStructuralNode specific input, output, argument, and result subclasses after that.