### PR TITLE
DNE: fix performance issue in sweep phase

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/UnusedStateRemoval.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/UnusedStateRemoval.cpp
@@ -142,7 +142,7 @@ static void
 RemoveUnusedStatesFromGammaNode(rvsdg::GammaNode & gammaNode)
 {
   std::vector<rvsdg::GammaNode::EntryVar> deadEntryVars;
-  std::vector<rvsdg::GammaNode::ExitVar> deadExitVars;
+  std::vector<rvsdg::Output *> deadGammaOutputs;
 
   for (const auto & entryvar : gammaNode.GetEntryVars())
   {
@@ -163,11 +163,11 @@ RemoveUnusedStatesFromGammaNode(rvsdg::GammaNode & gammaNode)
     {
       exitvar0->output->divert_users(entryvar.input->origin());
       deadEntryVars.push_back(entryvar);
-      deadExitVars.push_back(*exitvar0);
+      deadGammaOutputs.push_back(exitvar0->output);
     }
   }
 
-  gammaNode.RemoveExitVars(deadExitVars);
+  gammaNode.RemoveExitVars(deadGammaOutputs);
   gammaNode.RemoveEntryVars(deadEntryVars);
 }
 

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -417,7 +417,7 @@ DeadNodeElimination::sweepStructuralNode(rvsdg::StructuralNode & node) const
 void
 DeadNodeElimination::sweepGamma(rvsdg::GammaNode & gammaNode) const
 {
-  // Remove dead exit vars.
+  // Remove dead exit variables.
   const auto deadGammaOutputs = gammaNode.GetOutputsWhere(
       [this](const rvsdg::Output & output)
       {
@@ -431,7 +431,7 @@ DeadNodeElimination::sweepGamma(rvsdg::GammaNode & gammaNode) const
     sweepRegion(subregion);
   }
 
-  // Remove dead entry vars.
+  // Remove dead entry variables.
   std::vector<rvsdg::GammaNode::EntryVar> deadEntryVars;
   for (const auto & entryVar : gammaNode.GetEntryVars())
   {

--- a/jlm/llvm/opt/DeadNodeElimination.cpp
+++ b/jlm/llvm/opt/DeadNodeElimination.cpp
@@ -418,15 +418,12 @@ void
 DeadNodeElimination::sweepGamma(rvsdg::GammaNode & gammaNode) const
 {
   // Remove dead exit vars.
-  std::vector<rvsdg::GammaNode::ExitVar> deadExitVars;
-  for (const auto & exitVar : gammaNode.GetExitVars())
-  {
-    if (!Context_->isAlive(*exitVar.output))
-    {
-      deadExitVars.push_back(exitVar);
-    }
-  }
-  gammaNode.RemoveExitVars(deadExitVars);
+  const auto deadGammaOutputs = gammaNode.GetOutputsWhere(
+      [this](const rvsdg::Output & output)
+      {
+        return !Context_->isAlive(output);
+      });
+  gammaNode.RemoveExitVars(deadGammaOutputs);
 
   // Sweep gamma subregions
   for (auto & subregion : gammaNode.Subregions())

--- a/jlm/rvsdg/gamma.cpp
+++ b/jlm/rvsdg/gamma.cpp
@@ -423,6 +423,7 @@ GammaNode::RemoveExitVars(const std::vector<Output *> & gammaOutputs)
   util::HashSet<size_t> indices;
   for (const auto output : gammaOutputs)
   {
+    JLM_ASSERT(output->IsDead());
     JLM_ASSERT(TryGetOwnerNode<GammaNode>(*output) == this);
     indices.insert(output->index());
   }

--- a/jlm/rvsdg/gamma.cpp
+++ b/jlm/rvsdg/gamma.cpp
@@ -418,10 +418,10 @@ GammaNode::MapBranchResultExitVar(const rvsdg::Input & input) const
 }
 
 void
-GammaNode::RemoveExitVars(const std::vector<ExitVar> & exitVars)
+GammaNode::RemoveExitVars(const std::vector<Output *> & gammaOutputs)
 {
   util::HashSet<size_t> indices;
-  for (const auto & [_, output] : exitVars)
+  for (const auto output : gammaOutputs)
   {
     JLM_ASSERT(TryGetOwnerNode<GammaNode>(*output) == this);
     indices.insert(output->index());

--- a/jlm/rvsdg/gamma.hpp
+++ b/jlm/rvsdg/gamma.hpp
@@ -306,6 +306,29 @@ public:
   GetExitVars() const;
 
   /**
+   * \brief Gets all gamma outputs that match condition defined by \p match.
+   *
+   * @tparam F A type supporting function call operator: bool operator(const Output&)
+   * @param match Defines the condition of the elements to return.
+   * @return The gamma outputs that matched the condition.
+   */
+  template<typename F>
+  std::vector<Output *>
+  GetOutputsWhere(const F & match)
+  {
+    std::vector<Output *> outputs;
+    for (auto & output : Outputs())
+    {
+      if (match(output))
+      {
+        outputs.push_back(&output);
+      }
+    }
+
+    return outputs;
+  }
+
+  /**
    * \brief Maps gamma output to exit variable description.
    *
    * \param output
@@ -343,16 +366,17 @@ public:
   MapBranchResultExitVar(const rvsdg::Input & input) const;
 
   /**
-   * \brief Removes the given exit variables.
+   * \brief Removes the exit variables corresponding to the given \p gammaOutputs.
+   *   * \pre
+   *    1. All outputs must belong to a gamma node.
+   *    1. All outputs must be dead.
    *
-   * \pre
-   *   All exit variables must be unused (= the corresponding gamma outputs
-   *   must not have any users).
+   * @param gammaOutputs The outputs indicating the corresponding exit variables.
    *
-   * Removes the variables as exit variables from this gamma.
+   * @see Output::IsDead()
    */
   void
-  RemoveExitVars(const std::vector<ExitVar> & exitVars);
+  RemoveExitVars(const std::vector<Output *> & gammaOutputs);
 
   /**
    * \brief Removes the given entry variables
@@ -374,16 +398,12 @@ public:
   void
   PruneExitVars()
   {
-    std::vector<ExitVar> exitVars;
-    for (auto exitVar : GetExitVars())
-    {
-      if (exitVar.output->IsDead())
-      {
-        exitVars.push_back(exitVar);
-      }
-    }
-
-    RemoveExitVars(exitVars);
+    const auto deadGammaOutputs = GetOutputsWhere(
+        [](const Output & output)
+        {
+          return output.IsDead();
+        });
+    RemoveExitVars(deadGammaOutputs);
   }
 
   GammaNode *

--- a/jlm/rvsdg/gamma.hpp
+++ b/jlm/rvsdg/gamma.hpp
@@ -306,10 +306,10 @@ public:
   GetExitVars() const;
 
   /**
-   * \brief Gets all gamma outputs that match condition defined by \p match.
+   * \brief Gets all gamma outputs that match the condition defined by \p match.
    *
    * @tparam F A type supporting function call operator: bool operator(const Output&)
-   * @param match Defines the condition of the elements to return.
+   * @param match Defines the condition of the outputs to return.
    * @return The gamma outputs that matched the condition.
    */
   template<typename F>
@@ -367,7 +367,8 @@ public:
 
   /**
    * \brief Removes the exit variables corresponding to the given \p gammaOutputs.
-   *   * \pre
+   *
+   * \pre
    *    1. All outputs must belong to a gamma node.
    *    1. All outputs must be dead.
    *


### PR DESCRIPTION
The old implementation build up an entire vector of all exit variables where we then filtered out the ones we cared about. Moreover, it collected and carried around the results of the exit variable even though they were never used.

This was inefficient for gamma-heavy code. The new implementation only collects the gamma outputs as well as only those outputs we care about.