### PR TITLE
Add conversions of FMulAddIntrinsicOp to/from MLIR

### DIFF
--- a/jlm/mlir/backend/JlmToMlirConverter.cpp
+++ b/jlm/mlir/backend/JlmToMlirConverter.cpp
@@ -22,7 +22,9 @@
 #include <jlm/rvsdg/node.hpp>
 #include <jlm/rvsdg/traverser.hpp>
 #include <jlm/rvsdg/UnitType.hpp>
+
 #include <llvm/Support/raw_os_ostream.h>
+
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/Verifier.h>
@@ -668,11 +670,10 @@ JlmToMlirConverter::ConvertSimpleNode(
       mappingVector.push_back(matchRule);
     }
     //! The default alternative has an empty mapping
-    mappingVector.push_back(
-        ::mlir::rvsdg::MatchRuleAttr::get(
-            Builder_->getContext(),
-            ::llvm::ArrayRef<int64_t>(),
-            matchOp->default_alternative()));
+    mappingVector.push_back(::mlir::rvsdg::MatchRuleAttr::get(
+        Builder_->getContext(),
+        ::llvm::ArrayRef<int64_t>(),
+        matchOp->default_alternative()));
     // ** endregion Create the MLIR mapping vector **
 
     MlirOp = Builder_->create<::mlir::rvsdg::Match>(
@@ -814,9 +815,8 @@ JlmToMlirConverter::ConvertLambda(
   attributes.push_back(symbolName);
   auto linkage = Builder_->getNamedAttr(
       Builder_->getStringAttr("linkage"),
-      Builder_->getStringAttr(
-          llvm::ToString(
-              dynamic_cast<llvm::LlvmLambdaOperation &>(lambdaNode.GetOperation()).linkage())));
+      Builder_->getStringAttr(llvm::ToString(
+          dynamic_cast<llvm::LlvmLambdaOperation &>(lambdaNode.GetOperation()).linkage())));
   attributes.push_back(linkage);
 
   auto lambda = Builder_->create<::mlir::rvsdg::LambdaNode>(

--- a/jlm/mlir/frontend/MlirToJlmConverter.cpp
+++ b/jlm/mlir/frontend/MlirToJlmConverter.cpp
@@ -4,29 +4,22 @@
  * See COPYING for terms of redistribution.
  */
 
-#include <jlm/mlir/frontend/MlirToJlmConverter.hpp>
-#include <jlm/mlir/MLIRConverterCommon.hpp>
-
-#include <llvm/Support/raw_os_ostream.h>
-#include <mlir/Parser/Parser.h>
-#include <mlir/Transforms/TopologicalSortUtils.h>
-
-#include <jlm/llvm/ir/operators/sext.hpp>
-#include <jlm/rvsdg/bitstring/arithmetic.hpp>
-#include <jlm/rvsdg/bitstring/comparison.hpp>
-#include <jlm/rvsdg/bitstring/constant.hpp>
-
-#include <jlm/llvm/ir/operators/operators.hpp>
-
 #include <jlm/llvm/ir/operators/alloca.hpp>
 #include <jlm/llvm/ir/operators/call.hpp>
 #include <jlm/llvm/ir/operators/GetElementPtr.hpp>
+#include <jlm/llvm/ir/operators/IntegerOperations.hpp>
 #include <jlm/llvm/ir/operators/IOBarrier.hpp>
 #include <jlm/llvm/ir/operators/Load.hpp>
 #include <jlm/llvm/ir/operators/MemoryStateOperations.hpp>
+#include <jlm/llvm/ir/operators/operators.hpp>
+#include <jlm/llvm/ir/operators/sext.hpp>
+#include <jlm/llvm/ir/operators/SpecializedArithmeticIntrinsicOperations.hpp>
 #include <jlm/llvm/ir/operators/Store.hpp>
-
-#include <jlm/llvm/ir/operators/IntegerOperations.hpp>
+#include <jlm/mlir/frontend/MlirToJlmConverter.hpp>
+#include <jlm/mlir/MLIRConverterCommon.hpp>
+#include <jlm/rvsdg/bitstring/constant.hpp>
+#include <mlir/Parser/Parser.h>
+#include <mlir/Transforms/TopologicalSortUtils.h>
 
 namespace jlm::mlir
 {
@@ -420,6 +413,13 @@ MlirToJlmConverter::ConvertOperation(
   {
     return rvsdg::outputs(convertedFloatBinaryNode);
   }
+
+  if (::mlir::isa<::mlir::LLVM::FMulAddOp>(&mlirOperation))
+  {
+    JLM_ASSERT(inputs.size() == 3);
+    return rvsdg::outputs(
+        &llvm::FMulAddIntrinsicOperation::CreateNode(*inputs[0], *inputs[1], *inputs[2]));
+  }
   // ** endregion Arithmetic Float Operation **
 
   if (auto castedOp = ::mlir::dyn_cast<::mlir::arith::ExtUIOp>(&mlirOperation))
@@ -689,10 +689,6 @@ MlirToJlmConverter::ConvertOperation(
     return rvsdg::outputs(&rvsdg::CreateOpNode<llvm::IOBarrierOperation>(
         std::vector(inputs.begin(), inputs.end()),
         ConvertType(type)));
-  }
-  else if (auto MallocOp = ::mlir::dyn_cast<::mlir::jlm::Malloc>(&mlirOperation))
-  {
-    return jlm::llvm::MallocOperation::create(inputs[0]);
   }
   else if (auto StoreOp = ::mlir::dyn_cast<::mlir::jlm::Store>(&mlirOperation))
   {

--- a/jlm/tooling/Makefile.sub
+++ b/jlm/tooling/Makefile.sub
@@ -58,8 +58,8 @@ libtooling_TESTS = \
 libtooling_TEST_LIBS = \
     libtooling \
     libhls \
-    libllvm \
     libmlir \
+    libllvm \
     librvsdg \
     libutil \
     libjlmtest \

--- a/tests/jlm/mlir/TestJlmToMlirToJlm.cpp
+++ b/tests/jlm/mlir/TestJlmToMlirToJlm.cpp
@@ -688,9 +688,17 @@ TestFMulAddOp()
     auto convertedLambda =
         jlm::util::AssertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
     assert(convertedLambda->subregion()->nnodes() == 1);
+    const auto arguments = convertedLambda->GetFunctionArguments();
+    const auto results = convertedLambda->GetFunctionResults();
+    assert(arguments.size() == 3);
+    assert(results.size() == 1);
 
     auto & convertedNode = *convertedLambda->subregion()->Nodes().begin();
     assert(is<jlm::llvm::FMulAddIntrinsicOperation>(&convertedNode));
+    assert(convertedNode.input(0)->origin() == arguments[0]);
+    assert(convertedNode.input(1)->origin() == arguments[1]);
+    assert(convertedNode.input(2)->origin() == arguments[2]);
+    assert(results[0]->origin() == convertedNode.output(0));
   }
 }
 JLM_UNIT_TEST_REGISTER("jlm/mlir/TestMlirFMulAddOp", TestFMulAddOp)

--- a/tests/jlm/mlir/TestJlmToMlirToJlm.cpp
+++ b/tests/jlm/mlir/TestJlmToMlirToJlm.cpp
@@ -3,14 +3,13 @@
  * See COPYING for terms of redistribution.
  */
 
-#include "jlm/llvm/ir/operators/SpecializedArithmeticIntrinsicOperations.hpp"
 #include <test-registry.hpp>
 #include <TestRvsdgs.hpp>
 
 #include <jlm/llvm/ir/operators/IOBarrier.hpp>
+#include <jlm/llvm/ir/operators/SpecializedArithmeticIntrinsicOperations.hpp>
 #include <jlm/mlir/backend/JlmToMlirConverter.hpp>
 #include <jlm/mlir/frontend/MlirToJlmConverter.hpp>
-#include <jlm/rvsdg/traverser.hpp>
 
 static void
 TestUndef()

--- a/tests/jlm/mlir/TestJlmToMlirToJlm.cpp
+++ b/tests/jlm/mlir/TestJlmToMlirToJlm.cpp
@@ -238,9 +238,8 @@ TestLoad()
       assert(is<jlm::rvsdg::LambdaOperation>(convertedLambda));
 
       assert(convertedLambda->subregion()->nnodes() == 1);
-      assert(
-          is<LoadNonVolatileOperation>(
-              convertedLambda->subregion()->Nodes().begin()->GetOperation()));
+      assert(is<LoadNonVolatileOperation>(
+          convertedLambda->subregion()->Nodes().begin()->GetOperation()));
       auto convertedLoad = convertedLambda->subregion()->Nodes().begin().ptr();
       auto loadOperation =
           dynamic_cast<const LoadNonVolatileOperation *>(&convertedLoad->GetOperation());
@@ -335,9 +334,8 @@ TestStore()
       assert(is<jlm::rvsdg::LambdaOperation>(convertedLambda));
 
       assert(convertedLambda->subregion()->nnodes() == 1);
-      assert(
-          is<StoreNonVolatileOperation>(
-              convertedLambda->subregion()->Nodes().begin()->GetOperation()));
+      assert(is<StoreNonVolatileOperation>(
+          convertedLambda->subregion()->Nodes().begin()->GetOperation()));
       auto convertedStore = convertedLambda->subregion()->Nodes().begin().ptr();
       auto convertedStoreOperation =
           dynamic_cast<const StoreNonVolatileOperation *>(&convertedStore->GetOperation());

--- a/tools/Makefile.sub
+++ b/tools/Makefile.sub
@@ -7,8 +7,8 @@ jlc_SOURCES = \
 
 jlc_LIBS += \
 	libtooling \
-	libllvm \
 	libmlir \
+	libllvm \
 	librvsdg \
 	libutil \
 
@@ -23,8 +23,8 @@ jlm-opt_SOURCES = \
 
 jlm-opt_LIBS = \
 	libtooling \
-	libllvm \
 	libmlir \
+	libllvm \
 	librvsdg \
 	libutil \
 

--- a/tools/jhls/Makefile.sub
+++ b/tools/jhls/Makefile.sub
@@ -8,8 +8,8 @@ jhls_SOURCES = \
 jhls_LIBS = \
 	libtooling \
 	libhls \
-	libllvm \
 	libmlir \
+	libllvm \
 	librvsdg \
 	libutil \
 


### PR DESCRIPTION
We have previously linked together tests and tools (`jlm-opt`, `jlc`) with `libllvm.a` in front of `libmlir.a`.

This has for some reason worked perfectly fine before, and I have no idea why it suddenly stopped working, as the conversions I added are pretty much identical to existing conversions, and your class looks just like other operations.

However, I got a lot of "undefined reference to typeinfo for FMulAddIntrinsicOperation", "undefined reference to vtable for FMulAddIntrinsicOperation"

To appease the linker, I had to place the dependency (`libllvm.a`) after the dependant (`libmlir.a`). This is something I have previously had to do with `-l` libraries, but apparently it can also be necessary for regular input files... I wish I understood better. Do you know anything about this @caleridas?