### PR TITLE
Add depth info to regions, and use it for isAncestor

### DIFF
--- a/jlm/rvsdg/RegionTests.cpp
+++ b/jlm/rvsdg/RegionTests.cpp
@@ -650,6 +650,10 @@ TEST(RegionTests, Ancestor)
   // Ancestry works at multiple levels of nesting
   EXPECT_TRUE(Region::isAncestor(*structuralNode3->subregion(0), *structuralNode1->subregion(0)));
   EXPECT_TRUE(Region::isAncestor(*structuralNode4->subregion(0), *structuralNode1->subregion(0)));
+
+  // Swapping the order makes the function return false
+  EXPECT_FALSE(Region::isAncestor(*structuralNode1->subregion(0), *structuralNode3->subregion(0)));
+  EXPECT_FALSE(Region::isAncestor(*structuralNode1->subregion(0), *structuralNode4->subregion(0)));
 }
 
 TEST(RegionTests, DepthTest)

--- a/jlm/rvsdg/RegionTests.cpp
+++ b/jlm/rvsdg/RegionTests.cpp
@@ -651,3 +651,22 @@ TEST(RegionTests, Ancestor)
   EXPECT_TRUE(Region::isAncestor(*structuralNode3->subregion(0), *structuralNode1->subregion(0)));
   EXPECT_TRUE(Region::isAncestor(*structuralNode4->subregion(0), *structuralNode1->subregion(0)));
 }
+
+TEST(RegionTests, DepthTest)
+{
+  using namespace jlm::rvsdg;
+
+  // Arrange
+  jlm::rvsdg::Graph graph;
+
+  auto structuralNode = TestStructuralNode::create(&graph.GetRootRegion(), 2);
+  auto innerStructuralNode = TestStructuralNode::create(structuralNode->subregion(0), 1);
+
+  // Act & Assert
+  EXPECT_EQ(graph.GetRootRegion().getDepth(), 0);
+  EXPECT_EQ(structuralNode->region()->getDepth(), 0);
+  EXPECT_EQ(structuralNode->subregion(0)->getDepth(), 1);
+  EXPECT_EQ(structuralNode->subregion(1)->getDepth(), 1);
+  EXPECT_EQ(innerStructuralNode->region()->getDepth(), 1);
+  EXPECT_EQ(innerStructuralNode->subregion(0)->getDepth(), 2);
+}

--- a/jlm/rvsdg/graph.cpp
+++ b/jlm/rvsdg/graph.cpp
@@ -72,7 +72,7 @@ Graph::~Graph() noexcept = default;
 
 Graph::Graph()
     : nextRegionId_(0),
-      RootRegion_(new Region(nullptr, this))
+      RootRegion_(new Region(this))
 {}
 
 std::unique_ptr<Graph>

--- a/jlm/rvsdg/region.cpp
+++ b/jlm/rvsdg/region.cpp
@@ -4,6 +4,7 @@
  * See COPYING for terms of redistribution.
  */
 
+#include <filesystem>
 #include <jlm/rvsdg/DotWriter.hpp>
 #include <jlm/rvsdg/graph.hpp>
 #include <jlm/rvsdg/structural-node.hpp>
@@ -144,23 +145,25 @@ Region::~Region() noexcept
   }
 }
 
-Region::Region(Region *, Graph * graph)
-    : id_(graph->generateRegionId()),
-      index_(0),
-      graph_(graph),
-      nextNodeId_(0),
+Region::Region(Graph * graph)
+    : graph_(graph),
+      id_(graph->generateRegionId()),
+      depth_(0),
       node_(nullptr),
+      index_(0),
+      nextNodeId_(0),
       numTopNodes_(0),
       numBottomNodes_(0),
       numNodes_(0)
 {}
 
 Region::Region(StructuralNode * node, const size_t index)
-    : id_(node->graph()->generateRegionId()),
-      index_(index),
-      graph_(node->graph()),
-      nextNodeId_(0),
+    : graph_(node->graph()),
+      id_(node->graph()->generateRegionId()),
+      depth_(node->region()->getDepth() + 1),
       node_(node),
+      index_(index),
+      nextNodeId_(0),
       numTopNodes_(0),
       numBottomNodes_(0),
       numNodes_(0)
