### PR TITLE
Remove global tracker registry

### DIFF
--- a/jlm/rvsdg/graph.cpp
+++ b/jlm/rvsdg/graph.cpp
@@ -66,10 +66,7 @@ GraphExport::Create(Output & origin, std::string name)
   return *graphExport;
 }
 
-Graph::~Graph()
-{
-  JLM_ASSERT(!has_active_trackers(this));
-}
+Graph::~Graph() noexcept = default;
 
 Graph::Graph()
     : RootRegion_(new Region(nullptr, this))

--- a/jlm/rvsdg/graph.hpp
+++ b/jlm/rvsdg/graph.hpp
@@ -74,7 +74,7 @@ private:
 class Graph final
 {
 public:
-  ~Graph();
+  ~Graph() noexcept;
 
   Graph();
 

--- a/jlm/rvsdg/region.cpp
+++ b/jlm/rvsdg/region.cpp
@@ -134,6 +134,8 @@ Region::~Region() noexcept
 
   while (arguments_.size())
     RemoveArgument(arguments_.size() - 1);
+
+  JLM_ASSERT(!HasActiveTrackers());
 }
 
 Region::Region(Region *, Graph * graph)
@@ -510,6 +512,21 @@ Region::ToString(const util::Annotation & annotation, char labelValueSeparator)
   }
 
   return util::strfmt(annotation.Label(), labelValueSeparator, value);
+}
+
+bool
+Region::RegisterTracker(const Tracker & tracker)
+{
+  if (&tracker.GetRegion() != this)
+    return false;
+
+  return Trackers_.Insert(&tracker);
+}
+
+bool
+Region::UnregisterTracker(const Tracker & tracker)
+{
+  return Trackers_.Remove(&tracker);
 }
 
 size_t

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -9,6 +9,7 @@
 
 #include <jlm/rvsdg/node.hpp>
 #include <jlm/util/common.hpp>
+#include <jlm/util/HashSet.hpp>
 #include <jlm/util/iterator_range.hpp>
 
 namespace jlm::util
@@ -27,6 +28,7 @@ class StructuralInput;
 class StructuralNode;
 class StructuralOutput;
 class SubstitutionMap;
+class Tracker;
 
 /**
  * \brief Represents the argument of a region.
@@ -716,6 +718,50 @@ public:
   [[nodiscard]] static std::string
   ToTree(const rvsdg::Region & region) noexcept;
 
+  /**
+   * \brief Register a \ref Tracker for this region.
+   *
+   * @param tracker The \ref Tracker that is supposed to be registered for this region.
+   * @return True, if \p tracker was successfully registered, otherwise false.
+   *
+   * \pre \p tracker must have been initialized with this instance of \ref Region.
+   *
+   * \note This function is automatically invoked when an instance of \ref Tracker is constructed.
+   * There is no need to invoke this function manually.
+   *
+   * \see UnregisterTracker()
+   * \see HasActiveTrackers()
+   */
+  bool
+  RegisterTracker(const Tracker & tracker);
+
+  /**
+   * \brief Unregister a \ref Tracker for this region.
+   *
+   * @param tracker The \ref Tracker that is supposed to be unregistered for this region.
+   * @return True, if \p tracker was successfully unregistered, otherwise false.
+   *
+   * \note This function is automatically invoked when an instance of \ref Tracker is deconstructed.
+   * There is no need to invoke this function manually.
+   *
+   * \see RegisterTracker()
+   * \see HasActiveTrackers()
+   */
+  bool
+  UnregisterTracker(const Tracker & tracker);
+
+  /**
+   * @return True, if an instance of \ref Tracker is registered for this region, otherwise false.
+   *
+   * \see RegisterTracker()
+   * \see UnregisterTracker()
+   */
+  [[nodiscard]] bool
+  HasActiveTrackers() const noexcept
+  {
+    return !Trackers_.IsEmpty();
+  }
+
 private:
   static void
   ToTree(
@@ -748,6 +794,7 @@ private:
   region_bottom_node_list BottomNodes_;
   region_top_node_list TopNodes_;
   region_nodes_list Nodes_;
+  util::HashSet<const Tracker *> Trackers_;
 };
 
 static inline void

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -730,7 +730,7 @@ public:
     NodeId_++;
     return nodeId;
   }
-  
+
   /**
    * \brief Register a \ref Tracker for this region.
    *

--- a/jlm/rvsdg/tracker.cpp
+++ b/jlm/rvsdg/tracker.cpp
@@ -4,50 +4,14 @@
  * See COPYING for terms of redistribution.
  */
 
-#include <jlm/rvsdg/graph.hpp>
 #include <jlm/rvsdg/notifiers.hpp>
+#include <jlm/rvsdg/region.hpp>
 #include <jlm/rvsdg/tracker.hpp>
 
 using namespace std::placeholders;
 
