### PR TITLE
LLVM: Improve GEP type validation

### DIFF
--- a/jlm/llvm/TestRvsdgs.cpp
+++ b/jlm/llvm/TestRvsdgs.cpp
@@ -8,6 +8,7 @@
 #include <jlm/llvm/ir/operators/call.hpp>
 #include <jlm/llvm/ir/operators/ConversionOperations.hpp>
 #include <jlm/llvm/ir/operators/GetElementPtr.hpp>
+#include <jlm/llvm/ir/operators/IntegerOperations.hpp>
 #include <jlm/llvm/ir/operators/lambda.hpp>
 #include <jlm/llvm/ir/operators/Load.hpp>
 #include <jlm/llvm/ir/operators/MemoryStateOperations.hpp>
@@ -17,7 +18,6 @@
 #include <jlm/llvm/TestRvsdgs.hpp>
 #include <jlm/rvsdg/bitstring/arithmetic.hpp>
 #include <jlm/rvsdg/bitstring/comparison.hpp>
-#include <jlm/rvsdg/bitstring/constant.hpp>
 #include <jlm/rvsdg/gamma.hpp>
 #include <jlm/rvsdg/theta.hpp>
 
@@ -305,8 +305,8 @@ GetElementPtrTest::SetupRvsdg()
       graph->GetRootRegion(),
       llvm::LlvmLambdaOperation::Create(fcttype, "f", Linkage::externalLinkage));
 
-  auto zero = &BitConstantOperation::create(*fct->subregion(), { 32, 0 });
-  auto one = &BitConstantOperation::create(*fct->subregion(), { 32, 1 });
+  auto zero = IntegerConstantOperation::Create(*fct->subregion(), { 32, 0 }).output(0);
+  auto one = IntegerConstantOperation::Create(*fct->subregion(), { 32, 1 }).output(0);
 
   auto gepx =
       GetElementPtrOperation::create(fct->GetFunctionArguments()[0], { zero, zero }, structType);
@@ -3527,8 +3527,8 @@ LinkedListTest::SetupRvsdg()
 
     auto myListArgument = lambda->AddContextVar(myList).inner;
 
-    auto zero = &BitConstantOperation::create(*lambda->subregion(), { 32, 0 });
-    auto constantOne = &BitConstantOperation::create(*lambda->subregion(), { 32, 1 });
+    auto zero = IntegerConstantOperation::Create(*lambda->subregion(), { 32, 0 }).output(0);
+    auto constantOne = IntegerConstantOperation::Create(*lambda->subregion(), { 32, 1 }).output(0);
 
     auto alloca = AllocaOperation::create(pointerType, constantOne, 4);
     auto mergedMemoryState = MemoryStateMergeOperation::Create(

--- a/jlm/llvm/ir/operators/GetElementPtr.cpp
+++ b/jlm/llvm/ir/operators/GetElementPtr.cpp
@@ -3,6 +3,7 @@
  * See COPYING for terms of redistribution.
  */
 
+#include "IntegerOperations.hpp"
 #include <jlm/llvm/ir/operators/GetElementPtr.hpp>
 #include <jlm/llvm/ir/Trace.hpp>
 
@@ -104,4 +105,55 @@ GetElementPtrOperation::Constant::getOffsetInBytes() const noexcept
   offsetInBytes += computeIntraTypeOffset(1, *pointeeType);
   return offsetInBytes;
 }
+
+std::shared_ptr<const rvsdg::Type>
+GetElementPtrOperation::getIndexedType(
+    const std::shared_ptr<const rvsdg::Type> & gepType,
+    const std::vector<rvsdg::Output *> & indices)
+{
+  if (indices.empty())
+    return gepType;
+
+  auto currentType = gepType;
+
+  // We skip the first index as it always just steps through the container
+  for (size_t n = 1; n < indices.size(); ++n)
+  {
+    if (auto structType = std::dynamic_pointer_cast<const StructType>(currentType))
+    {
+      auto index = indices[n];
+      auto & tracedIndex = llvm::traceOutput(*index);
+      auto [constantNode, constantOperation] =
+          rvsdg::TryGetSimpleNodeAndOptionalOp<IntegerConstantOperation>(tracedIndex);
+      if (!constantOperation)
+      {
+        return nullptr;
+      }
+
+      if (constantOperation->Representation().nbits() != 32)
+        return nullptr;
+
+      auto idx = constantOperation->Representation().to_uint();
+      if (idx > structType->numElements())
+        return nullptr;
+
+      currentType = structType->getElementType(idx);
+    }
+    else if (const auto arrayType = std::dynamic_pointer_cast<const ArrayType>(currentType))
+    {
+      currentType = arrayType->GetElementType();
+    }
+    else if (const auto vectorType = std::dynamic_pointer_cast<const VectorType>(currentType))
+    {
+      currentType = vectorType->Type();
+    }
+    else
+    {
+      return nullptr;
+    }
+  }
+
+  return currentType;
+}
+
 }

