### PR TITLE
SVF: Replace loads of floatin point type from aggregate zero-initialized deltas

### DIFF
--- a/jlm/llvm/frontend/LlvmModuleConversion.cpp
+++ b/jlm/llvm/frontend/LlvmModuleConversion.cpp
@@ -509,7 +509,7 @@ convert_constantFP(
   auto c = ::llvm::cast<::llvm::ConstantFP>(constant);
 
   auto type = ctx.GetTypeConverter().ConvertLlvmType(*c->getType());
-  tacs.push_back(ConstantFP::create(c->getValueAPF(), type));
+  tacs.push_back(ConstantFP::createTac(c->getValueAPF(), type));
 
   return tacs.back()->result(0);
 }

--- a/jlm/llvm/ir/operators/operators.hpp
+++ b/jlm/llvm/ir/operators/operators.hpp
@@ -811,15 +811,26 @@ public:
     return std::static_pointer_cast<const FloatingPointType>(result(0))->size();
   }
 
-  static std::unique_ptr<llvm::ThreeAddressCode>
+  [[nodiscard]] static std::unique_ptr<ConstantFP>
   create(const ::llvm::APFloat & constant, const std::shared_ptr<const jlm::rvsdg::Type> & type)
   {
     auto ft = std::dynamic_pointer_cast<const FloatingPointType>(type);
     if (!ft)
       throw util::Error("expected floating point type.");
 
-    auto op = std::make_unique<ConstantFP>(std::move(ft), constant);
-    return ThreeAddressCode::create(std::move(op), {});
+    return std::make_unique<ConstantFP>(std::move(ft), constant);
+  }
+
+  [[nodiscard]] static std::unique_ptr<llvm::ThreeAddressCode>
+  createTac(const ::llvm::APFloat & constant, const std::shared_ptr<const jlm::rvsdg::Type> & type)
+  {
+    return ThreeAddressCode::create(create(constant, type), {});
+  }
+
+  [[nodiscard]] static rvsdg::Node &
+  createNode(rvsdg::Region & region, fpsize size, const ::llvm::APFloat & constant)
+  {
+    return rvsdg::CreateOpNode<ConstantFP>(region, size, constant);
   }
 
 private:

--- a/jlm/llvm/ir/operators/operators.hpp
+++ b/jlm/llvm/ir/operators/operators.hpp
@@ -6,7 +6,6 @@
 #ifndef JLM_LLVM_IR_OPERATORS_OPERATORS_HPP
 #define JLM_LLVM_IR_OPERATORS_OPERATORS_HPP
 
-#include "jlm/util/common.hpp"
 #include <jlm/llvm/ir/ipgraph-module.hpp>
 #include <jlm/llvm/ir/operators/ConversionOperations.hpp>
 #include <jlm/llvm/ir/tac.hpp>

--- a/jlm/llvm/ir/operators/operators.hpp
+++ b/jlm/llvm/ir/operators/operators.hpp
@@ -6,6 +6,7 @@
 #ifndef JLM_LLVM_IR_OPERATORS_OPERATORS_HPP
 #define JLM_LLVM_IR_OPERATORS_OPERATORS_HPP
 
+#include "jlm/util/common.hpp"
 #include <jlm/llvm/ir/ipgraph-module.hpp>
 #include <jlm/llvm/ir/operators/ConversionOperations.hpp>
 #include <jlm/llvm/ir/tac.hpp>
@@ -831,6 +832,29 @@ public:
   createNode(rvsdg::Region & region, fpsize size, const ::llvm::APFloat & constant)
   {
     return rvsdg::CreateOpNode<ConstantFP>(region, size, constant);
+  }
+
+  /**
+   * Helper function for creating a floating point constant value 0 of the correct type.
+   */
+  [[nodiscard]] static ::llvm::APFloat
+  getZeroRepresentation(fpsize size)
+  {
+    switch (size)
+    {
+    case fpsize::half:
+      return ::llvm::APFloat::getZero(::llvm::APFloat::IEEEhalf());
+    case fpsize::flt:
+      return ::llvm::APFloat::getZero(::llvm::APFloat::IEEEsingle());
+    case fpsize::dbl:
+      return ::llvm::APFloat::getZero(::llvm::APFloat::IEEEdouble());
+    case fpsize::x86fp80:
+      return ::llvm::APFloat::getZero(::llvm::APFloat::x87DoubleExtended());
+    case fpsize::fp128:
+      return ::llvm::APFloat::getZero(::llvm::APFloat::IEEEquad());
+    default:
+      JLM_UNREACHABLE("Unknown float size");
+    }
   }
 
 private:
@@ -2358,7 +2382,6 @@ private:
     return types;
   }
 };
-
 }
 
 #endif

--- a/jlm/llvm/opt/StoreValueForwarding.cpp
+++ b/jlm/llvm/opt/StoreValueForwarding.cpp
@@ -32,6 +32,7 @@
 #include <jlm/util/Statistics.hpp>
 #include <jlm/util/time.hpp>
 
+#include <llvm-18/llvm/ADT/APFloat.h>
 #include <memory>
 #include <queue>
 
