### PR TITLE
Make CNE handle invariant theta outputs when the loop variable itself is not invariant

### DIFF
--- a/jlm/llvm/opt/CommonNodeElimination.cpp
+++ b/jlm/llvm/opt/CommonNodeElimination.cpp
@@ -965,6 +965,48 @@ markTheta(const rvsdg::ThetaNode & theta, CommonNodeElimination::Context & conte
     }
   }
 
+  // Check if the given loop variable's output is loop invariant.
+  // If it is, the origin of the invariant value is returned.
+  // If it is not, nullptr is returned.
+  const auto isOutputInvariant = [&](const auto & loopVar) -> rvsdg::Output *
+  {
+    // First perform a trivial check
+    if (rvsdg::ThetaLoopVarIsInvariant(loopVar))
+    {
+      return loopVar.input->origin();
+    }
+
+    const auto resultSet = context.getSetFor(*loopVar.post->origin());
+    const auto & resultSetLeader = context.getLeader(resultSet);
+    // If the origin's leader is the loop variable's pre, the result is also invariant
+    if (&resultSetLeader == loopVar.pre)
+    {
+      return loopVar.input->origin();
+    }
+
+    // Finally check if the loop variable post takes its value from another loop variable,
+    // and if that other loop variable is invariant
+    if (rvsdg::TryGetRegionParentNode<rvsdg::ThetaNode>(resultSetLeader) == &theta)
+    {
+      const auto otherLoopVar = theta.MapPreLoopVar(resultSetLeader);
+      // Check if the other loop variable is trivially invariant
+      if (rvsdg::ThetaLoopVarIsInvariant(otherLoopVar))
+      {
+        return otherLoopVar.input->origin();
+      }
+
+      // Use the CNE context to check if the other loop variable is invariant
+      const auto otherLoopVarPostSet = context.getSetFor(*otherLoopVar.post->origin());
+      const auto & otherLoopVarPostLeader = context.getLeader(otherLoopVarPostSet);
+      if (&otherLoopVarPostLeader == otherLoopVar.pre)
+      {
+        return otherLoopVar.input->origin();
+      }
+    }
+
+    return nullptr;
+  };
+
   // Partition theta outputs
   std::unordered_map<
       CommonNodeElimination::Context::CongruenceSetIndex,
@@ -972,11 +1014,12 @@ markTheta(const rvsdg::ThetaNode & theta, CommonNodeElimination::Context & conte
       resultToOutputSetMapping;
   for (auto & loopVar : loopVars)
   {
-    // invariant loop variables become followers of the input origin
-    if (rvsdg::ThetaLoopVarIsInvariant(loopVar))
+    // If a loop variable is invariant, or its post result is congruent with
+    // another loop variable that is invariant, the output becomes a follower of the input origin.
+    if (const auto origin = isOutputInvariant(loopVar))
     {
-      const auto inputOriginSet = context.getSetFor(*loopVar.input->origin());
-      context.addFollower(inputOriginSet, *loopVar.output);
+      auto inputCongruenceSet = context.getSetFor(*origin);
+      context.addFollower(inputCongruenceSet, *loopVar.output);
       continue;
     }
 

--- a/jlm/llvm/opt/CommonNodeEliminationTests.cpp
+++ b/jlm/llvm/opt/CommonNodeEliminationTests.cpp
@@ -7,9 +7,11 @@
 
 #include <jlm/llvm/ir/operators/IntegerOperations.hpp>
 #include <jlm/llvm/ir/operators/lambda.hpp>
+#include <jlm/llvm/ir/operators/operators.hpp>
 #include <jlm/llvm/ir/RvsdgModule.hpp>
 #include <jlm/llvm/opt/CommonNodeElimination.hpp>
 #include <jlm/rvsdg/bitstring/constant.hpp>
+#include <jlm/rvsdg/bitstring/type.hpp>
 #include <jlm/rvsdg/control.hpp>
 #include <jlm/rvsdg/gamma.hpp>
 #include <jlm/rvsdg/Phi.hpp>
@@ -848,4 +850,79 @@ TEST(CommonNodeEliminationTests, InvariantThetaInTheta)
   // The add operations should take the corresponding loop variables as input
   EXPECT_EQ(plus1Node.input(0)->origin(), loopVarX0.pre);
   EXPECT_EQ(plus2Node.input(0)->origin(), loopVarY0.pre);
+}
+
+TEST(CommonNodeEliminationTests, InvariantLoopOutputs)
+{
+  /**
+   * Creates RVSDG that looks like
+   *
+   *        undef   0   undef
+   *           |    |    |
+   *           v    v    v
+   * +-theta---------------------+
+   * |         v    v    v       |
+   * | CTR(0)       |\--------\  |
+   * |     v        v         |  |
+   * |   +-gamma---+--------+ |  |
+   * |   |    v    |    v   | |  |
+   * |   |    |    |    |   | |  |
+   * |   |    v    |    v   | |  |
+   * |   +---------+--------+ |  |
+   * |              v         |  |
+   * |             /|    /----/  |
+   * |          /-/ |    |       |
+   * | CTR(0)  /    |    |       |
+   * |  v      v    v    v       |
+   * +---------------------------+
+   *           v    v    v
+   *    export(x)   |    export(z)
+   *                v
+   *            export(y)
+   *
+   * After running CNE, the exports "x", "y" and "z" should all take their value
+   * directly from the constant 0.
+   */
+
+  // Arrange
+  using namespace jlm::llvm;
+  using namespace jlm::rvsdg;
+
+  LlvmRvsdgModule rm(jlm::util::FilePath(""), "", "");
+  auto & graph = rm.Rvsdg();
+
+  const auto bit32 = BitType::Create(32);
+
+  auto & zero = *IntegerConstantOperation::Create(graph.GetRootRegion(), 32, 0).output(0);
+  auto & undefValue = *UndefValueOperation::Create(graph.GetRootRegion(), bit32);
+
+  auto theta = ThetaNode::create(&graph.GetRootRegion());
+  auto region = theta->subregion();
+
+  auto lvX = theta->AddLoopVar(&undefValue);
+  auto lvY = theta->AddLoopVar(&zero);
+  auto lvZ = theta->AddLoopVar(&undefValue);
+
+  auto & controlGamma = ControlConstantOperation::create(*region, 2, 0);
+  auto gamma = GammaNode::create(&controlGamma, 2);
+
+  auto entryY = gamma->AddEntryVar(lvY.pre);
+  auto & exitY = *gamma->AddExitVar({ entryY.branchArgument[0], entryY.branchArgument[1] }).output;
+
+  lvX.post->divert_to(&exitY);
+  lvY.post->divert_to(&exitY);
+  lvZ.post->divert_to(lvY.pre);
+
+  auto & exportX = GraphExport::Create(*lvX.output, "x");
+  auto & exportY = GraphExport::Create(*lvY.output, "y");
+  auto & exportZ = GraphExport::Create(*lvZ.output, "z");
+
+  // Act
+  CommonNodeElimination cne;
+  cne.Run(rm, statisticsCollector);
+
+  // Assert
+  EXPECT_EQ(exportX.origin(), &zero);
+  EXPECT_EQ(exportY.origin(), &zero);
+  EXPECT_EQ(exportZ.origin(), &zero);
 }


### PR DESCRIPTION
I did this while fixing the CNE bug from last week, but didn't include it in that PR.

Fixes #1564

Causes 27 additional loads to be removed in SVF