### PR TITLE
LLVM: add tryGetAsConstant() method to GetElementPtrOperation class

### DIFF
--- a/jlm/llvm/ir/operators/GetElementPtr.cpp
+++ b/jlm/llvm/ir/operators/GetElementPtr.cpp
@@ -45,17 +45,19 @@ GetElementPtrOperation::copy() const
   return std::make_unique<GetElementPtrOperation>(*this);
 }
 
-std::optional<std::vector<uint64_t>>
-GetElementPtrOperation::tryGetConstantIndices(const rvsdg::Node & node) noexcept
+std::optional<GetElementPtrOperation::Constant>
+GetElementPtrOperation::tryGetAsConstant(const rvsdg::SimpleNode & gepNode)
 {
-  JLM_ASSERT(is<GetElementPtrOperation>(node.GetOperation()));
+  const auto gepOperation = dynamic_cast<const GetElementPtrOperation *>(&gepNode.GetOperation());
+  if (!gepOperation)
+    return std::nullopt;
 
-  std::vector<size_t> constants;
-  for (auto & input : indices(node))
+  std::vector<uint64_t> indices;
+  for (auto & input : gepOperation->indices(gepNode))
   {
-    if (auto constant = tryGetConstantSignedInteger(*input.origin()))
+    if (auto indexOpt = tryGetConstantSignedInteger(*input.origin()))
     {
-      constants.push_back(constant.value());
+      indices.push_back(indexOpt.value());
     }
     else
     {
@@ -63,21 +65,7 @@ GetElementPtrOperation::tryGetConstantIndices(const rvsdg::Node & node) noexcept
     }
   }
 
-  return constants;
-}
-
-std::optional<GetElementPtrOperation::TypeOffset>
-GetElementPtrOperation::getTypeOffset(const rvsdg::SimpleNode & gepNode)
-{
-  const auto gepOperation = dynamic_cast<const GetElementPtrOperation *>(&gepNode.GetOperation());
-  if (!gepOperation)
-    return std::nullopt;
-
-  const auto indicesOpt = tryGetConstantIndices(gepNode);
-  if (!indicesOpt.has_value())
-    return std::nullopt;
-
-  return TypeOffset{ gepOperation->getPointeeType(), indicesOpt.value() };
+  return Constant{ gepOperation->getPointeeType(), indices };
 }
 
 /**

--- a/jlm/llvm/ir/operators/GetElementPtr.cpp
+++ b/jlm/llvm/ir/operators/GetElementPtr.cpp
@@ -66,6 +66,20 @@ GetElementPtrOperation::tryGetConstantIndices(const rvsdg::Node & node) noexcept
   return constants;
 }
 
+std::optional<GetElementPtrOperation::TypeOffset>
+GetElementPtrOperation::getTypeOffset(const rvsdg::SimpleNode & gepNode)
+{
+  const auto gepOperation = dynamic_cast<const GetElementPtrOperation *>(&gepNode.GetOperation());
+  if (!gepOperation)
+    return std::nullopt;
+
+  const auto indicesOpt = tryGetConstantIndices(gepNode);
+  if (!indicesOpt.has_value())
+    return std::nullopt;
+
+  return TypeOffset{ gepOperation->getPointeeType(), indicesOpt.value() };
+}
+
 /**
  * Calculates the byte offset inside the given type, starting at the given offset of GEP inputs.
  * Uses recursion to handle nested types.

--- a/jlm/llvm/ir/operators/GetElementPtr.hpp
+++ b/jlm/llvm/ir/operators/GetElementPtr.hpp
@@ -66,6 +66,26 @@ public:
   tryGetConstantIndices(const rvsdg::Node & node) noexcept;
 
   /**
+   * Represents the \ref GetElementPtrOperation pointee type and its indices.
+   */
+  struct TypeOffset
+  {
+    std::shared_ptr<const rvsdg::Type> pointeeType;
+    std::vector<uint64_t> indices;
+  };
+
+  /**
+   * Computes the offsets of the \ref GetElementPtrOperation node \p gepNode, iff they can be
+   * statically determined.
+   *
+   * @param gepNode A \ref GetElementPtrOperation node
+   * @return If all indices can be statically determined, then a \ref TypeOffset, otherwise
+   * std::nullopt.
+   */
+  [[nodiscard]] static std::optional<TypeOffset>
+  getTypeOffset(const rvsdg::SimpleNode & gepNode);
+
+  /**
    * Returns an iterator range to the indices of a \ref GetElementPtrOperation node.
    *
    * \pre \p node is expected to have a \ref GetElementPtrOperation.

--- a/jlm/llvm/ir/operators/GetElementPtr.hpp
+++ b/jlm/llvm/ir/operators/GetElementPtr.hpp
@@ -57,33 +57,23 @@ public:
   }
 
   /**
-   * Attempts to find the constant indices of a \ref GetElementPtrOperation node.
-   *
-   * @param node The \ref GetElementPtrOperation node.
-   * @return The constant indices if all of them are found to be constant, otherwise std::nullopt.
+   * Represents a statically known \ref GetElementPtrOperation.
    */
