### PR TITLE
mlir: Improved handling of GraphExport

### DIFF
--- a/jlm/mlir/backend/JlmToMlirConverter.cpp
+++ b/jlm/mlir/backend/JlmToMlirConverter.cpp
@@ -76,10 +76,9 @@ JlmToMlirConverter::ConvertModule(const llvm::LlvmRvsdgModule & rvsdgModule)
   // Collect export names from root region results.
   // The order of graph.GetRootRegion().results() matches regionResults.
   ::llvm::SmallVector<::mlir::Attribute> exportNames;
-  for (size_t i = 0; i < graph.GetRootRegion().nresults(); ++i)
+  for (auto & result : graph.GetRootRegion().Results())
   {
-    if (auto graphExport =
-            dynamic_cast<const rvsdg::GraphExport *>(graph.GetRootRegion().result(i)))
+    if (auto graphExport = dynamic_cast<const rvsdg::GraphExport *>(result))
     {
       exportNames.push_back(Builder_->getStringAttr(graphExport->Name()));
     }

--- a/jlm/mlir/backend/JlmToMlirConverter.cpp
+++ b/jlm/mlir/backend/JlmToMlirConverter.cpp
@@ -66,9 +66,41 @@ JlmToMlirConverter::ConvertModule(const llvm::LlvmRvsdgModule & rvsdgModule)
   ::llvm::SmallVector<::mlir::Value> regionResults =
       ConvertRegion(graph.GetRootRegion(), omegaBlock, true);
 
-  auto omegaResult =
-      Builder_->create<::mlir::rvsdg::OmegaResult>(Builder_->getUnknownLoc(), regionResults);
+  // Build result types from the region results
+  ::llvm::SmallVector<::mlir::Type> resultTypes;
+  for (auto & result : regionResults)
+  {
+    resultTypes.push_back(result.getType());
+  }
+
+  // Collect export names from root region results.
+  // The order of graph.GetRootRegion().results() matches regionResults.
+  ::llvm::SmallVector<::mlir::Attribute> exportNames;
+  for (size_t i = 0; i < graph.GetRootRegion().nresults(); ++i)
+  {
+    if (auto graphExport =
+            dynamic_cast<const rvsdg::GraphExport *>(graph.GetRootRegion().result(i)))
+    {
+      exportNames.push_back(Builder_->getStringAttr(graphExport->Name()));
+    }
+    else
+    {
+      JLM_UNREACHABLE("This should not happen. All omega results should be a GraphExport");
+    }
+  }
+
+  // Create OmegaResult with proper signature including export names.
+  auto exportNamesAttr = ::mlir::ArrayAttr::get(Builder_->getContext(), exportNames);
+  ::llvm::SmallVector<::mlir::NamedAttribute> namedAttrs;
+  namedAttrs.push_back({ Builder_->getStringAttr("exportNames"), exportNamesAttr });
+
+  auto omegaResult = Builder_->create<::mlir::rvsdg::OmegaResult>(
+      Builder_->getUnknownLoc(),
+      resultTypes,
+      regionResults,
+      namedAttrs);
   omegaBlock.push_back(omegaResult);
+
   return omega;
 }
 

--- a/jlm/mlir/frontend/MlirToJlmConverter.cpp
+++ b/jlm/mlir/frontend/MlirToJlmConverter.cpp
@@ -79,8 +79,9 @@ MlirToJlmConverter::ConvertOmega(::mlir::rvsdg::OmegaNode & omegaNode)
   auto omegaResult = ::mlir::dyn_cast<::mlir::rvsdg::OmegaResult>(terminator);
   JLM_ASSERT(omegaResult != nullptr);
 
-  // Get the exportNames from OmegaResult using its getExportNames() method.
+  // Get the exported names from OmegaResult
   auto exportNames = omegaResult.getExportNames();
+  // All omega results should have an exported name
   JLM_ASSERT(resultOutputs.size() == exportNames.size());
 
   // Register OmegaResult outputs as RVSDG root region exports (GraphExport).

--- a/jlm/mlir/frontend/MlirToJlmConverter.cpp
+++ b/jlm/mlir/frontend/MlirToJlmConverter.cpp
@@ -81,22 +81,22 @@ MlirToJlmConverter::ConvertOmega(::mlir::rvsdg::OmegaNode & omegaNode)
 
   // Get the exportNames from OmegaResult using its getExportNames() method.
   auto exportNames = omegaResult.getExportNames();
