### PR TITLE
Add IsOwnerNodeOperation and make use of it

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/check-rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/check-rhls.cpp
@@ -20,9 +20,8 @@ CheckAddrQueue(rvsdg::Node * node)
   JLM_ASSERT(rvsdg::is<AddressQueueOperation>(node));
   // Ensure that there is no buffer between state_gate and addr_queue enq.
   // This is SG1 in the paper. Otherwise, there might be a race condition in the disambiguation
-  auto [_, stateGateOperation] = rvsdg::TryGetSimpleNodeAndOptionalOp<StateGateOperation>(
-      *FindSourceNode(node->input(1)->origin()));
-  JLM_ASSERT(stateGateOperation);
+  JLM_ASSERT(
+      rvsdg::IsOwnerNodeOperation<StateGateOperation>(*FindSourceNode(node->input(1)->origin())));
   // make sure there is enough buffer space on the output, so there can be no race condition with
   // SG3
   auto [bufferNode, bufferOperation] =

--- a/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
@@ -83,11 +83,8 @@ TraceEdgeToMerge(rvsdg::Input * state_edge)
       state_edge = get_mem_state_user(sn->output(0));
     }
     else if (
-        std::get<1>(
-            rvsdg::TryGetSimpleNodeAndOptionalOp<llvm::MemoryStateMergeOperation>(*state_edge))
-        || std::get<1>(
-            rvsdg::TryGetSimpleNodeAndOptionalOp<llvm::LambdaExitMemoryStateMergeOperation>(
-                *state_edge)))
+        rvsdg::IsOwnerNodeOperation<llvm::MemoryStateMergeOperation>(*state_edge)
+        || rvsdg::IsOwnerNodeOperation<llvm::LambdaExitMemoryStateMergeOperation>(*state_edge))
     {
       return { state_edge, encountered_muxes };
     }

--- a/jlm/hls/backend/rvsdg2rhls/mem-queue.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-queue.cpp
@@ -3,12 +3,10 @@
  * See COPYING for terms of redistribution.
  */
 
-#include "../../../rvsdg/node.hpp"
 #include <jlm/hls/backend/rvsdg2rhls/decouple-mem-state.hpp>
 #include <jlm/hls/backend/rvsdg2rhls/hls-function-util.hpp>
 #include <jlm/hls/backend/rvsdg2rhls/mem-conv.hpp>
 #include <jlm/hls/backend/rvsdg2rhls/mem-queue.hpp>
-#include <jlm/hls/backend/rvsdg2rhls/mem-sep.hpp>
 #include <jlm/hls/ir/hls.hpp>
 #include <jlm/llvm/ir/LambdaMemoryState.hpp>
 #include <jlm/llvm/ir/operators/call.hpp>
@@ -16,12 +14,10 @@
 #include <jlm/llvm/ir/operators/Load.hpp>
 #include <jlm/llvm/ir/operators/MemoryStateOperations.hpp>
 #include <jlm/llvm/ir/operators/Store.hpp>
-#include <jlm/rvsdg/substitution.hpp>
+#include <jlm/rvsdg/node.hpp>
 #include <jlm/rvsdg/theta.hpp>
-#include <jlm/rvsdg/traverser.hpp>
 #include <jlm/rvsdg/view.hpp>
 
-#include "jlm/hls/util/view.hpp"
 #include <deque>
 
 void

--- a/jlm/hls/backend/rvsdg2rhls/mem-queue.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-queue.cpp
@@ -3,6 +3,7 @@
  * See COPYING for terms of redistribution.
  */
 
+#include "../../../rvsdg/node.hpp"
 #include <jlm/hls/backend/rvsdg2rhls/decouple-mem-state.hpp>
 #include <jlm/hls/backend/rvsdg2rhls/hls-function-util.hpp>
 #include <jlm/hls/backend/rvsdg2rhls/mem-conv.hpp>
