### PR TITLE
Fix incorrectly sending references to pointers to GraphWriter

### DIFF
--- a/jlm/llvm/opt/alias-analyses/PointsToGraph.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraph.cpp
@@ -514,7 +514,9 @@ PointsToGraph::dumpGraph(util::graph::Writer & graphWriter, const PointsToGraph 
     {
       // Memory nodes are boxes, and have an associated object
       node.SetShape("box");
-      node.SetAttributeObject("rvsdgObject", pointsToGraph.nodeObjects_[ptgNode]);
+      const void * object = pointsToGraph.nodeObjects_[ptgNode];
+      if (object)
+        node.SetAttributeObject("rvsdgObject", reinterpret_cast<uintptr_t>(object));
     }
     else
     {
@@ -530,7 +532,7 @@ PointsToGraph::dumpGraph(util::graph::Writer & graphWriter, const PointsToGraph 
   for (const auto & [rvsdgOutput, ptgNode] : pointsToGraph.registerMap_)
   {
     const auto count = outputCount[ptgNode]++;
-    nodes[ptgNode]->SetAttributeObject(util::strfmt("output", count), rvsdgOutput);
+    nodes[ptgNode]->SetAttributeObject(util::strfmt("output", count), *rvsdgOutput);
   }
 
   // Add all explicit edges

--- a/jlm/util/GraphWriter.hpp
+++ b/jlm/util/GraphWriter.hpp
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <type_traits>
 #include <unordered_map>
 #include <variant>
 #include <vector>
@@ -192,6 +193,7 @@ public:
   void
   SetAttributeObject(const std::string & attribute, const T & object)
   {
+    static_assert(!std::is_pointer_v<T>, "Sending a reference to a pointer is likely a bug");
     SetAttributeObject(attribute, reinterpret_cast<uintptr_t>(&object));
   }
 


### PR DESCRIPTION
It was a bit too easy to accidentally take the address of pointers, instead of taking the address of the actual object, when adding objects to the GraphWriter.