### PR TITLE
RVSDG: overhaul containsNodeType() and containsOperation() methods

### DIFF
--- a/jlm/hls/backend/rvsdg2rhls/GammaTests.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/GammaTests.cpp
@@ -52,7 +52,7 @@ TEST(GammaConversionTests, TestWithMatch)
 
   // Assert
   EXPECT_TRUE(
-      jlm::rvsdg::Region::ContainsOperation<jlm::hls::MuxOperation>(*lambda->subregion(), true));
+      jlm::rvsdg::Region::containsOperation<jlm::hls::MuxOperation>(*lambda->subregion(), true));
 }
 
 TEST(GammaConversionTests, TestWithoutMatch)
@@ -90,5 +90,5 @@ TEST(GammaConversionTests, TestWithoutMatch)
 
   // Assert
   EXPECT_TRUE(
-      jlm::rvsdg::Region::ContainsOperation<jlm::hls::MuxOperation>(*lambda->subregion(), true));
+      jlm::rvsdg::Region::containsOperation<jlm::hls::MuxOperation>(*lambda->subregion(), true));
 }

--- a/jlm/hls/backend/rvsdg2rhls/MemoryConverterTests.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/MemoryConverterTests.cpp
@@ -355,18 +355,18 @@ TEST(MemoryConverterTests, TestThetaLoad)
   ThetaNodeConversion::CreateAndRun(*rvsdgModule, statisticsCollector);
   // Simple assert as ConvertThetaNodes() is tested in separate unit tests
   jlm::rvsdg::view(rvsdgModule->Rvsdg(), stdout);
-  EXPECT_TRUE(jlm::rvsdg::Region::ContainsNodeType<LoopNode>(*lambdaRegion, true));
+  EXPECT_TRUE(jlm::rvsdg::Region::containsNodeType<LoopNode>(*lambdaRegion, true));
 
   // Act
   AddressQueueInsertion::CreateAndRun(*rvsdgModule, statisticsCollector);
 
   // Simple assert as mem_queue() is tested in separate unit tests
   jlm::rvsdg::view(rvsdgModule->Rvsdg(), stdout);
-  EXPECT_TRUE(jlm::rvsdg::Region::ContainsOperation<StateGateOperation>(*lambdaRegion, true));
+  EXPECT_TRUE(jlm::rvsdg::Region::containsOperation<StateGateOperation>(*lambdaRegion, true));
   EXPECT_TRUE(
-      jlm::rvsdg::Region::ContainsOperation<MemoryStateSplitOperation>(*lambdaRegion, true));
+      jlm::rvsdg::Region::containsOperation<MemoryStateSplitOperation>(*lambdaRegion, true));
   EXPECT_TRUE(
-      jlm::rvsdg::Region::ContainsOperation<MemoryStateMergeOperation>(*lambdaRegion, true));
+      jlm::rvsdg::Region::containsOperation<MemoryStateMergeOperation>(*lambdaRegion, true));
 
   // Act
   MemoryConverter::CreateAndRun(*rvsdgModule, statisticsCollector);
@@ -380,8 +380,8 @@ TEST(MemoryConverterTests, TestThetaLoad)
   lambda = jlm::util::assertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
   lambdaRegion = lambda->subregion();
 
-  EXPECT_TRUE(jlm::rvsdg::Region::ContainsOperation<MemoryResponseOperation>(*lambdaRegion, true));
-  EXPECT_TRUE(jlm::rvsdg::Region::ContainsOperation<MemoryRequestOperation>(*lambdaRegion, true));
+  EXPECT_TRUE(jlm::rvsdg::Region::containsOperation<MemoryResponseOperation>(*lambdaRegion, true));
+  EXPECT_TRUE(jlm::rvsdg::Region::containsOperation<MemoryRequestOperation>(*lambdaRegion, true));
 
   // Request Node
   auto requestNode =
@@ -483,7 +483,7 @@ TEST(MemoryConverterTests, TestThetaStore)
   ThetaNodeConversion::CreateAndRun(*rvsdgModule, statisticsCollector);
   // Simple assert as ConvertThetaNodes() is tested in separate unit tests
   jlm::rvsdg::view(rvsdgModule->Rvsdg(), stdout);
