### PR TITLE
LlvmModuleConversion: improve translation of switch statements

### DIFF
--- a/jlm/llvm/Makefile.sub
+++ b/jlm/llvm/Makefile.sub
@@ -176,6 +176,7 @@ run-libllvm-tests_SOURCES = \
     jlm/llvm/frontend/ExportTests.cpp \
     jlm/llvm/frontend/FNegTests.cpp \
     jlm/llvm/frontend/FunctionCallTests.cpp \
+    jlm/llvm/frontend/LlvmModuleConversionTests.cpp \
     jlm/llvm/frontend/LlvmPhiConversionTests.cpp \
     jlm/llvm/frontend/LoadTests.cpp \
     jlm/llvm/frontend/MemCpyTests.cpp \

--- a/jlm/llvm/frontend/LlvmModuleConversion.cpp
+++ b/jlm/llvm/frontend/LlvmModuleConversion.cpp
@@ -777,32 +777,47 @@ ConvertBranchInstruction(::llvm::Instruction * instruction, tacsvector_t & tacs,
 }
 
 static const Variable *
-ConvertSwitchInstruction(::llvm::Instruction * instruction, tacsvector_t & tacs, Context & ctx)
+convertSwitchInstruction(::llvm::SwitchInst * switchInstruction, tacsvector_t & tacs, Context & ctx)
 {
-  JLM_ASSERT(instruction->getOpcode() == ::llvm::Instruction::Switch);
-  auto i = ::llvm::cast<::llvm::SwitchInst>(instruction);
-  auto bb = ctx.get(i->getParent());
+  auto jlmSwitchBasicBlock = ctx.get(switchInstruction->getParent());
 
-  JLM_ASSERT(bb->NumOutEdges() == 0);
-  std::unordered_map<uint64_t, uint64_t> mapping;
-  for (auto it = i->case_begin(); it != i->case_end(); it++)
+  JLM_ASSERT(jlmSwitchBasicBlock->NumOutEdges() == 0);
+  std::unordered_map<uint64_t, uint64_t> matchMapping;
+  std::unordered_map<::llvm::BasicBlock *, ControlFlowGraphEdge *> outEdgeMapping;
+  for (auto caseIt = switchInstruction->case_begin(); caseIt != switchInstruction->case_end();
+       ++caseIt)
   {
-    JLM_ASSERT(it != i->case_default());
-    auto edge = bb->add_outedge(ctx.get(it->getCaseSuccessor()));
-    mapping[it->getCaseValue()->getZExtValue()] = edge->index();
+    JLM_ASSERT(caseIt != switchInstruction->case_default());
+    auto llvmCaseBasicBlock = caseIt->getCaseSuccessor();
+
+    if (auto outEdgeIt = outEdgeMapping.find(llvmCaseBasicBlock); outEdgeIt != outEdgeMapping.end())
+    {
+      // We have seen this LLVM basic block already and created an outgoing edge for it. Reuse that
+      // edge.
+      matchMapping[caseIt->getCaseValue()->getZExtValue()] = outEdgeIt->second->index();
+    }
+    else
+    {
+      auto jlmCaseBasicBlock = ctx.get(llvmCaseBasicBlock);
+      auto edge = jlmSwitchBasicBlock->add_outedge(jlmCaseBasicBlock);
+      outEdgeMapping[llvmCaseBasicBlock] = edge;
+      matchMapping[caseIt->getCaseValue()->getZExtValue()] = edge->index();
+    }
   }
 
-  auto defaultEdge = bb->add_outedge(ctx.get(i->case_default()->getCaseSuccessor()));
+  auto jlmDefaultBasicBlock = ctx.get(switchInstruction->case_default()->getCaseSuccessor());
+  auto defaultEdge = jlmSwitchBasicBlock->add_outedge(jlmDefaultBasicBlock);
 
-  auto c = ConvertValue(i->getCondition(), tacs, ctx);
-  auto nbits = i->getCondition()->getType()->getIntegerBitWidth();
+  auto c = ConvertValue(switchInstruction->getCondition(), tacs, ctx);
+  auto numBits = switchInstruction->getCondition()->getType()->getIntegerBitWidth();
   auto op = std::make_unique<rvsdg::MatchOperation>(
-      nbits,
-      mapping,
+      numBits,
+      matchMapping,
       defaultEdge->index(),
-      bb->NumOutEdges());
+      jlmSwitchBasicBlock->NumOutEdges());
   tacs.push_back(ThreeAddressCode::create(std::move(op), { c }));
-  tacs.push_back(BranchOperation::create(bb->NumOutEdges(), tacs.back()->result(0)));
+  tacs.push_back(
+      BranchOperation::create(jlmSwitchBasicBlock->NumOutEdges(), tacs.back()->result(0)));
 
   return nullptr;
 }
