### PR TITLE
ScalarEvolution: Fix a logic error in handling dependencies with multiplication

### DIFF
--- a/jlm/llvm/opt/ScalarEvolution.cpp
+++ b/jlm/llvm/opt/ScalarEvolution.cpp
@@ -12,6 +12,7 @@
 #include <jlm/llvm/opt/ScalarEvolution.hpp>
 #include <jlm/rvsdg/RvsdgModule.hpp>
 #include <jlm/rvsdg/theta.hpp>
+#include <jlm/rvsdg/Transformation.hpp>
 #include <jlm/util/Statistics.hpp>
 
 #include <algorithm>
@@ -233,7 +234,7 @@ public:
 };
 
 ScalarEvolution::ScalarEvolution()
-    : Transformation("ScalarEvolution")
+    : rvsdg::Transformation("ScalarEvolution")
 {}
 
 ScalarEvolution::~ScalarEvolution() noexcept = default;
@@ -1121,11 +1122,8 @@ ScalarEvolution::FindDependenciesForSCEV(
 
   if (const auto mulSCEV = dynamic_cast<const SCEVMulExpr *>(&scev))
   {
-    // Only pass Mul down if we haven't already seen Add in the path from root
-    // If op is already Add, preserve it; otherwise use Mul
-    const DependencyOp opToPass = (op == DependencyOp::Add) ? DependencyOp::Add : DependencyOp::Mul;
-    FindDependenciesForSCEV(*mulSCEV->GetLeftOperand(), dependencies, opToPass);
-    FindDependenciesForSCEV(*mulSCEV->GetRightOperand(), dependencies, opToPass);
+    FindDependenciesForSCEV(*mulSCEV->GetLeftOperand(), dependencies, DependencyOp::Mul);
+    FindDependenciesForSCEV(*mulSCEV->GetRightOperand(), dependencies, DependencyOp::Mul);
   }
 }
 
@@ -1913,19 +1911,17 @@ ScalarEvolution::CanCreateChainRecurrence(
 {
   auto deps = dependencyGraph[&output];
   if (deps.find(&output) != deps.end())
+  {
     if (deps[&output].count != 1)
     {
       // First check that variable has only one self-reference
       return false;
     }
-
-  if (rvsdg::TryGetRegionParentNode<rvsdg::ThetaNode>(output))
-  {
-    // If this is the output of a loop variable, check that it has no reference via a mult-operation
-    for (auto [out, dependencyInfo] : deps)
+    if (deps[&output].operation == DependencyOp::Mul)
     {
-      if (dependencyInfo.operation == DependencyOp::Mul)
-        return false;
+      // A variable cannot have a self-depencency via multiplication (results in a geometric
+      // induction variable)
+      return false;
     }
   }
 


### PR DESCRIPTION
Logic was wrong. Some invalid cases, like a = 2 * a + 1 would be counted as valid, and some valid cases like b = b + 2 * a would be rejected. Only the variables that depend on itself through multiplication should be rejected as these result in geometric sequences. This is now fixed in this PR.