### PR TITLE
ConvertOp() now returns the created node's outputs

### DIFF
--- a/jlm/mlir/frontend/MlirToJlmConverter.cpp
+++ b/jlm/mlir/frontend/MlirToJlmConverter.cpp
@@ -127,6 +127,7 @@ MlirToJlmConverter::ConvertBlock(::mlir::Block & block, rvsdg::Region & rvsdgReg
       ::llvm::SmallVector<jlm::rvsdg::Output *> inputs = GetConvertedInputs(mlirOp, outputMap);
 
       auto outputs = ConvertOperation(mlirOp, rvsdgRegion, inputs);
+      JLM_ASSERT(outputs.size() == mlirOp.getNumResults());
       for (size_t i = 0; i < mlirOp.getNumResults(); i++)
       {
         auto result = mlirOp.getResult(i);

--- a/jlm/mlir/frontend/MlirToJlmConverter.cpp
+++ b/jlm/mlir/frontend/MlirToJlmConverter.cpp
@@ -653,8 +653,7 @@ MlirToJlmConverter::ConvertOperation(
   }
   else if (auto MallocOp = ::mlir::dyn_cast<::mlir::jlm::Malloc>(&mlirOperation))
   {
-    auto mallocOutputs = jlm::llvm::MallocOperation::create(inputs[0]);
-    return { mallocOutputs[0] };
+    return jlm::llvm::MallocOperation::create(inputs[0]);
   }
   else if (auto StoreOp = ::mlir::dyn_cast<::mlir::jlm::Store>(&mlirOperation))
   {

--- a/jlm/mlir/frontend/MlirToJlmConverter.hpp
+++ b/jlm/mlir/frontend/MlirToJlmConverter.hpp
@@ -178,9 +178,9 @@ private:
    * \param mlirOperation The MLIR operation to be converted.
    * \param rvsdgRegion The RVSDG region that the generated RVSDG node is inserted into.
    * \param inputs The inputs for the RVSDG node.
-   * \result The converted RVSDG node.
+   * \result The outputs of the RVSDG node.
    */
-  rvsdg::Node *
+  std::vector<jlm::rvsdg::Output *>
   ConvertOperation(
       ::mlir::Operation & mlirOperation,
       rvsdg::Region & rvsdgRegion,


### PR DESCRIPTION
The ConvertOp() function used to return the node instead of the outputs of the created node.