### PR TITLE
Enable specifying JLC for 'make check'

### DIFF
--- a/tests/Makefile.sub
+++ b/tests/Makefile.sub
@@ -54,7 +54,7 @@ JLC_COMPILE_TESTS = \
 $(patsubst %, $(BUILD_OUT_PREFIX)%.jlm, $(JLC_COMPILE_TESTS)): $(BUILD_OUT_PREFIX)%.jlm : %.c $(BUILD_OUT_PREFIX)jlc
 	@mkdir -p $(dir $@)
 	@cp $< $$(dirname $@)/$$(basename $<)
-	$(BUILD_OUT_PREFIX)jlc -Wall -Werror -O3 -o $@ $$(dirname $@)/$$(basename $<)
+	$(JLC) -Wall -Werror -O3 -o $@ $$(dirname $@)/$$(basename $<)
 
 GENERATED_FILES+=$(patsubst %, $(BUILD_OUT_PREFIX)%.jlm, $(JLC_COMPILE_TESTS))
 GENERATED_FILES+=$(patsubst %, $(BUILD_OUT_PREFIX)%.c, $(JLC_COMPILE_TESTS))

--- a/tests/Makefile.sub
+++ b/tests/Makefile.sub
@@ -1,3 +1,5 @@
+JLC ?= $(BUILD_OUT_PREFIX)jlc
+
 libjlmtest_SOURCES = \
 	tests/test-operation.cpp \
 	tests/test-registry.cpp \


### PR DESCRIPTION
The change makes it possible to pass in an alternative for compiling the tests by providing JLC= to the 'make check' target. This makes is possible to use the ./scripts/jlc-mlir-roundtrip.py to test the MLIR frontend and backend.