### PR TITLE
Overhaul NormalizeLoadMux reduction

### DIFF
--- a/jlm/llvm/ir/operators/Load.cpp
+++ b/jlm/llvm/ir/operators/Load.cpp
@@ -37,30 +37,6 @@ LoadNonVolatileOperation::copy() const
 }
 
 /*
-  sx1 = MemStateMerge si1 ... siM
-  v sl1 = load_op a sx1
-  =>
-  v sl1 ... slM = load_op a si1 ... siM
-  sx1 = MemStateMerge sl1 ... slM
-
-  FIXME: The reduction can be generalized: A load node can have multiple operands from different
-  merge nodes.
-*/
-static bool
-is_load_mux_reducible(const std::vector<rvsdg::Output *> & operands)
-{
-  // Ignore loads that have no state edge.
-  // This can happen when the compiler can statically show that the address of a load is NULL.
-  if (operands.size() == 1)
-    return false;
-
-  if (operands.size() != 2)
-    return false;
-
-  return rvsdg::IsOwnerNodeOperation<MemoryStateMergeOperation>(*operands[1]);
-}
-
-/*
   If the producer of a load's address is an alloca, then we can remove
   all state edges originating from other allocas.
 
@@ -238,25 +214,6 @@ perform_load_store_reduction(
 }
 
 static std::vector<rvsdg::Output *>
-perform_load_mux_reduction(
-    const LoadNonVolatileOperation & op,
-    const std::vector<rvsdg::Output *> & operands)
-{
-  const auto memStateMergeNode = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(*operands[1]);
-
-  auto ld = LoadNonVolatileOperation::Create(
-      operands[0],
-      rvsdg::operands(memStateMergeNode),
-      op.GetLoadedType(),
-      op.GetAlignment());
-
-  std::vector<rvsdg::Output *> states = { std::next(ld.begin()), ld.end() };
-  auto mx = MemoryStateMergeOperation::Create(states);
-
-  return { ld[0], mx };
-}
-
-static std::vector<rvsdg::Output *>
 perform_load_alloca_reduction(
     const LoadNonVolatileOperation & op,
     const std::vector<rvsdg::Output *> & operands)
@@ -361,14 +318,65 @@ perform_multiple_origin_reduction(
 }
 
 std::optional<std::vector<rvsdg::Output *>>
-LoadNonVolatileOperation::NormalizeLoadMux(
+LoadNonVolatileOperation::NormalizeLoadMemoryStateMerge(
     const LoadNonVolatileOperation & operation,
     const std::vector<rvsdg::Output *> & operands)
 {
-  if (is_load_mux_reducible(operands))
-    return perform_load_mux_reduction(operation, operands);
+  auto & address = *operands[0];
+  const auto oldLoadMemoryStates = std::vector(std::next(operands.begin()), operands.end());
 
-  return std::nullopt;
+  bool foundMemoryStateMergeOperation = false;
+  std::vector<rvsdg::Output *> newLoadMemoryStates;
+  for (const auto memoryState : oldLoadMemoryStates)
+  {
+    auto [memoryStateMergeNode, memoryStateMergeOperation] =
+        rvsdg::TryGetSimpleNodeAndOptionalOp<MemoryStateMergeOperation>(*memoryState);
+    if (memoryStateMergeOperation)
+    {
+      foundMemoryStateMergeOperation = true;
+      auto memoryStateMergeOperands = rvsdg::operands(memoryStateMergeNode);
+      newLoadMemoryStates.insert(
+          newLoadMemoryStates.end(),
+          memoryStateMergeOperands.begin(),
+          memoryStateMergeOperands.end());
+    }
+    else
+    {
+      newLoadMemoryStates.push_back(memoryState);
+    }
+  }
+  if (!foundMemoryStateMergeOperation)
+    return std::nullopt;
+
+  auto & newLoadNode =
+      CreateNode(address, newLoadMemoryStates, operation.GetLoadedType(), operation.GetAlignment());
+
+  size_t newMemoryStateResultIndex = 1;
+  std::vector<rvsdg::Output *> results;
+  results.push_back(&LoadedValueOutput(newLoadNode));
+  for (auto & oldMemoryStateOperand : oldLoadMemoryStates)
+  {
+    auto [memoryStateMergeNode, memoryStateMergeOperation] =
+        rvsdg::TryGetSimpleNodeAndOptionalOp<MemoryStateMergeOperation>(*oldMemoryStateOperand);
+    if (memoryStateMergeOperation)
+    {
+      size_t numMemoryStates = memoryStateMergeNode->ninputs();
+      auto memoryStateMergeOperands =
+          rvsdg::Outputs(newLoadNode, newMemoryStateResultIndex, numMemoryStates);
+      const auto result = MemoryStateMergeOperation::CreateNode(memoryStateMergeOperands).output(0);
+      results.push_back(result);
+      newMemoryStateResultIndex += numMemoryStates;
+    }
+    else
+    {
+      results.push_back(newLoadNode.output(newMemoryStateResultIndex));
+      newMemoryStateResultIndex++;
+    }
+
+    JLM_ASSERT(newMemoryStateResultIndex <= newLoadNode.noutputs());
+  }
+
+  return results;
 }
 
 std::optional<std::vector<rvsdg::Output *>>

--- a/jlm/llvm/ir/operators/Load.hpp
+++ b/jlm/llvm/ir/operators/Load.hpp
@@ -281,14 +281,11 @@ public:
    * v sl1 ... slM = LoadNonVolatileOperation a si1 ... siM
    * sx1 = MemStateMergeOperation sl1 ... slM
    *
-   * FIXME: The reduction can be generalized: A load node can have multiple operands from different
-   * merge nodes.
-   *
    * @return If the normalization could be applied, then the results of the load operation after
    * the transformation. Otherwise, std::nullopt.
    */
   static std::optional<std::vector<rvsdg::Output *>>
