### PR TITLE
HLS: Transformation for dumping graph in different formats

### DIFF
--- a/jlm/hls/HlsDotWriter.cpp
+++ b/jlm/hls/HlsDotWriter.cpp
@@ -24,6 +24,11 @@ HlsDotWriter::AnnotateTypeGraphNode(const rvsdg::Type & type, util::graph::Node 
       typeGraph.CreateDirectedEdge(elementTypeNode, node);
     }
   }
+  else if (dynamic_cast<const TriggerType *>(&type))
+  {
+    // TriggerType is a singleton: the node/label are created by GetOrCreateTypeGraphNode(),
+    // and there are no subtype edges to add here.
+  }
   else
   {
     LlvmDotWriter::AnnotateTypeGraphNode(type, node);

--- a/jlm/hls/Makefile.sub
+++ b/jlm/hls/Makefile.sub
@@ -108,6 +108,7 @@ run-libhls-tests_SOURCES = \
     jlm/hls/backend/rvsdg2rhls/SinkInsertionTests.cpp \
     jlm/hls/backend/rvsdg2rhls/ThetaTests.cpp \
     jlm/hls/backend/rvsdg2rhls/UnusedStateRemovalTests.cpp \
+    jlm/hls/opt/DumpTransformationTests.cpp \
     jlm/hls/opt/IOBarrierRemovalTests.cpp \
     jlm/hls/opt/IOStateEliminationTests.cpp \
     jlm/hls/util/ViewTests.cpp \

--- a/jlm/hls/Makefile.sub
+++ b/jlm/hls/Makefile.sub
@@ -38,6 +38,7 @@ libhls_SOURCES = \
     jlm/hls/ir/hls.cpp \
     \
     jlm/hls/opt/cne.cpp \
+    jlm/hls/opt/DumpTransformation.cpp \
     jlm/hls/opt/IOBarrierRemoval.cpp \
     jlm/hls/opt/IOStateElimination.cpp \
     \
@@ -82,6 +83,7 @@ libhls_HEADERS = \
     jlm/hls/ir/hls.hpp \
     \
     jlm/hls/opt/cne.hpp \
+    jlm/hls/opt/DumpTransformation.hpp \
     jlm/hls/opt/IOBarrierRemoval.hpp \
     jlm/hls/opt/IOStateElimination.hpp \
     \

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -25,9 +25,9 @@
 #include <jlm/hls/backend/rvsdg2rhls/ThetaConversion.hpp>
 #include <jlm/hls/backend/rvsdg2rhls/UnusedStateRemoval.hpp>
 #include <jlm/hls/opt/cne.hpp>
+#include <jlm/hls/opt/DumpTransformation.hpp>
 #include <jlm/hls/opt/IOBarrierRemoval.hpp>
 #include <jlm/hls/opt/IOStateElimination.hpp>
-#include <jlm/hls/util/view.hpp>
 #include <jlm/llvm/backend/IpGraphToLlvmConverter.hpp>
 #include <jlm/llvm/backend/RvsdgToIpGraphConverter.hpp>
 #include <jlm/llvm/DotWriter.hpp>
@@ -46,7 +46,6 @@
 #include <jlm/llvm/opt/PredicateCorrelation.hpp>
 #include <jlm/rvsdg/Transformation.hpp>
 #include <jlm/rvsdg/traverser.hpp>
-#include <jlm/rvsdg/view.hpp>
 #include <jlm/util/Statistics.hpp>
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>
@@ -402,50 +401,144 @@ createTransformationSequence(rvsdg::DotWriter & dotWriter, const bool dumpRvsdgG
   auto bufferInsertion = std::make_shared<BufferInsertion>();
   auto rhlsVerification = std::make_shared<RhlsVerification>();
 
-  // Use this transformation to dump HLS dot graphs at specific points in the sequence
-  [[maybe_unused]] auto dumpDot = std::make_shared<DumpDotTransformation>();
+  // -------------------------------------------------------------------------
+  // Debug dumping: DumpTransformation
+  //
+  // Each Run() produces one file per configured format. All available annotation
+  // types are applied automatically — no per-format tuning needed.
+  //
+  //   [name]-[unique]-00X-pass-name.dot              GraphViz DOT (LlvmDotWriter)
+  //   [name]-[unique]-00X-pass-name-hls.dot          HLS-annotated DOT (HlsDotWriter)
+  //   [name]-[unique]-00X-pass-name.structural.dot   Structural node ports (ToDot)
+  //   [name]-[unique]-00X-pass-name.json             Structured JSON graph
+  //   [name]-[unique]-00X-pass-name.txt              Human-readable indented text
+  //   [name]-[unique]-00X-pass-name.tree.txt         Annotated tree view (all annotations)
+  //   [name]-[unique]-00X-pass-name.tree.json        Hierarchical JSON tree
+  //
+  // Usage: comment out formats you don't need, and set enableDumps = true.
+  // Each dump point is its own instance so the label is captured per-entry
+  // rather than being shared/mutated across the sequence.
+  // -------------------------------------------------------------------------
 
-  std::vector<std::shared_ptr<rvsdg::Transformation>> sequence({
-      loopUnswitching,
-      deadNodeElimination,
-      commonNodeElimination,
-      invariantValueRedirection,
-      predicateCorrelation,
-      deadNodeElimination,
-      commonNodeElimination,
-      deadNodeElimination,
-      ioBarrierRemoval,
-      ioStateElimination,
-      memoryStateSeparation,
-      gammaMerge,
-      unusedStateRemoval,
-      deadNodeElimination,
-      loopUnswitching,
-      commonNodeElimination,
-      deadNodeElimination,
-      gammaMerge,
-      deadNodeElimination,
-      unusedStateRemoval,
-      constantDistribution,
-      deadNodeElimination,
-      gammaNodeConversion,
-      thetaNodeConversion,
-      commonNodeElimination,
-      rhlsDeadNodeElimination,
-      allocaNodeConversion,
-      streamConversion,
-      addressQueueInsertion,
-      memoryStateDecoupling,
-      unusedStateRemoval,
-      memoryConverter,
-      nodeReduction,
-      memoryStateSplitConversion,
-      redundantBufferElimination,
-      sinkInsertion,
-      forkInsertion,
-      bufferInsertion,
-      rhlsVerification,
-  });
+  constexpr bool enableDumps = false;
+
+  std::vector<std::shared_ptr<rvsdg::Transformation>> sequence;
+  size_t dumpIndex = 0;
+  auto push = [&sequence, &dumpIndex](auto && t)
+  {
+    sequence.push_back(std::forward<decltype(t)>(t));
+  };
+  auto pushDump = [enableDumps, &sequence, &dumpIndex](const std::string & label)
+  {
+    if (!enableDumps)
+    {
+      sequence.push_back(std::make_shared<DumpTransformation>(DumpTransformation::Disabled));
+      return;
+    }
+
+    DumpTransformation::Config config;
+    config.formats = {
+      // GraphViz DOT via LlvmDotWriter — basic node/port structure.
+      DumpTransformation::OutputFormat::Dot,
+      // HLS-annotated DOT via HlsDotWriter — includes HLS types (TriggerType, BundleType).
+      DumpTransformation::OutputFormat::HlsDot,
+      // Structural ports via ToDot(view.hpp) — shows input/output connections.
+      DumpTransformation::OutputFormat::StructuralDot,
+      // Structured JSON per-region graph — machine-readable structure.
+      DumpTransformation::OutputFormat::Json,
+      // Human-readable indented text — quick inspection of RVSDG shape.
+      DumpTransformation::OutputFormat::Ascii,
+      // Annotated tree view (all annotation types applied).
+      DumpTransformation::OutputFormat::Tree,
+      // Hierarchical JSON tree — structured output for tooling.
+      DumpTransformation::OutputFormat::JsonTree,
+    };
+
+    auto dumpDot = std::make_shared<DumpTransformation>(std::move(config));
+    dumpDot->setLabel(label);
+    dumpDot->setPassNumber(dumpIndex++);
+    sequence.push_back(dumpDot);
+  };
+
+  // Push each transformation followed by its dump point.
+  push(loopUnswitching);
+  pushDump("loop-unswitching");
+  push(deadNodeElimination);
+  pushDump("dead-node-elimination");
+  push(commonNodeElimination);
+  pushDump("common-node-elimination");
+  push(invariantValueRedirection);
+  pushDump("invariant-value-redirection");
+  push(predicateCorrelation);
+  pushDump("predicate-correlation");
+  push(deadNodeElimination);
+  pushDump("dead-node-elimination-2");
+  push(commonNodeElimination);
+  pushDump("common-node-elimination-2");
+  push(deadNodeElimination);
+  pushDump("dead-node-elimination-3");
+  push(ioBarrierRemoval);
+  pushDump("io-barrier-removal");
+  push(ioStateElimination);
+  pushDump("io-state-elimination");
+  push(memoryStateSeparation);
+  pushDump("memory-state-separation");
+  push(gammaMerge);
+  pushDump("gamma-merge");
+  push(unusedStateRemoval);
+  pushDump("unused-state-removal");
+  push(deadNodeElimination);
+  pushDump("dead-node-elimination-4");
+  push(loopUnswitching);
+  pushDump("loop-unswitching-2");
+  push(commonNodeElimination);
+  pushDump("common-node-elimination-3");
+  push(deadNodeElimination);
+  pushDump("dead-node-elimination-5");
+  push(gammaMerge);
+  pushDump("gamma-merge-2");
+  push(deadNodeElimination);
+  pushDump("dead-node-elimination-6");
+  push(unusedStateRemoval);
+  pushDump("unused-state-removal-2");
+  push(constantDistribution);
+  pushDump("constant-distribution");
+  push(deadNodeElimination);
+  pushDump("dead-node-elimination-7");
+  push(gammaNodeConversion);
+  pushDump("gamma-node-conversion");
+  push(thetaNodeConversion);
+  pushDump("theta-node-conversion");
+  push(commonNodeElimination);
+  pushDump("common-node-elimination-4");
+  push(rhlsDeadNodeElimination);
+  pushDump("rhls-dead-node-elimination");
+  push(allocaNodeConversion);
+  pushDump("alloca-node-conversion");
+  push(streamConversion);
+  pushDump("stream-conversion");
+  push(addressQueueInsertion);
+  pushDump("address-queue-insertion");
+  push(memoryStateDecoupling);
+  pushDump("memory-state-decoupling");
+  push(unusedStateRemoval);
+  pushDump("unused-state-removal-3");
+  push(memoryConverter);
+  pushDump("memory-converter");
+  push(nodeReduction);
+  pushDump("node-reduction");
+  push(memoryStateSplitConversion);
+  pushDump("memory-state-split-conversion");
+  push(redundantBufferElimination);
+  pushDump("redundant-buffer-elimination");
+  push(sinkInsertion);
+  pushDump("sink-insertion");
+  push(forkInsertion);
+  pushDump("fork-insertion");
+  push(bufferInsertion);
+  pushDump("buffer-insertion");
+  push(rhlsVerification);
+  pushDump("rhls-verification");
 
   return std::make_unique<rvsdg::TransformationSequence>(
       std::move(sequence),

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -428,7 +428,7 @@ createTransformationSequence(rvsdg::DotWriter & dotWriter, const bool dumpRvsdgG
   {
     sequence.push_back(std::forward<decltype(t)>(t));
   };
-  auto pushDump = [enableDumps, &sequence, &dumpIndex](const std::string & label)
+  auto pushDump = [&sequence, &dumpIndex](const std::string & label)
   {
     if (!enableDumps)
     {

--- a/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
+++ b/jlm/hls/backend/rvsdg2rhls/rvsdg2rhls.cpp
@@ -407,8 +407,8 @@ createTransformationSequence(rvsdg::DotWriter & dotWriter, const bool dumpRvsdgG
   // Each Run() produces one file per configured format. All available annotation
   // types are applied automatically — no per-format tuning needed.
   //
-  //   [name]-[unique]-00X-pass-name.dot              GraphViz DOT (LlvmDotWriter)
-  //   [name]-[unique]-00X-pass-name-hls.dot          HLS-annotated DOT (HlsDotWriter)
+  //   [name]-[unique]-00X-pass-name.llvm.dot         GraphViz DOT (LlvmDotWriter)
+  //   [name]-[unique]-00X-pass-name.hls.dot          HLS-annotated DOT (HlsDotWriter)
   //   [name]-[unique]-00X-pass-name.structural.dot   Structural node ports (ToDot)
   //   [name]-[unique]-00X-pass-name.json             Structured JSON graph
   //   [name]-[unique]-00X-pass-name.txt              Human-readable indented text
@@ -424,7 +424,7 @@ createTransformationSequence(rvsdg::DotWriter & dotWriter, const bool dumpRvsdgG
 
   std::vector<std::shared_ptr<rvsdg::Transformation>> sequence;
   size_t dumpIndex = 0;
-  auto push = [&sequence, &dumpIndex](auto && t)
+  auto push = [&sequence](auto && t)
   {
     sequence.push_back(std::forward<decltype(t)>(t));
   };

--- a/jlm/hls/opt/DumpTransformation.cpp
+++ b/jlm/hls/opt/DumpTransformation.cpp
@@ -91,13 +91,16 @@ DumpTransformation::Run(
   std::ostringstream base;
   base << prefix << std::setw(3) << std::setfill('0') << passNumber_++ << "-" << label_;
 
+  // Determine output directory from the StatisticsCollector so files don't land in CWD.
+  const auto & settings = statisticsCollector.GetSettings();
+  auto outputPath = settings.GetOutputDirectory().to_str();
+
   for (auto format : Config_.formats)
   {
-    auto fileName = base.str() + "." + std::string(format_to_ext(format));
+    auto fileName = outputPath + "/" + base.str() + "." + std::string(format_to_ext(format));
 
     // Write directly to avoid createOutputFile generating a new unique string.
-    // We still use createOutputFile once to validate the output directory exists,
-    // then write files manually since all extensions are distinct now.
+    // All extensions are distinct so no collision risk.
     std::ofstream fs(fileName);
     if (!fs)
       throw util::Error("DumpTransformation: failed to open file " + fileName);
@@ -110,12 +113,7 @@ DumpTransformation::Run(
       outputAsGraph(rootRegion, format, fs);
       break;
     case OutputFormat::StructuralDot:
-      outputAsStructuralDot(
-          rootRegion,
-          Config_.outputColor,
-          Config_.inputColor,
-          Config_.tailLabel,
-          fs);
+      outputAsStructuralDot(rootRegion, fs);
       break;
     case OutputFormat::Ascii:
       outputAsAscii(rootRegion, fs);
@@ -157,24 +155,16 @@ DumpTransformation::outputAsGraph(
 }
 
 // ---------------------------------------------------------------------------
-// StructuralDot — HLS-structural rendering via ToDot() from view.hpp
+// StructuralDot — HLS-structural rendering via ToDot() from view.hpp.
 // ---------------------------------------------------------------------------
 
 void
-DumpTransformation::outputAsStructuralDot(
-    const rvsdg::Region & region,
-    const std::unordered_map<rvsdg::Output *, ViewColors> & outputColor,
-    const std::unordered_map<rvsdg::Input *, ViewColors> & inputColor,
-    const std::unordered_map<rvsdg::Output *, ViewColors> & tailLabel,
-    std::ofstream & out)
+DumpTransformation::outputAsStructuralDot(const rvsdg::Region & region, std::ofstream & out)
 {
-  auto dot = ToDot(
-      const_cast<rvsdg::Region *>(&region),
-      const_cast<std::unordered_map<rvsdg::Output *, ViewColors> &>(outputColor),
-      const_cast<std::unordered_map<rvsdg::Input *, ViewColors> &>(inputColor),
-      const_cast<std::unordered_map<rvsdg::Output *, ViewColors> &>(tailLabel));
-
-  out << dot;
+  std::unordered_map<rvsdg::Output *, ViewColors> outputColor;
+  std::unordered_map<rvsdg::Input *, ViewColors> inputColor;
+  std::unordered_map<rvsdg::Output *, ViewColors> tailLabel;
+  out << ToDot(const_cast<rvsdg::Region *>(&region), outputColor, inputColor, tailLabel);
 }
 
 // ---------------------------------------------------------------------------

--- a/jlm/hls/opt/DumpTransformation.cpp
+++ b/jlm/hls/opt/DumpTransformation.cpp
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2026 Magnus Sjalander <work@sjalander.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <jlm/hls/opt/DumpTransformation.hpp>
+
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+
+#include <jlm/llvm/ir/operators/alloca.hpp>
+#include <jlm/llvm/ir/operators/Load.hpp>
+#include <jlm/llvm/ir/operators/Store.hpp>
+#include <jlm/llvm/ir/RvsdgModule.hpp>
+#include <jlm/rvsdg/view.hpp>
+
+namespace jlm::hls
+{
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static std::string_view
+format_to_ext(DumpTransformation::OutputFormat format)
+{
+  using OF = DumpTransformation::OutputFormat;
+  switch (format)
+  {
+  case OF::Dot:
+    return "llvm.dot";
+  case OF::HlsDot:
+    return "hls.dot";
+  case OF::StructuralDot:
+    return "structural.dot";
+  case OF::Json:
+    return "json";
+  case OF::Ascii:
+    return "txt";
+  case OF::Tree:
+    return "tree.txt";
+  case OF::JsonTree:
+    return "tree.json";
+  default:
+    return "unknown";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Constructor / destructor
+// ---------------------------------------------------------------------------
+
+DumpTransformation::~DumpTransformation() noexcept = default;
+
+DumpTransformation::DumpTransformation(Config config)
+    : Transformation("DumpTransformation"),
+      Config_(std::move(config))
+{}
+
+DumpTransformation::DumpTransformation(DisabledTag)
+    : Transformation("DumpTransformation"),
+      enabled_(false)
+{}
+
+// ---------------------------------------------------------------------------
+// Public Run
+// ---------------------------------------------------------------------------
+
+void
+DumpTransformation::Run(
+    rvsdg::RvsdgModule & rvsdgModule,
+    util::StatisticsCollector & statisticsCollector)
+{
+  // Disabled variant returns immediately — zero overhead.
+  if (!enabled_)
+    return;
+
+  const auto * graph = &rvsdgModule.Rvsdg();
+  const auto & rootRegion = graph->GetRootRegion();
+
+  // Build the shared prefix once: "{ModuleName}-{UniqueString}"
+  std::string prefix;
+  if (!statisticsCollector.GetSettings().GetModuleName().empty())
+    prefix += statisticsCollector.GetSettings().GetModuleName() + "-";
+  if (!statisticsCollector.GetSettings().GetUniqueString().empty())
+    prefix += statisticsCollector.GetSettings().GetUniqueString() + "-";
+
+  // Generate the base name so all formats share one unique string,
+  // e.g. "jhls-bicg-AaG8EE-003-loop-unswitching"
+  std::ostringstream base;
+  base << prefix << std::setw(3) << std::setfill('0') << passNumber_++ << "-" << label_;
+
+  for (auto format : Config_.formats)
+  {
+    auto fileName = base.str() + "." + std::string(format_to_ext(format));
+
+    // Write directly to avoid createOutputFile generating a new unique string.
+    // We still use createOutputFile once to validate the output directory exists,
+    // then write files manually since all extensions are distinct now.
+    std::ofstream fs(fileName);
+    if (!fs)
+      throw util::Error("DumpTransformation: failed to open file " + fileName);
+
+    switch (format)
+    {
+    case OutputFormat::Dot:
+    case OutputFormat::HlsDot:
+    case OutputFormat::Json:
+      outputAsGraph(rootRegion, format, fs);
+      break;
+    case OutputFormat::StructuralDot:
+      outputAsStructuralDot(
+          rootRegion,
+          Config_.outputColor,
+          Config_.inputColor,
+          Config_.tailLabel,
+          fs);
+      break;
+    case OutputFormat::Ascii:
+      outputAsAscii(rootRegion, fs);
+      break;
+    case OutputFormat::Tree:
+      outputAsTree(*graph, rootRegion, fs);
+      break;
+    case OutputFormat::JsonTree:
+      outputAsJsonTree(rootRegion, fs);
+      break;
+    default:
+      throw util::Error("DumpTransformation: unhandled output format");
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Graph-based formats (Dot / HlsDot / Json)
+// ---------------------------------------------------------------------------
+
+void
+DumpTransformation::outputAsGraph(
+    const rvsdg::Region & region,
+    OutputFormat format,
+    std::ofstream & out)
+{
+  util::graph::Writer writer;
+
+  // Use HlsDotWriter for all DOT/JSON output — it extends LlvmDotWriter
+  // with support for HLS types (TriggerType, BundleType). For plain Dot/HlsDot
+  // the output is identical to what LlvmDotWriter would produce alone.
+  HlsDotWriter hlsWriter;
+  hlsWriter.WriteGraphs(writer, region, Config_.recursive);
+
+  auto outFmt = (format == OutputFormat::Json) ? util::graph::OutputFormat::Json
+                                               : util::graph::OutputFormat::Dot;
+
+  writer.outputAllGraphs(out, outFmt);
+}
+
+// ---------------------------------------------------------------------------
+// StructuralDot — HLS-structural rendering via ToDot() from view.hpp
+// ---------------------------------------------------------------------------
+
+void
+DumpTransformation::outputAsStructuralDot(
+    const rvsdg::Region & region,
+    const std::unordered_map<rvsdg::Output *, ViewColors> & outputColor,
+    const std::unordered_map<rvsdg::Input *, ViewColors> & inputColor,
+    const std::unordered_map<rvsdg::Output *, ViewColors> & tailLabel,
+    std::ofstream & out)
+{
+  auto dot = ToDot(
+      const_cast<rvsdg::Region *>(&region),
+      const_cast<std::unordered_map<rvsdg::Output *, ViewColors> &>(outputColor),
+      const_cast<std::unordered_map<rvsdg::Input *, ViewColors> &>(inputColor),
+      const_cast<std::unordered_map<rvsdg::Output *, ViewColors> &>(tailLabel));
+
+  out << dot;
+}
+
+// ---------------------------------------------------------------------------
+// ASCII format — reuses hls::view(region) to produce a human-readable indented text string.
+// ---------------------------------------------------------------------------
+
+void
+DumpTransformation::outputAsAscii(const rvsdg::Region & region, std::ofstream & out)
+{
+  auto ascii = view(&region);
+  out << ascii;
+}
+
+// ---------------------------------------------------------------------------
+// Tree format — reuses Region::ToTree(region, annotationMap)
+// ---------------------------------------------------------------------------
+
+void
+DumpTransformation::outputAsTree(
+    const rvsdg::Graph & graph,
+    const rvsdg::Region & region,
+    std::ofstream & out)
+{
+  auto tree = llvm::RvsdgTreePrinter::RenderAnnotatedTree(graph, region);
+
+  out << tree;
+}
+
+// ---------------------------------------------------------------------------
+// JSON Tree format — reuses Region::toJson(region)
+// ---------------------------------------------------------------------------
+
+void
+DumpTransformation::outputAsJsonTree(const rvsdg::Region & region, std::ofstream & out)
+{
+  auto json = rvsdg::Region::toJson(region);
+
+  out << json;
+}
+
+} // namespace jlm::hls

--- a/jlm/hls/opt/DumpTransformation.hpp
+++ b/jlm/hls/opt/DumpTransformation.hpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2026 Magnus Sjalander <work@sjalander.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#ifndef JLM_HLS_OPT_DUMPTRANSFORMATION_HPP
+#define JLM_HLS_OPT_DUMPTRANSFORMATION_HPP
+
+#include <jlm/hls/HlsDotWriter.hpp>
+#include <jlm/hls/util/view.hpp>
+#include <jlm/llvm/DotWriter.hpp>
+#include <jlm/llvm/opt/RvsdgTreePrinter.hpp>
+#include <jlm/rvsdg/Transformation.hpp>
+#include <string>
+#include <vector>
+
+namespace jlm::hls
+{
+
+/** \brief RVSDG dump transformation that writes the graph in various formats after a pass.
+ *
+ * This is a reusable transformation that can be interleaved in a transformation sequence
+ * alongside regular optimization passes. After each Run() call, it captures the current state
+ * of the RVSDG module and writes one or more files to the statistics collector's output
+ * directory. The filename uses a sequential number prefix (e.g. "003-") combined with a label
+ * set via setLabel() so that output files read like
+ * "003-dead-node-elimination.dot".
+ *
+ * Construct with Disabled{} to create a zero-cost no-op that can stand in for an enabled dump
+ * transformation — Run() returns immediately. Use this when the same sequence must compile with
+ * or without debugging dumps, toggled by a constructor argument at setup time.
+ */
+class DumpTransformation final : public rvsdg::Transformation
+{
+public:
+  /** Tag type for creating a disabled (no-op) instance. */
+  struct DisabledTag
+  {
+  };
+
+  static constexpr DisabledTag
+      Disabled{}; /**< Convenience constant, e.g. DumpTransformation{Disabled} */
+
+  /** Supported output formats. Each corresponds to an existing rendering backend. */
+  enum class OutputFormat
+  {
+    FirstEnumValue, /**< Must always be first -- used for iteration. */
+
+    Dot,           /**< GraphViz DOT (uses LlvmDotWriter + util::graph::Writer) */
+    HlsDot,        /**< GraphViz DOT with HLS type annotations (HlsDotWriter) */
+    StructuralDot, /**< RVSDG structural node ports (ToDot from view.hpp) */
+    Json,          /**< Structured JSON per-region graph (LlvmDotWriter + json) */
+    Ascii,         /**< Human-readable indented text (rvsdg::view) */
+    Tree,          /**< Annotated tree view (rvsdg::Region::ToTree with annotations) */
+    JsonTree,      /**< Hierarchical JSON tree (rvsdg::Region::toJson) */
+
+    LastEnumValue /**< Must always be last -- used for iteration. */
+  };
+
+  /** Lightweight configuration passed to the constructor. */
+  struct Config
+  {
+    bool recursive = true;             /**< Include subregions (for Dot/Json only). */
+    std::vector<OutputFormat> formats; /**< Formats to produce in a single Run(). */
+
+    /** Optional color maps for StructuralDot rendering. Empty maps are ignored. */
+    std::unordered_map<rvsdg::Output *, ViewColors> outputColor;
+    std::unordered_map<rvsdg::Input *, ViewColors> inputColor;
+    std::unordered_map<rvsdg::Output *, ViewColors> tailLabel;
+  };
+
+  ~DumpTransformation() noexcept override;
+
+  /** Construct an enabled dump transformation with the given configuration. */
+  explicit DumpTransformation(Config config);
+
+  /** Construct a disabled (no-op) dump transformation. */
+  explicit DumpTransformation(DisabledTag);
+
+  DumpTransformation(const DumpTransformation &) = delete;
+  DumpTransformation &
+  operator=(const DumpTransformation &) = delete;
+
+  /**
+   * Set the label used in output filenames.
+   *
+   * The filename produced by Run() is: "{pass_number}-{label}.{ext}"
+   * e.g. "003-dead-node-elimination.dot"
+   *
+   * Call this before each transformation so that the label reflects
+   * the preceding transformation's name (i.e., what you're dumping after).
+   */
+  void
+  setLabel(std::string label) noexcept
+  {
+    label_ = std::move(label);
+  }
+
+  /** Set the sequence number used in output filenames. */
+  void
+  setPassNumber(size_t num) noexcept
+  {
+    passNumber_ = num;
+  }
+
+  /** Add an output format to the list of formats produced by each Run() call. */
+  void
+  addFormat(OutputFormat format) noexcept
+  {
+    Config_.formats.push_back(format);
+  }
+
+  /**
+   * Dump the RVSDG module in all configured formats.
+   * Files are placed in the output directory of statisticsCollector,
+   * with names like "[module]-[unique]-005-{label}.{ext}".
+   */
+  void
+  Run(rvsdg::RvsdgModule & rvsdgModule, util::StatisticsCollector & statisticsCollector) override;
+
+private:
+  /** Output Dot, HlsDot, or Json via writer + util::graph::Writer. */
+  void
+  outputAsGraph(const rvsdg::Region & region, OutputFormat format, std::ofstream & out);
+
+  /** Output HLS-structural DOT with optional color maps (ToDot from view.hpp). */
+  static void
+  outputAsStructuralDot(
+      const rvsdg::Region & region,
+      const std::unordered_map<rvsdg::Output *, ViewColors> & outputColor,
+      const std::unordered_map<rvsdg::Input *, ViewColors> & inputColor,
+      const std::unordered_map<rvsdg::Output *, ViewColors> & tailLabel,
+      std::ofstream & out);
+
+  /** Output human-readable ASCII tree via rvsdg::view(). */
+  static void
+  outputAsAscii(const rvsdg::Region & region, std::ofstream & out);
+
+  /** Output annotated tree view (all annotation types are always applied). */
+  static void
+  outputAsTree(const rvsdg::Graph & graph, const rvsdg::Region & region, std::ofstream & out);
+
+  /** Output hierarchical JSON tree. */
+  static void
+  outputAsJsonTree(const rvsdg::Region & region, std::ofstream & out);
+
+  Config Config_;
+  bool enabled_ = true;
+  std::string label_ = "dump"; /**< Default label — set via setLabel() before Run(). */
+  size_t passNumber_ = 0;
+};
+
+} // namespace jlm::hls
+
+#endif

--- a/jlm/hls/opt/DumpTransformation.hpp
+++ b/jlm/hls/opt/DumpTransformation.hpp
@@ -44,17 +44,13 @@ public:
   /** Supported output formats. Each corresponds to an existing rendering backend. */
   enum class OutputFormat
   {
-    FirstEnumValue, /**< Must always be first -- used for iteration. */
-
     Dot,           /**< GraphViz DOT (uses LlvmDotWriter + util::graph::Writer) */
     HlsDot,        /**< GraphViz DOT with HLS type annotations (HlsDotWriter) */
     StructuralDot, /**< RVSDG structural node ports (ToDot from view.hpp) */
     Json,          /**< Structured JSON per-region graph (LlvmDotWriter + json) */
     Ascii,         /**< Human-readable indented text (rvsdg::view) */
     Tree,          /**< Annotated tree view (rvsdg::Region::ToTree with annotations) */
-    JsonTree,      /**< Hierarchical JSON tree (rvsdg::Region::toJson) */
-
-    LastEnumValue /**< Must always be last -- used for iteration. */
+    JsonTree       /**< Hierarchical JSON tree (rvsdg::Region::toJson) */
   };
 
   /** Lightweight configuration passed to the constructor. */
@@ -62,11 +58,6 @@ public:
   {
     bool recursive = true;             /**< Include subregions (for Dot/Json only). */
     std::vector<OutputFormat> formats; /**< Formats to produce in a single Run(). */
-
-    /** Optional color maps for StructuralDot rendering. Empty maps are ignored. */
-    std::unordered_map<rvsdg::Output *, ViewColors> outputColor;
-    std::unordered_map<rvsdg::Input *, ViewColors> inputColor;
-    std::unordered_map<rvsdg::Output *, ViewColors> tailLabel;
   };
 
   ~DumpTransformation() noexcept override;
@@ -123,14 +114,9 @@ private:
   void
   outputAsGraph(const rvsdg::Region & region, OutputFormat format, std::ofstream & out);
 
-  /** Output HLS-structural DOT with optional color maps (ToDot from view.hpp). */
+  /** Output HLS-structural DOT with default colors (ToDot from view.hpp). */
   static void
-  outputAsStructuralDot(
-      const rvsdg::Region & region,
-      const std::unordered_map<rvsdg::Output *, ViewColors> & outputColor,
-      const std::unordered_map<rvsdg::Input *, ViewColors> & inputColor,
-      const std::unordered_map<rvsdg::Output *, ViewColors> & tailLabel,
-      std::ofstream & out);
+  outputAsStructuralDot(const rvsdg::Region & region, std::ofstream & out);
 
   /** Output human-readable ASCII tree via rvsdg::view(). */
   static void

--- a/jlm/hls/opt/DumpTransformationTests.cpp
+++ b/jlm/hls/opt/DumpTransformationTests.cpp
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2026 Magnus Sjalander <work@sjalander.com>
+ * See COPYING for terms of redistribution.
+ */
+
+#include <filesystem>
+#include <regex>
+#include <set>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include <jlm/hls/opt/DumpTransformation.hpp>
+#include <jlm/llvm/ir/operators/lambda.hpp>
+#include <jlm/rvsdg/simple-node.hpp>
+#include <jlm/util/strfmt.hpp>
+
+namespace fs = std::filesystem;
+
+namespace jlm::hls
+{
+using namespace jlm::llvm;
+using namespace jlm::rvsdg;
+
+TEST(DumpTransformationTests, DisabledDoesNothing)
+{
+  // Arrange — minimal module
+  LlvmRvsdgModule rvsdgModule(jlm::util::FilePath(""), "", "");
+  const auto & rvsdg = rvsdgModule.Rvsdg();
+
+  const auto functionType = FunctionType::Create({}, {});
+  const auto lambdaNode = LambdaNode::Create(
+      rvsdg.GetRootRegion(),
+      LlvmLambdaOperation::Create(functionType, "f", Linkage::externalLinkage));
+  lambdaNode->finalize({});
+
+  // Act — create disabled instance and run
+  DumpTransformation dump(DumpTransformation::Disabled);
+  jlm::util::StatisticsCollector statisticsCollector;
+
+  EXPECT_NO_THROW(dump.Run(rvsdgModule, statisticsCollector));
+
+  // Assert — no files created, Run() returns immediately
+}
+
+TEST(DumpTransformationTests, EnabledProducesOutputFiles)
+{
+  // Arrange — create a unique temp directory and pass it via the StatisticsCollector
+  // so files don't pollute the project directory.
+  auto tmpDirName = "jlm-dump-test-" + jlm::util::CreateRandomAlphanumericString(6);
+  auto tmpDir = fs::temp_directory_path() / tmpDirName;
+  fs::create_directories(tmpDir);
+
+  LlvmRvsdgModule rvsdgModule(jlm::util::FilePath(""), "", "");
+  const auto & rvsdg = rvsdgModule.Rvsdg();
+
+  const auto functionType = FunctionType::Create({}, {});
+  const auto lambdaNode = LambdaNode::Create(
+      rvsdg.GetRootRegion(),
+      LlvmLambdaOperation::Create(functionType, "f", Linkage::externalLinkage));
+  lambdaNode->finalize({});
+
+  // Act — create enabled instance with all formats, run it
+  DumpTransformation::Config config;
+  config.formats = {
+    DumpTransformation::OutputFormat::Dot,           DumpTransformation::OutputFormat::HlsDot,
+    DumpTransformation::OutputFormat::StructuralDot, DumpTransformation::OutputFormat::Json,
+    DumpTransformation::OutputFormat::Ascii,         DumpTransformation::OutputFormat::Tree,
+    DumpTransformation::OutputFormat::JsonTree,
+  };
+
+  DumpTransformation dump(std::move(config));
+  dump.setLabel("test-pass");
+  dump.setPassNumber(42);
+
+  jlm::util::StatisticsCollector statisticsCollector(jlm::util::StatisticsCollectorSettings(
+      {},
+      std::optional<jlm::util::FilePath>(tmpDir),
+      "test-module"));
+
+  EXPECT_NO_THROW(dump.Run(rvsdgModule, statisticsCollector));
+
+  // Assert — all 7 files exist in the temp directory with correct naming pattern.
+  // The unique string is randomly generated, so we use a regex to validate the format.
+  std::set<std::string> expectedExtensions = {
+    "llvm.dot", "hls.dot", "structural.dot", "json", "txt", "tree.txt", "tree.json",
+  };
+
+  auto entries = fs::directory_iterator(tmpDir);
+  std::set<std::string> foundExtensions;
+  for (const auto & entry : entries)
+  {
+    if (entry.is_regular_file())
+    {
+      auto fname = entry.path().filename();
+      // Match the pattern: [modulename]-[unique]-NNN-label.ext
+      // Accept any prefix up to "-test-pass.", then capture the extension
+      std::string str = fname;
+      std::regex pattern("-042-test-pass\\.(.*)");
+      std::smatch match;
+      if (std::regex_search(str, match, pattern))
+      {
+        foundExtensions.insert(match[1]);
+      }
+    }
+  }
+
+  for (const auto & ext : expectedExtensions)
+  {
+    ASSERT_TRUE(foundExtensions.count(ext)) << "Missing expected file extension: ." << ext;
+  }
+}
+
+TEST(DumpTransformationTests, MultipleRunsGetSequentialNumbers)
+{
+  // Arrange — create a unique temp directory and pass it via the StatisticsCollector
+  // so files don't pollute the project directory.
+  auto tmpDirName = "jlm-dump-test-" + jlm::util::CreateRandomAlphanumericString(6);
+  auto tmpDir = fs::temp_directory_path() / tmpDirName;
+  fs::create_directories(tmpDir);
+
+  LlvmRvsdgModule rvsdgModule(jlm::util::FilePath(""), "", "");
+  const auto & rvsdg = rvsdgModule.Rvsdg();
+
+  const auto functionType = FunctionType::Create({}, {});
+  const auto lambdaNode = LambdaNode::Create(
+      rvsdg.GetRootRegion(),
+      LlvmLambdaOperation::Create(functionType, "f", Linkage::externalLinkage));
+  lambdaNode->finalize({});
+
+  // Act — run the same transformation twice, expecting sequential numbers
+  DumpTransformation::Config config;
+  config.formats = { DumpTransformation::OutputFormat::Dot };
+
+  jlm::util::StatisticsCollector statisticsCollector(jlm::util::StatisticsCollectorSettings(
+      {},
+      std::optional<jlm::util::FilePath>(tmpDir),
+      "test-module"));
+
+  {
+    DumpTransformation dump(config);
+    dump.setLabel("first");
+    dump.setPassNumber(0);
+    dump.Run(rvsdgModule, statisticsCollector);
+  }
+  {
+    DumpTransformation dump(config);
+    dump.setLabel("second");
+    dump.setPassNumber(1);
+    dump.Run(rvsdgModule, statisticsCollector);
+  }
+
+  // Assert — both files exist in the temp directory with sequential numbers.
+  auto entries = fs::directory_iterator(tmpDir);
+  int first_count = 0;
+  int second_count = 0;
+  for (const auto & entry : entries)
+  {
+    if (entry.is_regular_file())
+    {
+      std::string str = entry.path();
+
+      std::regex first_pattern("-000-first\\.llvm\\.dot");
+      std::regex second_pattern("-001-second\\.llvm\\.dot");
+
+      if (std::regex_search(str, first_pattern))
+        ++first_count;
+      if (std::regex_search(str, second_pattern))
+        ++second_count;
+    }
+  }
+
+  EXPECT_EQ(first_count, 1) << "Missing expected file matching *-000-first.llvm.dot";
+  EXPECT_EQ(second_count, 1) << "Missing expected file matching *-001-second.llvm.dot";
+}
+
+} // namespace jlm::hls

--- a/jlm/hls/util/view.cpp
+++ b/jlm/hls/util/view.cpp
@@ -501,19 +501,4 @@ DotToSvg(const std::string & file_name)
     exit(EXIT_FAILURE);
 }
 
-DumpDotTransformation::~DumpDotTransformation() noexcept = default;
-
-DumpDotTransformation::DumpDotTransformation()
-    : Transformation("DumpDotTransformation")
-{}
-
-void
-DumpDotTransformation::Run(
-    rvsdg::RvsdgModule & rvsdgModule,
-    util::StatisticsCollector & statisticsCollector)
-{
-  const auto file = statisticsCollector.createOutputFile("rvsdg-graph.dot", true);
-  DumpDot(&rvsdgModule.Rvsdg().GetRootRegion(), file.path().to_str());
-}
-
 } // namespace jlm::hls

--- a/jlm/hls/util/view.hpp
+++ b/jlm/hls/util/view.hpp
@@ -74,39 +74,5 @@ DumpDot(rvsdg::Region * region, const std::string & fileName);
 void
 DotToSvg(const std::string & fileName);
 
-/**
- * This transformation does nothing except dumping the RVSDG module to a dot file,
- * using the hls dot output.
- */
-class DumpDotTransformation final : public rvsdg::Transformation
-{
-public:
-  ~DumpDotTransformation() noexcept override;
-
-  DumpDotTransformation();
-
-  DumpDotTransformation(const DumpDotTransformation &) = delete;
-
-  DumpDotTransformation &
-  operator=(const DumpDotTransformation &) = delete;
-
-  /**
-   * Dumps the given \p rvsdgModule to an GraphViz dot file.
-   * The file is placed in the output folder of the \p statisticsCollector.
-   * @param rvsdgModule the module to dump
-   * @param statisticsCollector the statistics collector whose output folder is used
-   */
-  void
-  Run(rvsdg::RvsdgModule & rvsdgModule, util::StatisticsCollector & statisticsCollector) override;
-
-  static void
-  createAndRun(rvsdg::RvsdgModule & rvsdgModule, util::StatisticsCollector & statisticsCollector)
-  {
-    DumpDotTransformation dumpDot;
-    dumpDot.Run(rvsdgModule, statisticsCollector);
-  }
-};
-
 } // namespace jlm::hls
-
 #endif // JLM_BACKEND_HLS_UTIL_VIEW_HPP

--- a/jlm/llvm/opt/RvsdgTreePrinter.cpp
+++ b/jlm/llvm/opt/RvsdgTreePrinter.cpp
@@ -17,6 +17,49 @@
 namespace jlm::llvm
 {
 
+std::string
+RvsdgTreePrinter::RenderAnnotatedTree(const rvsdg::Graph & graph, const rvsdg::Region & region)
+{
+  util::AnnotationMap annotationMap;
+
+  auto matchAll = [](const rvsdg::Node &)
+  {
+    return true;
+  };
+
+  AnnotateDebugIds(graph, annotationMap);
+  AnnotateNumNodes(graph, matchAll, "NumRvsdgNodes", annotationMap);
+
+  auto isAggAlloca = [](const rvsdg::Node & node) -> bool
+  {
+    const auto * op = dynamic_cast<const AllocaOperation *>(&node.GetOperation());
+    return op != nullptr && IsAggregateType(*op->allocatedType());
+  };
+  AnnotateNumNodes(graph, isAggAlloca, "NumAggregateAllocaNodes", annotationMap);
+
+  auto isAlloca = [](const rvsdg::Node & node) -> bool
+  {
+    return rvsdg::is<AllocaOperation>(&node);
+  };
+  AnnotateNumNodes(graph, isAlloca, "NumAllocaNodes", annotationMap);
+
+  auto isLoad = [](const rvsdg::Node & node) -> bool
+  {
+    return rvsdg::is<LoadOperation>(&node);
+  };
+  AnnotateNumNodes(graph, isLoad, "NumLoadNodes", annotationMap);
+
+  auto isStore = [](const rvsdg::Node & node) -> bool
+  {
+    return rvsdg::is<StoreOperation>(&node);
+  };
+  AnnotateNumNodes(graph, isStore, "NumStoreNodes", annotationMap);
+
+  AnnotateNumMemoryStateInputsOutputs(graph, annotationMap);
+
+  return rvsdg::Region::ToTree(region, annotationMap);
+}
+
 class RvsdgTreePrinter::Statistics final : public util::Statistics
 {
 public:

--- a/jlm/llvm/opt/RvsdgTreePrinter.hpp
+++ b/jlm/llvm/opt/RvsdgTreePrinter.hpp
@@ -129,6 +129,23 @@ public:
   void
   Run(rvsdg::RvsdgModule & rvsdgModule, util::StatisticsCollector & statisticsCollector) override;
 
+public:
+  /**
+   * Render an annotated tree string for the given \p region with all available annotations.
+   *
+   * This convenience method applies every annotation type to the RVSDG and produces a
+   * human-readable indented tree output via \ref rvsdg::Region::ToTree. It encapsulates the full
+   * annotation-compute-and-render pipeline so callers do not need to invoke individual annotator
+   * functions or handle the intermediate \ref AnnotationMap.
+   *
+   * @param graph The RVSDG graph (required because annotation computation walks the entire region
+   *              tree).
+   * @param region The region whose annotated tree to render.
+   * @return A string containing the fully annotated tree.
+   */
+  [[nodiscard]] static std::string
+  RenderAnnotatedTree(const rvsdg::Graph & graph, const rvsdg::Region & region);
+
 private:
   /**
    * Computes a map with annotations based on the required \ref jlm::util::Annotation%s in the \ref
@@ -175,7 +192,7 @@ private:
   /**
    * Adds the ID of a region and structural node to \p annotationMap.
    *
-   * @param rvsdg The RVSDG for which to compute the annotation.
+   * @param rvsdg The RVSDG for which to compute the annotations.
    * @param annotationMap The annotation map in which the annotation is inserted.
    *
    * @see DebugIds


### PR DESCRIPTION
A new DumpTransformation is introduced that can be configured to use existing infrastructure to dump an RVSGD graph in different formats.