### PR TITLE
HLS MemoryConversion: add support for dead kernel arguments

### DIFF
--- a/jlm/hls/backend/rhls2firrtl/VerilatorHarnessAxi.cpp
+++ b/jlm/hls/backend/rhls2firrtl/VerilatorHarnessAxi.cpp
@@ -68,12 +68,15 @@ extern "C" )"
   {
     if (rvsdg::is<llvm::PointerType>(*kernel.GetOperation().type().Arguments()[i].get()))
     {
-      const auto res_bundle = util::assertedCast<const BundleType>(mem_resps[m]->Type().get());
-      auto size = JlmSize(&*res_bundle->get_element_type("data")) / 8;
-      cpp << "    memories[" << m << "] = std::make_unique<mm_magic_t>();" << std::endl;
-      cpp << "    memories[" << m << "]->init((uint8_t *) a" << i << ", 1UL << 31, " << size
-          << ", 64, MEMORY_LATENCY);" << std::endl;
-      m++;
+      if (m < mem_reqs.size())
+      {
+        const auto res_bundle = util::assertedCast<const BundleType>(mem_resps[m]->Type().get());
+        auto size = JlmSize(&*res_bundle->get_element_type("data")) / 8;
+        cpp << "    memories[" << m << "] = std::make_unique<mm_magic_t>();" << std::endl;
+        cpp << "    memories[" << m << "]->init((uint8_t *) a" << i << ", 1UL << 31, " << size
+            << ", 64, MEMORY_LATENCY);" << std::endl;
+        m++;
+      }
     }
   }
   // TODO: handle globals/ctxvars and ports without argument

--- a/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-conv.cpp
@@ -650,6 +650,9 @@ ConvertMemory(rvsdg::RvsdgModule & rvsdgModule)
   std::unordered_set<rvsdg::Node *> accountedNodes;
   for (auto & portNode : tracedPointerNodesVector)
   {
+    if (portNode.isEmpty())
+      continue;
+
     auto portWidth = CalculatePortWidth(portNode);
     auto responseTypePtr = get_mem_res_type(rvsdg::BitType::Create(portWidth));
     auto requestTypePtr = get_mem_req_type(rvsdg::BitType::Create(portWidth), false);
@@ -733,13 +736,16 @@ ConvertMemory(rvsdg::RvsdgModule & rvsdgModule)
   auto newArgumentsIndex = args.size();
   for (auto & portNode : tracedPointerNodesVector)
   {
-    newResults.push_back(ConnectRequestResponseMemPorts(
-        newLambda,
-        newArgumentsIndex++,
-        smap,
-        portNode.loadNodes,
-        portNode.storeNodes,
-        portNode.decoupleNodes));
+    if (!portNode.isEmpty())
+    {
+      newResults.push_back(ConnectRequestResponseMemPorts(
+          newLambda,
+          newArgumentsIndex++,
+          smap,
+          portNode.loadNodes,
+          portNode.storeNodes,
+          portNode.decoupleNodes));
+    }
   }
   if (!unknownLoadNodes.empty() || !unknownStoreNodes.empty() || !unknownDecoupledNodes.empty())
   {

--- a/jlm/hls/backend/rvsdg2rhls/mem-conv.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/mem-conv.hpp
@@ -15,6 +15,12 @@ namespace jlm::hls
 
 struct TracedPointerNodes
 {
+  [[nodiscard]] bool
+  isEmpty() const noexcept
+  {
+    return loadNodes.empty() && storeNodes.empty() && decoupleNodes.empty();
+  }
+
   std::vector<rvsdg::Node *> loadNodes{};
   std::vector<rvsdg::Node *> storeNodes{};
   std::vector<rvsdg::Node *> decoupleNodes{};


### PR DESCRIPTION
Avoid the creation of memory request and response nodes in the memory conversion pass if the kernel pointer argument is dead.