### PR TITLE
loopnode: entry/exit/backedge var API

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/DeadNodeElimination.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/DeadNodeElimination.cpp
@@ -3,6 +3,7 @@
  * See COPYING for terms of redistribution.
  */
 
+#include <algorithm>
 #include <jlm/hls/backend/rvsdg2rhls/DeadNodeElimination.hpp>
 #include <jlm/llvm/ir/operators/lambda.hpp>
 #include <jlm/rvsdg/traverser.hpp>
@@ -13,64 +14,64 @@ namespace jlm::hls
 static bool
 RemoveUnusedLoopOutputs(LoopNode & loopNode)
 {
-  bool anyChanged = false;
+  // Keep only those entry vars that are not dead.
+  std::vector<LoopNode::ExitVar> vars = loopNode.getExitVars();
+  vars.erase(
+      std::remove_if(
+          vars.begin(),
+          vars.end(),
+          [](const LoopNode::ExitVar & var)
+          {
+            return !var.output->IsDead();
+          }),
+      vars.end());
 
-  // go through in reverse because we might remove outputs
-  for (int i = loopNode.noutputs() - 1; i >= 0; --i)
-  {
-    auto output = loopNode.output(i);
-    if (output->nusers() == 0)
-    {
-      loopNode.removeLoopOutput(output);
-      anyChanged = true;
-    }
-  }
+  // Remove all dead vars.
+  bool anyChanged = !vars.empty();
+  loopNode.removeExitVars(std::move(vars));
   return anyChanged;
 }
 
 static bool
 RemoveUnusedInputs(LoopNode & loopNode)
 {
-  bool anyChanged = false;
-  auto loopSubregion = loopNode.subregion();
+  // Keep only those entry vars that are not dead.
+  std::vector<LoopNode::EntryVar> vars = loopNode.getEntryVars();
+  vars.erase(
+      std::remove_if(
+          vars.begin(),
+          vars.end(),
+          [](const LoopNode::EntryVar & var)
+          {
+            return !var.inner->IsDead();
+          }),
+      vars.end());
 
-  // go through in reverse because we might remove inputs
-  for (int i = loopNode.ninputs() - 1; i >= 0; --i)
-  {
-    auto input = loopNode.input(i);
-    JLM_ASSERT(input->arguments.size() == 1);
-    auto argument = input->arguments.begin();
+  // Remove all dead vars.
+  bool anyChanged = !vars.empty();
+  loopNode.removeEntryVars(std::move(vars));
+  return anyChanged;
+}
 
-    if (argument->nusers() == 0)
-    {
-      loopNode.removeLoopInput(input);
-      anyChanged = true;
-    }
-  }
-
-  // clean up unused arguments - only ones without an input should be left
-  // go through in reverse because we might remove some
-  for (int i = loopSubregion->narguments() - 1; i >= 0; --i)
-  {
-    auto argument = loopSubregion->argument(i);
-
-    if (auto backedgeArgument = dynamic_cast<BackEdgeArgument *>(argument))
-    {
-      auto result = backedgeArgument->result();
-      JLM_ASSERT(*result->Type() == *argument->Type());
-
-      if (argument->nusers() == 0 || (argument->nusers() == 1 && result->origin() == argument))
-      {
-        loopSubregion->RemoveResults({ result->index() });
-        loopSubregion->RemoveArguments({ argument->index() });
-      }
-    }
-    else
-    {
-      JLM_ASSERT(argument->nusers() != 0);
-    }
-  }
-
+static bool
+RemoveUnusedBackEdges(LoopNode & loopNode)
+{
+  // Keep only back edge vars that have a user (instead of
+  // simply forwarding to itself).
+  std::vector<LoopNode::BackEdgeVar> vars = loopNode.getBackEdgeVars();
+  vars.erase(
+      std::remove_if(
+          vars.begin(),
+          vars.end(),
+          [](const LoopNode::BackEdgeVar & var)
+          {
+            return !(var.pre->nusers() == 1 && var.post->origin() == var.pre);
+          }),
+      vars.end());
+  // Remove all that have exactly one user, namely forward itself
+  // to next loop iteration.
+  bool anyChanged = !vars.empty();
+  loopNode.removeBackEdgeVars(std::move(vars));
   return anyChanged;
 }
 
