### PR TITLE
Remove Cache and Unknown memory from MemoryStateEncodeer

### DIFF
--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
@@ -500,7 +500,6 @@ public:
   }
 
 private:
-
   StateMap &
   GetStateMap(const rvsdg::Region & region) const noexcept
   {

--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoder.cpp
@@ -390,17 +390,25 @@ public:
     return GetStateMap(*state.region()).InsertState(memoryNode, state);
   }
 
-  StateMap::MemoryNodeStatePair *
-  InsertUndefinedState(rvsdg::Region & region, const PointsToGraph::MemoryNode & memoryNode)
-  {
-    auto & undefinedState = GetOrInsertUndefinedMemoryState(region);
-    return InsertState(memoryNode, undefinedState);
-  }
-
   void
   ReplaceAddress(const rvsdg::Output & oldAddress, const rvsdg::Output & newAddress)
   {
-    GetMemoryNodeCache(*oldAddress.region()).ReplaceAddress(oldAddress, newAddress);
+    // TODO: This method is temporary until the new ModRefSummary interface is added
+    ReplacementMap_[&newAddress] = &oldAddress;
+  }
+
+  const rvsdg::Output &
+  LookupAddress(const rvsdg::Output & output)
+  {
+    // TODO: This method is temporary until the new ModRefSummary interface is added
+    const rvsdg::Output * result = &output;
+    while (true)
+    {
+      auto it = ReplacementMap_.find(result);
+      if (it == ReplacementMap_.end())
+        return *result;
+      result = it->second;
+    }
   }
 
   bool
@@ -432,7 +440,49 @@ public:
   util::HashSet<const PointsToGraph::MemoryNode *>
   GetSimpleNodeModRef(const rvsdg::SimpleNode & node)
   {
-    return ModRefSummary_.GetSimpleNodeModRef(node);
+    // TODO: This implementation is temporary, until the new ModRefSummary interface is added
+    util::HashSet<const PointsToGraph::MemoryNode *> result;
+    const auto & addOutputToModRefSet = [&](const rvsdg::Output & output)
+    {
+      auto & trueOutput = LookupAddress(output);
+      auto memoryNodes = ModRefSummary_.GetOutputNodes(trueOutput);
+      result.UnionWithAndClear(memoryNodes);
+    };
+
+    if (jlm::rvsdg::is<StoreOperation>(&node))
+    {
+      addOutputToModRefSet(*StoreOperation::AddressInput(node).origin());
+    }
+    else if (jlm::rvsdg::is<LoadOperation>(&node))
+    {
+      addOutputToModRefSet(*LoadOperation::AddressInput(node).origin());
+    }
+    else if (jlm::rvsdg::is<FreeOperation>(&node))
+    {
+      addOutputToModRefSet(*node.input(0)->origin());
+    }
+    else if (jlm::rvsdg::is<MemCpyOperation>(&node))
+    {
+      addOutputToModRefSet(*node.input(0)->origin());
+      addOutputToModRefSet(*node.input(1)->origin());
+    }
+    else if (jlm::rvsdg::is<AllocaOperation>(&node))
+    {
+      result.Insert(&ModRefSummary_.GetPointsToGraph().GetAllocaNode(node));
+    }
+    else if (jlm::rvsdg::is<MallocOperation>(&node))
+    {
+      result.Insert(&ModRefSummary_.GetPointsToGraph().GetMallocNode(node));
+    }
+    else if (jlm::rvsdg::is<CallOperation>(&node))
+    {
+      return ModRefSummary_.GetCallEntryNodes(node);
+    }
+    else
+    {
+      JLM_UNREACHABLE("Unhandled node type.");
+    }
+    return result;
   }
 
   void
@@ -450,33 +500,6 @@ public:
   }
 
 private:
-  rvsdg::Output &
-  GetOrInsertUndefinedMemoryState(rvsdg::Region & region)
-  {
-    return HasUndefinedMemoryState(region) ? GetUndefinedMemoryState(region)
-                                           : InsertUndefinedMemoryState(region);
-  }
-
-  bool
-  HasUndefinedMemoryState(const rvsdg::Region & region) const noexcept
-  {
-    return UndefinedMemoryStates_.find(&region) != UndefinedMemoryStates_.end();
-  }
-
-  rvsdg::Output &
-  GetUndefinedMemoryState(const rvsdg::Region & region) const noexcept
-  {
-    JLM_ASSERT(HasUndefinedMemoryState(region));
-    return *UndefinedMemoryStates_.find(&region)->second;
-  }
-
-  rvsdg::Output &
-  InsertUndefinedMemoryState(rvsdg::Region & region) noexcept
-  {
-    auto undefinedMemoryState = UndefValueOperation::Create(region, MemoryStateType::Create());
-    UndefinedMemoryStates_[&region] = undefinedMemoryState;
-    return *undefinedMemoryState;
-  }
 
   StateMap &
   GetStateMap(const rvsdg::Region & region) const noexcept
@@ -487,8 +510,10 @@ private:
 
   const ModRefSummary & ModRefSummary_;
 
+  // TODO: Temporary until new ModRefSummary interface is added
+  std::unordered_map<const rvsdg::Output *, const rvsdg::Output *> ReplacementMap_;
+
   std::unordered_map<const rvsdg::Region *, std::unique_ptr<StateMap>> StateMaps_;