@@ -470,17 +473,19 @@ Region::NumRegions(const rvsdg::Region & region) noexcept
 bool
 Region::isAncestor(const Region & region, const Region & ancestor) noexcept
 {
-  auto current = &region;
+  const auto ancestorDepth = ancestor.getDepth();
+  // If region starts at the same level or higher than ancestor, it can not be an ancestor
+  if (region.getDepth() <= ancestorDepth)
+    return false;
 
-  while (!current->IsRootRegion())
+  // Follow the parent chain until the ancestor depth is reached
+  auto current = &region;
+  do
   {
     current = current->node()->region();
+  } while (current->getDepth() > ancestorDepth);
 
-    if (current == &ancestor)
-      return true;
-  }
-
-  return false;
+  return current == &ancestor;
 }
 
 std::string

--- a/jlm/rvsdg/region.cpp
+++ b/jlm/rvsdg/region.cpp
@@ -4,7 +4,6 @@
  * See COPYING for terms of redistribution.
  */
 
-#include <filesystem>
 #include <jlm/rvsdg/DotWriter.hpp>
 #include <jlm/rvsdg/graph.hpp>
 #include <jlm/rvsdg/structural-node.hpp>

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -826,7 +826,7 @@ private:
   // The depth of the region. The root region has depth 0, all others have parent region depth + 1
   size_t depth_;
 
-  // The structural node this region belong to, or nullptr if it is the root region
+  // The structural node this region belongs to, or nullptr if it is the root region
   rvsdg::StructuralNode * node_;
   // The index of the region, if it is a subregion of a structural node
   size_t index_;

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -820,26 +820,26 @@ private:
   ToString(const util::Annotation & annotation, char labelValueSeparator);
 
   /**
-   * The graph this region belongs to
+   * The graph this region belongs to.
    */
-  Graph * graph_;
+  Graph * const graph_;
   /**
    * A region ID unique to all regions in the graph
    */
-  Id id_;
+  const Id id_;
   /**
-   * The depth of the region. The root region has depth 0, all others have parent region depth + 1
+   * The depth of the region. The root region has depth 0, all others have parent region depth + 1.
    */
-  size_t depth_;
+  const size_t depth_;
 
   /**
-   * The structural node this region belongs to, or nullptr if it is the root region
+   * The structural node this region belongs to, or nullptr if it is the root region.
    */
-  rvsdg::StructuralNode * node_;
+  rvsdg::StructuralNode * const node_;
   /**
    * The index of the region, if it is a subregion of a structural node
    */
-  size_t index_;
+  const size_t index_;
 
   /**
    * The ID that will be given to the next node created in this region

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -824,7 +824,7 @@ private:
    */
   Graph * const graph_;
   /**
-   * A region ID unique to all regions in the graph
+   * A region ID unique to all regions in the graph.
    */
   const Id id_;
   /**
@@ -837,12 +837,12 @@ private:
    */
   rvsdg::StructuralNode * const node_;
   /**
-   * The index of the region, if it is a subregion of a structural node
+   * The index of the region, if it is a subregion of a structural node.
    */
   const size_t index_;
 
   /**
-   * The ID that will be given to the next node created in this region
+   * The ID that will be given to the next node created in this region.
    */
   Node::Id nextNodeId_;
 

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -245,14 +245,29 @@ public:
 
   ~Region() noexcept;
 
-  Region(rvsdg::Region * parent, Graph * graph);
+  /**
+   * Constructor for the root region of a graph
+   */
+  Region(Graph * graph);
 
+  /**
+   * Constructor for a subregion in a structural node
+   */
   Region(rvsdg::StructuralNode * node, size_t index);
 
   Region(const Region &) = delete;
 
   Region &
   operator=(const Region &) = delete;