--- a/jlm/llvm/ir/operators/GetElementPtr.cpp
+++ b/jlm/llvm/ir/operators/GetElementPtr.cpp
@@ -3,8 +3,8 @@
  * See COPYING for terms of redistribution.
  */
 
-#include "IntegerOperations.hpp"
 #include <jlm/llvm/ir/operators/GetElementPtr.hpp>
+#include <jlm/llvm/ir/operators/IntegerOperations.hpp>
 #include <jlm/llvm/ir/Trace.hpp>
 
 namespace jlm::llvm

--- a/jlm/llvm/ir/operators/GetElementPtr.hpp
+++ b/jlm/llvm/ir/operators/GetElementPtr.hpp
@@ -180,7 +180,7 @@ public:
     // 1. Validate that the base address is a pointer or vector of pointers
     checkBaseAddressType(*baseAddressType);
 
-    // 2. Validate that the index types are pointers or vector of integers
+    // 2. Validate that the index types are integers or vector of integers
     checkIndexTypes(indexTypes);
 
     // FIXME: Validate vector components align such as uniform lane count, etc.

--- a/jlm/llvm/ir/operators/GetElementPtr.hpp
+++ b/jlm/llvm/ir/operators/GetElementPtr.hpp
@@ -30,14 +30,16 @@ class GetElementPtrOperation final : public rvsdg::SimpleOperation
 public:
   ~GetElementPtrOperation() noexcept override;
 
+  // FIXME: I would love to have this private. It makes no sense to have this public as it allows to
+  // create illegal getelementptr operations.
   GetElementPtrOperation(
       const std::shared_ptr<const rvsdg::Type> & baseAddressType,
       const std::vector<std::shared_ptr<const rvsdg::Type>> & indexTypes,
-      std::shared_ptr<const rvsdg::Type> pointeeType)
+      std::shared_ptr<const rvsdg::Type> gepType)
       : SimpleOperation(
             createOperandTypes(baseAddressType, indexTypes),
             { getResultType(baseAddressType, indexTypes) }),
