### PR TITLE
LSR: Generalize reduction of GEP operations

### DIFF
--- a/jlm/llvm/opt/LoopStrengthReduction.cpp
+++ b/jlm/llvm/opt/LoopStrengthReduction.cpp
@@ -5,6 +5,7 @@
 
 #include <jlm/llvm/ir/operators/GetElementPtr.hpp>
 #include <jlm/llvm/ir/operators/IntegerOperations.hpp>
+#include <jlm/llvm/ir/operators/sext.hpp>
 #include <jlm/llvm/ir/Trace.hpp>
 #include <jlm/llvm/opt/LoopStrengthReduction.hpp>
 #include <jlm/llvm/opt/ScalarEvolution.hpp>
@@ -51,6 +52,18 @@ public:
     return OperationsReducedMap_;
   }
 
+  size_t NumArithmeticCandidates = 0;
+  size_t NumGEPCandidates = 0;
+
+  size_t NumGEPDoesNotDependOnIV = 0;
+  size_t NumArithmeticDoesNotDependOnIV = 0;
+  size_t NumArithmeticNotContainsMul = 0;
+  size_t NumGEPIsUnknown = 0;
+  size_t NumArithmeticIsUnknown = 0;
+
+  size_t NumArithmeticOperationsReduced = 0;
+  size_t NumGEPOperationsReduced = 0;
+
 private:
   std::unordered_map<const rvsdg::ThetaNode *, size_t> OperationsReducedMap_;
 };
