### PR TITLE
Allow memcpy and memset to take no memory states

### DIFF
--- a/jlm/llvm/ir/operators/StdLibIntrinsicOperations.hpp
+++ b/jlm/llvm/ir/operators/StdLibIntrinsicOperations.hpp
@@ -28,7 +28,7 @@ protected:
       const std::vector<std::shared_ptr<const rvsdg::Type>> & resultTypes)
       : SimpleOperation(operandTypes, resultTypes)
   {
-    JLM_ASSERT(operandTypes.size() >= 4);
+    JLM_ASSERT(operandTypes.size() >= 3);
 
     auto & dstAddressType = *operandTypes[0];
     JLM_ASSERT(is<PointerType>(dstAddressType));
@@ -40,12 +40,6 @@ protected:
     if (lengthType != *rvsdg::BitType::Create(32) && lengthType != *rvsdg::BitType::Create(64))
     {
       throw util::Error("Expected 32 bit or 64 bit integer type.");
-    }
-
-    auto & memoryStateType = *operandTypes.back();
-    if (!is<MemoryStateType>(memoryStateType))
-    {
-      throw util::Error("Number of memory states cannot be zero.");
     }
   }
 
@@ -346,7 +340,7 @@ protected:
       const std::vector<std::shared_ptr<const rvsdg::Type>> & resultTypes)
       : SimpleOperation(operandTypes, resultTypes)
   {
-    JLM_ASSERT(operandTypes.size() >= 4);
+    JLM_ASSERT(operandTypes.size() >= 3);
 
     auto & dstAddressType = *operandTypes[0];
     JLM_ASSERT(is<PointerType>(dstAddressType));
@@ -360,11 +354,6 @@ protected:
         lengthType != *rvsdg::BitType::Create(32) && lengthType != *rvsdg::BitType::Create(64))
     {
       throw util::Error("Expected 32 bit or 64 bit integer type.");
-    }
-
-    if (auto & memoryStateType = *operandTypes.back(); !is<MemoryStateType>(memoryStateType))
-    {
-      throw util::Error("Number of memory states cannot be zero.");
     }
   }
 

--- a/tests/Makefile.sub
+++ b/tests/Makefile.sub
@@ -28,6 +28,7 @@ JLC_COMPILE_TESTS = \
 	tests/c-tests/test-loop-return \
 	tests/c-tests/test-main \
 	tests/c-tests/test-memcpy \
+	tests/c-tests/test-memcpy-null \
 	tests/c-tests/test-printf \
 	tests/c-tests/test-ptr-comparison \
 	tests/c-tests/test-recfct \

--- a/tests/c-tests/test-memcpy-null.c
+++ b/tests/c-tests/test-memcpy-null.c
@@ -1,14 +1,15 @@
 #include <string.h>
 
 static char * buffer = NULL;
+static char * buffer2 = NULL;
 
 // Calling either of these functions will lead to undefined behavior,
 // but the compiler should not crash
 
 void
-func1(char* other, int length)
+func1(int length)
 {
-    memcpy(buffer, other, length);
+    memcpy(buffer, buffer2, length);
 }
 
 void

--- a/tests/c-tests/test-memcpy-null.c
+++ b/tests/c-tests/test-memcpy-null.c
@@ -1,0 +1,23 @@
+#include <string.h>
+
+static char * buffer = NULL;
+
+// Calling either of these functions will lead to undefined behavior,
+// but the compiler should not crash
+
+void
+func1(char* other, int length)
+{
+    memcpy(buffer, other, length);
+}
+
+void
+func2(int value, int length)
+{
+    memset(buffer, value, length);
+}
+
+int main()
+{
+    return 0;
+}


### PR DESCRIPTION
Fixes #1733.

I ended up adding a C test instead of a unit test, as the unit test looked a bit silly.

I doubled checked: before this PR, the C test does cause a crash in jlc.