### PR TITLE
Llvm: Fix miscompilation of theta nodes

### DIFF
--- a/jlm/llvm/frontend/ControlFlowRestructuring.cpp
+++ b/jlm/llvm/frontend/ControlFlowRestructuring.cpp
@@ -240,6 +240,60 @@ RestructureControlFlow(
     ControlFlowGraphNode &,
     std::vector<TailControlledLoop> &);
 
+/**
+ * The RVSDG theta node expects that the repetition of its body always happens on control value 1.
+ * Thus, we need to ensure that the repetition edge of the tail-controlled
+ * loop has index 1 in order to avoid miscompilations.
+ *
+ * @param sccStructure The \ref StronglyConnectedComponentStructure that represents the
+ * tail-controlled loop.
+ */
+static void
+adjustLoopRepetitionEdge(const StronglyConnectedComponentStructure & sccStructure)
+{
+  JLM_ASSERT(sccStructure.IsTailControlledLoop());
+
+  const auto repetitionEdge = *sccStructure.RepetitionEdges().begin();
+  if (repetitionEdge->index() == 1)
+  {
+    // Nothing needs to be done. The repetition edge has already index 1.
+    return;
+  }
+
+  // The repetition edge has index 0.
+  // We need to adjust the tail-controlled loop such that the repetition edge is on index 1.
+  auto exitNode = util::assertedCast<BasicBlock>((*sccStructure.ExitEdges().begin())->source());
+  auto exitEdge = *sccStructure.ExitEdges().begin();
+  auto exitEdgeSink = exitEdge->sink();
+  auto repetitionEdgeSink = repetitionEdge->sink();
+
+  repetitionEdge->divert(exitEdgeSink);
+  exitEdge->divert(repetitionEdgeSink);
+
+  // Branch and match operations are always created together in the \ref LlvmModuleConversion
+  // Thus, we would expect them to also be together here. Just to be sure, we plastered the path
+  // with asserts.
+  auto & threeAddressCodes = exitNode->tacs();
+  JLM_ASSERT(is<BranchOperation>(threeAddressCodes.last()));
+  auto matchTac = *std::next(threeAddressCodes.rbegin(), 1);
+  JLM_ASSERT(is<rvsdg::MatchOperation>(matchTac));
+  auto matchOperation = util::assertedCast<const rvsdg::MatchOperation>(&matchTac->operation());
+  JLM_ASSERT(matchOperation->nalternatives() == 2);
+  JLM_ASSERT(matchOperation->default_alternative() == 0);
+  JLM_ASSERT(matchOperation->alternative(1) == 1);
+
+  const size_t numBits = matchOperation->nbits();
+  auto newMatchOperand = matchTac->operand(0);
+  threeAddressCodes.drop_last(); // drop branch operation
+  threeAddressCodes.drop_last(); // drop match operation
+
+  auto newMatchOperation = std::unique_ptr<rvsdg::MatchOperation>(
+      new rvsdg::MatchOperation(numBits, { { 0, 1 } }, 0, 2));
+  threeAddressCodes.append_last(
+      ThreeAddressCode::create(std::move(newMatchOperation), { newMatchOperand }));
+  threeAddressCodes.append_last(BranchOperation::create(2, threeAddressCodes.last()->result(0)));
+}
+
 static void
 RestructureLoops(
     ControlFlowGraphNode & regionEntry,
@@ -258,49 +312,58 @@ RestructureLoops(
 
     if (sccStructure->IsTailControlledLoop())
     {
+      // We already have a tail-controlled loop
       auto loopEntry = *sccStructure->EntryNodes().begin();
       auto loopExit = (*sccStructure->ExitEdges().begin())->source();
       RestructureControlFlow(*loopEntry, *loopExit, loops);
+      adjustLoopRepetitionEdge(*sccStructure);
       loops.push_back(ExtractLoop(*loopEntry, *loopExit));
-      continue;
     }
-
-    auto & newEntryNode = *BasicBlock::create(cfg);
-    auto & newRepetitionNode = *BasicBlock::create(cfg);
-    auto & newExitNode = *BasicBlock::create(cfg);
-    newRepetitionNode.add_outedge(&newExitNode);
-    newRepetitionNode.add_outedge(&newEntryNode);
-
-    const ThreeAddressCodeVariable * entryVariable = nullptr;
-    if (sccStructure->NumEntryNodes() > 1)
+    else
     {
-      auto bb = GetEntryVariableBlock(&regionEntry);
-      entryVariable =
-          &CreateLoopEntryVariable(*bb, rvsdg::ControlType::Create(sccStructure->NumEntryNodes()));
+      // It is not a tail-controlled loop. We need to restructure the loop.
+      auto & newEntryNode = *BasicBlock::create(cfg);
+      auto & newRepetitionNode = *BasicBlock::create(cfg);
+      auto & newExitNode = *BasicBlock::create(cfg);
+      newRepetitionNode.add_outedge(&newExitNode);
+      newRepetitionNode.add_outedge(&newEntryNode);
+
+      const ThreeAddressCodeVariable * entryVariable = nullptr;
+      if (sccStructure->NumEntryNodes() > 1)
+      {
+        auto bb = GetEntryVariableBlock(&regionEntry);
+        entryVariable = &CreateLoopEntryVariable(
+            *bb,
+            rvsdg::ControlType::Create(sccStructure->NumEntryNodes()));
+      }
+
+      auto & repetitionVariable = CreateLoopRepetitionVariable(newEntryNode);
+
+      const ThreeAddressCodeVariable * exitVariable = nullptr;
+      if (sccStructure->NumExitNodes() > 1)
+        exitVariable = &CreateLoopExitVariable(
+            newEntryNode,
+            rvsdg::ControlType::Create(sccStructure->NumExitNodes()));
+
+      AppendBranch(newRepetitionNode, &repetitionVariable);
+
+      RestructureLoopEntry(*sccStructure, &newEntryNode, entryVariable);
+      RestructureLoopExit(
+          *sccStructure,
+          newRepetitionNode,
+          newExitNode,
+          regionExit,
+          repetitionVariable,
+          exitVariable);
+      RestructureLoopRepetition(
+          *sccStructure,
+          newRepetitionNode,
+          entryVariable,
+          repetitionVariable);
+
+      RestructureControlFlow(newEntryNode, newRepetitionNode, loops);
+      loops.push_back(ExtractLoop(newEntryNode, newRepetitionNode));
     }
-
-    auto & repetitionVariable = CreateLoopRepetitionVariable(newEntryNode);
-
-    const ThreeAddressCodeVariable * exitVariable = nullptr;
-    if (sccStructure->NumExitNodes() > 1)
-      exitVariable = &CreateLoopExitVariable(
-          newEntryNode,
-          rvsdg::ControlType::Create(sccStructure->NumExitNodes()));
-
-    AppendBranch(newRepetitionNode, &repetitionVariable);
-
-    RestructureLoopEntry(*sccStructure, &newEntryNode, entryVariable);
-    RestructureLoopExit(
-        *sccStructure,
-        newRepetitionNode,
-        newExitNode,
-        regionExit,
-        repetitionVariable,
-        exitVariable);
-    RestructureLoopRepetition(*sccStructure, newRepetitionNode, entryVariable, repetitionVariable);
-
-    RestructureControlFlow(newEntryNode, newRepetitionNode, loops);
-    loops.push_back(ExtractLoop(newEntryNode, newRepetitionNode));
   }
 }
 

