### PR TITLE
Dump json instead of dot when doing --dumpRvsdgDotGraphs

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -371,7 +371,7 @@ rvsdg2ref(llvm::LlvmRvsdgModule & rhls, const util::FilePath & path)
 }
 
 std::unique_ptr<rvsdg::TransformationSequence>
-createTransformationSequence(rvsdg::DotWriter & dotWriter, const bool dumpRvsdgDotGraphs)
+createTransformationSequence(rvsdg::DotWriter & dotWriter, const bool dumpRvsdgGraphs)
 {
   auto predicateCorrelation = std::make_shared<llvm::PredicateCorrelation>();
   auto deadNodeElimination = std::make_shared<llvm::DeadNodeElimination>();
@@ -450,7 +450,7 @@ createTransformationSequence(rvsdg::DotWriter & dotWriter, const bool dumpRvsdgD
   return std::make_unique<rvsdg::TransformationSequence>(
       std::move(sequence),
       dotWriter,
-      dumpRvsdgDotGraphs);
+      dumpRvsdgGraphs);
 }
 
 void

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.hpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.hpp
@@ -25,7 +25,7 @@ is_constant(const rvsdg::Node * node)
 }
 
 std::unique_ptr<rvsdg::TransformationSequence>
-createTransformationSequence(rvsdg::DotWriter & dotWriter, bool dumpRvsdgDotGraphs);
+createTransformationSequence(rvsdg::DotWriter & dotWriter, bool dumpRvsdgGraphs);
 
 void
 rvsdg2ref(llvm::LlvmRvsdgModule & rm, const util::FilePath & function_name);

--- a/jlm/rvsdg/Transformation.cpp
+++ b/jlm/rvsdg/Transformation.cpp
@@ -88,7 +88,7 @@ TransformationSequence::Run(
     statistics->StartMeasuring();
 
   size_t numPasses = 0;
-  if (DumpRvsdgDotGraphs_)
+  if (dumpRvsdgGraphs_)
   {
     DumpDotGraphs(
         rvsdgModule,
@@ -111,7 +111,7 @@ TransformationSequence::Run(
     if (statistics)
       statistics->EndTransformationMeasuring();
 
-    if (DumpRvsdgDotGraphs_)
+    if (dumpRvsdgGraphs_)
     {
       DumpDotGraphs(
           rvsdgModule,

--- a/jlm/rvsdg/Transformation.cpp
+++ b/jlm/rvsdg/Transformation.cpp
@@ -144,11 +144,11 @@ TransformationSequence::DumpDotGraphs(
 
   std::stringstream filePath;
   filePath << outputDir.to_str() << "/" << std::setw(3) << std::setfill('0') << numPass << "-"
-           << passName << ".dot";
+           << passName << ".json";
 
   std::ofstream outputFile;
   outputFile.open(filePath.str());
-  graphWriter.outputAllGraphs(outputFile, util::graph::OutputFormat::Dot);
+  graphWriter.outputAllGraphs(outputFile, util::graph::OutputFormat::Json);
   outputFile.close();
 }
 

--- a/jlm/rvsdg/Transformation.hpp
+++ b/jlm/rvsdg/Transformation.hpp
@@ -78,10 +78,10 @@ public:
   explicit TransformationSequence(
       std::vector<std::shared_ptr<Transformation>> transformations,
       DotWriter & dotWriter,
-      const bool dumpRvsdgDotGraphs)
+      const bool dumpRvsdgGraphs)
       : Transformation("TransformationSequence"),
         DotWriter_(dotWriter),
-        DumpRvsdgDotGraphs_(dumpRvsdgDotGraphs),
+        dumpRvsdgGraphs_(dumpRvsdgGraphs),
         Transformations_(std::move(transformations))
   {}
 
@@ -101,7 +101,7 @@ public:
    * @param statisticsCollector Statistics collector for collecting transformation statistics.
    * @param transformations The transformations that are sequentially applied to \p rvsdgModule.
    * @param dotWriter The DOT writer for dumping the RVSDG graphs.
-   * @param dumpRvsdgDotGraphs Determines whether to dump the RVSDG graphs.
+   * @param dumpRvsdgGraphs Determines whether to dump the RVSDG graphs.
    */
   static void
   CreateAndRun(
@@ -109,12 +109,12 @@ public:
       util::StatisticsCollector & statisticsCollector,
       std::vector<std::shared_ptr<Transformation>> transformations,
       DotWriter & dotWriter,
-      const bool dumpRvsdgDotGraphs)
+      const bool dumpRvsdgGraphs)
   {
     TransformationSequence sequentialApplication(
         std::move(transformations),
         dotWriter,
-        dumpRvsdgDotGraphs);
+        dumpRvsdgGraphs);
     sequentialApplication.Run(rvsdgModule, statisticsCollector);
   }
 
@@ -127,7 +127,7 @@ private:
       size_t numPass) const;
 
   DotWriter & DotWriter_;
-  bool DumpRvsdgDotGraphs_;
+  bool dumpRvsdgGraphs_;
   std::vector<std::shared_ptr<Transformation>> Transformations_;
 };
 

--- a/jlm/rvsdg/TransformationSequenceTests.cpp
+++ b/jlm/rvsdg/TransformationSequenceTests.cpp
@@ -70,6 +70,6 @@ TEST(ArgumentTests, RvsdgDumping)
       true);
 
   // Assert
