### PR TITLE
Rename localArray in memcpyTest to better represent its actual definition

### DIFF
--- a/jlm/llvm/TestRvsdgs.cpp
+++ b/jlm/llvm/TestRvsdgs.cpp
@@ -782,8 +782,8 @@ CallTest2::SetupRvsdg()
   this->CallCreate1_ = callCreate1;
   this->CallCreate2_ = callCreate2;
 
-  this->CallDestroy1_ = callCreate1;
-  this->CallDestroy2_ = callCreate2;
+  this->CallDestroy1_ = callDestroy1;
+  this->CallDestroy2_ = callDestroy2;
 
   return module;
 }
@@ -3211,13 +3211,13 @@ MemcpyTest::SetupRvsdg()
 
   auto arrayType = ArrayType::Create(jlm::rvsdg::BitType::Create(32), 5);
 
-  auto SetupLocalArray = [&]()
+  auto SetupInitArray = [&]()
   {
     auto delta = jlm::rvsdg::DeltaNode::Create(
         &rvsdg->GetRootRegion(),
         jlm::llvm::DeltaOperation::Create(
             arrayType,
-            "localArray",
+            "initArray",
             Linkage::externalLinkage,
             "",
             false,
@@ -3233,7 +3233,7 @@ MemcpyTest::SetupRvsdg()
 
     auto deltaOutput = &delta->finalize(constantDataArray);
 
-    GraphExport::Create(*deltaOutput, "localArray");
+    GraphExport::Create(*deltaOutput, "initArray");
 
     return deltaOutput;
   };
@@ -3342,17 +3342,17 @@ MemcpyTest::SetupRvsdg()
         &rvsdg::AssertGetOwnerNode<rvsdg::SimpleNode>(*memcpyResults[0]));
   };
 
-  auto localArray = SetupLocalArray();
+  auto initArray = SetupInitArray();
   auto globalArray = SetupGlobalArray();
   auto lambdaF = SetupFunctionF(*globalArray);
-  auto [lambdaG, callF, memcpyNode] = SetupFunctionG(*localArray, *globalArray, *lambdaF);
+  auto [lambdaG, callF, memcpyNode] = SetupFunctionG(*initArray, *globalArray, *lambdaF);
 
   /*
    * Assign nodes
    */
   this->LambdaF_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaF);
   this->LambdaG_ = &rvsdg::AssertGetOwnerNode<rvsdg::LambdaNode>(*lambdaG);
-  this->LocalArray_ = &rvsdg::AssertGetOwnerNode<rvsdg::DeltaNode>(*localArray);
+  this->InitArray_ = &rvsdg::AssertGetOwnerNode<rvsdg::DeltaNode>(*initArray);
   this->GlobalArray_ = &rvsdg::AssertGetOwnerNode<rvsdg::DeltaNode>(*globalArray);
   this->CallF_ = callF;
   this->Memcpy_ = memcpyNode;

--- a/jlm/llvm/TestRvsdgs.hpp
+++ b/jlm/llvm/TestRvsdgs.hpp
@@ -1835,6 +1835,7 @@ public:
  *  #include <string.h>
  *
  *  int globalArray[5];
+ *  int initArray[5] = {0, 1, 2, 3, 4};
  *
  *  int
  *  f()
@@ -1846,8 +1847,7 @@ public:
  *  int
  *  g()
  *  {
- *    int localArray[5] = {0, 1, 2, 3, 4};
- *    memcpy(globalArray, localArray, sizeof(int)*5);
+ *    memcpy(globalArray, initArray, sizeof(int)*5);
  *    return f();
  *  }
  * \endcode
@@ -1870,9 +1870,9 @@ public:
   }
 
   [[nodiscard]] const jlm::rvsdg::DeltaNode &
-  LocalArray() const noexcept
+  InitArray() const noexcept
   {
-    return *LocalArray_;
+    return *InitArray_;
   }
 
   [[nodiscard]] const jlm::rvsdg::DeltaNode &
@@ -1900,7 +1900,7 @@ private:
   jlm::rvsdg::LambdaNode * LambdaF_{};
   jlm::rvsdg::LambdaNode * LambdaG_{};
 