+  JLM_ASSERT(resultOutputs.size() == exportNames.size());
 
   // Register OmegaResult outputs as RVSDG root region exports (GraphExport).
   // The resultOutputs vector is populated by ConvertBlock() which extracts the operands
   // from the OmegaResult terminator operation.
   for (size_t i = 0; i < resultOutputs.size(); ++i)
   {
-    std::string exportName;
-    if (i < exportNames.size())
+    auto nameAttr = exportNames[i].dyn_cast_or_null<::mlir::StringAttr>();
+    if (nameAttr)
     {
-      auto nameAttr = exportNames[i].dyn_cast_or_null<::mlir::StringAttr>();
-      if (nameAttr)
-      {
-        exportName = nameAttr.getValue().str();
-      }
+      rvsdg::GraphExport::Create(*resultOutputs[i], nameAttr.getValue().str());
     }
-    rvsdg::GraphExport::Create(*resultOutputs[i], exportName);
+    else
+    {
+      JLM_UNREACHABLE("All omega results should have a name.");
+    }
   }
 
   return rvsdgModule;

--- a/jlm/mlir/frontend/MlirToJlmConverter.cpp
+++ b/jlm/mlir/frontend/MlirToJlmConverter.cpp
@@ -69,7 +69,35 @@ MlirToJlmConverter::ConvertOmega(::mlir::rvsdg::OmegaNode & omegaNode)
       llvm::LlvmRvsdgModule::Create(util::FilePath(""), std::string(), std::string());
   auto & graph = rvsdgModule->Rvsdg();
   auto & root = graph.GetRootRegion();
-  ConvertRegion(omegaNode.getRegion(), root);
+
+  // Convert all operations in the omega's region.
+  auto resultOutputs = ConvertRegion(omegaNode.getRegion(), root);
+
+  // Get the OmegaResult terminator to extract export names.
+  auto & omegaBlock = omegaNode.getRegion().front();
+  ::mlir::Operation * terminator = omegaBlock.getTerminator();
+  auto omegaResult = ::mlir::dyn_cast<::mlir::rvsdg::OmegaResult>(terminator);
+  JLM_ASSERT(omegaResult != nullptr);
+
+  // Get the exportNames from OmegaResult using its getExportNames() method.
+  auto exportNames = omegaResult.getExportNames();
+
+  // Register OmegaResult outputs as RVSDG root region exports (GraphExport).
+  // The resultOutputs vector is populated by ConvertBlock() which extracts the operands
+  // from the OmegaResult terminator operation.
+  for (size_t i = 0; i < resultOutputs.size(); ++i)
+  {
+    std::string exportName;
+    if (i < exportNames.size())
+    {
+      auto nameAttr = exportNames[i].dyn_cast_or_null<::mlir::StringAttr>();
+      if (nameAttr)
+      {
+        exportName = nameAttr.getValue().str();
+      }
+    }
+    rvsdg::GraphExport::Create(*resultOutputs[i], exportName);
+  }
 
   return rvsdgModule;
 }
