### PR TITLE
Changed to using shared_ptr for types

### DIFF
--- a/jlm/mlir/frontend/MlirToJlmConverter.hpp
+++ b/jlm/mlir/frontend/MlirToJlmConverter.hpp
@@ -227,7 +227,7 @@ private:
    * \param type The MLIR type to be converted.
    * \result The converted RVSDG type.
    */
-  static std::unique_ptr<rvsdg::Type>
+  static std::shared_ptr<const rvsdg::Type>
   ConvertType(const ::mlir::Type & type);
 
   std::unique_ptr<::mlir::MLIRContext> Context_;


### PR DESCRIPTION
The MLIR frontend was creating unique_ptr when converting types. This has now been changed to shared_ptr<const rvsdg::Type>.