### PR TITLE
Store store reduction fix

### DIFF
--- a/jlm/llvm/ir/operators/Store.cpp
+++ b/jlm/llvm/ir/operators/Store.cpp
@@ -8,6 +8,8 @@
 #include <jlm/llvm/ir/operators/MemoryStateOperations.hpp>
 #include <jlm/llvm/ir/operators/Store.hpp>
 #include <jlm/llvm/ir/Trace.hpp>
+#include <jlm/llvm/ir/types.hpp>
+#include <jlm/rvsdg/simple-node.hpp>
 #include <jlm/util/HashSet.hpp>
 
 namespace jlm::llvm
@@ -56,31 +58,38 @@ is_store_mux_reducible(const std::vector<jlm::rvsdg::Output *> & operands)
 
 static bool
 is_store_store_reducible(
-    const StoreNonVolatileOperation & op,
+    const StoreNonVolatileOperation & store2Op,
     const std::vector<jlm::rvsdg::Output *> & operands)
 {
   JLM_ASSERT(operands.size() > 2);
 
-  const auto storeNode = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(*operands[2]);
-  if (!is<StoreNonVolatileOperation>(storeNode))
+  // Try tracing a memory state edge to a previous store
+  const auto [store1Node, store1Op] =
+      rvsdg::TryGetSimpleNodeAndOptionalOp<StoreNonVolatileOperation>(*operands[2]);
+  if (!store1Node || !store1Op)
     return false;
 
-  if (op.NumMemoryStates() != storeNode->noutputs())
+  const auto & store1Address = *StoreOperation::AddressInput(*store1Node).origin();
+  const auto & store2Address = *operands[0];
+
+  // only continue if store1 and store2 have the same address
+  if (&llvm::traceOutput(store1Address) != &llvm::traceOutput(store2Address))
     return false;
 
-  /* check for same address */
-  if (operands[0] != storeNode->input(0)->origin())
-    return false;
-
+  // Check that all memory state inputs come from store1Node, and have no other users
   for (size_t n = 2; n < operands.size(); n++)
   {
-    if (rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(*operands[n]) != storeNode
+    if (rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(*operands[n]) != store1Node
         || operands[n]->nusers() != 1)
       return false;
   }
 
-  auto other = static_cast<const StoreNonVolatileOperation *>(&storeNode->GetOperation());
-  JLM_ASSERT(op.GetAlignment() == other->GetAlignment());
+  // Check that store2 fully overwrites store1
+  const auto & store1Type = store1Op->GetStoredType();
+  const auto & store2Type = store2Op.GetStoredType();
+  if (GetTypeStoreSize(store2Type) < GetTypeStoreSize(store1Type))
+    return false;
+
   return true;
 }
 

--- a/jlm/llvm/ir/operators/Store.cpp
+++ b/jlm/llvm/ir/operators/Store.cpp
@@ -66,7 +66,7 @@ is_store_store_reducible(
   // Try tracing a memory state edge to a previous store
   const auto [store1Node, store1Op] =
       rvsdg::TryGetSimpleNodeAndOptionalOp<StoreNonVolatileOperation>(*operands[2]);
-  if (!store1Node || !store1Op)
+  if (!store1Op)
     return false;
 
   const auto & store1Address = *StoreOperation::AddressInput(*store1Node).origin();

--- a/jlm/llvm/ir/operators/Store.hpp
+++ b/jlm/llvm/ir/operators/Store.hpp
@@ -185,11 +185,11 @@ public:
    * =>
    * sx1 sx2 = StoreNonVolatileOperation a v2 si1 si2
    *
-   * @param operation The operation of the StoreNonVolatile node.
-   * @param operands The operands of the StoreNonVolatile node.
+   * @param operation The operation of the second StoreNonVolatile node.
+   * @param operands The operands of the second StoreNonVolatile node.
    *
-   * @return If the normalization could be applied, then the results of the store operation after
-   * the transformation. Otherwise, std::nullopt.
+   * @return If the normalization could be applied, the results of the
+   * remaining store operation are returned. Otherwise std::nullopt.
    */
   static std::optional<std::vector<rvsdg::Output *>>
   NormalizeStoreStore(

--- a/jlm/llvm/ir/operators/StoreTests.cpp
+++ b/jlm/llvm/ir/operators/StoreTests.cpp
@@ -320,14 +320,14 @@ TEST(StoreOperationTests, TestStoreStoreReduction)
   using namespace jlm::rvsdg;
 
   // Arrange
-  auto vt = TestType::createValueType();
+  auto int64 = BitType::Create(64);
   auto pt = PointerType::Create();
   auto mt = MemoryStateType::Create();
 
   jlm::rvsdg::Graph graph;
   auto a = &jlm::rvsdg::GraphImport::Create(graph, pt, "address");
-  auto v1 = &jlm::rvsdg::GraphImport::Create(graph, vt, "value");
-  auto v2 = &jlm::rvsdg::GraphImport::Create(graph, vt, "value");
+  auto v1 = &jlm::rvsdg::GraphImport::Create(graph, int64, "value");
+  auto v2 = &jlm::rvsdg::GraphImport::Create(graph, int64, "value");
   auto s = &jlm::rvsdg::GraphImport::Create(graph, mt, "state");
 
   auto & storeNode1 = StoreNonVolatileOperation::CreateNode(*a, *v1, { s }, 4);


### PR DESCRIPTION
The reduction had an assert that would trigger on alignment mismatch, but that is no reason to fail.

Instead I replaced it with an actual test that ensures that the size of the second store actually overrides the first store.

I also pass the address inputs through `traceOutput` just in case we can remove some more stores.

(As a side note, we could make a much greater effort to remove dead stores, but it does not fit that well in the reduction interface)