### PR TITLE
Llvm: Replace byte offset by GEP constants in TracedPointerOrigin struct

### DIFF
--- a/jlm/llvm/ir/Trace.cpp
+++ b/jlm/llvm/ir/Trace.cpp
@@ -139,6 +139,7 @@ TracePointerOriginPrecise(const rvsdg::Output & p)
 {
   // The original pointer p is always equal to base + byte offset
   const rvsdg::Output * base = &p;
+  std::vector<GetElementPtrOperation::Constant> gepConstants;
   int64_t offset = 0;
 
   while (true)
@@ -156,6 +157,11 @@ TracePointerOriginPrecise(const rvsdg::Output & p)
       if (!calculatedOffset.has_value())
         break;
 
+      auto gepConstant = GetElementPtrOperation::tryGetAsConstant(*node);
+      // The offset calculation above succeeded, so this should always succeed as well.
+      JLM_ASSERT(gepConstant.has_value());
+      gepConstants.emplace_back(gepConstant.value());
+
       base = node->input(0)->origin();
       offset += *calculatedOffset;
 
@@ -166,7 +172,7 @@ TracePointerOriginPrecise(const rvsdg::Output & p)
     break;
   }
 
-  return TracedPointerOrigin{ base, offset };
+  return TracedPointerOrigin{ base, offset, gepConstants };
 }
 
 bool

--- a/jlm/llvm/ir/Trace.cpp
+++ b/jlm/llvm/ir/Trace.cpp
@@ -12,9 +12,7 @@
 #include <jlm/llvm/ir/Trace.hpp>
 #include <jlm/llvm/ir/types.hpp>
 #include <jlm/rvsdg/bitstring/constant.hpp>
-#include <jlm/rvsdg/bitstring/type.hpp>
 #include <jlm/rvsdg/gamma.hpp>
-#include <jlm/rvsdg/reduction-helpers.hpp>
 #include <jlm/rvsdg/simple-node.hpp>
 #include <jlm/rvsdg/theta.hpp>
 #include <jlm/rvsdg/Trace.hpp>

--- a/jlm/llvm/ir/Trace.cpp
+++ b/jlm/llvm/ir/Trace.cpp
@@ -14,6 +14,7 @@
 #include <jlm/rvsdg/bitstring/constant.hpp>
 #include <jlm/rvsdg/bitstring/type.hpp>
 #include <jlm/rvsdg/gamma.hpp>
+#include <jlm/rvsdg/reduction-helpers.hpp>
 #include <jlm/rvsdg/simple-node.hpp>
 #include <jlm/rvsdg/theta.hpp>
 #include <jlm/rvsdg/Trace.hpp>
@@ -134,50 +135,56 @@ tryGetConstantSignedInteger(const rvsdg::Output & output)
   return std::nullopt;
 }
 
+std::optional<int64_t>
+TracedPointerOrigin::getOffsetInBytes() const noexcept
+{
+  if (!gepConstants.has_value())
+    return std::nullopt;
+
+  int64_t offsetInBytes = 0;
+  for (auto gepConstant : *gepConstants)
+  {
+    offsetInBytes += gepConstant.getOffsetInBytes();
+  }
+
+  return offsetInBytes;
+}
+
 TracedPointerOrigin
 TracePointerOriginPrecise(const rvsdg::Output & p)
 {
-  // The original pointer p is always equal to base + byte offset
   const rvsdg::Output * base = &p;
   std::vector<GetElementPtrOperation::Constant> gepConstants;
-  int64_t offset = 0;
 
   while (true)
   {
     // Use normalization function to get past all trivially invariant operations
     base = &llvm::traceOutput(*base);
 
-    if (const auto [node, gep] =
+    if (const auto [gepNode, gepOperation] =
             rvsdg::TryGetSimpleNodeAndOptionalOp<GetElementPtrOperation>(*base);
-        gep)
+        gepOperation)
     {
-      auto calculatedOffset = GetElementPtrOperation::CalculateOffset(*node);
-
-      // Only trace through GEPs with statically known offsets
-      if (!calculatedOffset.has_value())
-        break;
-
-      auto gepConstant = GetElementPtrOperation::tryGetAsConstant(*node);
-      // The offset calculation above succeeded, so this should always succeed as well.
-      JLM_ASSERT(gepConstant.has_value());
-      gepConstants.emplace_back(gepConstant.value());
-
-      base = node->input(0)->origin();
-      offset += *calculatedOffset;
-
-      continue;
+      if (const auto gepConstantOpt = GetElementPtrOperation::tryGetAsConstant(*gepNode);
+          gepConstantOpt.has_value())
+      {
+        base = gepNode->input(0)->origin();
+        gepConstants.emplace_back(gepConstantOpt.value());
+        continue;
+      }
     }
 
     // We were not able to trace further
     break;
   }
 
-  return TracedPointerOrigin{ base, offset, gepConstants };
+  return TracedPointerOrigin{ base, gepConstants };
 }
 