-  EXPECT_TRUE(jlm::rvsdg::Region::ContainsNodeType<LoopNode>(*lambdaRegion, true));
+  EXPECT_TRUE(jlm::rvsdg::Region::containsNodeType<LoopNode>(*lambdaRegion, true));
 
   // Act
   AddressQueueInsertion::CreateAndRun(*rvsdgModule, statisticsCollector);
@@ -491,9 +491,9 @@ TEST(MemoryConverterTests, TestThetaStore)
   // Simple assert as mem_queue() is tested in separate unit tests
   jlm::rvsdg::view(rvsdgModule->Rvsdg(), stdout);
   EXPECT_TRUE(
-      jlm::rvsdg::Region::ContainsOperation<MemoryStateSplitOperation>(*lambdaRegion, true));
+      jlm::rvsdg::Region::containsOperation<MemoryStateSplitOperation>(*lambdaRegion, true));
   EXPECT_TRUE(
-      jlm::rvsdg::Region::ContainsOperation<MemoryStateMergeOperation>(*lambdaRegion, true));
+      jlm::rvsdg::Region::containsOperation<MemoryStateMergeOperation>(*lambdaRegion, true));
 
   // Act
   MemoryConverter::CreateAndRun(*rvsdgModule, statisticsCollector);
@@ -507,7 +507,7 @@ TEST(MemoryConverterTests, TestThetaStore)
   lambda = jlm::util::assertedCast<jlm::rvsdg::LambdaNode>(region->Nodes().begin().ptr());
   lambdaRegion = lambda->subregion();
 
-  EXPECT_TRUE(jlm::rvsdg::Region::ContainsOperation<MemoryRequestOperation>(*lambdaRegion, true));
+  EXPECT_TRUE(jlm::rvsdg::Region::containsOperation<MemoryRequestOperation>(*lambdaRegion, true));
 
   // Request Node
   auto requestNode =

--- a/jlm/hls/backend/rvsdg2rhls/MemoryQueueTests.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/MemoryQueueTests.cpp
@@ -81,15 +81,15 @@ TEST(MemoryQueueTests, TestSingleLoad)
   ThetaNodeConversion::CreateAndRun(*rvsdgModule, statisticsCollector);
   // Simple assert as ConvertThetaNodes() is tested in separate unit tests
   jlm::rvsdg::view(rvsdgModule->Rvsdg(), stdout);
-  EXPECT_TRUE(jlm::rvsdg::Region::ContainsNodeType<LoopNode>(*lambdaRegion, true));
+  EXPECT_TRUE(jlm::rvsdg::Region::containsNodeType<LoopNode>(*lambdaRegion, true));
 
   // Act
   AddressQueueInsertion::CreateAndRun(*rvsdgModule, statisticsCollector);
 
   // Assert
   jlm::rvsdg::view(rvsdgModule->Rvsdg(), stdout);
-  EXPECT_TRUE(jlm::rvsdg::Region::ContainsOperation<StateGateOperation>(*lambdaRegion, true));
-  EXPECT_FALSE(jlm::rvsdg::Region::ContainsOperation<AddressQueueOperation>(*lambdaRegion, true));
+  EXPECT_TRUE(jlm::rvsdg::Region::containsOperation<StateGateOperation>(*lambdaRegion, true));
+  EXPECT_FALSE(jlm::rvsdg::Region::containsOperation<AddressQueueOperation>(*lambdaRegion, true));
 }
 
 TEST(MemoryQueueTests, TestLoadStore)
@@ -162,15 +162,15 @@ TEST(MemoryQueueTests, TestLoadStore)
   ThetaNodeConversion::CreateAndRun(*rvsdgModule, statisticsCollector);
   // Simple assert as ConvertThetaNodes() is tested in separate unit tests
   jlm::rvsdg::view(rvsdgModule->Rvsdg(), stdout);
