### PR TITLE
Create alternative TopDown and BottomUp Traverser

### DIFF
--- a/tests/jlm/rvsdg/test-topdown.cpp
+++ b/tests/jlm/rvsdg/test-topdown.cpp
@@ -126,18 +126,11 @@ test_traversal_insertion()
     auto n4 = jlm::tests::TestOperation::create(&graph.GetRootRegion(), { n3->output(0) }, {});
     auto n5 = jlm::tests::TestOperation::create(&graph.GetRootRegion(), { n2->output(0) }, {});
 
-    /*
-      The newly created nodes n3 and n4 will not be visited,
-      as they were not created as descendants of unvisited
-      nodes. n5 must be visited, as n2 has not been visited yet.
-    */
+    // None of the created nodes should be visited
 
     bool visited_n2 = false, visited_n3 = false, visited_n4 = false, visited_n5 = false;
-    for (;;)
+    while ((node = trav.next()))
     {
-      node = trav.next();
-      if (!node)
-        break;
       if (node == n2)
         visited_n2 = true;
       if (node == n3)
@@ -151,7 +144,7 @@ test_traversal_insertion()
     assert(visited_n2);
     assert(!visited_n3);
     assert(!visited_n4);
-    assert(visited_n5);
+    assert(!visited_n5);
   }
 }
 


### PR DESCRIPTION
Looking at #1294 gave me some ideas, so I had a go at writing the `TopDownTraverser` and `BottomUpTraverser` in a way that takes a `template <bool IsConst>` to create both a const and non-const version.

I went for a slightly different implementation to remove the need for notifications from region changes, and made the rules regarding modifying regions during traversal a bit more strictly defined:
 - It is illegal to delete nodes that have not yet been visited. Deleting the current node is okay.
 - Any node added after traversal begins will NOT be visited, no matter where you add it.

With the old implementation is was technically possible to visit a node before its predecessor had been visited, if an input was diverted after the node was added to the frontier. This implementation adds a check, but the check only runs in the non-const version. The const version does not bother checking.

Because I do not use notifications from the region, it is possible for the frontier to become empty, despite nodes still being left. This will trigger a "re-frontiering", which is a O(n) operation, but it only happens if the region is changed in a very weird way during traversal.