-        pointeeType_(std::move(pointeeType))
+        gepType_(std::move(gepType))
   {
     checkBaseAddressType(*baseAddressType);
     checkIndexTypes(indexTypes);
@@ -59,7 +61,7 @@ public:
   [[nodiscard]] std::shared_ptr<const rvsdg::Type>
   getPointeeType() const noexcept
   {
-    return pointeeType_;
+    return gepType_;
   }
 
   /**
@@ -169,10 +171,7 @@ public:
   {
     auto indexTypes = extractIndexTypes<const Variable>(offsets);
 
-    auto operation = std::make_unique<GetElementPtrOperation>(
-        baseAddress->Type(),
-        indexTypes,
-        std::move(pointeeType));
+    auto operation = std::make_unique<GetElementPtrOperation>(baseAddress->Type(), indexTypes, std::move(pointeeType));
     std::vector operands(1, baseAddress);
     operands.insert(operands.end(), offsets.begin(), offsets.end());
 
@@ -225,10 +224,31 @@ public:
   }
 
 private:
+  static std::shared_ptr<const rvsdg::Type>
+  getIndexedType(
+      const std::shared_ptr<const rvsdg::Type> & gepType,
+      const std::vector<rvsdg::Output *> & indices);
+
+  static void
+  checkIndexTypes(
+      const std::shared_ptr<const rvsdg::Type> & gepType,
+      const std::vector<rvsdg::Output *> & indices)
+  {
+    const auto indexedType = getIndexedType(gepType, indices);
+    if (indexedType == nullptr)
+    {
+      throw std::logic_error("Invalid GetElementPtrOperation indices for type!");
+    }
+  }
+
   static void
   checkBaseAddressType(const rvsdg::Type & type)
   {
-    if (!is<PointerType>(type) && !isVectorOf<PointerType>(type))
+    const auto isPointerType = is<PointerType>(type);
+    const auto vectorType = dynamic_cast<const VectorType *>(&type);
+    const auto isVectorOfPointerType = vectorType && is<PointerType>(vectorType->Type());
+
+    if (!isPointerType && !isVectorOfPointerType)
     {
       throw std::logic_error("Expected pointer type.");
     }
@@ -287,7 +307,7 @@ private:
   extractIndexTypes(const std::vector<T *> & indices)
   {
     std::vector<std::shared_ptr<const rvsdg::Type>> indexTypes;
-    for (const auto & offset : indices)
+    for (const auto & index : indices)
     {
       indexTypes.emplace_back(std::move(offset->Type()));
     }
@@ -306,7 +326,7 @@ private:
     return types;
   }
 
-  std::shared_ptr<const rvsdg::Type> pointeeType_;
+  std::shared_ptr<const rvsdg::Type> gepType_;
 };
 
 }

--- a/jlm/llvm/ir/operators/GetElementPtr.hpp
+++ b/jlm/llvm/ir/operators/GetElementPtr.hpp
@@ -20,31 +20,23 @@ namespace jlm::llvm
  * See [LLVM Language Reference
  * Manual](https://llvm.org/docs/LangRef.html#getelementptr-instruction) for more details.
  *
- * FIXME: We should type check that pointeeType and the number/types of indices fit together.
- *
- * FIXME: We should type check that the index and baseAddress vectors (if any) fit together with
- * each other
  */
 class GetElementPtrOperation final : public rvsdg::SimpleOperation
 {
 public:
   ~GetElementPtrOperation() noexcept override;
 
-  // FIXME: I would love to have this private. It makes no sense to have this public as it allows to
-  // create illegal getelementptr operations.
+private:
   GetElementPtrOperation(
       const std::shared_ptr<const rvsdg::Type> & baseAddressType,
       const std::vector<std::shared_ptr<const rvsdg::Type>> & indexTypes,
-      std::shared_ptr<const rvsdg::Type> gepType)
-      : SimpleOperation(
-            createOperandTypes(baseAddressType, indexTypes),
-            { getResultType(baseAddressType, indexTypes) }),
+      std::shared_ptr<const rvsdg::Type> gepType,
+      std::shared_ptr<const rvsdg::Type> resultType)
+      : SimpleOperation(createOperandTypes(baseAddressType, indexTypes), { resultType }),
         gepType_(std::move(gepType))
-  {
-    checkBaseAddressType(*baseAddressType);
-    checkIndexTypes(indexTypes);
-  }
+  {}
 
+public:
   GetElementPtrOperation(const GetElementPtrOperation & other) = default;
 
   GetElementPtrOperation(GetElementPtrOperation && other) noexcept = default;
@@ -159,7 +151,7 @@ public:
    *
    * @param baseAddress The base address for the pointer calculation.
    * @param offsets The offsets from the base address.
-   * @param pointeeType The type the base address points to.
+   * @param gepType The type used for address calculation.
    *
    * @return A getElementPtr three address code.
    */
@@ -167,15 +159,36 @@ public:
   createTAC(
       const Variable * baseAddress,
       const std::vector<const Variable *> & offsets,
-      std::shared_ptr<const rvsdg::Type> pointeeType)
+      std::shared_ptr<const rvsdg::Type> gepType)
   {
     auto indexTypes = extractIndexTypes<const Variable>(offsets);
+    auto operation = createOperation(baseAddress->Type(), indexTypes, std::move(gepType));
 
-    auto operation = std::make_unique<GetElementPtrOperation>(baseAddress->Type(), indexTypes, std::move(pointeeType));
     std::vector operands(1, baseAddress);
     operands.insert(operands.end(), offsets.begin(), offsets.end());
 
+    // FIXME: Validate structural integrity of GEP type
     return ThreeAddressCode::create(std::move(operation), operands);
+  }
+
+  static std::unique_ptr<GetElementPtrOperation>
+  createOperation(
+      const std::shared_ptr<const rvsdg::Type> & baseAddressType,
+      const std::vector<std::shared_ptr<const rvsdg::Type>> & indexTypes,
+      const std::shared_ptr<const rvsdg::Type> & gepType)
+  {
+    // 1. Validate that the base address is a pointer or vector of pointers
+    checkBaseAddressType(*baseAddressType);
+
+    // 2. Validate that the index types are pointers or vector of integers
+    checkIndexTypes(indexTypes);
+
+    // FIXME: Validate vector components align such as uniform lane count, etc.
+
+    auto resultType = getResultType(baseAddressType, indexTypes);
+
+    return std::unique_ptr<GetElementPtrOperation>(
+        new GetElementPtrOperation(baseAddressType, indexTypes, gepType, std::move(resultType)));
   }
 
   /**
@@ -183,7 +196,7 @@ public:
    *
    * @param baseAddress The base address for the pointer calculation.
    * @param indices The offsets from the base address.
-   * @param pointeeType The type the base address points to.
+   * @param gepType The type used for address calculation.
    *
    * @return The created GetElementPtr RVSDG node.
    */