-  EXPECT_TRUE(jlm::rvsdg::Region::ContainsNodeType<LoopNode>(*lambdaRegion, true));
+  EXPECT_TRUE(jlm::rvsdg::Region::containsNodeType<LoopNode>(*lambdaRegion, true));
 
   // Act
   AddressQueueInsertion::CreateAndRun(*rvsdgModule, statisticsCollector);
 
   // Assert
   jlm::rvsdg::view(rvsdgModule->Rvsdg(), stdout);
-  EXPECT_TRUE(jlm::rvsdg::Region::ContainsOperation<StateGateOperation>(*lambdaRegion, true));
-  EXPECT_FALSE(jlm::rvsdg::Region::ContainsOperation<AddressQueueOperation>(*lambdaRegion, true));
+  EXPECT_TRUE(jlm::rvsdg::Region::containsOperation<StateGateOperation>(*lambdaRegion, true));
+  EXPECT_FALSE(jlm::rvsdg::Region::containsOperation<AddressQueueOperation>(*lambdaRegion, true));
 }
 
 TEST(MemoryQueueTests, TestAddrQueue)
@@ -237,15 +237,15 @@ TEST(MemoryQueueTests, TestAddrQueue)
   ThetaNodeConversion::CreateAndRun(*rvsdgModule, statisticsCollector);
   // Simple assert as ConvertThetaNodes() is tested in separate unit tests
   jlm::rvsdg::view(rvsdgModule->Rvsdg(), stdout);
-  EXPECT_TRUE(jlm::rvsdg::Region::ContainsNodeType<LoopNode>(*lambdaRegion, true));
+  EXPECT_TRUE(jlm::rvsdg::Region::containsNodeType<LoopNode>(*lambdaRegion, true));
 
   // Act
   AddressQueueInsertion::CreateAndRun(*rvsdgModule, statisticsCollector);
 
   // Assert
   jlm::rvsdg::view(rvsdgModule->Rvsdg(), stdout);
-  EXPECT_TRUE(jlm::rvsdg::Region::ContainsOperation<StateGateOperation>(*lambdaRegion, true));
-  EXPECT_TRUE(jlm::rvsdg::Region::ContainsOperation<AddressQueueOperation>(*lambdaRegion, true));
+  EXPECT_TRUE(jlm::rvsdg::Region::containsOperation<StateGateOperation>(*lambdaRegion, true));
+  EXPECT_TRUE(jlm::rvsdg::Region::containsOperation<AddressQueueOperation>(*lambdaRegion, true));
 
   for (auto & node : jlm::rvsdg::TopDownTraverser(lambdaRegion))
   {

--- a/jlm/hls/backend/rvsdg2rhls/ThetaTests.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/ThetaTests.cpp
@@ -54,14 +54,14 @@ TEST(ThetaConversionTests, TestUnknownBoundaries)
 
   // Assert
   auto lambdaRegion = lambda->subregion();
-  EXPECT_TRUE(jlm::rvsdg::Region::ContainsNodeType<LoopNode>(*lambdaRegion, true));
-  EXPECT_TRUE(jlm::rvsdg::Region::ContainsOperation<PredicateBufferOperation>(*lambdaRegion, true));
+  EXPECT_TRUE(jlm::rvsdg::Region::containsNodeType<LoopNode>(*lambdaRegion, true));
+  EXPECT_TRUE(jlm::rvsdg::Region::containsOperation<PredicateBufferOperation>(*lambdaRegion, true));
   EXPECT_TRUE(
-      jlm::rvsdg::Region::ContainsOperation<jlm::hls::BranchOperation>(*lambdaRegion, true));
-  EXPECT_TRUE(jlm::rvsdg::Region::ContainsOperation<MuxOperation>(*lambdaRegion, true));
+      jlm::rvsdg::Region::containsOperation<jlm::hls::BranchOperation>(*lambdaRegion, true));
+  EXPECT_TRUE(jlm::rvsdg::Region::containsOperation<MuxOperation>(*lambdaRegion, true));
   // Check that two constant buffers are created for the loop invariant variables
   EXPECT_TRUE(
-      jlm::rvsdg::Region::ContainsOperation<LoopConstantBufferOperation>(*lambdaRegion, true));
+      jlm::rvsdg::Region::containsOperation<LoopConstantBufferOperation>(*lambdaRegion, true));
   EXPECT_EQ(lambdaRegion->argument(0)->nusers(), 1u);
   auto & loopNode =
       jlm::rvsdg::AssertGetOwnerNode<LoopNode>(lambdaRegion->argument(0)->SingleUser());

