### PR TITLE
Make benchmark CI job fail when the benchmarking fails

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -38,14 +38,15 @@ jobs:
             cactuBSSN,
             x264,
             blender,
+            imagick,
             nab,
             xz,
             emacs,
             ghostscript,
             gdb,
             sendmail,
-            embench,
             polybench,
+            embench,
           ]
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -33,6 +33,7 @@ jobs:
       matrix:
         benchmark:
           [
+          # Programs from SPEC CPU2017 (redist version)
             perlbench,
             gcc,
             cactuBSSN,
@@ -41,12 +42,16 @@ jobs:
             imagick,
             nab,
             xz,
-            emacs,
-            ghostscript,
-            gdb,
-            sendmail,
-            polybench,
+
+          # Other benchmark suites
             embench,
+            polybench,
+
+          # Open source programs
+            emacs,
+            gdb,
+            ghostscript,
+            sendmail,
           ]
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -63,5 +63,5 @@ jobs:
         run: ln -s ${{ github.workspace }}/build-release ${{ github.workspace }}/build
         shell: bash
       - name: "Run benchmark"
-        run: ./scripts/run-benchmarks.sh --apt-install-deps --benchmark ${{ matrix.benchmark }}
+        run: ./scripts/run-benchmarks.sh --apt-install-deps --ci --benchmark ${{ matrix.benchmark }}
         shell: bash

--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -33,7 +33,6 @@ jobs:
       matrix:
         benchmark:
           [
-            polybench,
             perlbench,
             gcc,
             cactuBSSN,
@@ -41,6 +40,12 @@ jobs:
             blender,
             nab,
             xz,
+            emacs,
+            ghostscript,
+            gdb,
+            sendmail,
+            embench,
+            polybench,
           ]
     runs-on: ubuntu-24.04
     steps:

--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -3,7 +3,7 @@ set -eu +x
 
 # URL to the benchmark git repository and the commit to be used
 GIT_REPOSITORY=https://github.com/haved/jlm-benchmark.git
-GIT_COMMIT=50bf014fe8dacfaad7bbbfdd620b5b839518153c
+GIT_COMMIT=bcb41d42e465981b560abb50f4c33a96c01258e9
 
 # Get the absolute path to this script and set default JLM paths
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
@@ -21,7 +21,11 @@ fi
 
 APT_INSTALL_DEPS=false
 CLEAN_RUNS=false
-RUN_OPTIONS=""
+
+# Used for filtering to only run certain benchmarks
+BENCHMARKS=""
+# Other options to pass to the ./run.sh script
+EXTRA_RUN_OPTIONS=""
 
 function commit()
 {
@@ -36,10 +40,10 @@ function usage()
 	echo "                        Default=[${BENCHMARK_DIR}]"
 	echo "  --apt-install-deps    For CI runner or Ubuntu 24. Installs apt package dependencies before running."
 	echo "  --ci                  Use a benchmark configuration intended for running and validating in CI."
- 	echo "  --parallel #THREADS   The number of threads to run in parallel."
+	echo "  --parallel #THREADS   The number of threads to run in parallel."
 	echo "                        Default=[${NUM_PARALLEL_THREADS}]"
 	echo "  --benchmark BENCH     Only extract and build a specific benchamrk."
-	echo "                        Default=[ALL]. See list of options in benchmark's run.sh"
+	echo "                        Default=[ALL]. See list of options in the benchmark repository's run.sh"
 	echo "  --clean-runs          Delete build files and statistics from previous runs."
 	echo "  --get-commit-hash     Prints the commit hash used for the build."
 	echo "  --help                Prints this message and stops."
@@ -61,7 +65,7 @@ while [[ "$#" -ge 1 ]] ; do
 			shift
 			;;
 		--ci)
-			RUN_OPTIONS="${RUN_OPTIONS} --ci"
+			EXTRA_RUN_OPTIONS="${EXTRA_RUN_OPTIONS} --ci"
 			shift
 			;;
 		--parallel)
@@ -71,7 +75,7 @@ while [[ "$#" -ge 1 ]] ; do
 			;;
 		--benchmark)
 			shift
-			RUN_OPTIONS="${RUN_OPTIONS} --$1"
+			BENCHMARKS="${BENCHMARKS} --$1"
 			shift
 			;;
 		--get-commit-hash)
@@ -112,4 +116,4 @@ if [ "${CLEAN_RUNS}" = true ]; then
 	exit 0
 fi
 