@@ -1703,7 +1718,10 @@ convertInstruction(
   case ::llvm::Instruction::Br:
     return ConvertBranchInstruction(instruction, threeAddressCodes, context);
   case ::llvm::Instruction::Switch:
-    return ConvertSwitchInstruction(instruction, threeAddressCodes, context);
+    return convertSwitchInstruction(
+        ::llvm::cast<::llvm::SwitchInst>(instruction),
+        threeAddressCodes,
+        context);
   case ::llvm::Instruction::Unreachable:
     return convert_unreachable_instruction(instruction, threeAddressCodes, context);
   case ::llvm::Instruction::FNeg:

--- a/jlm/llvm/frontend/LlvmModuleConversionTests.cpp
+++ b/jlm/llvm/frontend/LlvmModuleConversionTests.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Nico Reißmann <nico.reissmann@gmail.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <gtest/gtest.h>
+
+#include <jlm/llvm/frontend/LlvmModuleConversion.hpp>
+#include <jlm/llvm/ir/print.hpp>
+
+#include <llvm/IR/BasicBlock.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Module.h>
+
+TEST(LlvmModuleConversionTests, SwitchConversion)
+{
+  using namespace llvm;
+
+  // Arrange
+  LLVMContext context;
+  const std::unique_ptr<Module> llvmModule(new Module("module", context));
+
+  auto int64Type = Type::getInt64Ty(context);
+
+  auto functionType = FunctionType::get(int64Type, ArrayRef<Type *>({ int64Type }), false);
+  auto function =
+      Function::Create(functionType, GlobalValue::ExternalLinkage, "f", llvmModule.get());
+
+  auto bbSplit = BasicBlock::Create(context, "BasicBlockSplit", function);
+  auto bb1 = BasicBlock::Create(context, "BasicBlock1", function);
+  auto bb2 = BasicBlock::Create(context, "BasicBlock2", function);
+  auto bb3 = BasicBlock::Create(context, "BasicBlock4", function);
+  auto bb4 = BasicBlock::Create(context, "BasicBlock4", function);
+  auto bbJoin = BasicBlock::Create(context, "BasicBlockJoin", function);
+
+  IRBuilder builder(bbSplit);
+  auto switchInstruction = builder.CreateSwitch(function->arg_begin(), bb4);
+  switchInstruction->addCase(ConstantInt::get(int64Type, 1), bb1);
+  switchInstruction->addCase(ConstantInt::get(int64Type, 2), bb2);
+  switchInstruction->addCase(ConstantInt::get(int64Type, 3), bb2);
+  switchInstruction->addCase(ConstantInt::get(int64Type, 4), bb3);
+  switchInstruction->addCase(ConstantInt::get(int64Type, 5), bb3);
+
+  builder.SetInsertPoint(bb1);
+  builder.CreateBr(bbJoin);
+
+  builder.SetInsertPoint(bb2);
+  builder.CreateBr(bbJoin);
+
+  builder.SetInsertPoint(bb3);
+  builder.CreateBr(bbJoin);
+
+  builder.SetInsertPoint(bb4);
+  builder.CreateBr(bbJoin);
+
+  builder.SetInsertPoint(bbJoin);
+  auto phiInstruction = builder.CreatePHI(int64Type, 4);
+  phiInstruction->addIncoming(ConstantInt::get(int64Type, 1), bb1);
+  phiInstruction->addIncoming(ConstantInt::get(int64Type, 2), bb2);
+  phiInstruction->addIncoming(ConstantInt::get(int64Type, 3), bb3);
+  phiInstruction->addIncoming(ConstantInt::get(int64Type, 4), bb4);
+  builder.CreateRet(phiInstruction);
+
+  llvmModule->print(errs(), nullptr);
+
+  // Act
+  auto ipgModule = jlm::llvm::ConvertLlvmModule(*llvmModule);
+  print(*ipgModule, stdout);
+
+  // Assert
+  {
+    using namespace jlm::llvm;
+
+    auto controlFlowGraph =
+        dynamic_cast<const FunctionNode *>(ipgModule->ipgraph().find("f"))->cfg();
+
+    EXPECT_EQ(controlFlowGraph->nnodes(), 6);
+
+    // FIXME: add test for structure
+  }
+}

--- a/jlm/llvm/frontend/LlvmModuleConversionTests.cpp
+++ b/jlm/llvm/frontend/LlvmModuleConversionTests.cpp
@@ -71,11 +71,14 @@ TEST(LlvmModuleConversionTests, SwitchConversion)
   {
     using namespace jlm::llvm;
 
-    auto controlFlowGraph =
+    const auto controlFlowGraph =
         dynamic_cast<const FunctionNode *>(ipgModule->ipgraph().find("f"))->cfg();
 
     EXPECT_EQ(controlFlowGraph->nnodes(), 6);
 
-    // FIXME: add test for structure
+    // We expect the split node to only have 4 outgoing edges. One for each target basic block of
+    // the original LLVM switch statement
+    const auto splitNode = controlFlowGraph->entry()->OutEdge(0)->sink();
+    EXPECT_EQ(splitNode->NumOutEdges(), 4u);
   }
 }


### PR DESCRIPTION
A switch statement was translated by creating an outgoing edge for every case of the switch. However, this did not take into account that cases can have duplicated target basic blocks. This PR changes the translation to only create a single outgoing edge for each target basic block instead of for each case. This should improve the resulting RVSDG structure as it avoids CFG restructuring for these switch statements as well as improving the runtime behavior of subsequent transformations.