--- a/jlm/hls/backend/rvsdg2rhls/UnusedStateRemovalTests.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/UnusedStateRemovalTests.cpp
@@ -327,10 +327,10 @@ TEST(UnusedStateRemovalTests, TestInvariantMemoryState)
   EXPECT_EQ(lambdaSubregion->narguments(), 2u);
   EXPECT_EQ(lambdaSubregion->nresults(), 1u);
   EXPECT_TRUE(is<MemoryStateType>(lambdaSubregion->result(0)->Type()));
-  EXPECT_TRUE(jlm::rvsdg::Region::ContainsOperation<LambdaEntryMemoryStateSplitOperation>(
+  EXPECT_TRUE(jlm::rvsdg::Region::containsOperation<LambdaEntryMemoryStateSplitOperation>(
       *lambdaSubregion,
       true));
-  EXPECT_TRUE(jlm::rvsdg::Region::ContainsOperation<LambdaExitMemoryStateMergeOperation>(
+  EXPECT_TRUE(jlm::rvsdg::Region::containsOperation<LambdaExitMemoryStateMergeOperation>(
       *lambdaSubregion,
       true));
 }

--- a/jlm/hls/opt/IOBarrierRemovalTests.cpp
+++ b/jlm/hls/opt/IOBarrierRemovalTests.cpp
@@ -50,5 +50,5 @@ TEST(IOBarrierRemovalTests, IOBarrierRemoval)
   ioBarrierRemoval.Run(rvsdgModule, statisticsCollector);
 
   // Assert
-  EXPECT_FALSE(Region::ContainsOperation<IOBarrierOperation>(rvsdg.GetRootRegion(), true));
+  EXPECT_FALSE(Region::containsOperation<IOBarrierOperation>(rvsdg.GetRootRegion(), true));
 }

--- a/jlm/llvm/opt/AggregateAllocaSplittingTests.cpp
+++ b/jlm/llvm/opt/AggregateAllocaSplittingTests.cpp
@@ -552,5 +552,5 @@ TEST(AggregateAllocaSplittingTests, allocaWithCountBiggerThanOne)
   // Assert
   // We expect that the GetElementPtrOperation node was not replaced as it has a count that is
   // bigger than one.
-  EXPECT_TRUE(Region::ContainsOperation<GetElementPtrOperation>(*lambdaNode->subregion(), false));
+  EXPECT_TRUE(Region::containsOperation<GetElementPtrOperation>(*lambdaNode->subregion(), false));
 }

--- a/jlm/llvm/opt/DeadNodeEliminationTests.cpp
+++ b/jlm/llvm/opt/DeadNodeEliminationTests.cpp
@@ -535,6 +535,6 @@ TEST(DeadNodeEliminationTests, LoadNodes)
   // Assert
   // We expect that both load nodes have been removed.
   EXPECT_FALSE(
-      Region::ContainsOperation<LoadNonVolatileOperation>(*lambdaNode->subregion(), false));
+      Region::containsOperation<LoadNonVolatileOperation>(*lambdaNode->subregion(), false));
   EXPECT_EQ(lambdaNode->subregion()->numNodes(), 4u);
 }

--- a/jlm/llvm/opt/InliningTests.cpp
+++ b/jlm/llvm/opt/InliningTests.cpp
@@ -165,8 +165,8 @@ TEST(FunctionInliningTests, testSimpleInlining)
 
   // Assert
   // Check that the call has been replaced by the test operation inside f1