@@ -94,6 +95,7 @@ EliminateDeadNodesInRegion(rvsdg::Region & region)
       {
         changed |= RemoveUnusedLoopOutputs(*loopNode);
         changed |= RemoveUnusedInputs(*loopNode);
+        changed |= RemoveUnusedBackEdges(*loopNode);
         changed |= EliminateDeadNodesInRegion(*loopNode->subregion());
       }
     }

--- a/jlm/hls/backend/rvsdg2rhls/rhls-dne.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rhls-dne.cpp
@@ -3,6 +3,7 @@
  * See COPYING for terms of redistribution.
  */
 
+#include <algorithm>
 #include <jlm/hls/backend/rvsdg2rhls/hls-function-util.hpp>
 #include <jlm/hls/backend/rvsdg2rhls/rhls-dne.hpp>
 #include <jlm/hls/ir/hls.hpp>
@@ -14,112 +15,93 @@ namespace jlm::hls
 {
 
 static bool
-remove_unused_loop_backedges(LoopNode * loopNode)
+remove_loop_passthrough(LoopNode * ln)
 {
-  util::HashSet<size_t> resultIndices;
-  util::HashSet<size_t> argumentIndices;
-  const auto subregion = loopNode->subregion();
-  for (const auto argument : subregion->Arguments())
+  bool any_changed = false;
+
+  // Check if any output directly maps to an input into the loop.
+  // If yes, divert users of this output to the pre-loop value.
+  // As a consequence, this output is now unused and will be
+  // removed by remove_unused_loop_outputs (and then lead to
+  // the input also removed by remove_unused_loop_inputs).
+  for (auto exitvar : ln->getExitVars())
   {
-    if ((dynamic_cast<BackEdgeArgument *>(argument) && argument->nusers() == 1))
+    auto loopval = exitvar.inner->origin();
+    if (rvsdg::TryGetRegionParentNode<LoopNode>(*loopval) == ln)
     {
-      auto & user = *argument->Users().begin();
-      if (const auto result = dynamic_cast<BackEdgeResult *>(&user))
+      auto loopvar = ln->mapArgument(*loopval);
+      if (auto entry = std::get_if<LoopNode::EntryVar>(&loopvar))
       {
-        resultIndices.insert(result->index());
-        argumentIndices.insert(argument->index());
+        exitvar.output->divert_users(entry->input->origin());
+        any_changed = true;
       }
     }
   }
 
-  [[maybe_unused]] const auto numRemovedResults = subregion->RemoveResults(resultIndices);
-  JLM_ASSERT(numRemovedResults == resultIndices.Size());
-
-  [[maybe_unused]] const auto numRemovedArguments = subregion->RemoveArguments(argumentIndices);
-  JLM_ASSERT(numRemovedArguments == argumentIndices.Size());
-
-  return numRemovedArguments != 0;
+  return any_changed;
 }
 
 static bool
 remove_unused_loop_outputs(LoopNode * ln)
 {
-  bool any_changed = false;
-  // go through in reverse because we remove some
-  for (int i = ln->noutputs() - 1; i >= 0; --i)
-  {
-    const auto out = ln->output(i);
-    if (out->nusers() == 0)
-    {
-      ln->removeLoopOutput(out);
-      any_changed = true;
-    }
-  }
-  return any_changed;
-}
+  // Keep only those entry vars that are not dead.
+  std::vector<LoopNode::ExitVar> vars = ln->getExitVars();
+  vars.erase(
+      std::remove_if(
+          vars.begin(),
+          vars.end(),
+          [](const LoopNode::ExitVar & var)
+          {
+            return !var.output->IsDead();
+          }),
+      vars.end());
 
-static bool
-remove_loop_passthrough(LoopNode * ln)
-{
-  bool any_changed = false;
-  // go through in reverse because we remove some
-  for (int i = ln->ninputs() - 1; i >= 0; --i)
-  {
-    const auto in = ln->input(i);
-    JLM_ASSERT(in->arguments.size() == 1);
-    const auto arg = in->arguments.begin();
-    if (arg->nusers() != 1)
-      continue;
-
-    auto & user = *arg->Users().begin();
-    if (const auto result = dynamic_cast<rvsdg::RegionResult *>(&user))
-    {
-      result->output()->divert_users(in->origin());
-      ln->removeLoopOutput(result->output());
-      ln->removeLoopInput(arg->input());
-      any_changed = true;
-    }
-  }
+  // Remove all dead vars.
+  bool any_changed = !vars.empty();
+  ln->removeExitVars(std::move(vars));
   return any_changed;
 }
 
 static bool
 remove_unused_loop_inputs(LoopNode * ln)
 {
-  bool any_changed = false;
-  auto sr = ln->subregion();
-  // go through in reverse because we remove some
-  for (int i = ln->ninputs() - 1; i >= 0; --i)
-  {
-    auto in = ln->input(i);
-    JLM_ASSERT(in->arguments.size() == 1);
-    auto arg = in->arguments.begin();
-    if (arg->nusers() == 0)
-    {
-      ln->removeLoopInput(in);
-      any_changed = true;
-    }
-  }
-  // clean up unused arguments - only ones without an input should be left
-  // go through in reverse because we remove some
-  for (int i = sr->narguments() - 1; i >= 0; --i)
-  {
-    auto arg = sr->argument(i);
-    if (auto ba = dynamic_cast<BackEdgeArgument *>(arg))
-    {
-      auto result = ba->result();
-      JLM_ASSERT(*result->Type() == *arg->Type());
-      if (arg->nusers() == 0 || (arg->nusers() == 1 && result->origin() == arg))
-      {
-        sr->RemoveResults({ result->index() });
-        sr->RemoveArguments({ arg->index() });
-      }
-    }
-    else
-    {
-      JLM_ASSERT(arg->nusers() != 0);
-    }
-  }
+  // Keep only those entry vars that are not dead.
+  std::vector<LoopNode::EntryVar> vars = ln->getEntryVars();
+  vars.erase(
+      std::remove_if(
+          vars.begin(),
+          vars.end(),
+          [](const LoopNode::EntryVar & var)
+          {
+            return !var.inner->IsDead();
+          }),
+      vars.end());
+
+  // Remove all dead vars.
+  bool any_changed = !vars.empty();
+  ln->removeEntryVars(std::move(vars));
+  return any_changed;
+}
+
+static bool
+remove_unused_loop_backedges(LoopNode * ln)
+{
+  // Keep only back edge vars that have a user (instead of
+  // simply forwarding to itself).
+  std::vector<LoopNode::BackEdgeVar> vars = ln->getBackEdgeVars();
+  vars.erase(
+      std::remove_if(
+          vars.begin(),
+          vars.end(),
+          [](const LoopNode::BackEdgeVar & var)
+          {
+            return !(var.pre->nusers() == 1 && var.post->origin() == var.pre);
+          }),
+      vars.end());
+  // Remove all that have exactly one user, namely forward itself
+  // to next loop iteration.
+  bool any_changed = !vars.empty();
+  ln->removeBackEdgeVars(std::move(vars));
   return any_changed;
 }
 
@@ -458,10 +440,10 @@ RhlsDeadNodeElimination::Run(
       }
       else if (auto ln = dynamic_cast<LoopNode *>(node))
       {
+        changed |= remove_loop_passthrough(ln);
         changed |= remove_unused_loop_outputs(ln);
         changed |= remove_unused_loop_inputs(ln);
         changed |= remove_unused_loop_backedges(ln);
-        changed |= remove_loop_passthrough(ln);
         changed |= Run(*ln->subregion(), statisticsCollector);
       }
       else if (const auto mux = dynamic_cast<const MuxOperation *>(&node->GetOperation()))

--- a/jlm/hls/ir/hls.cpp
+++ b/jlm/hls/ir/hls.cpp
@@ -3,6 +3,7 @@
  * See COPYING for terms of redistribution.
  */
 
+#include <algorithm>
 #include <cmath>
 #include <jlm/hls/ir/hls.hpp>
 #include <jlm/util/Hash.hpp>
@@ -193,30 +194,6 @@ LoopNode::addRequestOutput(rvsdg::Output * origin)
   return output;
 }
 
