### PR TITLE
Fix region predicate tracing

### DIFF
--- a/jlm/rvsdg/RegionPredicateTrace.cpp
+++ b/jlm/rvsdg/RegionPredicateTrace.cpp
@@ -9,6 +9,8 @@
 #include <jlm/rvsdg/MatchType.hpp>
 #include <jlm/rvsdg/theta.hpp>
 
+#include <unordered_map>
+
 namespace jlm::rvsdg
 {
 
@@ -101,8 +103,7 @@ RegionPredicateTrace::ObserveRegion(Region & region)
 }
 
 // This function recurses through the "definition tree" of
-// predicate outputs / inputs. It records observations per
-// region.
+// predicate outputs / inputs. It records observations per region.
 PredicateValueRange
 RegionPredicateTrace::ComputeAndRecord(
     RegionPredRange & regionPredRange,
@@ -110,8 +111,23 @@ RegionPredicateTrace::ComputeAndRecord(
     const ControlType & type)
 {
   auto range = Compute(regionPredRange, input, type);
-  regionPredRange.emplace(input.region(), range);
-  ObserveRegion(*input.region());
+
+  // If the input is a region result, add its value range to the region
+  if (TryGetRegionParentNode<rvsdg::StructuralNode>(input))
+  {
+    auto it = regionPredRange.find(input.region());
+
+    if (it != regionPredRange.end())
+    {
+      it->second.UpdateUnion(range);
+    }
+    else
+    {
+      regionPredRange.emplace(input.region(), range);
+      ObserveRegion(*input.region());
+    }
+  }
+
   return range;
 }
 

--- a/jlm/rvsdg/RegionPredicateTrace.cpp
+++ b/jlm/rvsdg/RegionPredicateTrace.cpp
@@ -9,8 +9,6 @@
 #include <jlm/rvsdg/MatchType.hpp>
 #include <jlm/rvsdg/theta.hpp>
 
-#include <unordered_map>
-
 namespace jlm::rvsdg
 {
 

--- a/jlm/rvsdg/RegionPredicateTrace.hpp
+++ b/jlm/rvsdg/RegionPredicateTrace.hpp
@@ -10,8 +10,6 @@
 #include <jlm/rvsdg/graph.hpp>
 #include <jlm/rvsdg/node.hpp>
 
-#include <unordered_map>
-
 namespace jlm::rvsdg
 {
 
@@ -222,7 +220,7 @@ private:
   // For a given target region, what predicates must be satisfied to reach it
   std::unordered_map<Region *, PredicateSatRequired> predSat_;
 
-  // Observers registered to handle cache invalidation
+  // Observers registered on region to inform the tracer when caches must be invalidated
   std::unordered_map<Region *, std::unique_ptr<Observer>> observers_;
 };
 

--- a/jlm/rvsdg/RegionPredicateTrace.hpp
+++ b/jlm/rvsdg/RegionPredicateTrace.hpp
@@ -10,6 +10,8 @@
 #include <jlm/rvsdg/graph.hpp>
 #include <jlm/rvsdg/node.hpp>
 
+#include <unordered_map>
+
 namespace jlm::rvsdg
 {
 
@@ -187,6 +189,8 @@ public:
   CheckPredicatesSatisfiable(Region & originRegion, Region & targetRegion);
 
 private:
+  // For a given input, its RegionPredRange provides a map from regions to the
+  // set of values than can end up being routed to the input, from results of the region.
   using RegionPredRange = std::unordered_map<Region *, PredicateValueRange>;
   class Observer;
 
@@ -196,14 +200,29 @@ private:
   void
   ObserveRegion(Region & region);
 
+  /**
+   * Traces from the given \p input to find the regions that may provide its value.
+   * @param regionPredRange the resulting map of possible values provided in each region.
+   * @param input the input being traced from
+   * @param type the type of the input
+   */
   PredicateValueRange
   ComputeAndRecord(RegionPredRange & regionPredRange, Input & input, const ControlType & type);
 
+  /**
+   * Helper function for the above \ref ComputeAndRecord
+   */
   PredicateValueRange
   Compute(RegionPredRange & regionPredRange, Input & input, const ControlType & type);
 
+  // For a given input, gives the regions where we know which the set of values
+  // the region may provide to the input
   std::unordered_map<Input *, RegionPredRange> predAssignment_;
+
+  // For a given target region, what predicates must be satisfied to reach it
   std::unordered_map<Region *, PredicateSatRequired> predSat_;
+
+  // Observers registered to handle cache invalidation
   std::unordered_map<Region *, std::unique_ptr<Observer>> observers_;
 };
 

--- a/jlm/rvsdg/RegionPredicateTraceTests.cpp
+++ b/jlm/rvsdg/RegionPredicateTraceTests.cpp
@@ -5,13 +5,18 @@
 
 #include <gtest/gtest.h>
 
+#include <jlm/rvsdg/bitstring/arithmetic.hpp>
+#include <jlm/rvsdg/bitstring/constant.hpp>
+#include <jlm/rvsdg/bitstring/type.hpp>
 #include <jlm/rvsdg/control.hpp>
 #include <jlm/rvsdg/gamma.hpp>
 #include <jlm/rvsdg/graph.hpp>
 #include <jlm/rvsdg/RegionPredicateTrace.hpp>
+#include <jlm/rvsdg/simple-node.hpp>
 #include <jlm/rvsdg/TestNodes.hpp>
 #include <jlm/rvsdg/TestOperations.hpp>
 #include <jlm/rvsdg/TestType.hpp>
+#include <jlm/rvsdg/theta.hpp>
 
 TEST(RegionPredicateTraceTests, TestTracing)
 {
@@ -76,4 +81,180 @@ TEST(RegionPredicateTraceTests, TestTracing)
   EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*g1_right, *g3_left));
   EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*g1_left, *g3_left));
   EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*g1_right, *g3_right));
