### PR TITLE
Add PointsToGraphAliasAnalysis and tests

### DIFF
--- a/jlm/llvm/Makefile.sub
+++ b/jlm/llvm/Makefile.sub
@@ -54,6 +54,7 @@ libllvm_SOURCES = \
     jlm/llvm/opt/alias-analyses/Optimization.cpp \
     jlm/llvm/opt/alias-analyses/PointerObjectSet.cpp \
     jlm/llvm/opt/alias-analyses/PointsToGraph.cpp \
+    jlm/llvm/opt/alias-analyses/PointsToGraphAliasAnalysis.cpp \
     jlm/llvm/opt/alias-analyses/RegionAwareModRefSummarizer.cpp \
     jlm/llvm/opt/alias-analyses/Steensgaard.cpp \
     jlm/llvm/opt/alias-analyses/TopDownModRefEliminator.cpp \
@@ -99,6 +100,7 @@ libllvm_HEADERS = \
     jlm/llvm/opt/alias-analyses/RegionAwareModRefSummarizer.hpp \
     jlm/llvm/opt/alias-analyses/PointsToAnalysis.hpp \
     jlm/llvm/opt/alias-analyses/PointsToGraph.hpp \
+    jlm/llvm/opt/alias-analyses/PointsToGraphAliasAnalysis.hpp \
     jlm/llvm/opt/pull.hpp \
     jlm/llvm/opt/reduction.hpp \
     jlm/llvm/opt/IfConversion.hpp \
@@ -194,6 +196,7 @@ libllvm_TESTS += \
     tests/jlm/llvm/ir/TypeConverterTests \
     tests/jlm/llvm/opt/alias-analyses/AgnosticModRefSummarizerTests \
     tests/jlm/llvm/opt/alias-analyses/LocalAliasAnalysisTests \
+    tests/jlm/llvm/opt/alias-analyses/PointsToGraphAliasAnalysisTests \
     tests/jlm/llvm/opt/alias-analyses/TestAndersen \
     tests/jlm/llvm/opt/alias-analyses/TestDifferencePropagation \
     tests/jlm/llvm/opt/alias-analyses/TestLazyCycleDetection \

--- a/jlm/llvm/ir/attribute.hpp
+++ b/jlm/llvm/ir/attribute.hpp
@@ -10,6 +10,7 @@
 #include <jlm/util/common.hpp>
 #include <jlm/util/HashSet.hpp>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>

