### PR TITLE
Supress gtest sign comparison errors

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -172,7 +172,7 @@ fi
 mkdir -p build-"${TARGET}"
 rm -rf build ; ln -sf build-"${TARGET}" build
 
-GTEST_CPPFLAGS=$(pkg-config --cflags gtest_main)
+GTEST_CPPFLAGS=$(pkg-config --cflags gtest_main | sed 's/-I/-isystem /g')
 GTEST_LDFLAGS=$(pkg-config --libs gtest_main)
 
 (


### PR DESCRIPTION
Change `GTEST_CPPFLAGS` in configure.sh to use `-isystem` instead of `-I` flag. This tells the compiler to treat gtest headers as system/third-party headers. This suppresses warnings from the third-party code, which would lead to errors when compiling the project on Clang versions with stricter handling of -Wsign-compare warnings (particularly Apple Clang). It has no impact on Linux builds, and is standard practice for third-party library headers AFAIK.

An example of the error can be seen below:
```c++
/opt/homebrew/Cellar/googletest/1.17.0/include/gtest/gtest.h:1394:11: warning: comparison of integers of different signs: 'const unsigned long long' and 'const int' [-Wsign-compare]
 1394 |   if (lhs == rhs) {
      |       ~~~ ^  ~~~
/opt/homebrew/Cellar/googletest/1.17.0/include/gtest/gtest.h:1413:12: note: in instantiation of function template specialization 'testing::internal::CmpHelperEQ<unsigned long long, int>' requested here
 1413 |     return CmpHelperEQ(lhs_expression, rhs_expression, lhs, rhs);
      |            ^
tests/jlm/util/AnnotationMapTests.cpp:32:3: note: in instantiation of function template specialization 'testing::internal::EqHelper::Compare<unsigned long long, int, nullptr>' requested here
   32 |   EXPECT_EQ(uintAnnotation.Value<uint64_t>(), 1);
      |   ^
/opt/homebrew/Cellar/googletest/1.17.0/include/gtest/gtest.h:1885:54: note: expanded from macro 'EXPECT_EQ'
 1885 |   EXPECT_PRED_FORMAT2(::testing::internal::EqHelper::Compare, val1, val2)
```