### PR TITLE
Add simple caching to RegionPredicateTrace

### DIFF
--- a/jlm/rvsdg/RegionPredicateTrace.cpp
+++ b/jlm/rvsdg/RegionPredicateTrace.cpp
@@ -9,6 +9,8 @@
 #include <jlm/rvsdg/MatchType.hpp>
 #include <jlm/rvsdg/theta.hpp>
 
+#include <unordered_map>
+
 namespace jlm::rvsdg
 {
 
@@ -102,13 +104,17 @@ RegionPredicateTrace::ObserveRegion(Region & region)
 
 // This function recurses through the "definition tree" of
 // predicate outputs / inputs. It records observations per region.
-PredicateValueRange
+const PredicateValueRange &
 RegionPredicateTrace::ComputeAndRecord(
     RegionPredRange & regionPredRange,
     Input & input,
+    std::unordered_map<Input *, PredicateValueRange> & visitedInputs,
     const ControlType & type)
 {
-  auto range = Compute(regionPredRange, input, type);
+  if (auto it = visitedInputs.find(&input); it != visitedInputs.end())
+    return it->second;
+
+  auto range = Compute(regionPredRange, input, visitedInputs, type);
 
   // If the input is a region result, add its value range to the region
   if (TryGetRegionParentNode<rvsdg::StructuralNode>(input))
@@ -126,7 +132,10 @@ RegionPredicateTrace::ComputeAndRecord(
     }
   }
 
-  return range;
+  auto [it, inserted] = visitedInputs.emplace(&input, std::move(range));
+  JLM_ASSERT(inserted);
+
+  return it->second;
 }
 
 // Second part of the recursion, helper to the function above:
@@ -136,6 +145,7 @@ PredicateValueRange
 RegionPredicateTrace::Compute(
     RegionPredRange & regionPredRange,
     Input & input,
+    std::unordered_map<Input *, PredicateValueRange> & visitedInputs,
     const ControlType & type)
 {
   // Given a predicate use site, record the predicate definition
@@ -173,7 +183,7 @@ RegionPredicateTrace::Compute(
           auto range = PredicateValueRange::CreateEmpty(type);
           for (auto res : exitVar.branchResult)
           {
-            range.UpdateUnion(ComputeAndRecord(regionPredRange, *res, type));
+            range.UpdateUnion(ComputeAndRecord(regionPredRange, *res, visitedInputs, type));
           }
 
           return range;
@@ -186,11 +196,11 @@ RegionPredicateTrace::Compute(
           auto loopVar = node.MapOutputLoopVar(*origin);
           if (loopVar.post->origin() == loopVar.pre)
           {
-            return ComputeAndRecord(regionPredRange, *loopVar.input, type);
+            return ComputeAndRecord(regionPredRange, *loopVar.input, visitedInputs, type);
           }
           else
           {
-            return ComputeAndRecord(regionPredRange, *loopVar.post, type);
+            return ComputeAndRecord(regionPredRange, *loopVar.post, visitedInputs, type);
           }
         },
         [&]()
@@ -211,7 +221,7 @@ RegionPredicateTrace::Compute(
 
           if (auto entry = std::get_if<GammaNode::EntryVar>(&argVar))
           {
-            return ComputeAndRecord(regionPredRange, *entry->input, type);
+            return ComputeAndRecord(regionPredRange, *entry->input, visitedInputs, type);
           }
           else
           {
@@ -223,7 +233,7 @@ RegionPredicateTrace::Compute(
           auto loopVar = node.MapPreLoopVar(*origin);
           if (loopVar.post->origin() == loopVar.pre)
           {
-            return ComputeAndRecord(regionPredRange, *loopVar.input, type);
+            return ComputeAndRecord(regionPredRange, *loopVar.input, visitedInputs, type);
           }
           else
           {
@@ -258,7 +268,8 @@ RegionPredicateTrace::GetRegionPredicateAssignConstraints(Region & region, Input
     // definition sites in different regions. Record predicate
     // assignments per region.
     RegionPredRange range;
-    ComputeAndRecord(range, predUse, *controlType);
+    std::unordered_map<Input *, PredicateValueRange> visitedInputs;
+    ComputeAndRecord(range, predUse, visitedInputs, *controlType);
     i = predAssignment_.emplace(&predUse, std::move(range)).first;
   }
 

--- a/jlm/rvsdg/RegionPredicateTrace.hpp
+++ b/jlm/rvsdg/RegionPredicateTrace.hpp
@@ -10,6 +10,8 @@
 #include <jlm/rvsdg/graph.hpp>
 #include <jlm/rvsdg/node.hpp>
 
+#include <unordered_map>
+
 namespace jlm::rvsdg
 {
 
@@ -202,16 +204,25 @@ private:
    * Traces from the given \p input to find the regions that may provide its value.
    * @param regionPredRange the resulting map of possible values provided in each region.
    * @param input the input being traced from
+   * @param visitedInputs set of seen inputs, to avoid re-visiting
    * @param type the type of the input
    */
-  PredicateValueRange
-  ComputeAndRecord(RegionPredRange & regionPredRange, Input & input, const ControlType & type);
+  const PredicateValueRange &
+  ComputeAndRecord(
+      RegionPredRange & regionPredRange,
+      Input & input,
+      std::unordered_map<Input *, PredicateValueRange> & visitedInputs,
+      const ControlType & type);
 
   /**
    * Helper function for the above \ref ComputeAndRecord
    */
   PredicateValueRange
-  Compute(RegionPredRange & regionPredRange, Input & input, const ControlType & type);
+  Compute(
+      RegionPredRange & regionPredRange,
+      Input & input,
+      std::unordered_map<Input *, PredicateValueRange> & visitedInputs,
+      const ControlType & type);
 
   // For a given input, gives the regions where we know which the set of values
   // the region may provide to the input


### PR DESCRIPTION
Simple caching that stores the computed ranges for inputs to avoid re-traversing. The cache is not stored in the class between method calls, so it does not need to be invalidated.

Without this caching some of the files in the benchmark suite took tens of minutes. With it the slowest file is 6 minutes end-to-end (region predication gets added to SVF in the next PR)