### PR TITLE
Updated unit tests to compile on MAC

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/DeadNodeEliminationTests.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/DeadNodeEliminationTests.cpp
@@ -37,7 +37,7 @@ TEST(DeadNodeEliminationTests, TestDeadLoopNode)
   EliminateDeadNodes(rvsdgModule);
 
   // Assert
-  EXPECT_EQ(lambdaNode->subregion()->numNodes(), 0);
+  EXPECT_EQ(lambdaNode->subregion()->numNodes(), 0u);
 }
 
 TEST(DeadNodeEliminationTests, TestDeadLoopNodeOutput)
@@ -78,8 +78,8 @@ TEST(DeadNodeEliminationTests, TestDeadLoopNodeOutput)
   EliminateDeadNodes(rvsdgModule);
 
   // Assert
-  EXPECT_EQ(loopNode->noutputs(), 1);
-  EXPECT_EQ(loopNode->ninputs(), 2); // I believe that it actually should only have one input.
+  EXPECT_EQ(loopNode->noutputs(), 1u);
+  EXPECT_EQ(loopNode->ninputs(), 2u); // I believe that it actually should only have one input.
   // FIXME: The DNE seems to already be broken for a simple dead edge through it. It removes the
   // output from the loop node, but then seems to fail to remove the corresponding input, arguments,
   // and results.

--- a/jlm/hls/backend/rvsdg2rhls/DistributeConstantsTests.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/DistributeConstantsTests.cpp
@@ -65,23 +65,23 @@ TEST(DistributeConstantsTests, GammaSubregionUsage)
   view(rvsdg, stdout);
 
   // Assert
-  EXPECT_EQ(lambdaNode->subregion()->numNodes(), 2);
+  EXPECT_EQ(lambdaNode->subregion()->numNodes(), 2u);
 
   {
     // check subregion 0 - we expect the constantNode to be distributed into this subregion
-    EXPECT_EQ(gammaNode->subregion(0)->numNodes(), 2);
+    EXPECT_EQ(gammaNode->subregion(0)->numNodes(), 2u);
     EXPECT_TRUE(IsOwnerNodeOperation<IntegerConstantOperation>(*testNode0->input(0)->origin()));
   }
 
   {
     // check subregion 1 - we expect the constantNode to be distributed into this subregion
-    EXPECT_EQ(gammaNode->subregion(1)->numNodes(), 2);
+    EXPECT_EQ(gammaNode->subregion(1)->numNodes(), 2u);
     EXPECT_TRUE(IsOwnerNodeOperation<IntegerConstantOperation>(*testNode1->input(0)->origin()));
   }
 
   {
     // check subregion 2 - we expect the constantNode to be distributed into this subregion
-    EXPECT_EQ(gammaNode->subregion(2)->numNodes(), 1);
+    EXPECT_EQ(gammaNode->subregion(2)->numNodes(), 1u);
     EXPECT_TRUE(
         IsOwnerNodeOperation<IntegerConstantOperation>(*exitVariable.branchResult[2]->origin()));
   }
@@ -145,11 +145,11 @@ TEST(DistributeConstantsTests, NestedGammas)
   view(rvsdg, stdout);
 
   // Assert
-  EXPECT_EQ(lambdaNode->subregion()->numNodes(), 3);
+  EXPECT_EQ(lambdaNode->subregion()->numNodes(), 3u);
 
   {
     // check gammaNodeOuter subregion 0
-    EXPECT_EQ(gammaNodeOuter->subregion(0)->numNodes(), 2);
+    EXPECT_EQ(gammaNodeOuter->subregion(0)->numNodes(), 2u);
     EXPECT_TRUE(IsOwnerNodeOperation<IntegerConstantOperation>(*testNode0->input(0)->origin()));
   }
 
@@ -157,16 +157,16 @@ TEST(DistributeConstantsTests, NestedGammas)
     // check gammaNodeOuter subregion 1
     // The constantNode was copied into this region (even though it does not have a user), so we
     // expect one more node than before the transformation.
-    EXPECT_EQ(gammaNodeOuter->subregion(1)->numNodes(), 3);
+    EXPECT_EQ(gammaNodeOuter->subregion(1)->numNodes(), 3u);
 
     {
       // check gammaNodeInner subregion 0
-      EXPECT_EQ(gammaNodeInner->subregion(0)->numNodes(), 0);
+      EXPECT_EQ(gammaNodeInner->subregion(0)->numNodes(), 0u);
     }
 
     {
       // check gammaNodeInner subregion 1
-      EXPECT_EQ(gammaNodeInner->subregion(1)->numNodes(), 0);
+      EXPECT_EQ(gammaNodeInner->subregion(1)->numNodes(), 0u);
     }
   }
 
@@ -227,10 +227,10 @@ TEST(DistributeConstantsTests, Theta)
 
   // Arrange
   // We expect constantNode1 to be distributed from the theta subregion to the lambda subregion
-  EXPECT_EQ(lambdaNode->subregion()->numNodes(), 5);
+  EXPECT_EQ(lambdaNode->subregion()->numNodes(), 5u);
 
   // We expect constantNode2 to be distributed from the lambda subregion to the theta subregion
-  EXPECT_EQ(thetaNode->subregion()->numNodes(), 5);
+  EXPECT_EQ(thetaNode->subregion()->numNodes(), 5u);
 
   {
     // We expect no changes with loopVar0
@@ -253,7 +253,7 @@ TEST(DistributeConstantsTests, Theta)
         TryGetSimpleNodeAndOptionalOp<IntegerConstantOperation>(
             *lambdaNode->subregion()->result(1)->origin());
     EXPECT_TRUE(constantNode && constantOperation);
-    EXPECT_EQ(constantOperation->Representation(), 1);
+    EXPECT_EQ(constantOperation->Representation(), 1u);
   }
 
   {
@@ -270,7 +270,7 @@ TEST(DistributeConstantsTests, Theta)
     auto [constantNode, constantOperation] =
         TryGetSimpleNodeAndOptionalOp<IntegerConstantOperation>(*testNode2->input(0)->origin());
     EXPECT_TRUE(constantNode && constantOperation);
-    EXPECT_EQ(constantOperation->Representation(), 2);
+    EXPECT_EQ(constantOperation->Representation(), 2u);
   }
 }
 
@@ -307,5 +307,5 @@ TEST(DistributeConstantsTests, Lambda)
 
   // Arrange
   // We expect no change at all in the graph
-  EXPECT_EQ(lambdaNode->subregion()->numNodes(), 1);
+  EXPECT_EQ(lambdaNode->subregion()->numNodes(), 1u);
 }

--- a/jlm/hls/backend/rvsdg2rhls/ForkTests.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/ForkTests.cpp
@@ -59,20 +59,20 @@ TEST(ForkInsertionTests, ForkInsertion)
 
   // Assert
   {
-    EXPECT_EQ(rootRegion.numNodes(), 1);
+    EXPECT_EQ(rootRegion.numNodes(), 1u);
     auto lambda = util::assertedCast<jlm::rvsdg::LambdaNode>(rootRegion.Nodes().begin().ptr());
     EXPECT_NE(dynamic_cast<const jlm::rvsdg::LambdaNode *>(lambda), nullptr);
 
     auto lambdaSubregion = lambda->subregion();
-    EXPECT_EQ(lambdaSubregion->numNodes(), 1);
+    EXPECT_EQ(lambdaSubregion->numNodes(), 1u);
     auto loop = util::assertedCast<hls::LoopNode>(lambdaSubregion->Nodes().begin().ptr());
     EXPECT_NE(dynamic_cast<const hls::LoopNode *>(loop), nullptr);
 
     auto [forkNode, forkOperation] = rvsdg::TryGetSimpleNodeAndOptionalOp<hls::ForkOperation>(
         *loop->subregion()->result(0)->origin());
     EXPECT_TRUE(forkNode && forkOperation);
-    EXPECT_EQ(forkNode->ninputs(), 1);
-    EXPECT_EQ(forkNode->noutputs(), 4);
+    EXPECT_EQ(forkNode->ninputs(), 1u);
+    EXPECT_EQ(forkNode->noutputs(), 4u);
     EXPECT_FALSE(forkOperation->IsConstant());
   }
 }
@@ -117,12 +117,12 @@ TEST(SinkInsertionTests, ConstantForkInsertion)
 
   // Assert
   {
-    EXPECT_EQ(rootRegion.numNodes(), 1);
+    EXPECT_EQ(rootRegion.numNodes(), 1u);
     auto lambda = util::assertedCast<jlm::rvsdg::LambdaNode>(rootRegion.Nodes().begin().ptr());
     EXPECT_TRUE(rvsdg::is<jlm::rvsdg::LambdaOperation>(lambda));
 
     auto lambdaRegion = lambda->subregion();
-    EXPECT_EQ(lambdaRegion->numNodes(), 1);
+    EXPECT_EQ(lambdaRegion->numNodes(), 1u);
 
     const rvsdg::NodeOutput * loopOutput =
         dynamic_cast<jlm::rvsdg::NodeOutput *>(lambdaRegion->result(0)->origin());
@@ -134,16 +134,16 @@ TEST(SinkInsertionTests, ConstantForkInsertion)
     auto [forkNode, forkOperation] = rvsdg::TryGetSimpleNodeAndOptionalOp<hls::ForkOperation>(
         *loop->subregion()->result(0)->origin());
     EXPECT_TRUE(forkNode && forkOperation);
-    EXPECT_EQ(forkNode->ninputs(), 1);
-    EXPECT_EQ(forkNode->noutputs(), 2);
+    EXPECT_EQ(forkNode->ninputs(), 1u);
+    EXPECT_EQ(forkNode->noutputs(), 2u);
     EXPECT_FALSE(forkOperation->IsConstant());
 
     auto matchNode = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(*forkNode->input(0)->origin());
     auto bitsUltNode = rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(*matchNode->input(0)->origin());
     auto [cForkNode, cForkOperation] =
         rvsdg::TryGetSimpleNodeAndOptionalOp<hls::ForkOperation>(*bitsUltNode->input(1)->origin());
-    EXPECT_EQ(cForkNode->ninputs(), 1);
-    EXPECT_EQ(cForkNode->noutputs(), 2);
+    EXPECT_EQ(cForkNode->ninputs(), 1u);
+    EXPECT_EQ(cForkNode->noutputs(), 2u);
     EXPECT_TRUE(cForkOperation->IsConstant());
   }
 }

--- a/jlm/hls/backend/rvsdg2rhls/MemoryConverterTests.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/MemoryConverterTests.cpp
@@ -61,15 +61,15 @@ TEST(MemoryConverterTests, TestTraceArgument)
   jlm::rvsdg::view(rvsdgModule->Rvsdg(), stdout);
 
   // Assert
-  EXPECT_EQ(tracedPointerNodesVector.size(), 2);               // 2 pointer arguments
-  EXPECT_EQ(tracedPointerNodesVector[0].loadNodes.size(), 1);  // 1 load for the first pointer
-  EXPECT_EQ(tracedPointerNodesVector[0].storeNodes.size(), 0); // 0 store for the first pointer
+  EXPECT_EQ(tracedPointerNodesVector.size(), 2u);               // 2 pointer arguments
+  EXPECT_EQ(tracedPointerNodesVector[0].loadNodes.size(), 1u);  // 1 load for the first pointer
+  EXPECT_EQ(tracedPointerNodesVector[0].storeNodes.size(), 0u); // 0 store for the first pointer
   EXPECT_EQ(
       tracedPointerNodesVector[0].decoupleNodes.size(),
-      0);                                                      // 0 decouple for the first pointer
-  EXPECT_EQ(tracedPointerNodesVector[1].loadNodes.size(), 0);  // 0 load for the first pointer
-  EXPECT_EQ(tracedPointerNodesVector[1].storeNodes.size(), 1); // 1 store for the second pointer
-  EXPECT_EQ(tracedPointerNodesVector[1].decoupleNodes.size(), 0); // 0 load for the first pointer
+      0u);                                                      // 0 decouple for the first pointer
+  EXPECT_EQ(tracedPointerNodesVector[1].loadNodes.size(), 0u);  // 0 load for the first pointer
+  EXPECT_EQ(tracedPointerNodesVector[1].storeNodes.size(), 1u); // 1 store for the second pointer
+  EXPECT_EQ(tracedPointerNodesVector[1].decoupleNodes.size(), 0u); // 0 load for the first pointer
 }
 
 TEST(MemoryConverterTests, TestLoad)
@@ -111,14 +111,14 @@ TEST(MemoryConverterTests, TestLoad)
 
   // Memory Converter replaces the lambda so we start from the root of the graph
   auto region = &rvsdgModule->Rvsdg().GetRootRegion();
-  EXPECT_EQ(region->numNodes(), 1);
+  EXPECT_EQ(region->numNodes(), 1u);
   lambda = jlm::util::assertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
 
   // Assert
   auto lambdaRegion = lambda->subregion();
-  EXPECT_EQ(lambdaRegion->numNodes(), 3);
-  EXPECT_EQ(lambdaRegion->narguments(), 3);
-  EXPECT_EQ(lambdaRegion->nresults(), 3);
+  EXPECT_EQ(lambdaRegion->numNodes(), 3u);
+  EXPECT_EQ(lambdaRegion->narguments(), 3u);
+  EXPECT_EQ(lambdaRegion->nresults(), 3u);
 
   // Memory state
   EXPECT_TRUE(is<MemoryStateType>(lambdaRegion->result(1)->origin()->Type()));
@@ -146,7 +146,7 @@ TEST(MemoryConverterTests, TestLoad)
   // Response source
   auto responseSource = responseNode->input(0)->origin();
   auto regionArgument = jlm::util::assertedCast<jlm::rvsdg::RegionArgument>(responseSource);
-  EXPECT_EQ(regionArgument->index(), 2);
+  EXPECT_EQ(regionArgument->index(), 2u);
 }
 
 TEST(MemoryConverterTests, TestStore)
@@ -188,14 +188,14 @@ TEST(MemoryConverterTests, TestStore)
 
   // Memory Converter replaces the lambda so we start from the root of the graph
   auto region = &rvsdgModule->Rvsdg().GetRootRegion();
-  EXPECT_EQ(region->numNodes(), 1);
+  EXPECT_EQ(region->numNodes(), 1u);
   lambda = jlm::util::assertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
 
   // Assert
   auto lambdaRegion = lambda->subregion();
-  EXPECT_EQ(lambdaRegion->numNodes(), 4);
-  EXPECT_EQ(lambdaRegion->narguments(), 4);
-  EXPECT_EQ(lambdaRegion->nresults(), 2);
+  EXPECT_EQ(lambdaRegion->numNodes(), 4u);
+  EXPECT_EQ(lambdaRegion->narguments(), 4u);
+  EXPECT_EQ(lambdaRegion->nresults(), 2u);
 
   EXPECT_TRUE(is<MemoryStateType>(lambdaRegion->result(0)->origin()->Type()));
   auto bufferNode =
@@ -257,14 +257,14 @@ TEST(MemoryConverterTests, TestLoadStore)
 
   // Memory Converter replaces the lambda so we start from the root of the graph
   auto region = &rvsdgModule->Rvsdg().GetRootRegion();
-  EXPECT_EQ(region->numNodes(), 1);
+  EXPECT_EQ(region->numNodes(), 1u);
   lambda = jlm::util::assertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
 
   // Assert
   auto lambdaRegion = lambda->subregion();
-  EXPECT_EQ(lambdaRegion->numNodes(), 7);
-  EXPECT_EQ(lambdaRegion->narguments(), 5);
-  EXPECT_EQ(lambdaRegion->nresults(), 3);
+  EXPECT_EQ(lambdaRegion->numNodes(), 7u);
+  EXPECT_EQ(lambdaRegion->narguments(), 5u);
+  EXPECT_EQ(lambdaRegion->nresults(), 3u);
 
   std::cout << lambdaRegion->result(0)->origin()->Type()->debug_string() << std::endl;
   EXPECT_TRUE(is<MemoryStateType>(lambdaRegion->result(0)->origin()->Type()));
@@ -376,7 +376,7 @@ TEST(MemoryConverterTests, TestThetaLoad)
 
   // Memory Converter replaces the lambda so we start from the root of the graph
   auto region = &rvsdgModule->Rvsdg().GetRootRegion();
-  EXPECT_EQ(region->numNodes(), 1);
+  EXPECT_EQ(region->numNodes(), 1u);
   lambda = jlm::util::assertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
   lambdaRegion = lambda->subregion();
 
@@ -395,7 +395,7 @@ TEST(MemoryConverterTests, TestThetaLoad)
   EXPECT_NE(dynamic_cast<const LoopNode *>(loopNode), nullptr);
   // Loop Result
   auto & thetaResult = loopOutput->results;
-  EXPECT_EQ(thetaResult.size(), 1);
+  EXPECT_EQ(thetaResult.size(), 1u);
   // Load Node
   auto loadNode =
       jlm::util::assertedCast<const jlm::rvsdg::NodeOutput>(thetaResult.first()->origin())->node();
@@ -503,7 +503,7 @@ TEST(MemoryConverterTests, TestThetaStore)
 
   // Memory Converter replaces the lambda so we start from the root of the graph
   auto region = &rvsdgModule->Rvsdg().GetRootRegion();
-  EXPECT_EQ(region->numNodes(), 1);
+  EXPECT_EQ(region->numNodes(), 1u);
   lambda = jlm::util::assertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
   lambdaRegion = lambda->subregion();
 
@@ -521,7 +521,7 @@ TEST(MemoryConverterTests, TestThetaStore)
   EXPECT_NE(dynamic_cast<const LoopNode *>(loopNode), nullptr);
   // Loop Result
   auto & thetaResult = loopOutput->results;
-  EXPECT_EQ(thetaResult.size(), 1);
+  EXPECT_EQ(thetaResult.size(), 1u);
   // Load Node
   auto storeNode =
       jlm::util::assertedCast<const jlm::rvsdg::NodeOutput>(thetaResult.first()->origin())->node();

--- a/jlm/hls/backend/rvsdg2rhls/MemoryStateSplitConversionTests.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/MemoryStateSplitConversionTests.cpp
@@ -55,13 +55,13 @@ TEST(MemoryStateSplitConversionTests, SplitConversion)
   view(rvsdg, stdout);
 
   // Assert