@@ -191,18 +204,18 @@ public:
   createNode(
       rvsdg::Output & baseAddress,
       const std::vector<rvsdg::Output *> & indices,
-      std::shared_ptr<const rvsdg::Type> pointeeType)
+      const std::shared_ptr<const rvsdg::Type> & gepType)
   {
-    const auto indexTypes = extractIndexTypes<rvsdg::Output>(indices);
-
-    std::vector operands(1, &baseAddress);
+    std::vector operands({ &baseAddress });
     operands.insert(operands.end(), indices.begin(), indices.end());
 
-    return rvsdg::CreateOpNode<GetElementPtrOperation>(
-        operands,
-        baseAddress.Type(),
-        indexTypes,
-        std::move(pointeeType));
+    auto indexTypes = extractIndexTypes(indices);
+    auto gepOperation = createOperation(baseAddress.Type(), indexTypes, gepType);
+
+    // 4. Validate structural integrity of GEP type
+    checkIndexedType(gepType, indices);
+
+    return rvsdg::SimpleNode::Create(*baseAddress.region(), std::move(gepOperation), operands);
   }
 
   /**
@@ -210,7 +223,7 @@ public:
    *
    * @param baseAddress The base address for the pointer calculation.
    * @param indices The offsets from the base address.
-   * @param pointeeType The type the base address points to.
+   * @param gepType The type used for address calculation.
    *
    * @return The output of the created GetElementPtr RVSDG node.
    */
@@ -218,9 +231,9 @@ public:
   create(
       rvsdg::Output * baseAddress,
       const std::vector<rvsdg::Output *> & indices,
-      std::shared_ptr<const rvsdg::Type> pointeeType)
+      std::shared_ptr<const rvsdg::Type> gepType)
   {
-    return createNode(*baseAddress, indices, std::move(pointeeType)).output(0);
+    return createNode(*baseAddress, indices, std::move(gepType)).output(0);
   }
 
 private:
@@ -230,7 +243,7 @@ private:
       const std::vector<rvsdg::Output *> & indices);
 
   static void