-bool
-TraceAllPointerOrigins(
-    TracedPointerOrigin p,
+static bool
+traceAllPointerOriginsInternal(
+    const rvsdg::Output * basePointer,
+    std::optional<int64_t> offsetInBytes,
     TraceCollection & traceCollection,
     const size_t maxTraceCollectionSize)
 {
@@ -185,9 +192,9 @@ TraceAllPointerOrigins(
     return false;
 
   // Normalize the pointer first, to avoid tracing trivial temporary outputs
-  p.BasePointer = &llvm::traceOutput(*p.BasePointer);
+  basePointer = &llvm::traceOutput(*basePointer);
 
-  auto it = traceCollection.AllTracedOutputs.find(p.BasePointer);
+  auto it = traceCollection.AllTracedOutputs.find(basePointer);
   if (it != traceCollection.AllTracedOutputs.end())
   {
     // If the base pointer has already been traced with an unknown offset, we have nothing to add
@@ -198,66 +205,75 @@ TraceAllPointerOrigins(
     const auto prevOffset = *it->second;
 
     // If we are visiting the same base pointer again with the same offset, we have nothing to add
-    if (p.Offset.has_value() && *p.Offset == prevOffset)
+    if (offsetInBytes.has_value() && *offsetInBytes == prevOffset)
       return true;
 
     // We have different offsets to last time, collapse to unknown offset
-    p.Offset = std::nullopt;
+    offsetInBytes = std::nullopt;
   }
 
-  traceCollection.AllTracedOutputs[p.BasePointer] = p.Offset;
+  traceCollection.AllTracedOutputs[basePointer] = offsetInBytes;
 
   // If it is a GEP, we can trace through it, but possibly lose precise offset information
   if (const auto [node, gep] =
-          rvsdg::TryGetSimpleNodeAndOptionalOp<GetElementPtrOperation>(*p.BasePointer);
+          rvsdg::TryGetSimpleNodeAndOptionalOp<GetElementPtrOperation>(*basePointer);
       gep)
   {
     // Update the base pointer and offset to represent the other side of the GEP
-    p.BasePointer = node->input(0)->origin();
+    basePointer = node->input(0)->origin();
 
     // If we have precisely tracked the offset so far, try updating it with the GEPs offset
-    if (p.Offset.has_value())
+    if (offsetInBytes.has_value())
     {
       const auto gepOffset = GetElementPtrOperation::CalculateOffset(*node);
       if (gepOffset.has_value())
-        p.Offset = *p.Offset + *gepOffset;
+        offsetInBytes = *offsetInBytes + *gepOffset;
       else
-        p.Offset = std::nullopt;
+        offsetInBytes = std::nullopt;
     }
 
-    return TraceAllPointerOrigins(p, traceCollection, maxTraceCollectionSize);
+    return traceAllPointerOriginsInternal(
+        basePointer,
+        offsetInBytes,
+        traceCollection,
+        maxTraceCollectionSize);
   }
 
   // If the node is a \ref SelectOperation, trace through both possible inputs
   if (const auto [node, select] =
-          rvsdg::TryGetSimpleNodeAndOptionalOp<SelectOperation>(*p.BasePointer);
+          rvsdg::TryGetSimpleNodeAndOptionalOp<SelectOperation>(*basePointer);
       select)
   {
-    auto leftTrace = p;
-    leftTrace.BasePointer = node->input(1)->origin();
-    auto rightTrace = p;
-    rightTrace.BasePointer = node->input(2)->origin();
-
-    return TraceAllPointerOrigins(leftTrace, traceCollection, maxTraceCollectionSize)
-        && TraceAllPointerOrigins(rightTrace, traceCollection, maxTraceCollectionSize);
+    return traceAllPointerOriginsInternal(
+               node->input(1)->origin(),
+               offsetInBytes,
+               traceCollection,
+               maxTraceCollectionSize)
+        && traceAllPointerOriginsInternal(
+               node->input(2)->origin(),
+               offsetInBytes,
+               traceCollection,
+               maxTraceCollectionSize);
   }
 
   // If we reach undef nodes, do not include them in the TopOrigins
-  if (rvsdg::IsOwnerNodeOperation<UndefValueOperation>(*p.BasePointer))
+  if (rvsdg::IsOwnerNodeOperation<UndefValueOperation>(*basePointer))
   {
     return true;
   }
 
   // Trace into gamma nodes
-  if (auto gamma = rvsdg::TryGetOwnerNode<rvsdg::GammaNode>(*p.BasePointer))
+  if (auto gamma = rvsdg::TryGetOwnerNode<rvsdg::GammaNode>(*basePointer))
   {
-    auto exitVar = gamma->MapOutputExitVar(*p.BasePointer);
+    auto exitVar = gamma->MapOutputExitVar(*basePointer);
     for (auto result : exitVar.branchResult)
     {
-      TracedPointerOrigin inside = { result->origin(), p.Offset };
-
       // If tracing gives up, we give up
-      if (!TraceAllPointerOrigins(inside, traceCollection, maxTraceCollectionSize))
+      if (!traceAllPointerOriginsInternal(
+              result->origin(),
+              offsetInBytes,
+              traceCollection,
+              maxTraceCollectionSize))
         return false;
     }
 
@@ -265,20 +281,35 @@ TraceAllPointerOrigins(
   }
 
   // Trace into theta nodes
-  if (auto theta = rvsdg::TryGetOwnerNode<rvsdg::ThetaNode>(*p.BasePointer))
+  if (auto theta = rvsdg::TryGetOwnerNode<rvsdg::ThetaNode>(*basePointer))
   {
-    auto loopVar = theta->MapOutputLoopVar(*p.BasePointer);
+    auto loopVar = theta->MapOutputLoopVar(*basePointer);
 
     // Invariant loop variables should already have been handled by normalization
     JLM_ASSERT(!rvsdg::ThetaLoopVarIsInvariant(loopVar));
-
-    TracedPointerOrigin inside = { loopVar.post->origin(), p.Offset };
-    return TraceAllPointerOrigins(inside, traceCollection, maxTraceCollectionSize);
+    return traceAllPointerOriginsInternal(
+        loopVar.post->origin(),
+        offsetInBytes,
+        traceCollection,
+        maxTraceCollectionSize);
   }
 
   // We could not trace further, add p as a TopOrigin
-  traceCollection.TopOrigins[p.BasePointer] = p.Offset;
+  traceCollection.TopOrigins[basePointer] = offsetInBytes;
   return true;
+}
+
+bool
+TraceAllPointerOrigins(
+    TracedPointerOrigin p,
+    TraceCollection & traceCollection,
+    const size_t maxTraceCollectionSize)
+{
+  return traceAllPointerOriginsInternal(
+      p.BasePointer,
+      p.getOffsetInBytes(),
+      traceCollection,
+      maxTraceCollectionSize);
 }
 
 }

--- a/jlm/llvm/ir/Trace.hpp
+++ b/jlm/llvm/ir/Trace.hpp
@@ -93,8 +93,11 @@ tryGetConstantSignedInteger(const rvsdg::Output & output);
  */
 struct TracedPointerOrigin
 {
+  // FIXME: documentation
+  [[nodiscard]] std::optional<int64_t>
+  getOffsetInBytes() const noexcept;
+
   const rvsdg::Output * BasePointer = nullptr;
-  std::optional<int64_t> Offset;
   std::optional<std::vector<GetElementPtrOperation::Constant>> gepConstants{};
 };
 

--- a/jlm/llvm/ir/Trace.hpp
+++ b/jlm/llvm/ir/Trace.hpp
@@ -6,6 +6,7 @@
 #ifndef JLM_LLVM_IR_TRACE_HPP
 #define JLM_LLVM_IR_TRACE_HPP
 
+#include <jlm/llvm/ir/operators/GetElementPtr.hpp>
 #include <jlm/rvsdg/node.hpp>
 #include <jlm/rvsdg/Trace.hpp>
 
@@ -78,6 +79,8 @@ traceOutput(const rvsdg::Output & output, const rvsdg::Region * withinRegion = n
 std::optional<int64_t>
 tryGetConstantSignedInteger(const rvsdg::Output & output);
 
+// FIXME: update documentation
+
 /**
  * Represents the result of tracing a pointer p to some origin,
  * as a traced base pointer value plus an optional byte offset.
@@ -92,6 +95,7 @@ struct TracedPointerOrigin
 {
   const rvsdg::Output * BasePointer = nullptr;
   std::optional<int64_t> Offset;
+  std::optional<std::vector<GetElementPtrOperation::Constant>> gepConstants{};
 };
 
 /**

--- a/jlm/llvm/ir/Trace.hpp
+++ b/jlm/llvm/ir/Trace.hpp
@@ -79,21 +79,22 @@ traceOutput(const rvsdg::Output & output, const rvsdg::Region * withinRegion = n
 std::optional<int64_t>
 tryGetConstantSignedInteger(const rvsdg::Output & output);
 
-// FIXME: update documentation
-
 /**
  * Represents the result of tracing a pointer p to some origin,
- * as a traced base pointer value plus an optional byte offset.
+ * as a traced base pointer value plus the encountered statically known \ref GetElementPtrOperation
+ * offsets.
  *
- * If the offset is present, that means
- *  p = base pointer + offset
+ * If the offsets are present, that means
+ *  p = base pointer + offsets
  *
- * If the offset is not present, that means
+ * If the offsets are not present, that means
  *  p = base pointer + [unknown offset]
  */
 struct TracedPointerOrigin
 {
-  // FIXME: documentation
+  /**
+   * @return Return the offset in bytes of the traced pointer if possible, otherwise std::nullopt.
+   */
   [[nodiscard]] std::optional<int64_t>
   getOffsetInBytes() const noexcept;
 

--- a/jlm/llvm/ir/operators/GetElementPtr.cpp
+++ b/jlm/llvm/ir/operators/GetElementPtr.cpp
@@ -160,7 +160,7 @@ GetElementPtrOperation::CalculateOffset(const rvsdg::SimpleNode & gepNode)
 int64_t
 GetElementPtrOperation::Constant::getOffsetInBytes() const noexcept
 {
-  JLM_ASSERT(indices.size() >= 2);
+  JLM_ASSERT(indices.size() >= 1);
 
   std::function<uint64_t(size_t, const rvsdg::Type &)> computeIntraTypeOffset =
       [&](const size_t index, const rvsdg::Type & type)

--- a/jlm/llvm/opt/StoreValueForwarding.cpp
+++ b/jlm/llvm/opt/StoreValueForwarding.cpp
@@ -874,7 +874,8 @@ StoreValueForwarding::traceLoadWithoutMemoryStates(const rvsdg::SimpleNode & loa
 
   auto & loadAddress = *LoadOperation::AddressInput(loadNode).origin();
   const auto tracedAddress = TracePointerOriginPrecise(loadAddress);
-  if (!tracedAddress.Offset.has_value())
+  auto offsetInBytesOpt = tracedAddress.getOffsetInBytes();
+  if (!offsetInBytesOpt.has_value())
   {
     return std::nullopt;
   }
@@ -886,7 +887,7 @@ StoreValueForwarding::traceLoadWithoutMemoryStates(const rvsdg::SimpleNode & loa
   }
 
   context_->numLoadsTracedToDeltaNode++;
-  return std::optional<TracedDelta>({ deltaNode, tracedAddress.Offset.value() });
+  return std::optional<TracedDelta>({ deltaNode, offsetInBytesOpt.value() });
 }
 
 void

--- a/jlm/llvm/opt/alias-analyses/LocalAliasAnalysis.cpp
+++ b/jlm/llvm/opt/alias-analyses/LocalAliasAnalysis.cpp
@@ -61,7 +61,9 @@ LocalAliasAnalysis::Query(const rvsdg::Output & p1, size_t s1, const rvsdg::Outp
   // to avoid giving up on MustAlias prematurely
   const auto p1Traced = TracePointerOriginPrecise(p1Norm);
   const auto p2Traced = TracePointerOriginPrecise(p2Norm);
-  JLM_ASSERT(p1Traced.Offset.has_value() && p2Traced.Offset.has_value());
+  auto p1OffsetInBytesOpt = p1Traced.getOffsetInBytes();
+  auto p2OffsetInBytesOpt = p2Traced.getOffsetInBytes();
+  JLM_ASSERT(p1OffsetInBytesOpt.has_value() && p2OffsetInBytesOpt.has_value());
 
   if (p1Traced.BasePointer == p2Traced.BasePointer)
   {
@@ -69,7 +71,7 @@ LocalAliasAnalysis::Query(const rvsdg::Output & p1, size_t s1, const rvsdg::Outp
     // p1 = base + p1Offset
     // p2 = base + p2Offset
 
-    return QueryOffsets(p1Traced.Offset, s1, p2Traced.Offset, s2);
+    return QueryOffsets(p1OffsetInBytesOpt, s1, p2OffsetInBytesOpt, s2);
   }
 
   // If the max trace collection size is set to 1,
@@ -117,12 +119,12 @@ LocalAliasAnalysis::Query(const rvsdg::Output & p1, size_t s1, const rvsdg::Outp
 
   // In case the trace collections contain unknown offsets, also try using the
   // precise p1Traced and p2Traced, which always have a known offset
-  if (*p1Traced.Offset > 0)
+  if (*p1OffsetInBytesOpt > 0)
     minimumP1OffsetFromStart =
-        std::max(minimumP1OffsetFromStart, static_cast<size_t>(*p1Traced.Offset));
-  if (*p2Traced.Offset > 0)
+        std::max(minimumP1OffsetFromStart, static_cast<size_t>(*p1OffsetInBytesOpt));
+  if (*p2OffsetInBytesOpt > 0)
     minimumP2OffsetFromStart =
-        std::max(minimumP2OffsetFromStart, static_cast<size_t>(*p2Traced.Offset));
+        std::max(minimumP2OffsetFromStart, static_cast<size_t>(*p2OffsetInBytesOpt));
 
   // Since we have given up on MustAlias, we can remove some targets even if they are valid.
   // Even if p1 might point to an 4-byte int foo,
@@ -264,20 +266,22 @@ LocalAliasAnalysis::GetOriginalOriginSize(const rvsdg::Output & pointer)
 }
 
 std::optional<size_t>
-LocalAliasAnalysis::GetRemainingSize(TracedPointerOrigin trace)
+LocalAliasAnalysis::GetRemainingSize(
+    const rvsdg::Output & basePointer,
+    const std::optional<int64_t> & offsetInBytes)
 {
-  const auto totalSize = GetOriginalOriginSize(*trace.BasePointer);
+  const auto totalSize = GetOriginalOriginSize(basePointer);
   if (!totalSize.has_value())
     return std::nullopt;
 
-  if (!trace.Offset.has_value())
+  if (!offsetInBytes.has_value())
     return *totalSize;
 
   // Avoid wrap-around by truncating remaining size to min 0
-  if (*trace.Offset > 0 && static_cast<size_t>(*trace.Offset) > *totalSize)
+  if (*offsetInBytes > 0 && static_cast<size_t>(*offsetInBytes) > *totalSize)
     return 0;
 
-  return *totalSize - *trace.Offset;
+  return *totalSize - *offsetInBytes;
 }
 
 void
@@ -286,7 +290,7 @@ LocalAliasAnalysis::RemoveTopOriginsWithRemainingSizeBelow(TraceCollection & tra
   auto it = traces.TopOrigins.begin();
   while (it != traces.TopOrigins.end())
   {
-    const auto remainingSize = GetRemainingSize({ it->first, it->second });
+    const auto remainingSize = GetRemainingSize(*it->first, it->second);
     if (remainingSize.has_value())
     {
       // This top origin leaves too little room, and can be fully removed

--- a/jlm/llvm/opt/alias-analyses/LocalAliasAnalysis.hpp
+++ b/jlm/llvm/opt/alias-analyses/LocalAliasAnalysis.hpp
@@ -115,11 +115,12 @@ private:
    * If the offset is larger than the size of the target, the size 0 is returned.
    * If the offset is unknown, the size of the target is returned.
    *
-   * @param trace the traced pointer
+   * @param basePointer The base pointer of the traced pointer.
+   * @param offsetInBytes The offset in bytes of the traced pointer.
    * @return the number of bytes left after the given traced pointer, or nullopt if unknown.
    */
   [[nodiscard]] static std::optional<size_t>
-  GetRemainingSize(TracedPointerOrigin trace);
+  GetRemainingSize(const rvsdg::Output & basePointer, const std::optional<int64_t> & offsetInBytes);
 
   /**
    * For each top origin in the given trace collection, it is removed if it is deemed too small.


### PR DESCRIPTION
The GEP constants are more general than the offset in bytes. They can be used to compute the offset in bytes if it is required later.