### PR TITLE
Add call blocking to region aware mod ref summarizer

### DIFF
--- a/jlm/llvm/opt/alias-analyses/MemoryStateEncoderTests.cpp
+++ b/jlm/llvm/opt/alias-analyses/MemoryStateEncoderTests.cpp
@@ -843,15 +843,14 @@ TEST(MemoryStateEncoderTests, indirectCallTest2AndersenRegionAware)
 
   // validate function test()
   {
-    EXPECT_EQ(test.GetLambdaTest().subregion()->numNodes(), 15u);
+    EXPECT_EQ(test.GetLambdaTest().subregion()->numNodes(), 13u);
 
-    auto lambdaEntrySplit = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(
-        test.GetLambdaTest().GetFunctionArguments().back()->SingleUser());
-    EXPECT_TRUE(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 1));
+    // There is no lambda entry split, as no memory states are routed into the function body
+    EXPECT_TRUE(test.GetLambdaTest().GetFunctionArguments().back()->IsDead());
 
     auto lambdaExitMerge = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(
         *test.GetLambdaTest().GetFunctionResults()[2]->origin());
-    EXPECT_TRUE(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 1, 1));
+    EXPECT_TRUE(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 0, 1));
 
     // The variables g1 and g2 are effectively read-only, since they never get stored to.
     // This means their loads do not have any memory state edges going through them.
@@ -866,15 +865,14 @@ TEST(MemoryStateEncoderTests, indirectCallTest2AndersenRegionAware)
 
   // validate function test2()
   {
-    EXPECT_EQ(test.GetLambdaTest2().subregion()->numNodes(), 7u);
+    EXPECT_EQ(test.GetLambdaTest2().subregion()->numNodes(), 5u);
 
-    auto lambdaEntrySplit = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(
-        test.GetLambdaTest2().GetFunctionArguments().back()->SingleUser());
-    EXPECT_TRUE(is<LambdaEntryMemoryStateSplitOperation>(*lambdaEntrySplit, 1, 1));
+    // There is no lambda entry split, as no memory states are routed into the function body
+    EXPECT_TRUE(test.GetLambdaTest2().GetFunctionArguments().back()->IsDead());
 
     auto lambdaExitMerge = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(
         *test.GetLambdaTest2().GetFunctionResults()[2]->origin());
-    EXPECT_TRUE(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 1, 1));
+    EXPECT_TRUE(is<LambdaExitMemoryStateMergeOperation>(*lambdaExitMerge, 0, 1));
   }
 }
 

--- a/jlm/llvm/opt/alias-analyses/RegionAwareModRefSummarizer.cpp
+++ b/jlm/llvm/opt/alias-analyses/RegionAwareModRefSummarizer.cpp
@@ -66,6 +66,13 @@ static const bool ENABLE_CONSTANT_MEMORY_BLOCKING =
  */
 static const bool ENABLE_READ_ONLY_DETECTION = !std::getenv("JLM_DISABLE_READ_ONLY_DETECTION");
 
+/**
+ * When doing a call, any Simple Alloca that is not reachable from the arguments to the call
+ * can be blocked from being added to the call's ModRefSet.
+ */
+static const bool ENABLE_CALL_SIMPLE_ALLOCA_BLOCKING =
+    !std::getenv("JLM_DISABLE_CALL_SIMPLE_ALLOCA_BLOCKING");
+
 /** \brief Region-aware mod/ref summarizer statistics
  *
  * The statistics collected when running the region-aware mod/ref summarizer.
@@ -838,7 +845,14 @@ struct RegionAwareModRefSummarizer::Context
       NonReentrantAllocas;
 
   /**
-   * Simple edges in the \ref ModRefSet constraint graph.
+   * Used for blocking simple allocas from being propagated to the ModRefSet of calls
+   * where none of the call's arguments can reach the simple alloca.
+   * The sets are placed in a deque, since references to elements stay valid.
+   */
+  std::deque<util::HashSet<PointsToGraph::NodeIndex>> CallBlocklists;
+
+  /**
+   * Simple edges in the ModRefSet constraint graph.
    * A simple edge a -> b indicates that the \ref ModRefSet b should contain everything in a.
    * ModRefSetSimpleEdges[a] contains b, as well as any other simple edge successors.
    */