-./run.sh --jlm-opt "${JLM_ROOT_DIR}/build/jlm-opt" --llvm-config "${LLVMCONFIG}" --parallel "${NUM_PARALLEL_THREADS}" ${RUN_OPTIONS}
+./run.sh --jlm-opt "${JLM_ROOT_DIR}/build/jlm-opt" --llvm-config "${LLVMCONFIG}" --parallel "${NUM_PARALLEL_THREADS}" ${BENCHMARKS} ${EXTRA_RUN_OPTIONS}

--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -3,7 +3,7 @@ set -eu +x
 
 # URL to the benchmark git repository and the commit to be used
 GIT_REPOSITORY=https://github.com/haved/jlm-benchmark.git
-GIT_COMMIT=48d89bd28a2075976ea7f1dc0b4278fc0bf398b7
+GIT_COMMIT=989c9f8d55504affe88b6c474b05ad9c6a954c8c
 
 # Get the absolute path to this script and set default JLM paths
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"

--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -3,7 +3,7 @@ set -eu +x
 
 # URL to the benchmark git repository and the commit to be used
 GIT_REPOSITORY=https://github.com/haved/jlm-benchmark.git
-GIT_COMMIT=5e0451d4ba7282b2a152787aef98de09403bf4cb
+GIT_COMMIT=50bf014fe8dacfaad7bbbfdd620b5b839518153c
 
 # Get the absolute path to this script and set default JLM paths
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
@@ -20,8 +20,8 @@ else
 fi
 
 APT_INSTALL_DEPS=false
-CLEAN=false
-BENCHMARK=""
+CLEAN_RUNS=false
+RUN_OPTIONS=""
 
 function commit()
 {
@@ -35,12 +35,12 @@ function usage()
 	echo "  --path PATH           The path where to place the benchmarks."
 	echo "                        Default=[${BENCHMARK_DIR}]"
 	echo "  --apt-install-deps    For CI runner or Ubuntu 24. Installs apt package dependencies before running."
+	echo "  --ci                  Use a benchmark configuration intended for running and validating in CI."
  	echo "  --parallel #THREADS   The number of threads to run in parallel."
 	echo "                        Default=[${NUM_PARALLEL_THREADS}]"
 	echo "  --benchmark BENCH     Only extract and build a specific benchamrk."
-	echo "                        Default=[ALL]"
-	echo "                        BENCH=[polybench|spec|emacs|ghostscript|gdb|sendmail]"
-	echo "  --clean               Delete extracted sources and build files."
+	echo "                        Default=[ALL]. See list of options in benchmark's run.sh"
+	echo "  --clean-runs          Delete build files and statistics from previous runs."
 	echo "  --get-commit-hash     Prints the commit hash used for the build."
 	echo "  --help                Prints this message and stops."
 }
@@ -60,6 +60,10 @@ while [[ "$#" -ge 1 ]] ; do
 			APT_INSTALL_DEPS=true
 			shift
 			;;
+		--ci)
+			RUN_OPTIONS="${RUN_OPTIONS} --ci"
+			shift
+			;;
 		--parallel)
 			shift
 			NUM_PARALLEL_THREADS=$1
@@ -67,7 +71,7 @@ while [[ "$#" -ge 1 ]] ; do
 			;;
 		--benchmark)
 			shift
-			BENCHMARK="--$1"
+			RUN_OPTIONS="${RUN_OPTIONS} --$1"
 			shift
 			;;
 		--get-commit-hash)
@@ -103,9 +107,9 @@ if [[ "${APT_INSTALL_DEPS}" = true ]]; then
 	sudo ./apt-install-dependencies.sh
 fi
 
-if [ "${CLEAN}" = true ]; then
-	./run.sh --clean
-	exit  0
+if [ "${CLEAN_RUNS}" = true ]; then
+	./run.sh clean-runs
+	exit 0
 fi
 
-./run.sh --jlm-opt "${JLM_ROOT_DIR}/build/jlm-opt" --llvm-config "${LLVMCONFIG}" --parallel "${NUM_PARALLEL_THREADS}" ${BENCHMARK}
+./run.sh --jlm-opt "${JLM_ROOT_DIR}/build/jlm-opt" --llvm-config "${LLVMCONFIG}" --parallel "${NUM_PARALLEL_THREADS}" ${RUN_OPTIONS}

