### PR TITLE
HLS: Remove fix_match_inversion() from merge gamma pass

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/merge-gamma.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/merge-gamma.cpp
@@ -233,8 +233,7 @@ merge_gamma(rvsdg::Region * region)
           merge_gamma(structnode->subregion(n));
         if (auto gamma = dynamic_cast<rvsdg::GammaNode *>(node))
         {
-          if (eliminate_gamma_ctl(gamma) || eliminate_gamma_eol(gamma) || merge_gamma(gamma)
-              )
+          if (eliminate_gamma_ctl(gamma) || eliminate_gamma_eol(gamma) || merge_gamma(gamma))
           {
             changed = true;
             break;


### PR DESCRIPTION
There is no need for this part of the merge gamma pass any longer as the predicate correlation pass already takes part of it.