### PR TITLE
Check graph invariant in InvariantValueRedirection pass

### DIFF
--- a/jlm/llvm/opt/InvariantValueRedirection.cpp
+++ b/jlm/llvm/opt/InvariantValueRedirection.cpp
@@ -252,6 +252,11 @@ InvariantValueRedirection::RedirectCallOutputs(rvsdg::SimpleNode & callNode)
             *callEntryMerge,
             lambdaEntryMemoryNodeId);
 
+        // We expect that the memory node IDs for a given state between a
+        // LambdaEntryMemoryStateMergeOperation node and a LambdaExitMemoryStateSplitOperation node
+        // are always the same, otherwise we have a bug in the memory state encoding.
+        JLM_ASSERT(lambdaExitMemoryNodeId == lambdaEntryMemoryNodeId);
+
         if (callExitSplitOutput != nullptr && callEntryMergeInput != nullptr)
         {
           callExitSplitOutput->divert_users(callEntryMergeInput->origin());

--- a/tests/jlm/llvm/opt/InvariantValueRedirectionTests.cpp
+++ b/tests/jlm/llvm/opt/InvariantValueRedirectionTests.cpp
@@ -263,8 +263,8 @@ TestCallWithMemoryStateNodes()
     auto gammaInputMemoryState2 = gammaNode->AddEntryVar(lambdaEntrySplitNode.output(1));
 
     auto gammaOutputX = gammaNode->AddExitVar(gammaInputX.branchArgument);
-    auto gammaOutputMemoryState1 = gammaNode->AddExitVar(gammaInputMemoryState2.branchArgument);
-    auto gammaOutputMemoryState2 = gammaNode->AddExitVar(gammaInputMemoryState1.branchArgument);
+    auto gammaOutputMemoryState1 = gammaNode->AddExitVar(gammaInputMemoryState1.branchArgument);
+    auto gammaOutputMemoryState2 = gammaNode->AddExitVar(gammaInputMemoryState2.branchArgument);
 
     auto & lambdaExitMergeNode = LambdaExitMemoryStateMergeOperation::CreateNode(
         *lambdaNode->subregion(),
@@ -306,12 +306,12 @@ TestCallWithMemoryStateNodes()
 
     auto & callExitSplitNode = CallExitMemoryStateSplitOperation::CreateNode(
         CallOperation::GetMemoryStateOutput(callNode),
-        { 0, 1 });
+        { 1, 0 });
 
     auto & lambdaExitMergeNode = LambdaExitMemoryStateMergeOperation::CreateNode(
         *lambdaNode->subregion(),
         outputs(&callExitSplitNode),
-        { 0, 1 });
+        { 1, 0 });
 
     lambdaOutputTest2 = lambdaNode->finalize({ callNode.output(0),
                                                &CallOperation::GetIOStateOutput(callNode),


### PR DESCRIPTION
 We always expect that the memory node IDs for a given state between a LambdaEntryMemoryStateMergeOperation node and a LambdaExitMemoryStateSplitOperation node are the same, otherwise we have a bug in the memory state encoding.