-  EXPECT_EQ(rvsdg.GetRootRegion().numNodes(), 2);
-  EXPECT_EQ(structuralNode->subregion(0)->numNodes(), 1);
+  EXPECT_EQ(rvsdg.GetRootRegion().numNodes(), 2u);
+  EXPECT_EQ(structuralNode->subregion(0)->numNodes(), 1u);
 
   // The memory state split conversion pass should have replaced the
   // LambdaEntryMemoryStateSplitOperation node with a ForkOperation node
   {
-    EXPECT_EQ(outputVar0.output->nusers(), 1);
+    EXPECT_EQ(outputVar0.output->nusers(), 1u);
     EXPECT_TRUE(IsOwnerNodeOperation<ForkOperation>(*inputVar.argument[0]->Users().begin()));
   }
 

--- a/jlm/hls/backend/rvsdg2rhls/RedundantBufferEliminationTests.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/RedundantBufferEliminationTests.cpp
@@ -45,10 +45,10 @@ TEST(RedundantBufferEliminationTests, BufferWithLocalLoad)
 
   // Assert
   // We expect the BufferOperation node to be replaced by a passthrough BufferOperation node
-  EXPECT_EQ(rvsdg.GetRootRegion().numNodes(), 2);
+  EXPECT_EQ(rvsdg.GetRootRegion().numNodes(), 2u);
   auto [bufferNode, bufferOperation] = TryGetSimpleNodeAndOptionalOp<BufferOperation>(*x.origin());
   EXPECT_TRUE(bufferNode && bufferOperation);
-  EXPECT_EQ(bufferOperation->Capacity(), 4);
+  EXPECT_EQ(bufferOperation->Capacity(), 4u);
   EXPECT_TRUE(bufferOperation->IsPassThrough());
 }
 
@@ -85,10 +85,10 @@ TEST(RedundantBufferEliminationTests, BufferWithLocalStore)
 
   // Assert
   // We expect the BufferOperation node to be replaced by a passthrough BufferOperation node
-  EXPECT_EQ(rvsdg.GetRootRegion().numNodes(), 2);
+  EXPECT_EQ(rvsdg.GetRootRegion().numNodes(), 2u);
   auto [bufferNode, bufferOperation] = TryGetSimpleNodeAndOptionalOp<BufferOperation>(*x.origin());
   EXPECT_TRUE(bufferNode && bufferOperation);
-  EXPECT_EQ(bufferOperation->Capacity(), 4);
+  EXPECT_EQ(bufferOperation->Capacity(), 4u);
   EXPECT_TRUE(bufferOperation->IsPassThrough());
 }
 
@@ -125,10 +125,10 @@ TEST(RedundantBufferEliminationTests, BufferWithLoad)
 
   // Assert
   // We expect the BufferOperation node to be replaced by a passthrough BufferOperation node
-  EXPECT_EQ(rvsdg.GetRootRegion().numNodes(), 2);
+  EXPECT_EQ(rvsdg.GetRootRegion().numNodes(), 2u);
   auto [bufferNode, bufferOperation] = TryGetSimpleNodeAndOptionalOp<BufferOperation>(*x.origin());
   EXPECT_TRUE(bufferNode && bufferOperation);
-  EXPECT_EQ(bufferOperation->Capacity(), 4);
+  EXPECT_EQ(bufferOperation->Capacity(), 4u);
   EXPECT_TRUE(bufferOperation->IsPassThrough());
 }
 
@@ -170,10 +170,10 @@ TEST(RedundantBufferEliminationTests, BufferWithStore)
 
   // Assert
   // We expect the BufferOperation node to be replaced by a passthrough BufferOperation node
-  EXPECT_EQ(rvsdg.GetRootRegion().numNodes(), 2);
+  EXPECT_EQ(rvsdg.GetRootRegion().numNodes(), 2u);
   auto [bufferNode, bufferOperation] = TryGetSimpleNodeAndOptionalOp<BufferOperation>(*x.origin());
   EXPECT_TRUE(bufferNode && bufferOperation);
-  EXPECT_EQ(bufferOperation->Capacity(), 4);
+  EXPECT_EQ(bufferOperation->Capacity(), 4u);
   EXPECT_TRUE(bufferOperation->IsPassThrough());
 }
 
@@ -211,10 +211,10 @@ TEST(RedundantBufferEliminationTests, BufferWithForkAndLocalLoad)
 
   // Assert
   // We expect the BufferOperation node to be replaced by a passthrough BufferOperation node
-  EXPECT_EQ(rvsdg.GetRootRegion().numNodes(), 3);
+  EXPECT_EQ(rvsdg.GetRootRegion().numNodes(), 3u);
   auto [bufferNode, bufferOperation] = TryGetSimpleNodeAndOptionalOp<BufferOperation>(*x.origin());
   EXPECT_TRUE(bufferNode && bufferOperation);
-  EXPECT_EQ(bufferOperation->Capacity(), 4);
+  EXPECT_EQ(bufferOperation->Capacity(), 4u);
   EXPECT_TRUE(bufferOperation->IsPassThrough());
 }
 
@@ -254,10 +254,10 @@ TEST(RedundantBufferEliminationTests, BufferWithBranchAndLocalLoad)
 
   // Assert
   // We expect the BufferOperation node to be replaced by a passthrough BufferOperation node
-  EXPECT_EQ(rvsdg.GetRootRegion().numNodes(), 3);
+  EXPECT_EQ(rvsdg.GetRootRegion().numNodes(), 3u);
   auto [bufferNode, bufferOperation] = TryGetSimpleNodeAndOptionalOp<BufferOperation>(*x.origin());
   EXPECT_TRUE(bufferNode && bufferOperation);
-  EXPECT_EQ(bufferOperation->Capacity(), 4);
+  EXPECT_EQ(bufferOperation->Capacity(), 4u);
   EXPECT_TRUE(bufferOperation->IsPassThrough());
 }
 
@@ -293,11 +293,11 @@ TEST(RedundantBufferEliminationTests, BufferWithOtherNode)
   // Assert
   // We expect the BufferOperation node to NOT have been replaced as the operand of the
   // BufferOperation node cannot be traced to a Load-/Store-/LocalLoad-/LocalStoreOperation node
-  EXPECT_EQ(rvsdg.GetRootRegion().numNodes(), 2);
+  EXPECT_EQ(rvsdg.GetRootRegion().numNodes(), 2u);
   EXPECT_EQ(x.origin(), bufferResults[0]);
   auto [bufferNode, bufferOperation] = TryGetSimpleNodeAndOptionalOp<BufferOperation>(*x.origin());
   EXPECT_TRUE(bufferNode && bufferOperation);
-  EXPECT_EQ(bufferOperation->Capacity(), 4);
+  EXPECT_EQ(bufferOperation->Capacity(), 4u);
   EXPECT_FALSE(bufferOperation->IsPassThrough());
 }
 
@@ -335,11 +335,11 @@ TEST(RedundantBufferEliminationTests, BufferWithNonMemoryStateOperand)
   // Assert
   // We expect the BufferOperation node to NOT have been replaced as the operand of the
   // BufferOperation node is not of type llvm::MemoryStateType
-  EXPECT_EQ(rvsdg.GetRootRegion().numNodes(), 2);
+  EXPECT_EQ(rvsdg.GetRootRegion().numNodes(), 2u);
   EXPECT_EQ(x.origin(), bufferResults[0]);
   auto [bufferNode, bufferOperation] = TryGetSimpleNodeAndOptionalOp<BufferOperation>(*x.origin());
   EXPECT_TRUE(bufferNode && bufferOperation);
-  EXPECT_EQ(bufferOperation->Capacity(), 4);
+  EXPECT_EQ(bufferOperation->Capacity(), 4u);
   EXPECT_FALSE(bufferOperation->IsPassThrough());
 }
 
@@ -377,10 +377,10 @@ TEST(RedundantBufferEliminationTests, PassthroughBuffer)
   // Assert
   // We expect the BufferOperation node to NOT have been replaced as the BufferOperation is already
   // marked as passthrough.
-  EXPECT_EQ(rvsdg.GetRootRegion().numNodes(), 2);
+  EXPECT_EQ(rvsdg.GetRootRegion().numNodes(), 2u);
   EXPECT_EQ(x.origin(), bufferResults[0]);
   auto [bufferNode, bufferOperation] = TryGetSimpleNodeAndOptionalOp<BufferOperation>(*x.origin());
   EXPECT_TRUE(bufferNode && bufferOperation);
-  EXPECT_EQ(bufferOperation->Capacity(), 4);
+  EXPECT_EQ(bufferOperation->Capacity(), 4u);
   EXPECT_TRUE(bufferOperation->IsPassThrough());
 }

--- a/jlm/hls/backend/rvsdg2rhls/SinkInsertionTests.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/SinkInsertionTests.cpp
@@ -52,19 +52,19 @@ TEST(SinkInsertionTests, SinkInsertion)
   view(rvsdg, stdout);
 
   // Assert
-  EXPECT_EQ(structuralNode->subregion(0)->numNodes(), 1);
-  EXPECT_EQ(lambdaNode->subregion()->numNodes(), 2);
+  EXPECT_EQ(structuralNode->subregion(0)->numNodes(), 1u);
+  EXPECT_EQ(lambdaNode->subregion()->numNodes(), 2u);
 
   // The sink insertion pass should have inserted a SinkOperation node at output o0
   {
-    EXPECT_EQ(outputVar0.output->nusers(), 1);
+    EXPECT_EQ(outputVar0.output->nusers(), 1u);
     EXPECT_TRUE(IsOwnerNodeOperation<SinkOperation>(*outputVar0.output->Users().begin()));
   }
 
   // The sink insertion pass should have inserted a SinkOperation node at the argument of i0
   {
     auto & i0Argument = *inputVar0.argument[0];
-    EXPECT_EQ(i0Argument.nusers(), 1);
+    EXPECT_EQ(i0Argument.nusers(), 1u);
     EXPECT_TRUE(IsOwnerNodeOperation<SinkOperation>(*i0Argument.Users().begin()));
   }
 }

--- a/jlm/hls/backend/rvsdg2rhls/ThetaTests.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/ThetaTests.cpp
@@ -62,7 +62,7 @@ TEST(ThetaConversionTests, TestUnknownBoundaries)
   // Check that two constant buffers are created for the loop invariant variables
   EXPECT_TRUE(
       jlm::rvsdg::Region::ContainsOperation<LoopConstantBufferOperation>(*lambdaRegion, true));
-  EXPECT_EQ(lambdaRegion->argument(0)->nusers(), 1);
+  EXPECT_EQ(lambdaRegion->argument(0)->nusers(), 1u);
   auto & loopNode =
       jlm::rvsdg::AssertGetOwnerNode<LoopNode>(lambdaRegion->argument(0)->SingleUser());
   {

--- a/jlm/hls/backend/rvsdg2rhls/UnusedStateRemovalTests.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/UnusedStateRemovalTests.cpp
@@ -63,10 +63,10 @@ TEST(UnusedStateRemovalTests, TestGamma)
   jlm::hls::UnusedStateRemoval::CreateAndRun(*rvsdgModule, statisticsCollector);
 
   // Assert
-  EXPECT_EQ(gammaNode->ninputs(), 7);  // gammaInput1 was removed
-  EXPECT_EQ(gammaNode->noutputs(), 4); // gammaOutput1 was removed
-  EXPECT_EQ(gammaInput2.input->index(), 1);
-  EXPECT_EQ(gammaOutput2.output->index(), 0);
+  EXPECT_EQ(gammaNode->ninputs(), 7u);  // gammaInput1 was removed
+  EXPECT_EQ(gammaNode->noutputs(), 4u); // gammaOutput1 was removed
+  EXPECT_EQ(gammaInput2.input->index(), 1u);
+  EXPECT_EQ(gammaOutput2.output->index(), 0u);
   // FIXME: The transformation is way too conservative here. The only input and output it removes
   // are gammaInput1 and gammaOutput1, respectively. However, it could also remove gammaOutput3,
   // gammaOutput4, and gammaOutput5 as they are all invariant. This in turn would also render some
@@ -113,8 +113,8 @@ TEST(UnusedStateRemovalTests, TestTheta)
   jlm::hls::UnusedStateRemoval::CreateAndRun(*rvsdgModule, statisticsCollector);
 
   // Assert
-  EXPECT_EQ(thetaNode->ninputs(), 3);
-  EXPECT_EQ(thetaNode->noutputs(), 3);
+  EXPECT_EQ(thetaNode->ninputs(), 3u);
+  EXPECT_EQ(thetaNode->noutputs(), 3u);
 
   EXPECT_EQ(TryGetOwnerNode<ThetaNode>(*exportP.origin()), thetaNode);
   EXPECT_EQ(exportX.origin(), importX);
@@ -167,12 +167,12 @@ TEST(UnusedStateRemovalTests, TestLambda)
   jlm::hls::UnusedStateRemoval::CreateAndRun(*rvsdgModule, statisticsCollector);
 
   // Assert
-  EXPECT_EQ(rvsdg.GetRootRegion().numNodes(), 1);
+  EXPECT_EQ(rvsdg.GetRootRegion().numNodes(), 1u);
   auto & newLambdaNode =
       dynamic_cast<const jlm::rvsdg::LambdaNode &>(*rvsdg.GetRootRegion().Nodes().begin());
-  EXPECT_EQ(newLambdaNode.ninputs(), 2);
-  EXPECT_EQ(newLambdaNode.subregion()->narguments(), 3);
-  EXPECT_EQ(newLambdaNode.subregion()->nresults(), 2);
+  EXPECT_EQ(newLambdaNode.ninputs(), 2u);
+  EXPECT_EQ(newLambdaNode.subregion()->narguments(), 3u);
+  EXPECT_EQ(newLambdaNode.subregion()->nresults(), 2u);
   // FIXME For lambdas, the transformation has the following issues:
   // 1. It works only for lambda nodes in the root region. It throws an assert for all other lambdas
   // 2. It does not check whether the lambda is only exported. Removing passthrough values works
@@ -224,7 +224,7 @@ TEST(UnusedStateRemovalTests, TestUsedMemoryState)
   auto * node = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::Node>(
       *rvsdgModule->Rvsdg().GetRootRegion().result(0)->origin());
   auto lambdaSubregion = jlm::util::assertedCast<jlm::rvsdg::LambdaNode>(node)->subregion();
-  EXPECT_EQ(lambdaSubregion->nresults(), 1);
+  EXPECT_EQ(lambdaSubregion->nresults(), 1u);
   EXPECT_TRUE(is<MemoryStateType>(lambdaSubregion->result(0)->Type()));
 }
 
@@ -267,8 +267,8 @@ TEST(UnusedStateRemovalTests, TestUnusedMemoryState)
       *rvsdgModule->Rvsdg().GetRootRegion().result(0)->origin());
   auto lambdaSubregion = jlm::util::assertedCast<jlm::rvsdg::LambdaNode>(node)->subregion();
   jlm::rvsdg::view(rvsdgModule->Rvsdg(), stdout);
-  EXPECT_EQ(lambdaSubregion->narguments(), 2);
-  EXPECT_EQ(lambdaSubregion->nresults(), 1);
+  EXPECT_EQ(lambdaSubregion->narguments(), 2u);
+  EXPECT_EQ(lambdaSubregion->nresults(), 1u);
   EXPECT_TRUE(is<MemoryStateType>(lambdaSubregion->result(0)->Type()));
 }
 
@@ -324,8 +324,8 @@ TEST(UnusedStateRemovalTests, TestInvariantMemoryState)
       *rvsdgModule->Rvsdg().GetRootRegion().result(0)->origin());
   auto lambdaSubregion = jlm::util::assertedCast<jlm::rvsdg::LambdaNode>(node)->subregion();
   jlm::rvsdg::view(rvsdgModule->Rvsdg(), stdout);
-  EXPECT_EQ(lambdaSubregion->narguments(), 2);
-  EXPECT_EQ(lambdaSubregion->nresults(), 1);
+  EXPECT_EQ(lambdaSubregion->narguments(), 2u);
+  EXPECT_EQ(lambdaSubregion->nresults(), 1u);
   EXPECT_TRUE(is<MemoryStateType>(lambdaSubregion->result(0)->Type()));
   EXPECT_TRUE(jlm::rvsdg::Region::ContainsOperation<LambdaEntryMemoryStateSplitOperation>(
       *lambdaSubregion,

--- a/jlm/hls/opt/IOStateEliminationTests.cpp
+++ b/jlm/hls/opt/IOStateEliminationTests.cpp
@@ -118,5 +118,5 @@ TEST(IOStateEliminationTests, testNesting)
   EXPECT_TRUE(exitVar.output->IsDead());
   EXPECT_EQ(lambdaNode->GetFunctionResults()[0]->origin(), ioStateArgument);
 
-  EXPECT_EQ(gammaNode->GetEntryVars().size(), 3);
+  EXPECT_EQ(gammaNode->GetEntryVars().size(), 3u);
 }

--- a/jlm/hls/util/ViewTests.cpp
+++ b/jlm/hls/util/ViewTests.cpp
@@ -48,7 +48,7 @@ TEST(ViewTests, TestDumpDot)
   auto dotOutput = ToDot(lambda->region(), outputColor, inputColor, tailLabel);
 
   // Assert
-  EXPECT_GT(dotOutput.size(), 0);
+  EXPECT_GT(dotOutput.size(), 0u);
   EXPECT_NE(dotOutput.find("digraph G {"), std::string::npos);
   EXPECT_NE(dotOutput.find("subgraph cluster_"), std::string::npos);
   EXPECT_NE(dotOutput.find("tooltip=\"bit32\""), std::string::npos);
@@ -95,7 +95,7 @@ TEST(ViewTests, TestDumpDotTheta)
   auto dotOutput = ToDot(lambda->region(), outputColor, inputColor, tailLabel);
 
   // Assert
-  EXPECT_GT(dotOutput.size(), 0);
+  EXPECT_GT(dotOutput.size(), 0u);
   EXPECT_NE(dotOutput.find("digraph G {"), std::string::npos);
   EXPECT_NE(dotOutput.find("subgraph cluster_"), std::string::npos);
   EXPECT_NE(dotOutput.find("tooltip=\"bit32\""), std::string::npos);

--- a/jlm/llvm/backend/IpGraphToLlvmConverterTests.cpp
+++ b/jlm/llvm/backend/IpGraphToLlvmConverterTests.cpp
@@ -574,7 +574,7 @@ TEST(IpGraphToLlvmConverterTests, Malloc)
     auto f = m.getFunction("f");
     auto & bb = f->getEntryBlock();
 
-    EXPECT_EQ(bb.sizeWithoutDebug(), 2);
+    EXPECT_EQ(bb.sizeWithoutDebug(), 2u);
     EXPECT_EQ(bb.getFirstNonPHI()->getOpcode(), llvm::Instruction::Call);
     EXPECT_EQ(bb.getTerminator()->getOpcode(), llvm::Instruction::Ret);
   };