-  std::unordered_map<const rvsdg::Region *, rvsdg::Output *> UndefinedMemoryStates_;
 };
 
 /** \brief Context for the memory state encoder
@@ -709,8 +734,9 @@ MemoryStateEncoder::EncodeAlloca(const rvsdg::SimpleNode & allocaNode)
   JLM_ASSERT(is<AllocaOperation>(&allocaNode));
 
   auto & stateMap = Context_->GetRegionalizedStateMap();
-  auto & allocaMemoryNode =
-      Context_->GetModRefSummary().GetPointsToGraph().GetAllocaNode(allocaNode);
+  auto allocaMemoryNodes = stateMap.GetSimpleNodeModRef(allocaNode);
+  JLM_ASSERT(allocaMemoryNodes.Size() == 1);
+  auto & allocaMemoryNode = **allocaMemoryNodes.Items().begin();
   auto & allocaNodeStateOutput = *allocaNode.output(1);
 
   // If a state representing the alloca already exists in the region,
@@ -734,8 +760,10 @@ MemoryStateEncoder::EncodeMalloc(const rvsdg::SimpleNode & mallocNode)
 {
   JLM_ASSERT(is<MallocOperation>(&mallocNode));
   auto & stateMap = Context_->GetRegionalizedStateMap();
-  auto & mallocMemoryNode =
-      Context_->GetModRefSummary().GetPointsToGraph().GetMallocNode(mallocNode);
+  auto mallocMemoryNodes = stateMap.GetSimpleNodeModRef(mallocNode);
+  JLM_ASSERT(mallocMemoryNodes.Size() == 1);
+  auto & mallocMemoryNode = **mallocMemoryNodes.Items().begin();
+
   auto & mallocNodeStateOutput = *mallocNode.output(1);
 
   // We use a static heap model. This means that multiple invocations of an malloc
@@ -776,7 +804,7 @@ MemoryStateEncoder::EncodeLoad(const rvsdg::SimpleNode & node)
 
   if (is<PointerType>(LoadOperation::LoadedValueOutput(node).Type()))
   {
-    stateMap.ReplaceOutput(
+    stateMap.ReplaceAddress(
         LoadOperation::LoadedValueOutput(node),
         LoadOperation::LoadedValueOutput(newLoadNode));
   }
@@ -840,17 +868,7 @@ MemoryStateEncoder::EncodeCallEntry(const rvsdg::SimpleNode & callNode)
   std::vector<MemoryNodeId> memoryNodeIds;
   for (const auto memoryNode : memoryNodes.Items())
   {
-    if (regionalizedStateMap.HasState(*region, *memoryNode))
-    {
-      states.emplace_back(&regionalizedStateMap.GetState(*region, *memoryNode)->State());
-    }
-    else
-    {
-      // The state might not exist on the call side in case of lifetime aware mod/ref summarization
-      states.emplace_back(
-          &regionalizedStateMap.InsertUndefinedState(*region, *memoryNode)->State());
-    }
-
+    states.emplace_back(&regionalizedStateMap.GetState(*region, *memoryNode)->State());
     memoryNodeIds.push_back(memoryNode->GetId());
   }
 

--- a/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
+++ b/tests/jlm/llvm/opt/alias-analyses/TestMemoryStateEncoder.cpp
@@ -1521,10 +1521,10 @@ ValidateMemcpySteensgaardAgnostic(const jlm::tests::MemcpyTest & test)
         memcpy = node;
     }
     assert(memcpy != nullptr);
-    assert(is<MemCpyNonVolatileOperation>(*memcpy, 7, 4));
+    assert(is<MemCpyNonVolatileOperation>(*memcpy, 5, 2));
 
     auto lambdaEntrySplit =
-        jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*memcpy->input(5)->origin());
+        jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*memcpy->input(4)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 5));
   }
 }
@@ -1572,13 +1572,13 @@ ValidateMemcpySteensgaardRegionAware(const jlm::tests::MemcpyTest & test)
 
     auto memcpyNode =
         jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*callEntryMerge->input(0)->origin());
-    assert(is<MemCpyNonVolatileOperation>(*memcpyNode, 7, 4));
+    assert(is<MemCpyNonVolatileOperation>(*memcpyNode, 5, 2));
 
     auto lambdaEntrySplit =
-        jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*memcpyNode->input(4)->origin());
+        jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*memcpyNode->input(3)->origin());
     assert(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 2));
     assert(
-        jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*memcpyNode->input(5)->origin())
+        jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(*memcpyNode->input(4)->origin())
         == lambdaEntrySplit);
 
     auto lambdaExitMerge =


### PR DESCRIPTION
This is a step towards #1288, which changes how the `MemoryStateEncoder` works internally to make it more ready for the new `ModRefSummary` interface. 

The changes include:
 - Remove the MemoryNodeCache
 - Remove tracking of states related to Unknown memory

It has its own shim between the old interface and the new one, called `GetSimpleNodeModRef`, which looks a bit ugly now, but will be greatly simplified with #1288. The `ReplacementMap_` will also be removed.

Lastly, I discovered a bug in the memcpy encoding when updating the interface. The current implementation will add duplicate inputs and output if the same state is targeted by both the `src` and `dst` part of the memcpy:
<img width="467" height="407" alt="image" src="https://github.com/user-attachments/assets/618da2ef-0437-4f33-ac9f-ec687dbdf15f" />

This PR accidentally fixed this, so that is why some tests are touched.