@@ -135,6 +163,12 @@ MlirToJlmConverter::ConvertBlock(::mlir::Block & block, rvsdg::Region & rvsdgReg
 
       auto key = argument.getResult().getAsOpaquePointer();
       outputMap[key] = &jlmArgument;
+    }
+    else if (::mlir::isa<::mlir::rvsdg::OmegaResult>(mlirOp))
+    {
+      // OmegaResult is handled as the block terminator in ConvertBlock.
+      // Skip it here to avoid processing it as a regular operation.
+      continue;
     }
     else
     {

--- a/jlm/mlir/frontend/MlirToJlmConverter.cpp
+++ b/jlm/mlir/frontend/MlirToJlmConverter.cpp
@@ -88,8 +88,7 @@ MlirToJlmConverter::ConvertOmega(::mlir::rvsdg::OmegaNode & omegaNode)
   // from the OmegaResult terminator operation.
   for (size_t i = 0; i < resultOutputs.size(); ++i)
   {
-    auto nameAttr = exportNames[i].dyn_cast_or_null<::mlir::StringAttr>();
-    if (nameAttr)
+    if (auto nameAttr = exportNames[i].dyn_cast_or_null<::mlir::StringAttr>())
     {
       rvsdg::GraphExport::Create(*resultOutputs[i], nameAttr.getValue().str());
     }

--- a/jlm/mlir/frontend/MlirToJlmConverterTests.cpp
+++ b/jlm/mlir/frontend/MlirToJlmConverterTests.cpp
@@ -99,8 +99,10 @@ TEST(MlirToJlmConverterTests, TestLambda)
     ::llvm::SmallVector<mlir::Type> omegaResultTypes;
     omegaResultTypes.push_back(lambda.getResult().getType());
 
-    // Create empty exportNames ArrayAttr
-    auto exportNamesAttr = ::mlir::ArrayAttr::get(Builder_->getContext(), {});
+    // Create exportNames ArrayAttr
+    ::llvm::SmallVector<::mlir::Attribute> exportNamesList;
+    exportNamesList.push_back(Builder_->getStringAttr("test"));
+    auto exportNamesAttr = ::mlir::ArrayAttr::get(Builder_->getContext(), exportNamesList);
     ::llvm::SmallVector<::mlir::NamedAttribute> namedAttrs;
     namedAttrs.push_back({ Builder_->getStringAttr("exportNames"), exportNamesAttr });
 
@@ -257,8 +259,10 @@ TEST(MlirToJlmConverterTests, TestDivOperation)
     ::llvm::SmallVector<mlir::Type> omegaResultTypes;
     omegaResultTypes.push_back(lambda.getResult().getType());
 
-    // Create empty exportNames ArrayAttr
-    auto exportNamesAttr = ::mlir::ArrayAttr::get(Builder_->getContext(), {});
+    // Create exportNames ArrayAttr
+    ::llvm::SmallVector<::mlir::Attribute> exportNamesList;
+    exportNamesList.push_back(Builder_->getStringAttr("test"));
+    auto exportNamesAttr = ::mlir::ArrayAttr::get(Builder_->getContext(), exportNamesList);
     ::llvm::SmallVector<::mlir::NamedAttribute> namedAttrs;
     namedAttrs.push_back({ Builder_->getStringAttr("exportNames"), exportNamesAttr });
 
@@ -441,8 +445,10 @@ TEST(MlirToJlmConverterTests, TestCompZeroExt)
     ::llvm::SmallVector<mlir::Type> omegaResultTypes;
     omegaResultTypes.push_back(lambda.getResult().getType());
 
-    // Create empty exportNames ArrayAttr
-    auto exportNamesAttr = ::mlir::ArrayAttr::get(Builder_->getContext(), {});
+    // Create exportNames ArrayAttr
+    ::llvm::SmallVector<::mlir::Attribute> exportNamesList;
+    exportNamesList.push_back(Builder_->getStringAttr("test"));
+    auto exportNamesAttr = ::mlir::ArrayAttr::get(Builder_->getContext(), exportNamesList);
     ::llvm::SmallVector<::mlir::NamedAttribute> namedAttrs;
     namedAttrs.push_back({ Builder_->getStringAttr("exportNames"), exportNamesAttr });
 
@@ -662,8 +668,10 @@ TEST(MlirToJlmConverterTests, TestMatchOp)
     ::llvm::SmallVector<mlir::Type> omegaResultTypes;
     omegaResultTypes.push_back(lambda.getResult().getType());
 
-    // Create empty exportNames ArrayAttr
-    auto exportNamesAttr = ::mlir::ArrayAttr::get(Builder_->getContext(), {});
+    // Create exportNames ArrayAttr
+    ::llvm::SmallVector<::mlir::Attribute> exportNamesList;
+    exportNamesList.push_back(Builder_->getStringAttr("test"));
+    auto exportNamesAttr = ::mlir::ArrayAttr::get(Builder_->getContext(), exportNamesList);
     ::llvm::SmallVector<::mlir::NamedAttribute> namedAttrs;
     namedAttrs.push_back({ Builder_->getStringAttr("exportNames"), exportNamesAttr });
 
@@ -839,8 +847,10 @@ TEST(MlirToJlmConverterTests, TestGammaOp)
     ::llvm::SmallVector<mlir::Type> omegaResultTypes;
     omegaResultTypes.push_back(lambda.getResult().getType());
 
-    // Create empty exportNames ArrayAttr
-    auto exportNamesAttr = ::mlir::ArrayAttr::get(Builder_->getContext(), {});
+    // Create exportNames ArrayAttr
+    ::llvm::SmallVector<::mlir::Attribute> exportNamesList;
+    exportNamesList.push_back(Builder_->getStringAttr("test"));
+    auto exportNamesAttr = ::mlir::ArrayAttr::get(Builder_->getContext(), exportNamesList);
     ::llvm::SmallVector<::mlir::NamedAttribute> namedAttrs;
     namedAttrs.push_back({ Builder_->getStringAttr("exportNames"), exportNamesAttr });
 
@@ -975,8 +985,10 @@ TEST(MlirToJlmConverterTests, TestThetaOp)
     ::llvm::SmallVector<mlir::Type> omegaResultTypes;
     omegaResultTypes.push_back(lambda.getResult().getType());
 
-    // Create empty exportNames ArrayAttr
-    auto exportNamesAttr = ::mlir::ArrayAttr::get(Builder_->getContext(), {});
+    // Create exportNames ArrayAttr
+    ::llvm::SmallVector<::mlir::Attribute> exportNamesList;
+    exportNamesList.push_back(Builder_->getStringAttr("test"));
+    auto exportNamesAttr = ::mlir::ArrayAttr::get(Builder_->getContext(), exportNamesList);
     ::llvm::SmallVector<::mlir::NamedAttribute> namedAttrs;
     namedAttrs.push_back({ Builder_->getStringAttr("exportNames"), exportNamesAttr });
 

--- a/jlm/mlir/frontend/MlirToJlmConverterTests.cpp
+++ b/jlm/mlir/frontend/MlirToJlmConverterTests.cpp
@@ -96,7 +96,19 @@ TEST(MlirToJlmConverterTests, TestLambda)
     std::cout << "Creating OmegaResult" << std::endl;
     ::llvm::SmallVector<mlir::Value> omegaRegionResults;
     omegaRegionResults.push_back(lambda.getResult());
-    auto omegaResult = Builder_->create<OmegaResult>(Builder_->getUnknownLoc(), omegaRegionResults);
+    ::llvm::SmallVector<mlir::Type> omegaResultTypes;
+    omegaResultTypes.push_back(lambda.getResult().getType());
+
+    // Create empty exportNames ArrayAttr
+    auto exportNamesAttr = ::mlir::ArrayAttr::get(Builder_->getContext(), {});
+    ::llvm::SmallVector<::mlir::NamedAttribute> namedAttrs;
+    namedAttrs.push_back({ Builder_->getStringAttr("exportNames"), exportNamesAttr });
+
+    auto omegaResult = Builder_->create<OmegaResult>(
+        Builder_->getUnknownLoc(),
+        omegaResultTypes,
+        omegaRegionResults,
+        namedAttrs);
     omegaBlock->push_back(omegaResult);
 
     std::unique_ptr<mlir::Block> rootBlock = std::make_unique<mlir::Block>();
@@ -242,7 +254,19 @@ TEST(MlirToJlmConverterTests, TestDivOperation)
     std::cout << "Creating OmegaResult" << std::endl;
     ::llvm::SmallVector<mlir::Value> omegaRegionResults;
     omegaRegionResults.push_back(lambda.getResult());
-    auto omegaResult = Builder_->create<OmegaResult>(Builder_->getUnknownLoc(), omegaRegionResults);
+    ::llvm::SmallVector<mlir::Type> omegaResultTypes;
+    omegaResultTypes.push_back(lambda.getResult().getType());
+
+    // Create empty exportNames ArrayAttr
+    auto exportNamesAttr = ::mlir::ArrayAttr::get(Builder_->getContext(), {});
+    ::llvm::SmallVector<::mlir::NamedAttribute> namedAttrs;
+    namedAttrs.push_back({ Builder_->getStringAttr("exportNames"), exportNamesAttr });
+
+    auto omegaResult = Builder_->create<OmegaResult>(
+        Builder_->getUnknownLoc(),
+        omegaResultTypes,
+        omegaRegionResults,
+        namedAttrs);
     omegaBlock->push_back(omegaResult);
 
     std::unique_ptr<mlir::Block> rootBlock = std::make_unique<mlir::Block>();
@@ -414,7 +438,19 @@ TEST(MlirToJlmConverterTests, TestCompZeroExt)
     std::cout << "Creating OmegaResult" << std::endl;
     ::llvm::SmallVector<mlir::Value> omegaRegionResults;
     omegaRegionResults.push_back(lambda.getResult());
-    auto omegaResult = Builder_->create<OmegaResult>(Builder_->getUnknownLoc(), omegaRegionResults);
+    ::llvm::SmallVector<mlir::Type> omegaResultTypes;
+    omegaResultTypes.push_back(lambda.getResult().getType());
+
+    // Create empty exportNames ArrayAttr
+    auto exportNamesAttr = ::mlir::ArrayAttr::get(Builder_->getContext(), {});
+    ::llvm::SmallVector<::mlir::NamedAttribute> namedAttrs;
+    namedAttrs.push_back({ Builder_->getStringAttr("exportNames"), exportNamesAttr });
+
+    auto omegaResult = Builder_->create<OmegaResult>(
+        Builder_->getUnknownLoc(),
+        omegaResultTypes,
+        omegaRegionResults,
+        namedAttrs);
     omegaBlock->push_back(omegaResult);
 
     std::unique_ptr<mlir::Block> rootBlock = std::make_unique<mlir::Block>();
@@ -623,7 +659,19 @@ TEST(MlirToJlmConverterTests, TestMatchOp)
     std::cout << "Creating OmegaResult" << std::endl;
     ::llvm::SmallVector<mlir::Value> omegaRegionResults;
     omegaRegionResults.push_back(lambda.getResult());
-    auto omegaResult = Builder_->create<OmegaResult>(Builder_->getUnknownLoc(), omegaRegionResults);
+    ::llvm::SmallVector<mlir::Type> omegaResultTypes;
+    omegaResultTypes.push_back(lambda.getResult().getType());
+
+    // Create empty exportNames ArrayAttr
+    auto exportNamesAttr = ::mlir::ArrayAttr::get(Builder_->getContext(), {});
+    ::llvm::SmallVector<::mlir::NamedAttribute> namedAttrs;
+    namedAttrs.push_back({ Builder_->getStringAttr("exportNames"), exportNamesAttr });
+
+    auto omegaResult = Builder_->create<OmegaResult>(
+        Builder_->getUnknownLoc(),
+        omegaResultTypes,
+        omegaRegionResults,
+        namedAttrs);
     omegaBlock->push_back(omegaResult);
 
     // Convert the MLIR to RVSDG and check the result
@@ -788,7 +836,19 @@ TEST(MlirToJlmConverterTests, TestGammaOp)
     std::cout << "Creating OmegaResult" << std::endl;
     ::llvm::SmallVector<mlir::Value> omegaRegionResults;
     omegaRegionResults.push_back(lambda.getResult());
-    auto omegaResult = Builder_->create<OmegaResult>(Builder_->getUnknownLoc(), omegaRegionResults);
+    ::llvm::SmallVector<mlir::Type> omegaResultTypes;
+    omegaResultTypes.push_back(lambda.getResult().getType());
+
+    // Create empty exportNames ArrayAttr
+    auto exportNamesAttr = ::mlir::ArrayAttr::get(Builder_->getContext(), {});
+    ::llvm::SmallVector<::mlir::NamedAttribute> namedAttrs;
+    namedAttrs.push_back({ Builder_->getStringAttr("exportNames"), exportNamesAttr });
+
+    auto omegaResult = Builder_->create<OmegaResult>(
+        Builder_->getUnknownLoc(),
+        omegaResultTypes,
+        omegaRegionResults,
+        namedAttrs);
     omegaBlock->push_back(omegaResult);
 
     // Convert the MLIR to RVSDG and check the result
@@ -911,8 +971,20 @@ TEST(MlirToJlmConverterTests, TestThetaOp)
     // Handle the result of the omega
     std::cout << "Creating OmegaResult" << std::endl;
     ::llvm::SmallVector<mlir::Value> omegaRegionResults;
-    omegaRegionResults.push_back(lambda);
-    auto omegaResult = Builder_->create<OmegaResult>(Builder_->getUnknownLoc(), omegaRegionResults);
+    omegaRegionResults.push_back(lambda.getResult());
+    ::llvm::SmallVector<mlir::Type> omegaResultTypes;
+    omegaResultTypes.push_back(lambda.getResult().getType());
+
+    // Create empty exportNames ArrayAttr
+    auto exportNamesAttr = ::mlir::ArrayAttr::get(Builder_->getContext(), {});
+    ::llvm::SmallVector<::mlir::NamedAttribute> namedAttrs;
+    namedAttrs.push_back({ Builder_->getStringAttr("exportNames"), exportNamesAttr });
+
+    auto omegaResult = Builder_->create<OmegaResult>(
+        Builder_->getUnknownLoc(),
+        omegaResultTypes,
+        omegaRegionResults,
+        namedAttrs);
     omegaBlock->push_back(omegaResult);
 
     // Convert the MLIR to RVSDG and check the result

--- a/scripts/build-mlir.sh
+++ b/scripts/build-mlir.sh
@@ -2,7 +2,7 @@
 set -eu
 
 GIT_REPOSITORY=https://github.com/EECS-NTNU/mlir_rvsdg.git
-GIT_COMMIT=1452aaa47c41b6b8fec004ba4f665962a57fcbe6
+GIT_COMMIT=d4d1184c5da9f83356de5fd42b09251fe15a2e13
 
 # Get the absolute path to this script and set default build and install paths
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"


### PR DESCRIPTION
Handles exported names for GraphExports that are stored as an attribute in the omega result.