@@ -632,7 +632,7 @@ TEST(IpGraphToLlvmConverterTests, Free)
     auto f = module.getFunction("f");
     auto & bb = f->getEntryBlock();
 
-    EXPECT_EQ(bb.sizeWithoutDebug(), 2);
+    EXPECT_EQ(bb.sizeWithoutDebug(), 2u);
     EXPECT_EQ(bb.getFirstNonPHI()->getOpcode(), Instruction::Call);
     EXPECT_EQ(bb.getTerminator()->getOpcode(), Instruction::Ret);
   };

--- a/jlm/llvm/frontend/LlvmModuleConversionTests.cpp
+++ b/jlm/llvm/frontend/LlvmModuleConversionTests.cpp
@@ -149,7 +149,7 @@ TEST(LlvmModuleConversionTests, FreezeConversion)
       EXPECT_EQ(*freezeOperation->result(0), *jlmInt64Type);
     }
 
-    EXPECT_EQ(numFreezeThreeAddressCodes, 1);
+    EXPECT_EQ(numFreezeThreeAddressCodes, 1u);
   }
 }
 

--- a/jlm/llvm/frontend/LlvmPhiConversionTests.cpp
+++ b/jlm/llvm/frontend/LlvmPhiConversionTests.cpp
@@ -145,7 +145,7 @@ TEST(LlvmPhiConversionTests, TestPhiConversion)
       jlm::util::assertedCast<const jlm::llvm::ThreeAddressCodeVariable>(phiPopcnt->operand(0));
   auto constant0op = jlm::util::assertedCast<const jlm::llvm::IntegerConstantOperation>(
       &constant0variable->tac()->operation());
-  EXPECT_EQ(constant0op->Representation(), 0);
+  EXPECT_EQ(constant0op->Representation(), 0u);
   // The last operand of the popcnt phi is the result of the phi itself
   EXPECT_EQ(phiPopcnt->operand(2), phiPopcnt->result(0));
 }
@@ -239,5 +239,5 @@ TEST(LlvmPhiConversionTests, TestPhiOperandElision)
       jlm::util::assertedCast<const jlm::llvm::ThreeAddressCodeVariable>(phiTac->operand(0));
   auto constant0op = jlm::util::assertedCast<const jlm::llvm::IntegerConstantOperation>(
       &constant0variable->tac()->operation());
-  EXPECT_EQ(constant0op->Representation(), 0);
+  EXPECT_EQ(constant0op->Representation(), 0u);
 }

--- a/jlm/llvm/ir/TraceTests.cpp
+++ b/jlm/llvm/ir/TraceTests.cpp
@@ -125,10 +125,10 @@ TEST(TraceTests, testGetConstantSignedInteger)
   EXPECT_EQ(tryGetConstantSignedInteger(*bits64CtxVar), -37);
 
   // The 20 can be found both before, inside and after the gamma
-  EXPECT_EQ(tryGetConstantSignedInteger(*integerConstantNode.output(0)), 20);
-  EXPECT_EQ(tryGetConstantSignedInteger(*entryVar.branchArgument[0]), 20);
-  EXPECT_EQ(tryGetConstantSignedInteger(*entryVar.branchArgument[1]), 20);
-  EXPECT_EQ(tryGetConstantSignedInteger(*exitVarOutput), 20);
+  EXPECT_EQ(tryGetConstantSignedInteger(*integerConstantNode.output(0)), 20u);
+  EXPECT_EQ(tryGetConstantSignedInteger(*entryVar.branchArgument[0]), 20u);
+  EXPECT_EQ(tryGetConstantSignedInteger(*entryVar.branchArgument[1]), 20u);
+  EXPECT_EQ(tryGetConstantSignedInteger(*exitVarOutput), 20u);
 
   // A match output is not a constant integer, neither is the lambda output
   EXPECT_EQ(tryGetConstantSignedInteger(*matchOutput), std::nullopt);
@@ -187,20 +187,20 @@ TEST(TraceTests, testGetConstantSignedIntegerExtAndTrunc)
 
   // Assert
   // c = BITS32(5), sext = SExt(32 -> 64), zext = ZExt(32 -> 64)
-  EXPECT_EQ(tryGetConstantSignedInteger(bits32Output5), 5);
-  EXPECT_EQ(tryGetConstantSignedInteger(sextOutput), 5);
-  EXPECT_EQ(tryGetConstantSignedInteger(zextOutput), 5);
+  EXPECT_EQ(tryGetConstantSignedInteger(bits32Output5), 5u);
+  EXPECT_EQ(tryGetConstantSignedInteger(sextOutput), 5u);
+  EXPECT_EQ(tryGetConstantSignedInteger(zextOutput), 5u);
 
   // c2 = BITS8(-20), sext2 = SExt(8 -> 32), zext2 = ZExt(8 -> 32)
   EXPECT_EQ(tryGetConstantSignedInteger(bits8OutputMinus20), -20);
   EXPECT_EQ(tryGetConstantSignedInteger(sext2Output), -20);
-  EXPECT_EQ(tryGetConstantSignedInteger(zext2Output), 236);
+  EXPECT_EQ(tryGetConstantSignedInteger(zext2Output), 236u);
 
   // c3 = BITS32(1023), trunc3 = Trunc(32 -> 8), sext3 = SExt(8 -> 32), zext3 = ZExt(8 -> 32)
-  EXPECT_EQ(tryGetConstantSignedInteger(bits32Output1023), 1023);
+  EXPECT_EQ(tryGetConstantSignedInteger(bits32Output1023), 1023u);
   EXPECT_EQ(tryGetConstantSignedInteger(truncOutput), -1);
   EXPECT_EQ(tryGetConstantSignedInteger(sext3Output), -1);
-  EXPECT_EQ(tryGetConstantSignedInteger(zext3Output), 255);
+  EXPECT_EQ(tryGetConstantSignedInteger(zext3Output), 255u);
 }
 
 TEST(TraceTests, testGetConstantSignedIntegerExtThroughGamma)
@@ -253,5 +253,5 @@ TEST(TraceTests, testGetConstantSignedIntegerExtThroughGamma)
   // After extensions and truncation
   EXPECT_EQ(tryGetConstantSignedInteger(sextOutput), -20);
   EXPECT_EQ(tryGetConstantSignedInteger(truncOutput), -20);
-  EXPECT_EQ(tryGetConstantSignedInteger(zextOutput), 65516);
+  EXPECT_EQ(tryGetConstantSignedInteger(zextOutput), 65516u);
 }

--- a/jlm/llvm/ir/operators/CallTests.cpp
+++ b/jlm/llvm/ir/operators/CallTests.cpp
@@ -86,9 +86,9 @@ TEST(CallOperationTests, TestCallNodeAccessors)
   // Assert
   EXPECT_EQ(CallOperation::NumArguments(callNode), 3u);
   EXPECT_EQ(CallOperation::NumArguments(callNode), callNode.ninputs() - 1);
-  EXPECT_EQ(CallOperation::Argument(callNode, 0)->origin(), v);
-  EXPECT_EQ(CallOperation::Argument(callNode, 1)->origin(), i);
-  EXPECT_EQ(CallOperation::Argument(callNode, 2)->origin(), m);
+  EXPECT_EQ(CallOperation::Argument(callNode, 0u)->origin(), v);
+  EXPECT_EQ(CallOperation::Argument(callNode, 1u)->origin(), i);
+  EXPECT_EQ(CallOperation::Argument(callNode, 2u)->origin(), m);
 
   EXPECT_EQ(callNode.noutputs(), 3u);
   EXPECT_EQ(*callNode.output(0)->Type(), *valueType);

--- a/jlm/llvm/ir/operators/ConversionOperationsTests.cpp
+++ b/jlm/llvm/ir/operators/ConversionOperationsTests.cpp
@@ -50,14 +50,14 @@ TEST(ConversionOperationsTests, testSextZextConstantReductions)
     auto [_, op] = TryGetSimpleNodeAndOptionalOp<BitConstantOperation>(*sextExport.origin());
     EXPECT_TRUE(op);
     EXPECT_EQ(op->value().to_int(), -126);
-    EXPECT_EQ(op->value().nbits(), 32);
+    EXPECT_EQ(op->value().nbits(), 32u);
   }
 
   {
     // Check zext
     auto [_, op] = TryGetSimpleNodeAndOptionalOp<BitConstantOperation>(*zextExport.origin());
     EXPECT_TRUE(op);
-    EXPECT_EQ(op->value().to_int(), 130);
-    EXPECT_EQ(op->value().nbits(), 32);
+    EXPECT_EQ(op->value().to_int(), 130u);
+    EXPECT_EQ(op->value().nbits(), 32u);
   }
 }

--- a/jlm/llvm/ir/operators/GetElementPtrTests.cpp
+++ b/jlm/llvm/ir/operators/GetElementPtrTests.cpp
@@ -99,10 +99,10 @@ TEST(GetElementPtrTests, TestGetElementPtrOperationConstant_OffestInBytes)
   GetElementPtrOperation::Constant constant5{ arrayType2, { 0, 2, 2 } };
 
   // Act & Assert
-  EXPECT_EQ(constant0.getOffsetInBytes(), 0);
-  EXPECT_EQ(constant1.getOffsetInBytes(), 8);
-  EXPECT_EQ(constant2.getOffsetInBytes(), 20);
-  EXPECT_EQ(constant3.getOffsetInBytes(), 8);
-  EXPECT_EQ(constant4.getOffsetInBytes(), 20);
-  EXPECT_EQ(constant5.getOffsetInBytes(), 32);
+  EXPECT_EQ(constant0.getOffsetInBytes(), 0u);
+  EXPECT_EQ(constant1.getOffsetInBytes(), 8u);
+  EXPECT_EQ(constant2.getOffsetInBytes(), 20u);
+  EXPECT_EQ(constant3.getOffsetInBytes(), 8u);
+  EXPECT_EQ(constant4.getOffsetInBytes(), 20u);
+  EXPECT_EQ(constant5.getOffsetInBytes(), 32u);
 }

--- a/jlm/llvm/opt/IfConversionTests.cpp
+++ b/jlm/llvm/opt/IfConversionTests.cpp
@@ -133,7 +133,7 @@ TEST(IfConversionTests, EmptyGammaWithTwoSubregionsAndMatch)
     auto constantOperation =
         dynamic_cast<const IntegerConstantOperation *>(&constantNode->GetOperation());
     EXPECT_NE(constantOperation, nullptr);
-    EXPECT_EQ(constantOperation->Representation(), 24);
+    EXPECT_EQ(constantOperation->Representation(), 24u);
   }
   else
   {
@@ -142,7 +142,7 @@ TEST(IfConversionTests, EmptyGammaWithTwoSubregionsAndMatch)
     auto constantOperation =
         dynamic_cast<const IntegerConstantOperation *>(&constantNode->GetOperation());
     EXPECT_NE(constantOperation, nullptr);
-    EXPECT_EQ(constantOperation->Representation(), 24);
+    EXPECT_EQ(constantOperation->Representation(), 24u);
   }
 }
 

--- a/jlm/llvm/opt/InvariantValueRedirectionTests.cpp
+++ b/jlm/llvm/opt/InvariantValueRedirectionTests.cpp
@@ -260,7 +260,7 @@ TEST(InvariantValueRedirectionTests, TestCallWithMemoryStateNodes)
    */
 
   // The memory node representing external has index 0, and is avoided in this test
-  EXPECT_EQ(aa::PointsToGraph::externalMemoryNode, 0);
+  EXPECT_EQ(aa::PointsToGraph::externalMemoryNode, 0u);
 
   auto ioStateType = IOStateType::Create();
   auto memoryStateType = MemoryStateType::Create();
@@ -376,7 +376,7 @@ TEST(InvariantValueRedirectionTests, TestCallWithMissingMemoryStateNodes)
   using namespace jlm::rvsdg;
 
   // The memory node representing external has index 0, and is avoided in this test
-  EXPECT_EQ(aa::PointsToGraph::externalMemoryNode, 0);
+  EXPECT_EQ(aa::PointsToGraph::externalMemoryNode, 0u);
 
   auto ioStateType = IOStateType::Create();
   auto memoryStateType = MemoryStateType::Create();
@@ -541,7 +541,7 @@ TEST(InvariantValueRedirectionTests, TestCallWithDifferentExternalCompression)
    */
 
   // The memory node representing external has index 0
-  EXPECT_EQ(aa::PointsToGraph::externalMemoryNode, 0);
+  EXPECT_EQ(aa::PointsToGraph::externalMemoryNode, 0u);
 
   const auto ioStateType = IOStateType::Create();
   const auto memoryStateType = MemoryStateType::Create();
@@ -657,12 +657,12 @@ TEST(InvariantValueRedirectionTests, TestCallWithDifferentExternalCompression)
   RunInvariantValueRedirection(*rvsdgModule);
 
   // Assert
-  ASSERT_EQ(lambdaEntrySplitNode->noutputs(), 3);
-  ASSERT_EQ(callEntryMergeNodeA->ninputs(), 3);
-  ASSERT_EQ(callExitSplitNodeA->noutputs(), 3);
-  ASSERT_EQ(callEntryMergeNodeB->ninputs(), 3);
-  ASSERT_EQ(callExitSplitNodeB->noutputs(), 3);
-  ASSERT_EQ(lambdaExitMergeNode->ninputs(), 3);
+  ASSERT_EQ(lambdaEntrySplitNode->noutputs(), 3u);
+  ASSERT_EQ(callEntryMergeNodeA->ninputs(), 3u);
+  ASSERT_EQ(callExitSplitNodeA->noutputs(), 3u);
+  ASSERT_EQ(callEntryMergeNodeB->ninputs(), 3u);
+  ASSERT_EQ(callExitSplitNodeB->noutputs(), 3u);
+  ASSERT_EQ(lambdaExitMergeNode->ninputs(), 3u);
 
   // the memory state edge representing the external node has not been re-routed around anything
   EXPECT_EQ(callEntryMergeNodeA->input(0)->origin(), lambdaEntrySplitNode->output(0));

--- a/jlm/llvm/opt/StoreValueForwardingTests.cpp
+++ b/jlm/llvm/opt/StoreValueForwardingTests.cpp
@@ -23,7 +23,7 @@
 #include <jlm/rvsdg/UnitType.hpp>
 #include <jlm/rvsdg/view.hpp>
 #include <jlm/util/Statistics.hpp>
-#include <llvm-18/llvm/ADT/APFloat.h>
+#include <llvm/ADT/APFloat.h>
 
 static void
 RunStoreValueForwarding(jlm::llvm::LlvmRvsdgModule & rvsdgModule)
@@ -140,7 +140,7 @@ TEST(StoreValueForwardingTests, NestedAllocas)
   // Verify that the return value is a constant 20
   const auto & result = *lambdaNode.GetFunctionResults()[0]->origin();
   const auto resultValue = tryGetConstantSignedInteger(result);
-  EXPECT_EQ(resultValue, 20);
+  EXPECT_EQ(resultValue, 20u);
 }
 
 TEST(StoreValueForwardingTests, GetElementPointerOffsets)
@@ -266,8 +266,8 @@ TEST(StoreValueForwardingTests, GetElementPointerOffsets)
   const auto r2 = tryGetConstantSignedInteger(*results[1]->origin());
   const auto r3 = tryGetConstantSignedInteger(*results[2]->origin());
   EXPECT_FALSE(r1.has_value());
-  EXPECT_EQ(r2, 40);
-  EXPECT_EQ(r3, 20);
+  EXPECT_EQ(r2, 40u);
+  EXPECT_EQ(r3, 20u);
 }
 
 TEST(StoreValueForwardingTests, RoutingIn)
@@ -377,7 +377,7 @@ TEST(StoreValueForwardingTests, RoutingIn)
   // The result in gamma region 0 should be the constant 40
   auto & branch0Result = *lExitVar.branchResult[0]->origin();
   auto resultValue = tryGetConstantSignedInteger(branch0Result);
-  EXPECT_EQ(resultValue, 40);
+  EXPECT_EQ(resultValue, 40u);
 
   // The result should be routed in from the constant 40 node
   auto & resultTraced = jlm::llvm::traceOutput(branch0Result);
@@ -500,7 +500,7 @@ TEST(StoreValueForwardingTests, RouteOut)
   // In the 0th subregion, the output should be a constant integer
   const auto constInteger =
       jlm::llvm::tryGetConstantSignedInteger(*exitVar.branchResult[0]->origin());
-  EXPECT_EQ(constInteger, 20);
+  EXPECT_EQ(constInteger, 20u);
 
   // In the 1st subregion, the output should be traced back to the loop var input
   const auto & traced1stRegionOrigin = jlm::llvm::traceOutput(*exitVar.branchResult[1]->origin());
@@ -508,7 +508,7 @@ TEST(StoreValueForwardingTests, RouteOut)
   EXPECT_EQ(loopVar.pre, loopVar2.pre);
 
   const auto constInputInteger = jlm::llvm::tryGetConstantSignedInteger(*loopVar.input->origin());
-  EXPECT_EQ(constInputInteger, 40);
+  EXPECT_EQ(constInputInteger, 40u);
 }
 
 TEST(StoreValueForwardingTests, RouteAroundLoadLoop)
@@ -605,11 +605,11 @@ TEST(StoreValueForwardingTests, RouteAroundLoadLoop)
   const auto loopVar1 = thetaNode.MapOutputLoopVar(addLhsOrigin);
   const auto loopVar2 = thetaNode.MapPreLoopVar(*loopVar1.post->origin());
   EXPECT_TRUE(rvsdg::ThetaLoopVarIsInvariant(loopVar2));
-  EXPECT_EQ(tryGetConstantSignedInteger(*loopVar2.input->origin()), 40);
+  EXPECT_EQ(tryGetConstantSignedInteger(*loopVar2.input->origin()), 40u);
 
   // The value replacing l3 should come from the constant directly, not a theta output.
   const auto & addRhsOrigin = *addNode.input(1)->origin();
-  EXPECT_EQ(tryGetConstantSignedInteger(addRhsOrigin), 40);
+  EXPECT_EQ(tryGetConstantSignedInteger(addRhsOrigin), 40u);
   EXPECT_EQ(rvsdg::TryGetOwnerNode<rvsdg::ThetaNode>(addRhsOrigin), nullptr);
 }
 
@@ -702,7 +702,7 @@ TEST(StoreValueForwardingTests, RouteUninitialized)
   EXPECT_NE(rvsdg::TryGetOwnerNode<rvsdg::GammaNode>(resultOrigin), nullptr);
 
   const auto exitVar = gammaNode.MapOutputExitVar(resultOrigin);
