### PR TITLE
Add support for dumping RVSDGs to jlm-opt

### DIFF
--- a/jlm/rvsdg/Makefile.sub
+++ b/jlm/rvsdg/Makefile.sub
@@ -95,6 +95,7 @@ librvsdg_TESTS = \
     tests/jlm/rvsdg/test-typemismatch \
     tests/jlm/rvsdg/TestStructuralNode \
     tests/jlm/rvsdg/TrackerTests \
+    tests/jlm/rvsdg/TransformationSequenceTests \
     tests/jlm/rvsdg/UnaryOperationTests \
 
 librvsdg_TEST_LIBS = \

--- a/jlm/rvsdg/Transformation.hpp
+++ b/jlm/rvsdg/Transformation.hpp
@@ -6,6 +6,7 @@
 #ifndef JLM_RVSDG_TRANSFORMATION_HPP
 #define JLM_RVSDG_TRANSFORMATION_HPP
 
+#include <jlm/rvsdg/DotWriter.hpp>
 #include <jlm/util/Statistics.hpp>
 
 namespace jlm::rvsdg
@@ -24,6 +25,12 @@ public:
   explicit Transformation(std::string_view Name)
       : Name_(Name)
   {}
+
+  [[nodiscard]] const std::string_view &
+  GetName() const noexcept
+  {
+    return Name_;
+  }
 
   /**
    * \brief Perform RVSDG transformation
@@ -68,8 +75,13 @@ class TransformationSequence final : public Transformation
 public:
   ~TransformationSequence() noexcept override;
 
-  explicit TransformationSequence(std::vector<Transformation *> transformations)
+  explicit TransformationSequence(
+      std::vector<Transformation *> transformations,
+      DotWriter & dotWriter,
+      const bool dumpRvsdgDotGraphs)
       : Transformation("TransformationSequence"),
+        DotWriter_(dotWriter),
+        DumpRvsdgDotGraphs_(dumpRvsdgDotGraphs),
         Transformations_(std::move(transformations))
   {}
 
@@ -88,18 +100,34 @@ public:
    * @param rvsdgModule RVSDG module the transformation is performed on.
    * @param statisticsCollector Statistics collector for collecting transformation statistics.
    * @param transformations The transformations that are sequentially applied to \p rvsdgModule.
+   * @param dotWriter The DOT writer for dumping the RVSDG graphs.
+   * @param dumpRvsdgDotGraphs Determines whether to dump the RVSDG graphs.
    */
   static void
   CreateAndRun(
       RvsdgModule & rvsdgModule,
       util::StatisticsCollector & statisticsCollector,
-      std::vector<Transformation *> transformations)
+      std::vector<Transformation *> transformations,
+      DotWriter & dotWriter,
+      const bool dumpRvsdgDotGraphs)
   {
-    TransformationSequence sequentialApplication(std::move(transformations));
+    TransformationSequence sequentialApplication(
+        std::move(transformations),
+        dotWriter,
+        dumpRvsdgDotGraphs);
     sequentialApplication.Run(rvsdgModule, statisticsCollector);
   }
 
 private:
+  void
+  DumpDotGraphs(
+      RvsdgModule & rvsdgModule,
+      const util::FilePath & filePath,
+      const std::string & passName,
+      size_t numPass) const;
+
+  DotWriter & DotWriter_;
+  bool DumpRvsdgDotGraphs_;
   std::vector<Transformation *> Transformations_;
 };
 

--- a/jlm/tooling/Command.cpp
+++ b/jlm/tooling/Command.cpp
@@ -359,10 +359,13 @@ JlmOptCommand::Run() const
       CommandLineOptions_.GetInputFormat(),
       statisticsCollector);
 