@@ -1646,6 +1660,16 @@ RegionAwareModRefSummarizer::AnnotateCall(
   if (pointsToGraph.isTargetingAllExternallyAvailable(targetPtgNode))
   {
     ModRefSummary_->markSetAsCallingExternalFunction(callModRef);
+  }
+
+  if (ENABLE_CALL_SIMPLE_ALLOCA_BLOCKING)
+  {
+    const auto reachableSimpleAllocas = getSimpleAllocasReachableFromCallArguments(callNode);
+    auto blocklist = Context_->SimpleAllocas;
+    blocklist.DifferenceWith(reachableSimpleAllocas);
+    // Move the blocklist to the deque to keep it alive during solving
+    Context_->CallBlocklists.push_back(std::move(blocklist));
+    AddModRefSetBlocklist(callModRef, Context_->CallBlocklists.back());
   }
 
   return callModRef;

--- a/jlm/llvm/opt/alias-analyses/RegionAwareModRefSummarizerTests.cpp
+++ b/jlm/llvm/opt/alias-analyses/RegionAwareModRefSummarizerTests.cpp
@@ -646,21 +646,16 @@ TEST(RegionAwareModRefSummarizerTests, TestIndirectCall2)
     {
       // g1 and g2 are effectively read-only so they get omitted from the lambda's set
       auto & lambdaEntryNodes = modRefSummary.GetLambdaEntryModRef(test.GetLambdaTest());
-      ASSERT_TRUE(
-          assertSetContains(lambdaEntryNodes, { { allocaPzMemoryNode, ModRefEffect::ModOnly } }));
+      ASSERT_TRUE(assertSetContains(lambdaEntryNodes, {}));
 
       auto & callXNodes = modRefSummary.GetSimpleNodeModRef(test.GetTestCallX());
-      ASSERT_TRUE(assertSetContains(
-          callXNodes,
-          { { allocaPxMemoryNode, ModRefEffect::ModOnly },
-            { allocaPzMemoryNode, ModRefEffect::ModOnly } }));
+      ASSERT_TRUE(assertSetContains(callXNodes, { { allocaPxMemoryNode, ModRefEffect::ModOnly } }));
 
       auto & callYNodes = modRefSummary.GetSimpleNodeModRef(test.GetCallY());
       ASSERT_TRUE(assertSetContains(callYNodes, { { allocaPyMemoryNode, ModRefEffect::ModOnly } }));
 
       auto & lambdaExitNodes = modRefSummary.GetLambdaExitModRef(test.GetLambdaTest());
-      ASSERT_TRUE(
-          assertSetContains(lambdaExitNodes, { { allocaPzMemoryNode, ModRefEffect::ModOnly } }));
+      ASSERT_TRUE(assertSetContains(lambdaExitNodes, {}));
     }
 
     /*
@@ -668,18 +663,13 @@ TEST(RegionAwareModRefSummarizerTests, TestIndirectCall2)
      */
     {
       auto & lambdaEntryNodes = modRefSummary.GetLambdaEntryModRef(test.GetLambdaTest2());
-      ASSERT_TRUE(
-          assertSetContains(lambdaEntryNodes, { { allocaPxMemoryNode, ModRefEffect::ModOnly } }));
+      ASSERT_TRUE(assertSetContains(lambdaEntryNodes, {}));
 
       auto & callXNodes = modRefSummary.GetSimpleNodeModRef(test.GetTest2CallX());
-      ASSERT_TRUE(assertSetContains(
-          callXNodes,
-          { { allocaPxMemoryNode, ModRefEffect::ModOnly },
-            { allocaPzMemoryNode, ModRefEffect::ModOnly } }));
+      ASSERT_TRUE(assertSetContains(callXNodes, { { allocaPzMemoryNode, ModRefEffect::ModOnly } }));
 
       auto & lambdaExitNodes = modRefSummary.GetLambdaExitModRef(test.GetLambdaTest2());
-      ASSERT_TRUE(
-          assertSetContains(lambdaExitNodes, { { allocaPxMemoryNode, ModRefEffect::ModOnly } }));
+      ASSERT_TRUE(assertSetContains(lambdaExitNodes, {}));
     }
   };
 
