### PR TITLE
rhls-dne: remove unreachable check

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/rhls-dne.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rhls-dne.cpp
@@ -21,8 +21,7 @@ remove_unused_loop_backedges(LoopNode * loopNode)
   const auto subregion = loopNode->subregion();
   for (const auto argument : subregion->Arguments())
   {
-    if ((dynamic_cast<BackEdgeArgument *>(argument) && argument->nusers() == 1)
-        || argument->IsDead())
+    if ((dynamic_cast<BackEdgeArgument *>(argument) && argument->nusers() == 1))
     {
       auto & user = *argument->Users().begin();
       if (const auto result = dynamic_cast<BackEdgeResult *>(&user))


### PR DESCRIPTION
rhls-dne IsDead argument check never triggers in practice. Even if it would trigger, the following code path would immediately cause UB (unconditionally deferences first user, which by definition cannot exist if the argument is dead).