### PR TITLE
Fix bug in Region::toJson()

### DIFF
--- a/jlm/rvsdg/RegionTests.cpp
+++ b/jlm/rvsdg/RegionTests.cpp
@@ -499,6 +499,7 @@ TEST(RegionTests, toJson_EmptyRvsdgWithAnnotations)
 TEST(RegionTests, toJson_RvsdgWithStructuralNodes)
 {
   using namespace jlm::rvsdg;
+  using namespace jlm::util;
 
   // Arrange
   Graph rvsdg;
@@ -507,8 +508,13 @@ TEST(RegionTests, toJson_RvsdgWithStructuralNodes)
   TestStructuralNode::create(structuralNode->subregion(1), 1);
   TestStructuralNode::create(structuralNode->subregion(1), 3);
 
+  AnnotationMap annotationMap;
+  annotationMap.AddAnnotation(
+      structuralNode->subregion(1),
+      { "RegionId", structuralNode->subregion(1)->getRegionId() });
+
   // Act
-  const auto json = Region::toJson(rvsdg.GetRootRegion());
+  const auto json = Region::toJson(rvsdg.GetRootRegion(), annotationMap);
   std::cout << json << std::flush;
 
   // Assert
@@ -516,9 +522,9 @@ TEST(RegionTests, toJson_RvsdgWithStructuralNodes)
       json,
       "{\"StructuralNodes\" : [{\"DebugString\": \"TestStructuralOperation\", \"Subregions\" : "
       "[{\"StructuralNodes\" : [{\"DebugString\": \"TestStructuralOperation\", \"Subregions\" : "
-      "[{}]}]}, {\"StructuralNodes\" : [{\"DebugString\": \"TestStructuralOperation\", "
-      "\"Subregions\" : [{}]}, {\"DebugString\": \"TestStructuralOperation\", \"Subregions\" : "
-      "[{}, {}, {}]}]}]}]}");
+      "[{}]}]}, {\"RegionId\": 2,\"StructuralNodes\" : [{\"DebugString\": "
+      "\"TestStructuralOperation\", \"Subregions\" : [{}]}, {\"DebugString\": "
+      "\"TestStructuralOperation\", \"Subregions\" : [{}, {}, {}]}]}]}]}");
 }
 
 TEST(RegionTests, toJson_RvsdgWithStructuralNodesAndAnnotations)

--- a/jlm/rvsdg/region.cpp
+++ b/jlm/rvsdg/region.cpp
@@ -517,6 +517,9 @@ Region::toJson(
 
   if (!structuralNodes.empty())
   {
+    if (annotationMap.HasAnnotations(&region))
+      stream << ",";
+    
     bool firstNode = true;
     stream << "\"StructuralNodes\" : [";
     for (const auto & structuralNode : structuralNodes)

--- a/jlm/rvsdg/region.cpp
+++ b/jlm/rvsdg/region.cpp
@@ -519,7 +519,7 @@ Region::toJson(
   {
     if (annotationMap.HasAnnotations(&region))
       stream << ",";
-    
+
     bool firstNode = true;
     stream << "\"StructuralNodes\" : [";
     for (const auto & structuralNode : structuralNodes)


### PR DESCRIPTION
The method did not produce correct JSON when attributes were given for a region which contains structural nodes.