-namespace
-{
-
-typedef std::unordered_set<const jlm::rvsdg::Graph *> tracker_set;
-
-tracker_set *
-active_trackers()
-{
-  static std::unique_ptr<tracker_set> trackers;
-  if (!trackers)
-    trackers.reset(new tracker_set());
-
-  return trackers.get();
-}
-
-void
-register_tracker(const jlm::rvsdg::Tracker * tracker)
-{
-  active_trackers()->insert(tracker->graph());
-}
-
-void
-unregister_tracker(const jlm::rvsdg::Tracker * tracker)
-{
-  active_trackers()->erase(tracker->graph());
-}
-
-}
-
 namespace jlm::rvsdg
 {
-
-bool
-has_active_trackers(const Graph * graph)
-{
-  auto at = active_trackers();
-  return at->find(graph) != at->end();
-}
 
 class TrackerDepthState
 {
@@ -157,11 +121,12 @@ private:
 
 Tracker::~Tracker() noexcept
 {
-  unregister_tracker(this);
+  [[maybe_unused]] const auto isUnregistered = GetRegion().UnregisterTracker(*this);
+  JLM_ASSERT(isUnregistered);
 }
 
-Tracker::Tracker(Graph * graph, size_t nstates)
-    : graph_(graph),
+Tracker::Tracker(Region & region, size_t nstates)
+    : Region_(&region),
       states_(nstates)
 {
   for (size_t n = 0; n < states_.size(); n++)
@@ -171,7 +136,8 @@ Tracker::Tracker(Graph * graph, size_t nstates)
       on_node_depth_change.connect(std::bind(&Tracker::node_depth_change, this, _1, _2));
   destroy_callback_ = on_node_destroy.connect(std::bind(&Tracker::node_destroy, this, _1));
 
-  register_tracker(this);
+  [[maybe_unused]] const auto isRegistered = region.RegisterTracker(*this);
+  JLM_ASSERT(isRegistered);
 }
 
 void

--- a/jlm/rvsdg/tracker.hpp
+++ b/jlm/rvsdg/tracker.hpp
@@ -16,26 +16,22 @@ namespace jlm::rvsdg
 
 static const size_t tracker_nodestate_none = (size_t)-1;
 
-class Graph;
 class Node;
 class Region;
 class TrackerDepthState;
 class TrackerNodeState;
 
-bool
-has_active_trackers(const Graph * graph);
-
 /**
- * Track states of nodes within the graph. Each node can logically be in
+ * Track states of nodes within a region. Each node can logically be in
  * one of the numbered states, plus another "initial" state. All nodes are
  * at the beginning assumed to be implicitly in this "initial" state.
  */
-struct Tracker
+class Tracker final
 {
 public:
   ~Tracker() noexcept;
 
-  Tracker(Graph * graph, size_t nstates);
+  Tracker(Region & region, size_t nstates);
 
   /* get state of the node */
   ssize_t
@@ -53,10 +49,10 @@ public:
   Node *
   peek_bottom(size_t state) const;
 
-  [[nodiscard]] Graph *
-  graph() const noexcept
+  [[nodiscard]] Region &
+  GetRegion() const noexcept
   {
-    return graph_;
+    return *Region_;
   }
 
 private:
@@ -69,7 +65,7 @@ private:
   void
   node_destroy(Node * node);
 
-  jlm::rvsdg::Graph * graph_;
+  Region * Region_;
 
   /* FIXME: need RAII idiom for state reservation */
   std::vector<std::unique_ptr<TrackerDepthState>> states_;

--- a/jlm/rvsdg/traverser.cpp
+++ b/jlm/rvsdg/traverser.cpp
@@ -18,8 +18,7 @@ namespace jlm::rvsdg
 TopDownTraverser::~TopDownTraverser() noexcept = default;
 
 TopDownTraverser::TopDownTraverser(Region * region)
-    : region_(region),
-      tracker_(region->graph())
+    : tracker_(*region)
 {
   for (auto & node : region->TopNodes())
     tracker_.set_nodestate(&node, traversal_nodestate::frontier);
@@ -86,7 +85,7 @@ TopDownTraverser::next()
 void
 TopDownTraverser::node_create(Node * node)
 {
-  if (node->region() != region())
+  if (node->region() != &tracker_.GetRegion())
     return;
 
   if (predecessors_visited(node))
@@ -98,7 +97,7 @@ TopDownTraverser::node_create(Node * node)
 void
 TopDownTraverser::input_change(Input * in, Output *, Output *)
 {
-  if (in->region() != region())
+  if (in->region() != &tracker_.GetRegion())
     return;
 
   auto node = TryGetOwnerNode<Node>(*in);
@@ -136,8 +135,7 @@ HasSuccessors(const Node & node)
 BottomUpTraverser::~BottomUpTraverser() noexcept = default;
 
 BottomUpTraverser::BottomUpTraverser(Region * region, bool revisit)
-    : region_(region),
-      tracker_(region->graph()),
+    : tracker_(*region),
       new_node_state_(revisit ? traversal_nodestate::frontier : traversal_nodestate::behind)
 {
   for (auto & bottomNode : region->BottomNodes())
@@ -180,7 +178,7 @@ BottomUpTraverser::next()
 void
 BottomUpTraverser::node_create(Node * node)
 {
-  if (node->region() != region())
+  if (node->region() != &tracker_.GetRegion())
     return;
 
   tracker_.set_nodestate(node, new_node_state_);
@@ -189,7 +187,7 @@ BottomUpTraverser::node_create(Node * node)
 void
 BottomUpTraverser::node_destroy(Node * node)
 {
-  if (node->region() != region())
+  if (node->region() != &tracker_.GetRegion())
     return;
 
   for (size_t n = 0; n < node->ninputs(); n++)
@@ -203,7 +201,7 @@ BottomUpTraverser::node_destroy(Node * node)
 void
 BottomUpTraverser::input_change(Input * in, Output * old_origin, Output *)
 {
-  if (in->region() != region())
+  if (in->region() != &tracker_.GetRegion())
     return;
 
   if (!TryGetOwnerNode<Node>(*in))

--- a/jlm/rvsdg/traverser.hpp
+++ b/jlm/rvsdg/traverser.hpp
@@ -83,7 +83,7 @@ enum class traversal_nodestate
 class TraversalTracker final
 {
 public:
-  explicit inline TraversalTracker(Graph * graph);
+  explicit inline TraversalTracker(Region & region);
 
   inline traversal_nodestate
   get_nodestate(Node * node);
@@ -96,6 +96,12 @@ public:
 
   inline Node *
   peek_bottom();
+
+  [[nodiscard]] Region &
+  GetRegion() const noexcept
+  {
+    return tracker_.GetRegion();
+  }
 
 private:
   Tracker tracker_;
@@ -143,12 +149,6 @@ public:
   Node *
   next();
 
-  [[nodiscard]] rvsdg::Region *
-  region() const noexcept
-  {
-    return region_;
-  }
-
   typedef detail::TraverserIterator<TopDownTraverser> iterator;
   typedef Node * value_type;
 
@@ -174,7 +174,6 @@ private:
   void
   input_change(Input * in, Output * old_origin, Output * new_origin);
 
-  rvsdg::Region * region_;
   TraversalTracker tracker_;
   std::vector<jlm::util::Callback> callbacks_;
 };
@@ -188,12 +187,6 @@ public:
 
   Node *
   next();
-
-  [[nodiscard]] rvsdg::Region *
-  region() const noexcept
-  {
-    return region_;
-  }
 
   typedef detail::TraverserIterator<BottomUpTraverser> iterator;
   typedef Node * value_type;
@@ -220,7 +213,6 @@ private:
   void
   input_change(Input * in, Output * old_origin, Output * new_origin);
 
-  rvsdg::Region * region_;
   TraversalTracker tracker_;
   std::vector<jlm::util::Callback> callbacks_;
   traversal_nodestate new_node_state_;
@@ -228,8 +220,8 @@ private:
 
 /* traversal tracker implementation */
 
-TraversalTracker::TraversalTracker(Graph * graph)
-    : tracker_(graph, 2)
+TraversalTracker::TraversalTracker(Region & region)
+    : tracker_(region, 2)
 {}
 
 traversal_nodestate

--- a/tests/jlm/rvsdg/test-bottomup.cpp
+++ b/tests/jlm/rvsdg/test-bottomup.cpp
@@ -57,7 +57,7 @@ test_basic_traversal()
     assert(tmp == 0);
   }
 
-  assert(!has_active_trackers(&graph));
+  assert(!graph.GetRootRegion().HasActiveTrackers());
 }
 
 static void
@@ -86,7 +86,7 @@ test_order_enforcement_traversal()
     assert(tmp == nullptr);
   }
 
-  assert(!has_active_trackers(&graph));
+  assert(!graph.GetRootRegion().HasActiveTrackers());
 }
 
 static void

--- a/tests/jlm/rvsdg/test-topdown.cpp
+++ b/tests/jlm/rvsdg/test-topdown.cpp
@@ -70,7 +70,7 @@ test_basic_traversal()
     assert(tmp == nullptr);
   }
 
-  assert(!has_active_trackers(&graph));
+  assert(!graph.GetRootRegion().HasActiveTrackers());
 }
 
 static void
@@ -100,7 +100,7 @@ test_order_enforcement_traversal()
     assert(tmp == nullptr);
   }
 
-  assert(!has_active_trackers(&graph));
+  assert(!graph.GetRootRegion().HasActiveTrackers());
 }
 
 static void
@@ -158,7 +158,7 @@ test_traversal_insertion()
     assert(visited_n5);
   }
 
-  assert(!has_active_trackers(&graph));
+  assert(!graph.GetRootRegion().HasActiveTrackers());
 }
 
 static void


### PR DESCRIPTION
Replaces the global tracker registry with a per-region registry as trackers work nowadays solely on a per-region basis and not on a per-graph basis any longer.