### PR TITLE
Repair test coverage computation

### DIFF
--- a/Makefile.macros
+++ b/Makefile.macros
@@ -41,21 +41,6 @@ ifeq ($$(ENABLE_SHARED), yes)
 SHARED_LIBRARIES += $$(BUILD_OUT_PREFIX)$1.so
 endif
 
-### test rules
-
-# list of test binaries within the target build directory
-$1_TESTBINARIES = $$(patsubst %, $$(BUILD_OUT_PREFIX)%, $$($1_TESTS))
-
-# add to global list of tests
-TESTS += $$(patsubst %, $$(BUILD_OUT_PREFIX)%, $$($1_TESTS))
-
-# linking of test binaries
-$$($1_TESTBINARIES): $$(patsubst %, $$(BUILD_OUT_PREFIX)%.a, $$($1_TEST_LIBS)) $$(BUILD_OUT_PREFIX)$1.a
-$$($1_TESTBINARIES): LDFLAGS+=$$(patsubst %, $$(BUILD_OUT_PREFIX)%.a, $$($1_TEST_LIBS)) $$($1_TEST_EXTRA_LDFLAGS)
-
-# add test source files to list of sources
-SOURCES += $$(patsubst %, %.cpp, $$($1_TESTS))
-
 ### test coverage rules
 
 ifeq ($$(ENABLE_COVERAGE), yes)
@@ -67,18 +52,6 @@ $$(BUILD_OUT_PREFIX)$1.coverage.a: $$(patsubst %.cpp, $$(BUILD_OUT_PREFIX)%.cove
 
 # add to clobal list of test coverage libraries
 COVERAGE_LIBRARIES += $$(BUILD_OUT_PREFIX)$1.coverage.a
-
-## rules to build the tests for this library with coverage support
-
-# list of test coverage binaries for this library, within the target build directory
-$1_COVERAGEBINARIES = $$(patsubst %, $$(BUILD_OUT_PREFIX)%.coverage, $$($1_TESTS))
-
-# add to global list of test coverage binaries
-COVERAGE_TESTS += $$($1_COVERAGEBINARIES)
-
-# linking of coverage binaries; we need to link the "coverage" version of dependent libraries, transitively
-$$($1_COVERAGEBINARIES): $$(patsubst %, $$(BUILD_OUT_PREFIX)%.coverage.a, $$($1_TEST_LIBS)) $$(BUILD_OUT_PREFIX)$1.coverage.a
-$$($1_COVERAGEBINARIES): LDFLAGS+=$$(patsubst %, $$(BUILD_OUT_PREFIX)%.coverage.a, $$($1_TEST_LIBS)) $$($1_TEST_EXTRA_LDFLAGS)
 
 STATIC_LIBRARIES += $$(BUILD_OUT_PREFIX)$1.coverage.a
 
@@ -145,4 +118,11 @@ GTESTS += $$(BUILD_OUT_PREFIX)$1
 ifndef ($$(BUILD_OUT_PREFIX),)
 $1: $$(BUILD_OUT_PREFIX)$1
 endif
+
+ifeq ($$(ENABLE_COVERAGE), yes)
+$$(BUILD_OUT_PREFIX)$1.coverage: $$(patsubst %.cpp, $$(BUILD_OUT_PREFIX)%.la, $$($1_SOURCES)) $$(patsubst %, $$(BUILD_OUT_PREFIX)%.coverage.a, $$($1_LIBS))
+$$(BUILD_OUT_PREFIX)$1.coverage: LDFLAGS+=$$(patsubst %, $$(BUILD_OUT_PREFIX)%.coverage.a, $$($1_LIBS)) $$($1_EXTRA_LDFLAGS)
+COVERAGE_TESTS += $$(BUILD_OUT_PREFIX)$1.coverage
+endif
+
 endef

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -155,15 +155,16 @@ $(BUILD_OUT_PREFIX)%.coverage.la: %.cpp
 	@mkdir -p $(dir $@)
 	$(CXX) -c $(CXXFLAGS) $(CPPFLAGS) $(COVERAGEFLAGS) -o $@ $<
 
-$(COVERAGE_TESTS): $(BUILD_OUT_PREFIX)%.coverage : $(BUILD_OUT_PREFIX)%.coverage.la
-$(COVERAGE_TESTS): LDFLAGS += -pthread $(COVERAGEFLAGS)
+$(COVERAGE_TESTS): LDFLAGS += -pthread $(COVERAGEFLAGS) $(GTEST_LDFLAGS)
 
-coverage: $(COVERAGE_TESTS) .PHONY
+coverage: $(COVERAGE_TESTS)
 	for CTEST in $(COVERAGE_TESTS) ; do $$CTEST ; done
 	mkdir -p $(BUILD_OUT_PREFIX)coverage
 	gcovr $(BUILD_OUT_PREFIX) --html-details -o $(BUILD_OUT_PREFIX)coverage/coverage.html
 
 endif
+
+.PHONY: coverage
 
 ################################################################################
 # Documentation rules


### PR DESCRIPTION
Tests are now targets of their own, since they are not "attached" to libraries themselves anymore, delete all support within the "common_library" macro to deal with tests.

Add the required glue to the test targets to support test coverage build and computation. As it is wholly contained within the "test" macro machinery, this is now significantly cleaner than before.