-  NormalizeLoadMux(
+  NormalizeLoadMemoryStateMerge(
       const LoadNonVolatileOperation & operation,
       const std::vector<rvsdg::Output *> & operands);
 

--- a/jlm/llvm/opt/reduction.cpp
+++ b/jlm/llvm/opt/reduction.cpp
@@ -246,7 +246,7 @@ NodeReduction::NormalizeLoadNode(
     const std::vector<rvsdg::Output *> & operands)
 {
   static std::vector<rvsdg::NodeNormalization<LoadNonVolatileOperation>> loadNodeNormalizations(
-      { LoadNonVolatileOperation::NormalizeLoadMux,
+      { LoadNonVolatileOperation::NormalizeLoadMemoryStateMerge,
         LoadNonVolatileOperation::NormalizeLoadStore,
         LoadNonVolatileOperation::NormalizeLoadAlloca,
         LoadNonVolatileOperation::NormalizeDuplicateStates,

--- a/jlm/rvsdg/node.hpp
+++ b/jlm/rvsdg/node.hpp
@@ -1051,6 +1051,29 @@ outputs(const Node * node)
   return outputs;
 }
 
+/**
+ * Returns a subset of the outputs from a node as a vector.
+ *
+ * @param node The node from which the outputs are taken.
+ * @param startIdx The index of the first output.
+ * @param size The number of outputs that are returned.
+ * @return A vector of outputs.
+ *
+ * \pre The \p startIdx + \p size must be smaller or equal than the number of outputs of \p node.
+ */
+static inline std::vector<Output *>
+Outputs(const Node & node, const size_t startIdx, const size_t size)
+{
+  JLM_ASSERT(startIdx + size <= node.noutputs());
+
+  std::vector<Output *> outputs;
+  for (size_t n = startIdx; n < startIdx + size; n++)
+    outputs.push_back(node.output(n));
+
+  JLM_ASSERT(outputs.size() == size);
+  return outputs;
+}
+
 static inline void
 divert_users(Node * node, const std::vector<Output *> & outputs)
 {


### PR DESCRIPTION
This PR does the following:

1. Renames the NormalizeLoadMux to the more descriptive name NormalizeLoadMemoryStateMerge
2. Adapts the reduction to the new reduction API interface
3. Generalizes the reduction such that it works for load nodes with multiple state inputs and multiple merge nodes as input