-  EXPECT_FALSE(Region::ContainsOperation<CallOperation>(graph.GetRootRegion(), true));
-  EXPECT_TRUE(Region::ContainsOperation<TestOperation>(*gammaRegion0, true));
+  EXPECT_FALSE(Region::containsOperation<CallOperation>(graph.GetRootRegion(), true));
+  EXPECT_TRUE(Region::containsOperation<TestOperation>(*gammaRegion0, true));
 
   // Check that the statistics match what we expect. f2 is technically inlineable
   EXPECT_EQ(statistics->GetMeasurementValue<uint64_t>("#Functions"), 2u);
@@ -302,13 +302,13 @@ TEST(FunctionInliningTests, testInliningWithAlloca)
 
   // Assert
   // Check that the call is gone
-  EXPECT_FALSE(Region::ContainsOperation<CallOperation>(graph.GetRootRegion(), true));
+  EXPECT_FALSE(Region::containsOperation<CallOperation>(graph.GetRootRegion(), true));
   // A store should have taken its place in the gamma subregion
-  EXPECT_TRUE(Region::ContainsOperation<StoreNonVolatileOperation>(*gammaRegion0, true));
+  EXPECT_TRUE(Region::containsOperation<StoreNonVolatileOperation>(*gammaRegion0, true));
   // Check that the alloca operation is not inside the gamma subregion
-  EXPECT_FALSE(Region::ContainsOperation<AllocaOperation>(*gammaRegion0, true));
+  EXPECT_FALSE(Region::containsOperation<AllocaOperation>(*gammaRegion0, true));
   // The alloca should have been moved to the top level of f2
-  EXPECT_TRUE(Region::ContainsOperation<AllocaOperation>(*f2Region, false));
+  EXPECT_TRUE(Region::containsOperation<AllocaOperation>(*f2Region, false));
 }
 
 TEST(FunctionInliningTests, testIndirectCall)

--- a/jlm/llvm/opt/StoreValueForwardingTests.cpp
+++ b/jlm/llvm/opt/StoreValueForwardingTests.cpp
@@ -1169,7 +1169,7 @@ TEST(StoreValueForwardingTests, LoadForwardingFromDeltaWithAggregateZeroConstant
 
   // Assert
   // We expect all load nodes to be forwarded
-  EXPECT_FALSE(Region::ContainsNodeType<LoadNonVolatileOperation>(graph.GetRootRegion(), true));
+  EXPECT_FALSE(Region::containsOperation<LoadNonVolatileOperation>(graph.GetRootRegion(), true));
 }
 
 TEST(StoreValueForwardingTests, LoadForwardingFloatFromDeltaWithAggregateZeroConstant)
@@ -1263,7 +1263,7 @@ TEST(StoreValueForwardingTests, LoadForwardingFloatFromDeltaWithAggregateZeroCon
   RunStoreValueForwarding(rvsdgModule);
 
   // Assert - Check that both loads were forwarded to float zero constants
-  EXPECT_FALSE(Region::ContainsNodeType<LoadNonVolatileOperation>(graph.GetRootRegion(), true));
+  EXPECT_FALSE(Region::containsOperation<LoadNonVolatileOperation>(graph.GetRootRegion(), true));
 
   {
     auto floatResult = getFloatLambdaNode.GetFunctionResults()[0];
@@ -1328,7 +1328,7 @@ TEST(StoreValueForwardingTests, LoadForwardingFromDeltaCtxVar)
 
   // Assert
   // We expect all load nodes to be forwarded
-  EXPECT_FALSE(Region::ContainsNodeType<LoadNonVolatileOperation>(graph.GetRootRegion(), true));
+  EXPECT_FALSE(Region::containsOperation<LoadNonVolatileOperation>(graph.GetRootRegion(), true));
   // We expect that deltaOutput1 has now lambdaNode as user on top of deltaNode2.
   EXPECT_EQ(deltaOutput1.nusers(), 2u);
 }
@@ -1371,7 +1371,7 @@ TEST(StoreValueForwardingTests, LoadForwardingFromDeltaWithConstantFP)
 
   // Assert
   // We expect all load nodes to be forwarded
-  EXPECT_FALSE(Region::ContainsNodeType<LoadNonVolatileOperation>(graph.GetRootRegion(), true));
+  EXPECT_FALSE(Region::containsOperation<LoadNonVolatileOperation>(graph.GetRootRegion(), true));
 }
 
 TEST(StoreValueForwardingTests, LoadForwardingFromDeltaWithConstantPointerNull)
