### PR TITLE
Llvm: fix inversion of match operation in CFR

### DIFF
--- a/jlm/llvm/frontend/ControlFlowRestructuring.cpp
+++ b/jlm/llvm/frontend/ControlFlowRestructuring.cpp
@@ -241,6 +241,30 @@ RestructureControlFlow(
     std::vector<TailControlledLoop> &);
 
 /**
+ * Inverts the control values of a \ref rvsdg::MatchOperation with 2 alternatives.
+ *
+ * @param matchOperation The \ref rvsdg::MatchOperation for which to invert the control values.
+ * @return A new \ref rvsdg::MatchOperation where the control values are inverted.
+ */
+static std::unique_ptr<rvsdg::MatchOperation>
+invertMatchOperation(const rvsdg::MatchOperation & matchOperation)
+{
+  JLM_ASSERT(matchOperation.nalternatives() == 2);
+
+  const size_t numBits = matchOperation.nbits();
+  const auto oldDefaultAlternative = matchOperation.default_alternative();
+  auto [oldValue, oldAlternative] = *matchOperation.begin();
+  const auto newDefaultAlternative = oldAlternative;
+  auto newAlternative = oldDefaultAlternative;
+
+  return std::unique_ptr<rvsdg::MatchOperation>(new rvsdg::MatchOperation(
+      numBits,
+      { { oldValue, newAlternative } },
+      newDefaultAlternative,
+      matchOperation.nalternatives()));
+}
+
+/**
  * The RVSDG theta node expects that the repetition of its body always happens on control value 1.
  * Thus, we need to ensure that the repetition edge of the tail-controlled
  * loop has index 1 in order to avoid miscompilations.
@@ -281,16 +305,12 @@ adjustLoopRepetitionEdge(const StronglyConnectedComponentStructure & sccStructur
   JLM_ASSERT(branchTac->operand(0) == matchTac->result(0));
   auto matchOperation = util::assertedCast<const rvsdg::MatchOperation>(&matchTac->operation());
   JLM_ASSERT(matchOperation->nalternatives() == 2);
-  JLM_ASSERT(matchOperation->default_alternative() == 0);
-  JLM_ASSERT(matchOperation->alternative(1) == 1);
 
-  const size_t numBits = matchOperation->nbits();
+  auto newMatchOperation = invertMatchOperation(*matchOperation);
   auto newMatchOperand = matchTac->operand(0);
   threeAddressCodes.drop_last(); // drop branch operation
   threeAddressCodes.drop_last(); // drop match operation
 
-  auto newMatchOperation = std::unique_ptr<rvsdg::MatchOperation>(
-      new rvsdg::MatchOperation(numBits, { { 0, 1 } }, 0, 2));
   threeAddressCodes.append_last(
       ThreeAddressCode::create(std::move(newMatchOperation), { newMatchOperand }));
   threeAddressCodes.append_last(BranchOperation::create(2, threeAddressCodes.last()->result(0)));

--- a/jlm/llvm/frontend/ControlFlowRestructuringTests.cpp
+++ b/jlm/llvm/frontend/ControlFlowRestructuringTests.cpp
@@ -139,8 +139,9 @@ TEST(ControlFlowRestructuringTests, DoWhileLoopWithWrongRepetitionEdge)
   auto matchTac = *std::next(bb1->tacs().rbegin(), 1);
   auto newMatchOperation = jlm::util::assertedCast<const MatchOperation>(&matchTac->operation());
   EXPECT_EQ(newMatchOperation->nalternatives(), 2u);
-  EXPECT_EQ(newMatchOperation->default_alternative(), 0u);
-  EXPECT_EQ(newMatchOperation->alternative(0), 1u);
+  EXPECT_EQ(newMatchOperation->default_alternative(), 1u);
+  EXPECT_EQ(newMatchOperation->begin()->first, 1u);
+  EXPECT_EQ(newMatchOperation->begin()->second, 0u);
 }
 
 TEST(ControlFlowRestructuringTests, WhileLoop)


### PR DESCRIPTION
The code before relied on a fixed pattern for the match operation as we thought that this would be sufficient. Apparently, it is not. This code just generalizes the pattern by inverting the control values of the match operation.