### PR TITLE
Ignore warning that appear in LLVM 18 library headers

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -93,7 +93,7 @@ while [[ "$#" -ge 1 ]] ; do
 done
 
 
-CXXFLAGS_COMMON="--std=c++17 -Wall -Wpedantic -Wextra -Wno-unused-parameter -Werror -Wfatal-errors -gdwarf-4 -g"
+CXXFLAGS_COMMON="--std=c++17 -Wall -Wpedantic -Wextra -Wno-unused-parameter -Wno-unnecessary-virtual-specifier -Werror -Wfatal-errors -gdwarf-4 -g"
 CPPFLAGS_COMMON="-I. -Itests"
 
 CPPFLAGS_LLVM=$(${LLVM_CONFIG_BIN} --cflags)


### PR DESCRIPTION
Later versions of clang++ have a warning about methods in `final` classes being `virtual`.

This is a very reasonable warning, but some of the headers in LLVM18 have them.
Since we have `-Werror`, this is preventing me from building.