@@ -1410,7 +1410,7 @@ TEST(StoreValueForwardingTests, LoadForwardingFromDeltaWithConstantPointerNull)
 
   // Assert
   // We expect all load nodes to be forwarded
-  EXPECT_FALSE(Region::ContainsNodeType<LoadNonVolatileOperation>(graph.GetRootRegion(), true));
+  EXPECT_FALSE(Region::containsOperation<LoadNonVolatileOperation>(graph.GetRootRegion(), true));
 }
 
 TEST(StoreValueForwardingTests, LoadForwardingFromDeltaWithConstantDataArray)

--- a/jlm/rvsdg/RegionTests.cpp
+++ b/jlm/rvsdg/RegionTests.cpp
@@ -103,12 +103,12 @@ TEST(RegionTests, Contains)
 
   // Act & Assert
   EXPECT_TRUE(
-      jlm::rvsdg::Region::ContainsNodeType<TestStructuralNode>(graph.GetRootRegion(), false));
+      jlm::rvsdg::Region::containsNodeType<TestStructuralNode>(graph.GetRootRegion(), false));
   EXPECT_TRUE(
-      jlm::rvsdg::Region::ContainsOperation<TestUnaryOperation>(graph.GetRootRegion(), true));
+      jlm::rvsdg::Region::containsOperation<TestUnaryOperation>(graph.GetRootRegion(), true));
   EXPECT_TRUE(
-      jlm::rvsdg::Region::ContainsOperation<TestBinaryOperation>(graph.GetRootRegion(), true));
-  EXPECT_TRUE(!jlm::rvsdg::Region::ContainsOperation<TestOperation>(graph.GetRootRegion(), true));
+      jlm::rvsdg::Region::containsOperation<TestBinaryOperation>(graph.GetRootRegion(), true));
+  EXPECT_TRUE(!jlm::rvsdg::Region::containsOperation<TestOperation>(graph.GetRootRegion(), true));
 }
 
 TEST(RegionTests, IsRootRegion)

--- a/jlm/rvsdg/binary.cpp
+++ b/jlm/rvsdg/binary.cpp
@@ -246,7 +246,7 @@ FlattenedBinaryOperation::reduce(
     }
   }
 
-  JLM_ASSERT(!Region::ContainsOperation<FlattenedBinaryOperation>(*region, true));
+  JLM_ASSERT(!Region::containsOperation<FlattenedBinaryOperation>(*region, true));
 }
 
 std::optional<std::vector<rvsdg::Output *>>

--- a/jlm/rvsdg/region.hpp
+++ b/jlm/rvsdg/region.hpp
@@ -665,28 +665,32 @@ public:
   /**
    * Checks if an operation is contained within the given \p region. If \p checkSubregions is true,
    * then the subregions of all contained structural nodes are recursively checked as well.
-   * @tparam Operation The operation to check for.
+   *
+   * @tparam TOperation The operation to check for.
    * @param region The region to check.
    * @param checkSubregions If true, then the subregions of all contained structural nodes will be
    * checked as well.
+   *
    * @return True, if the operation is found. Otherwise, false.
    */
-  template<class Operation>
-  static inline bool
-  ContainsOperation(const rvsdg::Region & region, bool checkSubregions);
+  template<class TOperation>
+  static bool
+  containsOperation(const Region & region, bool checkSubregions);
 
   /**
    * Checks if a node type is contained within the given \p region. If \p checkSubregions is true,
    * then the subregions of all contained structural nodes are recursively checked as well.
-   * @tparam Operation The operation to check for.
+   *
+   * @tparam TNodeType The node type to check for.
    * @param region The region to check.
    * @param checkSubregions If true, then the subregions of all contained structural nodes will be
    * checked as well.
-   * @return True, if the operation is found. Otherwise, false.
+   *
+   * @return True, if the node type is found. Otherwise, false.
    */