@@ -247,9 +248,7 @@ separate_load_edge(
         else
         {
           // end of loop
-          auto [branchNode, branchOperation] =
-              jlm::rvsdg::TryGetSimpleNodeAndOptionalOp<jlm::hls::BranchOperation>(addr_edge_user);
-          JLM_ASSERT(branchNode && branchOperation);
+          JLM_ASSERT(jlm::rvsdg::IsOwnerNodeOperation<jlm::hls::BranchOperation>(addr_edge_user));
           return nullptr;
         }
       }

--- a/jlm/hls/backend/rvsdg2rhls/merge-gamma.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/merge-gamma.cpp
@@ -3,6 +3,7 @@
  * See COPYING for terms of redistribution.
  */
 
+#include "../../../util/common.hpp"
 #include <jlm/hls/backend/rvsdg2rhls/hls-function-util.hpp>
 #include <jlm/hls/backend/rvsdg2rhls/merge-gamma.hpp>
 #include <jlm/hls/ir/hls.hpp>
@@ -83,9 +84,7 @@ bit_type_to_ctl_type(rvsdg::GammaNode * old_gamma)
     for (size_t j = 0; j < old_gamma->nsubregions(); ++j)
     {
       auto origin = old_gamma->subregion(j)->result(i)->origin();
-      if (auto [_, op] =
-              rvsdg::TryGetSimpleNodeAndOptionalOp<llvm::IntegerConstantOperation>(*origin);
-          !op)
+      if (!rvsdg::IsOwnerNodeOperation<llvm::IntegerConstantOperation>(*origin))
       {
         all_bittype = false;
         break;
@@ -100,6 +99,7 @@ bit_type_to_ctl_type(rvsdg::GammaNode * old_gamma)
       auto origin = old_gamma->subregion(j)->result(i)->origin();
       auto [_, constantOperation] =
           rvsdg::TryGetSimpleNodeAndOptionalOp<llvm::IntegerConstantOperation>(*origin);
+      JLM_ASSERT(constantOperation);
       auto ctl_value = matchOperation->alternative(constantOperation->Representation().to_uint());
       auto no = rvsdg::ctlconstant_op::create(
           origin->region(),

--- a/jlm/hls/backend/rvsdg2rhls/merge-gamma.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/merge-gamma.cpp
@@ -3,7 +3,6 @@
  * See COPYING for terms of redistribution.
  */
 
-#include "../../../util/common.hpp"
 #include <jlm/hls/backend/rvsdg2rhls/hls-function-util.hpp>
 #include <jlm/hls/backend/rvsdg2rhls/merge-gamma.hpp>
 #include <jlm/hls/ir/hls.hpp>

--- a/jlm/hls/backend/rvsdg2rhls/remove-redundant-buf.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/remove-redundant-buf.cpp
@@ -70,22 +70,16 @@ RedundantBufferElimination::CanTraceToLoadOrStore(const rvsdg::Output & output)
 {
   JLM_ASSERT(rvsdg::is<llvm::MemoryStateType>(output.Type()));
 
-  auto [loadNode, loadOperation] = rvsdg::TryGetSimpleNodeAndOptionalOp<LoadOperation>(output);
-  if (loadNode && loadOperation)
+  if (rvsdg::IsOwnerNodeOperation<LoadOperation>(output))
     return true;
 
-  auto [localLoadNode, localLoadOperation] =
-      rvsdg::TryGetSimpleNodeAndOptionalOp<LocalLoadOperation>(output);
-  if (localLoadNode && localLoadOperation)
+  if (rvsdg::IsOwnerNodeOperation<LocalLoadOperation>(output))
     return true;
 
-  auto [storeNode, storeOperation] = rvsdg::TryGetSimpleNodeAndOptionalOp<StoreOperation>(output);
-  if (storeNode && storeOperation)
+  if (rvsdg::IsOwnerNodeOperation<StoreOperation>(output))
     return true;
 
-  auto [localStoreNode, localStoreOperation] =
-      rvsdg::TryGetSimpleNodeAndOptionalOp<LocalStoreOperation>(output);
-  if (localStoreNode && localStoreOperation)
+  if (rvsdg::IsOwnerNodeOperation<LocalStoreOperation>(output))
     return true;
 
   auto [forkNode, forkOperation] = rvsdg::TryGetSimpleNodeAndOptionalOp<ForkOperation>(output);

--- a/jlm/hls/backend/rvsdg2rhls/rhls-dne.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rhls-dne.cpp
@@ -343,8 +343,7 @@ fix_mem_split(rvsdg::Node * split_node)
     if (split_node->output(i)->IsDead())
       continue;
     auto user = get_mem_state_user(split_node->output(i));
-    if (auto [_, op] = rvsdg::TryGetSimpleNodeAndOptionalOp<llvm::MemoryStateSplitOperation>(*user);
-        op)
+    if (rvsdg::IsOwnerNodeOperation<llvm::MemoryStateSplitOperation>(*user))
     {
       auto sub_split = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(*user);
       for (size_t j = 0; j < sub_split->noutputs(); ++j)
@@ -387,9 +386,7 @@ fix_mem_merge(rvsdg::Node * merge_node)
   for (size_t i = 0; i < merge_node->ninputs(); ++i)
   {
     auto origin = merge_node->input(i)->origin();
-    if (auto [_, op] =
-            rvsdg::TryGetSimpleNodeAndOptionalOp<llvm::MemoryStateMergeOperation>(*origin);
-        op)
+    if (rvsdg::IsOwnerNodeOperation<llvm::MemoryStateMergeOperation>(*origin))
     {
       auto sub_merge = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(*origin);
       for (size_t j = 0; j < sub_merge->ninputs(); ++j)
@@ -397,9 +394,7 @@ fix_mem_merge(rvsdg::Node * merge_node)
         combined_origins.push_back(sub_merge->input(j)->origin());
       }
     }
-    else if (auto [_, op] =
-                 rvsdg::TryGetSimpleNodeAndOptionalOp<llvm::MemoryStateSplitOperation>(*origin);
-             op)
+    else if (rvsdg::IsOwnerNodeOperation<llvm::MemoryStateSplitOperation>(*origin))
     {
       // ensure that there is only one direct connection to a split.
       // We need to keep one, so that the optimizations for decouple edges work

--- a/jlm/llvm/ir/operators/Load.cpp
+++ b/jlm/llvm/ir/operators/Load.cpp
@@ -57,12 +57,7 @@ is_load_mux_reducible(const std::vector<rvsdg::Output *> & operands)
   if (operands.size() != 2)
     return false;
 
-  auto [_, memStateMergeOperation] =
-      rvsdg::TryGetSimpleNodeAndOptionalOp<MemoryStateMergeOperation>(*operands[1]);
-  if (!memStateMergeOperation)
-    return false;
-
-  return true;
+  return rvsdg::IsOwnerNodeOperation<MemoryStateMergeOperation>(*operands[1]);
 }
 
 /*
@@ -493,9 +488,7 @@ LoadNonVolatileOperation::NormalizeIOBarrierAllocaAddress(
     return std::nullopt;
 
   const auto barredAddress = IOBarrierOperation::BarredInput(*ioBarrierNode).origin();
-  auto [allocaNode, allocaOperation] =
-      rvsdg::TryGetSimpleNodeAndOptionalOp<AllocaOperation>(*barredAddress);
-  if (!allocaOperation)
+  if (!rvsdg::IsOwnerNodeOperation<AllocaOperation>(*barredAddress))
     return std::nullopt;
 
   auto & loadNode = CreateNode(

--- a/jlm/llvm/ir/operators/MemoryStateOperations.cpp
+++ b/jlm/llvm/ir/operators/MemoryStateOperations.cpp
@@ -405,8 +405,7 @@ LambdaExitMemoryStateMergeOperation::NormalizeLoadFromAlloca(
     }
 
     auto loadAddress = LoadOperation::AddressInput(*loadNode).origin();
-    auto [_, allocaOperation] = rvsdg::TryGetSimpleNodeAndOptionalOp<AllocaOperation>(*loadAddress);
-    if (!allocaOperation)
+    if (!rvsdg::IsOwnerNodeOperation<AllocaOperation>(*loadAddress))
     {
       newOperands.push_back(operand);
       continue;
@@ -446,9 +445,7 @@ LambdaExitMemoryStateMergeOperation::NormalizeStoreToAlloca(
     }
 
     auto storeAddress = StoreOperation::AddressInput(*storeNode).origin();
-    auto [_, allocaOperation] =
-        rvsdg::TryGetSimpleNodeAndOptionalOp<AllocaOperation>(*storeAddress);
-    if (!allocaOperation)
+    if (!rvsdg::IsOwnerNodeOperation<AllocaOperation>(*storeAddress))
     {
       newOperands.push_back(operand);
       continue;

--- a/jlm/llvm/ir/operators/Store.cpp
+++ b/jlm/llvm/ir/operators/Store.cpp
@@ -255,9 +255,7 @@ StoreNonVolatileOperation::NormalizeIOBarrierAllocaAddress(
     return std::nullopt;
 
   const auto barredAddress = IOBarrierOperation::BarredInput(*ioBarrierNode).origin();
-  auto [allocaNode, allocaOperation] =
-      rvsdg::TryGetSimpleNodeAndOptionalOp<AllocaOperation>(*barredAddress);
-  if (!allocaOperation)
+  if (!rvsdg::IsOwnerNodeOperation<AllocaOperation>(*barredAddress))
     return std::nullopt;
 
   auto & storeNode = CreateNode(

--- a/jlm/llvm/ir/operators/operators.cpp
+++ b/jlm/llvm/ir/operators/operators.cpp
@@ -394,9 +394,7 @@ rvsdg::unop_reduction_path_t
 ZExtOperation::can_reduce_operand(const rvsdg::Output * operand) const noexcept
 {
   auto & tracedOperand = rvsdg::TraceOutputIntraProcedurally(*operand);
-  auto [_, constantOperation] =
-      rvsdg::TryGetSimpleNodeAndOptionalOp<rvsdg::bitconstant_op>(tracedOperand);
-  if (constantOperation)
+  if (rvsdg::IsOwnerNodeOperation<rvsdg::bitconstant_op>(tracedOperand))
     return rvsdg::unop_reduction_constant;
 
   return rvsdg::unop_reduction_none;

--- a/jlm/llvm/ir/operators/sext.cpp
+++ b/jlm/llvm/ir/operators/sext.cpp
@@ -98,9 +98,7 @@ rvsdg::unop_reduction_path_t
 SExtOperation::can_reduce_operand(const rvsdg::Output * operand) const noexcept
 {
   auto & tracedOutput = rvsdg::TraceOutputIntraProcedurally(*operand);
-  auto [constantNode, constantOperation] =
-      rvsdg::TryGetSimpleNodeAndOptionalOp<rvsdg::bitconstant_op>(tracedOutput);
-  if (constantNode && constantOperation)
+  if (rvsdg::IsOwnerNodeOperation<rvsdg::bitconstant_op>(tracedOutput))
     return rvsdg::unop_reduction_constant;
 
   if (is_bitunary_reducible(operand))

--- a/jlm/llvm/opt/alias-analyses/LocalAliasAnalysis.cpp
+++ b/jlm/llvm/opt/alias-analyses/LocalAliasAnalysis.cpp
@@ -388,9 +388,7 @@ LocalAliasAnalysis::TraceAllPointerOrigins(TracedPointerOrigin p, TraceCollectio
   }
 
   // If we reach undef nodes, do not include them in the TopOrigins
-  if (const auto [node, undef] =
-          rvsdg::TryGetSimpleNodeAndOptionalOp<UndefValueOperation>(*p.BasePointer);
-      undef)
+  if (rvsdg::IsOwnerNodeOperation<UndefValueOperation>(*p.BasePointer))
   {
     return true;
   }
@@ -624,8 +622,7 @@ bool
 LocalAliasAnalysis::IsOriginalOriginFullyTraceable(const rvsdg::Output & pointer)
 {
   // The only original origins that can be fully traced for escaping are ALLOCAs
-  if (const auto [_, allocaOp] = rvsdg::TryGetSimpleNodeAndOptionalOp<AllocaOperation>(pointer);
-      !allocaOp)
+  if (!rvsdg::IsOwnerNodeOperation<AllocaOperation>(pointer))
     return false;
 
   // Check if the result for this ALLOCA is already memoized

--- a/jlm/rvsdg/bitstring/bitoperation-classes.cpp
+++ b/jlm/rvsdg/bitstring/bitoperation-classes.cpp
@@ -16,8 +16,7 @@ unop_reduction_path_t
 BitUnaryOperation::can_reduce_operand(const jlm::rvsdg::Output * arg) const noexcept
 {
   auto & tracedOperand = TraceOutputIntraProcedurally(*arg);
-  auto [_, constantOperation] = rvsdg::TryGetSimpleNodeAndOptionalOp<bitconstant_op>(tracedOperand);
-  if (constantOperation)
+  if (rvsdg::IsOwnerNodeOperation<bitconstant_op>(tracedOperand))
     return unop_reduction_constant;
 
   return unop_reduction_none;
@@ -45,13 +44,10 @@ BitBinaryOperation::can_reduce_operand_pair(
     const jlm::rvsdg::Output * arg2) const noexcept
 {
   auto & tracedOperand1 = TraceOutputIntraProcedurally(*arg1);
-  auto [constantNode1, constantOperation1] =
-      rvsdg::TryGetSimpleNodeAndOptionalOp<bitconstant_op>(tracedOperand1);
   auto & tracedOperand2 = TraceOutputIntraProcedurally(*arg2);
-  auto [constantNode2, constantOperation2] =
-      rvsdg::TryGetSimpleNodeAndOptionalOp<bitconstant_op>(tracedOperand2);
 
-  if (constantOperation1 && constantOperation2)
+  if (rvsdg::IsOwnerNodeOperation<bitconstant_op>(tracedOperand1)
+      && rvsdg::IsOwnerNodeOperation<bitconstant_op>(tracedOperand2))
     return binop_reduction_constants;
 
   return binop_reduction_none;

--- a/jlm/rvsdg/control.cpp
+++ b/jlm/rvsdg/control.cpp
@@ -108,8 +108,7 @@ unop_reduction_path_t
 MatchOperation::can_reduce_operand(const jlm::rvsdg::Output * arg) const noexcept
 {
   auto & tracedOutput = TraceOutputIntraProcedurally(*arg);
-  auto [_, constantOperation] = TryGetSimpleNodeAndOptionalOp<bitconstant_op>(tracedOutput);
-  if (constantOperation)
+  if (rvsdg::IsOwnerNodeOperation<bitconstant_op>(tracedOutput))
     return unop_reduction_constant;
 
   return unop_reduction_none;

--- a/jlm/rvsdg/node.hpp
+++ b/jlm/rvsdg/node.hpp
@@ -800,6 +800,28 @@ private:
 };
 
 /**
+ * \brief Checks if the given node is not null, and has an operation of the specified type.
+ *
+ * \tparam OperationType
+ *   The subclass of operation to check for.
+ *
+ * \param node
+ *   The node being checked.
+ *
+ * \returns
+ *   true if node has an operation that is an instance of the specified type, otherwise false.
+ */
+template<class OperationType>
+inline bool
+is(const Node * node) noexcept
+{
+  if (!node)
+    return false;
+
+  return is<OperationType>(node->GetOperation());
+}
+
+/**
  * \brief Checks if this is an input to a node of specified type.
  *
  * \tparam NodeType
@@ -929,6 +951,46 @@ AssertGetOwnerNode(const rvsdg::Output & output)
   return *node;
 }
 
+/**
+ * \brief Checks if the input belongs to a node of the specified operation type.
+ *
+ * \tparam OperationType
+ *   The subclass of Operation to check for.
+ *
+ * \param input
+ *   The output being checked.
+ *
+ * \returns
+ *   True if the input is owned by a node, whose operation is an instance of the specified type.
+ *   Otherwise, false.
+ */
+template<typename OperationType>
+bool
+IsOwnerNodeOperation(const rvsdg::Input & input) noexcept
+{
+  return is<OperationType>(TryGetOwnerNode<Node>(input));
+}
+
+/**
+ * \brief Checks if the output belongs to a node of the specified operation type.
+ *
+ * \tparam OperationType
+ *   The subclass of Operation to check for.
+ *
+ * \param output
+ *   The output being checked.
+ *
+ * \returns
+ *   True if the output is owned by a node, whose operation is an instance of the specified type.
+ *   Otherwise, false.
+ */
+template<typename OperationType>
+bool
+IsOwnerNodeOperation(const rvsdg::Output & output) noexcept
+{
+  return is<OperationType>(TryGetOwnerNode<Node>(output));
+}
+
 inline Region *
 TryGetOwnerRegion(const rvsdg::Input & input) noexcept
 {
@@ -982,16 +1044,6 @@ divert_users(Node * node, const std::vector<Output *> & outputs)
 
   for (size_t n = 0; n < outputs.size(); n++)
     node->output(n)->divert_users(outputs[n]);
-}
-
-template<class T>
-static inline bool
-is(const Node * node) noexcept
-{
-  if (!node)
-    return false;
-
-  return is<T>(node->GetOperation());
 }
 
 /**

--- a/tests/jlm/hls/backend/rvsdg2rhls/DistributeConstantsTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/DistributeConstantsTests.cpp
@@ -71,26 +71,19 @@ GammaSubregionUsage()
   {
     // check subregion 0 - we expect the constantNode to be distributed into this subregion
     assert(gammaNode->subregion(0)->nnodes() == 2);
-    auto [constantNode, constantOperation] =
-        TryGetSimpleNodeAndOptionalOp<IntegerConstantOperation>(*testNode0->input(0)->origin());
-    assert(constantNode && constantOperation);
+    assert(IsOwnerNodeOperation<IntegerConstantOperation>(*testNode0->input(0)->origin()));
   }
 
   {
     // check subregion 1 - we expect the constantNode to be distributed into this subregion
     assert(gammaNode->subregion(1)->nnodes() == 2);
-    auto [constantNode, constantOperation] =
-        TryGetSimpleNodeAndOptionalOp<IntegerConstantOperation>(*testNode1->input(0)->origin());
-    assert(constantNode && constantOperation);
+    assert(IsOwnerNodeOperation<IntegerConstantOperation>(*testNode1->input(0)->origin()));
   }
 
   {
     // check subregion 2 - we expect the constantNode to be distributed into this subregion
     assert(gammaNode->subregion(2)->nnodes() == 1);
-    auto [constantNode, constantOperation] =
-        TryGetSimpleNodeAndOptionalOp<IntegerConstantOperation>(
-            *exitVariable.branchResult[2]->origin());
-    assert(constantNode && constantOperation);
+    assert(IsOwnerNodeOperation<IntegerConstantOperation>(*exitVariable.branchResult[2]->origin()));
   }
 }
 
@@ -160,9 +153,7 @@ NestedGammas()
   {
     // check gammaNodeOuter subregion 0
     assert(gammaNodeOuter->subregion(0)->nnodes() == 2);
-    auto [constantNode, constantOperation] =
-        TryGetSimpleNodeAndOptionalOp<IntegerConstantOperation>(*testNode0->input(0)->origin());
-    assert(constantNode && constantOperation);
+    assert(IsOwnerNodeOperation<IntegerConstantOperation>(*testNode0->input(0)->origin()));
   }
 
   {
@@ -174,19 +165,15 @@ NestedGammas()
     {
       // check gammaNodeInner subregion 0
       assert(gammaNodeInner->subregion(0)->nnodes() == 1);
-      auto [constantNode, constantOperation] =
-          TryGetSimpleNodeAndOptionalOp<IntegerConstantOperation>(
-              *exitVariableInner.branchResult[0]->origin());
-      assert(constantNode && constantOperation);
+      assert(IsOwnerNodeOperation<IntegerConstantOperation>(
+          *exitVariableInner.branchResult[0]->origin()));
     }
 
     {
       // check gammaNodeInner subregion 1
       assert(gammaNodeInner->subregion(1)->nnodes() == 1);
-      auto [constantNode, constantOperation] =
-          TryGetSimpleNodeAndOptionalOp<IntegerConstantOperation>(
-              *exitVariableInner.branchResult[1]->origin());
-      assert(constantNode && constantOperation);
+      assert(IsOwnerNodeOperation<IntegerConstantOperation>(
+          *exitVariableInner.branchResult[1]->origin()));
     }
   }
 

--- a/tests/jlm/hls/backend/rvsdg2rhls/MemoryStateSplitConversionTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/MemoryStateSplitConversionTests.cpp
@@ -62,17 +62,13 @@ SplitConversion()
   // LambdaEntryMemoryStateSplitOperation node with a ForkOperation node
   {
     assert(outputVar0.output->nusers() == 1);
-    auto [forkNode, forkOperation] =
-        TryGetSimpleNodeAndOptionalOp<ForkOperation>(*inputVar.argument[0]->Users().begin());
-    assert(forkNode && forkOperation);
+    assert(IsOwnerNodeOperation<ForkOperation>(*inputVar.argument[0]->Users().begin()));
   }
 
   // The memory state split conversion pass should have replaced the
   // MemoryStateSplitOperation node with a ForkOperation node
   {
-    auto [forkNode, forkOperation] =
-        TryGetSimpleNodeAndOptionalOp<ForkOperation>(*importY.Users().begin());
-    assert(forkNode && forkOperation);
+    assert(IsOwnerNodeOperation<ForkOperation>(*importY.Users().begin()));
   }
 }
 

--- a/tests/jlm/hls/backend/rvsdg2rhls/SinkInsertionTests.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/SinkInsertionTests.cpp
@@ -59,18 +59,14 @@ SinkInsertion()
   // The sink insertion pass should have inserted a SinkOperation node at output o0
   {
     assert(outputVar0.output->nusers() == 1);
-    auto [sinkNode, sinkOperation] =
-        TryGetSimpleNodeAndOptionalOp<SinkOperation>(*outputVar0.output->Users().begin());
-    assert(sinkNode && sinkOperation);
+    assert(IsOwnerNodeOperation<SinkOperation>(*outputVar0.output->Users().begin()));
   }
 
   // The sink insertion pass should have inserted a SinkOperation node at the argument of i0
   {
     auto & i0Argument = *inputVar0.argument[0];
     assert(i0Argument.nusers() == 1);
-    auto [sinkNode, sinkOperation] =
-        TryGetSimpleNodeAndOptionalOp<SinkOperation>(*i0Argument.Users().begin());
-    assert(sinkNode && sinkOperation);
+    assert(IsOwnerNodeOperation<SinkOperation>(*i0Argument.Users().begin()));
   }
 }
 

--- a/tests/jlm/hls/backend/rvsdg2rhls/TestTheta.cpp
+++ b/tests/jlm/hls/backend/rvsdg2rhls/TestTheta.cpp
@@ -59,16 +59,12 @@ TestUnknownBoundaries()
   auto & loopNode =
       jlm::rvsdg::AssertGetOwnerNode<LoopNode>(lambdaRegion->argument(0)->SingleUser());
   {
-    auto [bufferNode, bufferOperation] =
-        jlm::rvsdg::TryGetSimpleNodeAndOptionalOp<LoopConstantBufferOperation>(
-            loopNode.subregion()->argument(3)->SingleUser());
-    assert(bufferNode && bufferOperation);
+    assert(jlm::rvsdg::IsOwnerNodeOperation<LoopConstantBufferOperation>(
+        loopNode.subregion()->argument(3)->SingleUser()));
   }
   {
-    auto [bufferNode, bufferOperation] =
-        jlm::rvsdg::TryGetSimpleNodeAndOptionalOp<LoopConstantBufferOperation>(
-            loopNode.subregion()->argument(4)->SingleUser());
-    assert(bufferNode && bufferOperation);
+    assert(jlm::rvsdg::IsOwnerNodeOperation<LoopConstantBufferOperation>(
+        loopNode.subregion()->argument(4)->SingleUser()));
   }
 }
 


### PR DESCRIPTION
As talked about previously, many calls to `TryGetSimpleNodeAndOptionalOp` were only used to check the type of the operation. This function does it directly.

I searched for all `TryGetSimpleNodeAndOptionalOp` and replaced when applicable