### PR TITLE
Add handling of MemSet in AgnosticModRefSummarizer

### DIFF
--- a/jlm/llvm/opt/alias-analyses/AgnosticModRefSummarizer.cpp
+++ b/jlm/llvm/opt/alias-analyses/AgnosticModRefSummarizer.cpp
@@ -242,6 +242,13 @@ AgnosticModRefSummarizer::AnnotateSimpleNode(const rvsdg::SimpleNode & node)
         AddPointerTargetsToModRefSet(dstAddress, modRefSet);
         ModRefSummary_->SetSimpleNodeModRef(node, std::move(modRefSet));
       },
+      [&](const MemSetOperation &)
+      {
+        util::HashSet<PointsToGraph::NodeIndex> modRefSet;
+        const auto & dstAddress = *MemSetOperation::destinationInput(node).origin();
+        AddPointerTargetsToModRefSet(dstAddress, modRefSet);
+        ModRefSummary_->SetSimpleNodeModRef(node, std::move(modRefSet));
+      },
       [&](const FreeOperation &)
       {
         util::HashSet<PointsToGraph::NodeIndex> modRefSet;


### PR DESCRIPTION
The reason the llvm-test-suite fails on agnostic is simply the addition of MemSet