-  template<class NodeType>
-  static inline bool
-  ContainsNodeType(const rvsdg::Region & region, bool checkSubregions);
+  template<class TNodeType>
+  static bool
+  containsNodeType(const Region & region, bool checkSubregions);
 
   /**
    * Counts the number of (sub-)regions contained within \p region. The count includes \p region,

--- a/jlm/rvsdg/structural-node.hpp
+++ b/jlm/rvsdg/structural-node.hpp
@@ -158,10 +158,14 @@ StructuralNode::addOutput(std::unique_ptr<StructuralOutput> output)
   return static_cast<StructuralOutput *>(Node::addOutput(std::move(output)));
 }
 
-template<class Operation>
+template<class TOperation>
 bool
-Region::ContainsOperation(const rvsdg::Region & region, bool checkSubregions)
+Region::containsOperation(const Region & region, bool checkSubregions)
 {
+  static_assert(
+      std::is_base_of_v<Operation, TOperation>,
+      "Template parameter TOperation must be derived from rvsdg::Operation.");
+
   for (auto & node : region.Nodes())
   {
     if (auto simpleNode = dynamic_cast<const SimpleNode *>(&node))
@@ -181,7 +185,7 @@ Region::ContainsOperation(const rvsdg::Region & region, bool checkSubregions)
     {
       for (size_t n = 0; n < structuralNode->nsubregions(); n++)
       {
-        if (ContainsOperation<Operation>(*structuralNode->subregion(n), checkSubregions))
+        if (containsOperation<Operation>(*structuralNode->subregion(n), checkSubregions))
         {
           return true;
         }
@@ -192,13 +196,17 @@ Region::ContainsOperation(const rvsdg::Region & region, bool checkSubregions)
   return false;
 }
 
-template<class NodeType>
+template<class TNodeType>
 bool
-Region::ContainsNodeType(const rvsdg::Region & region, bool checkSubregions)
+Region::containsNodeType(const Region & region, bool checkSubregions)
 {
+  static_assert(
+      std::is_base_of_v<Node, TNodeType>,
+      "Template parameter TNodeType must be derived from rvsdg::Node.");
+
   for (auto & node : region.Nodes())
   {
-    if (dynamic_cast<const NodeType *>(&node))
+    if (dynamic_cast<const TNodeType *>(&node))
     {
       return true;
     }
@@ -212,7 +220,7 @@ Region::ContainsNodeType(const rvsdg::Region & region, bool checkSubregions)
     {
       for (size_t n = 0; n < structuralNode->nsubregions(); n++)
       {
-        if (ContainsNodeType<NodeType>(*structuralNode->subregion(n), checkSubregions))
+        if (containsNodeType<TNodeType>(*structuralNode->subregion(n), checkSubregions))
         {
           return true;
         }

--- a/jlm/rvsdg/structural-node.hpp
+++ b/jlm/rvsdg/structural-node.hpp
@@ -170,7 +170,7 @@ Region::containsOperation(const Region & region, bool checkSubregions)
   {
     if (auto simpleNode = dynamic_cast<const SimpleNode *>(&node))
     {
-      if (is<Operation>(simpleNode->GetOperation()))
+      if (is<TOperation>(simpleNode->GetOperation()))
       {
         return true;
       }
@@ -185,7 +185,7 @@ Region::containsOperation(const Region & region, bool checkSubregions)
     {
       for (size_t n = 0; n < structuralNode->nsubregions(); n++)
       {
-        if (containsOperation<Operation>(*structuralNode->subregion(n), checkSubregions))
+        if (containsOperation<TOperation>(*structuralNode->subregion(n), checkSubregions))
         {
           return true;
         }


### PR DESCRIPTION
We had some misuses of the methods in our unit tests. See StoreValueForwardingTests.cpp for examples. This PR does the following:

1. Renames them to camelCase
2. Inserts static asserts into both methods to ensure such misuses cannot happen in the future.
3. Fixes the misuses
4. Updates the documentation of both methods.