+
+  /**
+   * @return the Graph the region belongs to
+   */
+  [[nodiscard]] Graph *
+  graph() const noexcept
+  {
+    return graph_;
+  }
 
   /**
    * @return The unique identifier of the region instance within the graph.
@@ -263,6 +278,38 @@ public:
   getRegionId() const noexcept
   {
     return id_;
+  }
+
+  /**
+   * Gets the depth of the region.
+   * Region depth is defined as 0 for the root region,
+   * while all other regions have a depth equal to the depth of their parent region + 1.
+   *
+   * @return the depth of the region
+   */
+  size_t
+  getDepth() const noexcept
+  {
+    return depth_;
+  }
+
+  /**
+   * @return the structual node this region is a subregion of.
+   * If the region is the root region, nullptr is returned instead.
+   */
+  inline rvsdg::StructuralNode *
+  node() const noexcept
+  {
+    return node_;
+  }
+
+  /**
+   * @return the index of the region within the surrounding structural node.
+   */
+  size_t
+  index() const noexcept
+  {
+    return index_;
   }
 
   /**
@@ -357,24 +404,6 @@ public:
   BottomNodes() const noexcept
   {
     return { bottomNodes_.begin(), bottomNodes_.end() };
-  }
-
-  [[nodiscard]] Graph *
-  graph() const noexcept
-  {
-    return graph_;
-  }
-
-  inline rvsdg::StructuralNode *
-  node() const noexcept
-  {
-    return node_;
-  }
-
-  size_t
-  index() const noexcept
-  {
-    return index_;
   }
 
   /**
@@ -790,11 +819,20 @@ private:
   [[nodiscard]] static std::string
   ToString(const util::Annotation & annotation, char labelValueSeparator);
 
-  Id id_;
-  size_t index_;
+  // The graph this region belongs to
   Graph * graph_;
-  Node::Id nextNodeId_;
+  // A region ID unique to all regions in the graph
+  Id id_;
+  // The depth of the region. The root region has depth 0, all others have parent region depth + 1
+  size_t depth_;
+
+  // The structural node this region belong to, or nullptr if it is the root region
   rvsdg::StructuralNode * node_;
+  // The index of the region, if it is a subregion of a structural node
+  size_t index_;
+
+  // The ID that will be given to the next node created in this region
+  Node::Id nextNodeId_;
 
   // The region owns its results, arguments and nodes
   std::vector<RegionResult *> results_;

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -287,7 +287,7 @@ public:
    *
    * @return the depth of the region
    */
-  size_t
+  [[nodiscard]] size_t
   getDepth() const noexcept
   {
     return depth_;
@@ -297,7 +297,7 @@ public:
    * @return the structual node this region is a subregion of.
    * If the region is the root region, nullptr is returned instead.
    */
-  inline rvsdg::StructuralNode *
+  [[nodiscard]] rvsdg::StructuralNode *
   node() const noexcept
   {
     return node_;
@@ -306,7 +306,7 @@ public:
   /**
    * @return the index of the region within the surrounding structural node.
    */
-  size_t
+  [[nodiscard]] size_t
   index() const noexcept
   {
     return index_;

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -819,19 +819,31 @@ private:
   [[nodiscard]] static std::string
   ToString(const util::Annotation & annotation, char labelValueSeparator);
 
-  // The graph this region belongs to
+  /**
+   * The graph this region belongs to
+   */
   Graph * graph_;
-  // A region ID unique to all regions in the graph
+  /**
+   * A region ID unique to all regions in the graph
+   */
   Id id_;
-  // The depth of the region. The root region has depth 0, all others have parent region depth + 1
+  /**
+   * The depth of the region. The root region has depth 0, all others have parent region depth + 1
+   */
   size_t depth_;
 
-  // The structural node this region belongs to, or nullptr if it is the root region
+  /**
+   * The structural node this region belongs to, or nullptr if it is the root region
+   */
   rvsdg::StructuralNode * node_;
-  // The index of the region, if it is a subregion of a structural node
+  /**
+   * The index of the region, if it is a subregion of a structural node
+   */
   size_t index_;
 
-  // The ID that will be given to the next node created in this region
+  /**
+   * The ID that will be given to the next node created in this region
+   */
   Node::Id nextNodeId_;
 
   // The region owns its results, arguments and nodes
@@ -844,7 +856,10 @@ private:
   region_nodes_list nodes_;
   size_t numNodes_;
 
-  // Allow RegionObservers to register themselves on const Regions
+  /**
+   * A linked list of RegionObservers registered on the Region.
+   * The field is mutable to allow observers to register on const Regions.
+   */
   mutable RegionObserver * observers_ = nullptr;
 
   friend class Node;


### PR DESCRIPTION
Having depth info in necessary for figuring out routing between sibling regions in a reasonable way.

Along with adding a depth field I added comments to the fields in the `Region` class and docstrings to the getters.

The `Region::isAncestor` function is updated to make use of the depth info.

I also removed the unused `Region*` parameter from the `Region` constructor.