-  EXPECT_TRUE(std::filesystem::exists("/tmp/000-Pristine.dot"));
-  EXPECT_TRUE(std::filesystem::exists("/tmp/001-AfterTestTransformation.dot"));
+  EXPECT_TRUE(std::filesystem::exists("/tmp/000-Pristine.json"));
+  EXPECT_TRUE(std::filesystem::exists("/tmp/001-AfterTestTransformation.json"));
 }

--- a/jlm/tooling/Command.cpp
+++ b/jlm/tooling/Command.cpp
@@ -362,7 +362,7 @@ JlmOptCommand::Run() const
       statisticsCollector,
       GetTransformations(),
       dotWriter,
-      CommandLineOptions_.DumpRvsdgDotGraphs());
+      CommandLineOptions_.dumpRvsdgGraphs());
 
   PrintRvsdgModule(
       *rvsdgModule,

--- a/jlm/tooling/CommandLine.cpp
+++ b/jlm/tooling/CommandLine.cpp
@@ -690,10 +690,10 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, const char * const 
       cl::desc(statisticDirectoryDescription),
       cl::value_desc("dir"));
 
-  cl::opt<bool> dumpRvsdgDotGraphs(
-      "dumpRvsdgDotGraphs",
+  cl::opt<bool> dumpRvsdgGraphs(
+      "dumpRvsdgGraphs",
       cl::init(false),
-      cl::desc("Dump RVSDG as dot graphs after each transformation in debug folder."));
+      cl::desc("Dump RVSDG as json graphs after each transformation in debug folder."));
 
   cl::list<util::Statistics::Id> printStatistics(
       cl::values(
@@ -983,7 +983,7 @@ JlmOptCommandLineParser::ParseCommandLineArguments(int argc, const char * const 
       std::move(statisticsCollectorSettings),
       std::move(treePrinterConfiguration),
       std::move(optimizationIds),
-      dumpRvsdgDotGraphs);
+      dumpRvsdgGraphs);
 
   return *CommandLineOptions_;
 }
@@ -1038,10 +1038,10 @@ JlmHlsCommandLineParser::ParseCommandLineArguments(int argc, const char * const 
       cl::Prefix,
       cl::desc("Extracts function specified by hls-function"));
 