--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -3,7 +3,7 @@ set -eu +x
 
 # URL to the benchmark git repository and the commit to be used
 GIT_REPOSITORY=https://github.com/haved/jlm-benchmark.git
-GIT_COMMIT=c1cdce1acdc18969adc2b97710701c6dc7858336
+GIT_COMMIT=4eb47075f00299743d980acb3cabe168b1f160f4
 
 # Get the absolute path to this script and set default JLM paths
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"

--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -47,8 +47,8 @@ function usage()
 
 while [[ "$#" -ge 1 ]] ; do
 	case "$1" in
-		--clean)
-			CLEAN=true
+		--clean-runs)
+			CLEAN_RUNS=true
 			shift
 			;;
 		--path)

--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -3,7 +3,7 @@ set -eu +x
 
 # URL to the benchmark git repository and the commit to be used
 GIT_REPOSITORY=https://github.com/haved/jlm-benchmark.git
-GIT_COMMIT=bcb41d42e465981b560abb50f4c33a96c01258e9
+GIT_COMMIT=c1cdce1acdc18969adc2b97710701c6dc7858336
 
 # Get the absolute path to this script and set default JLM paths
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
@@ -24,8 +24,8 @@ CLEAN_RUNS=false
 
 # Used for filtering to only run certain benchmarks
 BENCHMARKS=""
-# Other options to pass to the ./run.sh script
-EXTRA_RUN_OPTIONS=""
+# When set, the benchmark repository's run.sh is passed --ci
+USE_CI_CONFIGURATION=false
 
 function commit()
 {
@@ -65,7 +65,7 @@ while [[ "$#" -ge 1 ]] ; do
 			shift
 			;;
 		--ci)
-			EXTRA_RUN_OPTIONS="${EXTRA_RUN_OPTIONS} --ci"
+			USE_CI_CONFIGURATION=true
 			shift
 			;;
 		--parallel)
@@ -116,4 +116,9 @@ if [ "${CLEAN_RUNS}" = true ]; then
 	exit 0
 fi
 
-./run.sh --jlm-opt "${JLM_ROOT_DIR}/build/jlm-opt" --llvm-config "${LLVMCONFIG}" --parallel "${NUM_PARALLEL_THREADS}" ${BENCHMARKS} ${EXTRA_RUN_OPTIONS}
+RUN_FLAGS="${BENCHMARKS}"
+if [ "${USE_CI_CONFIGURATION}" = true ]; then
+    RUN_FLAGS="${EXTRA_FLAGS} --ci"
+fi
+
+./run.sh --jlm-opt "${JLM_ROOT_DIR}/build/jlm-opt" --llvm-config "${LLVMCONFIG}" --parallel "${NUM_PARALLEL_THREADS}" ${RUN_FLAGS}

--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -3,7 +3,7 @@ set -eu +x
 
 # URL to the benchmark git repository and the commit to be used
 GIT_REPOSITORY=https://github.com/haved/jlm-benchmark.git
-GIT_COMMIT=1c46cfb687095943e0138b3bf76d52e615e4dd99
+GIT_COMMIT=48d89bd28a2075976ea7f1dc0b4278fc0bf398b7
 
 # Get the absolute path to this script and set default JLM paths
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"

--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -118,7 +118,7 @@ fi
 
 RUN_FLAGS="${BENCHMARKS}"
 if [ "${USE_CI_CONFIGURATION}" = true ]; then
-    RUN_FLAGS="${EXTRA_FLAGS} --ci"
+    RUN_FLAGS="${RUN_FLAGS} --ci"
 fi
 
 ./run.sh --jlm-opt "${JLM_ROOT_DIR}/build/jlm-opt" --llvm-config "${LLVMCONFIG}" --parallel "${NUM_PARALLEL_THREADS}" ${RUN_FLAGS}

--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -3,7 +3,7 @@ set -eu +x
 
 # URL to the benchmark git repository and the commit to be used
 GIT_REPOSITORY=https://github.com/haved/jlm-benchmark.git
-GIT_COMMIT=4eb47075f00299743d980acb3cabe168b1f160f4
+GIT_COMMIT=1c46cfb687095943e0138b3bf76d52e615e4dd99
 
 # Get the absolute path to this script and set default JLM paths
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"


### PR DESCRIPTION
This also updates the commit such that we get validation of the compiled benchmarks as well, for those that have a validation script (currently only embench and a tiny list script for emacs)