### PR TITLE
LambdaBuilder and one API clarification

### DIFF
--- a/jlm/rvsdg/delta.cpp
+++ b/jlm/rvsdg/delta.cpp
@@ -27,7 +27,7 @@ DeltaNode::MapInputContextVar(const rvsdg::Input & input) const noexcept
   return ContextVar{ const_cast<rvsdg::Input *>(&input), subregion()->argument(input.index()) };
 }
 
-[[nodiscard]] std::optional<DeltaNode::ContextVar>
+[[nodiscard]] DeltaNode::ContextVar
 DeltaNode::MapBinderContextVar(const rvsdg::Output & output) const noexcept
 {
   JLM_ASSERT(rvsdg::TryGetOwnerRegion(output) == subregion());

--- a/jlm/rvsdg/delta.hpp
+++ b/jlm/rvsdg/delta.hpp
@@ -216,7 +216,7 @@ public:
    * Returns the context variable description corresponding
    * to this bound variable reference in the delta node region.
    */
-  [[nodiscard]] std::optional<ContextVar>
+  [[nodiscard]] ContextVar
   MapBinderContextVar(const rvsdg::Output & output) const noexcept;
 
   /**


### PR DESCRIPTION
Add a lambda builder object. This allows incrementally building a lambda construct. It offers an API that allows to determine the full type signature (including return types) of the function at the very end.

Remove one superfluous std::optional specification in a delta API.