### PR TITLE
Fix build rules for gtest

### DIFF
--- a/Makefile.macros
+++ b/Makefile.macros
@@ -139,7 +139,6 @@ HEADERS += $$($1_HEADERS)
 
 $$(BUILD_OUT_PREFIX)$1: $$(patsubst %.cpp, $$(BUILD_OUT_PREFIX)%.la, $$($1_SOURCES)) $$(patsubst %, $$(BUILD_OUT_PREFIX)%.a, $$($1_LIBS))
 $$(BUILD_OUT_PREFIX)$1: LDFLAGS+=$$(patsubst %, $$(BUILD_OUT_PREFIX)%.a, $$($1_LIBS)) $$($1_EXTRA_LDFLAGS)
-TESTS += $$(BUILD_OUT_PREFIX)$1
 GTESTS += $$(BUILD_OUT_PREFIX)$1
 
 # alias rule to allow issuing "make foo" instead of "make build/foo"

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -1,4 +1,4 @@
-TEST_EXECUTABLES += $(TESTS)
+TEST_EXECUTABLES += $(TESTS) $(GTESTS)
 COVERAGE_EXECUTABLES += $(COVERAGE_TESTS)
 
 EXECUTABLES += $(TARGET_EXECUTABLES) $(TEST_EXECUTABLES) $(COVERAGE_EXECUTABLES)
@@ -119,8 +119,8 @@ check-headers: depend
 ################################################################################
 # Unit testing rules
 
-RUNTESTS=$(patsubst %, run-%, $(TESTS))
-VALGRINDTESTS=$(patsubst %, valgrind-%, $(TESTS))
+RUNTESTS=$(patsubst %, run-%, $(TESTS)) $(patsubst %, run-%, $(GTESTS))
+VALGRINDTESTS=$(patsubst %, valgrind-%, $(TESTS)) $(patsubst %, valgrind-%, $(GTESTS))
 
 $(TESTS): % : %.la
 $(TESTS): LDFLAGS += -pthread


### PR DESCRIPTION
Do not add an implied source named after the test to gtest rules.