### PR TITLE
Replace Value/StateType as classes, implement as traits

### DIFF
--- a/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.cpp
+++ b/jlm/hls/backend/rhls2firrtl/RhlsToFirrtlConverter.cpp
@@ -749,7 +749,7 @@ RhlsToFirrtlConverter::MlirGenHlsMemResp(const jlm::rvsdg::SimpleNode * node)
     auto elseBody = body;
     for (size_t i = 0; i < node->noutputs(); ++i)
     {
-      bool isStore = rvsdg::is<rvsdg::StateType>(node->output(i)->Type());
+      bool isStore = node->output(i)->Type()->Kind() == rvsdg::TypeKind::State;
       auto outBundle = GetOutPort(module, i);
       auto outValid = GetSubfield(elseBody, outBundle, "valid");
       auto outReady = GetSubfield(elseBody, outBundle, "ready");
@@ -2766,7 +2766,7 @@ RhlsToFirrtlConverter::MlirGen(const rvsdg::LambdaNode * lambdaNode)
   for (size_t i = 0; i < reg_args.size(); ++i)
   {
     // don't generate ports for state edges
-    if (rvsdg::is<rvsdg::StateType>(reg_args[i]->Type()))
+    if (reg_args[i]->Type()->Kind() == rvsdg::TypeKind::State)
       continue;
     std::string portName("data_");
     portName.append(std::to_string(i));
@@ -2789,7 +2789,7 @@ RhlsToFirrtlConverter::MlirGen(const rvsdg::LambdaNode * lambdaNode)
   for (size_t i = 0; i < reg_results.size(); ++i)
   {
     // don't generate ports for state edges
-    if (rvsdg::is<rvsdg::StateType>(reg_results[i]->Type()))
+    if (reg_results[i]->Type()->Kind() == rvsdg::TypeKind::State)
       continue;
     std::string portName("data_");
     portName.append(std::to_string(i));
@@ -3014,7 +3014,7 @@ RhlsToFirrtlConverter::MlirGen(const rvsdg::LambdaNode * lambdaNode)
   for (size_t i = 0; i < outputDataRegs.size(); i++)
   {
     // don't generate ports for state edges
-    if (rvsdg::is<rvsdg::StateType>(reg_results[i]->Type()))
+    if (reg_results[i]->Type()->Kind() == rvsdg::TypeKind::State)
       continue;
     auto outData = GetSubfield(body, outBundle, "data_" + std::to_string(i));
     Connect(body, outData, outputDataRegs[i].getResult());
@@ -3034,7 +3034,7 @@ RhlsToFirrtlConverter::MlirGen(const rvsdg::LambdaNode * lambdaNode)
     {
       Connect(thenBody, inputValidRegs[i].getResult(), oneBitValue);
       // don't generate ports for state edges
-      if (rvsdg::is<rvsdg::StateType>(reg_args[i]->Type()))
+      if (reg_args[i]->Type()->Kind() == rvsdg::TypeKind::State)
         continue;
       auto inData = GetSubfield(thenBody, inBundle, "data_" + std::to_string(i));
       Connect(thenBody, inputDataRegs[i].getResult(), inData);

--- a/jlm/hls/backend/rhls2firrtl/json-hls.cpp
+++ b/jlm/hls/backend/rhls2firrtl/json-hls.cpp
@@ -26,7 +26,7 @@ JsonHLS::GetText(llvm::RvsdgModule & rm)
   for (size_t i = 0; i < reg_args.size(); ++i)
   {
     // don't generate ports for state edges
-    if (rvsdg::is<rvsdg::StateType>(reg_args[i]->Type()))
+    if (reg_args[i]->Type()->Kind() == rvsdg::TypeKind::State)
       continue;
     if (i != 0)
     {
@@ -39,7 +39,7 @@ JsonHLS::GetText(llvm::RvsdgModule & rm)
   for (size_t i = 0; i < reg_results.size(); ++i)
   {
     // don't generate ports for state edges
-    if (rvsdg::is<rvsdg::StateType>(reg_results[i]->Type()))
+    if (reg_results[i]->Type()->Kind() == rvsdg::TypeKind::State)
       continue;
     if (i != 0)
     {

--- a/jlm/hls/backend/rhls2firrtl/verilator-harness-hls.cpp
+++ b/jlm/hls/backend/rhls2firrtl/verilator-harness-hls.cpp
@@ -69,7 +69,7 @@ GetReturnTypeAsC(const rvsdg::LambdaNode & kernel)
 
   const auto & type = results.front();
 
-  if (rvsdg::is<rvsdg::StateType>(type))
+  if (type->Kind() == rvsdg::TypeKind::State)
     return std::nullopt;
 
   return ConvertToCType(type.get());
@@ -92,7 +92,7 @@ GetParameterListAsC(const rvsdg::LambdaNode & kernel)
 
   for (auto & argType : kernel.GetOperation().type().Arguments())
   {
-    if (rvsdg::is<rvsdg::StateType>(argType))
+    if (argType->Kind() == rvsdg::TypeKind::State)
       continue;
     if (rvsdg::is<BundleType>(argType))
       continue;
@@ -423,7 +423,7 @@ static void verilator_init(int argc, char **argv) {
   for (size_t i = 0; i < first_ctx_var; i++)
   {
     // don't generate ports for state edges
-    if (rvsdg::is<rvsdg::StateType>(reg_args[i]->Type()))
+    if (reg_args[i]->Type()->Kind() == rvsdg::TypeKind::State)
       continue;
     cpp << "    top->i_data_" << i << " = 0;" << std::endl;
   }

--- a/jlm/hls/backend/rvsdg2rhls/GammaConversion.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/GammaConversion.cpp
@@ -94,7 +94,7 @@ CanGammaNodeBeSpeculative(const rvsdg::GammaNode & gammaNode)
   for (size_t i = 0; i < gammaNode.noutputs(); ++i)
   {
     auto gammaOutput = gammaNode.output(i);
-    if (rvsdg::is<rvsdg::StateType>(gammaOutput->Type()))
+    if (gammaOutput->Type()->Kind() == rvsdg::TypeKind::State)
     {
       // don't allow state outputs since they imply operations with side effects
       return false;

--- a/jlm/hls/backend/rvsdg2rhls/add-buffers.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/add-buffers.cpp
@@ -121,7 +121,7 @@ OptimizeFork(rvsdg::SimpleNode * node)
     {
       bufferSize = BufferSizeForkControl;
     }
-    else if (rvsdg::is<rvsdg::StateType>(node->input(0)->Type()))
+    else if (node->input(0)->Type()->Kind() == rvsdg::TypeKind::State)
     {
       bufferSize = BufferSizeForkState;
     }
@@ -145,7 +145,7 @@ OptimizeBranch(rvsdg::SimpleNode * node)
     // TODO: this optimization is for long stores with responses. It might be better to do it
     // somewhere else and more selectively (only when there is a store in one of the gamma
     // subregions, and only on outputs that don't go to store)
-    if (rvsdg::is<rvsdg::StateType>(node->input(1)->Type()))
+    if (node->input(1)->Type()->Kind() == rvsdg::TypeKind::State)
     {
       for (size_t i = 0; i < node->noutputs(); ++i)
       {

--- a/jlm/hls/backend/rvsdg2rhls/decouple-mem-state.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/decouple-mem-state.cpp
@@ -437,7 +437,7 @@ follow_state_edge(
 void
 convert_loop_state_to_lcb(rvsdg::Input * loop_state_input)
 {
-  JLM_ASSERT(rvsdg::is<rvsdg::StateType>(loop_state_input->Type()));
+  JLM_ASSERT(loop_state_input->Type()->Kind() == rvsdg::TypeKind::State);
   JLM_ASSERT(rvsdg::TryGetOwnerNode<LoopNode>(*loop_state_input));
   auto si = util::AssertedCast<rvsdg::StructuralInput>(loop_state_input);
   auto arg = si->arguments.begin().ptr();

--- a/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
@@ -636,7 +636,7 @@ ConnectRequestResponseMemPorts(
     auto channel = decoupleRequest->input(1)->origin();
     auto channelConstant = trace_constant(channel);
     auto reponse = find_decouple_response(lambda, channelConstant);
-    auto vt = std::dynamic_pointer_cast<const rvsdg::ValueType>(reponse->output(0)->Type());
+    auto vt = reponse->output(0)->Type();
     responseTypes.push_back(vt);
   }
   std::vector<rvsdg::SimpleNode *> storeNodes;
@@ -659,7 +659,7 @@ ConnectRequestResponseMemPorts(
       responseTypes,
       portWidth);
   // The (decoupled) load nodes are replaced so the pointer to the types will become invalid
-  std::vector<std::shared_ptr<const rvsdg::ValueType>> loadTypes;
+  std::vector<std::shared_ptr<const rvsdg::Type>> loadTypes;
   std::vector<rvsdg::Output *> loadAddresses;
   for (size_t i = 0; i < loadNodes.size(); ++i)
   {
@@ -670,7 +670,7 @@ ConnectRequestResponseMemPorts(
     auto address =
         route_request_rhls(lambdaRegion, replacement->output(replacement->noutputs() - 1));
     loadAddresses.push_back(address);
-    std::shared_ptr<const rvsdg::ValueType> type;
+    std::shared_ptr<const rvsdg::Type> type;
     if (auto loadOperation = dynamic_cast<const LoadOperation *>(&replacement->GetOperation()))
     {
       type = loadOperation->GetLoadedType();

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -206,7 +206,7 @@ convert_alloca(rvsdg::Region * region)
       auto db = rvsdg::DeltaNode::Create(
           rr,
           llvm::DeltaOperation::Create(
-              std::static_pointer_cast<const rvsdg::ValueType>(po->ValueType()),
+              po->ValueType(),
               delta_name,
               llvm::linkage::external_linkage,
               "",
@@ -270,7 +270,7 @@ rename_delta(rvsdg::DeltaNode * odn)
   auto db = rvsdg::DeltaNode::Create(
       odn->region(),
       llvm::DeltaOperation::Create(
-          std::static_pointer_cast<const rvsdg::ValueType>(odn->Type()),
+          odn->Type(),
           name,
           llvm::linkage::external_linkage,
           "",

--- a/jlm/hls/backend/rvsdg2rhls/stream-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/stream-conv.cpp
@@ -32,7 +32,7 @@ ConnectStreamBuffer(rvsdg::SimpleNode * enq_call, rvsdg::SimpleNode * deq_call)
   // remove call nodes
   for (size_t i = 0; i < deq_call->ninputs(); ++i)
   {
-    if (rvsdg::is<const rvsdg::StateType>(deq_call->input(i)->Type()))
+    if (deq_call->input(i)->Type()->Kind() == rvsdg::TypeKind::State)
     {
       int oi = deq_call->noutputs() - deq_call->ninputs() + i;
       deq_call->output(oi)->divert_users(deq_call->input(i)->origin());
@@ -42,7 +42,7 @@ ConnectStreamBuffer(rvsdg::SimpleNode * enq_call, rvsdg::SimpleNode * deq_call)
   remove(deq_call);
   for (size_t i = 0; i < enq_call->ninputs(); ++i)
   {
-    if (rvsdg::is<const rvsdg::StateType>(enq_call->input(i)->Type()))
+    if (enq_call->input(i)->Type()->Kind() == rvsdg::TypeKind::State)
     {
       int oi = enq_call->noutputs() - enq_call->ninputs() + i;
       enq_call->output(oi)->divert_users(enq_call->input(i)->origin());

--- a/jlm/hls/ir/hls.cpp
+++ b/jlm/hls/ir/hls.cpp
@@ -62,6 +62,12 @@ TriggerType::ComputeHash() const noexcept
   return typeid(TriggerType).hash_code();
 }
 
+rvsdg::TypeKind
+TriggerType::Kind() const noexcept
+{
+  return rvsdg::TypeKind::State;
+}
+
 std::shared_ptr<const TriggerType>
 TriggerType::Create()
 {
@@ -80,6 +86,12 @@ BundleType::ComputeHash() const noexcept
   }
 
   return seed;
+}
+
+rvsdg::TypeKind
+BundleType::Kind() const noexcept
+{
+  return rvsdg::TypeKind::Value;
 }
 
 EntryArgument::~EntryArgument() noexcept = default;
@@ -248,7 +260,7 @@ LoopNode::set_predicate(jlm::rvsdg::Output * p)
 }
 
 std::shared_ptr<const BundleType>
-get_mem_req_type(std::shared_ptr<const rvsdg::ValueType> elementType, bool write)
+get_mem_req_type(std::shared_ptr<const rvsdg::Type> elementType, bool write)
 {
   std::vector<std::pair<std::string, std::shared_ptr<const jlm::rvsdg::Type>>> elements;
   elements.emplace_back("addr", llvm::PointerType::Create());
@@ -263,7 +275,7 @@ get_mem_req_type(std::shared_ptr<const rvsdg::ValueType> elementType, bool write
 }
 
 std::shared_ptr<const BundleType>
-get_mem_res_type(std::shared_ptr<const jlm::rvsdg::ValueType> dataType)
+get_mem_res_type(std::shared_ptr<const jlm::rvsdg::Type> dataType)
 {
   std::vector<std::pair<std::string, std::shared_ptr<const jlm::rvsdg::Type>>> elements;
   elements.emplace_back("data", std::move(dataType));
@@ -294,7 +306,7 @@ JlmSize(const jlm::rvsdg::Type * type)
   {
     return ceil(log2(ct->nalternatives()));
   }
-  else if (dynamic_cast<const rvsdg::StateType *>(type))
+  else if (type->Kind() == rvsdg::TypeKind::State)
   {
     return 1;
   }

--- a/jlm/llvm/DotWriter.cpp
+++ b/jlm/llvm/DotWriter.cpp
@@ -22,7 +22,7 @@ LlvmDotWriter::AnnotateTypeGraphNode(const rvsdg::Type & type, util::graph::Node
   auto & typeGraph = node.GetGraph();
 
   // Some types get special handling, such as adding incoming edges from aggregate types
-  if (rvsdg::is<rvsdg::StateType>(type) || rvsdg::is<rvsdg::BitType>(type)
+  if (type.Kind() == rvsdg::TypeKind::State || rvsdg::is<rvsdg::BitType>(type)
       || rvsdg::is<PointerType>(type) || rvsdg::is<FloatingPointType>(type)
       || rvsdg::is<VariableArgumentType>(type) || rvsdg::is<rvsdg::UnitType>(type))
   {

--- a/jlm/llvm/backend/IpGraphToLlvmConverter.hpp
+++ b/jlm/llvm/backend/IpGraphToLlvmConverter.hpp
@@ -425,7 +425,7 @@ private:
 
   ::llvm::Value *
   CreateLoadInstruction(
-      const rvsdg::ValueType & loadedType,
+      const rvsdg::Type & loadedType,
       const Variable * address,
       bool isVolatile,
       size_t alignment,

--- a/jlm/llvm/ir/RvsdgModule.hpp
+++ b/jlm/llvm/ir/RvsdgModule.hpp
@@ -23,8 +23,8 @@ class GraphImport final : public rvsdg::GraphImport
 private:
   GraphImport(
       rvsdg::Graph & graph,
-      std::shared_ptr<const rvsdg::ValueType> valueType,
-      std::shared_ptr<const rvsdg::ValueType> importedType,
+      std::shared_ptr<const rvsdg::Type> valueType,
+      std::shared_ptr<const rvsdg::Type> importedType,
       std::string name,
       llvm::linkage linkage)
       : rvsdg::GraphImport(graph, importedType, std::move(name)),
@@ -40,13 +40,13 @@ public:
     return Linkage_;
   }
 
-  [[nodiscard]] const std::shared_ptr<const jlm::rvsdg::ValueType> &
+  [[nodiscard]] const std::shared_ptr<const jlm::rvsdg::Type> &
   ValueType() const noexcept
   {
     return ValueType_;
   }
 
-  [[nodiscard]] const std::shared_ptr<const jlm::rvsdg::ValueType> &
+  [[nodiscard]] const std::shared_ptr<const jlm::rvsdg::Type> &
   ImportedType() const noexcept
   {
     return ImportedType_;
@@ -58,8 +58,8 @@ public:
   static GraphImport &
   Create(
       rvsdg::Graph & graph,
-      std::shared_ptr<const rvsdg::ValueType> valueType,
-      std::shared_ptr<const rvsdg::ValueType> importedType,
+      std::shared_ptr<const rvsdg::Type> valueType,
+      std::shared_ptr<const rvsdg::Type> importedType,
       std::string name,
       llvm::linkage linkage)
   {
@@ -75,8 +75,8 @@ public:
 
 private:
   llvm::linkage Linkage_;
-  std::shared_ptr<const rvsdg::ValueType> ValueType_;
-  std::shared_ptr<const rvsdg::ValueType> ImportedType_;
+  std::shared_ptr<const rvsdg::Type> ValueType_;
+  std::shared_ptr<const rvsdg::Type> ImportedType_;
 };
 
 /**

--- a/jlm/llvm/ir/TypeConverter.cpp
+++ b/jlm/llvm/ir/TypeConverter.cpp
@@ -67,7 +67,7 @@ TypeConverter::ConvertFunctionType(
   // The return type can either be (ValueType, StateType, StateType, ...) if the function has
   // a return value, or (StateType, StateType, ...) if the function returns void.
   auto resultType = ::llvm::Type::getVoidTy(context);
-  if (functionType.NumResults() > 0 && rvsdg::is<rvsdg::ValueType>(functionType.ResultType(0)))
+  if (functionType.NumResults() > 0 && functionType.ResultType(0).Kind() == rvsdg::TypeKind::Value)
     resultType = ConvertJlmType(functionType.ResultType(0), context);
 
   return ::llvm::FunctionType::get(resultType, argumentTypes, isVariableArgument);
@@ -217,7 +217,7 @@ TypeConverter::ConvertJlmType(const rvsdg::Type & type, ::llvm::LLVMContext & co
   JLM_UNREACHABLE("TypeConverter::ConvertJlmType: Unhandled jlm type.");
 }
 
-std::shared_ptr<const rvsdg::ValueType>
+std::shared_ptr<const rvsdg::Type>
 TypeConverter::ConvertLlvmType(::llvm::Type & type)
 {
   switch (type.getTypeID())

--- a/jlm/llvm/ir/TypeConverter.hpp
+++ b/jlm/llvm/ir/TypeConverter.hpp
@@ -78,7 +78,7 @@ public:
   static std::shared_ptr<const PointerType>
   ConvertPointerType(const ::llvm::PointerType & pointerType);
 
-  std::shared_ptr<const rvsdg::ValueType>
+  std::shared_ptr<const rvsdg::Type>
   ConvertLlvmType(::llvm::Type & type);
 
   /**

--- a/jlm/llvm/ir/attribute.hpp
+++ b/jlm/llvm/ir/attribute.hpp
@@ -227,12 +227,12 @@ class TypeAttribute final : public EnumAttribute
 public:
   ~TypeAttribute() noexcept override;
 
-  TypeAttribute(Attribute::kind kind, std::shared_ptr<const jlm::rvsdg::ValueType> type)
+  TypeAttribute(Attribute::kind kind, std::shared_ptr<const jlm::rvsdg::Type> type)
       : EnumAttribute(kind),
         type_(std::move(type))
   {}
 
-  [[nodiscard]] const jlm::rvsdg::ValueType &
+  [[nodiscard]] const jlm::rvsdg::Type &
   type() const noexcept
   {
     return *type_;
@@ -242,7 +242,7 @@ public:
   operator==(const Attribute &) const override;
 
 private:
-  std::shared_ptr<const jlm::rvsdg::ValueType> type_;
+  std::shared_ptr<const jlm::rvsdg::Type> type_;
 };
 
 }

--- a/jlm/llvm/ir/ipgraph.hpp
+++ b/jlm/llvm/ir/ipgraph.hpp
@@ -317,7 +317,7 @@ private:
   DataNode(
       InterProceduralGraph & clg,
       const std::string & name,
-      std::shared_ptr<const jlm::rvsdg::ValueType> valueType,
+      std::shared_ptr<const jlm::rvsdg::Type> valueType,
       const llvm::linkage & linkage,
       std::string section,
       bool constant)
@@ -336,7 +336,7 @@ public:
   std::shared_ptr<const jlm::rvsdg::Type>
   Type() const override;
 
-  [[nodiscard]] const std::shared_ptr<const jlm::rvsdg::ValueType> &
+  [[nodiscard]] const std::shared_ptr<const jlm::rvsdg::Type> &
   GetValueType() const noexcept
   {
     return ValueType_;
@@ -385,7 +385,7 @@ public:
   Create(
       InterProceduralGraph & clg,
       const std::string & name,
-      std::shared_ptr<const jlm::rvsdg::ValueType> valueType,
+      std::shared_ptr<const jlm::rvsdg::Type> valueType,
       const llvm::linkage & linkage,
       std::string section,
       bool constant)
@@ -402,7 +402,7 @@ private:
   std::string name_;
   std::string Section_;
   llvm::linkage linkage_;
-  std::shared_ptr<const jlm::rvsdg::ValueType> ValueType_;
+  std::shared_ptr<const jlm::rvsdg::Type> ValueType_;
   std::unique_ptr<DataNodeInit> init_;
 };
 

--- a/jlm/llvm/ir/operators/GetElementPtr.hpp
+++ b/jlm/llvm/ir/operators/GetElementPtr.hpp
@@ -28,7 +28,7 @@ public:
 public:
   GetElementPtrOperation(
       const std::vector<std::shared_ptr<const rvsdg::BitType>> & offsetTypes,
-      std::shared_ptr<const rvsdg::ValueType> pointeeType)
+      std::shared_ptr<const rvsdg::Type> pointeeType)
       : SimpleOperation(CreateOperandTypes(offsetTypes), { PointerType::Create() }),
         PointeeType_(std::move(pointeeType))
   {}
@@ -46,10 +46,10 @@ public:
   [[nodiscard]] std::unique_ptr<Operation>
   copy() const override;
 
-  [[nodiscard]] const rvsdg::ValueType &
+  [[nodiscard]] const rvsdg::Type &
   GetPointeeType() const noexcept
   {
-    return *dynamic_cast<const rvsdg::ValueType *>(PointeeType_.get());
+    return *PointeeType_.get();
   }
 
   /**
@@ -69,7 +69,7 @@ public:
   Create(
       const Variable * baseAddress,
       const std::vector<const Variable *> & offsets,
-      std::shared_ptr<const rvsdg::ValueType> pointeeType,
+      std::shared_ptr<const rvsdg::Type> pointeeType,
       std::shared_ptr<const rvsdg::Type> resultType)
   {
     CheckPointerType(baseAddress->type());
@@ -100,7 +100,7 @@ public:
   Create(
       rvsdg::Output * baseAddress,
       const std::vector<rvsdg::Output *> & offsets,
-      std::shared_ptr<const rvsdg::ValueType> pointeeType,
+      std::shared_ptr<const rvsdg::Type> pointeeType,
       std::shared_ptr<const rvsdg::Type> resultType)
   {
     CheckPointerType(*baseAddress->Type());
@@ -155,7 +155,7 @@ private:
     return types;
   }
 
-  std::shared_ptr<const rvsdg::ValueType> PointeeType_;
+  std::shared_ptr<const rvsdg::Type> PointeeType_;
 };
 
 }

--- a/jlm/llvm/ir/operators/Load.cpp
+++ b/jlm/llvm/ir/operators/Load.cpp
@@ -446,7 +446,7 @@ LoadNonVolatileOperation::NormalizeLoadLoadState(
       rvsdg::Output *(size_t, rvsdg::Output *, std::vector<std::vector<rvsdg::Output *>> &)>
       traceLoadState = [&](size_t index, rvsdg::Output * operand, auto & joinOperands)
   {
-    JLM_ASSERT(rvsdg::is<rvsdg::StateType>(operand->Type()));
+    JLM_ASSERT(operand->Type()->Kind() == rvsdg::TypeKind::State);
 
     if (!is<LoadNonVolatileOperation>(rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(*operand)))
       return operand;

--- a/jlm/llvm/ir/operators/Load.hpp
+++ b/jlm/llvm/ir/operators/Load.hpp
@@ -40,7 +40,7 @@ protected:
     JLM_ASSERT(is<PointerType>(addressType));
 
     auto & loadedType = *resultTypes[0];
-    JLM_ASSERT(is<rvsdg::ValueType>(loadedType));
+    JLM_ASSERT(loadedType.Kind() == rvsdg::TypeKind::Value);
 
     JLM_ASSERT(operandTypes.size() == resultTypes.size());
     for (size_t n = 1; n < operandTypes.size(); n++)
@@ -48,7 +48,7 @@ protected:
       auto & operandType = *operandTypes[n];
       auto & resultType = *resultTypes[n];
       JLM_ASSERT(operandType == resultType);
-      JLM_ASSERT(is<rvsdg::StateType>(operandType));
+      JLM_ASSERT(operandType.Kind() == rvsdg::TypeKind::State);
     }
   }
 
@@ -59,12 +59,10 @@ public:
     return Alignment_;
   }
 
-  [[nodiscard]] std::shared_ptr<const rvsdg::ValueType>
+  [[nodiscard]] std::shared_ptr<const rvsdg::Type>
   GetLoadedType() const noexcept
   {
-    auto type = std::dynamic_pointer_cast<const rvsdg::ValueType>(result(0));
-    JLM_ASSERT(type);
-    return type;
+    return result(0);
   }
 
   [[nodiscard]] size_t
@@ -87,7 +85,7 @@ public:
   {
     JLM_ASSERT(is<LoadOperation>(&node));
     const auto output = node.output(0);
-    JLM_ASSERT(is<rvsdg::ValueType>(output->Type()));
+    JLM_ASSERT(output->Type()->Kind() == rvsdg::TypeKind::Value);
     return *output;
   }
 
@@ -143,7 +141,7 @@ public:
   ~LoadVolatileOperation() noexcept override;
 
   LoadVolatileOperation(
-      std::shared_ptr<const rvsdg::ValueType> loadedType,
+      std::shared_ptr<const rvsdg::Type> loadedType,
       size_t numMemoryStates,
       size_t alignment)
       : LoadOperation(
@@ -185,7 +183,7 @@ public:
       const Variable * address,
       const Variable * iOState,
       const Variable * memoryState,
-      std::shared_ptr<const rvsdg::ValueType> loadedType,
+      std::shared_ptr<const rvsdg::Type> loadedType,
       size_t alignment)
   {
     LoadVolatileOperation operation(std::move(loadedType), 1, alignment);
@@ -203,7 +201,7 @@ public:
       rvsdg::Output & address,
       rvsdg::Output & iOState,
       const std::vector<rvsdg::Output *> & memoryStates,
-      std::shared_ptr<const rvsdg::ValueType> loadedType,
+      std::shared_ptr<const rvsdg::Type> loadedType,
       size_t alignment)
   {
     std::vector operands({ &address, &iOState });
@@ -230,7 +228,7 @@ private:
   }
 
   static std::vector<std::shared_ptr<const rvsdg::Type>>
-  CreateResultTypes(std::shared_ptr<const rvsdg::ValueType> loadedType, size_t numMemoryStates)
+  CreateResultTypes(std::shared_ptr<const rvsdg::Type> loadedType, size_t numMemoryStates)
   {
     std::vector<std::shared_ptr<const rvsdg::Type>> types(
         { std::move(loadedType), IOStateType::Create() });
@@ -253,7 +251,7 @@ public:
   ~LoadNonVolatileOperation() noexcept override;
 
   LoadNonVolatileOperation(
-      std::shared_ptr<const rvsdg::ValueType> loadedType,
+      std::shared_ptr<const rvsdg::Type> loadedType,
       size_t numMemoryStates,
       size_t alignment)
       : LoadOperation(
@@ -424,7 +422,7 @@ public:
   Create(
       const Variable * address,
       const Variable * state,
-      std::shared_ptr<const rvsdg::ValueType> loadedType,
+      std::shared_ptr<const rvsdg::Type> loadedType,
       size_t alignment)
   {
     LoadNonVolatileOperation operation(std::move(loadedType), 1, alignment);
@@ -435,7 +433,7 @@ public:
   Create(
       rvsdg::Output * address,
       const std::vector<rvsdg::Output *> & memoryStates,
-      std::shared_ptr<const rvsdg::ValueType> loadedType,
+      std::shared_ptr<const rvsdg::Type> loadedType,
       const size_t alignment)
   {
     return rvsdg::outputs(&CreateNode(*address, memoryStates, std::move(loadedType), alignment));
@@ -463,7 +461,7 @@ public:
   CreateNode(
       rvsdg::Output & address,
       const std::vector<rvsdg::Output *> & memoryStates,
-      std::shared_ptr<const rvsdg::ValueType> loadedType,
+      std::shared_ptr<const rvsdg::Type> loadedType,
       size_t alignment)
   {
     std::vector operands({ &address });
@@ -489,7 +487,7 @@ private:
   }
 
   static std::vector<std::shared_ptr<const rvsdg::Type>>
-  CreateResultTypes(std::shared_ptr<const rvsdg::ValueType> loadedType, size_t numMemoryStates)
+  CreateResultTypes(std::shared_ptr<const rvsdg::Type> loadedType, size_t numMemoryStates)
   {
     std::vector<std::shared_ptr<const rvsdg::Type>> types(1, std::move(loadedType));
     std::vector<std::shared_ptr<const rvsdg::Type>> states(

--- a/jlm/llvm/ir/operators/Store.hpp
+++ b/jlm/llvm/ir/operators/Store.hpp
@@ -40,7 +40,7 @@ protected:
     JLM_ASSERT(is<PointerType>(addressType));
 
     auto & storedType = *operandTypes[1];
-    JLM_ASSERT(is<rvsdg::ValueType>(storedType));
+    JLM_ASSERT(storedType.Kind() == rvsdg::TypeKind::Value);
 
     JLM_ASSERT(operandTypes.size() == resultTypes.size() + 2);
     for (size_t n = 0; n < resultTypes.size(); n++)
@@ -48,7 +48,7 @@ protected:
       auto & operandType = *operandTypes[n + 2];
       auto & resultType = *resultTypes[n];
       JLM_ASSERT(operandType == resultType);
-      JLM_ASSERT(is<rvsdg::StateType>(operandType));
+      JLM_ASSERT(operandType.Kind() == rvsdg::TypeKind::State);
     }
   }
 
@@ -59,10 +59,10 @@ public:
     return Alignment_;
   }
 
-  [[nodiscard]] const rvsdg::ValueType &
+  [[nodiscard]] const rvsdg::Type &
   GetStoredType() const noexcept
   {
-    return *util::AssertedCast<const rvsdg::ValueType>(argument(1).get());
+    return *argument(1).get();
   }
 
   [[nodiscard]] size_t
@@ -85,7 +85,7 @@ public:
   {
     JLM_ASSERT(is<StoreOperation>(&node));
     auto & input = *node.input(1);
-    JLM_ASSERT(is<rvsdg::ValueType>(input.Type()));
+    JLM_ASSERT(input.Type()->Kind() == rvsdg::TypeKind::Value);
     return input;
   }
 
@@ -135,7 +135,7 @@ public:
   ~StoreNonVolatileOperation() noexcept override;
 
   StoreNonVolatileOperation(
-      std::shared_ptr<const rvsdg::ValueType> storedType,
+      std::shared_ptr<const rvsdg::Type> storedType,
       const size_t numMemoryStates,
       const size_t alignment)
       : StoreOperation(
@@ -317,19 +317,19 @@ public:
   }
 
 private:
-  static const std::shared_ptr<const jlm::rvsdg::ValueType>
+  static const std::shared_ptr<const jlm::rvsdg::Type>
   CheckAndExtractStoredType(const std::shared_ptr<const rvsdg::Type> & type)
   {
-    if (auto storedType = std::dynamic_pointer_cast<const rvsdg::ValueType>(type))
+    if (type->Kind() == rvsdg::TypeKind::Value)
     {
-      return storedType;
+      return type;
     }
 
     throw util::Error("Expected value type");
   }
 
   static std::vector<std::shared_ptr<const rvsdg::Type>>
-  CreateOperandTypes(std::shared_ptr<const rvsdg::ValueType> storedType, size_t numMemoryStates)
+  CreateOperandTypes(std::shared_ptr<const rvsdg::Type> storedType, size_t numMemoryStates)
   {
     std::vector<std::shared_ptr<const rvsdg::Type>> types(
         { PointerType::Create(), std::move(storedType) });
@@ -358,7 +358,7 @@ public:
   ~StoreVolatileOperation() noexcept override;
 
   StoreVolatileOperation(
-      std::shared_ptr<const rvsdg::ValueType> storedType,
+      std::shared_ptr<const rvsdg::Type> storedType,
       const size_t numMemoryStates,
       const size_t alignment)
       : StoreOperation(
@@ -446,17 +446,17 @@ public:
   }
 
 private:
-  static std::shared_ptr<const rvsdg::ValueType>
+  static std::shared_ptr<const rvsdg::Type>
   CheckAndExtractStoredType(const std::shared_ptr<const rvsdg::Type> & type)
   {
-    if (auto storedType = std::dynamic_pointer_cast<const rvsdg::ValueType>(type))
-      return storedType;
+    if (type->Kind() == rvsdg::TypeKind::Value)
+      return type;
 
     throw util::Error("Expected value type");
   }
 
   static std::vector<std::shared_ptr<const rvsdg::Type>>
-  CreateOperandTypes(std::shared_ptr<const rvsdg::ValueType> storedType, size_t numMemoryStates)
+  CreateOperandTypes(std::shared_ptr<const rvsdg::Type> storedType, size_t numMemoryStates)
   {
     std::vector<std::shared_ptr<const rvsdg::Type>> types(
         { PointerType::Create(), std::move(storedType), IOStateType::Create() });

--- a/jlm/llvm/ir/operators/alloca.hpp
+++ b/jlm/llvm/ir/operators/alloca.hpp
@@ -20,7 +20,7 @@ public:
   ~AllocaOperation() noexcept override;
 
   AllocaOperation(
-      std::shared_ptr<const rvsdg::ValueType> allocatedType,
+      std::shared_ptr<const rvsdg::Type> allocatedType,
       std::shared_ptr<const rvsdg::BitType> btype,
       size_t alignment)
       : SimpleOperation({ btype }, { { PointerType::Create() }, { MemoryStateType::Create() } }),
@@ -47,13 +47,13 @@ public:
     return *std::static_pointer_cast<const rvsdg::BitType>(argument(0));
   }
 
-  [[nodiscard]] const rvsdg::ValueType &
+  [[nodiscard]] const rvsdg::Type &
   value_type() const noexcept
   {
     return *AllocatedType_;
   }
 
-  [[nodiscard]] const std::shared_ptr<const rvsdg::ValueType> &
+  [[nodiscard]] const std::shared_ptr<const rvsdg::Type> &
   ValueType() const noexcept
   {
     return AllocatedType_;
@@ -66,10 +66,7 @@ public:
   }
 
   static std::unique_ptr<llvm::ThreeAddressCode>
-  create(
-      std::shared_ptr<const rvsdg::ValueType> allocatedType,
-      const Variable * size,
-      size_t alignment)
+  create(std::shared_ptr<const rvsdg::Type> allocatedType, const Variable * size, size_t alignment)
   {
     auto bt = std::dynamic_pointer_cast<const rvsdg::BitType>(size->Type());
     if (!bt)
@@ -80,10 +77,7 @@ public:
   }
 
   static std::vector<rvsdg::Output *>
-  create(
-      std::shared_ptr<const rvsdg::ValueType> allocatedType,
-      rvsdg::Output * size,
-      size_t alignment)
+  create(std::shared_ptr<const rvsdg::Type> allocatedType, rvsdg::Output * size, size_t alignment)
   {
     auto bt = std::dynamic_pointer_cast<const rvsdg::BitType>(size->Type());
     if (!bt)
@@ -98,7 +92,7 @@ public:
 
 private:
   size_t alignment_;
-  std::shared_ptr<const rvsdg::ValueType> AllocatedType_;
+  std::shared_ptr<const rvsdg::Type> AllocatedType_;
 };
 
 }

--- a/jlm/llvm/ir/operators/delta.hpp
+++ b/jlm/llvm/ir/operators/delta.hpp
@@ -24,7 +24,7 @@ public:
   ~DeltaOperation() noexcept override;
 
   DeltaOperation(
-      std::shared_ptr<const rvsdg::ValueType> type,
+      std::shared_ptr<const rvsdg::Type> type,
       const std::string & name,
       const llvm::linkage & linkage,
       std::string section,
@@ -74,7 +74,7 @@ public:
 
   static inline std::unique_ptr<DeltaOperation>
   Create(
-      std::shared_ptr<const rvsdg::ValueType> type,
+      std::shared_ptr<const rvsdg::Type> type,
       const std::string & name,
       const llvm::linkage & linkage,
       std::string section,

--- a/jlm/llvm/ir/operators/operators.hpp
+++ b/jlm/llvm/ir/operators/operators.hpp
@@ -620,7 +620,7 @@ class ConstantDataArray final : public rvsdg::SimpleOperation
 public:
   ~ConstantDataArray() noexcept override;
 
-  ConstantDataArray(const std::shared_ptr<const jlm::rvsdg::ValueType> & type, size_t size)
+  ConstantDataArray(const std::shared_ptr<const jlm::rvsdg::Type> & type, size_t size)
       : SimpleOperation({ size, type }, { ArrayType::Create(type, size) })
   {
     if (size == 0)
@@ -642,7 +642,7 @@ public:
     return std::static_pointer_cast<const ArrayType>(result(0))->nelements();
   }
 
-  const jlm::rvsdg::ValueType &
+  const jlm::rvsdg::Type &
   type() const noexcept
   {
     return std::static_pointer_cast<const ArrayType>(result(0))->element_type();
@@ -654,8 +654,8 @@ public:
     if (elements.size() == 0)
       throw util::Error("expected at least one element.");
 
-    auto vt = std::dynamic_pointer_cast<const jlm::rvsdg::ValueType>(elements[0]->Type());
-    if (!vt)
+    auto vt = elements[0]->Type();
+    if (vt->Kind() != rvsdg::TypeKind::Value)
       throw util::Error("expected value type.");
 
     ConstantDataArray op(std::move(vt), elements.size());
@@ -668,8 +668,8 @@ public:
     if (elements.empty())
       throw util::Error("Expected at least one element.");
 
-    auto valueType = std::dynamic_pointer_cast<const jlm::rvsdg::ValueType>(elements[0]->Type());
-    if (!valueType)
+    auto valueType = elements[0]->Type();
+    if (valueType->Kind() != rvsdg::TypeKind::Value)
     {
       throw util::Error("Expected value type.");
     }
@@ -1059,7 +1059,7 @@ class PoisonValueOperation final : public rvsdg::SimpleOperation
 public:
   ~PoisonValueOperation() noexcept override;
 
-  explicit PoisonValueOperation(std::shared_ptr<const jlm::rvsdg::ValueType> type)
+  explicit PoisonValueOperation(std::shared_ptr<const jlm::rvsdg::Type> type)
       : SimpleOperation({}, { std::move(type) })
   {}
 
@@ -1082,10 +1082,10 @@ public:
   [[nodiscard]] std::unique_ptr<Operation>
   copy() const override;
 
-  const jlm::rvsdg::ValueType &
+  const jlm::rvsdg::Type &
   GetType() const noexcept
   {
-    return *util::AssertedCast<const rvsdg::ValueType>(result(0).get());
+    return *result(0).get();
   }
 
   static std::unique_ptr<llvm::ThreeAddressCode>
@@ -1106,11 +1106,11 @@ public:
   }
 
 private:
-  static std::shared_ptr<const jlm::rvsdg::ValueType>
+  static std::shared_ptr<const jlm::rvsdg::Type>
   CheckAndConvertType(const std::shared_ptr<const jlm::rvsdg::Type> & type)
   {
-    if (auto valueType = std::dynamic_pointer_cast<const jlm::rvsdg::ValueType>(type))
-      return valueType;
+    if (type->Kind() == rvsdg::TypeKind::Value)
+      return type;
 
     throw util::Error("Expected value type.");
   }
@@ -1462,12 +1462,6 @@ public:
   ~BitCastOperation() noexcept override;
 
   BitCastOperation(
-      std::shared_ptr<const jlm::rvsdg::ValueType> srctype,
-      std::shared_ptr<const jlm::rvsdg::ValueType> dsttype)
-      : UnaryOperation(std::move(srctype), std::move(dsttype))
-  {}
-
-  BitCastOperation(
       std::shared_ptr<const jlm::rvsdg::Type> srctype,
       std::shared_ptr<const jlm::rvsdg::Type> dsttype)
       : UnaryOperation(srctype, dsttype)
@@ -1518,22 +1512,18 @@ public:
   }
 
 private:
-  static std::pair<
-      std::shared_ptr<const jlm::rvsdg::ValueType>,
-      std::shared_ptr<const jlm::rvsdg::ValueType>>
+  static std::pair<std::shared_ptr<const jlm::rvsdg::Type>, std::shared_ptr<const jlm::rvsdg::Type>>
   check_types(
       const std::shared_ptr<const jlm::rvsdg::Type> & otype,
       const std::shared_ptr<const jlm::rvsdg::Type> & rtype)
   {
-    auto ot = std::dynamic_pointer_cast<const jlm::rvsdg::ValueType>(otype);
-    if (!ot)
+    if (otype->Kind() != rvsdg::TypeKind::Value)
       throw util::Error("expected value type.");
 
-    auto rt = std::dynamic_pointer_cast<const jlm::rvsdg::ValueType>(rtype);
-    if (!rt)
+    if (rtype->Kind() != rvsdg::TypeKind::Value)
       throw util::Error("expected value type.");
 
-    return std::make_pair(ot, rt);
+    return std::make_pair(otype, rtype);
   }
 };
 
@@ -1813,7 +1803,7 @@ class ConstantArrayOperation final : public rvsdg::SimpleOperation
 public:
   ~ConstantArrayOperation() noexcept override;
 
-  ConstantArrayOperation(const std::shared_ptr<const jlm::rvsdg::ValueType> & type, size_t size)
+  ConstantArrayOperation(const std::shared_ptr<const jlm::rvsdg::Type> & type, size_t size)
       : SimpleOperation({ size, type }, { ArrayType::Create(type, size) })
   {
     if (size == 0)
@@ -1835,7 +1825,7 @@ public:
     return std::static_pointer_cast<const ArrayType>(result(0))->nelements();
   }
 
-  const jlm::rvsdg::ValueType &
+  const jlm::rvsdg::Type &
   type() const noexcept
   {
     return std::static_pointer_cast<const ArrayType>(result(0))->element_type();
@@ -1847,8 +1837,8 @@ public:
     if (elements.size() == 0)
       throw util::Error("expected at least one element.\n");
 
-    auto vt = std::dynamic_pointer_cast<const jlm::rvsdg::ValueType>(elements[0]->Type());
-    if (!vt)
+    auto vt = elements[0]->Type();
+    if (vt->Kind() != rvsdg::TypeKind::Value)
       throw util::Error("expected value Type.\n");
 
     ConstantArrayOperation op(vt, elements.size());
@@ -1861,8 +1851,8 @@ public:
     if (operands.empty())
       throw util::Error("Expected at least one element.\n");
 
-    auto valueType = std::dynamic_pointer_cast<const rvsdg::ValueType>(operands[0]->Type());
-    if (!valueType)
+    auto valueType = operands[0]->Type();
+    if (valueType->Kind() != rvsdg::TypeKind::Value)
     {
       throw util::Error("Expected value type.\n");
     }
@@ -2044,7 +2034,7 @@ public:
 
   InsertElementOperation(
       const std::shared_ptr<const VectorType> & vectype,
-      const std::shared_ptr<const jlm::rvsdg::ValueType> & vtype,
+      const std::shared_ptr<const jlm::rvsdg::Type> & vtype,
       const std::shared_ptr<const jlm::rvsdg::BitType> & btype)
       : SimpleOperation({ vectype, vtype, btype }, { vectype })
   {
@@ -2072,8 +2062,8 @@ public:
     if (!vct)
       throw util::Error("expected vector type.");
 
-    auto vt = std::dynamic_pointer_cast<const jlm::rvsdg::ValueType>(value->Type());
-    if (!vt)
+    auto vt = value->Type();
+    if (vt->Kind() != rvsdg::TypeKind::Value)
       throw util::Error("expected value type.");
 
     auto bt = std::dynamic_pointer_cast<const jlm::rvsdg::BitType>(index->Type());
@@ -2295,7 +2285,7 @@ public:
     return std::static_pointer_cast<const VectorType>(result(0))->size();
   }
 
-  const jlm::rvsdg::ValueType &
+  const jlm::rvsdg::Type &
   type() const noexcept
   {
     return std::static_pointer_cast<const VectorType>(result(0))->type();
@@ -2307,8 +2297,8 @@ public:
     if (elements.empty())
       throw util::Error("Expected at least one element.");
 
-    auto vt = std::dynamic_pointer_cast<const jlm::rvsdg::ValueType>(elements[0]->Type());
-    if (!vt)
+    auto vt = elements[0]->Type();
+    if (vt->Kind() != rvsdg::TypeKind::Value)
       throw util::Error("Expected value type.");
 
     ConstantDataVectorOperation op(FixedVectorType::Create(vt, elements.size()));
@@ -2354,10 +2344,10 @@ public:
     return indices_.end();
   }
 
-  const jlm::rvsdg::ValueType &
+  const jlm::rvsdg::Type &
   type() const noexcept
   {
-    return *std::static_pointer_cast<const rvsdg::ValueType>(argument(0));
+    return *argument(0);
   }
 
   static inline std::unique_ptr<llvm::ThreeAddressCode>

--- a/jlm/llvm/ir/types.cpp
+++ b/jlm/llvm/ir/types.cpp
@@ -35,6 +35,12 @@ PointerType::ComputeHash() const noexcept
   return typeid(PointerType).hash_code();
 }
 
+rvsdg::TypeKind
+PointerType::Kind() const noexcept
+{
+  return rvsdg::TypeKind::Value;
+}
+
 std::shared_ptr<const PointerType>
 PointerType::Create()
 {
@@ -65,6 +71,12 @@ ArrayType::ComputeHash() const noexcept
   return util::CombineHashes(typeHash, type_->ComputeHash(), numElementsHash);
 }
 
+rvsdg::TypeKind
+ArrayType::Kind() const noexcept
+{
+  return rvsdg::TypeKind::Value;
+}
+
 FloatingPointType::~FloatingPointType() noexcept = default;
 
 std::string
@@ -93,6 +105,12 @@ FloatingPointType::ComputeHash() const noexcept
   const auto typeHash = typeid(FloatingPointType).hash_code();
   const auto sizeHash = std::hash<fpsize>()(size_);
   return util::CombineHashes(typeHash, sizeHash);
+}
+
+rvsdg::TypeKind
+FloatingPointType::Kind() const noexcept
+{
+  return rvsdg::TypeKind::Value;
 }
 
 std::shared_ptr<const FloatingPointType>
@@ -146,6 +164,12 @@ VariableArgumentType::ComputeHash() const noexcept
   return typeid(VariableArgumentType).hash_code();
 }
 
+rvsdg::TypeKind
+VariableArgumentType::Kind() const noexcept
+{
+  return rvsdg::TypeKind::State;
+}
+
 std::string
 VariableArgumentType::debug_string() const
 {
@@ -177,6 +201,12 @@ StructType::ComputeHash() const noexcept
   auto nameHash = std::hash<std::string>()(Name_);
   auto declarationHash = std::hash<const StructType::Declaration *>()(&Declaration_);
   return util::CombineHashes(typeHash, isPackedHash, nameHash, declarationHash);
+}
+
+rvsdg::TypeKind
+StructType::Kind() const noexcept
+{
+  return rvsdg::TypeKind::Value;
 }
 
 std::string
@@ -216,6 +246,12 @@ VectorType::operator==(const rvsdg::Type & other) const noexcept
 {
   const auto type = dynamic_cast<const VectorType *>(&other);
   return type && type->size_ == size_ && *type->type_ == *type_;
+}
+
+rvsdg::TypeKind
+VectorType::Kind() const noexcept
+{
+  return rvsdg::TypeKind::Value;
 }
 
 FixedVectorType::~FixedVectorType() noexcept = default;
@@ -276,6 +312,12 @@ IOStateType::ComputeHash() const noexcept
   return typeid(IOStateType).hash_code();
 }
 
+rvsdg::TypeKind
+IOStateType::Kind() const noexcept
+{
+  return rvsdg::TypeKind::State;
+}
+
 std::string
 IOStateType::debug_string() const
 {
@@ -312,6 +354,12 @@ MemoryStateType::ComputeHash() const noexcept
   return typeid(MemoryStateType).hash_code();
 }
 
+rvsdg::TypeKind
+MemoryStateType::Kind() const noexcept
+{
+  return rvsdg::TypeKind::State;
+}
+
 std::shared_ptr<const MemoryStateType>
 MemoryStateType::Create()
 {
@@ -320,7 +368,7 @@ MemoryStateType::Create()
 }
 
 size_t
-GetTypeSize(const rvsdg::ValueType & type)
+GetTypeSize(const rvsdg::Type & type)
 {
   if (const auto bits = dynamic_cast<const rvsdg::BitType *>(&type))
   {
@@ -403,7 +451,7 @@ GetTypeSize(const rvsdg::ValueType & type)
 }
 
 size_t
-GetTypeAlignment(const rvsdg::ValueType & type)
+GetTypeAlignment(const rvsdg::Type & type)
 {
   if (jlm::rvsdg::is<rvsdg::BitType>(type) || jlm::rvsdg::is<PointerType>(type)
       || jlm::rvsdg::is<FloatingPointType>(type) || jlm::rvsdg::is<VectorType>(type))

--- a/jlm/llvm/opt/alias-analyses/LocalAliasAnalysis.cpp
+++ b/jlm/llvm/opt/alias-analyses/LocalAliasAnalysis.cpp
@@ -190,7 +190,7 @@ static std::optional<int64_t>
 CalculateIntraTypeGepOffset(
     const rvsdg::SimpleNode & gepNode,
     size_t inputIndex,
-    const rvsdg::ValueType & type)
+    const rvsdg::Type & type)
 {
   // If we have no more input index values, we are not offsetting into the type
   if (inputIndex >= gepNode.ninputs())

--- a/jlm/llvm/opt/push.cpp
+++ b/jlm/llvm/opt/push.cpp
@@ -87,7 +87,7 @@ has_side_effects(const rvsdg::Node * node)
 {
   for (size_t n = 0; n < node->noutputs(); n++)
   {
-    if (rvsdg::is<const rvsdg::StateType>(node->output(n)->Type()))
+    if (node->output(n)->Type()->Kind() == rvsdg::TypeKind::State)
       return true;
   }
 

--- a/jlm/rvsdg/FunctionType.cpp
+++ b/jlm/rvsdg/FunctionType.cpp
@@ -17,7 +17,7 @@ FunctionType::~FunctionType() noexcept = default;
 FunctionType::FunctionType(
     std::vector<std::shared_ptr<const jlm::rvsdg::Type>> argumentTypes,
     std::vector<std::shared_ptr<const jlm::rvsdg::Type>> resultTypes)
-    : jlm::rvsdg::ValueType(),
+    : jlm::rvsdg::Type(),
       ArgumentTypes_(std::move(argumentTypes)),
       ResultTypes_(std::move(resultTypes))
 {}
@@ -103,6 +103,12 @@ FunctionType::ComputeHash() const noexcept
   }
 
   return seed;
+}
+
+TypeKind
+FunctionType::Kind() const noexcept
+{
+  return TypeKind::Value;
 }
 
 std::shared_ptr<const FunctionType>

--- a/jlm/rvsdg/FunctionType.hpp
+++ b/jlm/rvsdg/FunctionType.hpp
@@ -21,7 +21,7 @@ namespace jlm::rvsdg
  *
  * Represents the type of a callable function.
  */
-class FunctionType : public ValueType
+class FunctionType : public Type
 {
 public:
   ~FunctionType() noexcept override;
@@ -76,6 +76,9 @@ public:
 
   [[nodiscard]] std::size_t
   ComputeHash() const noexcept override;
+
+  TypeKind
+  Kind() const noexcept override;
 
   static std::shared_ptr<const FunctionType>
   Create(

--- a/jlm/rvsdg/UnitType.cpp
+++ b/jlm/rvsdg/UnitType.cpp
@@ -23,6 +23,12 @@ UnitType::ComputeHash() const noexcept
   return typeid(UnitType).hash_code();
 }
 
+TypeKind
+UnitType::Kind() const noexcept
+{
+  return TypeKind::Value;
+}
+
 std::shared_ptr<const UnitType>
 UnitType::Create()
 {

--- a/jlm/rvsdg/UnitType.hpp
+++ b/jlm/rvsdg/UnitType.hpp
@@ -20,7 +20,7 @@ namespace jlm::rvsdg
  *
  * This roughly corresponds to the "void" type in C/C++.
  */
-class UnitType final : public ValueType
+class UnitType final : public Type
 {
 public:
   ~UnitType() noexcept override;
@@ -33,6 +33,9 @@ public:
 
   std::size_t
   ComputeHash() const noexcept override;
+
+  TypeKind
+  Kind() const noexcept override;
 
   static std::shared_ptr<const UnitType>
   Create();

--- a/jlm/rvsdg/bitstring/type.cpp
+++ b/jlm/rvsdg/bitstring/type.cpp
@@ -35,6 +35,12 @@ BitType::ComputeHash() const noexcept
   return util::CombineHashes(typeHash, numBitsHash);
 }
 
+TypeKind
+BitType::Kind() const noexcept
+{
+  return TypeKind::Value;
+}
+
 std::shared_ptr<const BitType>
 BitType::Create(std::size_t nbits)
 {

--- a/jlm/rvsdg/bitstring/type.hpp
+++ b/jlm/rvsdg/bitstring/type.hpp
@@ -13,7 +13,7 @@
 namespace jlm::rvsdg
 {
 
-class BitType final : public ValueType
+class BitType final : public Type
 {
 public:
   ~BitType() noexcept override;
@@ -36,6 +36,9 @@ public:
 
   [[nodiscard]] std::size_t
   ComputeHash() const noexcept override;
+
+  TypeKind
+  Kind() const noexcept override;
 
   /**
    * \brief Creates bit type of specified width

--- a/jlm/rvsdg/control.cpp
+++ b/jlm/rvsdg/control.cpp
@@ -23,7 +23,7 @@ template class DomainConstOperation<
 ControlType::~ControlType() noexcept = default;
 
 ControlType::ControlType(size_t nalternatives)
-    : StateType(),
+    : Type(),
       nalternatives_(nalternatives)
 {}
 
@@ -46,6 +46,12 @@ ControlType::ComputeHash() const noexcept
   auto typeHash = typeid(ControlType).hash_code();
   auto numAlternativesHash = std::hash<size_t>()(nalternatives_);
   return util::CombineHashes(typeHash, numAlternativesHash);
+}
+
+TypeKind
+ControlType::Kind() const noexcept
+{
+  return TypeKind::State;
 }
 
 std::shared_ptr<const ControlType>

--- a/jlm/rvsdg/control.hpp
+++ b/jlm/rvsdg/control.hpp
@@ -19,7 +19,7 @@
 namespace jlm::rvsdg
 {
 
-class ControlType final : public StateType
+class ControlType final : public Type
 {
 public:
   ~ControlType() noexcept override;
@@ -34,6 +34,9 @@ public:
 
   std::size_t
   ComputeHash() const noexcept override;
+
+  TypeKind
+  Kind() const noexcept override;
 
   inline size_t
   nalternatives() const noexcept

--- a/jlm/rvsdg/delta.hpp
+++ b/jlm/rvsdg/delta.hpp
@@ -20,9 +20,9 @@ public:
   ~DeltaOperation() noexcept override;
 
   DeltaOperation(
-      std::shared_ptr<const rvsdg::ValueType> type,
+      std::shared_ptr<const rvsdg::Type> type,
       bool constant,
-      std::shared_ptr<const rvsdg::ValueType> reftype)
+      std::shared_ptr<const rvsdg::Type> reftype)
       : constant_(constant),
         type_(std::move(type)),
         reftype_(std::move(reftype))
@@ -53,19 +53,19 @@ public:
     return constant_;
   }
 
-  [[nodiscard]] const rvsdg::ValueType &
+  [[nodiscard]] const rvsdg::Type &
   type() const noexcept
   {
     return *type_;
   }
 
-  [[nodiscard]] const std::shared_ptr<const rvsdg::ValueType> &
+  [[nodiscard]] const std::shared_ptr<const rvsdg::Type> &
   Type() const noexcept
   {
     return type_;
   }
 
-  [[nodiscard]] const std::shared_ptr<const rvsdg::ValueType> &
+  [[nodiscard]] const std::shared_ptr<const rvsdg::Type> &
   ReferenceType() const noexcept
   {
     return reftype_;
@@ -91,17 +91,17 @@ public:
    */
   static inline std::unique_ptr<DeltaOperation>
   Create(
-      std::shared_ptr<const rvsdg::ValueType> type,
+      std::shared_ptr<const rvsdg::Type> type,
       bool constant,
-      std::shared_ptr<const rvsdg::ValueType> reftype)
+      std::shared_ptr<const rvsdg::Type> reftype)
   {
     return std::make_unique<DeltaOperation>(std::move(type), constant, std::move(reftype));
   }
 
 private:
   bool constant_;
-  std::shared_ptr<const rvsdg::ValueType> type_;
-  std::shared_ptr<const rvsdg::ValueType> reftype_;
+  std::shared_ptr<const rvsdg::Type> type_;
+  std::shared_ptr<const rvsdg::Type> reftype_;
 };
 
 /** \brief Delta node
@@ -239,7 +239,7 @@ public:
   [[nodiscard]] const DeltaOperation &
   GetOperation() const noexcept override;
 
-  [[nodiscard]] const std::shared_ptr<const rvsdg::ValueType> &
+  [[nodiscard]] const std::shared_ptr<const rvsdg::Type> &
   Type() const noexcept
   {
     return GetOperation().Type();

--- a/jlm/rvsdg/type.cpp
+++ b/jlm/rvsdg/type.cpp
@@ -11,8 +11,4 @@ namespace jlm::rvsdg
 
 Type::~Type() noexcept = default;
 
-ValueType::~ValueType() noexcept = default;
-
-StateType::~StateType() noexcept = default;
-
 }

--- a/jlm/rvsdg/type.hpp
+++ b/jlm/rvsdg/type.hpp
@@ -13,6 +13,30 @@
 namespace jlm::rvsdg
 {
 
+/**
+ * \brief The kinds of types supported in rvsdg
+ *
+ * Note: there might be reasons to make this extensible eventually.
+ */
+enum class TypeKind
+{
+  /**
+   * \brief Designate a value type
+   *
+   * Value types represent things that can be created, copied and
+   * destroyed at will.
+   */
+  Value,
+  /**
+   * \brief Designate a state type
+   *
+   * State types represent things that exist in mutable form.
+   * They cannot be copied, but objects of this kind must
+   * be used linearly.
+   */
+  State
+};
+
 class Type
 {
 public:
@@ -42,28 +66,12 @@ public:
    */
   [[nodiscard]] virtual std::size_t
   ComputeHash() const noexcept = 0;
-};
 
-class ValueType : public Type
-{
-public:
-  ~ValueType() noexcept override;
-
-protected:
-  constexpr ValueType() noexcept
-      : jlm::rvsdg::Type()
-  {}
-};
-
-class StateType : public Type
-{
-public:
-  ~StateType() noexcept override;
-
-protected:
-  constexpr StateType() noexcept
-      : Type()
-  {}
+  /**
+   * \brief Return the kind of this type
+   */
+  virtual TypeKind
+  Kind() const noexcept = 0;
 };
 
 template<class T>

--- a/tests/jlm/llvm/ir/TestTypes.cpp
+++ b/tests/jlm/llvm/ir/TestTypes.cpp
@@ -27,13 +27,10 @@ TestIsOrContains()
   assert(!IsOrContains<PointerType>(*memoryStateType));
   assert(!IsOrContains<PointerType>(*ioStateType));
 
-  // Checking supertypes should work
-  assert(IsOrContains<jlm::rvsdg::ValueType>(*pointerType));
-  assert(!IsOrContains<jlm::rvsdg::ValueType>(*memoryStateType));
-  assert(!IsOrContains<jlm::rvsdg::ValueType>(*ioStateType));
-  assert(!IsOrContains<jlm::rvsdg::StateType>(*pointerType));
-  assert(IsOrContains<jlm::rvsdg::StateType>(*memoryStateType));
-  assert(IsOrContains<jlm::rvsdg::StateType>(*ioStateType));
+  // Check type kinds
+  assert(pointerType->Kind() == jlm::rvsdg::TypeKind::Value);
+  assert(memoryStateType->Kind() == jlm::rvsdg::TypeKind::State);
+  assert(ioStateType->Kind() == jlm::rvsdg::TypeKind::State);
 
   // Function types are not aggregate types
   auto functionType = jlm::rvsdg::FunctionType::Create(
@@ -42,7 +39,7 @@ TestIsOrContains()
   assert(!IsAggregateType(*functionType));
   assert(IsOrContains<jlm::rvsdg::FunctionType>(*functionType));
   assert(!IsOrContains<PointerType>(*functionType));
-  assert(!IsOrContains<jlm::rvsdg::StateType>(*functionType));
+  assert(functionType->Kind() == jlm::rvsdg::TypeKind::Value);
 
   // Struct types are aggregates that can contain other types
   auto declaration = StructType::Declaration::Create({ valueType, pointerType });
@@ -50,7 +47,7 @@ TestIsOrContains()
   assert(IsAggregateType(*structType));
   assert(IsOrContains<StructType>(*structType));
   assert(IsOrContains<PointerType>(*structType));
-  assert(!IsOrContains<jlm::rvsdg::StateType>(*structType));
+  assert(structType->Kind() == jlm::rvsdg::TypeKind::Value);
 
   // Create an array containing the atruct type
   auto arrayType = ArrayType::Create(structType, 20);
@@ -58,7 +55,7 @@ TestIsOrContains()
   assert(IsOrContains<ArrayType>(*arrayType));
   assert(IsOrContains<StructType>(*arrayType));
   assert(IsOrContains<PointerType>(*arrayType));
-  assert(!IsOrContains<jlm::rvsdg::StateType>(*arrayType));
+  assert(arrayType->Kind() == jlm::rvsdg::TypeKind::Value);
 
   // Vector types are weird, as LLVM does not consider them to be aggregate types,
   // but they still contain other types
@@ -67,7 +64,7 @@ TestIsOrContains()
   assert(IsOrContains<VectorType>(*vectorType));
   assert(IsOrContains<StructType>(*vectorType));
   assert(IsOrContains<PointerType>(*vectorType));
-  assert(!IsOrContains<jlm::rvsdg::StateType>(*vectorType));
+  assert(vectorType->Kind() == jlm::rvsdg::TypeKind::Value);
 }
 JLM_UNIT_TEST_REGISTER("jlm/llvm/ir/TestTypes-TestIsOrContains", TestIsOrContains)
 

--- a/tests/test-types.cpp
+++ b/tests/test-types.cpp
@@ -30,6 +30,12 @@ ValueType::ComputeHash() const noexcept
   return typeid(ValueType).hash_code();
 }
 
+rvsdg::TypeKind
+ValueType::Kind() const noexcept
+{
+  return rvsdg::TypeKind::Value;
+}
+
 std::shared_ptr<const ValueType>
 ValueType::Create()
 {
@@ -55,6 +61,12 @@ std::size_t
 StateType::ComputeHash() const noexcept
 {
   return typeid(StateType).hash_code();
+}
+
+rvsdg::TypeKind
+StateType::Kind() const noexcept
+{
+  return rvsdg::TypeKind::State;
 }
 
 std::shared_ptr<const StateType>

--- a/tests/test-types.hpp
+++ b/tests/test-types.hpp
@@ -11,7 +11,7 @@
 namespace jlm::tests
 {
 
-class ValueType final : public rvsdg::ValueType
+class ValueType final : public rvsdg::Type
 {
 public:
   ~ValueType() noexcept override;
@@ -27,11 +27,14 @@ public:
   [[nodiscard]] std::size_t
   ComputeHash() const noexcept override;
 
+  rvsdg::TypeKind
+  Kind() const noexcept override;
+
   static std::shared_ptr<const ValueType>
   Create();
 };
 
-class StateType final : public rvsdg::StateType
+class StateType final : public rvsdg::Type
 {
 public:
   ~StateType() noexcept override;
@@ -46,6 +49,9 @@ public:
 
   [[nodiscard]] std::size_t
   ComputeHash() const noexcept override;
+
+  rvsdg::TypeKind
+  Kind() const noexcept override;
 
   static std::shared_ptr<const StateType>
   Create();


### PR DESCRIPTION
Remove the ValueType and StateType as base classes for further types -- every type used in rvsdg can just inherit from Type instead. Indicate whether a type is of "Value" or "State" kind by an attribute instead.

This is based on the following observations:

- there are only very few places where this distinction really matters

- where it matters (e.g. record elements), "ValueType" is actually not sufficiently restrictive

In summary, the distinction gains very little, and where it matters is better conveyed through more flexible attribute semantics.