-  checkIndexTypes(
+  checkIndexedType(
       const std::shared_ptr<const rvsdg::Type> & gepType,
       const std::vector<rvsdg::Output *> & indices)
   {
@@ -309,7 +322,7 @@ private:
     std::vector<std::shared_ptr<const rvsdg::Type>> indexTypes;
     for (const auto & index : indices)
     {
-      indexTypes.emplace_back(std::move(offset->Type()));
+      indexTypes.emplace_back(std::move(index->Type()));
     }
 
     return indexTypes;

--- a/jlm/llvm/ir/operators/GetElementPtrTests.cpp
+++ b/jlm/llvm/ir/operators/GetElementPtrTests.cpp
@@ -97,11 +97,12 @@ TEST(GetElementPtrOperationTests, TestOperationEquality)
   auto structType2 =
       StructType::CreateIdentified("myStructType", { arrayType, BitType::Create(32) }, false);
 
-  GetElementPtrOperation operation1(
+  auto operation1 = GetElementPtrOperation::createOperation(
       pointerType,
       { BitType::Create(32), BitType::Create(32) },
       structType1);
-  GetElementPtrOperation operation2(
+
+  auto operation2 = GetElementPtrOperation::createOperation(
       pointerType,
       { BitType::Create(32), BitType::Create(32) },
       structType2);
@@ -112,7 +113,7 @@ TEST(GetElementPtrOperationTests, TestOperationEquality)
   // Arrange 2: create a new type that is structurally identical to structType1
   auto copyOfStructType1 =
       StructType::CreateLiteral({ BitType::Create(64), BitType::Create(64) }, false);
-  GetElementPtrOperation operation3(
+  auto operation3 = GetElementPtrOperation::createOperation(
       pointerType,
       { BitType::Create(32), BitType::Create(32) },
       copyOfStructType1);
@@ -122,7 +123,7 @@ TEST(GetElementPtrOperationTests, TestOperationEquality)
   // The struct types have distinct pointers
   EXPECT_NE(structType1, copyOfStructType1);
   // Yet the GEPs compare equal
-  EXPECT_EQ(operation1, operation3);
+  EXPECT_EQ(*operation1, *operation3);
 }
 
 TEST(GetElementPtrTests, TryGetAsConstantTest)
@@ -138,6 +139,7 @@ TEST(GetElementPtrTests, TryGetAsConstantTest)
 
   auto structType =
       StructType::CreateIdentified("struct", { bits8Type, bits16Type, bits32Type }, false);
+  auto arrayType = ArrayType::Create(BitType::Create(32), 11);
 
   Graph rvsdg;
   auto & baseAddress = GraphImport::Create(rvsdg, pointerType, "base");
@@ -151,8 +153,8 @@ TEST(GetElementPtrTests, TryGetAsConstantTest)
       { zeroNode.output(0), oneNode.output(0) },
       structType);
   auto & gepNode1 =
-      GetElementPtrOperation::createNode(baseAddress, { zeroNode.output(0), &i32 }, structType);
-  auto & gepNode2 = GetElementPtrOperation::createNode(baseAddress, { &i32, &i32 }, structType);
+      GetElementPtrOperation::createNode(baseAddress, { zeroNode.output(0), &i32 }, arrayType);
+  auto & gepNode2 = GetElementPtrOperation::createNode(baseAddress, { &i32, &i32 }, arrayType);
 
   // Act
   auto gepConstant0 = GetElementPtrOperation::tryGetAsConstant(gepNode0);

--- a/jlm/llvm/opt/AggregateAllocaSplittingTests.cpp
+++ b/jlm/llvm/opt/AggregateAllocaSplittingTests.cpp
@@ -59,7 +59,7 @@ TEST(AggregateAllocaSplittingTests, getElementPtrTest)
   auto & gepXNode = GetElementPtrOperation::createNode(
       *allocaNode.output(0),
       { zero32Node.output(0), zero32Node.output(0) },
-      bit32Type);
+      structType);
   auto & storeGepXNode = StoreNonVolatileOperation::CreateNode(
       *gepXNode.output(0),
       *zero32Node.output(0),
@@ -69,7 +69,7 @@ TEST(AggregateAllocaSplittingTests, getElementPtrTest)
   auto & gepYNode = GetElementPtrOperation::createNode(
       *allocaNode.output(0),
       { zero32Node.output(0), one32Node.output(0) },
-      bit64Type);
+      structType);
   auto & storeGepYNode = StoreNonVolatileOperation::CreateNode(
       *gepYNode.output(0),
       *zero64Node.output(0),
@@ -144,7 +144,7 @@ TEST(AggregateAllocaSplittingTests, gammaTest)
     auto & gep0Node = GetElementPtrOperation::createNode(
         *baseAddressEntryVar.branchArgument[0],
         { zero32Node.output(0), zero32Node.output(0) },
-        bit16Type);
+        structType);
     storeGep0Node = &StoreNonVolatileOperation::CreateNode(
         *gep0Node.output(0),
         *zero16Node.output(0),
@@ -160,7 +160,7 @@ TEST(AggregateAllocaSplittingTests, gammaTest)
     auto & gep1Node = GetElementPtrOperation::createNode(
         *baseAddressEntryVar.branchArgument[1],
         { zero32Node.output(0), one32Node.output(0) },
-        bit32Type);
+        structType);
     storeGep1Node = &StoreNonVolatileOperation::CreateNode(
         *gep1Node.output(0),
         *zero32Node.output(0),
@@ -174,7 +174,7 @@ TEST(AggregateAllocaSplittingTests, gammaTest)
   auto & gep2Node = GetElementPtrOperation::createNode(
       *baseAddressExitVar.output,
       { zero.output(0), two.output(0) },
-      bit64Type);
+      structType);
 
   auto & zero64Node = IntegerConstantOperation::Create(*lambdaNode->subregion(), 64, 0);
   auto & storeGep2Node = StoreNonVolatileOperation::CreateNode(
@@ -257,7 +257,7 @@ TEST(AggregateAllocaSplittingTests, thetaTest)
     auto & gep0Node = GetElementPtrOperation::createNode(
         *addressLoopVar.pre,
         { zero32Node.output(0), zero32Node.output(0) },
-        bit16Type);
+        structType);
 
     storeGep0Node = &StoreNonVolatileOperation::CreateNode(
         *gep0Node.output(0),
@@ -272,7 +272,7 @@ TEST(AggregateAllocaSplittingTests, thetaTest)
   auto & gep1Node = GetElementPtrOperation::createNode(
       *addressLoopVar.output,
       { zero32Node.output(0), one.output(0) },
-      bit32Type);
+      structType);
   auto & storeGep1Node = StoreNonVolatileOperation::CreateNode(
       *gep1Node.output(0),
       *zero32Node.output(0),
@@ -353,7 +353,7 @@ TEST(AggregateAllocaSplittingTest, nestedStructTest)
   auto & gepBit8Node = GetElementPtrOperation::createNode(
       AllocaOperation::getPointerOutput(allocaNode),
       { zeroNode.output(0), zeroNode.output(0) },
-      bit8Type);
+      structType);
   auto & bit8ConstantNode = IntegerConstantOperation::Create(*lambdaNode->subregion(), 8, 8);
   auto storeGepBit8Node = &StoreNonVolatileOperation::CreateNode(
       *gepBit8Node.output(0),
@@ -364,7 +364,7 @@ TEST(AggregateAllocaSplittingTest, nestedStructTest)
   auto & gepBit12Node = GetElementPtrOperation::createNode(
       AllocaOperation::getPointerOutput(allocaNode),
       { zeroNode.output(0), oneNode.output(0), zeroNode.output(0) },
-      bit12Type);
+      structType);
   auto & bit12ConstantNode = IntegerConstantOperation::Create(*lambdaNode->subregion(), 12, 12);
   auto storeGepBit12Node = &StoreNonVolatileOperation::CreateNode(
       *gepBit12Node.output(0),
@@ -375,7 +375,7 @@ TEST(AggregateAllocaSplittingTest, nestedStructTest)
   auto & gepBit16Node = GetElementPtrOperation::createNode(
       AllocaOperation::getPointerOutput(allocaNode),
       { zeroNode.output(0), oneNode.output(0), oneNode.output(0) },
-      bit16Type);
+      structType);
   auto & bit16ConstantNode = IntegerConstantOperation::Create(*lambdaNode->subregion(), 16, 16);
   auto storeGepBit16Node = &StoreNonVolatileOperation::CreateNode(
       *gepBit16Node.output(0),
@@ -386,7 +386,7 @@ TEST(AggregateAllocaSplittingTest, nestedStructTest)
   auto & gepBit20Node = GetElementPtrOperation::createNode(
       AllocaOperation::getPointerOutput(allocaNode),
       { zeroNode.output(0), twoNode.output(0) },
-      bit20Type);
+      structType);
   auto & bit20ConstantNode = IntegerConstantOperation::Create(*lambdaNode->subregion(), 20, 20);
   auto storeGepBit20Node = &StoreNonVolatileOperation::CreateNode(
       *gepBit20Node.output(0),
@@ -397,7 +397,7 @@ TEST(AggregateAllocaSplittingTest, nestedStructTest)
   auto & gepBit32Node = GetElementPtrOperation::createNode(
       AllocaOperation::getPointerOutput(allocaNode),
       { zeroNode.output(0), threeNode.output(0), zeroNode.output(0) },
-      bit32Type);
+      structType);
   auto & bit32ConstantNode = IntegerConstantOperation::Create(*lambdaNode->subregion(), 32, 32);
   auto storeGepBit32Node = &StoreNonVolatileOperation::CreateNode(
       *gepBit32Node.output(0),
@@ -408,7 +408,7 @@ TEST(AggregateAllocaSplittingTest, nestedStructTest)
   auto & gepBit64Node = GetElementPtrOperation::createNode(
       AllocaOperation::getPointerOutput(allocaNode),
       { zeroNode.output(0), threeNode.output(0), oneNode.output(0) },
-      bit64Type);
+      structType);
   auto & bit64ConstantNode = IntegerConstantOperation::Create(*lambdaNode->subregion(), 64, 64);
   auto storeGepBit64Node = &StoreNonVolatileOperation::CreateNode(
       *gepBit64Node.output(0),
@@ -419,7 +419,7 @@ TEST(AggregateAllocaSplittingTest, nestedStructTest)
   auto & gepBit128Node = GetElementPtrOperation::createNode(
       AllocaOperation::getPointerOutput(allocaNode),
       { zeroNode.output(0), fourNode.output(0) },
-      bit64Type);
+      structType);
   auto & bit128ConstantNode = IntegerConstantOperation::Create(*lambdaNode->subregion(), 128, 128);
   auto storeGepBit128Node = &StoreNonVolatileOperation::CreateNode(
       *gepBit128Node.output(0),
@@ -527,14 +527,14 @@ TEST(AggregateAllocaSplittingTests, allocaWithCountBiggerThanOne)
 
   auto & zero32Node = IntegerConstantOperation::Create(*lambdaNode->subregion(), 32, 0);
   auto & zero64Node = IntegerConstantOperation::Create(*lambdaNode->subregion(), 64, 0);
-  auto & one32Node = IntegerConstantOperation::Create(*lambdaNode->subregion(), 32, 2);
+  auto & one32Node = IntegerConstantOperation::Create(*lambdaNode->subregion(), 32, 1);
   auto & two32Node = IntegerConstantOperation::Create(*lambdaNode->subregion(), 32, 2);
   auto & allocaNode = AllocaOperation::createNode(structType, *two32Node.output(0), 4);
 
   auto & gepNode = GetElementPtrOperation::createNode(
       *allocaNode.output(0),
       { zero32Node.output(0), one32Node.output(0) },
-      bit64Type);
+      structType);
   auto & storeGepNode = StoreNonVolatileOperation::CreateNode(
       *gepNode.output(0),
       *zero64Node.output(0),

--- a/jlm/llvm/opt/StoreValueForwardingTests.cpp
+++ b/jlm/llvm/opt/StoreValueForwardingTests.cpp
@@ -1445,10 +1445,10 @@ TEST(StoreValueForwardingTests, LoadForwardingFromDeltaWithConstantDataArray)
   auto gepOutput1 = GetElementPtrOperation::create(ctxVar.inner, { zero }, bits32Type);
   auto & loadNode1 = LoadNonVolatileOperation::CreateNode(*gepOutput1, {}, bits32Type, 4);
 
-  auto gepOutput2 = GetElementPtrOperation::create(ctxVar.inner, { zero, zero }, bits32Type);
+  auto gepOutput2 = GetElementPtrOperation::create(ctxVar.inner, { zero, zero }, arrayType);
   auto & loadNode2 = LoadNonVolatileOperation::CreateNode(*gepOutput2, {}, bits32Type, 4);
 
-  auto gepOutput3 = GetElementPtrOperation::create(ctxVar.inner, { zero, two }, bits32Type);
+  auto gepOutput3 = GetElementPtrOperation::create(ctxVar.inner, { zero, two }, arrayType);
   auto & loadNode3 = LoadNonVolatileOperation::CreateNode(*gepOutput3, {}, bits32Type, 4);
 
   auto gepOutput4 = GetElementPtrOperation::create(ctxVar.inner, { four }, bits8Type);


### PR DESCRIPTION
1. Ensures that the GEP type aligns with the indices provided.
2. Fixes GEP operations in the unit tests that did not type check.