+}
+
+TEST(RegionPredicateTraceTests, TraceOutOfTheta)
+{
+  /**
+   * Creates an RVSDG graph that looks like:
+   *
+   * +-theta0------------------x-------------------------+
+   * |                                                   |
+   * | +-theta1---x-----+ +-theta3-------------x-------+ |
+   * | |                | |                    v       | |
+   * | | CTRL(0) INT(3) | |         +-theta4---x-----+ | |
+   * | |   v      v     | |         |                | | |
+   * | +----------x-----+ |         | CTRL(0) INT(7) | | |
+   * |            v       |         |   v      v     | | |
+   * | +-theta2---x-----+ | CTRL(0) +----------x-----+ | |
+   * | | CTRL(0)  v     | |   v                v       | |
+   * | +----------x-----+ +--------------------x-------+ |
+   * |            |                            |         |
+   * |            \----------\   /-------------/         |
+   * |                        v v                        |
+   * | CTRL(0)                ADD                        |
+   * |   v                     v                         |
+   * +-------------------------x-------------------------+
+   *                           v
+   *                       export("x")
+   *
+   * and checks that all regions are considered reachable from all regions above it,
+   * both parent, child and sibling regions.
+   */
+
+  using namespace jlm;
+
+  // Arrange
+  auto bit32 = rvsdg::BitType::Create(32);
+
+  rvsdg::Graph rvsdg;
+  auto theta0 = rvsdg::ThetaNode::create(&rvsdg.GetRootRegion());
+  auto undef0 =
+      rvsdg::CreateOpNode<rvsdg::TestNullaryOperation>(rvsdg.GetRootRegion(), bit32).output(0);
+  auto loopVar0 = theta0->AddLoopVar(undef0);
+
+  // theta1
+  auto theta1 = rvsdg::ThetaNode::create(theta0->subregion());
+  auto undef1 =
+      rvsdg::CreateOpNode<rvsdg::TestNullaryOperation>(*theta0->subregion(), bit32).output(0);
+  auto loopVar1 = theta1->AddLoopVar(undef1);
+  auto & int3Output = rvsdg::BitConstantOperation::create(*theta1->subregion(), { 32, 3 });
+  loopVar1.post->divert_to(&int3Output);
+
+  // theta2
+  auto theta2 = rvsdg::ThetaNode::create(theta0->subregion());
+  auto loopVar2 = theta2->AddLoopVar(loopVar1.output);
+
+  // theta3
+  auto theta3 = rvsdg::ThetaNode::create(theta0->subregion());
+  auto undef3 =
+      rvsdg::CreateOpNode<rvsdg::TestNullaryOperation>(*theta0->subregion(), bit32).output(0);
+  auto loopVar3 = theta3->AddLoopVar(undef3);
+
+  // theta4
+  auto theta4 = rvsdg::ThetaNode::create(theta3->subregion());
+  auto loopVar4 = theta4->AddLoopVar(loopVar3.pre);
+  auto & int7Output = rvsdg::BitConstantOperation::create(*theta4->subregion(), { 32, 7 });
+  loopVar4.post->divert_to(&int7Output);
+  loopVar3.post->divert_to(loopVar4.output);
+
+  // ADD inside theta0's subregion, combining outputs from theta2 and theta3/theta4
+  auto & addOutput = *rvsdg::bitadd_op::create(32, loopVar2.output, loopVar3.output);
+  loopVar0.post->divert_to(&addOutput);
+
+  rvsdg::GraphExport::Create(*loopVar0.output, "x");
+
+  // Assert
+  rvsdg::RegionPredicateTrace trace;
+
+  // Every region can be reached from the root region
+  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(rvsdg.GetRootRegion(), *theta0->subregion()));
+  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(rvsdg.GetRootRegion(), *theta1->subregion()));
+  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(rvsdg.GetRootRegion(), *theta2->subregion()));
+  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(rvsdg.GetRootRegion(), *theta3->subregion()));
+  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(rvsdg.GetRootRegion(), *theta4->subregion()));
+
+  // Every region can reach the root region
+  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta0->subregion(), rvsdg.GetRootRegion()));
+  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta1->subregion(), rvsdg.GetRootRegion()));
+  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta1->subregion(), rvsdg.GetRootRegion()));
+  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta1->subregion(), rvsdg.GetRootRegion()));
+  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta1->subregion(), rvsdg.GetRootRegion()));
+
+  // theta0 can reach every region inside it
+  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta0->subregion(), *theta1->subregion()));
+  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta0->subregion(), *theta2->subregion()));
+  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta0->subregion(), *theta3->subregion()));
+  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta0->subregion(), *theta4->subregion()));
+
+  // theta0 can also be reached by every region inside it
+  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta1->subregion(), *theta0->subregion()));
+  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta2->subregion(), *theta0->subregion()));
+  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta3->subregion(), *theta0->subregion()));
+  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta4->subregion(), *theta0->subregion()));
+
+  // theta2 can be reached from theta1
+  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta1->subregion(), *theta2->subregion()));
+
+  // theta3 and theta4 can reach each other
+  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta3->subregion(), *theta4->subregion()));
+  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta4->subregion(), *theta3->subregion()));
+}
+
+TEST(RegionPredicateTraceTests, TraceIntoGamma)
+{
+  /**
+   * Creates an RVSDG graph that looks like:
+   *
+   * CTRL(0)
+   *   v
+   * +-gamma0------------------+---------+
+   * |                         |         |
+   * | CTRL(0)   CTRL(1)       |         |
+   * |   v  v      v           |         |
+   * | +-gamma1--+---------+   |         |
+   * | |   \     |     /   |   |         |
+   * | |    \    |    /    |   |         |
+   * | |    v    |    v    |   |         |
+   * | +---------+---------+   | CTRL(1) |
+   * |           v             |    v    |
+   * +-------------------------+---------+
+   *                    v
+   *                +-gamma2---+---------+
+   *                |          |         |
+   *                +----------+---------+
+   *
+   * Checks that the regions of gamma2 can only be reached from regions
+   * that provide the correct predicate value
+   */
+
+  using namespace jlm;
+
+  auto controlType = rvsdg::ControlType::Create(2);
+
+  rvsdg::Graph rvsdg;
+  auto & outerCtrl0 = rvsdg::ControlConstantOperation::createFalse(rvsdg.GetRootRegion());
+  auto & gamma0 = *rvsdg::GammaNode::create(&outerCtrl0, 2);
+
+  // Left subregion of gamma0
+  auto & leftCtrl0 = rvsdg::ControlConstantOperation::createFalse(*gamma0.subregion(0));
+  auto & leftCtrl1 = rvsdg::ControlConstantOperation::createTrue(*gamma0.subregion(0));
+
+  auto & gamma1 = *rvsdg::GammaNode::create(&leftCtrl0, 2);
+  auto gamma1Entry0 = gamma1.AddEntryVar(&leftCtrl0);
+  auto gamma1Entry1 = gamma1.AddEntryVar(&leftCtrl1);
+  auto gamma1Exit =
+      gamma1.AddExitVar({ gamma1Entry0.branchArgument[0], gamma1Entry1.branchArgument[1] });
+
+  // Right subregion of gamma1
+  auto & rightCtrl1 = rvsdg::ControlConstantOperation::createTrue(*gamma0.subregion(1));
+
+  auto gamma0Exit = gamma0.AddExitVar({ gamma1Exit.output, &rightCtrl1 });
+
+  auto & gamma2 = *rvsdg::GammaNode::create(gamma0Exit.output, 2);
+
+  // Assert
+  rvsdg::RegionPredicateTrace trace;
+
+  // targeting gamma2's left subregion
+  ASSERT_TRUE(trace.CheckPredicatesSatisfiable(*gamma1.subregion(0), *gamma2.subregion(0)));
+  ASSERT_FALSE(trace.CheckPredicatesSatisfiable(*gamma1.subregion(1), *gamma2.subregion(0)));
+  ASSERT_TRUE(trace.CheckPredicatesSatisfiable(*gamma0.subregion(0), *gamma2.subregion(0)));
+  ASSERT_FALSE(trace.CheckPredicatesSatisfiable(*gamma0.subregion(1), *gamma2.subregion(0)));
+
+  // targeting gamma2's right subregion
+  ASSERT_FALSE(trace.CheckPredicatesSatisfiable(*gamma1.subregion(0), *gamma2.subregion(1)));
+  ASSERT_TRUE(trace.CheckPredicatesSatisfiable(*gamma1.subregion(1), *gamma2.subregion(1)));
+  ASSERT_TRUE(trace.CheckPredicatesSatisfiable(*gamma0.subregion(0), *gamma2.subregion(1)));
+  ASSERT_TRUE(trace.CheckPredicatesSatisfiable(*gamma0.subregion(1), *gamma2.subregion(1)));
 }


### PR DESCRIPTION
Fixes the issue presented in the first half of #1764.

The actual fix is in `ComputeAndRecord`, where it now takes the union across all region results that may contribute to the input in question.