### PR TITLE
Avoid exporting strings with private linkage from the module

### DIFF
--- a/jlm/llvm/ir/linkage.hpp
+++ b/jlm/llvm/ir/linkage.hpp
@@ -14,6 +14,10 @@
 namespace jlm::llvm
 {
 
+/**
+ * Types of linkage for global variables, constants and functions.
+ * Based on LLVM's \ref ::llvm::GlobalValue::LinkageTypes
+ */
 enum class linkage
 {
   external_linkage,
@@ -29,14 +33,43 @@ enum class linkage
   common_linkage
 };
 
-static inline bool
+/**
+ * Determines if a function / global variable with the given linkage should be exported.
+ * @param lnk the linkage
+ * @return true if the function / global should be exported, false otherwise
+ */
+inline bool
 is_externally_visible(const linkage & lnk)
 {
-  /* FIXME: Refine this again. */
-  return lnk != linkage::internal_linkage;
+  // TODO: LLVM has a function isDiscardableIfUnused, which might be closer to what we mean
+  // It is true for:
+  //  - link once any
+  //  - link once odr
+  //  - internal
+  //  - private
+  //  - available_externally_linkage
+
+  switch (lnk)
+  {
+  case linkage::external_linkage:
+  case linkage::available_externally_linkage:
+  case linkage::link_once_any_linkage:
+  case linkage::link_once_odr_linkage:
+  case linkage::weak_any_linkage:
+  case linkage::weak_odr_linkage:
+  case linkage::appending_linkage:
+  case linkage::external_weak_linkage:
+  case linkage::common_linkage:
+    return true;
+  case linkage::internal_linkage:
+  case linkage::private_linkage:
+    return false;
+  default:
+    JLM_UNREACHABLE("Unknown linkage type");
+  }
 }
 
-static inline std::string
+inline std::string
 ToString(const linkage & lnk)
 {
   static std::unordered_map<linkage, std::string> strings = {
@@ -57,7 +90,7 @@ ToString(const linkage & lnk)
   return strings[lnk];
 }
 
-static inline linkage
+inline linkage
 FromString(const std::string_view stringValue)
 {
   static std::unordered_map<std::string_view, linkage> linkages = {


### PR DESCRIPTION
Fixes #1181.

The complete list of linkage types contains a lot of choices that are hard to truly understand.

I have been conservative, while writing down that there might be room for improvement.

With this change a program like:
```c
#include <stdio.h>

void f() {
    const char * c = "hi";
    printf("%c%c\n", c[0], c[1]);
}
```

gets a root region like:
<img width="342" height="447" alt="image" src="https://github.com/user-attachments/assets/7e09c839-32c1-4827-aee7-9bb4797e979b" />