-  static std::optional<std::vector<uint64_t>>
-  tryGetConstantIndices(const rvsdg::Node & node) noexcept;
-
-  /**
-   * Represents the \ref GetElementPtrOperation pointee type and its indices.
-   */
-  struct TypeOffset
+  struct Constant
   {
     std::shared_ptr<const rvsdg::Type> pointeeType;
     std::vector<uint64_t> indices;
   };
 
   /**
-   * Computes the offsets of the \ref GetElementPtrOperation node \p gepNode, iff they can be
-   * statically determined.
+   * Attempts to return the \ref GetElementPtrOperation as a \ref GetElementPtrOperation::Constant.
    *
    * @param gepNode A \ref GetElementPtrOperation node
-   * @return If all indices can be statically determined, then a \ref TypeOffset, otherwise
-   * std::nullopt.
+   * @return If all indices are statically known, then a \ref
+   * GetElementPtrOperation::Constant is returned, otherwise std::nullopt.
    */
-  [[nodiscard]] static std::optional<TypeOffset>
-  getTypeOffset(const rvsdg::SimpleNode & gepNode);
+  [[nodiscard]] static std::optional<Constant>
+  tryGetAsConstant(const rvsdg::SimpleNode & gepNode);
 
   /**
    * Returns an iterator range to the indices of a \ref GetElementPtrOperation node.

--- a/jlm/llvm/ir/operators/GetElementPtrTests.cpp
+++ b/jlm/llvm/ir/operators/GetElementPtrTests.cpp
@@ -6,6 +6,8 @@
 #include <gtest/gtest.h>
 
 #include <jlm/llvm/ir/operators/GetElementPtr.hpp>
+#include <jlm/llvm/ir/operators/IntegerOperations.hpp>
+#include <jlm/rvsdg/graph.hpp>
 
 TEST(GetElementPtrOperationTests, TestOperationEquality)
 {
@@ -26,4 +28,49 @@ TEST(GetElementPtrOperationTests, TestOperationEquality)
       structType2);
 
   EXPECT_NE(operation1, operation2);
+}
+
+TEST(GetElementPtrTests, GetTypeOffsetTest)
+{
+  using namespace jlm::llvm;
+  using namespace jlm::rvsdg;
+
+  // Arrange
+  const auto bits8Type = BitType::Create(32);
+  const auto bits16Type = BitType::Create(32);
+  const auto bits32Type = BitType::Create(32);
+  const auto pointerType = PointerType::Create();
+
+  auto structType =
+      StructType::CreateIdentified("struct", { bits8Type, bits16Type, bits32Type }, false);
+
+  Graph rvsdg;
+  auto & baseAddress = GraphImport::Create(rvsdg, pointerType, "base");
+  auto & i32 = GraphImport::Create(rvsdg, bits8Type, "i32");
+
+  auto & zeroNode = IntegerConstantOperation::Create(rvsdg.GetRootRegion(), 32, 0);
+  auto & oneNode = IntegerConstantOperation::Create(rvsdg.GetRootRegion(), 32, 1);
+
+  auto & gepNode0 = GetElementPtrOperation::createNode(
+      baseAddress,
+      { zeroNode.output(0), oneNode.output(0) },
+      structType);
+  auto & gepNode1 =
+      GetElementPtrOperation::createNode(baseAddress, { zeroNode.output(0), &i32 }, structType);
+  auto & gepNode2 = GetElementPtrOperation::createNode(baseAddress, { &i32, &i32 }, structType);
+
+  // Act
+  auto typeOffset0 = GetElementPtrOperation::getTypeOffset(gepNode0);
+  auto typeOffset1 = GetElementPtrOperation::getTypeOffset(gepNode1);
+  auto typeOffset2 = GetElementPtrOperation::getTypeOffset(gepNode2);
+
+  // Assert
+  // We expect typeOffset0 to be present as the \ref GetElementPtrOperation is statically completely
+  // known. All others should result in std::nullopt.
+  EXPECT_TRUE(typeOffset0.has_value());
+  EXPECT_EQ(typeOffset0.value().pointeeType, structType);
+  EXPECT_EQ(typeOffset0.value().indices, std::vector<uint64_t>({ 0, 1 }));
+
+  EXPECT_FALSE(typeOffset1.has_value());
+  EXPECT_FALSE(typeOffset2.has_value());
 }

--- a/jlm/llvm/ir/operators/GetElementPtrTests.cpp
+++ b/jlm/llvm/ir/operators/GetElementPtrTests.cpp
@@ -30,7 +30,7 @@ TEST(GetElementPtrOperationTests, TestOperationEquality)
   EXPECT_NE(operation1, operation2);
 }
 
-TEST(GetElementPtrTests, GetTypeOffsetTest)
+TEST(GetElementPtrTests, TryGetAsConstantTest)
 {
   using namespace jlm::llvm;
   using namespace jlm::rvsdg;
@@ -60,17 +60,17 @@ TEST(GetElementPtrTests, GetTypeOffsetTest)
   auto & gepNode2 = GetElementPtrOperation::createNode(baseAddress, { &i32, &i32 }, structType);
 
   // Act
-  auto typeOffset0 = GetElementPtrOperation::getTypeOffset(gepNode0);
-  auto typeOffset1 = GetElementPtrOperation::getTypeOffset(gepNode1);
-  auto typeOffset2 = GetElementPtrOperation::getTypeOffset(gepNode2);
+  auto gepConstant0 = GetElementPtrOperation::tryGetAsConstant(gepNode0);
+  auto gepConstant1 = GetElementPtrOperation::tryGetAsConstant(gepNode1);
+  auto gepConstant2 = GetElementPtrOperation::tryGetAsConstant(gepNode2);
 
   // Assert
-  // We expect typeOffset0 to be present as the \ref GetElementPtrOperation is statically completely
-  // known. All others should result in std::nullopt.
-  EXPECT_TRUE(typeOffset0.has_value());
-  EXPECT_EQ(typeOffset0.value().pointeeType, structType);
-  EXPECT_EQ(typeOffset0.value().indices, std::vector<uint64_t>({ 0, 1 }));
+  // We expect gepConstant0 to be present as the \ref GetElementPtrOperation is statically
+  // completely known. All others should result in std::nullopt.
+  EXPECT_TRUE(gepConstant0.has_value());
+  EXPECT_EQ(gepConstant0.value().pointeeType, structType);
+  EXPECT_EQ(gepConstant0.value().indices, std::vector<uint64_t>({ 0, 1 }));
 
-  EXPECT_FALSE(typeOffset1.has_value());
-  EXPECT_FALSE(typeOffset2.has_value());
+  EXPECT_FALSE(gepConstant1.has_value());
+  EXPECT_FALSE(gepConstant2.has_value());
 }

--- a/jlm/llvm/opt/AggregateAllocaSplitting.cpp
+++ b/jlm/llvm/opt/AggregateAllocaSplitting.cpp
@@ -232,8 +232,7 @@ AggregateAllocaSplitting::isSplitable(rvsdg::SimpleNode & allocaNode)
                   [&](const GetElementPtrOperation &)
                   {
                     JLM_ASSERT(userNode->input(0) == &user);
-                    JLM_ASSERT(
-                        GetElementPtrOperation::tryGetConstantIndices(simpleNode).has_value());
+                    JLM_ASSERT(GetElementPtrOperation::tryGetAsConstant(simpleNode).has_value());
                     allocaTraceInfo.allocaConsumers.push_back(&simpleNode);
                     return true;
                   },
@@ -563,11 +562,11 @@ AggregateAllocaSplitting::splitAllocaNode(const AllocaTraceInfo & allocaTraceInf
         {
           JLM_ASSERT(GetElementPtrOperation::numIndices(*allocaConsumer) >= 2);
           auto & consumerRegion = *allocaConsumer->region();
-          const auto indices =
-              GetElementPtrOperation::tryGetConstantIndices(*allocaConsumer).value();
-          JLM_ASSERT(indices[0] == 0);
+          const auto gepConstant =
+              GetElementPtrOperation::tryGetAsConstant(*allocaConsumer).value();
+          JLM_ASSERT(gepConstant.indices[0] == 0);
 
-          auto elementAlloca = elementAllocaMap.at(indices);
+          auto elementAlloca = elementAllocaMap.at(gepConstant.indices);
           // FIXME: Introduce caching of routed values to avoid duplicated routing.
           auto & routedAddress = rvsdg::RouteToRegion(
               AllocaOperation::getPointerOutput(*elementAlloca),


### PR DESCRIPTION
This method replaces the old tryGetConstantIndices() method as it is more general.