### PR TITLE
Add optional withinRegion parameter to trace methods

### DIFF
--- a/jlm/llvm/ir/Trace.cpp
+++ b/jlm/llvm/ir/Trace.cpp
@@ -51,17 +51,17 @@ OutputTracer::traceStep(rvsdg::Output & output, rvsdg::Region * withinRegion)
 }
 
 rvsdg::Output &
-traceOutput(rvsdg::Output & output)
+traceOutput(rvsdg::Output & output, rvsdg::Region * withinRegion)
 {
   constexpr bool enableCaching = false;
   OutputTracer tracer(enableCaching);
-  return tracer.trace(output);
+  return tracer.trace(output, withinRegion);
 }
 
 std::optional<int64_t>
 tryGetConstantSignedInteger(const rvsdg::Output & output)
 {
-  const auto & normalized = llvm::traceOutput(output);
+  const auto & normalized = llvm::traceOutput(output, nullptr);
 
   if (const auto [_, constant] =
           rvsdg::TryGetSimpleNodeAndOptionalOp<IntegerConstantOperation>(normalized);

--- a/jlm/llvm/ir/Trace.cpp
+++ b/jlm/llvm/ir/Trace.cpp
@@ -21,7 +21,7 @@ OutputTracer::OutputTracer(const bool enableCaching)
 {}
 
 rvsdg::Output &
-OutputTracer::traceStep(rvsdg::Output & output, rvsdg::Region * withinRegion)
+OutputTracer::traceStep(rvsdg::Output & output, const rvsdg::Region * withinRegion)
 {
   auto & trace1 = rvsdg::OutputTracer::traceStep(output, withinRegion);
 
@@ -51,7 +51,7 @@ OutputTracer::traceStep(rvsdg::Output & output, rvsdg::Region * withinRegion)
 }
 
 rvsdg::Output &
-traceOutput(rvsdg::Output & output, rvsdg::Region * withinRegion)
+traceOutput(rvsdg::Output & output, const rvsdg::Region * withinRegion)
 {
   constexpr bool enableCaching = false;
   OutputTracer tracer(enableCaching);

--- a/jlm/llvm/ir/Trace.cpp
+++ b/jlm/llvm/ir/Trace.cpp
@@ -21,9 +21,9 @@ OutputTracer::OutputTracer(const bool enableCaching)
 {}
 
 rvsdg::Output &
-OutputTracer::traceStep(rvsdg::Output & output, bool mayLeaveRegion, rvsdg::Region * targetRegion)
+OutputTracer::traceStep(rvsdg::Output & output, rvsdg::Region * withinRegion)
 {
-  auto & trace1 = rvsdg::OutputTracer::traceStep(output, mayLeaveRegion, targetRegion);
+  auto & trace1 = rvsdg::OutputTracer::traceStep(output, withinRegion);
 
   if (const auto [node, ioBarrierOp] =
           rvsdg::TryGetSimpleNodeAndOptionalOp<IOBarrierOperation>(trace1);

--- a/jlm/llvm/ir/Trace.cpp
+++ b/jlm/llvm/ir/Trace.cpp
@@ -21,9 +21,9 @@ OutputTracer::OutputTracer(const bool enableCaching)
 {}
 
 rvsdg::Output &
-OutputTracer::traceStep(rvsdg::Output & output, bool mayLeaveRegion)
+OutputTracer::traceStep(rvsdg::Output & output, bool mayLeaveRegion, rvsdg::Region * targetRegion)
 {
-  auto & trace1 = rvsdg::OutputTracer::traceStep(output, mayLeaveRegion);
+  auto & trace1 = rvsdg::OutputTracer::traceStep(output, mayLeaveRegion, targetRegion);
 
   if (const auto [node, ioBarrierOp] =
           rvsdg::TryGetSimpleNodeAndOptionalOp<IOBarrierOperation>(trace1);

--- a/jlm/llvm/ir/Trace.hpp
+++ b/jlm/llvm/ir/Trace.hpp
@@ -42,7 +42,7 @@ public:
 
 protected:
   [[nodiscard]] rvsdg::Output &
-  traceStep(rvsdg::Output & output, bool mayLeaveRegion) override;
+  traceStep(rvsdg::Output & output, bool mayLeaveRegion, rvsdg::Region * targetRegion) override;
 
 private:
   bool traceThroughLoadedStates_ = false;

--- a/jlm/llvm/ir/Trace.hpp
+++ b/jlm/llvm/ir/Trace.hpp
@@ -42,7 +42,7 @@ public:
 
 protected:
   [[nodiscard]] rvsdg::Output &
-  traceStep(rvsdg::Output & output, rvsdg::Region * withinRegion) override;
+  traceStep(rvsdg::Output & output, const rvsdg::Region * withinRegion) override;
 
 private:
   bool traceThroughLoadedStates_ = false;
@@ -60,14 +60,12 @@ private:
  * @return the maximally traced output
  */
 rvsdg::Output &
-traceOutput(rvsdg::Output & output, rvsdg::Region * withinRegion = nullptr);
+traceOutput(rvsdg::Output & output, const rvsdg::Region * withinRegion = nullptr);
 
 inline const rvsdg::Output &
 traceOutput(const rvsdg::Output & output, const rvsdg::Region * withinRegion = nullptr)
 {
-  return llvm::traceOutput(
-      const_cast<rvsdg::Output &>(output),
-      const_cast<rvsdg::Region *>(withinRegion));
+  return llvm::traceOutput(const_cast<rvsdg::Output &>(output), withinRegion);
 }
 
 /**

--- a/jlm/llvm/ir/Trace.hpp
+++ b/jlm/llvm/ir/Trace.hpp
@@ -49,20 +49,25 @@ private:
 };
 
 /**
- * Traces the origin of the given \p output to find the origin of the value.
- * Traces through everything handled by \ref jlm::rvsdg::traceOutput,
- * with the addition of LLVM-specific operations.
+ * Traces the origin of the given \p output to find the origin of the value. The optional parameter
+ * \p withinRegion prevents values from being traced out of the region. If it is a nullptr, tracing
+ * will continue until the output no longer changes.
+ * Traces through everything handled by \ref jlm::rvsdg::traceOutput, with the addition of
+ * LLVM-specific operations.
  *
  * @param output the output to start tracing from
+ * @param withinRegion the region to stop at (if any).
  * @return the maximally traced output
  */
 rvsdg::Output &
-traceOutput(rvsdg::Output & output);
+traceOutput(rvsdg::Output & output, rvsdg::Region * withinRegion = nullptr);
 
 inline const rvsdg::Output &
-traceOutput(const rvsdg::Output & output)
+traceOutput(const rvsdg::Output & output, const rvsdg::Region * withinRegion = nullptr)
 {
-  return llvm::traceOutput(const_cast<rvsdg::Output &>(output));
+  return llvm::traceOutput(
+      const_cast<rvsdg::Output &>(output),
+      const_cast<rvsdg::Region *>(withinRegion));
 }
 
 /**

--- a/jlm/llvm/ir/Trace.hpp
+++ b/jlm/llvm/ir/Trace.hpp
@@ -42,7 +42,7 @@ public:
 
 protected:
   [[nodiscard]] rvsdg::Output &
-  traceStep(rvsdg::Output & output, bool mayLeaveRegion, rvsdg::Region * targetRegion) override;
+  traceStep(rvsdg::Output & output, rvsdg::Region * withinRegion) override;
 
 private:
   bool traceThroughLoadedStates_ = false;

--- a/jlm/rvsdg/Trace.cpp
+++ b/jlm/rvsdg/Trace.cpp
@@ -291,7 +291,8 @@ traceOutputIntraProcedurally(Output & output)
 Output &
 traceOutput(Output & output, rvsdg::Region * targetRegion)
 {
-  OutputTracer tracer;
+  constexpr bool enableCaching = false;
+  OutputTracer tracer(enableCaching);
   return tracer.trace(output, targetRegion);
 }
 

--- a/jlm/rvsdg/Trace.cpp
+++ b/jlm/rvsdg/Trace.cpp
@@ -21,17 +21,11 @@ OutputTracer::OutputTracer(const bool enableCaching) noexcept
 Output &
 OutputTracer::trace(Output & output)
 {
-  return trace(output, true, nullptr);
+  return trace(output, nullptr);
 }
 
 Output &
-OutputTracer::trace(Output & output, rvsdg::Region * targetRegion)
-{
-  return trace(output, true, targetRegion);
-}
-
-Output &
-OutputTracer::trace(Output & output, bool mayLeaveRegion, rvsdg::Region * targetRegion)
+OutputTracer::trace(Output & output, rvsdg::Region * withinRegion)
 {
   Output * head = &output;
 
@@ -39,7 +33,7 @@ OutputTracer::trace(Output & output, bool mayLeaveRegion, rvsdg::Region * target
   while (true)
   {
     Output * prevHead = head;
-    head = &traceStep(*head, mayLeaveRegion, targetRegion);
+    head = &traceStep(*head, withinRegion);
     if (head == prevHead)
     {
       return *head;
@@ -80,7 +74,8 @@ OutputTracer::tryTraceThroughGamma(GammaNode & gammaNode, Output & output)
     // If deep tracing is enabled, make a greater effort to trace up to a region argument
     if (traceThroughStrucutalNodes_)
     {
-      tracedInner = &trace(*tracedInner, false, output.region());
+      // Trace the branch result origin, but only within the gamma subregion
+      tracedInner = &trace(*tracedInner, tracedInner->region());
     }
 
     // The traced output must reach a region argument in the gamma subregion
@@ -122,7 +117,8 @@ OutputTracer::tryTraceThroughTheta(ThetaNode & thetaNode, Output & output)
   // If deep tracing is enabled, make a greater effort in tracing up to a region argument
   if (traceThroughStrucutalNodes_)
   {
-    tracedInner = &trace(*tracedInner, false, output.region());
+    // trace the origin within the thetaNode, but only within the theta's subregion
+    tracedInner = &trace(*tracedInner, thetaNode.subregion());
   }
 
   // If tracing reached the pre argument of the same loop variable, it is invariant
@@ -146,16 +142,11 @@ OutputTracer::tryTraceThroughTheta(ThetaNode & thetaNode, Output & output)
 }
 
 Output &
-OutputTracer::traceStep(Output & output, bool mayLeaveRegion, rvsdg::Region * targetRegion)
+OutputTracer::traceStep(Output & output, rvsdg::Region * withinRegion)
 {
-  if (!mayLeaveRegion && TryGetRegionParentNode<Node>(output))
+  if (withinRegion && withinRegion == TryGetOwnerRegion(output))
   {
-    // We are not allowed to leave the region, so return early on region arguments
-    return output;
-  }
-
-  if (targetRegion && output.region() == targetRegion)
-  {
+    // We are not allowed to leave this region, and tracing has reached one of its arguments
     return output;
   }
 

--- a/jlm/rvsdg/Trace.cpp
+++ b/jlm/rvsdg/Trace.cpp
@@ -21,11 +21,17 @@ OutputTracer::OutputTracer(const bool enableCaching) noexcept
 Output &
 OutputTracer::trace(Output & output)
 {
-  return trace(output, true);
+  return trace(output, true, nullptr);
 }
 
 Output &
-OutputTracer::trace(Output & output, bool mayLeaveRegion)
+OutputTracer::trace(Output & output, rvsdg::Region * targetRegion)
+{
+  return trace(output, true, targetRegion);
+}
+
+Output &
+OutputTracer::trace(Output & output, bool mayLeaveRegion, rvsdg::Region * targetRegion)
 {
   Output * head = &output;
 
@@ -33,7 +39,7 @@ OutputTracer::trace(Output & output, bool mayLeaveRegion)
   while (true)
   {
     Output * prevHead = head;
-    head = &traceStep(*head, mayLeaveRegion);
+    head = &traceStep(*head, mayLeaveRegion, targetRegion);
     if (head == prevHead)
     {
       return *head;
@@ -74,7 +80,7 @@ OutputTracer::tryTraceThroughGamma(GammaNode & gammaNode, Output & output)
     // If deep tracing is enabled, make a greater effort to trace up to a region argument
     if (traceThroughStrucutalNodes_)
     {
-      tracedInner = &trace(*tracedInner, false);
+      tracedInner = &trace(*tracedInner, false, output.region());
     }
 
     // The traced output must reach a region argument in the gamma subregion
@@ -116,7 +122,7 @@ OutputTracer::tryTraceThroughTheta(ThetaNode & thetaNode, Output & output)
   // If deep tracing is enabled, make a greater effort in tracing up to a region argument
   if (traceThroughStrucutalNodes_)
   {
-    tracedInner = &trace(*tracedInner, false);
+    tracedInner = &trace(*tracedInner, false, output.region());
   }
 
   // If tracing reached the pre argument of the same loop variable, it is invariant
@@ -140,11 +146,16 @@ OutputTracer::tryTraceThroughTheta(ThetaNode & thetaNode, Output & output)
 }
 
 Output &
-OutputTracer::traceStep(Output & output, bool mayLeaveRegion)
+OutputTracer::traceStep(Output & output, bool mayLeaveRegion, rvsdg::Region * targetRegion)
 {
   if (!mayLeaveRegion && TryGetRegionParentNode<Node>(output))
   {
     // We are not allowed to leave the region, so return early on region arguments
+    return output;
+  }
+
+  if (targetRegion && output.region() == targetRegion)
+  {
     return output;
   }
 
@@ -284,6 +295,13 @@ traceOutputIntraProcedurally(Output & output)
   OutputTracer tracer(enableCaching);
   tracer.setInterprocedural(false);
   return tracer.trace(output);
+}
+
+Output &
+traceOutput(Output & output, rvsdg::Region * targetRegion)
+{
+  OutputTracer tracer;
+  return tracer.trace(output, targetRegion);
 }
 
 Output &

--- a/jlm/rvsdg/Trace.cpp
+++ b/jlm/rvsdg/Trace.cpp
@@ -289,19 +289,11 @@ traceOutputIntraProcedurally(Output & output)
 }
 
 Output &
-traceOutput(Output & output, rvsdg::Region * targetRegion)
+traceOutput(Output & output, rvsdg::Region * withinRegion)
 {
   constexpr bool enableCaching = false;
   OutputTracer tracer(enableCaching);
-  return tracer.trace(output, targetRegion);
-}
-
-Output &
-traceOutput(Output & output)
-{
-  constexpr bool enableCaching = false;
-  OutputTracer tracer(enableCaching);
-  return tracer.trace(output);
+  return tracer.trace(output, withinRegion);
 }
 
 }

--- a/jlm/rvsdg/Trace.cpp
+++ b/jlm/rvsdg/Trace.cpp
@@ -25,7 +25,7 @@ OutputTracer::trace(Output & output)
 }
 
 Output &
-OutputTracer::trace(Output & output, rvsdg::Region * withinRegion)
+OutputTracer::trace(Output & output, const rvsdg::Region * withinRegion)
 {
   Output * head = &output;
 
@@ -142,7 +142,7 @@ OutputTracer::tryTraceThroughTheta(ThetaNode & thetaNode, Output & output)
 }
 
 Output &
-OutputTracer::traceStep(Output & output, rvsdg::Region * withinRegion)
+OutputTracer::traceStep(Output & output, const rvsdg::Region * withinRegion)
 {
   if (withinRegion && withinRegion == TryGetOwnerRegion(output))
   {
@@ -289,7 +289,7 @@ traceOutputIntraProcedurally(Output & output)
 }
 
 Output &
-traceOutput(Output & output, rvsdg::Region * withinRegion)
+traceOutput(Output & output, const rvsdg::Region * withinRegion)
 {
   constexpr bool enableCaching = false;
   OutputTracer tracer(enableCaching);

--- a/jlm/rvsdg/Trace.hpp
+++ b/jlm/rvsdg/Trace.hpp
@@ -117,7 +117,11 @@ public:
 
   /**
    * Traces from the given \p output to find the source of the output's value.
-   * The optional parameter \p withinRegion prevents values from being traced out of the region.
+   * The optional parameter \p withinRegion prevents values from being traced out of the region. If
+   * \p withinRegion is a nullptr, the tracing will continue until the output no longer changes.
+   *
+   * @param output the output to trace from.
+   * @param withinRegion the region where we stop tracing.
    */
   Output &
   trace(Output & output, rvsdg::Region * withinRegion);
@@ -230,9 +234,10 @@ traceOutputIntraProcedurally(const Output & output)
 }
 
 /**
- * Traces \p output through the RVSDG.
- * The function is capable of tracing through everything \ref traceOutputIntraProcedurally is,
- * in addition to:
+ * Traces \p output through the RVSDG. The optional parameter \p withinRegion prevents values from
+ * being traced out of the region. If it is a nullptr, tracing will continue until the output no
+ * longer changes. The function is capable of tracing through everything \ref
+ * traceOutputIntraProcedurally is, in addition to:
  *
  * 1. From lambda context variables out of the lambda
  * 2. From delta context variables out of the delta
@@ -242,18 +247,16 @@ traceOutputIntraProcedurally(const Output & output)
  * It will not trace through phi recursion variables
  *
  * @param output the output to trace.
+ * @param withinRegion the region to stop at (if any).
  * @return the final value of the tracing
  */
 Output &
-traceOutput(Output & output);
-
-Output &
-traceOutput(Output & output, rvsdg::Region * targetRegion);
+traceOutput(Output & output, rvsdg::Region * withinRegion = nullptr);
 
 inline const Output &
-traceOutput(const Output & output)
+traceOutput(const Output & output, const rvsdg::Region * withinRegion = nullptr)
 {
-  return traceOutput(const_cast<Output &>(output));
+  return traceOutput(const_cast<Output &>(output), const_cast<Region *>(withinRegion));
 }
 
 }

--- a/jlm/rvsdg/Trace.hpp
+++ b/jlm/rvsdg/Trace.hpp
@@ -123,7 +123,7 @@ public:
    * @param output the output to trace from.
    * @param withinRegion the region where we stop tracing.
    */
-  Output &
+  [[nodiscard]] Output &
   trace(Output & output, rvsdg::Region * withinRegion);
 
   /**

--- a/jlm/rvsdg/Trace.hpp
+++ b/jlm/rvsdg/Trace.hpp
@@ -115,8 +115,12 @@ public:
   [[nodiscard]] Output &
   trace(Output & output);
 
+  /**
+   * Traces from the given \p output to find the source of the output's value.
+   * The optional parameter \p withinRegion prevents values from being traced out of the region.
+   */
   Output &
-  trace(Output & output, rvsdg::Region * targetRegion);
+  trace(Output & output, rvsdg::Region * withinRegion);
 
   /**
    * Attempts to trace the output of a gamma node through the node.
@@ -158,24 +162,14 @@ public:
 
 protected:
   /**
-   * Traces from the given \p output to find the source of the output's value.
-   * @param output the output to trace from.
-   * @param mayLeaveRegion if false, tracing stops if it reaches a region argument
-   * @param targetRegion
-   */
-  [[nodiscard]] Output &
-  trace(Output & output, bool mayLeaveRegion, rvsdg::Region * targetRegion);
-
-  /**
    * The innermost body of the tracing loop. Should trace at least one step, if possible.
    * If it is not possible to trace further, the same output is returned.
-   * @param output the output to trace from
-   * @param mayLeaveRegion if false, tracing stops if it reaches a region argument
-   * @param targetRegion
+   * @param output the output to trace from.
+   * @param withinRegion if not nullptr, tracing stops if it reaches an argument of the region.
    * @return the result of tracing from the given output, if possible. Otherwise, \p output.
    */
   [[nodiscard]] virtual Output &
-  traceStep(Output & output, bool mayLeaveRegion, rvsdg::Region * targetRegion);
+  traceStep(Output & output, rvsdg::Region * withinRegion);
 
   /**
    * Inserts a traced value into the tracing cache.

--- a/jlm/rvsdg/Trace.hpp
+++ b/jlm/rvsdg/Trace.hpp
@@ -115,6 +115,9 @@ public:
   [[nodiscard]] Output &
   trace(Output & output);
 
+  Output &
+  trace(Output & output, rvsdg::Region * targetRegion);
+
   /**
    * Attempts to trace the output of a gamma node through the node.
    * This is only possible if the output can be traced to a gamma entry variable in all subregions,
@@ -158,19 +161,21 @@ protected:
    * Traces from the given \p output to find the source of the output's value.
    * @param output the output to trace from.
    * @param mayLeaveRegion if false, tracing stops if it reaches a region argument
+   * @param targetRegion
    */
   [[nodiscard]] Output &
-  trace(Output & output, bool mayLeaveRegion);
+  trace(Output & output, bool mayLeaveRegion, rvsdg::Region * targetRegion);
 
   /**
    * The innermost body of the tracing loop. Should trace at least one step, if possible.
    * If it is not possible to trace further, the same output is returned.
    * @param output the output to trace from
    * @param mayLeaveRegion if false, tracing stops if it reaches a region argument
+   * @param targetRegion
    * @return the result of tracing from the given output, if possible. Otherwise, \p output.
    */
   [[nodiscard]] virtual Output &
-  traceStep(Output & output, bool mayLeaveRegion);
+  traceStep(Output & output, bool mayLeaveRegion, rvsdg::Region * targetRegion);
 
   /**
    * Inserts a traced value into the tracing cache.
@@ -247,6 +252,9 @@ traceOutputIntraProcedurally(const Output & output)
  */
 Output &
 traceOutput(Output & output);
+
+Output &
+traceOutput(Output & output, rvsdg::Region * targetRegion);
 
 inline const Output &
 traceOutput(const Output & output)

--- a/jlm/rvsdg/Trace.hpp
+++ b/jlm/rvsdg/Trace.hpp
@@ -124,7 +124,7 @@ public:
    * @param withinRegion the region where we stop tracing.
    */
   [[nodiscard]] Output &
-  trace(Output & output, rvsdg::Region * withinRegion);
+  trace(Output & output, const rvsdg::Region * withinRegion);
 
   /**
    * Attempts to trace the output of a gamma node through the node.
@@ -173,7 +173,7 @@ protected:
    * @return the result of tracing from the given output, if possible. Otherwise, \p output.
    */
   [[nodiscard]] virtual Output &
-  traceStep(Output & output, rvsdg::Region * withinRegion);
+  traceStep(Output & output, const rvsdg::Region * withinRegion);
 
   /**
    * Inserts a traced value into the tracing cache.
@@ -251,12 +251,12 @@ traceOutputIntraProcedurally(const Output & output)
  * @return the final value of the tracing
  */
 Output &
-traceOutput(Output & output, rvsdg::Region * withinRegion = nullptr);
+traceOutput(Output & output, const rvsdg::Region * withinRegion = nullptr);
 
 inline const Output &
 traceOutput(const Output & output, const rvsdg::Region * withinRegion = nullptr)
 {
-  return traceOutput(const_cast<Output &>(output), const_cast<Region *>(withinRegion));
+  return traceOutput(const_cast<Output &>(output), withinRegion);
 }
 
 }


### PR DESCRIPTION
Replaces `mayLeaveRegion` to allow tracing to stop at a certain region.