### PR TITLE
Fix NodeInputIteration tests

### DIFF
--- a/tests/jlm/rvsdg/test-nodes.cpp
+++ b/tests/jlm/rvsdg/test-nodes.cpp
@@ -241,7 +241,7 @@ NodeInputIteration()
   using namespace jlm::rvsdg;
 
   // Arrange
-  auto valueType = jlm::tests::ValueType::Create();
+  const auto valueType = jlm::tests::ValueType::Create();
 
   Graph rvsdg;
   auto i = &jlm::tests::GraphImport::Create(rvsdg, valueType, "i");
@@ -256,6 +256,14 @@ NodeInputIteration()
   // Act & Assert
   size_t n = 0;
   for (auto & input : node.Inputs())
+  {
+    assert(&input == node.input(n++));
+  }
+  assert(n == node.ninputs());
+
+  n = 0;
+  const Node * constNode = &node;
+  for (auto & input : constNode->Inputs())
   {
     assert(&input == node.input(n++));
   }
@@ -263,32 +271,3 @@ NodeInputIteration()
 }
 
 JLM_UNIT_TEST_REGISTER("jlm/rvsdg/test-nodes-NodeInputIteration", NodeInputIteration)
-
-static void
-NodeInputConstIteration()
-{
-  using namespace jlm::rvsdg;
-
-  // Arrange
-  auto valueType = jlm::tests::ValueType::Create();
-
-  Graph rvsdg;
-  auto i = &jlm::tests::GraphImport::Create(rvsdg, valueType, "i");
-
-  auto & node = CreateOpNode<jlm::tests::TestOperation>(
-      { i, i, i, i, i },
-      std::vector<std::shared_ptr<const Type>>(5, valueType),
-      std::vector<std::shared_ptr<const Type>>{ valueType });
-
-  jlm::tests::GraphExport::Create(*node.output(0), "x0");
-
-  // Act & Assert
-  size_t n = 0;
-  for (auto & input : node.Inputs())
-  {
-    assert(&input == node.input(n++));
-  }
-  assert(n == node.ninputs());
-}
-
-JLM_UNIT_TEST_REGISTER("jlm/rvsdg/test-nodes-NodeInputConstIteration", NodeInputConstIteration)


### PR DESCRIPTION
PR #1097 invalidated the NodeInputConstIteration unit test by removing the const from the node. Fix this as well as unifying the NodeInputIteration and NodeInputConstIteration unit test.