### PR TITLE
LoopUnswitching: add sanity check

### DIFF
--- a/jlm/llvm/opt/LoopUnswitching.cpp
+++ b/jlm/llvm/opt/LoopUnswitching.cpp
@@ -154,6 +154,21 @@ LoopUnswitching::CopyPredicateNodes(
 }
 
 bool
+LoopUnswitching::allLoopVarsAreRoutedThroughGamma(
+    const rvsdg::ThetaNode & thetaNode,
+    const rvsdg::GammaNode & gammaNode)
+{
+  for (const auto & loopVar : thetaNode.GetLoopVars())
+  {
+    const auto node = rvsdg::TryGetOwnerNode<rvsdg::GammaNode>(*loopVar.post->origin());
+    if (node != &gammaNode)
+      return false;
+  }
+
+  return true;
+}
+
+bool
 LoopUnswitching::UnswitchLoop(rvsdg::ThetaNode & oldThetaNode)
 {
   auto oldGammaNode = IsUnswitchable(oldThetaNode);
@@ -161,6 +176,8 @@ LoopUnswitching::UnswitchLoop(rvsdg::ThetaNode & oldThetaNode)
     return false;
 
   SinkNodesIntoGamma(*oldGammaNode, oldThetaNode);
+
+  JLM_ASSERT(allLoopVarsAreRoutedThroughGamma(oldThetaNode, *oldGammaNode));
 
   // Copy condition nodes for new gamma node
   rvsdg::SubstitutionMap substitutionMap;

--- a/jlm/llvm/opt/LoopUnswitching.hpp
+++ b/jlm/llvm/opt/LoopUnswitching.hpp
@@ -61,6 +61,18 @@ private:
       rvsdg::Region & target,
       rvsdg::SubstitutionMap & substitutionMap,
       const std::vector<std::vector<rvsdg::Node *>> & nodes);
+
+  /**
+   * Checks that the post-values from all loop variables are originating from \p gammaNode.
+   *
+   * @param thetaNode The theta node for which to perform the check.
+   * @param gammaNode The gamma node through which all loop variables need to be routed.
+   * @return True, if all post-values originate from \p gammaNode, otherwise false.
+   */
+  static bool
+  allLoopVarsAreRoutedThroughGamma(
+      const rvsdg::ThetaNode & thetaNode,
+      const rvsdg::GammaNode & gammaNode);
 };
 
 }


### PR DESCRIPTION
We expect that the post-values of all loop variables are originating from the gamma node within the the theta node before we start the entire transformation. Add a sanity check to ensure that this is really the case.