-  jlm::rvsdg::DeltaNode * LocalArray_{};
+  jlm::rvsdg::DeltaNode * InitArray_{};
   jlm::rvsdg::DeltaNode * GlobalArray_{};
 
   rvsdg::SimpleNode * CallF_{};

--- a/jlm/llvm/opt/alias-analyses/AndersenTests.cpp
+++ b/jlm/llvm/opt/alias-analyses/AndersenTests.cpp
@@ -835,7 +835,7 @@ TEST(AndersenTests, TestMemcpy)
   EXPECT_EQ(ptg->numLambdaNodes(), 2u);
   EXPECT_EQ(ptg->numMappedRegisters(), 11u);
 
-  auto localArray = ptg->getNodeForDelta(test.LocalArray());
+  auto initArray = ptg->getNodeForDelta(test.InitArray());
   auto globalArray = ptg->getNodeForDelta(test.GlobalArray());
 
   auto memCpyDest = ptg->getNodeForRegister(*test.Memcpy().input(0)->origin());
@@ -845,9 +845,9 @@ TEST(AndersenTests, TestMemcpy)
   auto lambdaG = ptg->getNodeForLambda(test.LambdaG());
 
   EXPECT_TRUE(TargetsExactly(*ptg, memCpyDest, { globalArray }));
-  EXPECT_TRUE(TargetsExactly(*ptg, memCpySrc, { localArray }));
+  EXPECT_TRUE(TargetsExactly(*ptg, memCpySrc, { initArray }));
 
-  EXPECT_TRUE(EscapedIsExactly(*ptg, { globalArray, localArray, lambdaF, lambdaG }));
+  EXPECT_TRUE(EscapedIsExactly(*ptg, { globalArray, initArray, lambdaF, lambdaG }));
 }
 
 TEST(AndersenTests, TestLinkedList)

--- a/jlm/llvm/opt/alias-analyses/RegionAwareModRefSummarizerTests.cpp
+++ b/jlm/llvm/opt/alias-analyses/RegionAwareModRefSummarizerTests.cpp
@@ -1074,7 +1074,7 @@ TEST(RegionAwareModRefSummarizerTests, TestMemcpy)
                              const jlm::llvm::aa::ModRefSummary & modRefSummary,
                              const jlm::llvm::aa::PointsToGraph & pointsToGraph)
   {
-    auto localArrayMemoryNode = pointsToGraph.getNodeForDelta(test.LocalArray());
+    auto initArrayMemoryNode = pointsToGraph.getNodeForDelta(test.InitArray());
     auto globalArrayMemoryNode = pointsToGraph.getNodeForDelta(test.GlobalArray());
 
     /*
@@ -1093,13 +1093,13 @@ TEST(RegionAwareModRefSummarizerTests, TestMemcpy)
      */
     {
       auto & lambdaEntryNodes = modRefSummary.GetLambdaEntryModRef(test.LambdaG());
-      EXPECT_TRUE(setsEqual(lambdaEntryNodes, { localArrayMemoryNode, globalArrayMemoryNode }));
+      EXPECT_TRUE(setsEqual(lambdaEntryNodes, { initArrayMemoryNode, globalArrayMemoryNode }));
 
       auto & callNodes = modRefSummary.GetSimpleNodeModRef(test.CallF());
       EXPECT_TRUE(setsEqual(callNodes, { globalArrayMemoryNode }));
 
       auto & lambdaExitNodes = modRefSummary.GetLambdaExitModRef(test.LambdaG());
-      EXPECT_TRUE(setsEqual(lambdaExitNodes, { localArrayMemoryNode, globalArrayMemoryNode }));
+      EXPECT_TRUE(setsEqual(lambdaExitNodes, { initArrayMemoryNode, globalArrayMemoryNode }));
     }
   };
 


### PR DESCRIPTION
As a part of working on the ModRefSummarizer, I found some issues in the TestRvsdgs.

 - CallTest2 had the wrong nodes for the destroy calls
 - MemcpyTest has a comment describing the RVSDG as C, but the C did not match up with the actual RVSDG being created. Looking into what clang does with local arrays with initializers, the initializer is moved out into a constant global, and a memcpy is created. As such, the test is still a good representation of what happens when we have local array initializers, but calling it localArray was a bit confusing.