@@ -1084,10 +1074,10 @@ TEST(RegionAwareModRefSummarizerTests, TestPhi2)
           assertSetContains(lambdaEntryNodes, allWithEffect(pTestCD, ModRefEffect::ModOnly)));
 
       auto & callBNodes = modRefSummary.GetSimpleNodeModRef(test.GetCallB());
-      ASSERT_TRUE(assertSetContains(callBNodes, allWithEffect(pTestAD, ModRefEffect::ModOnly)));
+      ASSERT_TRUE(assertSetContains(callBNodes, { { paAllocaMemoryNode, ModRefEffect::ModOnly } }));
 
       auto & callDNodes = modRefSummary.GetSimpleNodeModRef(test.GetCallD());
-      ASSERT_TRUE(assertSetContains(callDNodes, allWithEffect(pTestAC, ModRefEffect::ModOnly)));
+      ASSERT_TRUE(assertSetContains(callDNodes, { { paAllocaMemoryNode, ModRefEffect::ModOnly } }));
 
       auto & lambdaExitNodes = modRefSummary.GetLambdaExitModRef(test.GetLambdaA());
       ASSERT_TRUE(
@@ -1100,21 +1090,17 @@ TEST(RegionAwareModRefSummarizerTests, TestPhi2)
     {
       auto & lambdaEntryNodes = modRefSummary.GetLambdaEntryModRef(test.GetLambdaB());
       ASSERT_TRUE(
-          assertSetContains(lambdaEntryNodes, allWithEffect(pTestAD, ModRefEffect::ModOnly)));
+          assertSetContains(lambdaEntryNodes, { { paAllocaMemoryNode, ModRefEffect::ModOnly } }));
 
       auto & callINodes = modRefSummary.GetSimpleNodeModRef(test.GetCallI());
       ASSERT_TRUE(assertSetContains(callINodes, {}));
 
       auto & callCNodes = modRefSummary.GetSimpleNodeModRef(test.GetCallC());
-      ASSERT_TRUE(assertSetContains(
-          callCNodes,
-          { { pTestAllocaMemoryNode, ModRefEffect::ModOnly },
-            { pbAllocaMemoryNode, ModRefEffect::ModRef },
-            { pdAllocaMemoryNode, ModRefEffect::ModOnly } }));
+      ASSERT_TRUE(assertSetContains(callCNodes, { { pbAllocaMemoryNode, ModRefEffect::ModRef } }));
 
       auto & lambdaExitNodes = modRefSummary.GetLambdaExitModRef(test.GetLambdaB());
       ASSERT_TRUE(
-          assertSetContains(lambdaExitNodes, allWithEffect(pTestAD, ModRefEffect::ModOnly)));
+          assertSetContains(lambdaExitNodes, { { paAllocaMemoryNode, ModRefEffect::ModOnly } }));
     }
 
     /*
@@ -1122,21 +1108,15 @@ TEST(RegionAwareModRefSummarizerTests, TestPhi2)
      */
     {
       auto & lambdaEntryNodes = modRefSummary.GetLambdaEntryModRef(test.GetLambdaC());
-      ASSERT_TRUE(assertSetContains(
-          lambdaEntryNodes,
-          { { pTestAllocaMemoryNode, ModRefEffect::ModOnly },
-            { pbAllocaMemoryNode, ModRefEffect::ModRef },
-            { pdAllocaMemoryNode, ModRefEffect::ModOnly } }));
+      ASSERT_TRUE(
+          assertSetContains(lambdaEntryNodes, { { pbAllocaMemoryNode, ModRefEffect::ModRef } }));
 
       auto & callNodes = modRefSummary.GetSimpleNodeModRef(test.GetCallAFromC());
-      ASSERT_TRUE(assertSetContains(callNodes, allWithEffect(pTestCD, ModRefEffect::ModOnly)));
+      ASSERT_TRUE(assertSetContains(callNodes, { { pcAllocaMemoryNode, ModRefEffect::ModOnly } }));
 
       auto & lambdaExitNodes = modRefSummary.GetLambdaExitModRef(test.GetLambdaC());
-      ASSERT_TRUE(assertSetContains(
-          lambdaExitNodes,
-          { { pTestAllocaMemoryNode, ModRefEffect::ModOnly },
-            { pbAllocaMemoryNode, ModRefEffect::ModRef },
-            { pdAllocaMemoryNode, ModRefEffect::ModOnly } }));
+      ASSERT_TRUE(
+          assertSetContains(lambdaExitNodes, { { pbAllocaMemoryNode, ModRefEffect::ModRef } }));
     }
 
     /*
@@ -1145,14 +1125,14 @@ TEST(RegionAwareModRefSummarizerTests, TestPhi2)
     {
       auto & lambdaEntryNodes = modRefSummary.GetLambdaEntryModRef(test.GetLambdaD());
       ASSERT_TRUE(
-          assertSetContains(lambdaEntryNodes, allWithEffect(pTestAC, ModRefEffect::ModOnly)));
+          assertSetContains(lambdaEntryNodes, { { paAllocaMemoryNode, ModRefEffect::ModOnly } }));
 
       auto & callNodes = modRefSummary.GetSimpleNodeModRef(test.GetCallAFromD());
-      ASSERT_TRUE(assertSetContains(callNodes, allWithEffect(pTestCD, ModRefEffect::ModOnly)));
+      ASSERT_TRUE(assertSetContains(callNodes, { { pdAllocaMemoryNode, ModRefEffect::ModOnly } }));
 
       auto & lambdaExitNodes = modRefSummary.GetLambdaExitModRef(test.GetLambdaD());
       ASSERT_TRUE(
-          assertSetContains(lambdaExitNodes, allWithEffect(pTestAC, ModRefEffect::ModOnly)));
+          assertSetContains(lambdaExitNodes, { { paAllocaMemoryNode, ModRefEffect::ModOnly } }));
     }
 
     /*
@@ -1160,17 +1140,14 @@ TEST(RegionAwareModRefSummarizerTests, TestPhi2)
      */
     {
       auto & lambdaEntryNodes = modRefSummary.GetLambdaEntryModRef(test.GetLambdaTest());
-      ASSERT_TRUE(assertSetContains(
-          lambdaEntryNodes,
-          allWithEffect({ pcAllocaMemoryNode, pdAllocaMemoryNode }, ModRefEffect::ModOnly)));
+      ASSERT_TRUE(assertSetContains(lambdaEntryNodes, {}));
 
       auto & callNodes = modRefSummary.GetSimpleNodeModRef(test.GetCallAFromTest());
-      ASSERT_TRUE(assertSetContains(callNodes, allWithEffect(pTestCD, ModRefEffect::ModOnly)));
+      ASSERT_TRUE(
+          assertSetContains(callNodes, { { pTestAllocaMemoryNode, ModRefEffect::ModOnly } }));
 
       auto & lambdaExitNodes = modRefSummary.GetLambdaExitModRef(test.GetLambdaTest());
-      ASSERT_TRUE(assertSetContains(
-          lambdaExitNodes,
-          allWithEffect({ pcAllocaMemoryNode, pdAllocaMemoryNode }, ModRefEffect::ModOnly)));
+      ASSERT_TRUE(assertSetContains(lambdaExitNodes, {}));
     }
   };
 


### PR DESCRIPTION
Makes ModRefSets smaller by filtering out memory nodes representing simple allocas, when none of the arguments to the call can reach the simple alloca