+  llvm::dot::LlvmDotWriter dotWriter;
   rvsdg::TransformationSequence::CreateAndRun(
       *rvsdgModule,
       statisticsCollector,
-      GetTransformations());
+      GetTransformations(),
+      dotWriter,
+      CommandLineOptions_.DumpRvsdgDotGraphs());
 
   PrintRvsdgModule(
       *rvsdgModule,

--- a/jlm/tooling/CommandGraphGenerator.cpp
+++ b/jlm/tooling/CommandGraphGenerator.cpp
@@ -141,7 +141,8 @@ JlcCommandGraphGenerator::GenerateCommandGraph(const JlcCommandLineOptions & com
           JlmOptCommandLineOptions::OutputFormat::Llvm,
           std::move(statisticsCollectorSettings),
           jlm::llvm::RvsdgTreePrinter::Configuration({}),
-          commandLineOptions.JlmOptOptimizations_);
+          commandLineOptions.JlmOptOptimizations_,
+          false);
 
       auto & jlmOptCommandNode =
           JlmOptCommand::Create(*commandGraph, "jlm-opt", std::move(jlmOptCommandLineOptions));

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -697,6 +697,8 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, const char * const 
       cl::value_desc("file"));
 
   const auto statisticsDirectoryDefault = util::FilePath::TempDirectoryPath().Join("jlm");
+  statisticsDirectoryDefault.CreateDirectory();
+
   const auto statisticDirectoryDescription =
       "Write statistics and debug output to files in <dir>. Default is "
       + statisticsDirectoryDefault.to_str() + ".";
@@ -705,6 +707,11 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, const char * const 
       cl::init(statisticsDirectoryDefault.to_str()),
       cl::desc(statisticDirectoryDescription),
       cl::value_desc("dir"));
+
+  cl::opt<bool> dumpRvsdgDotGraphs(
+      "dumpRvsdgDotGraphs",
+      cl::init(false),
+      cl::desc("Dump RVSDG as dot graphs after each transformation in debug folder."));
 
   cl::list<util::Statistics::Id> printStatistics(
       cl::values(
@@ -959,7 +966,8 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, const char * const 
       outputFormat,
       std::move(statisticsCollectorSettings),
       std::move(treePrinterConfiguration),
-      std::move(optimizationIds));
+      std::move(optimizationIds),
+      dumpRvsdgDotGraphs);
 
   return *CommandLineOptions_;
 }

--- a/jlm/tooling/CommandLine.hpp
+++ b/jlm/tooling/CommandLine.hpp
@@ -92,14 +92,16 @@ public:
       OutputFormat outputFormat,
       util::StatisticsCollectorSettings statisticsCollectorSettings,
       llvm::RvsdgTreePrinter::Configuration rvsdgTreePrinterConfiguration,
-      std::vector<OptimizationId> optimizations)
+      std::vector<OptimizationId> optimizations,
+      const bool dumpRvsdgDotGraphs)
       : InputFile_(std::move(inputFile)),
         InputFormat_(inputFormat),
         OutputFile_(std::move(outputFile)),
         OutputFormat_(outputFormat),
         StatisticsCollectorSettings_(std::move(statisticsCollectorSettings)),
         OptimizationIds_(std::move(optimizations)),
-        RvsdgTreePrinterConfiguration_(std::move(rvsdgTreePrinterConfiguration))
+        RvsdgTreePrinterConfiguration_(std::move(rvsdgTreePrinterConfiguration)),
+        DumpRvsdgDotGraphs_(dumpRvsdgDotGraphs)
   {}
 
   void
@@ -147,6 +149,12 @@ public:
     return RvsdgTreePrinterConfiguration_;
   }
 
+  [[nodiscard]] bool
+  DumpRvsdgDotGraphs() const noexcept
+  {
+    return DumpRvsdgDotGraphs_;
+  }
+
   static OptimizationId
   FromCommandLineArgumentToOptimizationId(const std::string & commandLineArgument);
 
@@ -173,7 +181,8 @@ public:
       OutputFormat outputFormat,
       util::StatisticsCollectorSettings statisticsCollectorSettings,
       llvm::RvsdgTreePrinter::Configuration rvsdgTreePrinterConfiguration,
-      std::vector<OptimizationId> optimizations)
+      std::vector<OptimizationId> optimizations,
+      bool dumpRvsdgDotGraphs)
   {
     return std::make_unique<JlmOptCommandLineOptions>(
         std::move(inputFile),
@@ -182,7 +191,8 @@ public:
         outputFormat,
         std::move(statisticsCollectorSettings),
         std::move(rvsdgTreePrinterConfiguration),
-        std::move(optimizations));
+        std::move(optimizations),
+        dumpRvsdgDotGraphs);
   }
 
 private:
@@ -193,6 +203,7 @@ private:
   util::StatisticsCollectorSettings StatisticsCollectorSettings_;
   std::vector<OptimizationId> OptimizationIds_;
   llvm::RvsdgTreePrinter::Configuration RvsdgTreePrinterConfiguration_;
+  bool DumpRvsdgDotGraphs_;
 
   struct OptimizationCommandLineArgument
   {

--- a/tests/jlm/rvsdg/TransformationSequenceTests.cpp
+++ b/tests/jlm/rvsdg/TransformationSequenceTests.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <test-registry.hpp>
+
+#include <jlm/rvsdg/RvsdgModule.hpp>
+#include <jlm/rvsdg/Transformation.hpp>
+
+class TestTransformation final : public jlm::rvsdg::Transformation
+{
+public:
+  TestTransformation()
+      : Transformation("TestTransformation")
+  {}
+
+  void
+  Run(jlm::rvsdg::RvsdgModule & module,
+      jlm::util::StatisticsCollector & statisticsCollector) override
+  {}
+};
+
+class TestDotWriter final : public jlm::rvsdg::DotWriter
+{
+protected:
+  void
+  AnnotateTypeGraphNode(const jlm::rvsdg::Type & type, jlm::util::graph::Node & node) override
+  {}
+
+  void
+  AnnotateGraphNode(
+      const jlm::rvsdg::Node & rvsdgNode,
+      jlm::util::graph::Node & node,
+      jlm::util::graph::Graph * typeGraph) override
+  {}
+
+  void
+  AnnotateEdge(const jlm::rvsdg::Input & rvsdgInput, jlm::util::graph::Edge & edge) override
+  {}
+
+  void
+  AnnotateRegionArgument(
+      const jlm::rvsdg::RegionArgument & regionArgument,
+      jlm::util::graph::Node & node,
+      jlm::util::graph::Graph * typeGraph) override
+  {}
+};
+
+static void
+RvsdgDumping()
+{
+  using namespace jlm::rvsdg;
+  using namespace jlm::util;
+
+  // Arrange
+  RvsdgModule rvsdgModule(FilePath("/tmp/mySource"));
+
+  const StatisticsCollectorSettings statisticsCollectorSettings({}, FilePath("/tmp"), "moduleName");
+  StatisticsCollector statisticsCollector(statisticsCollectorSettings);
+
+  TestDotWriter dotWriter;
+  TestTransformation testTransformation;
+
+  // Act
+  TransformationSequence::CreateAndRun(
+      rvsdgModule,
+      statisticsCollector,
+      { &testTransformation },
+      dotWriter,
+      true);
+
+  // Assert
+  assert(std::filesystem::exists("/tmp/000-Pristine.dot"));
+  assert(std::filesystem::exists("/tmp/001-AfterTestTransformation.dot"));
+}
+
+JLM_UNIT_TEST_REGISTER("jlm/rvsdg/TransformationSequenceTests-RvsdgDumping", RvsdgDumping)

--- a/tests/jlm/tooling/TestJlmOptCommand.cpp
+++ b/tests/jlm/tooling/TestJlmOptCommand.cpp
@@ -35,7 +35,8 @@ TestStatistics()
       statisticsCollectorSettings,
       RvsdgTreePrinter::Configuration({}),
       { JlmOptCommandLineOptions::OptimizationId::DeadNodeElimination,
-        JlmOptCommandLineOptions::OptimizationId::LoopUnrolling });
+        JlmOptCommandLineOptions::OptimizationId::LoopUnrolling },
+      false);
 
   JlmOptCommand command("jlm-opt", commandLineOptions);
 
@@ -83,7 +84,8 @@ OptimizationIdToOptimizationTranslation()
       JlmOptCommandLineOptions::OutputFormat::Llvm,
       StatisticsCollectorSettings(),
       RvsdgTreePrinter::Configuration({}),
-      optimizationIds);
+      optimizationIds,
+      false);
 
   // Act & Assert
   // terminates on unhandled optimization id


### PR DESCRIPTION
Adds jlm-opt support for dumping RVSDGs as dot graphs after each performed transformation.