-  EXPECT_EQ(jlm::llvm::tryGetConstantSignedInteger(*exitVar.branchResult[0]->origin()), 20);
+  EXPECT_EQ(jlm::llvm::tryGetConstantSignedInteger(*exitVar.branchResult[0]->origin()), 20u);
   const auto [undefNode, undefOperation] =
       rvsdg::TryGetSimpleNodeAndOptionalOp<UndefValueOperation>(*exitVar.branchResult[1]->origin());
   EXPECT_TRUE(undefNode && undefOperation);
@@ -850,7 +850,7 @@ TEST(StoreValueForwardingTests, GepInLoop)
   // which takes 20 as its initial value, and loaded + 1 as its post origin
   const auto & loadedInLoopOrigin = *addLoadedOneNode.input(0)->origin();
   const auto loadedLoopVar = thetaNode.MapPreLoopVar(loadedInLoopOrigin);
-  EXPECT_EQ(jlm::llvm::tryGetConstantSignedInteger(*loadedLoopVar.input->origin()), 20);
+  EXPECT_EQ(jlm::llvm::tryGetConstantSignedInteger(*loadedLoopVar.input->origin()), 20u);
   EXPECT_EQ(loadedLoopVar.post->origin(), addLoadedOneNode.output(0));
 
   // Check that the final load of a[2] is replaced by the value of loaded + 1 in the loop

--- a/jlm/llvm/opt/alias-analyses/PointsToGraphTests.cpp
+++ b/jlm/llvm/opt/alias-analyses/PointsToGraphTests.cpp
@@ -300,9 +300,9 @@ TEST(PointsToGraphTests, testMemoryNodeSize)
     const auto f = ptg->addNodeForLambda(test.LambdaF(), false);
 
     // Assert
-    EXPECT_EQ(ptg->tryGetNodeSize(deltaG1), 4);
-    EXPECT_EQ(ptg->tryGetNodeSize(deltaG2), 8);
-    EXPECT_EQ(ptg->tryGetNodeSize(f), 0);
+    EXPECT_EQ(ptg->tryGetNodeSize(deltaG1), 4u);
+    EXPECT_EQ(ptg->tryGetNodeSize(deltaG2), 8u);
+    EXPECT_EQ(ptg->tryGetNodeSize(f), 0u);
   }
 
   {
@@ -315,8 +315,8 @@ TEST(PointsToGraphTests, testMemoryNodeSize)
     const auto allocaC = ptg->addNodeForAlloca(*test.alloca_c, false);
 
     // Assert 2
-    EXPECT_EQ(ptg->tryGetNodeSize(allocaD), 4);
-    EXPECT_EQ(ptg->tryGetNodeSize(allocaC), 8); // Pointers are 8 bytes
+    EXPECT_EQ(ptg->tryGetNodeSize(allocaD), 4u);
+    EXPECT_EQ(ptg->tryGetNodeSize(allocaC), 8u); // Pointers are 8 bytes
   }
 
   {
@@ -332,12 +332,12 @@ TEST(PointsToGraphTests, testMemoryNodeSize)
     const auto importNode = ptg->addNodeForImport(test.GetImportOutput(), true);
 
     // Assert 3
-    EXPECT_EQ(ptg->tryGetNodeSize(allocaNode), 8);
-    EXPECT_EQ(ptg->tryGetNodeSize(mallocNode), 4);
-    EXPECT_EQ(ptg->tryGetNodeSize(deltaNode), 8);
-    EXPECT_EQ(ptg->tryGetNodeSize(importNode), 4);
+    EXPECT_EQ(ptg->tryGetNodeSize(allocaNode), 8u);
+    EXPECT_EQ(ptg->tryGetNodeSize(mallocNode), 4u);
+    EXPECT_EQ(ptg->tryGetNodeSize(deltaNode), 8u);
+    EXPECT_EQ(ptg->tryGetNodeSize(importNode), 4u);
     // Function nodes have size 0
-    EXPECT_EQ(ptg->tryGetNodeSize(lambdaNode), 0);
+    EXPECT_EQ(ptg->tryGetNodeSize(lambdaNode), 0u);
   }
 }
 

--- a/jlm/llvm/opt/alias-analyses/RegionAwareModRefSummarizerTests.cpp
+++ b/jlm/llvm/opt/alias-analyses/RegionAwareModRefSummarizerTests.cpp
@@ -1670,7 +1670,7 @@ TEST(RegionAwareModRefSummarizerTests, testSetjmpHandling)
   // The call to opaque() within h() only contains the external memory node,
   // since the memory node representing a has been compressed into it
   const auto & callOpaqueModRef = modRefSummary->GetSimpleNodeModRef(*callOpaqueNode);
-  EXPECT_EQ(callOpaqueModRef.getModRefNodes().size(), 1);
+  EXPECT_EQ(callOpaqueModRef.getModRefNodes().size(), 1u);
 
   // Check the statistics to ensure that the right functions in the call graph were marked
   auto & statistic = *collector.CollectedStatistics().begin();