--- a/jlm/llvm/opt/alias-analyses/AliasAnalysis.cpp
+++ b/jlm/llvm/opt/alias-analyses/AliasAnalysis.cpp
@@ -47,7 +47,7 @@ ChainedAliasAnalysis::ChainedAliasAnalysis(AliasAnalysis & first, AliasAnalysis 
       Second_(second)
 {}
 
-ChainedAliasAnalysis::~ChainedAliasAnalysis() = default;
+ChainedAliasAnalysis::~ChainedAliasAnalysis() noexcept = default;
 
 AliasAnalysis::AliasQueryResponse
 ChainedAliasAnalysis::Query(

--- a/jlm/llvm/opt/alias-analyses/AliasAnalysis.cpp
+++ b/jlm/llvm/opt/alias-analyses/AliasAnalysis.cpp
@@ -28,7 +28,7 @@ AliasAnalysis::~AliasAnalysis() noexcept = default;
  * @param b second alias query response to check
  * @return true if the responses are compatible, false otherwise
  */
-bool
+static bool
 AreAliasResponsesCompatible(
     AliasAnalysis::AliasQueryResponse a,
     AliasAnalysis::AliasQueryResponse b)

--- a/jlm/llvm/opt/alias-analyses/AliasAnalysis.hpp
+++ b/jlm/llvm/opt/alias-analyses/AliasAnalysis.hpp
@@ -43,6 +43,7 @@ public:
   };
 
   AliasAnalysis();
+
   virtual ~AliasAnalysis() noexcept;
 
   /**
@@ -70,8 +71,9 @@ public:
 class ChainedAliasAnalysis final : public AliasAnalysis
 {
 public:
-  explicit ChainedAliasAnalysis(AliasAnalysis & first, AliasAnalysis & second);
-  ~ChainedAliasAnalysis() override;
+  ChainedAliasAnalysis(AliasAnalysis & first, AliasAnalysis & second);
+
+  ~ChainedAliasAnalysis() noexcept override;
 
   std::string
   ToString() const override;

--- a/jlm/llvm/opt/alias-analyses/LocalAliasAnalysis.cpp
+++ b/jlm/llvm/opt/alias-analyses/LocalAliasAnalysis.cpp
@@ -3,13 +3,14 @@
  * See COPYING for terms of redistribution.
  */
 
+#include <jlm/llvm/opt/alias-analyses/LocalAliasAnalysis.hpp>
+
 #include <jlm/llvm/ir/operators.hpp>
 #include <jlm/llvm/ir/operators/alloca.hpp>
 #include <jlm/llvm/ir/operators/delta.hpp>
 #include <jlm/llvm/ir/operators/IntegerOperations.hpp>
 #include <jlm/llvm/ir/operators/IOBarrier.hpp>
 #include <jlm/llvm/ir/types.hpp>
-#include <jlm/llvm/opt/alias-analyses/LocalAliasAnalysis.hpp>
 #include <jlm/rvsdg/gamma.hpp>
 #include <jlm/rvsdg/lambda.hpp>
 #include <jlm/rvsdg/theta.hpp>
@@ -20,34 +21,6 @@
 
 namespace jlm::llvm::aa
 {
-
-/**
- * Gets the value of the given \p output as a compile time constant, if possible.
- * The constant is interpreted as a signed value, and sign extended to int64 if needed.
- * This function does not perform any constant folding.
- *
- * @param output the output whose constant value is requested
- * @return the value of the output, or nullopt if it could not be determined.
- */
-static std::optional<int64_t>
-GetConstantSignedIntegerValue(const rvsdg::Output & output)
-{
-  const auto & normalized = NormalizeOutput(output);
-  if (const auto [_, constant] =
-          rvsdg::TryGetSimpleNodeAndOptionalOp<IntegerConstantOperation>(normalized);
-      constant)
-  {
-    return constant->Representation().to_int();
-  }
-  if (const auto [_, constant] =
-          rvsdg::TryGetSimpleNodeAndOptionalOp<rvsdg::bitconstant_op>(normalized);
-      constant)
-  {
-    return constant->value().to_int();
-  }
-
-  return std::nullopt;
-}
 
 LocalAliasAnalysis::LocalAliasAnalysis() = default;
 
@@ -229,7 +202,7 @@ CalculateIntraTypeGepOffset(
   JLM_ASSERT(inputIndex >= 2);
 
   auto & gepInput = *gepNode.input(inputIndex)->origin();
-  auto indexingValue = GetConstantSignedIntegerValue(gepInput);
+  auto indexingValue = TryGetConstantSignedInteger(gepInput);
 
   // Any unknown indexing value means the GEP offset is unknown overall
   if (!indexingValue.has_value())
@@ -275,7 +248,7 @@ LocalAliasAnalysis::CalculateGepOffset(const rvsdg::SimpleNode & gepNode)
   const auto & pointeeType = gep->GetPointeeType();
 
   const auto & wholeTypeIndexingOrigin = *gepNode.input(1)->origin();
-  const auto wholeTypeIndexing = GetConstantSignedIntegerValue(wholeTypeIndexingOrigin);
+  const auto wholeTypeIndexing = TryGetConstantSignedInteger(wholeTypeIndexingOrigin);
 
   if (!wholeTypeIndexing.has_value())
     return std::nullopt;
@@ -509,14 +482,14 @@ LocalAliasAnalysis::GetOriginalOriginSize(const rvsdg::Output & pointer)
   if (const auto [node, allocaOp] = rvsdg::TryGetSimpleNodeAndOptionalOp<AllocaOperation>(pointer);
       allocaOp)
   {
-    const auto elementCount = GetConstantSignedIntegerValue(*node->input(0)->origin());
+    const auto elementCount = TryGetConstantSignedInteger(*node->input(0)->origin());
     if (elementCount.has_value())
       return *elementCount * GetTypeSize(*allocaOp->ValueType());
   }
   if (const auto [node, mallocOp] = rvsdg::TryGetSimpleNodeAndOptionalOp<MallocOperation>(pointer);
       mallocOp)
   {
-    const auto mallocSize = GetConstantSignedIntegerValue(*node->input(0)->origin());
+    const auto mallocSize = TryGetConstantSignedInteger(*node->input(0)->origin());
     if (mallocSize.has_value())
       return *mallocSize;
   }

--- a/jlm/llvm/opt/alias-analyses/PointsToGraphAliasAnalysis.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraphAliasAnalysis.cpp
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2025 Håvard Krogstie <krogstie.havard@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <jlm/llvm/opt/alias-analyses/PointsToGraphAliasAnalysis.hpp>
+
+namespace jlm::llvm::aa
+{
+PointsToGraphAliasAnalysis::PointsToGraphAliasAnalysis(PointsToGraph & pointsToGraph)
+    : PointsToGraph_(pointsToGraph)
+{}
+
+PointsToGraphAliasAnalysis::~PointsToGraphAliasAnalysis() = default;
+
+std::string
+PointsToGraphAliasAnalysis::ToString() const
+{
+  return "PointsToGraphAA";
+}
+
+AliasAnalysis::AliasQueryResponse
+PointsToGraphAliasAnalysis::Query(
+    const rvsdg::Output & p1,
+    const size_t s1,
+    const rvsdg::Output & p2,
+    const size_t s2)
+{
+  // If the two pointers are the same value, they must alias
+  if (&p1 == &p2)
+    return MustAlias;
+
+  // Assume that all pointers actually exist in the PointsToGraph
+  auto & p1RegisterNode = PointsToGraph_.GetRegisterNode(p1);
+  auto & p2RegisterNode = PointsToGraph_.GetRegisterNode(p2);
+
+  // Check if both pointers may target the external node, to avoid iterating over large sets
+  const auto & externalNode = PointsToGraph_.GetExternalMemoryNode();
+  if (p1RegisterNode.HasTarget(externalNode) && p2RegisterNode.HasTarget(externalNode))
+    return MayAlias;
+
+  // Quickly checks if the given register node has only one possible target
+  const auto GetSingleTarget = [&](const PointsToGraph::RegisterNode & node,
+                                   size_t size) -> std::optional<const PointsToGraph::MemoryNode *>
+  {
+    std::optional<const PointsToGraph::MemoryNode *> singleTarget;
+    for (auto & target : node.Targets())
+    {
+      // Skip memory locations that are too small to hold size
+      const auto targetSize = GetMemoryNodeSize(target);
+      if (targetSize.has_value() && *targetSize < size)
+        continue;
+
+      if (singleTarget.has_value())
+        return std::nullopt;
+
+      singleTarget = &target;
+    }
+
+    return singleTarget;
+  };
+
+  // If both p1 and p2 have exactly one possible target, which is the same for both,
+  // and is the same size as the operations, and only represents one concrete memory location,
+  // we can respond with MustAlias
+  if (s1 == s2)
+  {
+    const auto p1SingleTarget = GetSingleTarget(p1RegisterNode, s1);
+    const auto p2SingleTarget = GetSingleTarget(p2RegisterNode, s2);
+    if (p1SingleTarget.has_value() && p2SingleTarget.has_value())
+    {
+      if (*p1SingleTarget == *p2SingleTarget)
+      {
+        if (IsRepresentingSingleMemoryLocation(**p1SingleTarget))
+        {
+          const auto targetSize = GetMemoryNodeSize(**p1SingleTarget);
+          if (targetSize.has_value() && *targetSize == s1)
+            return MustAlias;
+        }
+      }
+    }
+  }
+
+  // For a memory location to be the target of both p1 and p2, it needs to be large enough
+  // to represent both [p1, p1+s1) and [p2, p2+s2)
+  const auto neededSize = std::max(s1, s2);
+
+  for (auto & target : p1RegisterNode.Targets())
+  {
+    // Skip memory locations that are too small
+    const auto targetSize = GetMemoryNodeSize(target);
+    if (targetSize.has_value() && *targetSize < neededSize)
+      continue;
+
+    if (p2RegisterNode.HasTarget(target))
+      return MayAlias;
+  }
+
+  return NoAlias;
+}
+
+std::optional<size_t>
+PointsToGraphAliasAnalysis::GetMemoryNodeSize(const PointsToGraph::MemoryNode & node)
+{
+  if (auto delta = dynamic_cast<const PointsToGraph::DeltaNode *>(&node))
+    return GetTypeSize(*delta->GetDeltaNode().GetOperation().Type());
+  if (auto import = dynamic_cast<const PointsToGraph::ImportNode *>(&node))
+  {
+    auto size = GetTypeSize(*import->GetArgument().ValueType());
+    // Workaround for imported incomplete types appearing to have size 0 in the LLVM IR
+    if (size == 0)
+      return std::nullopt;
+
+    return size;
+  }
+  if (auto alloca = dynamic_cast<const PointsToGraph::AllocaNode *>(&node))
+  {
+    const auto & allocaNode = alloca->GetAllocaNode();
+    const auto allocaOp = util::AssertedCast<const AllocaOperation>(&allocaNode.GetOperation());
+
+    // An alloca has a count parameter, which on rare occasions is not just the constant 1.
+    const auto elementCount = TryGetConstantSignedInteger(*allocaNode.input(0)->origin());
+    if (elementCount.has_value())
+      return *elementCount * GetTypeSize(*allocaOp->ValueType());
+  }
+  if (auto malloc = dynamic_cast<const PointsToGraph::MallocNode *>(&node))
+  {
+    const auto & mallocNode = malloc->GetMallocNode();
+
+    const auto mallocSize = TryGetConstantSignedInteger(*mallocNode.input(0)->origin());
+    if (mallocSize.has_value())
+      return *mallocSize;
+  }
+
+  return std::nullopt;
+}
+
+bool
+PointsToGraphAliasAnalysis::IsRepresentingSingleMemoryLocation(
+    const PointsToGraph::MemoryNode & node)
+{
+  return PointsToGraph::Node::Is<PointsToGraph::DeltaNode>(node)
+      || PointsToGraph::Node::Is<PointsToGraph::ImportNode>(node)
+      || PointsToGraph::Node::Is<PointsToGraph::LambdaNode>(node);
+}
+
+}

--- a/jlm/llvm/opt/alias-analyses/PointsToGraphAliasAnalysis.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraphAliasAnalysis.hpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 Håvard Krogstie <krogstie.havard@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#ifndef JLM_LLVM_OPT_ALIAS_ANALYSES_POINTSTOGRAPHALIASANALYSIS_HPP
+#define JLM_LLVM_OPT_ALIAS_ANALYSES_POINTSTOGRAPHALIASANALYSIS_HPP
+
+#include <jlm/llvm/opt/alias-analyses/AliasAnalysis.hpp>
+#include <jlm/llvm/opt/alias-analyses/PointsToGraph.hpp>
+
+#include <string>
+
+namespace jlm::llvm::aa
+{
+
+/**
+ * Class for making alias analysis queries against a PointsToGraph
+ */
+class PointsToGraphAliasAnalysis : public AliasAnalysis
+{
+public:
+  explicit PointsToGraphAliasAnalysis(PointsToGraph & pointsToGraph);
+
+  ~PointsToGraphAliasAnalysis() override;
+
+  [[nodiscard]] std::string
+  ToString() const override;
+
+  AliasQueryResponse
+  Query(const rvsdg::Output & p1, size_t s1, const rvsdg::Output & p2, size_t s2) override;
+
+private:
+  /**
+   * Determines the size of the memory region represented by the given memory node, if possible.
+   * If the memory node represents multiple regions of the same size,
+   * (e.g., an ALLOCA[i32]), the size of each represented region (e.g., 4) is returned.
+   * @param node the MemoryNode representing an abstract memory location.
+   * @return the size of the memory region, in bytes
+   */
+  [[nodiscard]] static std::optional<size_t>
+  GetMemoryNodeSize(const PointsToGraph::MemoryNode & node);
+
+  /**
+   * Determines if the given abstract memory location represent exactly one region in memory,
+   * such as imports and global variables.
+   * As a counterexample, an ALLOCA[i32] can represent multiple 4-byte locations.
+   * @param node the MemoryNode for the abstract memory location in question
+   * @return true if node represents a single location
+   */
+  [[nodiscard]] static bool
+  IsRepresentingSingleMemoryLocation(const PointsToGraph::MemoryNode & node);
+
+  PointsToGraph & PointsToGraph_;
+};
+
+} // namespace jlm::llvm::aa
+
+#endif // JLM_LLVM_OPT_ALIAS_ANALYSES_POINTSTOGRAPHALIASANALYSIS_HPP

--- a/jlm/llvm/opt/alias-analyses/PointsToGraphAliasAnalysis.hpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraphAliasAnalysis.hpp
@@ -20,9 +20,9 @@ namespace jlm::llvm::aa
 class PointsToGraphAliasAnalysis : public AliasAnalysis
 {
 public:
-  explicit PointsToGraphAliasAnalysis(PointsToGraph & pointsToGraph);
+  explicit PointsToGraphAliasAnalysis(const PointsToGraph & pointsToGraph);
 
-  ~PointsToGraphAliasAnalysis() override;
+  ~PointsToGraphAliasAnalysis() noexcept override;
 
   [[nodiscard]] std::string
   ToString() const override;
@@ -31,6 +31,18 @@ public:
   Query(const rvsdg::Output & p1, size_t s1, const rvsdg::Output & p2, size_t s2) override;
 
 private:
+  /**
+   * Determines if there is a single valid target memory node for a given register node.
+   * A target is only considered valid if it is large enough to hold the specified size.
+   * If there are multiple valid targets, nullptr is returned.
+   * @param node The register node to check the targets of
+   * @param size The minimum size that the target memory node must be able to hold
+   * @return a pointer to the single valid target memory node, or nullptr if there are zero or
+   * multiple valid targets
+   */
+  [[nodiscard]] static const PointsToGraph::MemoryNode *
+  TryGetSingleTarget(const PointsToGraph::RegisterNode & node, size_t size);
+
   /**
    * Determines the size of the memory region represented by the given memory node, if possible.
    * If the memory node represents multiple regions of the same size,
@@ -51,7 +63,7 @@ private:
   [[nodiscard]] static bool
   IsRepresentingSingleMemoryLocation(const PointsToGraph::MemoryNode & node);
 
-  PointsToGraph & PointsToGraph_;
+  const PointsToGraph & PointsToGraph_;
 };
 
 } // namespace jlm::llvm::aa

--- a/jlm/rvsdg/control.hpp
+++ b/jlm/rvsdg/control.hpp
@@ -13,6 +13,7 @@
 #include <jlm/rvsdg/unary.hpp>
 #include <jlm/util/strfmt.hpp>
 
+#include <cstdint>
 #include <unordered_map>
 
 namespace jlm::rvsdg

--- a/tests/jlm/llvm/opt/alias-analyses/PointsToGraphAliasAnalysisTests.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/PointsToGraphAliasAnalysisTests.cpp
@@ -3,10 +3,10 @@
  * See COPYING for terms of redistribution.
  */
 
-#include "jlm/llvm/opt/alias-analyses/Andersen.hpp"
 #include <test-registry.hpp>
 #include <TestRvsdgs.hpp>
 
+#include <jlm/llvm/opt/alias-analyses/Andersen.hpp>
 #include <jlm/llvm/opt/alias-analyses/PointsToGraphAliasAnalysis.hpp>
 #include <jlm/rvsdg/view.hpp>
 

--- a/tests/jlm/llvm/opt/alias-analyses/PointsToGraphAliasAnalysisTests.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/PointsToGraphAliasAnalysisTests.cpp
@@ -1,0 +1,482 @@
+/*
+ * Copyright 2025 Håvard Krogstie <krogstie.havard@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include "jlm/llvm/opt/alias-analyses/Andersen.hpp"
+#include <test-registry.hpp>
+#include <TestRvsdgs.hpp>
+
+#include <jlm/llvm/opt/alias-analyses/PointsToGraphAliasAnalysis.hpp>
+#include <jlm/rvsdg/view.hpp>
+
+/**
+ * Helper function for expecting an alias query to return a given result
+ */
+static void
+Expect(
+    jlm::llvm::aa::AliasAnalysis & aa,
+    const jlm::rvsdg::Output & p1,
+    size_t s1,
+    const jlm::rvsdg::Output & p2,
+    size_t s2,
+    jlm::llvm::aa::AliasAnalysis::AliasQueryResponse expected)
+{
+  const auto actual = aa.Query(p1, s1, p2, s2);
+  assert(actual == expected);
+
+  // An alias analysis query should always be symmetrical, so check the opposite as well
+  const auto mirror = aa.Query(p2, s2, p1, s1);
+  assert(mirror == expected);
+}
+
+/**
+ * This class sets up an RVSDG representing the following code:
+ *
+ * \code{.c}
+ *   int* global = nullptr;
+ *   static int* local = nullptr;
+ *   extern int* imported;
+ *
+ *   int* getPtr();
+ *
+ *   void func(int** p) {
+ *     int alloca1, alloca2, alloca3, alloca4;
+ *
+ *     int* q = *p;
+ *     *p = &alloca1;
+ *
+ *     // Load global values into virtual registers
+ *     int* globalLoad = global;
+ *     int* localLoad = local;
+ *     int* importedLoad = imported;
+ *
+ *     // Store to global values
+ *     global = &alloca2;
+ *     local = &alloca3;
+ *     imported = &alloca4;
+ *
+ *     int* r = getPtr();
+ *
+ *     // All alias queries happen here
+ *   }
+ * \endcode
+ */
+class PtGAliasAnalysisTest final : public jlm::tests::RvsdgTest
+{
+  struct Outputs
+  {
+    jlm::rvsdg::Output * Global = {};
+    jlm::rvsdg::Output * Local = {};
+    jlm::rvsdg::Output * Imported = {};
+    jlm::rvsdg::Output * GetPtr = {};
+    jlm::rvsdg::Output * Func = {};
+    jlm::rvsdg::Output * P = {};
+    jlm::rvsdg::Output * Alloca1 = {};
+    jlm::rvsdg::Output * Alloca2 = {};
+    jlm::rvsdg::Output * Alloca3 = {};
+    jlm::rvsdg::Output * Alloca4 = {};
+    jlm::rvsdg::Output * Q = {};
+    jlm::rvsdg::Output * GlobalLoad = {};
+    jlm::rvsdg::Output * LocalLoad = {};
+    jlm::rvsdg::Output * ImportedLoad = {};
+    jlm::rvsdg::Output * R = {};
+  };
+
+public:
+  const Outputs &
+  GetOutputs() const noexcept
+  {
+    return Outputs_;
+  }
+
+private:
+  std::unique_ptr<jlm::llvm::RvsdgModule>
+  SetupRvsdg() override
+  {
+    using namespace jlm;
+    using namespace jlm::llvm;
+
+    auto rvsdgModule = RvsdgModule::Create(jlm::util::FilePath(""), "", "");
+    auto & rvsdg = rvsdgModule->Rvsdg();
+
+    const auto pointerType = PointerType::Create();
+    const auto intType = rvsdg::BitType::Create(32);
+    const auto ioStateType = IOStateType::Create();
+    const auto memoryStateType = MemoryStateType::Create();
+
+    const auto funcType = rvsdg::FunctionType::Create(
+        { pointerType, ioStateType, memoryStateType },
+        { ioStateType, memoryStateType });
+
+    const auto getPtrFuncType = rvsdg::FunctionType::Create(
+        { ioStateType, memoryStateType },
+        { pointerType, ioStateType, memoryStateType });
+
+    Outputs_.GetPtr = &GraphImport::Create(
+        rvsdg,
+        getPtrFuncType,
+        getPtrFuncType,
+        "getPtr",
+        linkage::external_linkage);
+
+    // Create the global pointer variable "global", that is exported
+    auto & globalDelta = *rvsdg::DeltaNode::Create(
+        &rvsdg.GetRootRegion(),
+        DeltaOperation::Create(pointerType, "global", linkage::external_linkage, "", false));
+    {
+      const auto nullPtr =
+          ConstantPointerNullOperation::Create(globalDelta.subregion(), pointerType);
+      globalDelta.finalize(nullPtr);
+    }
+    rvsdg::GraphExport::Create(globalDelta.output(), "global");
+    Outputs_.Global = &globalDelta.output();
+
+    // Create the global variable "local", that is not exported
+    auto & localDelta = *rvsdg::DeltaNode::Create(
+        &rvsdg.GetRootRegion(),
+        DeltaOperation::Create(pointerType, "local", linkage::internal_linkage, "", false));
+    {
+      const auto nullPtr =
+          ConstantPointerNullOperation::Create(localDelta.subregion(), pointerType);
+      localDelta.finalize(nullPtr);
+    }
+    Outputs_.Local = &localDelta.output();
+
+    Outputs_.Imported = &GraphImport::Create(
+        rvsdg,
+        pointerType,
+        pointerType,
+        "imported",
+        linkage::external_linkage);
+
+    // Setup the function "func"
+    {
+      auto & lambdaNode = *rvsdg::LambdaNode::Create(
+          rvsdg.GetRootRegion(),
+          LlvmLambdaOperation::Create(funcType, "func", linkage::internal_linkage));
+
+      Outputs_.P = lambdaNode.GetFunctionArguments()[0];
+      auto ioState = lambdaNode.GetFunctionArguments()[1];
+      auto memoryState = lambdaNode.GetFunctionArguments()[2];
+
+      const auto getPtrCtxVar = lambdaNode.AddContextVar(*Outputs_.GetPtr).inner;
+      const auto globalCtxVar = lambdaNode.AddContextVar(*Outputs_.Global).inner;
+      const auto localCtxVar = lambdaNode.AddContextVar(*Outputs_.Local).inner;
+      const auto importedCtxVar = lambdaNode.AddContextVar(*Outputs_.Imported).inner;
+
+      const auto constantOne = create_bitconstant(lambdaNode.subregion(), 32, 1);
+
+      const auto alloca1Outputs = AllocaOperation::create(intType, constantOne, 4);
+      const auto alloca2Outputs = AllocaOperation::create(intType, constantOne, 4);
+      const auto alloca3Outputs = AllocaOperation::create(intType, constantOne, 4);
+      const auto alloca4Outputs = AllocaOperation::create(intType, constantOne, 4);
+
+      Outputs_.Alloca1 = alloca1Outputs[0];
+      Outputs_.Alloca2 = alloca2Outputs[0];
+      Outputs_.Alloca3 = alloca3Outputs[0];
+      Outputs_.Alloca4 = alloca4Outputs[0];
+
+      memoryState = MemoryStateMergeOperation::Create({ memoryState,
+                                                        alloca1Outputs[1],
+                                                        alloca2Outputs[1],
+                                                        alloca3Outputs[1],
+                                                        alloca4Outputs[1] });
+
+      // Load: q = *p;
+      const auto loadP =
+          LoadNonVolatileOperation::Create(Outputs_.P, { memoryState }, pointerType, 8);
+      Outputs_.Q = loadP[0];
+      memoryState = loadP[1];
+
+      // Store the address of alloca1 to p
+      const auto storeP =
+          StoreNonVolatileOperation::Create(Outputs_.P, Outputs_.Alloca1, { memoryState }, 8);
+      memoryState = storeP[0];
+
+      // Create loads of the global variables
+      const auto loadGlobal =
+          LoadNonVolatileOperation::Create(globalCtxVar, { memoryState }, pointerType, 8);
+      Outputs_.GlobalLoad = loadGlobal[0];
+      memoryState = loadGlobal[1];
+
+      const auto loadLocal =
+          LoadNonVolatileOperation::Create(localCtxVar, { memoryState }, pointerType, 8);
+      Outputs_.LocalLoad = loadLocal[0];
+      memoryState = loadLocal[1];
+
+      const auto loadImported =
+          LoadNonVolatileOperation::Create(importedCtxVar, { memoryState }, pointerType, 8);
+      Outputs_.ImportedLoad = loadImported[0];
+      memoryState = loadImported[1];
+
+      // Store to global values
+      const auto storeGlobal =
+          StoreNonVolatileOperation::Create(globalCtxVar, Outputs_.Alloca2, { memoryState }, 8);
+      memoryState = storeGlobal[0];
+
+      const auto storeLocal =
+          StoreNonVolatileOperation::Create(localCtxVar, Outputs_.Alloca3, { memoryState }, 8);
+      memoryState = storeLocal[0];
+
+      const auto storeImported =
+          StoreNonVolatileOperation::Create(importedCtxVar, Outputs_.Alloca4, { memoryState }, 8);
+      memoryState = storeImported[0];
+
+      // Get r by calling getPtr()
+      const auto callOutputs =
+          CallOperation::Create(getPtrCtxVar, getPtrFuncType, { ioState, memoryState });
+      Outputs_.R = callOutputs[0];
+      ioState = callOutputs[1];
+      memoryState = callOutputs[2];
+
+      lambdaNode.finalize({ ioState, memoryState });
+      Outputs_.Func = lambdaNode.output();
+    }
+    rvsdg::GraphExport::Create(*Outputs_.Func, "func");
+
+    return rvsdgModule;
+  }
+
+  Outputs Outputs_ = {};
+};
+
+void
+TestPtGAliasAnalysis()
+{
+  using namespace jlm::llvm::aa;
+
+  // Arrange
+  PtGAliasAnalysisTest rvsdg;
+  rvsdg.InitializeTest();
+  const auto & outputs = rvsdg.GetOutputs();
+
+  // jlm::rvsdg::view(&rvsdg.graph().GetRootRegion(), stdout);
+
+  Andersen andersen;
+  auto pointsToGraph = andersen.Analyze(rvsdg.module());
+  // std::cout << PointsToGraph::ToDot(*pointsToGraph) << std::endl;
+  PointsToGraphAliasAnalysis aa(*pointsToGraph);
+
+  // Assert
+
+  // Distinct global variables do not alias
+  Expect(aa, *outputs.Global, 8, *outputs.Local, 8, AliasAnalysis::NoAlias);
+  Expect(aa, *outputs.Global, 8, *outputs.Imported, 8, AliasAnalysis::NoAlias);
+  Expect(aa, *outputs.Local, 8, *outputs.Imported, 8, AliasAnalysis::NoAlias);
+
+  // The same global variable aliases itself
+  Expect(aa, *outputs.Global, 8, *outputs.Global, 8, AliasAnalysis::MustAlias);
+  Expect(aa, *outputs.Local, 8, *outputs.Local, 8, AliasAnalysis::MustAlias);
+  Expect(aa, *outputs.Imported, 4, *outputs.Imported, 4, AliasAnalysis::MustAlias);
+
+  // Distinct allocas never alias with each other or globals
+  Expect(aa, *outputs.Alloca1, 8, *outputs.Alloca2, 8, AliasAnalysis::NoAlias);
+  Expect(aa, *outputs.Alloca1, 8, *outputs.Alloca3, 8, AliasAnalysis::NoAlias);
+  Expect(aa, *outputs.Alloca1, 8, *outputs.Alloca4, 8, AliasAnalysis::NoAlias);
+  Expect(aa, *outputs.Alloca1, 8, *outputs.Global, 8, AliasAnalysis::NoAlias);
+  Expect(aa, *outputs.Alloca1, 8, *outputs.Local, 8, AliasAnalysis::NoAlias);
+  Expect(aa, *outputs.Alloca1, 8, *outputs.Imported, 8, AliasAnalysis::NoAlias);
+
+  // The pointer argument may point to any escaped memory
+  Expect(aa, *outputs.P, 8, *outputs.Global, 8, AliasAnalysis::MayAlias);
+  Expect(aa, *outputs.P, 8, *outputs.Imported, 8, AliasAnalysis::MayAlias);
+  // But not things that have not escaped
+  Expect(aa, *outputs.P, 8, *outputs.Local, 8, AliasAnalysis::NoAlias);
+  Expect(aa, *outputs.P, 8, *outputs.Alloca3, 8, AliasAnalysis::NoAlias);
+
+  // The pointer q, loaded from p, is likewise unknown
+  Expect(aa, *outputs.Q, 8, *outputs.Global, 8, AliasAnalysis::MayAlias);
+  Expect(aa, *outputs.Q, 8, *outputs.Imported, 8, AliasAnalysis::MayAlias);
+  Expect(aa, *outputs.Q, 8, *outputs.P, 8, AliasAnalysis::MayAlias);
+  Expect(aa, *outputs.Q, 8, *outputs.Local, 8, AliasAnalysis::NoAlias);
+  Expect(aa, *outputs.Q, 8, *outputs.Alloca3, 8, AliasAnalysis::NoAlias);
+
+  // The pointer value loaded from global can point to anything externally available
+  Expect(aa, *outputs.GlobalLoad, 4, *outputs.Global, 4, AliasAnalysis::MayAlias);
+  Expect(aa, *outputs.GlobalLoad, 4, *outputs.Imported, 4, AliasAnalysis::MayAlias);
+  Expect(aa, *outputs.GlobalLoad, 4, *outputs.Alloca1, 4, AliasAnalysis::MayAlias);
+  Expect(aa, *outputs.GlobalLoad, 4, *outputs.Local, 4, AliasAnalysis::NoAlias);
+
+  // The pointer value loaded from local can not point to anything (except alloca3)
+  Expect(aa, *outputs.LocalLoad, 4, *outputs.Global, 4, AliasAnalysis::NoAlias);
+  Expect(aa, *outputs.LocalLoad, 4, *outputs.Imported, 4, AliasAnalysis::NoAlias);
+  Expect(aa, *outputs.LocalLoad, 4, *outputs.Alloca1, 4, AliasAnalysis::NoAlias);
+  Expect(aa, *outputs.LocalLoad, 4, *outputs.Alloca2, 4, AliasAnalysis::NoAlias);
+  Expect(aa, *outputs.LocalLoad, 4, *outputs.Alloca4, 4, AliasAnalysis::NoAlias);
+  Expect(aa, *outputs.LocalLoad, 4, *outputs.P, 4, AliasAnalysis::NoAlias);
+  Expect(aa, *outputs.LocalLoad, 4, *outputs.Q, 4, AliasAnalysis::NoAlias);
+
+  // The pointer value loaded from imported is just like the one loaded from global
+  Expect(aa, *outputs.ImportedLoad, 4, *outputs.Global, 4, AliasAnalysis::MayAlias);
+  Expect(aa, *outputs.ImportedLoad, 4, *outputs.Imported, 4, AliasAnalysis::MayAlias);
+  Expect(aa, *outputs.ImportedLoad, 4, *outputs.Alloca1, 4, AliasAnalysis::MayAlias);
+  Expect(aa, *outputs.ImportedLoad, 4, *outputs.Local, 4, AliasAnalysis::NoAlias);
+
+  // The pointer we get from getPtr() can point to anything that is externally available
+  Expect(aa, *outputs.R, 4, *outputs.Global, 4, AliasAnalysis::MayAlias);
+  Expect(aa, *outputs.R, 4, *outputs.Imported, 4, AliasAnalysis::MayAlias);
+  Expect(aa, *outputs.R, 4, *outputs.Alloca1, 4, AliasAnalysis::MayAlias);
+  Expect(aa, *outputs.R, 4, *outputs.Alloca2, 4, AliasAnalysis::MayAlias);
+  Expect(aa, *outputs.R, 4, *outputs.Alloca4, 4, AliasAnalysis::MayAlias);
+  Expect(aa, *outputs.R, 4, *outputs.P, 4, AliasAnalysis::MayAlias);
+  Expect(aa, *outputs.R, 4, *outputs.Q, 4, AliasAnalysis::MayAlias);
+
+  // It can not point to alloca3, as it never escaped the module
+  Expect(aa, *outputs.R, 4, *outputs.Alloca3, 4, AliasAnalysis::NoAlias);
+}
+
+JLM_UNIT_TEST_REGISTER(
+    "jlm/llvm/opt/alias-analyses/PointsToGraphAliasAnalysisTests-TestPtGAliasAnalysis",
+    TestPtGAliasAnalysis);
+
+/**
+ * This class sets up an RVSDG representing the following code:
+ *
+ * \code{.c}
+ *   extern int32 globalInt;
+ *   extern int64 globalLong;
+ *
+ *   void func(int32* p, int offset) {
+ *
+ *     int32* intWithOffset = (int32*) ((char*)globalInt + offset);
+ *     int64* longWithOffset = (int64*) ((char*)globallong + offset);
+ *
+ *     // All alias queries happen here
+ *   }
+ * \endcode
+ */
+class PtGAliasAnalysisTestOffsets final : public jlm::tests::RvsdgTest
+{
+  struct Outputs
+  {
+    jlm::rvsdg::Output * GlobalInt = {};
+    jlm::rvsdg::Output * GlobalLong = {};
+    jlm::rvsdg::Output * Func = {};
+    jlm::rvsdg::Output * P = {};
+    jlm::rvsdg::Output * Offset = {};
+    jlm::rvsdg::Output * IntWithOffset = {};
+    jlm::rvsdg::Output * LongWithOffset = {};
+  };
+
+public:
+  const Outputs &
+  GetOutputs() const noexcept
+  {
+    return Outputs_;
+  }
+
+private:
+  std::unique_ptr<jlm::llvm::RvsdgModule>
+  SetupRvsdg() override
+  {
+    using namespace jlm;
+    using namespace jlm::llvm;
+
+    auto rvsdgModule = RvsdgModule::Create(jlm::util::FilePath(""), "", "");
+    auto & rvsdg = rvsdgModule->Rvsdg();
+
+    const auto pointerType = PointerType::Create();
+    const auto byteType = rvsdg::BitType::Create(8);
+    const auto int32Type = rvsdg::BitType::Create(32);
+    const auto int64Type = rvsdg::BitType::Create(64);
+    const auto ioStateType = IOStateType::Create();
+    const auto memoryStateType = MemoryStateType::Create();
+
+    const auto funcType = rvsdg::FunctionType::Create(
+        { pointerType, int32Type, ioStateType, memoryStateType },
+        { ioStateType, memoryStateType });
+
+    Outputs_.GlobalInt =
+        &GraphImport::Create(rvsdg, int32Type, pointerType, "globalInt", linkage::external_linkage);
+
+    Outputs_.GlobalLong = &GraphImport::Create(
+        rvsdg,
+        int64Type,
+        pointerType,
+        "globalLong",
+        linkage::external_linkage);
+
+    // Setup the function "func"
+    {
+      auto & lambdaNode = *rvsdg::LambdaNode::Create(
+          rvsdg.GetRootRegion(),
+          LlvmLambdaOperation::Create(funcType, "func", linkage::internal_linkage));
+
+      Outputs_.P = lambdaNode.GetFunctionArguments()[0];
+      Outputs_.Offset = lambdaNode.GetFunctionArguments()[1];
+      auto ioState = lambdaNode.GetFunctionArguments()[2];
+      auto memoryState = lambdaNode.GetFunctionArguments()[3];
+
+      const auto globalIntCtxVar = lambdaNode.AddContextVar(*Outputs_.GlobalInt).inner;
+      const auto globalLongCtxVar = lambdaNode.AddContextVar(*Outputs_.GlobalLong).inner;
+
+      Outputs_.IntWithOffset = GetElementPtrOperation::Create(
+          globalIntCtxVar,
+          { Outputs_.Offset },
+          byteType,
+          pointerType);
+      Outputs_.LongWithOffset = GetElementPtrOperation::Create(
+          globalLongCtxVar,
+          { Outputs_.Offset },
+          byteType,
+          pointerType);
+
+      lambdaNode.finalize({ ioState, memoryState });
+      Outputs_.Func = lambdaNode.output();
+    }
+    // Ensure func is being called from external modules
+    rvsdg::GraphExport::Create(*Outputs_.Func, "func");
+
+    return rvsdgModule;
+  }
+
+  Outputs Outputs_ = {};
+};
+
+void
+TestPtGAliasAnalysisOffsets()
+{
+  using namespace jlm::llvm::aa;
+
+  // Arrange
+  PtGAliasAnalysisTestOffsets rvsdg;
+  rvsdg.InitializeTest();
+  const auto & outputs = rvsdg.GetOutputs();
+
+  // jlm::rvsdg::view(&rvsdg.graph().GetRootRegion(), stdout);
+
+  Andersen andersen;
+  auto pointsToGraph = andersen.Analyze(rvsdg.module());
+  // std::cout << PointsToGraph::ToDot(*pointsToGraph) << std::endl;
+  PointsToGraphAliasAnalysis aa(*pointsToGraph);
+
+  // Assert
+
+  // Distinct global variables do not alias
+  Expect(aa, *outputs.GlobalInt, 4, *outputs.GlobalLong, 4, AliasAnalysis::NoAlias);
+
+  // The pointer argument can alias with either
+  Expect(aa, *outputs.P, 4, *outputs.GlobalInt, 4, AliasAnalysis::MayAlias);
+  Expect(aa, *outputs.P, 8, *outputs.GlobalLong, 8, AliasAnalysis::MayAlias);
+
+  // If the accessed size is too large, the pointer argument can't access smaller memory objects
+  Expect(aa, *outputs.P, 5, *outputs.GlobalInt, 4, AliasAnalysis::NoAlias);
+  Expect(aa, *outputs.P, 9, *outputs.GlobalLong, 8, AliasAnalysis::NoAlias);
+
+  // With small access sizes, the unknown offset causes MayAlias
+  Expect(aa, *outputs.IntWithOffset, 2, *outputs.GlobalInt, 2, AliasAnalysis::MayAlias);
+  Expect(aa, *outputs.LongWithOffset, 2, *outputs.GlobalLong, 2, AliasAnalysis::MayAlias);
+
+  // Even with an unknown offset, the pointers are not mixed
+  Expect(aa, *outputs.IntWithOffset, 2, *outputs.GlobalLong, 2, AliasAnalysis::NoAlias);
+  Expect(aa, *outputs.LongWithOffset, 2, *outputs.GlobalInt, 2, AliasAnalysis::NoAlias);
+
+  // With full access sizes, the unknown offset can be ignored, and we get MustAlias
+  Expect(aa, *outputs.IntWithOffset, 4, *outputs.GlobalInt, 4, AliasAnalysis::MustAlias);
+  Expect(aa, *outputs.LongWithOffset, 8, *outputs.GlobalLong, 8, AliasAnalysis::MustAlias);
+}
+
+JLM_UNIT_TEST_REGISTER(
+    "jlm/llvm/opt/alias-analyses/PointsToGraphAliasAnalysisTests-TestPtGAliasAnalysisOffsets",
+    TestPtGAliasAnalysisOffsets);


### PR DESCRIPTION
It also includes the `ChainedAliasAnalysis` because it is a very small class.

I also had to add some `#includes` to make things compile on my machine after a system update.

`TryGetConstantSignedInteger` is moved to `AliasAnalysis.{cpp,hpp}` because it is needed by both analyses, but ideally it should live somewhere even more general. It uses `NormalizeOutputs` however, which should also be moved somewhere more general.