@@ -951,6 +952,15 @@ StoreValueForwarding::forwardLoadWithoutMemoryStates(
           {
             const auto & zeroNode =
                 IntegerConstantOperation::Create(*loadNode.region(), bitType->nbits(), 0);
+            LoadOperation::LoadedValueOutput(loadNode).divert_users(zeroNode.output(0));
+          }
+          else if (
+              const auto floatType =
+                  std::dynamic_pointer_cast<const llvm::FloatingPointType>(loadedType))
+          {
+            const auto zero = ::llvm::APFloat::getZero(::llvm::APFloat::IEEEdouble());
+            const auto & zeroNode =
+                ConstantFP::createNode(*loadNode.region(), floatType->size(), zero);
             LoadOperation::LoadedValueOutput(loadNode).divert_users(zeroNode.output(0));
           }
           else

--- a/jlm/llvm/opt/StoreValueForwarding.cpp
+++ b/jlm/llvm/opt/StoreValueForwarding.cpp
@@ -32,7 +32,6 @@
 #include <jlm/util/Statistics.hpp>
 #include <jlm/util/time.hpp>
 
-#include <llvm-18/llvm/ADT/APFloat.h>
 #include <memory>
 #include <queue>
 

--- a/jlm/llvm/opt/StoreValueForwarding.cpp
+++ b/jlm/llvm/opt/StoreValueForwarding.cpp
@@ -957,10 +957,17 @@ StoreValueForwarding::forwardLoadWithoutMemoryStates(
               const auto floatType =
                   std::dynamic_pointer_cast<const llvm::FloatingPointType>(loadedType))
           {
-            const auto zero = ::llvm::APFloat::getZero(::llvm::APFloat::IEEEdouble());
+            const auto zero = ConstantFP::getZeroRepresentation(floatType->size());
             const auto & zeroNode =
                 ConstantFP::createNode(*loadNode.region(), floatType->size(), zero);
             LoadOperation::LoadedValueOutput(loadNode).divert_users(zeroNode.output(0));
+          }
+          else if (
+              const auto vectorType =
+                  std::dynamic_pointer_cast<const llvm::FixedVectorType>(loadedType))
+          {
+            // FIXME: Handle loading of vectors of zero values
+            return;
           }
           else
           {

--- a/jlm/llvm/opt/StoreValueForwarding.cpp
+++ b/jlm/llvm/opt/StoreValueForwarding.cpp
@@ -980,6 +980,10 @@ StoreValueForwarding::forwardLoadWithoutMemoryStates(
         {
           // FIXME: handle operation
         },
+        [&](const IntegerToPointerOperation &)
+        {
+          // FIXME: handle operation
+        },
         [&]()
         {
           throw std::logic_error("Unsupported operation: " + node->DebugString());

--- a/jlm/llvm/opt/StoreValueForwardingTests.cpp
+++ b/jlm/llvm/opt/StoreValueForwardingTests.cpp
@@ -1137,3 +1137,115 @@ TEST(StoreValueForwardingTests, LoadForwardingFromDeltaWithAggregateZeroConstant
   // We expect all load nodes to be forwarded
   EXPECT_FALSE(Region::ContainsNodeType<LoadNonVolatileOperation>(graph.GetRootRegion(), true));
 }
+
+TEST(StoreValueForwardingTests, LoadForwardingFloatFromDeltaWithAggregateZeroConstant)
+{
+  using namespace jlm::llvm;
+  using namespace jlm::rvsdg;
+
+  /**
+   * Creates RVSDG corresponding to the C code:
+   *
+   * struct S {
+   *   float f;
+   *   double d;
+   * };
+   *
+   * static const struct S myS;
+   *
+   * float getFloat() {
+   *   return myS.f;
+   * }
+   * double getDouble() {
+   *   return myS.d;
+   * }
+   *
+   * where the loads in the functions have no memory state going through them,
+   * since they are loading from constant memory.
+   *
+   * The test checks that StoreValueForwarding is able to replace the loads in the functions
+   * with floating point 0.0 constants.
+   */
+
+  // Arrange - Create a single lambda with two return values for simplicity
+  LlvmRvsdgModule rvsdgModule(jlm::util::FilePath(""), "", "");
+  auto & graph = rvsdgModule.Rvsdg();
+
+  const auto pointerType = PointerType::Create();
+  const auto floatType = FloatingPointType::Create(fpsize::flt);
+  const auto doubleType = FloatingPointType::Create(fpsize::dbl);
+  const auto structType = StructType::CreateIdentified("struct", { floatType, doubleType }, false);
+
+  auto deltaNode = DeltaNode::Create(
+      &graph.GetRootRegion(),
+      DeltaOperation::Create(structType, true, pointerType));
+  auto aggregateZero = ConstantAggregateZeroOperation::Create(*deltaNode->subregion(), structType);
+  auto & deltaOutput = deltaNode->finalize(aggregateZero);
+
+  // function types for getFloat() and getDouble()
+  const auto getFloatFunctionType = FunctionType::Create({}, { floatType });
+  const auto getDoubleFunctionType = FunctionType::Create({}, { doubleType });
+
+  // Create getFloat()
+  auto & getFloatLambdaNode = *LambdaNode::Create(
+      graph.GetRootRegion(),
+      LlvmLambdaOperation::Create(getFloatFunctionType, "getFloat", Linkage::internalLinkage));
+  {
+    auto ctxVar = getFloatLambdaNode.AddContextVar(deltaOutput);
+
+    // Load float field (offset 0)
+    auto & zeroNode = IntegerConstantOperation::Create(*getFloatLambdaNode.subregion(), 32, 0);
+    auto & gepFloatNode = GetElementPtrOperation::createNode(
+        *ctxVar.inner,
+        { zeroNode.output(0), zeroNode.output(0) },
+        structType);
+    auto & loadFloatNode =
+        LoadNonVolatileOperation::CreateNode(*gepFloatNode.output(0), {}, floatType, 4);
+    getFloatLambdaNode.finalize({ &LoadOperation::LoadedValueOutput(loadFloatNode) });
+  }
+
+  // Create getDouble()
+  auto & getDoubleFunctionNode = *LambdaNode::Create(
+      graph.GetRootRegion(),
+      LlvmLambdaOperation::Create(getDoubleFunctionType, "getDouble", Linkage::internalLinkage));
+  {
+    auto ctxVar = getDoubleFunctionNode.AddContextVar(deltaOutput);
+
+    // Load double field (offset 1)
+    auto & zeroNode = IntegerConstantOperation::Create(*getDoubleFunctionNode.subregion(), 32, 0);
+    auto & oneNode = IntegerConstantOperation::Create(*getDoubleFunctionNode.subregion(), 32, 1);
+    auto & gepDoubleNode = GetElementPtrOperation::createNode(
+        *ctxVar.inner,
+        { zeroNode.output(0), oneNode.output(0) },
+        structType);
+    auto & loadDoubleNode =
+        LoadNonVolatileOperation::CreateNode(*gepDoubleNode.output(0), {}, doubleType, 8);
+    getDoubleFunctionNode.finalize({ &LoadOperation::LoadedValueOutput(loadDoubleNode) });
+  }
+
+  // std::cout << jlm::rvsdg::view(&rvsdgModule.Rvsdg().GetRootRegion()) << std::endl;
+
+  // Act
+  RunStoreValueForwarding(rvsdgModule);
+
+  // Assert - Check that both loads were forwarded to float zero constants
+  EXPECT_FALSE(Region::ContainsNodeType<LoadNonVolatileOperation>(graph.GetRootRegion(), true));
+
+  {
+    auto floatResult = getFloatLambdaNode.GetFunctionResults()[0];
+    const auto [_, floatOp] =
+        jlm::rvsdg::TryGetSimpleNodeAndOptionalOp<ConstantFP>(*floatResult->origin());
+    EXPECT_NE(floatOp, nullptr);
+    EXPECT_TRUE(*floatOp->result(0) == *floatType);
+    EXPECT_TRUE(floatOp->constant().isZero());
+  }
+
+  {
+    auto doubleResult = getDoubleFunctionNode.GetFunctionResults()[0];
+    const auto [_, doubleOp] =
+        jlm::rvsdg::TryGetSimpleNodeAndOptionalOp<ConstantFP>(*doubleResult->origin());
+    EXPECT_NE(doubleOp, nullptr);
+    EXPECT_TRUE(*doubleOp->result(0) == *doubleType);
+    EXPECT_TRUE(doubleOp->constant().isZero());
+  }
+}

--- a/jlm/llvm/opt/StoreValueForwardingTests.cpp
+++ b/jlm/llvm/opt/StoreValueForwardingTests.cpp
@@ -23,6 +23,7 @@
 #include <jlm/rvsdg/UnitType.hpp>
 #include <jlm/rvsdg/view.hpp>
 #include <jlm/util/Statistics.hpp>
+#include <llvm-18/llvm/ADT/APFloat.h>
 
 static void
 RunStoreValueForwarding(jlm::llvm::LlvmRvsdgModule & rvsdgModule)
@@ -1238,6 +1239,7 @@ TEST(StoreValueForwardingTests, LoadForwardingFloatFromDeltaWithAggregateZeroCon
     EXPECT_NE(floatOp, nullptr);
     EXPECT_TRUE(*floatOp->result(0) == *floatType);
     EXPECT_TRUE(floatOp->constant().isZero());
+    EXPECT_EQ(&floatOp->constant().getSemantics(), &::llvm::APFloat::IEEEsingle());
   }
 
   {
@@ -1247,5 +1249,6 @@ TEST(StoreValueForwardingTests, LoadForwardingFloatFromDeltaWithAggregateZeroCon
     EXPECT_NE(doubleOp, nullptr);
     EXPECT_TRUE(*doubleOp->result(0) == *doubleType);
     EXPECT_TRUE(doubleOp->constant().isZero());
+    EXPECT_EQ(&doubleOp->constant().getSemantics(), &::llvm::APFloat::IEEEdouble());
   }
 }


### PR DESCRIPTION
Some of the benchmark programs threw exceptions during compilation due to missing this