### PR TITLE
SVF: forward loads with no memory states

### DIFF
--- a/jlm/llvm/ir/operators/IntegerOperations.hpp
+++ b/jlm/llvm/ir/operators/IntegerOperations.hpp
@@ -118,6 +118,12 @@ public:
 
   enum flags
   flags() const noexcept override;
+
+  static rvsdg::Node &
+  createNode(const size_t numBits, rvsdg::Output & operand1, rvsdg::Output & operand2)
+  {
+    return rvsdg::CreateOpNode<IntegerAddOperation>({ &operand1, &operand2 }, numBits);
+  }
 };
 
 /**

--- a/jlm/llvm/opt/StoreValueForwarding.cpp
+++ b/jlm/llvm/opt/StoreValueForwarding.cpp
@@ -854,12 +854,11 @@ StoreValueForwarding::processLoadWithoutMemoryStates(rvsdg::SimpleNode & loadNod
 
   context_->statistics.startTracing();
   const auto tracedDelta = traceLoadWithoutMemoryStates(loadNode);
+  context_->statistics.stopTracing();
   if (!tracedDelta.has_value())
   {
-    context_->statistics.stopTracing();
     return;
   }
-  context_->statistics.stopTracing();
 
   context_->statistics.startForwarding();
   forwardLoadWithoutMemoryStates(loadNode, tracedDelta.value());
@@ -873,7 +872,7 @@ StoreValueForwarding::traceLoadWithoutMemoryStates(const rvsdg::SimpleNode & loa
   JLM_ASSERT(LoadOperation::numMemoryStates(loadNode) == 0);
 
   auto & loadAddress = *LoadOperation::AddressInput(loadNode).origin();
-  const auto & tracedAddress = TracePointerOriginPrecise(loadAddress);
+  const auto tracedAddress = TracePointerOriginPrecise(loadAddress);
   if (!tracedAddress.Offset.has_value())
   {
     return std::nullopt;

--- a/jlm/llvm/opt/StoreValueForwarding.cpp
+++ b/jlm/llvm/opt/StoreValueForwarding.cpp
@@ -91,8 +91,12 @@ struct AliasQueryResponseCounter
  */
 class StoreValueForwarding::Statistics final : public util::Statistics
 {
-  static constexpr auto NumTotalLoadsLabel_ = "#TotalLoads";
-  static constexpr auto NumLoadsForwardedLabel_ = "#LoadsForwarded";
+  static constexpr auto NumLoadsWithMemoryStateLabel_ = "#LoadsWithMemoryState";
+  static constexpr auto NumLoadsWithoutMemoryStateLabel_ = "#LoadsWithoutMemoryState";
+  static constexpr auto NumLoadsTracedToDeltaNodeLabel_ = "#LoadsTracedToDeltaNode";
+  static constexpr auto NumForwardedLoadsWithMemoryStateLabel_ = "#ForwardedLoadsWithMemoryState";
+  static constexpr auto NumForwardedLoadsWithoutMemoryStateLabel_ =
+      "#ForwardedLoadsWithoutMemoryState";
   static constexpr auto numNoAliasStoreLabel_ = "#NoAliasStore";
   static constexpr auto numMayAliasStoreLabel_ = "#MayAliasStore";
   static constexpr auto numMustAliasStoreLabel_ = "#MustAliasStore";
@@ -120,14 +124,20 @@ public:
 
   void
   StopStatistics(
-      const size_t numTotalLoads,
-      const size_t numLoadsForwarded,
+      const size_t numLoadsWithMemoryState,
+      const size_t numLoadsWithoutMemoryState,
+      const size_t numLoadsTracedtoDeltaNode,
+      const size_t numForwardedLoadsWithMemoryState,
+      const size_t numForwardedLoadsWithoutMemoryState,
       const AliasQueryResponseCounter & storeAAResponses,
       const AliasQueryResponseCounter & loadAAResponses) noexcept
   {
     GetTimer(Label::Timer).stop();
-    AddMeasurement(NumTotalLoadsLabel_, numTotalLoads);
-    AddMeasurement(NumLoadsForwardedLabel_, numLoadsForwarded);
+    AddMeasurement(NumLoadsWithMemoryStateLabel_, numLoadsWithMemoryState);
+    AddMeasurement(NumLoadsWithoutMemoryStateLabel_, numLoadsWithoutMemoryState);
+    AddMeasurement(NumLoadsTracedToDeltaNodeLabel_, numLoadsTracedtoDeltaNode);
+    AddMeasurement(NumForwardedLoadsWithMemoryStateLabel_, numForwardedLoadsWithMemoryState);
+    AddMeasurement(NumForwardedLoadsWithoutMemoryStateLabel_, numForwardedLoadsWithoutMemoryState);
     AddMeasurement(numNoAliasStoreLabel_, storeAAResponses.numNoAliasAnalysisQueries);
     AddMeasurement(numMayAliasStoreLabel_, storeAAResponses.numMayAliasAnalysisQueries);
     AddMeasurement(numMustAliasStoreLabel_, storeAAResponses.numMustAliasAnalysisQueries);
@@ -183,8 +193,11 @@ struct StoreValueForwarding::Context final
   }
 
   // Counters used for statistics
-  size_t numTotalLoads = 0;
-  size_t numLoadsForwarded = 0;
+  size_t numLoadsWithMemoryState = 0;
+  size_t numLoadsWithoutMemoryState = 0;
+  size_t numLoadsTracedToDeltaNode = 0;
+  size_t numForwardedLoadsWithMemoryState = 0;
+  size_t numForwardedLoadsWithoutMemoryState = 0;
   AliasQueryResponseCounter storeAAResponses;
   AliasQueryResponseCounter loadAAResponses;
 
@@ -265,7 +278,7 @@ StoreValueForwarding::traverseIntraProceduralRegion(rvsdg::Region & region)
         {
           if (is<LoadNonVolatileOperation>(&simpleNode))
           {
-            processLoadNode(simpleNode);
+            processLoad(simpleNode);
           }
 
           // For other node types, we don't need to do anything for store value forwarding
@@ -408,10 +421,7 @@ public:
   bool
   traceAllMemoryStateInputs()
   {
-    // Forwarding of loads with no memory states is not possible
-    // TODO: We could load values from constant globals
-    if (LoadOperation::numMemoryStates(loadNode) == 0)
-      return false;
+    JLM_ASSERT(LoadOperation::numMemoryStates(loadNode) != 0);
 
     // Perform tracing from each memory state input to find exactly what store it leads to
     for (auto & memoryStateInput : LoadOperation::MemoryStateInputs(loadNode))
@@ -797,22 +807,37 @@ public:
 };
 
 void
-StoreValueForwarding::processLoadNode(rvsdg::SimpleNode & loadNode)
+StoreValueForwarding::processLoad(rvsdg::SimpleNode & loadNode)
 {
-  context_->numTotalLoads++;
-
-  // Only non-volatile loads are candidates for being forwarded to
   JLM_ASSERT(is<LoadNonVolatileOperation>(&loadNode));
+
+  if (LoadOperation::numMemoryStates(loadNode) == 0)
+  {
+    context_->numLoadsWithoutMemoryState++;
+    processLoadWithoutMemoryStates(loadNode);
+  }
+  else
+  {
+    context_->numLoadsWithMemoryState++;
+    processLoadWithMemoryStates(loadNode);
+  }
+}
+
+void
+StoreValueForwarding::processLoadWithMemoryStates(rvsdg::SimpleNode & loadNode)
+{
+  JLM_ASSERT(is<LoadNonVolatileOperation>(&loadNode));
+  JLM_ASSERT(LoadOperation::numMemoryStates(loadNode) != 0);
 
   context_->statistics.startTracing();
   LoadTracingInfo loadTracingInfo(loadNode, context_->outputTracer, context_->aliasAnalysis);
-  const bool success = loadTracingInfo.traceAllMemoryStateInputs();
+  const auto shouldForwardValueOrigins = loadTracingInfo.traceAllMemoryStateInputs();
   context_->statistics.stopTracing();
 
   context_->storeAAResponses.addFromCounter(loadTracingInfo.storeAAResponses);
   context_->loadAAResponses.addFromCounter(loadTracingInfo.loadAAResponses);
 
-  if (success)
+  if (shouldForwardValueOrigins)
   {
     context_->statistics.startForwarding();
     forwardValueOrigins(loadTracingInfo);
@@ -820,11 +845,53 @@ StoreValueForwarding::processLoadNode(rvsdg::SimpleNode & loadNode)
   }
 }
 
+void
+StoreValueForwarding::processLoadWithoutMemoryStates(rvsdg::SimpleNode & loadNode)
+{
+  JLM_ASSERT(is<LoadNonVolatileOperation>(&loadNode));
+  JLM_ASSERT(LoadOperation::numMemoryStates(loadNode) == 0);
+
+  context_->statistics.startTracing();
+  auto & loadAddress = *LoadOperation::AddressInput(loadNode).origin();
+  // auto & loadedValue = LoadOperation::LoadedValueOutput(loadNode);
+  const auto & tracedAddress = context_->outputTracer.trace(loadAddress);
+
+  const auto deltaNode = rvsdg::TryGetOwnerNode<rvsdg::DeltaNode>(tracedAddress);
+  if (!deltaNode)
+  {
+    context_->statistics.stopTracing();
+    return;
+  }
+  context_->numLoadsTracedToDeltaNode++;
+
+  auto & deltaSubregion = *deltaNode->subregion();
+  if (deltaSubregion.numNodes() != 1)
+  {
+    context_->statistics.stopTracing();
+    return;
+  }
+
+  auto & subregionNode = *deltaSubregion.Nodes().begin();
+  JLM_ASSERT(subregionNode.noutputs() == 1);
+  if (subregionNode.ninputs() != 0)
+  {
+    context_->statistics.stopTracing();
+    return;
+  }
+  context_->statistics.stopTracing();
+
+  context_->statistics.startForwarding();
+  // auto & copiedNode = *subregionNode.copy(loadNode.region(), {});
+  // loadedValue.divert_users(copiedNode.output(0));
+  context_->numForwardedLoadsWithoutMemoryState++;
+  context_->statistics.stopForwarding();
+}
+
 // Performs StoreValueForwarding to the load node represented by the tracingInfo.
 void
 StoreValueForwarding::forwardValueOrigins(LoadTracingInfo & tracingInfo)
 {
-  context_->numLoadsForwarded++;
+  context_->numForwardedLoadsWithMemoryState++;
 
   auto & loadNode = tracingInfo.loadNode;
   auto & loadedValueOutput = LoadOperation::LoadedValueOutput(loadNode);
@@ -1100,8 +1167,11 @@ StoreValueForwarding::Run(
   traverseInterProceduralRegion(rvsdg.GetRootRegion());
 
   statistics->StopStatistics(
-      context_->numTotalLoads,
-      context_->numLoadsForwarded,
+      context_->numLoadsWithMemoryState,
+      context_->numLoadsWithoutMemoryState,
+      context_->numLoadsTracedToDeltaNode,
+      context_->numForwardedLoadsWithMemoryState,
+      context_->numForwardedLoadsWithoutMemoryState,
       context_->storeAAResponses,
       context_->loadAAResponses);
   statisticsCollector.CollectDemandedStatistics(std::move(statistics));

--- a/jlm/llvm/opt/StoreValueForwarding.cpp
+++ b/jlm/llvm/opt/StoreValueForwarding.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <jlm/llvm/ir/operators/alloca.hpp>
+#include <jlm/llvm/ir/operators/IntegerOperations.hpp>
 #include <jlm/llvm/ir/operators/Load.hpp>
 #include <jlm/llvm/ir/operators/MemoryStateOperations.hpp>
 #include <jlm/llvm/ir/operators/operators.hpp>
@@ -845,6 +846,13 @@ StoreValueForwarding::processLoadWithMemoryStates(rvsdg::SimpleNode & loadNode)
   }
 }
 
+// FIXME: documentation
+struct StoreValueForwarding::TracedDelta
+{
+  rvsdg::DeltaNode * deltaNode;
+  int64_t offset;
+};
+
 void
 StoreValueForwarding::processLoadWithoutMemoryStates(rvsdg::SimpleNode & loadNode)
 {
@@ -852,28 +860,8 @@ StoreValueForwarding::processLoadWithoutMemoryStates(rvsdg::SimpleNode & loadNod
   JLM_ASSERT(LoadOperation::numMemoryStates(loadNode) == 0);
 
   context_->statistics.startTracing();
-  auto & loadAddress = *LoadOperation::AddressInput(loadNode).origin();
-  // auto & loadedValue = LoadOperation::LoadedValueOutput(loadNode);
-  const auto & tracedAddress = context_->outputTracer.trace(loadAddress);
-
-  const auto deltaNode = rvsdg::TryGetOwnerNode<rvsdg::DeltaNode>(tracedAddress);
-  if (!deltaNode)
-  {
-    context_->statistics.stopTracing();
-    return;
-  }
-  context_->numLoadsTracedToDeltaNode++;
-
-  auto & deltaSubregion = *deltaNode->subregion();
-  if (deltaSubregion.numNodes() != 1)
-  {
-    context_->statistics.stopTracing();
-    return;
-  }
-
-  auto & subregionNode = *deltaSubregion.Nodes().begin();
-  JLM_ASSERT(subregionNode.noutputs() == 1);
-  if (subregionNode.ninputs() != 0)
+  const auto tracedDelta = traceLoadWithoutMemoryStates(loadNode);
+  if (!tracedDelta.has_value())
   {
     context_->statistics.stopTracing();
     return;
@@ -881,10 +869,71 @@ StoreValueForwarding::processLoadWithoutMemoryStates(rvsdg::SimpleNode & loadNod
   context_->statistics.stopTracing();
 
   context_->statistics.startForwarding();
-  // auto & copiedNode = *subregionNode.copy(loadNode.region(), {});
-  // loadedValue.divert_users(copiedNode.output(0));
-  context_->numForwardedLoadsWithoutMemoryState++;
+  forwardLoadWithoutMemoryStates(loadNode, tracedDelta.value());
   context_->statistics.stopForwarding();
+}
+
+std::optional<StoreValueForwarding::TracedDelta>
+StoreValueForwarding::traceLoadWithoutMemoryStates(const rvsdg::SimpleNode & loadNode)
+{
+  JLM_ASSERT(is<LoadNonVolatileOperation>(&loadNode));
+  JLM_ASSERT(LoadOperation::numMemoryStates(loadNode) == 0);
+
+  auto & loadAddress = *LoadOperation::AddressInput(loadNode).origin();
+  const auto & tracedAddress = TracePointerOriginPrecise(loadAddress);
+  if (!tracedAddress.Offset.has_value())
+  {
+    return std::nullopt;
+  }
+
+  const auto deltaNode = rvsdg::TryGetOwnerNode<rvsdg::DeltaNode>(*tracedAddress.BasePointer);
+  if (!deltaNode)
+  {
+    return std::nullopt;
+  }
+
+  context_->numLoadsTracedToDeltaNode++;
+  return std::optional<TracedDelta>({ deltaNode, tracedAddress.Offset.value() });
+}
+
+void
+StoreValueForwarding::forwardLoadWithoutMemoryStates(
+    rvsdg::SimpleNode & loadNode,
+    const TracedDelta & tracedDelta)
+{
+  JLM_ASSERT(is<LoadNonVolatileOperation>(&loadNode));
+  JLM_ASSERT(LoadOperation::numMemoryStates(loadNode) == 0);
+  auto loadOperation = dynamic_cast<const LoadNonVolatileOperation *>(&loadNode.GetOperation());
+
+  if (tracedDelta.offset != 0)
+  {
+    // FIXME: start dealing with offsets
+    return;
+  }
+  auto deltaSubregion = tracedDelta.deltaNode->subregion();
+  if (deltaSubregion->numNodes() != 1)
+  {
+    // FIXME: start dealing with it
+    return;
+  }
+  auto & node = *deltaSubregion->Nodes().begin();
+
+  if (!is<IntegerConstantOperation>(node.GetOperation()))
+  {
+    // FIXME: We only care about integer constants right now
+    return;
+  }
+
+  if (*loadOperation->GetLoadedType() != *node.output(0)->Type())
+  {
+    // FIXME: deal with non-matching types
+    return;
+  }
+
+  auto copiedNode = node.copy(loadNode.region(), {});
+  LoadOperation::LoadedValueOutput(loadNode).divert_users(copiedNode->output(0));
+
+  context_->numForwardedLoadsWithoutMemoryState++;
 }
 
 // Performs StoreValueForwarding to the load node represented by the tracingInfo.

--- a/jlm/llvm/opt/StoreValueForwarding.cpp
+++ b/jlm/llvm/opt/StoreValueForwarding.cpp
@@ -846,13 +846,6 @@ StoreValueForwarding::processLoadWithMemoryStates(rvsdg::SimpleNode & loadNode)
   }
 }
 
-// FIXME: documentation
-struct StoreValueForwarding::TracedDelta
-{
-  rvsdg::DeltaNode * deltaNode;
-  int64_t offset;
-};
-
 void
 StoreValueForwarding::processLoadWithoutMemoryStates(rvsdg::SimpleNode & loadNode)
 {

--- a/jlm/llvm/opt/StoreValueForwarding.cpp
+++ b/jlm/llvm/opt/StoreValueForwarding.cpp
@@ -903,35 +903,45 @@ StoreValueForwarding::forwardLoadWithoutMemoryStates(
 {
   JLM_ASSERT(is<LoadNonVolatileOperation>(&loadNode));
   JLM_ASSERT(LoadOperation::numMemoryStates(loadNode) == 0);
-  auto loadOperation = dynamic_cast<const LoadNonVolatileOperation *>(&loadNode.GetOperation());
+  const auto loadOperation =
+      dynamic_cast<const LoadNonVolatileOperation *>(&loadNode.GetOperation());
+  const auto & deltaResult = tracedDelta.deltaNode->result();
 
-  if (tracedDelta.offset != 0)
+  if (const auto node = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(*deltaResult.origin()))
   {
-    // FIXME: start dealing with offsets
-    return;
+    const auto success = rvsdg::MatchTypeWithDefault(
+        node->GetOperation(),
+        [&](const IntegerConstantOperation &)
+        {
+          JLM_ASSERT(tracedDelta.offset == 0);
+
+          auto copiedNode = node->copy(loadNode.region(), {});
+          if (*loadOperation->GetLoadedType() != *node->output(0)->Type())
+          {
+            copiedNode =
+                &TruncOperation::createNode(*copiedNode->output(0), loadOperation->GetLoadedType());
+          }
+          LoadOperation::LoadedValueOutput(loadNode).divert_users(copiedNode->output(0));
+
+          return true;
+        },
+        []()
+        {
+          // FIXME: support other operations
+          return false;
+        });
+
+    // FIXME: Once we handled all nodes, this statement can be removed
+    if (!success)
+    {
+      return;
+    }
   }
-  auto deltaSubregion = tracedDelta.deltaNode->subregion();
-  if (deltaSubregion->numNodes() != 1)
+  else
   {
     // FIXME: start dealing with it
     return;
   }
-  auto & node = *deltaSubregion->Nodes().begin();
-
-  if (!is<IntegerConstantOperation>(node.GetOperation()))
-  {
-    // FIXME: We only care about integer constants right now
-    return;
-  }
-
-  if (*loadOperation->GetLoadedType() != *node.output(0)->Type())
-  {
-    // FIXME: deal with non-matching types
-    return;
-  }
-
-  auto copiedNode = node.copy(loadNode.region(), {});
-  LoadOperation::LoadedValueOutput(loadNode).divert_users(copiedNode->output(0));
 
   context_->numForwardedLoadsWithoutMemoryState++;
 }

--- a/jlm/llvm/opt/StoreValueForwarding.cpp
+++ b/jlm/llvm/opt/StoreValueForwarding.cpp
@@ -901,7 +901,7 @@ StoreValueForwarding::forwardLoadWithoutMemoryStates(
 
   if (const auto node = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(*deltaResult.origin()))
   {
-    const auto success = rvsdg::MatchTypeWithDefault(
+    rvsdg::MatchTypeWithDefault(
         node->GetOperation(),
         [&](const IntegerConstantOperation &)
         {
@@ -915,27 +915,33 @@ StoreValueForwarding::forwardLoadWithoutMemoryStates(
           }
           LoadOperation::LoadedValueOutput(loadNode).divert_users(copiedNode->output(0));
 
-          return true;
+          context_->numForwardedLoadsWithoutMemoryState++;
         },
-        []()
+        [&](const ConstantStruct &)
         {
-          // FIXME: support other operations
-          return false;
+          // FIXME: handle operation
+        },
+        [&](const ConstantDataArray &)
+        {
+          // FIXME: handle operation
+        },
+        [&](const ConstantArrayOperation &)
+        {
+          // FIXME: handle operation
+        },
+        [&](const ConstantAggregateZeroOperation &)
+        {
+          // FIXME: handle operation
+        },
+        [&]()
+        {
+          throw std::logic_error("Unsupported operation: " + node->DebugString());
         });
-
-    // FIXME: Once we handled all nodes, this statement can be removed
-    if (!success)
-    {
-      return;
-    }
   }
   else
   {
-    // FIXME: start dealing with it
-    return;
+    throw std::logic_error("Unsupported output owner");
   }
-
-  context_->numForwardedLoadsWithoutMemoryState++;
 }
 
 // Performs StoreValueForwarding to the load node represented by the tracingInfo.

--- a/jlm/llvm/opt/StoreValueForwarding.hpp
+++ b/jlm/llvm/opt/StoreValueForwarding.hpp
@@ -6,12 +6,12 @@
 #ifndef JLM_LLVM_OPT_STOREVALUEFORWARDING_HPP
 #define JLM_LLVM_OPT_STOREVALUEFORWARDING_HPP
 
-#include <jlm/llvm/opt/alias-analyses/AliasAnalysis.hpp>
 #include <jlm/rvsdg/simple-node.hpp>
 #include <jlm/rvsdg/Transformation.hpp>
 
 namespace jlm::rvsdg
 {
+class DeltaNode;
 class Region;
 }
 
@@ -50,8 +50,6 @@ public:
   Run(rvsdg::RvsdgModule & module, util::StatisticsCollector & statisticsCollector) override;
 
 private:
-  struct TracedDelta;
-
   /**
    * Traverse the given inter-procedural region
    *
@@ -76,19 +74,55 @@ private:
   void
   processLoad(rvsdg::SimpleNode & loadNode);
 
-  // FIXME: documentation
+  /**
+   * Process a \ref LoadNonVolatileOperation node with no memory states during traversal
+   *
+   * @param loadNode The \ref LoadNonVolatileOperation node to handle
+   */
   void
   processLoadWithMemoryStates(rvsdg::SimpleNode & loadNode);
 
-  // FIXME: documentation
+  /**
+   * Process a \ref LoadNonVolatileOperation node with memory states during traversal
+   *
+   * @param loadNode The \ref LoadNonVolatileOperation node to handle
+   */
   void
   processLoadWithoutMemoryStates(rvsdg::SimpleNode & loadNode);
 
-  // FIXME: documentation
+  /**
+   * Contains the information after a \ref LoadNonVolatileOperation node without memory states could
+   * successfully be traced to a \ref rvsdg::DeltaNode.
+   */
+  struct TracedDelta
+  {
+    /**
+     * The \ref rvsdg::DeltaNode the load could be traced to.
+     */
+    rvsdg::DeltaNode * deltaNode{};
+
+    /**
+     * The offset in bytes from the base pointer of the delta node that was encountered throughout
+     * tracing.
+     */
+    int64_t offset = 0;
+  };
+
+  /**
+   * Try to trace a \ref LoadNonVolatileOperation node without memory states to a delta node.
+   *
+   * @param loadNode The \ref LoadNonVolatileOperation node to handle
+   * @return The \ref TracedDelta information if tracing was successful, otherwise std::nullopt.
+   */
   std::optional<TracedDelta>
   traceLoadWithoutMemoryStates(const rvsdg::SimpleNode & loadNode);
 
-  // FIXME: documentation
+  /**
+   * Forwards a traced \ref LoadNonVolatileOperation node without memory states.
+   *
+   * @param loadNode The \ref LoadNonVolatileOperation node to handle.
+   * @param tracedDelta The \ref TracedDelta information of \p loadNode.
+   */
   void
   forwardLoadWithoutMemoryStates(rvsdg::SimpleNode & loadNode, const TracedDelta & tracedDelta);
 

--- a/jlm/llvm/opt/StoreValueForwarding.hpp
+++ b/jlm/llvm/opt/StoreValueForwarding.hpp
@@ -72,7 +72,15 @@ private:
    * @param loadNode the load node to handle
    */
   void
-  processLoadNode(rvsdg::SimpleNode & loadNode);
+  processLoad(rvsdg::SimpleNode & loadNode);
+
+  // FIXME: documentation
+  void
+  processLoadWithMemoryStates(rvsdg::SimpleNode & loadNode);
+
+  // FIXME: documentation
+  void
+  processLoadWithoutMemoryStates(rvsdg::SimpleNode & loadNode);
 
   /**
    * Performs store value forwarding to the load node represented by the given \p tracingInfo.

--- a/jlm/llvm/opt/StoreValueForwarding.hpp
+++ b/jlm/llvm/opt/StoreValueForwarding.hpp
@@ -50,6 +50,8 @@ public:
   Run(rvsdg::RvsdgModule & module, util::StatisticsCollector & statisticsCollector) override;
 
 private:
+  struct TracedDelta;
+
   /**
    * Traverse the given inter-procedural region
    *
@@ -81,6 +83,14 @@ private:
   // FIXME: documentation
   void
   processLoadWithoutMemoryStates(rvsdg::SimpleNode & loadNode);
+
+  // FIXME: documentation
+  std::optional<TracedDelta>
+  traceLoadWithoutMemoryStates(const rvsdg::SimpleNode & loadNode);
+
+  // FIXME: documentation
+  void
+  forwardLoadWithoutMemoryStates(rvsdg::SimpleNode & loadNode, const TracedDelta & tracedDelta);
 
   /**
    * Performs store value forwarding to the load node represented by the given \p tracingInfo.

--- a/jlm/llvm/opt/StoreValueForwarding.hpp
+++ b/jlm/llvm/opt/StoreValueForwarding.hpp
@@ -75,14 +75,6 @@ private:
   processLoad(rvsdg::SimpleNode & loadNode);
 
   /**
-   * Process a \ref LoadNonVolatileOperation node with no memory states during traversal
-   *
-   * @param loadNode The \ref LoadNonVolatileOperation node to handle
-   */
-  void
-  processLoadWithMemoryStates(rvsdg::SimpleNode & loadNode);
-
-  /**
    * Process a \ref LoadNonVolatileOperation node with memory states during traversal
    *
    * @param loadNode The \ref LoadNonVolatileOperation node to handle
@@ -125,6 +117,14 @@ private:
    */
   void
   forwardLoadWithoutMemoryStates(rvsdg::SimpleNode & loadNode, const TracedDelta & tracedDelta);
+
+  /**
+   * Process a \ref LoadNonVolatileOperation node with no memory states during traversal
+   *
+   * @param loadNode The \ref LoadNonVolatileOperation node to handle
+   */
+  void
+  processLoadWithMemoryStates(rvsdg::SimpleNode & loadNode);
 
   /**
    * Performs store value forwarding to the load node represented by the given \p tracingInfo.

--- a/jlm/llvm/opt/StoreValueForwardingTests.cpp
+++ b/jlm/llvm/opt/StoreValueForwardingTests.cpp
@@ -15,6 +15,7 @@
 #include <jlm/llvm/ir/RvsdgModule.hpp>
 #include <jlm/llvm/ir/Trace.hpp>
 #include <jlm/llvm/opt/StoreValueForwarding.hpp>
+#include <jlm/rvsdg/delta.hpp>
 #include <jlm/rvsdg/gamma.hpp>
 #include <jlm/rvsdg/simple-node.hpp>
 #include <jlm/rvsdg/TestType.hpp>
@@ -1037,4 +1038,49 @@ TEST(StoreValueForwardingTests, LoadForwardingIntoTheta)
   const auto & memoryResultOrigin =
       jlm::llvm::traceOutput(*lambdaNode.GetFunctionResults()[2]->origin());
   EXPECT_EQ(&memoryResultOrigin, &mem1);
+}
+
+TEST(StoreValueForwardingTests, LoadForwardingFromDeltaWithIntegerConstant)
+{
+  using namespace jlm::llvm;
+  using namespace jlm::rvsdg;
+
+  // Arrange
+  LlvmRvsdgModule rvsdgModule(jlm::util::FilePath(""), "", "");
+  auto & graph = rvsdgModule.Rvsdg();
+
+  const auto pointerType = PointerType::Create();
+  const auto bits8Type = BitType::Create(8);
+  const auto bits32Type = BitType::Create(32);
+  const auto functionType = FunctionType::Create(
+      {},
+      {
+          bits32Type,
+      });
+
+  auto deltaNode = DeltaNode::Create(
+      &graph.GetRootRegion(),
+      DeltaOperation::Create(bits32Type, true, pointerType));
+  auto & four = IntegerConstantOperation::Create(*deltaNode->subregion(), 32, 4);
+  auto & deltaOutput = deltaNode->finalize(four.output(0));
+
+  auto & lambdaNode = *LambdaNode::Create(
+      graph.GetRootRegion(),
+      LlvmLambdaOperation::Create(functionType, "func", Linkage::internalLinkage));
+  auto ctxVar = lambdaNode.AddContextVar(deltaOutput);
+
+  auto & load32Node = LoadNonVolatileOperation::CreateNode(*ctxVar.inner, {}, bits32Type, 4);
+  auto & load8Node = LoadNonVolatileOperation::CreateNode(*ctxVar.inner, {}, bits8Type, 4);
+
+  auto & zextResult = ZExtOperation::create(32, *load8Node.output(0));
+  auto & addNode = IntegerAddOperation::createNode(32, *load32Node.output(0), zextResult);
+
+  lambdaNode.finalize({ addNode.output(0) });
+
+  // Act
+  RunStoreValueForwarding(rvsdgModule);
+
+  // Assert
+  // We expect all load nodes to be forwarded
+  EXPECT_FALSE(Region::ContainsNodeType<LoadNonVolatileOperation>(graph.GetRootRegion(), true));
 }


### PR DESCRIPTION
This adds support for forwarding loads with no memory state that can be traced to a delta node containing an integer constant.