-void
-LoopNode::removeLoopOutput(rvsdg::StructuralOutput * output)
-{
-  JLM_ASSERT(output->node() == this);
-  JLM_ASSERT(output->IsDead());
-  JLM_ASSERT(output->results.size() == 1);
-  auto result = output->results.begin();
-
-  subregion()->RemoveResults({ result->index() });
-  RemoveOutputs({ output->index() });
-}
-
-void
-LoopNode::removeLoopInput(rvsdg::StructuralInput * input)
-{
-  JLM_ASSERT(input->node() == this);
-  JLM_ASSERT(input->arguments.size() == 1);
-  auto argument = input->arguments.begin();
-  JLM_ASSERT(argument->IsDead());
-
-  subregion()->RemoveArguments({ argument->index() });
-  RemoveInputs({ input->index() });
-}
-
 [[nodiscard]] const rvsdg::Operation &
 LoopNode::GetOperation() const noexcept
 {
@@ -224,10 +201,149 @@ LoopNode::GetOperation() const noexcept
   return singleton;
 }
 
+LoopNode::EntryVar
+LoopNode::mapInput(const rvsdg::Input & input)
+{
+  return EntryVar{ const_cast<rvsdg::Input *>(&input),
+                   const_cast<rvsdg::RegionArgument *>(
+                       &*static_cast<const rvsdg::StructuralInput &>(input).arguments.begin()) };
+}
+
+LoopNode::ExitVar
+LoopNode::mapOutput(const rvsdg::Output & output)
+{
+  return ExitVar{ const_cast<rvsdg::RegionResult *>(
+                      &*static_cast<const rvsdg::StructuralOutput &>(output).results.begin()),
+                  const_cast<rvsdg::Output *>(&output) };
+}
+
+std::variant<LoopNode::EntryVar, LoopNode::BackEdgeVar>
+LoopNode::mapArgument(const rvsdg::Output & argument)
+{
+  if (auto backedge = dynamic_cast<const BackEdgeArgument *>(&argument))
+  {
+    return BackEdgeVar{ const_cast<BackEdgeArgument *>(backedge),
+                        const_cast<BackEdgeArgument *>(backedge)->result() };
+  }
+  else if (auto entry = dynamic_cast<const EntryArgument *>(&argument))
+  {
+    return EntryVar{ entry->input(), const_cast<EntryArgument *>(entry) };
+  }
+  else
+  {
+    abort();
+  }
+}
+
+std::variant<LoopNode::ExitVar, LoopNode::BackEdgeVar>
+LoopNode::mapResult(const rvsdg::Input & result)
+{
+  if (auto backedge = dynamic_cast<const BackEdgeResult *>(&result))
+  {
+    return BackEdgeVar{ const_cast<BackEdgeResult *>(backedge)->argument(),
+                        const_cast<BackEdgeResult *>(backedge) };
+  }
+  else if (auto exit = dynamic_cast<const ExitResult *>(&result))
+  {
+    return ExitVar{ const_cast<ExitResult *>(exit), exit->output() };
+  }
+  else
+  {
+    abort();
+  }
+}
+
+std::vector<LoopNode::EntryVar>
+LoopNode::getEntryVars()
+{
+  std::vector<EntryVar> entryvars;
+  for (const auto & input : Inputs())
+  {
+    entryvars.push_back(mapInput(input));
+  }
+  return entryvars;
+}
+
+std::vector<LoopNode::ExitVar>
+LoopNode::getExitVars()
+{
+  std::vector<ExitVar> exitvars;
+  for (const auto & output : Outputs())
+  {
+    exitvars.push_back(mapOutput(output));
+  }
+  return exitvars;
+}
+
+std::vector<LoopNode::BackEdgeVar>
+LoopNode::getBackEdgeVars()
+{
+  std::vector<BackEdgeVar> backedges;
+  for (const auto & argument : subregion()->Arguments())
+  {
+    auto var = mapArgument(*argument);
+    if (auto backedge = std::get_if<BackEdgeVar>(&var))
+    {
+      backedges.push_back(*backedge);
+    }
+  }
+  return backedges;
+}
+
+void
+LoopNode::removeEntryVars(std::vector<EntryVar> vars)
+{
+  jlm::util::HashSet<std::size_t> inputs;
+  jlm::util::HashSet<std::size_t> arguments;
+  for (const auto & var : vars)
+  {
+    JLM_ASSERT(dynamic_cast<rvsdg::StructuralInput *>(var.input)->node() == this);
+    JLM_ASSERT(dynamic_cast<EntryArgument *>(var.inner)->input() == var.input);
+    JLM_ASSERT(var.inner->IsDead());
+    inputs.insert(var.input->index());
+    arguments.insert(var.inner->index());
+  }
+  subregion()->RemoveArguments(arguments);
+  RemoveInputs(inputs);
+}
+
+void
+LoopNode::removeExitVars(std::vector<ExitVar> vars)
+{
+  jlm::util::HashSet<std::size_t> results;
+  jlm::util::HashSet<std::size_t> outputs;
+  for (const auto & var : vars)
+  {
+    JLM_ASSERT(dynamic_cast<rvsdg::StructuralOutput *>(var.output)->node() == this);
+    JLM_ASSERT(dynamic_cast<ExitResult *>(var.inner)->output() == var.output);
+    JLM_ASSERT(var.output->IsDead());
+    results.insert(var.inner->index());
+    outputs.insert(var.output->index());
+  }
+  subregion()->RemoveResults(results);
+  RemoveOutputs(outputs);
+}
+
+void
+LoopNode::removeBackEdgeVars(std::vector<BackEdgeVar> vars)
+{
+  jlm::util::HashSet<std::size_t> arguments;
+  jlm::util::HashSet<std::size_t> results;
+  for (const auto & var : vars)
+  {
+    JLM_ASSERT(dynamic_cast<BackEdgeArgument *>(var.pre)->region() == subregion());
+    JLM_ASSERT(dynamic_cast<BackEdgeResult *>(var.post)->region() == subregion());
+    arguments.insert(var.pre->index());
+    results.insert(var.post->index());
+  }
+  subregion()->RemoveArguments(arguments);
+  subregion()->RemoveResults(results);
+}
+
 LoopNode *
 LoopNode::copy(rvsdg::Region * region, rvsdg::SubstitutionMap & smap) const
 {
-  auto loop = create(region, false);
+  auto loop = new LoopNode(region);
 
   for (size_t i = 0; i < ninputs(); ++i)
   {
@@ -291,19 +407,16 @@ LoopNode::add_backedge(std::shared_ptr<const jlm::rvsdg::Type> type)
 }
 
 LoopNode *
-LoopNode::create(rvsdg::Region * parent, bool init)
+LoopNode::create(rvsdg::Region * parent)
 {
   auto ln = new LoopNode(parent);
-  if (init)
-  {
-    auto predicate = &rvsdg::ControlConstantOperation::createFalse(*ln->subregion());
-    auto pred_arg = ln->add_backedge(rvsdg::ControlType::Create(2));
-    pred_arg->result()->divert_to(predicate);
-    // we need a buffer without pass-through behavior to avoid a combinatorial cycle of ready
-    // signals
-    auto pre_buffer = BufferOperation::create(*pred_arg, 2)[0];
-    ln->PredicateBuffer_ = PredicateBufferOperation::create(*pre_buffer)[0];
-  }
+  auto predicate = &rvsdg::ControlConstantOperation::createFalse(*ln->subregion());
+  auto pred_arg = ln->add_backedge(rvsdg::ControlType::Create(2));
+  pred_arg->result()->divert_to(predicate);
+  // we need a buffer without pass-through behavior to avoid a combinatorial cycle of ready
+  // signals
+  auto pre_buffer = BufferOperation::create(*pred_arg, 2)[0];
+  ln->PredicateBuffer_ = PredicateBufferOperation::create(*pre_buffer)[0];
   return ln;
 }
 

--- a/jlm/hls/ir/hls.hpp
+++ b/jlm/hls/ir/hls.hpp
@@ -715,11 +715,86 @@ private:
   {}
 
 public:
+  /**
+   * \brief Variable entering the hls loop.
+   */
+  struct EntryVar
+  {
+    /**
+     * \brief Variable at loop entry.
+     */
+    rvsdg::Input * input;
+    /**
+     * \brief Variable in region representing entry value.
+     */
+    rvsdg::Output * inner;
+  };
+
+  /**
+   * \brief Variable exiting the hls loop.
+   */
+  struct ExitVar
+  {
+    /**
+     * \brief Variable in region representing exit value.
+     */
+    rvsdg::Input * inner;
+    /**
+     * \brief Variable after loop exit.
+     */
+    rvsdg::Output * output;
+  };
+
+  /**
+   * \brief Variable passed between hls loop iterations.
+   */
+  struct BackEdgeVar
+  {
+    /**
+     * \brief Variable at beginning of loop (pre-iteration value).
+     */
+    rvsdg::Output * pre;
+    /**
+     * \brief Variable at end of loop (post-iteration value).
+     */
+    rvsdg::Input * post;
+  };
+
   [[nodiscard]] const rvsdg::Operation &
   GetOperation() const noexcept override;
 
+  EntryVar
+  mapInput(const rvsdg::Input & input);
+
+  ExitVar
+  mapOutput(const rvsdg::Output & output);
+
+  std::variant<EntryVar, BackEdgeVar>
+  mapArgument(const rvsdg::Output & argument);
+
+  std::variant<ExitVar, BackEdgeVar>
+  mapResult(const rvsdg::Input & result);
+
+  std::vector<EntryVar>
+  getEntryVars();
+
+  std::vector<ExitVar>
+  getExitVars();
+
+  std::vector<BackEdgeVar>
+  getBackEdgeVars();
+
+  void
+  removeEntryVars(std::vector<EntryVar> vars);
+
+  void
+  removeExitVars(std::vector<ExitVar> vars);
+
+  void
+  removeBackEdgeVars(std::vector<BackEdgeVar> vars);
+
   static LoopNode *
-  create(rvsdg::Region * parent, bool init = true);
+  create(rvsdg::Region * parent);
 
   rvsdg::Region *
   subregion() const noexcept
@@ -797,20 +872,6 @@ public:
    */
   rvsdg::Output *
   addRequestOutput(rvsdg::Output * origin);
-
-  /**
-   * Removes the given node output, and the corresponding region result.
-   * @param output the node output to remove. Must be dead.
-   */
-  void
-  removeLoopOutput(rvsdg::StructuralOutput * output);
-
-  /**
-   * Removes the given node input, and the corresponding region argument.
-   * @param input the node input to remove. Its argument must be dead.
-   */
-  void
-  removeLoopInput(rvsdg::StructuralInput * input);
 
   LoopNode *
   copy(rvsdg::Region * region, rvsdg::SubstitutionMap & smap) const override;


### PR DESCRIPTION
Add API grouping vars as EntryVar/ExitVar/BackEdgeVar. Provide functions similar to theta, gamma etc to deal with these variables.

Use this API in DNE, and simplify how they operate.

This does not yet consistently use the new API or
eliminate the subclasses of RegionArgument/RegionResult, but is a necessary step.