### PR TITLE
Fix non-determinism in JSON generation

### DIFF
--- a/jlm/llvm/opt/RvsdgTreePrinterTests.cpp
+++ b/jlm/llvm/opt/RvsdgTreePrinterTests.cpp
@@ -269,7 +269,7 @@ TEST(RvsdgTreePrinterTests, printAllocaNodes)
   std::cout << tree;
 
   // Assert
-  const auto expectedTree = "{\"NumAllocaNodes\":2,\"NumAggregateAllocaNodes\":1}\n";
+  const auto expectedTree = "{\"NumAggregateAllocaNodes\":1,\"NumAllocaNodes\":2}\n";
 
   EXPECT_EQ(tree, expectedTree);
 }

--- a/jlm/rvsdg/RegionTests.cpp
+++ b/jlm/rvsdg/RegionTests.cpp
@@ -555,7 +555,7 @@ TEST(RegionTests, toJson_RvsdgWithStructuralNodesAndAnnotations)
       json,
       "{\"StructuralNodes\":[{\"DebugString\":\"TestStructuralOperation\",\"Subregions\":"
       "[{},{\"StructuralNodes\":[{\"DebugString\":\"TestStructuralOperation\",\"Subregions\""
-      ":[{},{},{\"NumNodes\":0,\"NumArguments\":0}]}]}]}]}");
+      ":[{},{},{\"NumArguments\":0,\"NumNodes\":0}]}]}]}]}");
 }
 
 TEST(RegionTests, BottomNodeTests)

--- a/jlm/rvsdg/region.cpp
+++ b/jlm/rvsdg/region.cpp
@@ -515,13 +515,15 @@ Region::toJson(
 
   if (annotationMap.HasAnnotations(&region))
   {
-    auto annotations = const_cast<std::vector<util::Annotation> &>(
-        annotationMap.GetAnnotations(&region));
+    auto annotations =
+        const_cast<std::vector<util::Annotation> &>(annotationMap.GetAnnotations(&region));
     std::sort(
         annotations.begin(),
         annotations.end(),
         [](const util::Annotation & a, const util::Annotation & b)
-        { return a.Label() < b.Label(); });
+        {
+          return a.Label() < b.Label();
+        });
 
     bool first = true;
     for (auto & annotation : annotations)
@@ -577,13 +579,15 @@ Region::toJson(
   {
     stream << ",";
 
-    auto annotations = const_cast<std::vector<util::Annotation> &>(
-        annotationMap.GetAnnotations(&structuralNode));
+    auto annotations =
+        const_cast<std::vector<util::Annotation> &>(annotationMap.GetAnnotations(&structuralNode));
     std::sort(
         annotations.begin(),
         annotations.end(),
         [](const util::Annotation & a, const util::Annotation & b)
-        { return a.Label() < b.Label(); });
+        {
+          return a.Label() < b.Label();
+        });
 
     bool first = true;
     for (auto & annotation : annotations)

--- a/jlm/rvsdg/region.cpp
+++ b/jlm/rvsdg/region.cpp
@@ -515,8 +515,7 @@ Region::toJson(
 
   if (annotationMap.HasAnnotations(&region))
   {
-    auto annotations =
-        const_cast<std::vector<util::Annotation> &>(annotationMap.GetAnnotations(&region));
+    auto annotations = annotationMap.GetAnnotations(&region);
     std::sort(
         annotations.begin(),
         annotations.end(),
@@ -526,7 +525,7 @@ Region::toJson(
         });
 
     bool first = true;
-    for (auto & annotation : annotations)
+    for (const auto & annotation : annotations)
     {
       if (first)
         first = false;
@@ -579,8 +578,7 @@ Region::toJson(
   {
     stream << ",";
 
-    auto annotations =
-        const_cast<std::vector<util::Annotation> &>(annotationMap.GetAnnotations(&structuralNode));
+    auto annotations = annotationMap.GetAnnotations(&structuralNode);
     std::sort(
         annotations.begin(),
         annotations.end(),
@@ -590,7 +588,7 @@ Region::toJson(
         });
 
     bool first = true;
-    for (auto & annotation : annotations)
+    for (const auto & annotation : annotations)
     {
       if (first)
         first = false;

--- a/jlm/rvsdg/region.cpp
+++ b/jlm/rvsdg/region.cpp
@@ -14,6 +14,7 @@
 #include <jlm/util/Program.hpp>
 #include <jlm/util/strfmt.hpp>
 
+#include <algorithm>
 #include <fstream>
 
 namespace jlm::rvsdg
@@ -514,8 +515,16 @@ Region::toJson(
 
   if (annotationMap.HasAnnotations(&region))
   {
+    auto annotations = const_cast<std::vector<util::Annotation> &>(
+        annotationMap.GetAnnotations(&region));
+    std::sort(
+        annotations.begin(),
+        annotations.end(),
+        [](const util::Annotation & a, const util::Annotation & b)
+        { return a.Label() < b.Label(); });
+
     bool first = true;
-    for (auto & annotation : annotationMap.GetAnnotations(&region))
+    for (auto & annotation : annotations)
     {
       if (first)
         first = false;
@@ -568,8 +577,16 @@ Region::toJson(
   {
     stream << ",";
 
+    auto annotations = const_cast<std::vector<util::Annotation> &>(
+        annotationMap.GetAnnotations(&structuralNode));
+    std::sort(
+        annotations.begin(),
+        annotations.end(),
+        [](const util::Annotation & a, const util::Annotation & b)
+        { return a.Label() < b.Label(); });
+
     bool first = true;
-    for (auto & annotation : annotationMap.GetAnnotations(&structuralNode))
+    for (auto & annotation : annotations)
     {
       if (first)
         first = false;


### PR DESCRIPTION
Depending on platform (Linux or MAC) the generated JSON is ordered differently, which breaks the unit tests. This fix sorts the generated JSON such that the order becomes deterministic.