### PR TITLE
LLVM: Fix store-store reduction

### DIFF
--- a/jlm/llvm/ir/operators/Store.cpp
+++ b/jlm/llvm/ir/operators/Store.cpp
@@ -196,14 +196,22 @@ StoreNonVolatileOperation::normalizeStoreStore(
     return std::nullopt;
 
   // Check that all memory state inputs originate from store1 AND have no other users
+  std::vector<rvsdg::Output *> newMemoryStates;
   for (size_t n = 2; n < operands.size(); n++)
   {
     auto & memoryState = *operands[n];
     JLM_ASSERT(is<MemoryStateType>(memoryState.Type()));
 
-    if (rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(memoryState) != store1Node
-        || memoryState.nusers() != 1)
+    if (rvsdg::TryGetOwnerNode<rvsdg::SimpleNode>(memoryState) == store1Node
+        && memoryState.nusers() == 1)
+    {
+      auto & memoryStateInput = MapMemoryStateOutputToInput(memoryState);
+      newMemoryStates.push_back(memoryStateInput.origin());
+    }
+    else
+    {
       return std::nullopt;
+    }
   }
 
   // Check that store2 fully overwrites store1
@@ -212,11 +220,7 @@ StoreNonVolatileOperation::normalizeStoreStore(
   if (GetTypeStoreSize(store2Type) < GetTypeStoreSize(store1Type))
     return std::nullopt;
 
-  return Create(
-      &store2Address,
-      &store2Value,
-      getMemoryStateOperands(*store1Node),
-      store2Op.GetAlignment());
+  return Create(&store2Address, &store2Value, newMemoryStates, store2Op.GetAlignment());
 }
 
 std::optional<std::vector<rvsdg::Output *>>

--- a/jlm/llvm/ir/operators/StoreTests.cpp
+++ b/jlm/llvm/ir/operators/StoreTests.cpp
@@ -378,11 +378,23 @@ TEST(StoreOperationTests, testStoreStoreReduction)
       StoreNonVolatileOperation::CreateNode(*addressImport1, *i64Import2, outputs(&storeNode9), 4);
   GraphExport::Create(*outputs(&storeNode9).front(), "");
 
+  auto & storeNode11 = StoreNonVolatileOperation::CreateNode(
+      *addressImport1,
+      *i64Import1,
+      { memoryStateImport1, memoryStateImport2 },
+      4);
+  auto & storeNode12 = StoreNonVolatileOperation::CreateNode(
+      *addressImport1,
+      *i64Import2,
+      { storeNode11.output(0) },
+      4);
+
   auto & ex1 = GraphExport::Create(*storeNode2.output(0), "ex1");
   auto & ex2 = GraphExport::Create(*storeNode4.output(0), "ex2");
   auto & ex3 = GraphExport::Create(*storeNode6.output(0), "ex3");
   auto & ex4 = GraphExport::Create(*storeNode8.output(0), "ex4");
   auto & ex5 = GraphExport::Create(*storeNode10.output(0), "ex5");
+  auto & ex6 = GraphExport::Create(*storeNode12.output(0), "ex6");
 
   view(&graph.GetRootRegion(), stdout);
 
@@ -406,6 +418,10 @@ TEST(StoreOperationTests, testStoreStoreReduction)
   auto success5 = ReduceNode<StoreNonVolatileOperation>(
       StoreNonVolatileOperation::normalizeStoreStore,
       storeNode10);
+
+  auto success6 = ReduceNode<StoreNonVolatileOperation>(
+      StoreNonVolatileOperation::normalizeStoreStore,
+      storeNode12);
 
   graph.PruneNodes();
 
@@ -472,6 +488,20 @@ TEST(StoreOperationTests, testStoreStoreReduction)
     auto [sndStoreNode, sndStoreOp] = TryGetSimpleNodeAndOptionalOp<StoreNonVolatileOperation>(
         *StoreOperation::getMemoryStateInputs(*fstStoreNode).begin()->origin());
     EXPECT_EQ(sndStoreNode, &storeNode9);
+  }
+
+  {
+    // We expect the storeNode11 - storeNode12 chain to be reduced to a single store node.
+    EXPECT_TRUE(success6);
+    auto [storeNode, storeOp] =
+        TryGetSimpleNodeAndOptionalOp<StoreNonVolatileOperation>(*ex6.origin());
+    EXPECT_NE(storeOp, nullptr);
+    EXPECT_EQ(StoreOperation::AddressInput(*storeNode).origin(), addressImport1);
+    EXPECT_EQ(StoreOperation::StoredValueInput(*storeNode).origin(), i64Import2);
+    EXPECT_EQ(storeOp->NumMemoryStates(), 1u);
+    EXPECT_EQ(
+        StoreOperation::getMemoryStateInputs(*storeNode).begin()->origin(),
+        memoryStateImport1);
   }
 }
 


### PR DESCRIPTION
It might happen that the upper store in the store-store chain has more memory states than the lower store even though they both load from the same address. This might occur if encoding was (at the time) unable to determine the minimal set of states for the upper store. The old code simply assumed that both stores had the same number of memory states, which lead to an assert being triggered when the reduction was applied. An example RVSDG looks as follows:

<img width="799" height="964" alt="image" src="https://github.com/user-attachments/assets/32f719e9-8d91-49fb-a652-86648248b5bb" />

Both stores ultimately load from the same alloca node, but this can only be determined after some node reductions were applied.