-  cl::opt<bool> dumpRvsdgDotGraphs(
-      "dumpRvsdgDotGraphs",
+  cl::opt<bool> dumpRvsdgGraphs(
+      "dumpRvsdgGraphs",
       cl::init(false),
-      cl::desc("Dump RVSDG as dot graphs after each transformation in debug folder."));
+      cl::desc("Dump RVSDG as json graphs after each transformation in debug folder."));
 
   cl::opt<JlmHlsCommandLineOptions::OutputFormat> format(
       cl::values(
@@ -1066,7 +1066,7 @@ JlmHlsCommandLineParser::ParseCommandLineArguments(int argc, const char * const 
   CommandLineOptions_.OutputFiles_ = util::FilePath(outputFolder);
   CommandLineOptions_.ExtractHlsFunction_ = extractHlsFunction;
   CommandLineOptions_.OutputFormat_ = format;
-  CommandLineOptions_.dumpRvsdgDotGraphs_ = dumpRvsdgDotGraphs;
+  CommandLineOptions_.dumpRvsdgGraphs_ = dumpRvsdgGraphs;
 
   if (latency < 1)
   {

--- a/jlm/tooling/CommandLine.hpp
+++ b/jlm/tooling/CommandLine.hpp
@@ -96,7 +96,7 @@ public:
       util::StatisticsCollectorSettings statisticsCollectorSettings,
       llvm::RvsdgTreePrinter::Configuration rvsdgTreePrinterConfiguration,
       std::vector<OptimizationId> optimizations,
-      const bool dumpRvsdgDotGraphs)
+      const bool dumpRvsdgGraphs)
       : InputFile_(std::move(inputFile)),
         InputFormat_(inputFormat),
         OutputFile_(std::move(outputFile)),
@@ -104,7 +104,7 @@ public:
         StatisticsCollectorSettings_(std::move(statisticsCollectorSettings)),
         OptimizationIds_(std::move(optimizations)),
         RvsdgTreePrinterConfiguration_(std::move(rvsdgTreePrinterConfiguration)),
-        DumpRvsdgDotGraphs_(dumpRvsdgDotGraphs)
+        dumpRvsdgGraphs_(dumpRvsdgGraphs)
   {}
 
   void
@@ -153,9 +153,9 @@ public:
   }
 
   [[nodiscard]] bool
-  DumpRvsdgDotGraphs() const noexcept
+  dumpRvsdgGraphs() const noexcept
   {
-    return DumpRvsdgDotGraphs_;
+    return dumpRvsdgGraphs_;
   }
 
   static OptimizationId
@@ -185,7 +185,7 @@ public:
       util::StatisticsCollectorSettings statisticsCollectorSettings,
       llvm::RvsdgTreePrinter::Configuration rvsdgTreePrinterConfiguration,
       std::vector<OptimizationId> optimizations,
-      bool dumpRvsdgDotGraphs)
+      bool dumpRvsdgGraphs)
   {
     return std::make_unique<JlmOptCommandLineOptions>(
         std::move(inputFile),
@@ -195,7 +195,7 @@ public:
         std::move(statisticsCollectorSettings),
         std::move(rvsdgTreePrinterConfiguration),
         std::move(optimizations),
-        dumpRvsdgDotGraphs);
+        dumpRvsdgGraphs);
   }
 
 private:
@@ -206,7 +206,7 @@ private:
   util::StatisticsCollectorSettings StatisticsCollectorSettings_;
   std::vector<OptimizationId> OptimizationIds_;
   llvm::RvsdgTreePrinter::Configuration RvsdgTreePrinterConfiguration_;
-  bool DumpRvsdgDotGraphs_;
+  bool dumpRvsdgGraphs_;
 
   static const util::BijectiveMap<util::Statistics::Id, std::string_view> &
   GetStatisticsIdCommandLineArguments();
@@ -397,7 +397,7 @@ public:
         OutputFormat_(OutputFormat::Firrtl),
         ExtractHlsFunction_(false),
         MemoryLatency_(10),
-        dumpRvsdgDotGraphs_(false)
+        dumpRvsdgGraphs_(false)
   {
     JLM_ASSERT(MemoryLatency_ > 0);
   }
@@ -411,7 +411,7 @@ public:
   std::string HlsFunction_;
   bool ExtractHlsFunction_;
   size_t MemoryLatency_;
-  bool dumpRvsdgDotGraphs_;
+  bool dumpRvsdgGraphs_;
 };
 
 /**

--- a/tools/jlm-hls/jlm-hls.cpp
+++ b/tools/jlm-hls/jlm-hls.cpp
@@ -92,7 +92,7 @@ main(int argc, char ** argv)
 
     jlm::hls::HlsDotWriter dotWriter;
     auto transformationSequence =
-        jlm::hls::createTransformationSequence(dotWriter, commandLineOptions.dumpRvsdgDotGraphs_);
+        jlm::hls::createTransformationSequence(dotWriter, commandLineOptions.dumpRvsdgGraphs_);
     transformationSequence->Run(*rvsdgModule, collector);
 
     // Writing the FIRRTL to a file and then reading it back in to convert to Verilog.
@@ -130,7 +130,7 @@ main(int argc, char ** argv)
   {
     jlm::hls::HlsDotWriter dotWriter;
     auto transformationSequence =
-        jlm::hls::createTransformationSequence(dotWriter, commandLineOptions.dumpRvsdgDotGraphs_);
+        jlm::hls::createTransformationSequence(dotWriter, commandLineOptions.dumpRvsdgGraphs_);
     transformationSequence->Run(*rvsdgModule, collector);
 
     jlm::hls::DotHLS dhls;


### PR DESCRIPTION
The latest improvements in the viewer only apply to json graphs, and the files are also smaller, so it makes sense to prefer json output.