### PR TITLE
Mark a few types non-final

### DIFF
--- a/jlm/rvsdg/FunctionType.hpp
+++ b/jlm/rvsdg/FunctionType.hpp
@@ -21,7 +21,7 @@ namespace jlm::rvsdg
  *
  * Represents the type of a callable function.
  */
-class FunctionType final : public ValueType
+class FunctionType : public ValueType
 {
 public:
   ~FunctionType() noexcept override;

--- a/jlm/rvsdg/gamma.hpp
+++ b/jlm/rvsdg/gamma.hpp
@@ -18,7 +18,7 @@ namespace jlm::rvsdg
 class Output;
 class Type;
 
-class GammaOperation final : public StructuralOperation
+class GammaOperation : public StructuralOperation
 {
 public:
   ~GammaOperation() noexcept override;


### PR DESCRIPTION
Mark function type and gamma operation non-final. It is useful for external code to be able to extend the representation.