### PR TITLE
Fix LambdaExitMemoryStateMergeOperation normalizations

### DIFF
--- a/jlm/llvm/ir/operators/MemoryStateOperations.cpp
+++ b/jlm/llvm/ir/operators/MemoryStateOperations.cpp
@@ -357,7 +357,7 @@ LambdaExitMemoryStateMergeOperation::NormalizeStoreToAlloca(
     return std::nullopt;
 
   return {
-    { CreateNode(*operands[0]->region(), newOperands, operation.GetMemoryNodeIds()).output(0) }
+    { CreateNode(*operands[0]->region(), newOperands, operation.MemoryNodeIds_).output(0) }
   };
 }
 
@@ -392,7 +392,7 @@ LambdaExitMemoryStateMergeOperation::NormalizeAlloca(
     return std::nullopt;
 
   return {
-    { CreateNode(*operands[0]->region(), newOperands, operation.GetMemoryNodeIds()).output(0) }
+    { CreateNode(*operands[0]->region(), newOperands, operation.MemoryNodeIds_).output(0) }
   };
 }
 

--- a/jlm/llvm/ir/operators/MemoryStateOperations.cpp
+++ b/jlm/llvm/ir/operators/MemoryStateOperations.cpp
@@ -281,7 +281,7 @@ LambdaExitMemoryStateMergeOperation::copy() const
 
 std::optional<std::vector<rvsdg::Output *>>
 LambdaExitMemoryStateMergeOperation::NormalizeLoadFromAlloca(
-    const LambdaExitMemoryStateMergeOperation &,
+    const LambdaExitMemoryStateMergeOperation & operation,
     const std::vector<rvsdg::Output *> & operands)
 {
   if (operands.empty())
@@ -314,12 +314,14 @@ LambdaExitMemoryStateMergeOperation::NormalizeLoadFromAlloca(
   if (!replacedOperands)
     return std::nullopt;
 
-  return { { &Create(*operands[0]->region(), newOperands) } };
+  return {
+    { CreateNode(*operands[0]->region(), newOperands, operation.MemoryNodeIds_).output(0) }
+  };
 }
 
 std::optional<std::vector<rvsdg::Output *>>
 LambdaExitMemoryStateMergeOperation::NormalizeStoreToAlloca(
-    const LambdaExitMemoryStateMergeOperation &,
+    const LambdaExitMemoryStateMergeOperation & operation,
     const std::vector<rvsdg::Output *> & operands)
 {
   if (operands.empty())
@@ -354,12 +356,14 @@ LambdaExitMemoryStateMergeOperation::NormalizeStoreToAlloca(
   if (!replacedOperands)
     return std::nullopt;
 
-  return { { &Create(*operands[0]->region(), newOperands) } };
+  return {
+    { CreateNode(*operands[0]->region(), newOperands, operation.GetMemoryNodeIds()).output(0) }
+  };
 }
 
 std::optional<std::vector<rvsdg::Output *>>
 LambdaExitMemoryStateMergeOperation::NormalizeAlloca(
-    const LambdaExitMemoryStateMergeOperation &,
+    const LambdaExitMemoryStateMergeOperation & operation,
     const std::vector<rvsdg::Output *> & operands)
 {
   if (operands.empty())
@@ -387,7 +391,9 @@ LambdaExitMemoryStateMergeOperation::NormalizeAlloca(
   if (!replacedOperands)
     return std::nullopt;
 
-  return { { &Create(*operands[0]->region(), newOperands) } };
+  return {
+    { CreateNode(*operands[0]->region(), newOperands, operation.GetMemoryNodeIds()).output(0) }
+  };
 }
 
 CallEntryMemoryStateMergeOperation::~CallEntryMemoryStateMergeOperation() noexcept = default;

--- a/jlm/llvm/ir/operators/MemoryStateOperations.hpp
+++ b/jlm/llvm/ir/operators/MemoryStateOperations.hpp
@@ -277,7 +277,7 @@ class LambdaExitMemoryStateMergeOperation final : public MemoryStateOperation
 public:
   ~LambdaExitMemoryStateMergeOperation() noexcept override;
 
-  LambdaExitMemoryStateMergeOperation(std::vector<MemoryNodeId> memoryNodeIds);
+  explicit LambdaExitMemoryStateMergeOperation(std::vector<MemoryNodeId> memoryNodeIds);
 
   bool
   operator==(const Operation & other) const noexcept override;
@@ -287,6 +287,12 @@ public:
 
   [[nodiscard]] std::unique_ptr<Operation>
   copy() const override;
+
+  [[nodiscard]] const std::vector<MemoryNodeId> &
+  GetMemoryNodeIds() const noexcept
+  {
+    return MemoryNodeIds_;
+  }
 
   /**
    * Performs the following transformation:
@@ -335,19 +341,6 @@ public:
       const LambdaExitMemoryStateMergeOperation & operation,
       const std::vector<rvsdg::Output *> & operands);
 
-  // FIXME: Deprecated, needs to be removed
-  static rvsdg::Node &
-  CreateNode(rvsdg::Region & region, const std::vector<rvsdg::Output *> & operands)
-  {
-    std::vector<MemoryNodeId> memoryNodeIds;
-    for (size_t i = 0; i < operands.size(); ++i)
-    {
-      memoryNodeIds.push_back(i);
-    }
-
-    return CreateNode(region, operands, std::move(memoryNodeIds));
-  }
-
   static rvsdg::Node &
   CreateNode(
       rvsdg::Region & region,
@@ -362,10 +355,17 @@ public:
                                   std::move(memoryNodeIds));
   }
 
+  // FIXME: Deprecated, needs to be removed
   static rvsdg::Output &
   Create(rvsdg::Region & region, const std::vector<rvsdg::Output *> & operands)
   {
-    return *CreateNode(region, operands).output(0);
+    std::vector<MemoryNodeId> memoryNodeIds;
+    for (size_t i = 0; i < operands.size(); ++i)
+    {
+      memoryNodeIds.push_back(i);
+    }
+
+    return *CreateNode(region, operands, std::move(memoryNodeIds)).output(0);
   }
 
 private:


### PR DESCRIPTION
Adjusts the LambdaExitMemoryStateMergeOperation normalizations to correctly handle memory node identifiers.