--- a/jlm/mlir/IntegerOperationsJlmToMlirToJlmTests.cpp
+++ b/jlm/mlir/IntegerOperationsJlmToMlirToJlmTests.cpp
@@ -91,15 +91,15 @@ TestIntegerBinaryOperation()
     {
       using namespace jlm::llvm;
 
-      EXPECT_EQ(region->numNodes(), 3);
+      EXPECT_EQ(region->numNodes(), 3u);
       bool foundBinaryOp = false;
       for (auto & node : region->Nodes())
       {
         auto convertedBinaryOp = dynamic_cast<const JlmOperation *>(&node.GetOperation());
         if (convertedBinaryOp)
         {
-          EXPECT_EQ(convertedBinaryOp->nresults(), 1);
-          EXPECT_EQ(convertedBinaryOp->narguments(), 2);
+          EXPECT_EQ(convertedBinaryOp->nresults(), 1u);
+          EXPECT_EQ(convertedBinaryOp->narguments(), 2u);
           auto inputBitType1 = jlm::util::assertedCast<const jlm::rvsdg::BitType>(
               convertedBinaryOp->argument(0).get());
           EXPECT_EQ(inputBitType1->nbits(), nbits);
@@ -198,7 +198,7 @@ TestIntegerComparisonOperation(const IntegerComparisonOpTest<JlmOperation> & tes
         // Check the output type is i1 (boolean)
         auto outputType = mlirCompOp.getResult().getType().dyn_cast<::mlir::IntegerType>();
         EXPECT_NE(outputType, nullptr);
-        EXPECT_EQ(outputType.getWidth(), 1);
+        EXPECT_EQ(outputType.getWidth(), 1u);
 
         // Verify the predicate is correct
         EXPECT_EQ(mlirCompOp.getPredicate(), test.predicate);
@@ -217,15 +217,15 @@ TestIntegerComparisonOperation(const IntegerComparisonOpTest<JlmOperation> & tes
     {
       using namespace jlm::llvm;
 
-      EXPECT_EQ(region->numNodes(), 3);
+      EXPECT_EQ(region->numNodes(), 3u);
       bool foundCompOp = false;
       for (auto & node : region->Nodes())
       {
         auto convertedCompOp = dynamic_cast<const JlmOperation *>(&node.GetOperation());
         if (convertedCompOp)
         {
-          EXPECT_EQ(convertedCompOp->nresults(), 1);
-          EXPECT_EQ(convertedCompOp->narguments(), 2);
+          EXPECT_EQ(convertedCompOp->nresults(), 1u);
+          EXPECT_EQ(convertedCompOp->narguments(), 2u);
           auto inputBitType1 = jlm::util::assertedCast<const jlm::rvsdg::BitType>(
               convertedCompOp->argument(0).get());
           EXPECT_EQ(inputBitType1->nbits(), nbits);
@@ -236,7 +236,7 @@ TestIntegerComparisonOperation(const IntegerComparisonOpTest<JlmOperation> & tes
           // Check the output type is bit1 (boolean)
           auto outputBitType =
               jlm::util::assertedCast<const jlm::rvsdg::BitType>(convertedCompOp->result(0).get());
-          EXPECT_EQ(outputBitType->nbits(), 1);
+          EXPECT_EQ(outputBitType->nbits(), 1u);
 
           foundCompOp = true;
         }

--- a/jlm/mlir/JlmToMlirToJlmTests.cpp
+++ b/jlm/mlir/JlmToMlirToJlmTests.cpp
@@ -36,10 +36,10 @@ TEST(JlmToMlirToJlmTests, TestUndef)
 
     std::cout << "Checking blocks and operations count" << std::endl;
     auto & omegaRegion = omega.getRegion();
-    EXPECT_EQ(omegaRegion.getBlocks().size(), 1);
+    EXPECT_EQ(omegaRegion.getBlocks().size(), 1u);
     auto & omegaBlock = omegaRegion.front();
     // 1 undef + omegaResult
-    EXPECT_EQ(omegaBlock.getOperations().size(), 2);
+    EXPECT_EQ(omegaBlock.getOperations().size(), 2u);
     EXPECT_TRUE(mlir::isa<mlir::jlm::Undef>(omegaBlock.front()));
     auto mlirUndefOp = mlir::dyn_cast<::mlir::jlm::Undef>(&omegaBlock.front());
     mlirUndefOp.dump();
@@ -54,7 +54,7 @@ TEST(JlmToMlirToJlmTests, TestUndef)
     {
       using namespace jlm::llvm;
 
-      EXPECT_EQ(region->numNodes(), 1);
+      EXPECT_EQ(region->numNodes(), 1u);
 
       // Get the undef op
       auto convertedUndef =
@@ -64,7 +64,7 @@ TEST(JlmToMlirToJlmTests, TestUndef)
 
       auto outputType = convertedUndef->result(0);
       EXPECT_TRUE(jlm::rvsdg::is<const jlm::rvsdg::BitType>(outputType));
-      EXPECT_EQ(std::dynamic_pointer_cast<const jlm::rvsdg::BitType>(outputType)->nbits(), 32);
+      EXPECT_EQ(std::dynamic_pointer_cast<const jlm::rvsdg::BitType>(outputType)->nbits(), 32u);
     }
   }
 }
@@ -97,11 +97,11 @@ TEST(JlmToMlirToJlmTests, TestAlloca)
 
     std::cout << "Checking blocks and operations count" << std::endl;
     auto & omegaRegion = omega.getRegion();
-    EXPECT_EQ(omegaRegion.getBlocks().size(), 1);
+    EXPECT_EQ(omegaRegion.getBlocks().size(), 1u);
     auto & omegaBlock = omegaRegion.front();
 
     // Bit-contant + alloca + omegaResult
-    EXPECT_EQ(omegaBlock.getOperations().size(), 3);
+    EXPECT_EQ(omegaBlock.getOperations().size(), 3u);
 
     bool foundAlloca = false;
     for (auto & op : omegaBlock)
@@ -109,12 +109,12 @@ TEST(JlmToMlirToJlmTests, TestAlloca)
       if (mlir::isa<mlir::jlm::Alloca>(op))
       {
         auto mlirAllocaOp = mlir::cast<mlir::jlm::Alloca>(op);
-        EXPECT_EQ(mlirAllocaOp.getAlignment(), 4);
-        EXPECT_EQ(mlirAllocaOp.getNumResults(), 2);
+        EXPECT_EQ(mlirAllocaOp.getAlignment(), 4u);
+        EXPECT_EQ(mlirAllocaOp.getNumResults(), 2u);
 
         auto valueType = mlir::cast<mlir::IntegerType>(mlirAllocaOp.getValueType());
         EXPECT_NE(valueType, nullptr);
-        EXPECT_EQ(valueType.getWidth(), 64);
+        EXPECT_EQ(valueType.getWidth(), 64u);
         foundAlloca = true;
       }
     }
@@ -130,28 +130,28 @@ TEST(JlmToMlirToJlmTests, TestAlloca)
     {
       using namespace jlm::llvm;
 
-      EXPECT_EQ(region->numNodes(), 2);
+      EXPECT_EQ(region->numNodes(), 2u);
 
       bool foundAlloca = false;
       for (auto & node : region->Nodes())
       {
         if (auto allocaOp = dynamic_cast<const AllocaOperation *>(&node.GetOperation()))
         {
-          EXPECT_EQ(allocaOp->alignment(), 4);
+          EXPECT_EQ(allocaOp->alignment(), 4u);
 
           EXPECT_TRUE(jlm::rvsdg::is<jlm::rvsdg::BitType>(allocaOp->allocatedType()));
           auto valueBitType =
               dynamic_cast<const jlm::rvsdg::BitType *>(allocaOp->allocatedType().get());
-          EXPECT_EQ(valueBitType->nbits(), 64);
+          EXPECT_EQ(valueBitType->nbits(), 64u);
 
-          EXPECT_EQ(allocaOp->narguments(), 1);
+          EXPECT_EQ(allocaOp->narguments(), 1u);
 
           EXPECT_TRUE(jlm::rvsdg::is<jlm::rvsdg::BitType>(allocaOp->argument(0)));
           auto inputBitType =
               dynamic_cast<const jlm::rvsdg::BitType *>(allocaOp->argument(0).get());
-          EXPECT_EQ(inputBitType->nbits(), 32);
+          EXPECT_EQ(inputBitType->nbits(), 32u);
 
-          EXPECT_EQ(allocaOp->nresults(), 2);
+          EXPECT_EQ(allocaOp->nresults(), 2u);
 
           EXPECT_TRUE(jlm::rvsdg::is<PointerType>(allocaOp->result(0)));
           EXPECT_TRUE(jlm::rvsdg::is<jlm::llvm::MemoryStateType>(allocaOp->result(1)));
@@ -211,15 +211,15 @@ TEST(JlmToMlirToJlmTests, TestLoad)
     EXPECT_TRUE(mlir::isa<mlir::jlm::Load>(mlirOp));
 
     auto mlirLoad = mlir::cast<mlir::jlm::Load>(mlirOp);
-    EXPECT_EQ(mlirLoad.getAlignment(), 4);
-    EXPECT_EQ(mlirLoad.getInputMemStates().size(), 1);
-    EXPECT_EQ(mlirLoad.getNumOperands(), 2);
-    EXPECT_EQ(mlirLoad.getNumResults(), 2);
+    EXPECT_EQ(mlirLoad.getAlignment(), 4u);
+    EXPECT_EQ(mlirLoad.getInputMemStates().size(), 1u);
+    EXPECT_EQ(mlirLoad.getNumOperands(), 2u);
+    EXPECT_EQ(mlirLoad.getNumResults(), 2u);
 
     auto outputType = mlirLoad.getOutput().getType();
     EXPECT_TRUE(mlir::isa<mlir::IntegerType>(outputType));
     auto integerType = mlir::cast<mlir::IntegerType>(outputType);
-    EXPECT_EQ(integerType.getWidth(), 32);
+    EXPECT_EQ(integerType.getWidth(), 32u);
 
     // // Convert the MLIR to RVSDG and check the result
     std::cout << "Converting MLIR to RVSDG" << std::endl;
@@ -231,20 +231,20 @@ TEST(JlmToMlirToJlmTests, TestLoad)
     {
       using namespace jlm::llvm;
 
-      EXPECT_EQ(region->numNodes(), 1);
+      EXPECT_EQ(region->numNodes(), 1u);
       auto convertedLambda =
           jlm::util::assertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
       EXPECT_TRUE(is<jlm::rvsdg::LambdaOperation>(convertedLambda));
 
-      EXPECT_EQ(convertedLambda->subregion()->numNodes(), 1);
+      EXPECT_EQ(convertedLambda->subregion()->numNodes(), 1u);
       EXPECT_TRUE(is<LoadNonVolatileOperation>(
           convertedLambda->subregion()->Nodes().begin()->GetOperation()));
       auto convertedLoad = convertedLambda->subregion()->Nodes().begin().ptr();
       auto loadOperation =
           dynamic_cast<const LoadNonVolatileOperation *>(&convertedLoad->GetOperation());
 
-      EXPECT_EQ(loadOperation->GetAlignment(), 4);
-      EXPECT_EQ(loadOperation->NumMemoryStates(), 1);
+      EXPECT_EQ(loadOperation->GetAlignment(), 4u);
+      EXPECT_EQ(loadOperation->NumMemoryStates(), 1u);
 
       EXPECT_TRUE(is<jlm::llvm::PointerType>(convertedLoad->input(0)->Type()));
       EXPECT_TRUE(is<jlm::llvm::MemoryStateType>(convertedLoad->input(1)->Type()));
@@ -254,7 +254,7 @@ TEST(JlmToMlirToJlmTests, TestLoad)
 
       auto outputBitType =
           std::dynamic_pointer_cast<const jlm::rvsdg::BitType>(convertedLoad->output(0)->Type());
-      EXPECT_EQ(outputBitType->nbits(), 32);
+      EXPECT_EQ(outputBitType->nbits(), 32u);
     }
   }
 }
@@ -306,14 +306,14 @@ TEST(JlmToMlirToJlmTests, TestStore)
     EXPECT_TRUE(mlir::isa<mlir::jlm::Store>(mlirOp));
 
     auto mlirStore = mlir::cast<mlir::jlm::Store>(mlirOp);
-    EXPECT_EQ(mlirStore.getAlignment(), 4);
-    EXPECT_EQ(mlirStore.getInputMemStates().size(), 1);
-    EXPECT_EQ(mlirStore.getNumOperands(), 3);
+    EXPECT_EQ(mlirStore.getAlignment(), 4u);
+    EXPECT_EQ(mlirStore.getInputMemStates().size(), 1u);
+    EXPECT_EQ(mlirStore.getNumOperands(), 3u);
 
     auto inputType = mlirStore.getValue().getType();
     EXPECT_TRUE(mlir::isa<mlir::IntegerType>(inputType));
     auto integerType = mlir::cast<mlir::IntegerType>(inputType);
-    EXPECT_EQ(integerType.getWidth(), 32);
+    EXPECT_EQ(integerType.getWidth(), 32u);
 
     // // Convert the MLIR to RVSDG and check the result
     std::cout << "Converting MLIR to RVSDG" << std::endl;
@@ -325,20 +325,20 @@ TEST(JlmToMlirToJlmTests, TestStore)
     {
       using namespace jlm::llvm;
 
-      EXPECT_EQ(region->numNodes(), 1);
+      EXPECT_EQ(region->numNodes(), 1u);
       auto convertedLambda =
           jlm::util::assertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
       EXPECT_TRUE(is<jlm::rvsdg::LambdaOperation>(convertedLambda));
 
-      EXPECT_EQ(convertedLambda->subregion()->numNodes(), 1);
+      EXPECT_EQ(convertedLambda->subregion()->numNodes(), 1u);
       EXPECT_TRUE(is<StoreNonVolatileOperation>(
           convertedLambda->subregion()->Nodes().begin()->GetOperation()));
       auto convertedStore = convertedLambda->subregion()->Nodes().begin().ptr();
       auto convertedStoreOperation =
           dynamic_cast<const StoreNonVolatileOperation *>(&convertedStore->GetOperation());
 
-      EXPECT_EQ(convertedStoreOperation->GetAlignment(), 4);
-      EXPECT_EQ(convertedStoreOperation->NumMemoryStates(), 1);
+      EXPECT_EQ(convertedStoreOperation->GetAlignment(), 4u);
+      EXPECT_EQ(convertedStoreOperation->NumMemoryStates(), 1u);
 
       EXPECT_TRUE(is<jlm::llvm::PointerType>(convertedStore->input(0)->Type()));
       EXPECT_TRUE(is<jlm::rvsdg::BitType>(convertedStore->input(1)->Type()));
@@ -348,7 +348,7 @@ TEST(JlmToMlirToJlmTests, TestStore)
 
       auto inputBitType =
           std::dynamic_pointer_cast<const jlm::rvsdg::BitType>(convertedStore->input(1)->Type());
-      EXPECT_EQ(inputBitType->nbits(), 32);
+      EXPECT_EQ(inputBitType->nbits(), 32u);
     }
   }
 }
@@ -409,19 +409,19 @@ TEST(JlmToMlirToJlmTests, TestSext)
     {
       using namespace jlm::llvm;
 
-      EXPECT_EQ(region->numNodes(), 1);
+      EXPECT_EQ(region->numNodes(), 1u);
       auto convertedLambda =
           jlm::util::assertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
       EXPECT_TRUE(is<jlm::rvsdg::LambdaOperation>(convertedLambda));
 
-      EXPECT_EQ(convertedLambda->subregion()->numNodes(), 1);
+      EXPECT_EQ(convertedLambda->subregion()->numNodes(), 1u);
       EXPECT_TRUE(is<SExtOperation>(convertedLambda->subregion()->Nodes().begin()->GetOperation()));
       auto convertedSext = dynamic_cast<const SExtOperation *>(
           &convertedLambda->subregion()->Nodes().begin()->GetOperation());
 
-      EXPECT_EQ(convertedSext->ndstbits(), 64);
-      EXPECT_EQ(convertedSext->nsrcbits(), 32);
-      EXPECT_EQ(convertedSext->nresults(), 1);
+      EXPECT_EQ(convertedSext->ndstbits(), 64u);
+      EXPECT_EQ(convertedSext->nsrcbits(), 32u);
+      EXPECT_EQ(convertedSext->nresults(), 1u);
     }
   }
 }
@@ -480,10 +480,10 @@ TEST(JlmToMlirToJlmTests, TestSitofp)
     {
       using namespace jlm::llvm;
 
-      EXPECT_EQ(region->numNodes(), 1);
+      EXPECT_EQ(region->numNodes(), 1u);
       auto convertedLambda =
           jlm::util::assertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
-      EXPECT_EQ(convertedLambda->subregion()->numNodes(), 1);
+      EXPECT_EQ(convertedLambda->subregion()->numNodes(), 1u);
       EXPECT_TRUE(
           is<SIToFPOperation>(convertedLambda->subregion()->Nodes().begin()->GetOperation()));
       auto convertedSitofp = dynamic_cast<const SIToFPOperation *>(
@@ -536,10 +536,10 @@ TEST(JlmToMlirToJlmTests, TestConstantFP)
     {
       using namespace jlm::llvm;
 
-      EXPECT_EQ(region->numNodes(), 1);
+      EXPECT_EQ(region->numNodes(), 1u);
       auto convertedLambda =
           jlm::util::assertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
-      EXPECT_EQ(convertedLambda->subregion()->numNodes(), 1);
+      EXPECT_EQ(convertedLambda->subregion()->numNodes(), 1u);
       EXPECT_TRUE(is<ConstantFP>(convertedLambda->subregion()->Nodes().begin()->GetOperation()));
       auto convertedConst = dynamic_cast<const ConstantFP *>(
           &convertedLambda->subregion()->Nodes().begin()->GetOperation());
@@ -614,17 +614,17 @@ TEST(JlmToMlirToJlmTests, TestFpBinary)
       {
         using namespace jlm::llvm;
 
-        EXPECT_EQ(region->numNodes(), 1);
+        EXPECT_EQ(region->numNodes(), 1u);
         auto convertedLambda =
             jlm::util::assertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
-        EXPECT_EQ(convertedLambda->subregion()->numNodes(), 1);
+        EXPECT_EQ(convertedLambda->subregion()->numNodes(), 1u);
 
         auto node = convertedLambda->subregion()->Nodes().begin().ptr();
         auto convertedFpbin =
             jlm::util::assertedCast<const FBinaryOperation>(&node->GetOperation());
         EXPECT_EQ(convertedFpbin->fpop(), binOp);
-        EXPECT_EQ(convertedFpbin->nresults(), 1);
-        EXPECT_EQ(convertedFpbin->narguments(), 2);
+        EXPECT_EQ(convertedFpbin->nresults(), 1u);
+        EXPECT_EQ(convertedFpbin->narguments(), 2u);
       }
     }
   }
@@ -673,14 +673,14 @@ TEST(JlmToMlirToJlmTests, TestFMulAddOp)
 
     // Assert
     auto region = &roundTripModule->Rvsdg().GetRootRegion();
-    EXPECT_EQ(region->numNodes(), 1);
+    EXPECT_EQ(region->numNodes(), 1u);
     auto convertedLambda =
         jlm::util::assertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
-    EXPECT_EQ(convertedLambda->subregion()->numNodes(), 1);
+    EXPECT_EQ(convertedLambda->subregion()->numNodes(), 1u);
     const auto arguments = convertedLambda->GetFunctionArguments();
     const auto results = convertedLambda->GetFunctionResults();
-    EXPECT_EQ(arguments.size(), 3);
-    EXPECT_EQ(results.size(), 1);
+    EXPECT_EQ(arguments.size(), 3u);
+    EXPECT_EQ(results.size(), 1u);
 
     auto & convertedNode = *convertedLambda->subregion()->Nodes().begin();
     EXPECT_TRUE(is<jlm::llvm::FMulAddIntrinsicOperation>(&convertedNode));
@@ -735,18 +735,18 @@ TEST(JlmToMlirToJlmTests, TestGetElementPtr)
     auto mlirArrayType = mlir::cast<mlir::LLVM::LLVMArrayType>(mlirGep.getElemType());
 
     EXPECT_TRUE(mlir::isa<mlir::IntegerType>(mlirArrayType.getElementType()));
-    EXPECT_EQ(mlirArrayType.getNumElements(), 2);
+    EXPECT_EQ(mlirArrayType.getNumElements(), 2u);
 
     auto indices = mlirGep.getIndices();
-    EXPECT_EQ(indices.size(), 2);
+    EXPECT_EQ(indices.size(), 2u);
     auto index0 = indices[0].dyn_cast<mlir::Value>();
     auto index1 = indices[1].dyn_cast<mlir::Value>();
     EXPECT_NE(index0, nullptr);
     EXPECT_NE(index1, nullptr);
     EXPECT_TRUE(index0.getType().isa<mlir::IntegerType>());
     EXPECT_TRUE(index1.getType().isa<mlir::IntegerType>());
-    EXPECT_EQ(index0.getType().getIntOrFloatBitWidth(), 32);
-    EXPECT_EQ(index1.getType().getIntOrFloatBitWidth(), 32);
+    EXPECT_EQ(index0.getType().getIntOrFloatBitWidth(), 32u);
+    EXPECT_EQ(index1.getType().getIntOrFloatBitWidth(), 32u);
 
     // // Convert the MLIR to RVSDG and check the result
     std::cout << "Converting MLIR to RVSDG" << std::endl;
@@ -758,10 +758,10 @@ TEST(JlmToMlirToJlmTests, TestGetElementPtr)
     {
       using namespace jlm::llvm;
 
-      EXPECT_EQ(region->numNodes(), 1);
+      EXPECT_EQ(region->numNodes(), 1u);
       auto convertedLambda =
           jlm::util::assertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
-      EXPECT_EQ(convertedLambda->subregion()->numNodes(), 1);
+      EXPECT_EQ(convertedLambda->subregion()->numNodes(), 1u);
 
       auto op = convertedLambda->subregion()->Nodes().begin();
       EXPECT_TRUE(is<GetElementPtrOperation>(op->GetOperation()));
@@ -819,7 +819,7 @@ TEST(JlmToMlirToJlmTests, TestDelta)
     std::cout << "Validate MLIR" << std::endl;
 
     auto & omegaBlock = omega.getRegion().front();
-    EXPECT_EQ(omegaBlock.getOperations().size(), 3); // 2 delta nodes + 1 omegaresult
+    EXPECT_EQ(omegaBlock.getOperations().size(), 3u); // 2 delta nodes + 1 omegaresult
     for (auto & op : omegaBlock.getOperations())
     {
       auto mlirDeltaNode = ::mlir::dyn_cast<::mlir::rvsdg::DeltaNode>(&op);
@@ -846,7 +846,7 @@ TEST(JlmToMlirToJlmTests, TestDelta)
       EXPECT_TRUE(mlirDeltaNode.getType().isa<mlir::LLVM::LLVMPointerType>());
       auto terminator = mlirDeltaNode.getRegion().front().getTerminator();
       EXPECT_NE(terminator, nullptr);
-      EXPECT_EQ(terminator->getNumOperands(), 1);
+      EXPECT_EQ(terminator->getNumOperands(), 1u);
       EXPECT_TRUE(terminator->getOperand(0).getType().isa<mlir::IntegerType>());
     }
 
@@ -860,11 +860,11 @@ TEST(JlmToMlirToJlmTests, TestDelta)
     {
       using namespace jlm::llvm;
 
-      EXPECT_EQ(region->numNodes(), 2);
+      EXPECT_EQ(region->numNodes(), 2u);
       for (auto & node : region->Nodes())
       {
         auto convertedDelta = jlm::util::assertedCast<jlm::rvsdg::DeltaNode>(&node);
-        EXPECT_EQ(convertedDelta->subregion()->numNodes(), 1);
+        EXPECT_EQ(convertedDelta->subregion()->numNodes(), 1u);
         auto dop = jlm::util::assertedCast<const jlm::llvm::DeltaOperation>(&node.GetOperation());
 
         if (convertedDelta->constant())
@@ -918,14 +918,14 @@ TEST(JlmToMlirToJlmTests, TestConstantDataArray)
       auto mlirConstantDataArray = ::mlir::dyn_cast<::mlir::jlm::ConstantDataArray>(&op);
       if (mlirConstantDataArray)
       {
-        EXPECT_EQ(mlirConstantDataArray.getNumOperands(), 2);
+        EXPECT_EQ(mlirConstantDataArray.getNumOperands(), 2u);
         EXPECT_TRUE(mlirConstantDataArray.getOperand(0).getType().isa<mlir::IntegerType>());
         EXPECT_TRUE(mlirConstantDataArray.getOperand(1).getType().isa<mlir::IntegerType>());
         auto mlirConstantDataArrayResultType =
             mlirConstantDataArray.getResult().getType().dyn_cast<mlir::LLVM::LLVMArrayType>();
         EXPECT_NE(mlirConstantDataArrayResultType, nullptr);
         EXPECT_TRUE(mlirConstantDataArrayResultType.getElementType().isa<mlir::IntegerType>());
-        EXPECT_EQ(mlirConstantDataArrayResultType.getNumElements(), 2);
+        EXPECT_EQ(mlirConstantDataArrayResultType.getNumElements(), 2u);
         foundConstantDataArray = true;
       }
     }
@@ -941,20 +941,20 @@ TEST(JlmToMlirToJlmTests, TestConstantDataArray)
     {
       using namespace jlm::llvm;
 
-      EXPECT_EQ(region->numNodes(), 3);
+      EXPECT_EQ(region->numNodes(), 3u);
       bool foundConstantDataArray = false;
       for (auto & node : region->Nodes())
       {
         if (auto constantDataArray = dynamic_cast<const ConstantDataArray *>(&node.GetOperation()))
         {
           foundConstantDataArray = true;
-          EXPECT_EQ(constantDataArray->nresults(), 1);
-          EXPECT_EQ(constantDataArray->narguments(), 2);
+          EXPECT_EQ(constantDataArray->nresults(), 1u);
+          EXPECT_EQ(constantDataArray->narguments(), 2u);
           auto resultType = constantDataArray->result(0);
           auto arrayType = dynamic_cast<const jlm::llvm::ArrayType *>(resultType.get());
           EXPECT_NE(arrayType, nullptr);
           EXPECT_TRUE(is<jlm::rvsdg::BitType>(arrayType->element_type()));
-          EXPECT_EQ(arrayType->nelements(), 2);
+          EXPECT_EQ(arrayType->nelements(), 2u);
           EXPECT_TRUE(is<jlm::rvsdg::BitType>(constantDataArray->argument(0)));
           EXPECT_TRUE(is<jlm::rvsdg::BitType>(constantDataArray->argument(1)));
         }
@@ -992,7 +992,7 @@ TEST(JlmToMlirToJlmTests, TestConstantAggregateZero)
         mlirConstantAggregateZero.getType().dyn_cast<mlir::LLVM::LLVMArrayType>();
     EXPECT_NE(mlirConstantAggregateZeroResultType, nullptr);
     EXPECT_TRUE(mlirConstantAggregateZeroResultType.getElementType().isa<mlir::IntegerType>());
-    EXPECT_EQ(mlirConstantAggregateZeroResultType.getNumElements(), 2);
+    EXPECT_EQ(mlirConstantAggregateZeroResultType.getNumElements(), 2u);
 
     // // Convert the MLIR to RVSDG and check the result
     std::cout << "Converting MLIR to RVSDG" << std::endl;
@@ -1004,17 +1004,17 @@ TEST(JlmToMlirToJlmTests, TestConstantAggregateZero)
     {
       using namespace jlm::llvm;
 
-      EXPECT_EQ(region->numNodes(), 1);
+      EXPECT_EQ(region->numNodes(), 1u);
       auto const convertedConstantAggregateZero =
           jlm::util::assertedCast<const ConstantAggregateZeroOperation>(
               &region->Nodes().begin().ptr()->GetOperation());
-      EXPECT_EQ(convertedConstantAggregateZero->nresults(), 1);
-      EXPECT_EQ(convertedConstantAggregateZero->narguments(), 0);
+      EXPECT_EQ(convertedConstantAggregateZero->nresults(), 1u);
+      EXPECT_EQ(convertedConstantAggregateZero->narguments(), 0u);
       auto resultType = convertedConstantAggregateZero->result(0);
       auto arrayType = dynamic_cast<const jlm::llvm::ArrayType *>(resultType.get());
       EXPECT_NE(arrayType, nullptr);
       EXPECT_TRUE(is<jlm::rvsdg::BitType>(arrayType->element_type()));
-      EXPECT_EQ(arrayType->nelements(), 2);
+      EXPECT_EQ(arrayType->nelements(), 2u);
     }
   }
 }
@@ -1048,7 +1048,7 @@ TEST(JlmToMlirToJlmTests, TestVarArgList)
       auto mlirVarArgOp = ::mlir::dyn_cast<::mlir::jlm::CreateVarArgList>(&op);
       if (mlirVarArgOp)
       {
-        EXPECT_EQ(mlirVarArgOp.getOperands().size(), 2);
+        EXPECT_EQ(mlirVarArgOp.getOperands().size(), 2u);
         EXPECT_TRUE(mlirVarArgOp.getOperands()[0].getType().isa<mlir::IntegerType>());
         EXPECT_TRUE(mlirVarArgOp.getOperands()[1].getType().isa<mlir::IntegerType>());
         EXPECT_TRUE(mlirVarArgOp.getResult().getType().isa<mlir::jlm::VarargListType>());
@@ -1067,7 +1067,7 @@ TEST(JlmToMlirToJlmTests, TestVarArgList)
     {
       using namespace jlm::llvm;
 
-      EXPECT_EQ(region->numNodes(), 3);
+      EXPECT_EQ(region->numNodes(), 3u);
       bool foundVarArgOp = false;
       for (auto & node : region->Nodes())
       {
@@ -1075,8 +1075,8 @@ TEST(JlmToMlirToJlmTests, TestVarArgList)
             dynamic_cast<const VariadicArgumentListOperation *>(&node.GetOperation());
         if (convertedVarArgOp)
         {
-          EXPECT_EQ(convertedVarArgOp->nresults(), 1);
-          EXPECT_EQ(convertedVarArgOp->narguments(), 2);
+          EXPECT_EQ(convertedVarArgOp->nresults(), 1u);
+          EXPECT_EQ(convertedVarArgOp->narguments(), 2u);
           auto resultType = convertedVarArgOp->result(0);
           EXPECT_TRUE(is<jlm::llvm::VariableArgumentType>(resultType));
           EXPECT_TRUE(is<jlm::rvsdg::BitType>(convertedVarArgOp->argument(0)));
@@ -1122,10 +1122,10 @@ TEST(JlmToMlirToJlmTests, TestFNeg)
       {
         auto inputFloatType = mlirFNegOp.getOperand().getType().dyn_cast<mlir::FloatType>();
         EXPECT_NE(inputFloatType, nullptr);
-        EXPECT_EQ(inputFloatType.getWidth(), 32);
+        EXPECT_EQ(inputFloatType.getWidth(), 32u);
         auto outputFloatType = mlirFNegOp.getResult().getType().dyn_cast<mlir::FloatType>();
         EXPECT_NE(outputFloatType, nullptr);
-        EXPECT_EQ(outputFloatType.getWidth(), 32);
+        EXPECT_EQ(outputFloatType.getWidth(), 32u);
         foundFNegOp = true;
       }
     }
@@ -1141,15 +1141,15 @@ TEST(JlmToMlirToJlmTests, TestFNeg)
     {
       using namespace jlm::llvm;
 
-      EXPECT_EQ(region->numNodes(), 2);
+      EXPECT_EQ(region->numNodes(), 2u);
       bool foundFNegOp = false;
       for (auto & node : region->Nodes())
       {
         auto convertedFNegOp = dynamic_cast<const FNegOperation *>(&node.GetOperation());
         if (convertedFNegOp)
         {
-          EXPECT_EQ(convertedFNegOp->nresults(), 1);
-          EXPECT_EQ(convertedFNegOp->narguments(), 1);
+          EXPECT_EQ(convertedFNegOp->nresults(), 1u);
+          EXPECT_EQ(convertedFNegOp->narguments(), 1u);
           auto inputFloatType = jlm::util::assertedCast<const jlm::llvm::FloatingPointType>(
               convertedFNegOp->argument(0).get());
           EXPECT_EQ(inputFloatType->size(), jlm::llvm::fpsize::flt);
@@ -1198,10 +1198,10 @@ TEST(JlmToMlirToJlmTests, TestFPExt)
       {
         auto inputFloatType = mlirFPExtOp.getOperand().getType().dyn_cast<mlir::FloatType>();
         EXPECT_NE(inputFloatType, nullptr);
-        EXPECT_EQ(inputFloatType.getWidth(), 32);
+        EXPECT_EQ(inputFloatType.getWidth(), 32u);
         auto outputFloatType = mlirFPExtOp.getResult().getType().dyn_cast<mlir::FloatType>();
         EXPECT_NE(outputFloatType, nullptr);
-        EXPECT_EQ(outputFloatType.getWidth(), 64);
+        EXPECT_EQ(outputFloatType.getWidth(), 64u);
         foundFPExtOp = true;
       }
     }
@@ -1217,15 +1217,15 @@ TEST(JlmToMlirToJlmTests, TestFPExt)
     {
       using namespace jlm::llvm;
 
-      EXPECT_EQ(region->numNodes(), 2);
+      EXPECT_EQ(region->numNodes(), 2u);
       bool foundFPExtOp = false;
       for (auto & node : region->Nodes())
       {
         auto convertedFPExtOp = dynamic_cast<const FPExtOperation *>(&node.GetOperation());
         if (convertedFPExtOp)
         {
-          EXPECT_EQ(convertedFPExtOp->nresults(), 1);
-          EXPECT_EQ(convertedFPExtOp->narguments(), 1);
+          EXPECT_EQ(convertedFPExtOp->nresults(), 1u);
+          EXPECT_EQ(convertedFPExtOp->narguments(), 1u);
           auto inputFloatType = jlm::util::assertedCast<const jlm::llvm::FloatingPointType>(
               convertedFPExtOp->argument(0).get());
           EXPECT_EQ(inputFloatType->size(), jlm::llvm::fpsize::flt);
@@ -1271,10 +1271,10 @@ TEST(JlmToMlirToJlmTests, TestTrunc)
       {
         auto inputBitType = mlirTruncOp.getOperand().getType().dyn_cast<mlir::IntegerType>();
         EXPECT_NE(inputBitType, nullptr);
-        EXPECT_EQ(inputBitType.getWidth(), 64);
+        EXPECT_EQ(inputBitType.getWidth(), 64u);
         auto outputBitType = mlirTruncOp.getResult().getType().dyn_cast<mlir::IntegerType>();
         EXPECT_NE(outputBitType, nullptr);
-        EXPECT_EQ(outputBitType.getWidth(), 32);
+        EXPECT_EQ(outputBitType.getWidth(), 32u);
         foundTruncOp = true;
       }
     }
@@ -1290,21 +1290,21 @@ TEST(JlmToMlirToJlmTests, TestTrunc)
     {
       using namespace jlm::llvm;
 
-      EXPECT_EQ(region->numNodes(), 2);
+      EXPECT_EQ(region->numNodes(), 2u);
       bool foundTruncOp = false;
       for (auto & node : region->Nodes())
       {
         auto convertedTruncOp = dynamic_cast<const TruncOperation *>(&node.GetOperation());
         if (convertedTruncOp)
         {
-          EXPECT_EQ(convertedTruncOp->nresults(), 1);
-          EXPECT_EQ(convertedTruncOp->narguments(), 1);
+          EXPECT_EQ(convertedTruncOp->nresults(), 1u);
+          EXPECT_EQ(convertedTruncOp->narguments(), 1u);
           auto inputBitType = jlm::util::assertedCast<const jlm::rvsdg::BitType>(
               convertedTruncOp->argument(0).get());
-          EXPECT_EQ(inputBitType->nbits(), 64);
+          EXPECT_EQ(inputBitType->nbits(), 64u);
           auto outputBitType =
               jlm::util::assertedCast<const jlm::rvsdg::BitType>(convertedTruncOp->result(0).get());
-          EXPECT_EQ(outputBitType->nbits(), 32);
+          EXPECT_EQ(outputBitType->nbits(), 32u);
           foundTruncOp = true;
         }
       }
@@ -1354,8 +1354,8 @@ TEST(JlmToMlirToJlmTests, TestFree)
     EXPECT_TRUE(mlir::isa<mlir::jlm::Free>(mlirOp));
 
     auto mlirFree = mlir::cast<mlir::jlm::Free>(mlirOp);
-    EXPECT_EQ(mlirFree.getNumOperands(), 3);
-    EXPECT_EQ(mlirFree.getNumResults(), 2);
+    EXPECT_EQ(mlirFree.getNumOperands(), 3u);
+    EXPECT_EQ(mlirFree.getNumResults(), 2u);
 
     auto inputType1 = mlirFree.getOperand(0).getType();
     auto inputType2 = mlirFree.getOperand(1).getType();
@@ -1379,18 +1379,18 @@ TEST(JlmToMlirToJlmTests, TestFree)
     {
       using namespace jlm::llvm;
 
-      EXPECT_EQ(region->numNodes(), 1);
+      EXPECT_EQ(region->numNodes(), 1u);
       auto convertedLambda =
           jlm::util::assertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
       EXPECT_TRUE(is<jlm::rvsdg::LambdaOperation>(convertedLambda));
 
-      EXPECT_EQ(convertedLambda->subregion()->numNodes(), 1);
+      EXPECT_EQ(convertedLambda->subregion()->numNodes(), 1u);
       EXPECT_TRUE(is<FreeOperation>(convertedLambda->subregion()->Nodes().begin()->GetOperation()));
       auto convertedFree = dynamic_cast<const FreeOperation *>(
           &convertedLambda->subregion()->Nodes().begin()->GetOperation());
 
-      EXPECT_EQ(convertedFree->narguments(), 3);
-      EXPECT_EQ(convertedFree->nresults(), 2);
+      EXPECT_EQ(convertedFree->narguments(), 3u);
+      EXPECT_EQ(convertedFree->nresults(), 2u);
 
       EXPECT_TRUE(is<jlm::llvm::PointerType>(convertedFree->argument(0)));
       EXPECT_TRUE(is<jlm::llvm::MemoryStateType>(convertedFree->argument(1)));
@@ -1447,8 +1447,8 @@ TEST(JlmToMlirToJlmTests, TestFunctionGraphImport)
     EXPECT_NE(mlirFunctionType, nullptr);
     EXPECT_NE(mlirImportedFunctionType, nullptr);
     EXPECT_EQ(mlirFunctionType, mlirImportedFunctionType);
-    EXPECT_EQ(mlirFunctionType.getNumInputs(), 3);
-    EXPECT_EQ(mlirFunctionType.getNumResults(), 2);
+    EXPECT_EQ(mlirFunctionType.getNumInputs(), 3u);
+    EXPECT_EQ(mlirFunctionType.getNumResults(), 2u);
     EXPECT_TRUE(mlir::isa<mlir::rvsdg::IOStateEdgeType>(mlirFunctionType.getInput(0)));
     EXPECT_TRUE(mlir::isa<mlir::rvsdg::MemStateEdgeType>(mlirFunctionType.getInput(1)));
     EXPECT_TRUE(mlir::isa<mlir::LLVM::LLVMPointerType>(mlirFunctionType.getInput(2)));
@@ -1467,9 +1467,9 @@ TEST(JlmToMlirToJlmTests, TestFunctionGraphImport)
     {
       using namespace jlm::llvm;
 
-      EXPECT_EQ(region->numNodes(), 0);
+      EXPECT_EQ(region->numNodes(), 0u);
 
-      EXPECT_EQ(region->graph()->GetRootRegion().narguments(), 1);
+      EXPECT_EQ(region->graph()->GetRootRegion().narguments(), 1u);
       auto arg = region->graph()->GetRootRegion().argument(0);
       auto imp = dynamic_cast<jlm::llvm::LlvmGraphImport *>(arg);
       EXPECT_NE(imp, nullptr);
@@ -1523,7 +1523,7 @@ TEST(JlmToMlirToJlmTests, TestPointerGraphImport)
 
     auto mlirIntType = valueType.dyn_cast<mlir::IntegerType>();
     EXPECT_NE(mlirIntType, nullptr);
-    EXPECT_EQ(mlirIntType.getWidth(), 32);
+    EXPECT_EQ(mlirIntType.getWidth(), 32u);
     EXPECT_EQ(linkage, "external_linkage");
     EXPECT_EQ(name, "test");
 
@@ -1537,9 +1537,9 @@ TEST(JlmToMlirToJlmTests, TestPointerGraphImport)
     {
       using namespace jlm::llvm;
 
-      EXPECT_EQ(region->numNodes(), 0);
+      EXPECT_EQ(region->numNodes(), 0u);
 
-      EXPECT_EQ(region->graph()->GetRootRegion().narguments(), 1);
+      EXPECT_EQ(region->graph()->GetRootRegion().narguments(), 1u);
       auto arg = region->graph()->GetRootRegion().argument(0);
       auto imp = dynamic_cast<jlm::llvm::LlvmGraphImport *>(arg);
       EXPECT_NE(imp, nullptr);
@@ -1588,7 +1588,7 @@ TEST(JlmToMlirToJlmTests, TestIOBarrier)
     // Validate the generated MLIR
     std::cout << "Validate MLIR" << std::endl;
     auto & omegaRegion = omega.getRegion();
-    EXPECT_EQ(omegaRegion.getBlocks().size(), 1);
+    EXPECT_EQ(omegaRegion.getBlocks().size(), 1u);
     auto & omegaBlock = omegaRegion.front();
     auto & mlirLambda = omegaBlock.front();
     auto & mlirLambdaRegion = mlirLambda.getRegion(0);
@@ -1603,18 +1603,18 @@ TEST(JlmToMlirToJlmTests, TestIOBarrier)
         foundIOBarrier = true;
 
         // Check that the IOBarrier has 2 operands (value and IO state)
-        EXPECT_EQ(ioBarrier->getNumOperands(), 2);
+        EXPECT_EQ(ioBarrier->getNumOperands(), 2u);
 
         // Check that the first operand is a 32-bit integer
         auto valueType = ioBarrier->getOperand(0).getType().dyn_cast<mlir::IntegerType>();
         EXPECT_NE(valueType, nullptr);
-        EXPECT_EQ(valueType.getWidth(), 32);
+        EXPECT_EQ(valueType.getWidth(), 32u);
         EXPECT_TRUE(mlir::isa<mlir::rvsdg::IOStateEdgeType>(ioBarrier->getOperand(1).getType()));
 
         // Check that the result type matches the input value type
         auto resultType = ioBarrier->getResult(0).getType().dyn_cast<mlir::IntegerType>();
         EXPECT_NE(resultType, nullptr);
-        EXPECT_EQ(resultType.getWidth(), 32);
+        EXPECT_EQ(resultType.getWidth(), 32u);
       }
     }
     EXPECT_TRUE(foundIOBarrier);
@@ -1630,7 +1630,7 @@ TEST(JlmToMlirToJlmTests, TestIOBarrier)
       using namespace jlm::llvm;
 
       // Direct access to the lambda node
-      EXPECT_EQ(region->numNodes(), 1);
+      EXPECT_EQ(region->numNodes(), 1u);
       auto & lambdaNode = *region->Nodes().begin();
       auto lambdaOperation = dynamic_cast<const jlm::rvsdg::LambdaNode *>(&lambdaNode);
       EXPECT_NE(lambdaOperation, nullptr);
@@ -1645,14 +1645,14 @@ TEST(JlmToMlirToJlmTests, TestIOBarrier)
           foundIOBarrier = true;
 
           // Check that it has correct number of inputs and outputs
-          EXPECT_EQ(ioBarrierOp->nresults(), 1);
-          EXPECT_EQ(ioBarrierOp->narguments(), 2);
+          EXPECT_EQ(ioBarrierOp->nresults(), 1u);
+          EXPECT_EQ(ioBarrierOp->narguments(), 2u);
 
           // Check that the first input is the 32-bit value
           auto valueType =
               dynamic_cast<const jlm::rvsdg::BitType *>(ioBarrierOp->argument(0).get());
           EXPECT_NE(valueType, nullptr);
-          EXPECT_EQ(valueType->nbits(), 32);
+          EXPECT_EQ(valueType->nbits(), 32u);
 
           // Check that the second input is an IO state
           auto ioStateType = dynamic_cast<const IOStateType *>(ioBarrierOp->argument(1).get());
@@ -1661,7 +1661,7 @@ TEST(JlmToMlirToJlmTests, TestIOBarrier)
           // Check that the output type matches the input value type
           auto outputType = dynamic_cast<const jlm::rvsdg::BitType *>(ioBarrierOp->result(0).get());
           EXPECT_NE(outputType, nullptr);
-          EXPECT_EQ(outputType->nbits(), 32);
+          EXPECT_EQ(outputType->nbits(), 32u);
         }
       }
       EXPECT_TRUE(foundIOBarrier);
@@ -1699,7 +1699,7 @@ TEST(JlmToMlirToJlmTests, TestMalloc)
       {
         auto inputBitType = mlirMallocOp.getOperand(0).getType().dyn_cast<mlir::IntegerType>();
         EXPECT_NE(inputBitType, nullptr);
-        EXPECT_EQ(inputBitType.getWidth(), 64);
+        EXPECT_EQ(inputBitType.getWidth(), 64u);
         EXPECT_TRUE(mlir::isa<mlir::LLVM::LLVMPointerType>(mlirMallocOp.getResult(0).getType()));
         EXPECT_TRUE(mlir::isa<mlir::rvsdg::IOStateEdgeType>(mlirMallocOp.getResult(1).getType()));
         EXPECT_TRUE(mlir::isa<mlir::rvsdg::MemStateEdgeType>(mlirMallocOp.getResult(2).getType()));
@@ -1718,18 +1718,18 @@ TEST(JlmToMlirToJlmTests, TestMalloc)
     {
       using namespace jlm::llvm;
 
-      EXPECT_EQ(region->numNodes(), 3);
+      EXPECT_EQ(region->numNodes(), 3u);
       bool foundMallocOp = false;
       for (auto & node : region->Nodes())
       {
         auto convertedMallocOp = dynamic_cast<const MallocOperation *>(&node.GetOperation());
         if (convertedMallocOp)
         {
-          EXPECT_EQ(convertedMallocOp->nresults(), 3);
-          EXPECT_EQ(convertedMallocOp->narguments(), 2);
+          EXPECT_EQ(convertedMallocOp->nresults(), 3u);
+          EXPECT_EQ(convertedMallocOp->narguments(), 2u);
           auto inputBitType = jlm::util::assertedCast<const jlm::rvsdg::BitType>(
               convertedMallocOp->argument(0).get());
-          EXPECT_EQ(inputBitType->nbits(), 64);
+          EXPECT_EQ(inputBitType->nbits(), 64u);
           EXPECT_TRUE(jlm::rvsdg::is<jlm::llvm::PointerType>(convertedMallocOp->result(0)));
           EXPECT_TRUE(jlm::rvsdg::is<jlm::llvm::IOStateType>(convertedMallocOp->result(1)));
           EXPECT_TRUE(jlm::rvsdg::is<jlm::llvm::MemoryStateType>(convertedMallocOp->result(2)));

--- a/jlm/mlir/backend/JlmToMlirConverterTests.cpp
+++ b/jlm/mlir/backend/JlmToMlirConverterTests.cpp
@@ -46,10 +46,10 @@ TEST(JlmToMlirConverterTests, TestLambda)
     // Validate the generated MLIR
     std::cout << "Validate MLIR" << std::endl;
     auto & omegaRegion = omega.getRegion();
-    EXPECT_EQ(omegaRegion.getBlocks().size(), 1);
+    EXPECT_EQ(omegaRegion.getBlocks().size(), 1u);
     auto & omegaBlock = omegaRegion.front();
     // Lamda + terminating operation
-    EXPECT_EQ(omegaBlock.getOperations().size(), 2);
+    EXPECT_EQ(omegaBlock.getOperations().size(), 2u);
     auto & mlirLambda = omegaBlock.front();
     EXPECT_TRUE(
         mlirLambda.getName().getStringRef().equals(mlir::rvsdg::LambdaNode::getOperationName()));
@@ -93,7 +93,7 @@ TEST(JlmToMlirConverterTests, TestLambda)
     auto & lambdaRegion = mlirLambda.getRegion(0);
     auto & lambdaBlock = lambdaRegion.front();
     // Bitconstant + terminating operation
-    EXPECT_EQ(lambdaBlock.getOperations().size(), 2);
+    EXPECT_EQ(lambdaBlock.getOperations().size(), 2u);
     EXPECT_TRUE(lambdaBlock.front().getName().getStringRef().equals(
         mlir::arith::ConstantIntOp::getOperationName()));
 
@@ -174,10 +174,10 @@ TEST(JlmToMlirConverterTests, TestAddOperation)
     // Checking blocks and operations count
     std::cout << "Checking blocks and operations count" << std::endl;
     auto & omegaRegion = omega.getRegion();
-    EXPECT_EQ(omegaRegion.getBlocks().size(), 1);
+    EXPECT_EQ(omegaRegion.getBlocks().size(), 1u);
     auto & omegaBlock = omegaRegion.front();
     // Lamda + terminating operation
-    EXPECT_EQ(omegaBlock.getOperations().size(), 2);
+    EXPECT_EQ(omegaBlock.getOperations().size(), 2u);
 
     // Checking lambda block operations
     std::cout << "Checking lambda block operations" << std::endl;
@@ -185,7 +185,7 @@ TEST(JlmToMlirConverterTests, TestAddOperation)
     auto & lambdaRegion = mlirLambda.getRegion(0);
     auto & lambdaBlock = lambdaRegion.front();
     // 2 Bits contants + add + terminating operation
-    EXPECT_EQ(lambdaBlock.getOperations().size(), 4);
+    EXPECT_EQ(lambdaBlock.getOperations().size(), 4u);
 
     // Checking lambda block operations types
     std::cout << "Checking lambda block operations types" << std::endl;
@@ -195,7 +195,7 @@ TEST(JlmToMlirConverterTests, TestAddOperation)
       operations.push_back(&operation);
     }
 
-    int constCount = 0;
+    unsigned constCount = 0;
     for (auto & operation : operations)
     {
       if (operation->getName().getStringRef().equals(mlir::rvsdg::LambdaResult::getOperationName()))
@@ -211,13 +211,13 @@ TEST(JlmToMlirConverterTests, TestAddOperation)
       EXPECT_TRUE(operation->getName().getStringRef().equals(
           mlir::arith::AddIOp::getOperationName())); // Last remaining operation is the add
                                                      // operation
-      EXPECT_EQ(operation->getNumOperands(), 2);
+      EXPECT_EQ(operation->getNumOperands(), 2u);
       auto addOperand1 = operation->getOperand(0);
       auto addOperand2 = operation->getOperand(1);
       EXPECT_TRUE(addOperand1.getType().isInteger(32));
       EXPECT_TRUE(addOperand2.getType().isInteger(32));
     }
-    EXPECT_EQ(constCount, 2);
+    EXPECT_EQ(constCount, 2u);
 
     useChainsUpTraverse(
         &lambdaBlock.getOperations().back(),
@@ -278,10 +278,10 @@ TEST(JlmToMlirConverterTests, TestComZeroExt)
     // Checking blocks and operations count
     std::cout << "Checking blocks and operations count" << std::endl;
     auto & omegaRegion = omega.getRegion();
-    EXPECT_EQ(omegaRegion.getBlocks().size(), 1);
+    EXPECT_EQ(omegaRegion.getBlocks().size(), 1u);
     auto & omegaBlock = omegaRegion.front();
     // Lamda + terminating operation
-    EXPECT_EQ(omegaBlock.getOperations().size(), 2);
+    EXPECT_EQ(omegaBlock.getOperations().size(), 2u);
 
     // Checking lambda block operations
     std::cout << "Checking lambda block operations" << std::endl;
@@ -289,7 +289,7 @@ TEST(JlmToMlirConverterTests, TestComZeroExt)
     auto & lambdaRegion = mlirLambda.getRegion(0);
     auto & lambdaBlock = lambdaRegion.front();
     // 3 Bits contants + ZeroExt + Mul + Comp + terminating operation
-    EXPECT_EQ(lambdaBlock.getOperations().size(), 7);
+    EXPECT_EQ(lambdaBlock.getOperations().size(), 7u);
 
     // Checking lambda block operations types
     std::cout << "Checking lambda block operations types" << std::endl;
@@ -300,10 +300,10 @@ TEST(JlmToMlirConverterTests, TestComZeroExt)
       operations.push_back(&operation);
     }
 
-    int constCount = 0;
-    int extCount = 0;
-    int mulCount = 0;
-    int compCount = 0;
+    unsigned constCount = 0;
+    unsigned extCount = 0;
+    unsigned mulCount = 0;
+    unsigned compCount = 0;
     for (auto & operation : operations)
     {
       if (operation->getName().getStringRef().equals(mlir::rvsdg::LambdaResult::getOperationName()))
@@ -319,19 +319,19 @@ TEST(JlmToMlirConverterTests, TestComZeroExt)
       }
       if (operation->getName().getStringRef().equals(mlir::arith::ExtUIOp::getOperationName()))
       {
-        EXPECT_EQ(operation->getNumOperands(), 1);
+        EXPECT_EQ(operation->getNumOperands(), 1u);
         EXPECT_TRUE(operation->getOperand(0).getType().isInteger(8));
-        EXPECT_EQ(operation->getNumResults(), 1);
+        EXPECT_EQ(operation->getNumResults(), 1u);
         EXPECT_TRUE(operation->getResult(0).getType().isInteger(16));
         extCount++;
         continue;
       }
       if (operation->getName().getStringRef().equals(mlir::arith::MulIOp::getOperationName()))
       {
-        EXPECT_EQ(operation->getNumOperands(), 2);
+        EXPECT_EQ(operation->getNumOperands(), 2u);
         EXPECT_TRUE(operation->getOperand(0).getType().isInteger(16));
         EXPECT_TRUE(operation->getOperand(1).getType().isInteger(16));
-        EXPECT_EQ(operation->getNumResults(), 1);
+        EXPECT_EQ(operation->getNumResults(), 1u);
         EXPECT_TRUE(operation->getResult(0).getType().isInteger(16));
         mulCount++;
         continue;
@@ -340,10 +340,10 @@ TEST(JlmToMlirConverterTests, TestComZeroExt)
       {
         auto comparisonOp = mlir::cast<mlir::arith::CmpIOp>(operation);
         EXPECT_EQ(comparisonOp.getPredicate(), mlir::arith::CmpIPredicate::sgt);
-        EXPECT_EQ(operation->getNumOperands(), 2);
+        EXPECT_EQ(operation->getNumOperands(), 2u);
         EXPECT_TRUE(operation->getOperand(0).getType().isInteger(16));
         EXPECT_TRUE(operation->getOperand(1).getType().isInteger(16));
-        EXPECT_EQ(operation->getNumResults(), 1);
+        EXPECT_EQ(operation->getNumResults(), 1u);
         compCount++;
         continue;
       }
@@ -352,10 +352,10 @@ TEST(JlmToMlirConverterTests, TestComZeroExt)
 
     // Check counts
     std::cout << "Checking counts" << std::endl;
-    EXPECT_EQ(constCount, 3);
-    EXPECT_EQ(extCount, 1);
-    EXPECT_EQ(mulCount, 1);
-    EXPECT_EQ(compCount, 1);
+    EXPECT_EQ(constCount, 3u);
+    EXPECT_EQ(extCount, 1u);
+    EXPECT_EQ(mulCount, 1u);
+    EXPECT_EQ(compCount, 1u);
 
     useChainsUpTraverse(
         &lambdaBlock.getOperations().back(),
@@ -410,10 +410,10 @@ TEST(JlmToMlirConverterTests, TestMatch)
     // Checking blocks and operations count
     std::cout << "Checking blocks and operations count" << std::endl;
     auto & omegaRegion = omega.getRegion();
-    EXPECT_EQ(omegaRegion.getBlocks().size(), 1);
+    EXPECT_EQ(omegaRegion.getBlocks().size(), 1u);
     auto & omegaBlock = omegaRegion.front();
     // Lamda + terminating operation
-    EXPECT_EQ(omegaBlock.getOperations().size(), 2);
+    EXPECT_EQ(omegaBlock.getOperations().size(), 2u);
 
     // Checking lambda block operations
     std::cout << "Checking lambda block operations" << std::endl;
@@ -421,7 +421,7 @@ TEST(JlmToMlirConverterTests, TestMatch)
     auto & lambdaRegion = mlirLambda.getRegion(0);
     auto & lambdaBlock = lambdaRegion.front();
     // 1 Bits contants + Match + terminating operation
-    EXPECT_EQ(lambdaBlock.getOperations().size(), 3);
+    EXPECT_EQ(lambdaBlock.getOperations().size(), 3u);
 
     bool matchFound = false;
     for (auto & operation : lambdaBlock.getOperations())
@@ -434,13 +434,13 @@ TEST(JlmToMlirConverterTests, TestMatch)
 
         EXPECT_TRUE(mlir::isa<mlir::arith::ConstantIntOp>(matchOp.getInput().getDefiningOp()));
         auto constant = mlir::cast<mlir::arith::ConstantIntOp>(matchOp.getInput().getDefiningOp());
-        EXPECT_EQ(constant.value(), 4);
+        EXPECT_EQ(constant.value(), 4u);
         EXPECT_TRUE(constant.getType().isInteger(8));
 
         auto mapping = matchOp.getMapping();
         mapping.dump();
         // 3 alternatives + default
-        EXPECT_EQ(mapping.size(), 4);
+        EXPECT_EQ(mapping.size(), 4u);
 
         // ** region check alternatives *$
         for (auto & attr : mapping)
@@ -449,12 +449,12 @@ TEST(JlmToMlirConverterTests, TestMatch)
           auto matchRuleAttr = attr.cast<::mlir::rvsdg::MatchRuleAttr>();
           if (matchRuleAttr.isDefault())
           {
-            EXPECT_EQ(matchRuleAttr.getIndex(), 2);
+            EXPECT_EQ(matchRuleAttr.getIndex(), 2u);
             EXPECT_TRUE(matchRuleAttr.getValues().empty());
             continue;
           }
 
-          EXPECT_EQ(matchRuleAttr.getValues().size(), 1);
+          EXPECT_EQ(matchRuleAttr.getValues().size(), 1u);
 
           const int64_t value = matchRuleAttr.getValues().front();
 
@@ -520,10 +520,10 @@ TEST(JlmToMlirConverterTests, TestGamma)
     // Checking blocks and operations count
     std::cout << "Checking blocks and operations count" << std::endl;
     auto & omegaRegion = omega.getRegion();
-    EXPECT_EQ(omegaRegion.getBlocks().size(), 1);
+    EXPECT_EQ(omegaRegion.getBlocks().size(), 1u);
     auto & omegaBlock = omegaRegion.front();
     // 1 control + 2 constants + gamma + terminating operation
-    EXPECT_EQ(omegaBlock.getOperations().size(), 5);
+    EXPECT_EQ(omegaBlock.getOperations().size(), 5u);
 
     bool gammaFound = false;
     for (auto & operation : omegaBlock.getOperations())
@@ -533,44 +533,44 @@ TEST(JlmToMlirConverterTests, TestGamma)
         gammaFound = true;
         std::cout << "Checking gamma operation" << std::endl;
         auto gammaOp = mlir::cast<mlir::rvsdg::GammaNode>(operation);
-        EXPECT_EQ(gammaOp.getNumRegions(), 3);
+        EXPECT_EQ(gammaOp.getNumRegions(), 3u);
         // 1 predicate + 2 entryVars
-        EXPECT_EQ(gammaOp.getNumOperands(), 3);
-        EXPECT_EQ(gammaOp.getNumResults(), 2);
+        EXPECT_EQ(gammaOp.getNumOperands(), 3u);
+        EXPECT_EQ(gammaOp.getNumResults(), 2u);
 
         std::cout << "Checking gamma predicate" << std::endl;
         EXPECT_TRUE(mlir::isa<mlir::rvsdg::ConstantCtrl>(gammaOp.getPredicate().getDefiningOp()));
         auto controlConstant =
             mlir::cast<mlir::rvsdg::ConstantCtrl>(gammaOp.getPredicate().getDefiningOp());
-        EXPECT_EQ(controlConstant.getValue(), 1);
+        EXPECT_EQ(controlConstant.getValue(), 1u);
         EXPECT_TRUE(mlir::isa<mlir::rvsdg::RVSDG_CTRLType>(controlConstant.getType()));
         auto ctrlType = mlir::cast<mlir::rvsdg::RVSDG_CTRLType>(controlConstant.getType());
-        EXPECT_EQ(ctrlType.getNumOptions(), 3);
+        EXPECT_EQ(ctrlType.getNumOptions(), 3u);
 
         std::cout << "Checking gamma entryVars" << std::endl;
         //! getInputs() corresponds to the entryVars
         auto entryVars = gammaOp.getInputs();
-        EXPECT_EQ(entryVars.size(), 2);
+        EXPECT_EQ(entryVars.size(), 2u);
         EXPECT_TRUE(mlir::isa<mlir::arith::ConstantIntOp>(entryVars[0].getDefiningOp()));
         EXPECT_TRUE(mlir::isa<mlir::arith::ConstantIntOp>(entryVars[1].getDefiningOp()));
         auto entryVar1 = mlir::cast<mlir::arith::ConstantIntOp>(entryVars[0].getDefiningOp());
         auto entryVar2 = mlir::cast<mlir::arith::ConstantIntOp>(entryVars[1].getDefiningOp());
-        EXPECT_EQ(entryVar1.value(), 5);
-        EXPECT_EQ(entryVar2.value(), 6);
+        EXPECT_EQ(entryVar1.value(), 5u);
+        EXPECT_EQ(entryVar2.value(), 6u);
 
         std::cout << "Checking gamma subregions" << std::endl;
         for (size_t i = 0; i < gammaOp.getNumRegions(); i++)
         {
-          EXPECT_EQ(gammaOp.getRegion(i).getBlocks().size(), 1);
+          EXPECT_EQ(gammaOp.getRegion(i).getBlocks().size(), 1u);
           auto & gammaBlock = gammaOp.getRegion(i).front();
           // 2 bit constants + gamma result
-          EXPECT_EQ(gammaBlock.getOperations().size(), 3);
+          EXPECT_EQ(gammaBlock.getOperations().size(), 3u);
 
           std::cout << "Checking gamma exitVars" << std::endl;
           auto gammaResult = gammaBlock.getTerminator();
           EXPECT_TRUE(mlir::isa<mlir::rvsdg::GammaResult>(gammaResult));
           auto gammaResultOp = mlir::cast<mlir::rvsdg::GammaResult>(gammaResult);
-          EXPECT_EQ(gammaResultOp.getNumOperands(), 2);
+          EXPECT_EQ(gammaResultOp.getNumOperands(), 2u);
           for (size_t j = 0; j < gammaResultOp.getNumOperands(); j++)
           {
             EXPECT_TRUE(
@@ -621,10 +621,10 @@ TEST(JlmToMlirConverterTests, TestTheta)
     // Checking blocks and operations count
     std::cout << "Checking blocks and operations count" << std::endl;
     auto & omegaRegion = omega.getRegion();
-    EXPECT_EQ(omegaRegion.getBlocks().size(), 1);
+    EXPECT_EQ(omegaRegion.getBlocks().size(), 1u);
     auto & omegaBlock = omegaRegion.front();
     // 1 theta + 1 predicate + 2 constants
-    EXPECT_EQ(omegaBlock.getOperations().size(), 4);
+    EXPECT_EQ(omegaBlock.getOperations().size(), 4u);
 
     bool thetaFound = false;
     for (auto & operation : omegaBlock.getOperations())
@@ -635,8 +635,8 @@ TEST(JlmToMlirConverterTests, TestTheta)
         std::cout << "Checking theta operation" << std::endl;
         auto thetaOp = mlir::cast<mlir::rvsdg::ThetaNode>(operation);
         // 2 loop vars
-        EXPECT_EQ(thetaOp.getNumOperands(), 2);
-        EXPECT_EQ(thetaOp.getNumResults(), 2);
+        EXPECT_EQ(thetaOp.getNumOperands(), 2u);
+        EXPECT_EQ(thetaOp.getNumResults(), 2u);
 
         auto & thetaBlock = thetaOp.getRegion().front();
         auto thetaResult = thetaBlock.getTerminator();
@@ -651,25 +651,25 @@ TEST(JlmToMlirConverterTests, TestTheta)
         auto controlConstant =
             mlir::cast<mlir::rvsdg::ConstantCtrl>(thetaResultOp.getPredicate().getDefiningOp());
 
-        EXPECT_EQ(controlConstant.getValue(), 0);
+        EXPECT_EQ(controlConstant.getValue(), 0u);
 
         EXPECT_TRUE(mlir::isa<mlir::rvsdg::RVSDG_CTRLType>(controlConstant.getType()));
         auto ctrlType = mlir::cast<mlir::rvsdg::RVSDG_CTRLType>(controlConstant.getType());
-        EXPECT_EQ(ctrlType.getNumOptions(), 2);
+        EXPECT_EQ(ctrlType.getNumOptions(), 2u);
 
         std::cout << "Checking theta loop vars" << std::endl;
         //! getInputs() corresponds to the loop vars
         auto loopVars = thetaOp.getInputs();
-        EXPECT_EQ(loopVars.size(), 2);
+        EXPECT_EQ(loopVars.size(), 2u);
         EXPECT_TRUE(mlir::isa<mlir::arith::ConstantIntOp>(loopVars[0].getDefiningOp()));
         EXPECT_TRUE(mlir::isa<mlir::arith::ConstantIntOp>(loopVars[1].getDefiningOp()));
         auto loopVar1 = mlir::cast<mlir::arith::ConstantIntOp>(loopVars[0].getDefiningOp());
         auto loopVar2 = mlir::cast<mlir::arith::ConstantIntOp>(loopVars[1].getDefiningOp());
-        EXPECT_EQ(loopVar1.value(), 5);
-        EXPECT_EQ(loopVar2.value(), 6);
+        EXPECT_EQ(loopVar1.value(), 5u);
+        EXPECT_EQ(loopVar2.value(), 6u);
 
         // Theta result, constant control predicate
-        EXPECT_EQ(thetaBlock.getOperations().size(), 2);
+        EXPECT_EQ(thetaBlock.getOperations().size(), 2u);
 
         std::cout << "Checking loop exitVars" << std::endl;
         std::cout << thetaResultOp.getNumOperands() << std::endl;
@@ -677,7 +677,7 @@ TEST(JlmToMlirConverterTests, TestTheta)
         std::cout << "Checking theta subregion" << std::endl;
 
         // Two arguments and predicate
-        EXPECT_EQ(thetaResultOp.getNumOperands(), 3);
+        EXPECT_EQ(thetaResultOp.getNumOperands(), 3u);
       }
     }
     // }

--- a/jlm/mlir/frontend/MlirToJlmConverterTests.cpp
+++ b/jlm/mlir/frontend/MlirToJlmConverterTests.cpp
@@ -110,12 +110,12 @@ TEST(MlirToJlmConverterTests, TestLambda)
       using namespace jlm::rvsdg;
       std::cout << "Checking the result" << std::endl;
 
-      EXPECT_EQ(region->numNodes(), 1);
+      EXPECT_EQ(region->numNodes(), 1u);
       auto convertedLambda =
           jlm::util::assertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
       EXPECT_TRUE(is<jlm::llvm::LlvmLambdaOperation>(convertedLambda->GetOperation()));
 
-      EXPECT_EQ(convertedLambda->subregion()->numNodes(), 1);
+      EXPECT_EQ(convertedLambda->subregion()->numNodes(), 1u);
       EXPECT_TRUE(is<jlm::llvm::IntegerConstantOperation>(
           convertedLambda->subregion()->Nodes().begin().ptr()));
     }
@@ -258,7 +258,7 @@ TEST(MlirToJlmConverterTests, TestDivOperation)
     {
       using namespace jlm::rvsdg;
 
-      EXPECT_EQ(region->numNodes(), 1);
+      EXPECT_EQ(region->numNodes(), 1u);
 
       // Get the lambda block
       auto convertedLambda =
@@ -266,7 +266,7 @@ TEST(MlirToJlmConverterTests, TestDivOperation)
       EXPECT_TRUE(is<jlm::llvm::LlvmLambdaOperation>(convertedLambda));
 
       // 2 Constants + 1 DivUIOp
-      EXPECT_EQ(convertedLambda->subregion()->numNodes(), 3);
+      EXPECT_EQ(convertedLambda->subregion()->numNodes(), 3u);
 
       // Traverse the rvsgd graph upwards to check connections
       NodeOutput * lambdaResultOriginNodeOutput =
@@ -274,14 +274,14 @@ TEST(MlirToJlmConverterTests, TestDivOperation)
       EXPECT_NE(lambdaResultOriginNodeOutput, nullptr);
       Node * lambdaResultOriginNode = lambdaResultOriginNodeOutput->node();
       EXPECT_TRUE(is<jlm::llvm::IntegerUDivOperation>(lambdaResultOriginNode->GetOperation()));
-      EXPECT_EQ(lambdaResultOriginNode->ninputs(), 2);
+      EXPECT_EQ(lambdaResultOriginNode->ninputs(), 2u);
 
       // Check first input
       RegionArgument * DivInput0 =
           dynamic_cast<jlm::rvsdg::RegionArgument *>(lambdaResultOriginNode->input(0)->origin());
       EXPECT_NE(DivInput0, nullptr);
       EXPECT_TRUE(jlm::rvsdg::is<BitType>(DivInput0->Type()));
-      EXPECT_EQ(std::dynamic_pointer_cast<const BitType>(DivInput0->Type())->nbits(), 32);
+      EXPECT_EQ(std::dynamic_pointer_cast<const BitType>(DivInput0->Type())->nbits(), 32u);
 
       // Check second input
       auto DivInput1Node = jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(
@@ -290,11 +290,11 @@ TEST(MlirToJlmConverterTests, TestDivOperation)
       EXPECT_TRUE(is<jlm::llvm::IntegerConstantOperation>(DivInput1Node->GetOperation()));
       auto DivInput1Constant =
           dynamic_cast<const jlm::llvm::IntegerConstantOperation *>(&DivInput1Node->GetOperation());
-      EXPECT_EQ(DivInput1Constant->Representation().to_int(), 5);
+      EXPECT_EQ(DivInput1Constant->Representation().to_int(), 5u);
       EXPECT_TRUE(is<const BitType>(DivInput1Constant->result(0)));
       EXPECT_EQ(
           std::dynamic_pointer_cast<const BitType>(DivInput1Constant->result(0))->nbits(),
-          32);
+          32u);
     }
   }
 }
@@ -430,7 +430,7 @@ TEST(MlirToJlmConverterTests, TestCompZeroExt)
 
       std::cout << "Checking the result" << std::endl;
 
-      EXPECT_EQ(region->numNodes(), 1);
+      EXPECT_EQ(region->numNodes(), 1u);
 
       // Get the lambda block
       auto convertedLambda =
@@ -438,7 +438,7 @@ TEST(MlirToJlmConverterTests, TestCompZeroExt)
       EXPECT_TRUE(is<jlm::llvm::LlvmLambdaOperation>(convertedLambda));
 
       // 2 Constants + AddOp + CompOp + ZeroExtOp
-      EXPECT_EQ(convertedLambda->subregion()->numNodes(), 5);
+      EXPECT_EQ(convertedLambda->subregion()->numNodes(), 5u);
 
       // Traverse the rvsgd graph upwards to check connections
       std::cout << "Testing lambdaResultOriginNodeOuput\n";
@@ -446,12 +446,12 @@ TEST(MlirToJlmConverterTests, TestCompZeroExt)
           *convertedLambda->subregion()->result(0)->origin());
       EXPECT_NE(ZExtNode, nullptr);
       EXPECT_TRUE(is<jlm::llvm::ZExtOperation>(ZExtNode->GetOperation()));
-      EXPECT_EQ(ZExtNode->ninputs(), 1);
+      EXPECT_EQ(ZExtNode->ninputs(), 1u);
 
       // Check ZExt
       auto ZExtOp = dynamic_cast<const jlm::llvm::ZExtOperation *>(&ZExtNode->GetOperation());
-      EXPECT_EQ(ZExtOp->nsrcbits(), 1);
-      EXPECT_EQ(ZExtOp->ndstbits(), 32);
+      EXPECT_EQ(ZExtOp->nsrcbits(), 1u);
+      EXPECT_EQ(ZExtOp->ndstbits(), 32u);
 
       // Check ZExt input
       std::cout << "Testing input 0\n";
@@ -464,14 +464,14 @@ TEST(MlirToJlmConverterTests, TestCompZeroExt)
           dynamic_cast<const jlm::llvm::IntegerEqOperation *>(&BitEqNode->GetOperation())
               ->Type()
               .nbits(),
-          32);
-      EXPECT_EQ(BitEqNode->ninputs(), 2);
+          32u);
+      EXPECT_EQ(BitEqNode->ninputs(), 2u);
 
       // Check BitEq input 0
       auto AddNode =
           jlm::rvsdg::TryGetOwnerNode<jlm::rvsdg::SimpleNode>(*BitEqNode->input(0)->origin());
       EXPECT_TRUE(is<jlm::llvm::IntegerAddOperation>(AddNode->GetOperation()));
-      EXPECT_EQ(AddNode->ninputs(), 2);
+      EXPECT_EQ(AddNode->ninputs(), 2u);
 
       // Check BitEq input 1
       auto Const2Node =
@@ -481,20 +481,20 @@ TEST(MlirToJlmConverterTests, TestCompZeroExt)
       // Check Const2
       auto Const2Op =
           dynamic_cast<const jlm::llvm::IntegerConstantOperation *>(&Const2Node->GetOperation());
-      EXPECT_EQ(Const2Op->Representation().to_int(), 5);
+      EXPECT_EQ(Const2Op->Representation().to_int(), 5u);
       EXPECT_TRUE(is<const BitType>(Const2Op->result(0)));
-      EXPECT_EQ(std::dynamic_pointer_cast<const BitType>(Const2Op->result(0))->nbits(), 32);
+      EXPECT_EQ(std::dynamic_pointer_cast<const BitType>(Const2Op->result(0))->nbits(), 32u);
 
       // Check add op
       auto AddOp = dynamic_cast<const jlm::llvm::IntegerAddOperation *>(&AddNode->GetOperation());
-      EXPECT_EQ(AddOp->Type().nbits(), 32);
+      EXPECT_EQ(AddOp->Type().nbits(), 32u);
 
       // Check add input0
       RegionArgument * AddInput0 =
           dynamic_cast<jlm::rvsdg::RegionArgument *>(AddNode->input(0)->origin());
       EXPECT_NE(AddInput0, nullptr);
       EXPECT_TRUE(jlm::rvsdg::is<BitType>(AddInput0->Type()));
-      EXPECT_EQ(std::dynamic_pointer_cast<const BitType>(AddInput0->Type())->nbits(), 32);
+      EXPECT_EQ(std::dynamic_pointer_cast<const BitType>(AddInput0->Type())->nbits(), 32u);
 
       // Check add input1
       auto Const1Node =
@@ -504,9 +504,9 @@ TEST(MlirToJlmConverterTests, TestCompZeroExt)
       // Check Const1
       auto Const1Op =
           dynamic_cast<const jlm::llvm::IntegerConstantOperation *>(&Const1Node->GetOperation());
-      EXPECT_EQ(Const1Op->Representation().to_int(), 20);
+      EXPECT_EQ(Const1Op->Representation().to_int(), 20u);
       EXPECT_TRUE(is<const BitType>(Const1Op->result(0)));
-      EXPECT_EQ(std::dynamic_pointer_cast<const BitType>(Const1Op->result(0))->nbits(), 32);
+      EXPECT_EQ(std::dynamic_pointer_cast<const BitType>(Const1Op->result(0))->nbits(), 32u);
     }
   }
 }
@@ -648,14 +648,14 @@ TEST(MlirToJlmConverterTests, TestMatchOp)
       EXPECT_TRUE(is<MatchOperation>(matchNode->GetOperation()));
 
       auto matchOp = dynamic_cast<const MatchOperation *>(&matchNode->GetOperation());
-      EXPECT_EQ(matchOp->narguments(), 1);
+      EXPECT_EQ(matchOp->narguments(), 1u);
       EXPECT_TRUE(is<const BitType>(matchOp->argument(0)));
-      EXPECT_EQ(std::dynamic_pointer_cast<const BitType>(matchOp->argument(0))->nbits(), 32);
+      EXPECT_EQ(std::dynamic_pointer_cast<const BitType>(matchOp->argument(0))->nbits(), 32u);
 
       // 3 alternatives + default
-      EXPECT_EQ(matchOp->nalternatives(), 4);
+      EXPECT_EQ(matchOp->nalternatives(), 4u);
 
-      EXPECT_EQ(matchOp->default_alternative(), 2);
+      EXPECT_EQ(matchOp->default_alternative(), 2u);
 
       for (auto mapping : *matchOp)
       {
@@ -801,7 +801,7 @@ TEST(MlirToJlmConverterTests, TestGammaOp)
     {
       using namespace jlm::rvsdg;
 
-      EXPECT_EQ(region->numNodes(), 1);
+      EXPECT_EQ(region->numNodes(), 1u);
 
       // Get the lambda block
       auto convertedLambda =
@@ -811,16 +811,16 @@ TEST(MlirToJlmConverterTests, TestGammaOp)
       auto lambdaRegion = convertedLambda->subregion();
 
       // 2 constants + gamma
-      EXPECT_EQ(lambdaRegion->numNodes(), 3);
+      EXPECT_EQ(lambdaRegion->numNodes(), 3u);
 
       auto gammaNode = &jlm::rvsdg::AssertGetOwnerNode<jlm::rvsdg::GammaNode>(
           *lambdaRegion->result(0)->origin());
 
       std::cout << "Checking gamma operation" << std::endl;
       auto gammaOp = dynamic_cast<const GammaOperation *>(&gammaNode->GetOperation());
-      EXPECT_EQ(gammaNode->ninputs(), 3);
-      EXPECT_EQ(gammaOp->nalternatives(), 3);
-      EXPECT_EQ(gammaNode->noutputs(), 2);
+      EXPECT_EQ(gammaNode->ninputs(), 3u);
+      EXPECT_EQ(gammaOp->nalternatives(), 3u);
+      EXPECT_EQ(gammaNode->noutputs(), 2u);
     }
   }
 }
@@ -925,7 +925,7 @@ TEST(MlirToJlmConverterTests, TestThetaOp)
     {
       using namespace jlm::rvsdg;
 
-      EXPECT_EQ(region->numNodes(), 1);
+      EXPECT_EQ(region->numNodes(), 1u);
 
       // Get the lambda block
       auto convertedLambda =
@@ -935,20 +935,20 @@ TEST(MlirToJlmConverterTests, TestThetaOp)
       auto lambdaRegion = convertedLambda->subregion();
 
       // Just the theta node
-      EXPECT_EQ(lambdaRegion->numNodes(), 1);
+      EXPECT_EQ(lambdaRegion->numNodes(), 1u);
 
       auto thetaNode = &jlm::rvsdg::AssertGetOwnerNode<jlm::rvsdg::ThetaNode>(
           *lambdaRegion->result(0)->origin());
 
       std::cout << "Checking theta node" << std::endl;
-      EXPECT_EQ(thetaNode->ninputs(), 2);
-      EXPECT_EQ(thetaNode->GetLoopVars().size(), 2);
-      EXPECT_EQ(thetaNode->noutputs(), 2);
-      EXPECT_EQ(thetaNode->nsubregions(), 1);
+      EXPECT_EQ(thetaNode->ninputs(), 2u);
+      EXPECT_EQ(thetaNode->GetLoopVars().size(), 2u);
+      EXPECT_EQ(thetaNode->noutputs(), 2u);
+      EXPECT_EQ(thetaNode->nsubregions(), 1u);
       EXPECT_TRUE(is<jlm::rvsdg::ControlType>(thetaNode->predicate()->Type()));
       auto predicateType =
           std::dynamic_pointer_cast<const ControlType>(thetaNode->predicate()->Type());
-      EXPECT_EQ(predicateType->nalternatives(), 2);
+      EXPECT_EQ(predicateType->nalternatives(), 2u);
       std::cout << predicate.getValue() << std::endl;
     }
   }

--- a/jlm/rvsdg/GraphTests.cpp
+++ b/jlm/rvsdg/GraphTests.cpp
@@ -118,7 +118,7 @@ TEST(GraphTests, Copy)
 
   EXPECT_EQ(newGraph->GetRootRegion().numNodes(), 1u);
   auto copiedNode = newGraph->GetRootRegion().Nodes().begin().ptr();
-  EXPECT_EQ(copiedNode->ninputs() == 1 && copiedNode->noutputs(), 1);
+  EXPECT_EQ(copiedNode->ninputs() == 1 && copiedNode->noutputs(), 1u);
   EXPECT_EQ(copiedNode->input(0)->origin(), copiedArgument);
 
   EXPECT_EQ(newGraph->GetRootRegion().nresults(), 1u);

--- a/jlm/rvsdg/RegionTests.cpp
+++ b/jlm/rvsdg/RegionTests.cpp
@@ -41,21 +41,21 @@ TEST(RegionTests, IteratorRanges)
 
   // Act & Assert
   auto numArguments = std::distance(subregion.Arguments().begin(), subregion.Arguments().end());
-  EXPECT_EQ(numArguments, 2);
+  EXPECT_EQ(numArguments, 2u);
   for (auto & argument : constSubregion.Arguments())
   {
     EXPECT_TRUE(argument == &argument0 || argument == &argument1);
   }
 
   auto numTopNodes = std::distance(subregion.TopNodes().begin(), subregion.TopNodes().end());
-  EXPECT_EQ(numTopNodes, 1);
+  EXPECT_EQ(numTopNodes, 1u);
   for (auto & topNode : constSubregion.TopNodes())
   {
     EXPECT_EQ(&topNode, topNode0);
   }
 
   auto numNodes = std::distance(subregion.Nodes().begin(), subregion.Nodes().end());
-  EXPECT_EQ(numNodes, 4);
+  EXPECT_EQ(numNodes, 4u);
   for (auto & node : constSubregion.Nodes())
   {
     EXPECT_TRUE(&node == topNode0 || &node == node0 || &node == node1 || &node == bottomNode0);
@@ -63,14 +63,14 @@ TEST(RegionTests, IteratorRanges)
 
   auto numBottomNodes =
       std::distance(subregion.BottomNodes().begin(), subregion.BottomNodes().end());
-  EXPECT_EQ(numBottomNodes, 1);
+  EXPECT_EQ(numBottomNodes, 1u);
   for (auto & bottomNode : constSubregion.BottomNodes())
   {
     EXPECT_EQ(&bottomNode, bottomNode0);
   }
 
   auto numResults = std::distance(subregion.Results().begin(), subregion.Results().end());
-  EXPECT_EQ(numResults, 3);
+  EXPECT_EQ(numResults, 3u);
   for (auto & result : constSubregion.Results())
   {
     EXPECT_TRUE(
@@ -419,7 +419,7 @@ TEST(RegionTests, ToTree_RvsdgWithStructuralNodes)
   auto numLines = std::count(tree.begin(), tree.end(), '\n');
 
   // We should find '\n' 10 times: 1 root region + 3 structural nodes + 6 subregions
-  EXPECT_EQ(numLines, 10);
+  EXPECT_EQ(numLines, 10u);
 
   // Check that the last line printed looks accordingly
   auto lastLine = std::string("----Region[2]\n");
@@ -453,7 +453,7 @@ TEST(RegionTests, ToTree_RvsdgWithStructuralNodesAndAnnotations)
   auto numLines = std::count(tree.begin(), tree.end(), '\n');
 
   // We should find '\n' 8 times: 1 root region + 2 structural nodes + 5 subregions
-  EXPECT_EQ(numLines, 8);
+  EXPECT_EQ(numLines, 8u);
 
   // Check that the last line printed looks accordingly
   auto lastLine = std::string("----Region[2] NumNodes:0 NumArguments:0\n");
@@ -667,10 +667,10 @@ TEST(RegionTests, DepthTest)
   auto innerStructuralNode = TestStructuralNode::create(structuralNode->subregion(0), 1);
 
   // Act & Assert
-  EXPECT_EQ(graph.GetRootRegion().getDepth(), 0);
-  EXPECT_EQ(structuralNode->region()->getDepth(), 0);
-  EXPECT_EQ(structuralNode->subregion(0)->getDepth(), 1);
-  EXPECT_EQ(structuralNode->subregion(1)->getDepth(), 1);
-  EXPECT_EQ(innerStructuralNode->region()->getDepth(), 1);
-  EXPECT_EQ(innerStructuralNode->subregion(0)->getDepth(), 2);
+  EXPECT_EQ(graph.GetRootRegion().getDepth(), 0u);
+  EXPECT_EQ(structuralNode->region()->getDepth(), 0u);
+  EXPECT_EQ(structuralNode->subregion(0)->getDepth(), 1u);
+  EXPECT_EQ(structuralNode->subregion(1)->getDepth(), 1u);
+  EXPECT_EQ(innerStructuralNode->region()->getDepth(), 1u);
+  EXPECT_EQ(innerStructuralNode->subregion(0)->getDepth(), 2u);
 }

--- a/jlm/rvsdg/bitstring/BitstringTests.cpp
+++ b/jlm/rvsdg/bitstring/BitstringTests.cpp
@@ -2125,14 +2125,14 @@ TEST(bitstring, test_value_representation)
 
     EXPECT_EQ(rbits.neg(), -r);
     EXPECT_EQ(rbits.shl(1), r << 1);
-    EXPECT_EQ(rbits.shl(32), 0);
+    EXPECT_EQ(rbits.shl(32), 0u);
     EXPECT_EQ(rbits.ashr(1), r >> 1);
     EXPECT_EQ(rbits.ashr(34), (r < 0 ? -1 : 0));
 
     if (r >= 0)
     {
       EXPECT_EQ(rbits.shr(1), r >> 1);
-      EXPECT_EQ(rbits.shr(34), 0);
+      EXPECT_EQ(rbits.shr(34), 0u);
     }
 
     for (ssize_t c = -4; c < 5; c++)

--- a/jlm/util/StatisticsTests.cpp
+++ b/jlm/util/StatisticsTests.cpp
@@ -103,7 +103,7 @@ TEST(StatisticsTests, TestStatisticsCollection)
   auto numCollectedStatistics =
       std::distance(collector.CollectedStatistics().begin(), collector.CollectedStatistics().end());
 
-  EXPECT_EQ(numCollectedStatistics, 1);
+  EXPECT_EQ(numCollectedStatistics, 1u);
   for (auto & statistic : collector.CollectedStatistics())
   {
     EXPECT_EQ(statistic.GetId(), Statistics::Id::Aggregation);


### PR DESCRIPTION
MAC is more picky when it comes to specifying the type of integers.