### PR TITLE
RvsdgToIpGraphConverter: fix routing of globals into loops

### DIFF
--- a/jlm/llvm/backend/RvsdgToIpGraphConverter.hpp
+++ b/jlm/llvm/backend/RvsdgToIpGraphConverter.hpp
@@ -102,7 +102,7 @@ private:
   CreateInitialization(const rvsdg::DeltaNode & deltaNode);
 
   static bool
-  RequiresSsaPhiOperation(const rvsdg::ThetaNode::LoopVar & loopVar, const Variable & v);
+  RequiresSsaPhiOperation(const rvsdg::ThetaNode::LoopVar & loopVar);
 
   std::unique_ptr<Context> Context_;
 };


### PR DESCRIPTION
When loop variables take globals as input, the old conversion to CFG would always consider them invariant. This PR fixes this.