--- a/jlm/llvm/frontend/ControlFlowRestructuring.cpp
+++ b/jlm/llvm/frontend/ControlFlowRestructuring.cpp
@@ -274,9 +274,11 @@ adjustLoopRepetitionEdge(const StronglyConnectedComponentStructure & sccStructur
   // Thus, we would expect them to also be together here. Just to be sure, we plastered the path
   // with asserts.
   auto & threeAddressCodes = exitNode->tacs();
-  JLM_ASSERT(is<BranchOperation>(threeAddressCodes.last()));
+  auto branchTac = threeAddressCodes.last();
+  JLM_ASSERT(is<BranchOperation>(branchTac));
   auto matchTac = *std::next(threeAddressCodes.rbegin(), 1);
   JLM_ASSERT(is<rvsdg::MatchOperation>(matchTac));
+  JLM_ASSERT(branchTac->operand(0) == matchTac->result(0));
   auto matchOperation = util::assertedCast<const rvsdg::MatchOperation>(&matchTac->operation());
   JLM_ASSERT(matchOperation->nalternatives() == 2);
   JLM_ASSERT(matchOperation->default_alternative() == 0);

--- a/jlm/llvm/frontend/ControlFlowRestructuringTests.cpp
+++ b/jlm/llvm/frontend/ControlFlowRestructuringTests.cpp
@@ -9,6 +9,9 @@
 #include <jlm/llvm/ir/basic-block.hpp>
 #include <jlm/llvm/ir/cfg-structure.hpp>
 #include <jlm/llvm/ir/ipgraph-module.hpp>
+#include <jlm/llvm/ir/operators/IntegerOperations.hpp>
+#include <jlm/llvm/ir/operators/operators.hpp>
+#include <jlm/rvsdg/control.hpp>
 
 TEST(ControlFlowRestructuringTests, AcyclicStructured)
 {
@@ -68,7 +71,7 @@ TEST(ControlFlowRestructuringTests, AcyclicUnstructured)
   EXPECT_TRUE(is_proper_structured(cfg));
 }
 
-TEST(ControlFlowRestructuringTests, DoWhileLoop)
+TEST(ControlFlowRestructuringTests, NestedDoWhileLoop)
 {
   using namespace jlm::llvm;
 
@@ -81,21 +84,63 @@ TEST(ControlFlowRestructuringTests, DoWhileLoop)
 
   cfg.exit()->divert_inedges(bb1);
   bb1->add_outedge(bb2);
-  bb2->add_outedge(bb2);
+
   bb2->add_outedge(bb3);
-  bb3->add_outedge(bb1);
+  bb2->add_outedge(bb2);
+
   bb3->add_outedge(cfg.exit());
+  bb3->add_outedge(bb1);
 
   //	jlm::view_ascii(cfg, stdout);
 
-  size_t nnodes = cfg.nnodes();
+  const size_t numNodesBeforeRestructuring = cfg.nnodes();
   RestructureControlFlow(cfg);
 
   //	jlm::view_ascii(cfg, stdout);
 
-  EXPECT_EQ(nnodes, cfg.nnodes());
-  EXPECT_EQ(bb2->OutEdge(0)->sink(), bb2);
-  EXPECT_EQ(bb3->OutEdge(0)->sink(), bb1);
+  EXPECT_EQ(cfg.nnodes(), numNodesBeforeRestructuring);
+  EXPECT_EQ(bb2->OutEdge(0)->sink(), bb3);
+  EXPECT_EQ(bb2->OutEdge(1)->sink(), bb2);
+  EXPECT_EQ(bb3->OutEdge(0)->sink(), cfg.exit());
+  EXPECT_EQ(bb3->OutEdge(1)->sink(), bb1);
+}
+
+TEST(ControlFlowRestructuringTests, DoWhileLoopWithWrongRepetitionEdge)
+{
+  using namespace jlm::llvm;
+  using namespace jlm::rvsdg;
+
+  // Arrange
+  InterProceduralGraphModule module(jlm::util::FilePath(""), "", "");
+
+  ControlFlowGraph cfg(module);
+  auto bb1 = BasicBlock::create(cfg);
+
+  cfg.exit()->divert_inedges(bb1);
+  bb1->add_outedge(bb1);
+  bb1->add_outedge(cfg.exit());
+
+  auto c1Operation = std::make_unique<IntegerConstantOperation>(BitValueRepresentation(1, 1));
+  bb1->append_last(ThreeAddressCode::create(std::move(c1Operation), {}));
+  auto matchOperation = std::unique_ptr<MatchOperation>(new MatchOperation(1, { { 1, 1 } }, 0, 2));
+  bb1->append_last(
+      ThreeAddressCode::create(std::move(matchOperation), { bb1->tacs().last()->result(0) }));
+  bb1->append_last(BranchOperation::create(2, bb1->tacs().last()->result(0)));
+
+  // Act
+  const size_t numNodesBeforeRestructuring = cfg.nnodes();
+  RestructureControlFlow(cfg);
+
+  // Assert
+  EXPECT_EQ(numNodesBeforeRestructuring, cfg.nnodes());
+  EXPECT_EQ(bb1->OutEdge(0)->sink(), cfg.exit());
+  EXPECT_EQ(bb1->OutEdge(1)->sink(), bb1);
+
+  auto matchTac = *std::next(bb1->tacs().rbegin(), 1);
+  auto newMatchOperation = jlm::util::assertedCast<const MatchOperation>(&matchTac->operation());
+  EXPECT_EQ(newMatchOperation->nalternatives(), 2u);
+  EXPECT_EQ(newMatchOperation->default_alternative(), 0u);
+  EXPECT_EQ(newMatchOperation->alternative(0), 1u);
 }
 
 TEST(ControlFlowRestructuringTests, WhileLoop)
@@ -172,8 +217,8 @@ TEST(ControlFlowRestructuringTests, AcyclicUnstructuredInDoWhileLoop)
   bb2->add_outedge(bb3);
   bb2->add_outedge(bb4);
   bb3->add_outedge(bb4);
-  bb4->add_outedge(bb1);
   bb4->add_outedge(cfg.exit());
+  bb4->add_outedge(bb1);
 
   //	jlm::view_ascii(cfg, stdout);
 

--- a/jlm/llvm/ir/aggregation.cpp
+++ b/jlm/llvm/ir/aggregation.cpp
@@ -232,19 +232,21 @@ aggregate(ControlFlowGraphNode *, ControlFlowGraphNode *, AggregationMap &);
  * the subgraph.
  */
 static void
-reduce_loop(const StronglyConnectedComponentStructure & sccstruct, AggregationMap & map)
+reduceLoop(const StronglyConnectedComponentStructure & sccStruct, AggregationMap & map)
 {
-  JLM_ASSERT(sccstruct.IsTailControlledLoop());
+  JLM_ASSERT(sccStruct.IsTailControlledLoop());
 
-  auto exit = (*sccstruct.ExitEdges().begin())->source();
-  auto entry = *sccstruct.EntryNodes().begin();
+  const auto entryNode = *sccStruct.EntryNodes().begin();
+  const auto exitNode = (*sccStruct.ExitEdges().begin())->source();
 
-  auto redge = *sccstruct.RepetitionEdges().begin();
-  redge->source()->remove_outedge(redge->index());
+  const auto repetitionEdge = *sccStruct.RepetitionEdges().begin();
+  // The RVSDG theta node always expects that the repetition of its body happens on control value 1.
+  JLM_ASSERT(repetitionEdge->index() == 1);
+  repetitionEdge->source()->remove_outedge(repetitionEdge->index());
 
-  auto sese = aggregate(entry, exit, map);
-  auto loop = LoopAggregationNode::create(std::move(map.lookup(sese)));
-  map.insert(sese, std::move(loop));
+  const auto seseNode = aggregate(entryNode, exitNode, map);
+  auto loop = LoopAggregationNode::create(std::move(map.lookup(seseNode)));
+  map.insert(seseNode, std::move(loop));
 }
 
 /**
@@ -379,7 +381,7 @@ aggregate_loops(ControlFlowGraphNode * entry, ControlFlowGraphNode * exit, Aggre
 
     if (sccStructure->IsTailControlledLoop())
     {
-      reduce_loop(*sccStructure, map);
+      reduceLoop(*sccStructure, map);
       continue;
     }
 

--- a/tests/Makefile.sub
+++ b/tests/Makefile.sub
@@ -37,6 +37,7 @@ JLC_COMPILE_TESTS = \
 	tests/c-tests/test-valist \
 	tests/c-tests/test-vector-bitcast \
 	tests/c-tests/test-vector-signextend \
+	tests/c-tests/test-while-with-break \
 	tests/c-tests/test-zeroinitialization
 
 $(patsubst %, $(BUILD_OUT_PREFIX)%.jlm, $(JLC_COMPILE_TESTS)): $(BUILD_OUT_PREFIX)%.jlm : %.c $(BUILD_OUT_PREFIX)jlc

--- a/tests/c-tests/test-while-with-break.c
+++ b/tests/c-tests/test-while-with-break.c
@@ -1,0 +1,26 @@
+#include <assert.h>
+
+static int c = 0;
+
+int
+get_next()
+{
+  return c++;
+}
+
+int
+main()
+{
+  int status;
+
+  while (1)
+  {
+    status = get_next();
+
+    if (status == 5)
+      break;
+  }
+
+  assert(status == 5);
+  return 0;
+}


### PR DESCRIPTION
We experienced a miscompilation if the repetition edge of a tail-controlled loop had index 0 in the control flow graph. This collided with the expectation of the RVSDG's theta node that the repetition happens on control value 1.

Closes #1691 