@@ -75,6 +88,22 @@ public:
   Stop(const Context & context) noexcept
   {
     GetTimer(Label::Timer).stop();
+
+    AddMeasurement(
+        Label::NumCandidates,
+        context.NumArithmeticCandidates + context.NumGEPCandidates);
+    AddMeasurement(Label::NumArithmeticCandidates, context.NumArithmeticCandidates);
+    AddMeasurement(Label::NumGEPCandidates, context.NumGEPCandidates);
+
+    AddMeasurement(Label::NumArithmeticDoesNotDependOnIV, context.NumArithmeticDoesNotDependOnIV);
+    AddMeasurement(Label::NumGEPDoesNotDependOnIV, context.NumGEPDoesNotDependOnIV);
+    AddMeasurement(Label::NumArithmeticNotContainsMul, context.NumArithmeticNotContainsMul);
+ AddMeasurement(Label::NumArithmeticIsUnknown, context.NumArithmeticIsUnknown);
+    AddMeasurement(Label::NumGEPIsUnknown, context.NumGEPIsUnknown);
+
+    AddMeasurement(Label::NumArithmeticOperationsReduced, context.NumArithmeticOperationsReduced);
+    AddMeasurement(Label::NumGEPOperationsReduced, context.NumGEPOperationsReduced);
+
     AddMeasurement(
         Label::NumOperationsReduced,
         GetStatisticsString(context.GetOperationsReducedMap()));
@@ -232,7 +261,7 @@ LoopStrengthReduction::ProcessOutput(
     if (SCEVMap_.find(&output) == SCEVMap_.end())
       return;
 
-    if (IsValidCandidateOperation(output))
+    if (IsValidCandidateOperation(output, operation))
     {
       candidateOperations.insert(&output);
       return; // Return early to not create unnecessary induction variables for nested operations
@@ -252,18 +281,47 @@ LoopStrengthReduction::ReplaceCandidateOperation(
   JLM_ASSERT(ChrecMap_.find(&output) != ChrecMap_.end());
   auto & chrec = ChrecMap_.at(&output);
 
+  JLM_ASSERT(chrec->NumOperands() <= 2);
+  std::cout << "We have this chrec: " << chrec->DebugString() << '\n';
+
+  const rvsdg::ThetaNode::LoopVar * newIV = nullptr;
   if (const auto & bitType = std::dynamic_pointer_cast<const rvsdg::BitType>(output.Type()))
   {
-    ReplaceArithmeticOperation(chrec, output, thetaNode, bitType);
+    const auto numBits = bitType->nbits();
+    const auto newIVOpt = CreateNewArithmeticInductionVariable(*chrec, thetaNode, numBits);
+    if (!newIVOpt.has_value())
+      return;
+
+    newIV = &newIVOpt.value();
+
+    Context_->NumArithmeticOperationsReduced++;
+    std::cout << "arithmetic operation reduced\n";
   }
   else if (const auto & pointerType = std::dynamic_pointer_cast<const PointerType>(output.Type()))
   {
-    ReplaceGEPOperation(chrec, output, thetaNode, pointerType);
+    const auto newIVOpt = CreateNewGEPInductionVariable(*chrec, thetaNode, pointerType);
+    if (!newIVOpt.has_value())
+      return;
+
+    newIV = &newIVOpt.value();
+
+    Context_->NumGEPOperationsReduced++;
+    std::cout << "GEP operation reduced\n";
   }
   else
   {
     throw std::logic_error("Invalid output type in ReplaceCandidateOperation!");
   }
+
+  JLM_ASSERT(newIV != nullptr);
+
+  output.divert_users(newIV->pre);
+  // Insert the chrec for the new induction variable
+  // NOTE: This only updates the *copy* of the original chrec map from the scalar evolution
+  // analysis. In the future, we would want to insert this into the "global" chrec map so other
+  // analyses and transformations can use it as well.
+  ChrecMap_[newIV->pre] = std::move(chrec);
+  Context_->IncrementOperationsReducedCount(thetaNode);
 }
 
 std::optional<rvsdg::Output *>
@@ -361,59 +419,106 @@ LoopStrengthReduction::HoistSCEVExpresssion(
   if (const auto addExpr = dynamic_cast<const SCEVNAryAddExpr *>(&scev))
   {
     auto rightMost = addExpr->GetOperand(addExpr->NumOperands() - 1);
-    auto rightSide = HoistSCEVExpresssion(*rightMost, thetaNode, numBits);
-    if (!rightSide.has_value())
+    auto rightSideOpt = HoistSCEVExpresssion(*rightMost, thetaNode, numBits);
+    if (!rightSideOpt.has_value())
       return std::nullopt;
 
     auto newAddExpr = SCEV::CloneAs<SCEVNAryAddExpr>(*addExpr);
     newAddExpr->RemoveOperand(addExpr->NumOperands() - 1);
 
-    std::optional<rvsdg::Output *> leftSide;
+    std::optional<rvsdg::Output *> leftSideOpt;
     if (newAddExpr->NumOperands() == 1)
     {
       // Only a constant
       const auto constantElement = newAddExpr->GetOperand(0);
-      leftSide = HoistSCEVExpresssion(*constantElement, thetaNode, numBits);
+      leftSideOpt = HoistSCEVExpresssion(*constantElement, thetaNode, numBits);
     }
     else
     {
-      leftSide = HoistSCEVExpresssion(*newAddExpr, thetaNode, numBits);
+      leftSideOpt = HoistSCEVExpresssion(*newAddExpr, thetaNode, numBits);
     }
 
-    if (!leftSide.has_value())
+    if (!leftSideOpt.has_value())
       return std::nullopt;
 
+    rvsdg::Output * leftSide = *leftSideOpt;
+    rvsdg::Output * rightSide = *rightSideOpt;
+    // If either side is a pointer, we use a GEP instead of IntegerAddOperation
+    const auto leftIsPtr = rvsdg::is<PointerType>(leftSide->Type());
+    const auto rightIsPtr = rvsdg::is<PointerType>(rightSide->Type());
+
+    if (leftIsPtr || rightIsPtr)
+    {
+      auto ptrSide = leftIsPtr ? leftSide : rightSide;
+      auto offsetSide = leftIsPtr ? rightSide : leftSide;
+
+      const auto ptrType = std::dynamic_pointer_cast<const PointerType>(ptrSide->Type());
+      JLM_ASSERT(ptrType);
+      auto newGep = GetElementPtrOperation::Create(
+          ptrSide,
+          { offsetSide },
+          rvsdg::BitType::Create(8), // Byte
+          ptrType);
+
+      return newGep;
+    }
+
+    if (auto leftBitType = std::dynamic_pointer_cast<const rvsdg::BitType>(leftSide->Type());
+        leftBitType->nbits() != numBits)
+    {
+      leftSide = SExtOperation::create(numBits, leftSide);
+    }
+    if (auto rightBitType = std::dynamic_pointer_cast<const rvsdg::BitType>(rightSide->Type());
+        rightBitType->nbits() != numBits)
+    {
+      rightSide = SExtOperation::create(numBits, rightSide);
+    }
+
     auto & newAddNode =
-        jlm::rvsdg::CreateOpNode<IntegerAddOperation>({ *leftSide, *rightSide }, numBits);
+        jlm::rvsdg::CreateOpNode<IntegerAddOperation>({ leftSide, rightSide }, numBits);
 
     return newAddNode.output(0);
   }
   if (const auto mulExpr = dynamic_cast<const SCEVNAryMulExpr *>(&scev))
   {
     auto rightMost = mulExpr->GetOperand(mulExpr->NumOperands() - 1);
-    auto rightSide = HoistSCEVExpresssion(*rightMost, thetaNode, numBits);
-    if (!rightSide.has_value())
+    auto rightSideOpt = HoistSCEVExpresssion(*rightMost, thetaNode, numBits);
+    if (!rightSideOpt.has_value())
       return std::nullopt;
 
     auto newMulExpr = SCEV::CloneAs<SCEVNAryMulExpr>(*mulExpr);
     newMulExpr->RemoveOperand(mulExpr->NumOperands() - 1);
 
-    std::optional<rvsdg::Output *> leftSide;
+    std::optional<rvsdg::Output *> leftSideOpt;
     if (newMulExpr->NumOperands() == 1)
     {
       const auto constantElement = newMulExpr->GetOperand(0);
-      leftSide = HoistSCEVExpresssion(*constantElement, thetaNode, numBits);
+      leftSideOpt = HoistSCEVExpresssion(*constantElement, thetaNode, numBits);
     }
     else
     {
-      leftSide = HoistSCEVExpresssion(*newMulExpr, thetaNode, numBits);
+      leftSideOpt = HoistSCEVExpresssion(*newMulExpr, thetaNode, numBits);
     }
 
-    if (!leftSide.has_value())
+    if (!leftSideOpt.has_value())
       return std::nullopt;
 
+    rvsdg::Output * leftSide = *leftSideOpt;
+    rvsdg::Output * rightSide = *rightSideOpt;
+    // Sign extend in cases where the input does not match the expected number of bits
+    if (auto leftBitType = std::dynamic_pointer_cast<const rvsdg::BitType>(leftSide->Type());
+        leftBitType->nbits() != numBits)
+    {
+      leftSide = SExtOperation::create(numBits, leftSide);
+    }
+    if (auto rightBitType = std::dynamic_pointer_cast<const rvsdg::BitType>(rightSide->Type());
+        rightBitType->nbits() != numBits)
+    {
+      rightSide = SExtOperation::create(numBits, rightSide);
+    }
+
     auto & newMulNode =
-        jlm::rvsdg::CreateOpNode<IntegerMulOperation>({ *leftSide, *rightSide }, numBits);
+        jlm::rvsdg::CreateOpNode<IntegerMulOperation>({ leftSide, rightSide }, numBits);
 
     return newMulNode.output(0);
   }
@@ -425,30 +530,6 @@ LoopStrengthReduction::HoistSCEVExpresssion(
     return HoistChrec(*chrec, thetaNode, numBits);
   }
   throw std::logic_error("Unknown SCEV type in HoistSCEVExpression\n");
-}
-
-void
-LoopStrengthReduction::ReplaceArithmeticOperation(
-    std::unique_ptr<SCEVChainRecurrence> & chrec,
-    rvsdg::Output & output,
-    rvsdg::ThetaNode & thetaNode,
-    const std::shared_ptr<const rvsdg::BitType> & bitType)
-{
-  JLM_ASSERT(chrec->NumOperands() <= 2);
-
-  const auto numBits = bitType->nbits();
-  auto newIV = CreateNewArithmeticInductionVariable(*chrec, thetaNode, numBits);
-  if (!newIV.has_value())
-    return;
-
-  output.divert_users(newIV->pre);
-
-  // Insert the chrec for the new induction variable
-  // NOTE: This only updates the *copy* of the original chrec map from the scalar evolution
-  // analysis. In the future, we would want to insert this into the "global" chrec map so other
-  // analyses and transformations can use it as well.
-  ChrecMap_[newIV->pre] = std::move(chrec);
-  Context_->IncrementOperationsReducedCount(thetaNode);
 }
 
 std::optional<rvsdg::ThetaNode::LoopVar>
@@ -477,39 +558,20 @@ LoopStrengthReduction::CreateNewArithmeticInductionVariable(
     JLM_ASSERT(stepPtr.has_value());
 
     const auto & stepSCEV = *stepPtr;
+
+    rvsdg::Output * stepOutput = nullptr;
     if (const auto stepConstant = dynamic_cast<const SCEVConstant *>(stepSCEV.get()))
     {
-      auto hoistedStart = HoistSCEVExpresssion(*startSCEV, thetaNode, numBits);
-
-      if (!hoistedStart.has_value())
-        return std::nullopt;
-
-      auto newIV = thetaNode.AddLoopVar(*hoistedStart);
       const auto stepValue = stepConstant->GetValue();
       const auto & stepValueNode =
           IntegerConstantOperation::Create(*thetaNode.subregion(), numBits, stepValue);
-      auto & newAddNode = jlm::rvsdg::CreateOpNode<IntegerAddOperation>(
-          { newIV.pre, stepValueNode.output(0) },
-          numBits);
-      newIV.post->divert_to(newAddNode.output(0));
-
-      return newIV;
+      stepOutput = stepValueNode.output(0);
     }
-    if (const auto stepInit = dynamic_cast<const SCEVInit *>(stepSCEV.get()))
+    else if (const auto stepInit = dynamic_cast<const SCEVInit *>(stepSCEV.get()))
     {
-      auto hoistedStart = HoistSCEVExpresssion(*startSCEV, thetaNode, numBits);
-      if (!hoistedStart.has_value())
-        return std::nullopt;
-
-      auto newIV = thetaNode.AddLoopVar(*hoistedStart);
-      auto & stepPrePointer = stepInit->GetPrePointer();
-      auto & newAddNode =
-          jlm::rvsdg::CreateOpNode<IntegerAddOperation>({ newIV.pre, &stepPrePointer }, numBits);
-      newIV.post->divert_to(newAddNode.output(0));
-
-      return newIV;
+      stepOutput = &stepInit->GetPrePointer();
     }
-    if (const auto stepNAryExpr = dynamic_cast<const SCEVNAryExpr *>(stepSCEV.get()))
+    else if (const auto stepNAryExpr = dynamic_cast<const SCEVNAryExpr *>(stepSCEV.get()))
     {
       const auto hoistedStep = HoistSCEVExpresssion(*stepNAryExpr, thetaNode, numBits);
       if (!hoistedStep.has_value())
@@ -517,89 +579,131 @@ LoopStrengthReduction::CreateNewArithmeticInductionVariable(
 
       auto newStepIV = thetaNode.AddLoopVar(*hoistedStep);
 
-      auto hoistedStart = HoistSCEVExpresssion(*startSCEV, thetaNode, numBits);
-      if (!hoistedStart.has_value())
-        return std::nullopt;
-
-      auto newIV = thetaNode.AddLoopVar(*hoistedStart);
-      auto & newAddNode =
-          jlm::rvsdg::CreateOpNode<IntegerAddOperation>({ newIV.pre, newStepIV.pre }, numBits);
-      newIV.post->divert_to(newAddNode.output(0));
-
-      return newIV;
+      stepOutput = newStepIV.pre;
+    }
+    else
+    {
+      return std::nullopt;
     }
 
-    return std::nullopt;
+    auto hoistedStart = HoistSCEVExpresssion(*startSCEV, thetaNode, numBits);
+    if (!hoistedStart.has_value())
+      return std::nullopt;
+
+    auto newIV = thetaNode.AddLoopVar(*hoistedStart);
+
+    auto & newAddNode =
+        jlm::rvsdg::CreateOpNode<IntegerAddOperation>({ newIV.pre, stepOutput }, numBits);
+    newIV.post->divert_to(newAddNode.output(0));
+
+    return newIV;
   }
   throw std::logic_error("Invalid chrec size in CreateNewArithmeticInductionVariable!");
 }
 
-void
-LoopStrengthReduction::ReplaceGEPOperation(
-    std::unique_ptr<SCEVChainRecurrence> & chrec,
-    rvsdg::Output & output,
+std::optional<rvsdg::ThetaNode::LoopVar>
+LoopStrengthReduction::CreateNewGEPInductionVariable(
+    const SCEVChainRecurrence & chrec,
     rvsdg::ThetaNode & thetaNode,
     const std::shared_ptr<const PointerType> & pointerType)
 {
-  JLM_ASSERT(chrec->NumOperands() <= 2);
-
-  const auto & baseAddressSCEV = chrec->GetStartValue();
-  const auto & baseAddressInit = dynamic_cast<const SCEVInit *>(baseAddressSCEV);
-
-  JLM_ASSERT(baseAddressInit);
-
-  const auto & baseAddressPointer = baseAddressInit->GetPrePointer();
-  const auto baseAddressLoopVar = thetaNode.MapPreLoopVar(baseAddressPointer);
-
-  if (SCEVChainRecurrence::IsConstant(*chrec))
+  const auto & baseAddressSCEV = chrec.GetStartValue();
+  if (SCEVChainRecurrence::IsConstant(chrec))
   {
-    // The offset for the address computed by the GEP is always zero. We can replace the GEP
-    // operation with just the base address
-    output.divert_users(baseAddressLoopVar.pre);
+    auto hoistedStart = HoistSCEVExpresssion(*baseAddressSCEV, thetaNode, 64);
+
+    if (!hoistedStart.has_value())
+      return std::nullopt;
+
+    return thetaNode.AddLoopVar(*hoistedStart);
   }
-  else if (SCEVChainRecurrence::IsAffine(*chrec))
+  if (SCEVChainRecurrence::IsAffine(chrec))
   {
     // Chrec has the form {Init(a),+,b} where Init(a) is the (initial) value of the base address
     // and b is the offset (in bytes).
-    const auto & stepPtr = chrec->GetStep();
+    const auto & stepPtr = chrec.GetStep();
 
     JLM_ASSERT(stepPtr.has_value());
 
     const auto & stepSCEV = *stepPtr;
-    const auto & stepConstant = dynamic_cast<const SCEVConstant *>(stepSCEV.get());
 
-    JLM_ASSERT(stepConstant);
+    rvsdg::Output * stepOutput = nullptr;
+    if (const auto stepConstant = dynamic_cast<const SCEVConstant *>(stepSCEV.get()))
+    {
+      const auto stepValue = stepConstant->GetValue();
+      const auto & stepValueNode =
+          IntegerConstantOperation::Create(*thetaNode.subregion(), 64, stepValue);
+      stepOutput = stepValueNode.output(0);
+    }
+    else if (const auto stepInit = dynamic_cast<const SCEVInit *>(stepSCEV.get()))
+    {
+      stepOutput = &stepInit->GetPrePointer();
+    }
+    else if (const auto stepNAryExpr = dynamic_cast<const SCEVNAryExpr *>(stepSCEV.get()))
+    {
+      const auto hoistedStep = HoistSCEVExpresssion(*stepNAryExpr, thetaNode, 64);
+      if (!hoistedStep.has_value())
+        return std::nullopt;
 
-    const auto newIV = thetaNode.AddLoopVar(baseAddressLoopVar.input->origin());
+      auto newStepIV = thetaNode.AddLoopVar(*hoistedStep);
+      stepOutput = newStepIV.pre;
+    }
+    else
+    {
+      return std::nullopt;
+    }
 
-    const auto stepValue = stepConstant->GetValue();
-    const auto & stepValueNode =
-        IntegerConstantOperation::Create(*thetaNode.subregion(), 64, stepValue);
+    auto hoistedStart = HoistSCEVExpresssion(*baseAddressSCEV, thetaNode, 64);
+
+    if (!hoistedStart.has_value())
+      return std::nullopt;
+
+    const auto newIV = thetaNode.AddLoopVar(*hoistedStart);
+
+    if (auto stepBitType = std::dynamic_pointer_cast<const rvsdg::BitType>(stepOutput->Type());
+        stepBitType->nbits() != 64)
+    {
+      stepOutput = SExtOperation::create(64, stepOutput);
+    }
 
     auto newGep = GetElementPtrOperation::Create(
         newIV.pre,
-        { stepValueNode.output(0) },
+        { stepOutput },
         rvsdg::BitType::Create(8), // Byte
         pointerType);
 
     newIV.post->divert_to(newGep);
-    output.divert_users(newIV.pre);
 
-    ChrecMap_[newIV.pre] = std::move(chrec);
-  }
-  else
-  {
-    throw std::logic_error("Invalid chrec size in ReplaceGepOperation!");
+    return newIV;
   }
 
-  Context_->IncrementOperationsReducedCount(thetaNode);
+  throw std::logic_error("Invalid chrec size in CreateNewGEPInductionVariable!");
 }
 
 bool
-LoopStrengthReduction::IsValidCandidateOperation(const rvsdg::Output & output)
+LoopStrengthReduction::IsValidCandidateOperation(
+    const rvsdg::Output & output,
+    const rvsdg::SimpleOperation & operation)
 {
+  bool isGEP = false;
+  if (rvsdg::is<GetElementPtrOperation>(operation))
+  {
+    Context_->NumGEPCandidates++;
+    isGEP = true;
+  }
+  else
+  {
+    Context_->NumArithmeticCandidates++;
+  }
+
   if (!DependsOnInductionVariable(output))
+  {
+    if (isGEP)
+      Context_->NumGEPDoesNotDependOnIV++;
+    else
+      Context_->NumArithmeticDoesNotDependOnIV++;
     return false;
+  }
 
   const auto & simpleNode = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(output);
 
@@ -609,36 +713,24 @@ LoopStrengthReduction::IsValidCandidateOperation(const rvsdg::Output & output)
 
   // We only reduce arithmetic operations if they contain a multiplication somewhere
   if (rvsdg::is<IntegerBinaryOperation>(simpleOperation) && !ContainsMul(output))
+  {
+    Context_->NumArithmeticNotContainsMul++;
     return false;
+  }
 
   const auto & chrec = ChrecMap_.at(&output);
 
   // We only support invariant and affine recurrences (1-2 operands) that are not unknown
-  if (ScalarEvolution::IsUnknown(*chrec))
-    return false;
-
   if (chrec->NumOperands() > 2)
     return false;
 
-  const auto & startSCEV = chrec->GetStartValue();
-
-  if (rvsdg::is<GetElementPtrOperation>(simpleOperation))
+  if (ScalarEvolution::IsUnknown(*chrec))
   {
-    const auto & startInit = dynamic_cast<const SCEVInit *>(startSCEV);
-    if (!startInit)
-      return false;
-
-    if (SCEVChainRecurrence::IsAffine(*chrec))
-    {
-      const auto & stepPtr = chrec->GetStep();
-
-      JLM_ASSERT(stepPtr.has_value());
-
-      const auto & stepSCEV = *stepPtr;
-      const auto & stepConstant = dynamic_cast<const SCEVConstant *>(stepSCEV.get());
-      if (!stepConstant)
-        return false;
-    }
+    if (isGEP)
+      Context_->NumGEPIsUnknown++;
+    else
+      Context_->NumArithmeticIsUnknown++;
+    return false;
   }
 
   return true;

--- a/jlm/llvm/opt/LoopStrengthReduction.cpp
+++ b/jlm/llvm/opt/LoopStrengthReduction.cpp
@@ -54,13 +54,6 @@ public:
 
   size_t NumArithmeticCandidates = 0;
   size_t NumGEPCandidates = 0;
-
-  size_t NumGEPDoesNotDependOnIV = 0;
-  size_t NumArithmeticDoesNotDependOnIV = 0;
-  size_t NumArithmeticNotContainsMul = 0;
-  size_t NumGEPIsUnknown = 0;
-  size_t NumArithmeticIsUnknown = 0;
-
   size_t NumArithmeticOperationsReduced = 0;
   size_t NumGEPOperationsReduced = 0;
 
@@ -90,20 +83,12 @@ public:
     GetTimer(Label::Timer).stop();
 
     AddMeasurement(
-        Label::NumCandidates,
+        Label::NumLSRCandidates,
         context.NumArithmeticCandidates + context.NumGEPCandidates);
-    AddMeasurement(Label::NumArithmeticCandidates, context.NumArithmeticCandidates);
-    AddMeasurement(Label::NumGEPCandidates, context.NumGEPCandidates);
-
-    AddMeasurement(Label::NumArithmeticDoesNotDependOnIV, context.NumArithmeticDoesNotDependOnIV);
-    AddMeasurement(Label::NumGEPDoesNotDependOnIV, context.NumGEPDoesNotDependOnIV);
-    AddMeasurement(Label::NumArithmeticNotContainsMul, context.NumArithmeticNotContainsMul);
- AddMeasurement(Label::NumArithmeticIsUnknown, context.NumArithmeticIsUnknown);
-    AddMeasurement(Label::NumGEPIsUnknown, context.NumGEPIsUnknown);
-
+    AddMeasurement(Label::NumArithmeticLSRCandidates, context.NumArithmeticCandidates);
+    AddMeasurement(Label::NumGepLSRCandidates, context.NumGEPCandidates);
     AddMeasurement(Label::NumArithmeticOperationsReduced, context.NumArithmeticOperationsReduced);
-    AddMeasurement(Label::NumGEPOperationsReduced, context.NumGEPOperationsReduced);
-
+    AddMeasurement(Label::NumGepOperationsReduced, context.NumGEPOperationsReduced);
     AddMeasurement(
         Label::NumOperationsReduced,
         GetStatisticsString(context.GetOperationsReducedMap()));
@@ -282,7 +267,6 @@ LoopStrengthReduction::ReplaceCandidateOperation(
   auto & chrec = ChrecMap_.at(&output);
 
   JLM_ASSERT(chrec->NumOperands() <= 2);
-  std::cout << "We have this chrec: " << chrec->DebugString() << '\n';
 
   const rvsdg::ThetaNode::LoopVar * newIV = nullptr;
   if (const auto & bitType = std::dynamic_pointer_cast<const rvsdg::BitType>(output.Type()))
@@ -295,7 +279,6 @@ LoopStrengthReduction::ReplaceCandidateOperation(
     newIV = &newIVOpt.value();
 
     Context_->NumArithmeticOperationsReduced++;
-    std::cout << "arithmetic operation reduced\n";
   }
   else if (const auto & pointerType = std::dynamic_pointer_cast<const PointerType>(output.Type()))
   {
@@ -306,7 +289,6 @@ LoopStrengthReduction::ReplaceCandidateOperation(
     newIV = &newIVOpt.value();
 
     Context_->NumGEPOperationsReduced++;
-    std::cout << "GEP operation reduced\n";
   }
   else
   {
@@ -347,7 +329,7 @@ LoopStrengthReduction::HoistChrec(
     // The chrec doesn't have a corresponding output. This can happen in cases where we have folded
     // some constant into the chrec of an induction variable, either with addition or
     // multiplication. In this case, we need to create a new induction variable for the chrec.
-    auto newIV = CreateNewArithmeticInductionVariable(chrec, targetLoop, numBits);
+    const auto newIV = CreateNewArithmeticInductionVariable(chrec, targetLoop, numBits);
     if (!newIV.has_value())
       return std::nullopt;
 
@@ -418,12 +400,12 @@ LoopStrengthReduction::HoistSCEVExpresssion(
   }
   if (const auto addExpr = dynamic_cast<const SCEVNAryAddExpr *>(&scev))
   {
-    auto rightMost = addExpr->GetOperand(addExpr->NumOperands() - 1);
-    auto rightSideOpt = HoistSCEVExpresssion(*rightMost, thetaNode, numBits);
+    const auto rightMost = addExpr->GetOperand(addExpr->NumOperands() - 1);
+    const auto rightSideOpt = HoistSCEVExpresssion(*rightMost, thetaNode, numBits);
     if (!rightSideOpt.has_value())
       return std::nullopt;
 
-    auto newAddExpr = SCEV::CloneAs<SCEVNAryAddExpr>(*addExpr);
+    const auto newAddExpr = SCEV::CloneAs<SCEVNAryAddExpr>(*addExpr);
     newAddExpr->RemoveOperand(addExpr->NumOperands() - 1);
 
     std::optional<rvsdg::Output *> leftSideOpt;
@@ -444,12 +426,11 @@ LoopStrengthReduction::HoistSCEVExpresssion(
     rvsdg::Output * leftSide = *leftSideOpt;
     rvsdg::Output * rightSide = *rightSideOpt;
     // If either side is a pointer, we use a GEP instead of IntegerAddOperation
-    const auto leftIsPtr = rvsdg::is<PointerType>(leftSide->Type());
-    const auto rightIsPtr = rvsdg::is<PointerType>(rightSide->Type());
-
-    if (leftIsPtr || rightIsPtr)
+    if (const auto rightIsPtr = rvsdg::is<PointerType>(rightSide->Type()),
+        leftIsPtr = rvsdg::is<PointerType>(leftSide->Type());
+        leftIsPtr || rightIsPtr)
     {
-      auto ptrSide = leftIsPtr ? leftSide : rightSide;
+      const auto ptrSide = leftIsPtr ? leftSide : rightSide;
       auto offsetSide = leftIsPtr ? rightSide : leftSide;
 
       const auto ptrType = std::dynamic_pointer_cast<const PointerType>(ptrSide->Type());
@@ -463,12 +444,13 @@ LoopStrengthReduction::HoistSCEVExpresssion(
       return newGep;
     }
 
-    if (auto leftBitType = std::dynamic_pointer_cast<const rvsdg::BitType>(leftSide->Type());
+    if (const auto leftBitType = std::dynamic_pointer_cast<const rvsdg::BitType>(leftSide->Type());
         leftBitType->nbits() != numBits)
     {
       leftSide = SExtOperation::create(numBits, leftSide);
     }
-    if (auto rightBitType = std::dynamic_pointer_cast<const rvsdg::BitType>(rightSide->Type());
+    if (const auto rightBitType =
+            std::dynamic_pointer_cast<const rvsdg::BitType>(rightSide->Type());
         rightBitType->nbits() != numBits)
     {
       rightSide = SExtOperation::create(numBits, rightSide);
@@ -481,12 +463,12 @@ LoopStrengthReduction::HoistSCEVExpresssion(
   }
   if (const auto mulExpr = dynamic_cast<const SCEVNAryMulExpr *>(&scev))
   {
-    auto rightMost = mulExpr->GetOperand(mulExpr->NumOperands() - 1);
-    auto rightSideOpt = HoistSCEVExpresssion(*rightMost, thetaNode, numBits);
+    const auto rightMost = mulExpr->GetOperand(mulExpr->NumOperands() - 1);
+    const auto rightSideOpt = HoistSCEVExpresssion(*rightMost, thetaNode, numBits);
     if (!rightSideOpt.has_value())
       return std::nullopt;
 
-    auto newMulExpr = SCEV::CloneAs<SCEVNAryMulExpr>(*mulExpr);
+    const auto newMulExpr = SCEV::CloneAs<SCEVNAryMulExpr>(*mulExpr);
     newMulExpr->RemoveOperand(mulExpr->NumOperands() - 1);
 
     std::optional<rvsdg::Output *> leftSideOpt;
@@ -506,12 +488,13 @@ LoopStrengthReduction::HoistSCEVExpresssion(
     rvsdg::Output * leftSide = *leftSideOpt;
     rvsdg::Output * rightSide = *rightSideOpt;
     // Sign extend in cases where the input does not match the expected number of bits
-    if (auto leftBitType = std::dynamic_pointer_cast<const rvsdg::BitType>(leftSide->Type());
+    if (const auto leftBitType = std::dynamic_pointer_cast<const rvsdg::BitType>(leftSide->Type());
         leftBitType->nbits() != numBits)
     {
       leftSide = SExtOperation::create(numBits, leftSide);
     }
-    if (auto rightBitType = std::dynamic_pointer_cast<const rvsdg::BitType>(rightSide->Type());
+    if (const auto rightBitType =
+            std::dynamic_pointer_cast<const rvsdg::BitType>(rightSide->Type());
         rightBitType->nbits() != numBits)
     {
       rightSide = SExtOperation::create(numBits, rightSide);
@@ -544,7 +527,7 @@ LoopStrengthReduction::CreateNewArithmeticInductionVariable(
   {
     // Chrec has the form {a}, which indicates a loop-invariant (trivial induction variable).
     // We can hoist this out of the loop by creating a new loop variable.
-    auto hoistedConstant = HoistSCEVExpresssion(*startSCEV, thetaNode, numBits);
+    const auto hoistedConstant = HoistSCEVExpresssion(*startSCEV, thetaNode, numBits);
     if (!hoistedConstant.has_value())
       return std::nullopt;
 
@@ -577,8 +560,7 @@ LoopStrengthReduction::CreateNewArithmeticInductionVariable(
       if (!hoistedStep.has_value())
         return std::nullopt;
 
-      auto newStepIV = thetaNode.AddLoopVar(*hoistedStep);
-
+      const auto newStepIV = thetaNode.AddLoopVar(*hoistedStep);
       stepOutput = newStepIV.pre;
     }
     else
@@ -586,7 +568,7 @@ LoopStrengthReduction::CreateNewArithmeticInductionVariable(
       return std::nullopt;
     }
 
-    auto hoistedStart = HoistSCEVExpresssion(*startSCEV, thetaNode, numBits);
+    const auto hoistedStart = HoistSCEVExpresssion(*startSCEV, thetaNode, numBits);
     if (!hoistedStart.has_value())
       return std::nullopt;
 
@@ -610,7 +592,7 @@ LoopStrengthReduction::CreateNewGEPInductionVariable(
   const auto & baseAddressSCEV = chrec.GetStartValue();
   if (SCEVChainRecurrence::IsConstant(chrec))
   {
-    auto hoistedStart = HoistSCEVExpresssion(*baseAddressSCEV, thetaNode, 64);
+    const auto hoistedStart = HoistSCEVExpresssion(*baseAddressSCEV, thetaNode, 64);
 
     if (!hoistedStart.has_value())
       return std::nullopt;
@@ -645,7 +627,7 @@ LoopStrengthReduction::CreateNewGEPInductionVariable(
       if (!hoistedStep.has_value())
         return std::nullopt;
 
-      auto newStepIV = thetaNode.AddLoopVar(*hoistedStep);
+      const auto newStepIV = thetaNode.AddLoopVar(*hoistedStep);
       stepOutput = newStepIV.pre;
     }
     else
@@ -653,14 +635,15 @@ LoopStrengthReduction::CreateNewGEPInductionVariable(
       return std::nullopt;
     }
 
-    auto hoistedStart = HoistSCEVExpresssion(*baseAddressSCEV, thetaNode, 64);
+    const auto hoistedStart = HoistSCEVExpresssion(*baseAddressSCEV, thetaNode, 64);
 
     if (!hoistedStart.has_value())
       return std::nullopt;
 
     const auto newIV = thetaNode.AddLoopVar(*hoistedStart);
 
-    if (auto stepBitType = std::dynamic_pointer_cast<const rvsdg::BitType>(stepOutput->Type());
+    if (const auto stepBitType =
+            std::dynamic_pointer_cast<const rvsdg::BitType>(stepOutput->Type());
         stepBitType->nbits() != 64)
     {
       stepOutput = SExtOperation::create(64, stepOutput);
@@ -685,53 +668,22 @@ LoopStrengthReduction::IsValidCandidateOperation(
     const rvsdg::Output & output,
     const rvsdg::SimpleOperation & operation)
 {
-  bool isGEP = false;
   if (rvsdg::is<GetElementPtrOperation>(operation))
-  {
     Context_->NumGEPCandidates++;
-    isGEP = true;
-  }
   else
-  {
     Context_->NumArithmeticCandidates++;
-  }
 
   if (!DependsOnInductionVariable(output))
-  {
-    if (isGEP)
-      Context_->NumGEPDoesNotDependOnIV++;
-    else
-      Context_->NumArithmeticDoesNotDependOnIV++;
     return false;
-  }
-
-  const auto & simpleNode = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(output);
-
-  JLM_ASSERT(simpleNode);
-
-  const auto & simpleOperation = simpleNode->GetOperation();
 
   // We only reduce arithmetic operations if they contain a multiplication somewhere
-  if (rvsdg::is<IntegerBinaryOperation>(simpleOperation) && !ContainsMul(output))
-  {
-    Context_->NumArithmeticNotContainsMul++;
+  if (rvsdg::is<IntegerBinaryOperation>(operation) && !ContainsMul(output))
     return false;
-  }
-
-  const auto & chrec = ChrecMap_.at(&output);
 
   // We only support invariant and affine recurrences (1-2 operands) that are not unknown
-  if (chrec->NumOperands() > 2)
+  if (const auto & chrec = ChrecMap_.at(&output);
+      chrec->NumOperands() > 2 || ScalarEvolution::IsUnknown(*chrec))
     return false;
-
-  if (ScalarEvolution::IsUnknown(*chrec))
-  {
-    if (isGEP)
-      Context_->NumGEPIsUnknown++;
-    else
-      Context_->NumArithmeticIsUnknown++;
-    return false;
-  }
 
   return true;
 }
@@ -750,9 +702,7 @@ LoopStrengthReduction::DependsOnInductionVariable(const rvsdg::Output & output)
     if (it == ChrecMap_.end())
       return DependsOnIVMemo_[&output] = false;
 
-    const auto & chrec = it->second;
-
-    if (ScalarEvolution::IsUnknown(*chrec))
+    if (const auto & chrec = it->second; ScalarEvolution::IsUnknown(*chrec))
       return DependsOnIVMemo_[&output] = false;
 
     return DependsOnIVMemo_[&output] = true;
@@ -783,9 +733,8 @@ LoopStrengthReduction::ContainsMul(const rvsdg::Output & output)
   if (!simpleNode)
     return ContainsMulMemo_[&output] = false;
 
-  const auto & simpleOperation = simpleNode->GetOperation();
-
-  if (rvsdg::is<IntegerMulOperation>(simpleOperation)
+  if (const auto & simpleOperation = simpleNode->GetOperation();
+      rvsdg::is<IntegerMulOperation>(simpleOperation)
       || rvsdg::is<IntegerShlOperation>(simpleOperation))
     return ContainsMulMemo_[&output] = true;
 

--- a/jlm/llvm/opt/LoopStrengthReduction.hpp
+++ b/jlm/llvm/opt/LoopStrengthReduction.hpp
@@ -65,7 +65,7 @@ private:
   DependsOnInductionVariable(const rvsdg::Output & output);
 
   bool
-  IsValidCandidateOperation(const rvsdg::Output & output);
+  IsValidCandidateOperation(const rvsdg::Output & output, const rvsdg::SimpleOperation & operation);
 
   void
   ProcessOutput(
@@ -83,19 +83,11 @@ private:
   std::optional<rvsdg::Output *>
   HoistSCEVExpresssion(const SCEV & scev, rvsdg::ThetaNode & thetaNode, size_t numBits);
 
-  void
-  ReplaceGEPOperation(
-      std::unique_ptr<SCEVChainRecurrence> & chrec,
-      rvsdg::Output & output,
+  std::optional<rvsdg::ThetaNode::LoopVar>
+  CreateNewGEPInductionVariable(
+      const SCEVChainRecurrence & chrec,
       rvsdg::ThetaNode & thetaNode,
       const std::shared_ptr<const PointerType> & pointerType);
-
-  void
-  ReplaceArithmeticOperation(
-      std::unique_ptr<SCEVChainRecurrence> & chrec,
-      rvsdg::Output & output,
-      rvsdg::ThetaNode & thetaNode,
-      const std::shared_ptr<const rvsdg::BitType> & bitType);
 
   std::optional<rvsdg::ThetaNode::LoopVar>
   CreateNewArithmeticInductionVariable(

--- a/jlm/llvm/opt/LoopStrengthReductionTests.cpp
+++ b/jlm/llvm/opt/LoopStrengthReductionTests.cpp
@@ -536,6 +536,131 @@ TEST(LoopStrengthReductionTests, SimpleGEPCandidateOperation)
   EXPECT_EQ(StoreOperation::AddressInput(*storeNode).origin(), newIV.pre);
 }
 
+TEST(LoopStrengthReductionTests, GEPCandidateOperationWithNAryStart)
+{
+  // Tests strength reduction of a GEP operation which takes j = (3 * i) + 4 as index. i has the
+  // recurrence {0,+,2} and j has recurrence {4,+,6}. Since the GEP has int type, the recurrence for
+  // the GEP is {(Init(a1) + 16),+,24}. We expect to strength reduce the original GEP to a new loop
+  // variable which has as input value a GEP operation with the ptr Init(a1) and 16 as offset,
+  // and is incremented by the value of a new GEP with byte type and offset 24
+  using namespace jlm::llvm;
+
+  // Arrange
+  const auto intType = jlm::rvsdg::BitType::Create(32);
+  const auto intArrayType = ArrayType::Create(intType, 5);
+  const auto pointerType = PointerType::Create();
+  const auto memoryStateType = MemoryStateType::Create();
+
+  LlvmRvsdgModule rvsdgModule(jlm::util::FilePath(""), "", "");
+  auto & graph = rvsdgModule.Rvsdg();
+
+  auto arrPtr = &jlm::rvsdg::GraphImport::Create(graph, pointerType, "arrPtr");
+  auto mem = &jlm::rvsdg::GraphImport::Create(graph, memoryStateType, "");
+
+  const auto & c0_1 = IntegerConstantOperation::Create(graph.GetRootRegion(), 32, 0);
+  const auto & theta = jlm::rvsdg::ThetaNode::create(&graph.GetRootRegion());
+
+  const auto memoryState = theta->AddLoopVar(mem);
+  const auto lv1 = theta->AddLoopVar(c0_1.output(0)); // i
+  const auto lv2 = theta->AddLoopVar(arrPtr);         // arr ptr
+
+  const auto & c2 = IntegerConstantOperation::Create(*theta->subregion(), 32, 2);
+  auto & addNode1 = jlm::rvsdg::CreateOpNode<IntegerAddOperation>({ lv1.pre, c2.output(0) }, 32);
+
+  const auto & c3 = IntegerConstantOperation::Create(*theta->subregion(), 32, 3);
+  auto & mulNode = jlm::rvsdg::CreateOpNode<IntegerMulOperation>({ lv1.pre, c3.output(0) }, 32);
+  const auto & c4 = IntegerConstantOperation::Create(*theta->subregion(), 32, 4);
+  auto & addNode2 =
+      jlm::rvsdg::CreateOpNode<IntegerAddOperation>({ mulNode.output(0), c4.output(0) }, 32);
+
+  const auto & sExtNode = SExtOperation::create(64, addNode2.output(0));
+
+  const auto & c0_2 = IntegerConstantOperation::Create(*theta->subregion(), 64, 0);
+  const auto gep = GetElementPtrOperation::Create(
+      lv2.pre,
+      { c0_2.output(0), sExtNode },
+      intArrayType,
+      pointerType);
+
+  const auto & c10 = IntegerConstantOperation::Create(*theta->subregion(), 32, 10);
+
+  auto storeOutputs = StoreNonVolatileOperation::Create(gep, c10.output(0), { memoryState.pre }, 4);
+  const auto & c5 = IntegerConstantOperation::Create(*theta->subregion(), 32, 5);
+
+  auto & sltNode =
+      jlm::rvsdg::CreateOpNode<IntegerSltOperation>({ addNode1.output(0), c5.output(0) }, 32);
+  const auto matchResult =
+      jlm::rvsdg::MatchOperation::Create(*sltNode.output(0), { { 1, 1 } }, 0, 2);
+
+  lv1.post->divert_to(addNode1.output(0));
+  memoryState.post->divert_to(storeOutputs[0]);
+  theta->set_predicate(matchResult);
+
+  jlm::rvsdg::GraphExport::Create(*memoryState.output, "");
+
+  // std::cout << "Before: \n";
+  // jlm::rvsdg::view(graph, stdout);
+
+  const auto numLoopVarsBefore = theta->GetLoopVars().size();
+
+  std::vector<jlm::rvsdg::Input *> oldGepNodeUsers;
+
+  // Act
+  RunLoopStrengthReduction(rvsdgModule);
+
+  // std::cout << "After: \n";
+  // jlm::rvsdg::view(graph, stdout);
+
+  const auto numLoopVarsAfter = theta->GetLoopVars().size();
+
+  // Assert
+
+  // Check that a new loop variable was added
+  EXPECT_EQ(numLoopVarsAfter, numLoopVarsBefore + 1);
+  auto newIV = theta->GetLoopVars()[numLoopVarsAfter - 1];
+
+  // Check that the base address of the new induction variable is a GEP operation with the original
+  // array ptr as lhs and the right offset as rhs
+  const auto & newIVInputNode =
+      jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*newIV.input->origin());
+  EXPECT_TRUE(jlm::rvsdg::is<GetElementPtrOperation>(newIVInputNode->GetOperation()));
+  auto lhs = newIVInputNode->input(0)->origin();
+  auto rhs = newIVInputNode->input(1)->origin();
+  EXPECT_EQ(lhs, arrPtr);
+  const auto rhsNode = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*rhs);
+  EXPECT_TRUE(jlm::rvsdg::is<IntegerConstantOperation>(rhsNode->GetOperation()));
+  const auto & constantOperation =
+      dynamic_cast<const IntegerConstantOperation *>(&rhsNode->GetOperation());
+  EXPECT_NE(constantOperation, nullptr);
+  EXPECT_EQ(constantOperation->Representation().to_uint(), 16u);
+
+  // Check that the post value of the new IV comes from a new GEP node
+  const auto & IVPostOrigin =
+      jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*newIV.post->origin());
+  EXPECT_TRUE(jlm::rvsdg::is<GetElementPtrOperation>(IVPostOrigin->GetOperation()));
+  const auto & stepGepOperation =
+      dynamic_cast<const GetElementPtrOperation *>(&IVPostOrigin->GetOperation());
+  EXPECT_NE(stepGepOperation, nullptr);
+  // Check that it has the right type
+  EXPECT_EQ(stepGepOperation->GetPointeeType(), *jlm::rvsdg::BitType::Create(8));
+
+  // Check that index of the GEP is an integer constant with the step value
+  const auto & gepIndexInputNode =
+      jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*IVPostOrigin->input(1)->origin());
+  EXPECT_TRUE(jlm::rvsdg::is<IntegerConstantOperation>(gepIndexInputNode));
+  const auto & indexConstantOperation =
+      dynamic_cast<const IntegerConstantOperation *>(&gepIndexInputNode->GetOperation());
+  EXPECT_NE(indexConstantOperation, nullptr);
+  EXPECT_EQ(indexConstantOperation->Representation().nbits(), 64u);
+  EXPECT_EQ(indexConstantOperation->Representation().to_uint(), 24u);
+
+  // Check that the both the load and store nodes use the new induction variable as address
+  auto storeNode = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*storeOutputs[0]);
+  EXPECT_NE(storeNode, nullptr);
+  EXPECT_TRUE(jlm::rvsdg::is<StoreNonVolatileOperation>(storeNode->GetOperation()));
+  EXPECT_EQ(StoreOperation::AddressInput(*storeNode).origin(), newIV.pre);
+}
+
 TEST(LoopStrengthReductionTests, CandidateOperationInNestedLoopTest)
 {
   // Tests strength reduction of a variable with the recurrence {{0,+,3}<1>}<2>. Since {0,+,3}<1> is

--- a/jlm/llvm/opt/ScalarEvolution.cpp
+++ b/jlm/llvm/opt/ScalarEvolution.cpp
@@ -280,6 +280,12 @@ ScalarEvolution::Run(
   AnalyzeRegion(rootRegion);
   CombineChrecsAcrossLoops();
 
+  // for (auto & [output, chrec] : Context_->GetChrecMap())
+  // {
+  //   std::cout << output << "(" << output->debug_string() << "): " << chrec->DebugString() <<
+  //   '\n';
+  // }
+
   statistics->Stop(*Context_);
   statisticsCollector.CollectDemandedStatistics(std::move(statistics));
 };

--- a/jlm/llvm/opt/ScalarEvolution.cpp
+++ b/jlm/llvm/opt/ScalarEvolution.cpp
@@ -280,12 +280,6 @@ ScalarEvolution::Run(
   AnalyzeRegion(rootRegion);
   CombineChrecsAcrossLoops();
 
-  // for (auto & [output, chrec] : Context_->GetChrecMap())
-  // {
-  //   std::cout << output << "(" << output->debug_string() << "): " << chrec->DebugString() <<
-  //   '\n';
-  // }
-
   statistics->Stop(*Context_);
   statisticsCollector.CollectDemandedStatistics(std::move(statistics));
 };

--- a/jlm/util/Statistics.hpp
+++ b/jlm/util/Statistics.hpp
@@ -240,7 +240,18 @@ protected:
     inline static const char * NumLoops = "#NumLoops";
     inline static const char * TripCounts = "#TripCounts";
 
+    inline static const char * NumCandidates = "#NumCandidates";
+    inline static const char * NumArithmeticCandidates = "#NumArithmeticCandidates";
+    inline static const char * NumGEPCandidates = "#NumGEPCandidates";
     inline static const char * NumOperationsReduced = "#NumOperationsReduced";
+    inline static const char * NumArithmeticOperationsReduced = "#NumArithmeticOperationsReduced";
+    inline static const char * NumGEPOperationsReduced = "#NumGEPOperationsReduced";
+
+    inline static const char * NumGEPDoesNotDependOnIV = "#NumGEPDoesNotDependOnIV";
+    inline static const char * NumArithmeticDoesNotDependOnIV = "#NumArithmeticDoesNotDependOnIV";
+    inline static const char * NumArithmeticNotContainsMul = "#NumArithmeticNotContainsMul";
+    inline static const char * NumGEPIsUnknown = "#NumGEPIsUnknown";
+    inline static const char * NumArithmeticIsUnknown = "#NumArithmeticIsUnknown";
 
     static inline const char * Timer = "Time";
   };

--- a/jlm/util/Statistics.hpp
+++ b/jlm/util/Statistics.hpp
@@ -240,18 +240,12 @@ protected:
     inline static const char * NumLoops = "#NumLoops";
     inline static const char * TripCounts = "#TripCounts";
 
-    inline static const char * NumCandidates = "#NumCandidates";
-    inline static const char * NumArithmeticCandidates = "#NumArithmeticCandidates";
-    inline static const char * NumGEPCandidates = "#NumGEPCandidates";
-    inline static const char * NumOperationsReduced = "#NumOperationsReduced";
-    inline static const char * NumArithmeticOperationsReduced = "#NumArithmeticOperationsReduced";
-    inline static const char * NumGEPOperationsReduced = "#NumGEPOperationsReduced";
-
-    inline static const char * NumGEPDoesNotDependOnIV = "#NumGEPDoesNotDependOnIV";
-    inline static const char * NumArithmeticDoesNotDependOnIV = "#NumArithmeticDoesNotDependOnIV";
-    inline static const char * NumArithmeticNotContainsMul = "#NumArithmeticNotContainsMul";
-    inline static const char * NumGEPIsUnknown = "#NumGEPIsUnknown";
-    inline static const char * NumArithmeticIsUnknown = "#NumArithmeticIsUnknown";
+    inline static const char * NumLSRCandidates = "#Candidates";
+    inline static const char * NumArithmeticLSRCandidates = "#ArithmeticCandidates";
+    inline static const char * NumGepLSRCandidates = "#GepCandidates";
+    inline static const char * NumOperationsReduced = "#OperationsReduced";
+    inline static const char * NumArithmeticOperationsReduced = "#ArithmeticOperationsReduced";
+    inline static const char * NumGepOperationsReduced = "#GepOperationsReduced";
 
     static inline const char * Timer = "Time";
   };


### PR DESCRIPTION
Previously we only reduced the simplest GEP candidates which had chrecs of the form {Init(a1),+,a}, where **a1** is the loop variable with the base address and **a** is a constant offset. This PR generalizes the implementation so we can reduce any GEP candidate as long as the start value involves the base address and the step value is invariant in the loop.

It essentially does the same as was done with arithmetic operations in the previous PR. Extends the `HoistSCEVExpression` method to be able to handle processing pointer types and 64 bit offsets. Also restructures the code so the reduction process for GEP candidates matches the one for arithmetic candidates, allowing us to reuse more of the code.