### PR TITLE
LLVM: Fix bug in NodeHoisting pass

### DIFF
--- a/jlm/llvm/opt/push.cpp
+++ b/jlm/llvm/opt/push.cpp
@@ -304,44 +304,46 @@ NodeHoisting::markNodes(const rvsdg::Region & region)
   }
 }
 
-rvsdg::Output &
-NodeHoisting::getOperandFromTargetRegion(rvsdg::Output & output, rvsdg::Region & targetRegion)
+rvsdg::Input &
+NodeHoisting::getUserFromTargetRegion(rvsdg::Input & input, rvsdg::Region & targetRegion)
 {
-  if (output.region() == &targetRegion)
-    return output;
+  if (input.region() == &targetRegion)
+    return input;
+
+  const auto & operand = *input.origin();
 
   // Handle gamma subregion arguments
-  if (const auto gammaNode = rvsdg::TryGetRegionParentNode<rvsdg::GammaNode>(output))
+  if (const auto gammaNode = rvsdg::TryGetRegionParentNode<rvsdg::GammaNode>(operand))
   {
-    const auto roleVar = gammaNode->MapBranchArgument(output);
+    const auto roleVar = gammaNode->MapBranchArgument(operand);
     if (const auto entryVar = std::get_if<rvsdg::GammaNode::EntryVar>(&roleVar))
     {
-      return getOperandFromTargetRegion(*entryVar->input->origin(), targetRegion);
+      return getUserFromTargetRegion(*entryVar->input, targetRegion);
     }
   }
 
   // Handle theta subregion arguments
-  if (const auto thetaNode = rvsdg::TryGetRegionParentNode<rvsdg::ThetaNode>(output))
+  if (const auto thetaNode = rvsdg::TryGetRegionParentNode<rvsdg::ThetaNode>(operand))
   {
-    const auto loopVar = thetaNode->MapPreLoopVar(output);
+    const auto loopVar = thetaNode->MapPreLoopVar(operand);
     JLM_ASSERT(rvsdg::ThetaLoopVarIsInvariant(loopVar) || isInvariantMemoryStateLoopVar(loopVar));
-    return getOperandFromTargetRegion(*loopVar.input->origin(), targetRegion);
+    return getUserFromTargetRegion(*loopVar.input, targetRegion);
   }
 
   throw std::logic_error("Unhandled output type!");
 }
 
-std::vector<rvsdg::Output *>
-NodeHoisting::getOperandsFromTargetRegion(rvsdg::Node & node, rvsdg::Region & targetRegion)
+std::vector<rvsdg::Input *>
+NodeHoisting::getUsersFromTargetRegion(rvsdg::Node & node, rvsdg::Region & targetRegion)
 {
-  std::vector<rvsdg::Output *> operands;
+  std::vector<rvsdg::Input *> users;
   for (auto & input : node.Inputs())
   {
-    auto & operand = getOperandFromTargetRegion(*input.origin(), targetRegion);
-    operands.push_back(&operand);
+    auto & user = getUserFromTargetRegion(input, targetRegion);
+    users.push_back(&user);
   }
 
-  return operands;
+  return users;
 }
 
 static rvsdg::Input *
@@ -402,7 +404,29 @@ NodeHoisting::copyNodeToTargetRegion(rvsdg::Node & node) const
   auto & targetRegion = context_->getTargetRegion(node);
   JLM_ASSERT(&targetRegion != node.region());
 
-  const auto operands = getOperandsFromTargetRegion(node, targetRegion);
+  const auto users = getUsersFromTargetRegion(node, targetRegion);
+
+  std::vector<rvsdg::Output *> operands;
+  operands.reserve(users.size());
+  std::transform(
+      users.begin(),
+      users.end(),
+      std::back_inserter(operands),
+      [](const rvsdg::Input * input) -> rvsdg::Output *
+      {
+        return input->origin();
+      });
+
+  std::vector<rvsdg::Input *> stateUsers;
+  stateUsers.reserve(users.size());
+  for (auto user : users)
+  {
+    if (user->Type()->Kind() == rvsdg::TypeKind::State)
+    {
+      stateUsers.push_back(user);
+    }
+  }
+
   const auto copiedNode = node.copy(&targetRegion, operands);
 
   // FIXME: I really would like to have a zip function here, but C++ does not really seem to have
@@ -413,6 +437,7 @@ NodeHoisting::copyNodeToTargetRegion(rvsdg::Node & node) const
   const auto endCpy = std::end(copiedNode->Outputs());
   JLM_ASSERT(std::distance(itOrg, endOrg) == std::distance(itCpy, endCpy));
 
+  size_t stateUserIdx = 0;
   for (; itOrg != endOrg; ++itOrg, ++itCpy)
   {
     auto & outputOrg = *itOrg;
@@ -427,16 +452,8 @@ NodeHoisting::copyNodeToTargetRegion(rvsdg::Node & node) const
         auto inputCpy = mapStateOutputToInput(outputCpy);
         JLM_ASSERT(inputCpy);
 
-        // FIXME: We introduce a slight impression here. If inputCpy->origin() has
-        // more than a single user, then all users will all in a sudden be
-        // sequentialized after the hoisted node even though they were only
-        // sequentialized by the producer of inputCpy->origin() before.
-        inputCpy->origin()->divertUsersWhere(
-            outputCpy,
-            [&inputCpy](const rvsdg::Input & input)
-            {
-              return &input != inputCpy;
-            });
+        auto stateUser = stateUsers[stateUserIdx++];
+        stateUser->divert_to(&outputCpy);
       }
       else
       {
@@ -456,6 +473,8 @@ NodeHoisting::copyNodeToTargetRegion(rvsdg::Node & node) const
       throw std::logic_error(util::strfmt("Unhandled type kind!"));
     }
   }
+
+  JLM_ASSERT(stateUserIdx == stateUsers.size());
 }
 
 void

--- a/jlm/llvm/opt/push.cpp
+++ b/jlm/llvm/opt/push.cpp
@@ -474,7 +474,7 @@ NodeHoisting::copyNodeToTargetRegion(rvsdg::Node & node) const
     }
   }
 
-  JLM_ASSERT(stateUserIdx == stateUsers.size());
+  //  JLM_ASSERT(stateUserIdx == stateUsers.size());
 }
 
 void

--- a/jlm/llvm/opt/push.cpp
+++ b/jlm/llvm/opt/push.cpp
@@ -417,16 +417,6 @@ NodeHoisting::copyNodeToTargetRegion(rvsdg::Node & node) const
         return input->origin();
       });
 
-  std::vector<rvsdg::Input *> stateUsers;
-  stateUsers.reserve(users.size());
-  for (auto user : users)
-  {
-    if (user->Type()->Kind() == rvsdg::TypeKind::State)
-    {
-      stateUsers.push_back(user);
-    }
-  }
-
   const auto copiedNode = node.copy(&targetRegion, operands);
 
   // FIXME: I really would like to have a zip function here, but C++ does not really seem to have
@@ -437,7 +427,6 @@ NodeHoisting::copyNodeToTargetRegion(rvsdg::Node & node) const
   const auto endCpy = std::end(copiedNode->Outputs());
   JLM_ASSERT(std::distance(itOrg, endOrg) == std::distance(itCpy, endCpy));
 
-  size_t stateUserIdx = 0;
   for (; itOrg != endOrg; ++itOrg, ++itCpy)
   {
     auto & outputOrg = *itOrg;
@@ -452,8 +441,8 @@ NodeHoisting::copyNodeToTargetRegion(rvsdg::Node & node) const
         auto inputCpy = mapStateOutputToInput(outputCpy);
         JLM_ASSERT(inputCpy);
 
-        auto stateUser = stateUsers[stateUserIdx++];
-        stateUser->divert_to(&outputCpy);
+        auto user = users[inputCpy->index()];
+        user->divert_to(&outputCpy);
       }
       else
       {
@@ -473,8 +462,6 @@ NodeHoisting::copyNodeToTargetRegion(rvsdg::Node & node) const
       throw std::logic_error(util::strfmt("Unhandled type kind!"));
     }
   }
-
-  //  JLM_ASSERT(stateUserIdx == stateUsers.size());
 }
 
 void

--- a/jlm/llvm/opt/push.hpp
+++ b/jlm/llvm/opt/push.hpp
@@ -63,11 +63,11 @@ private:
   void
   copyNodeToTargetRegion(rvsdg::Node & node) const;
 
-  static std::vector<rvsdg::Output *>
-  getOperandsFromTargetRegion(rvsdg::Node & node, rvsdg::Region & targetRegion);
+  static std::vector<rvsdg::Input *>
+  getUsersFromTargetRegion(rvsdg::Node & node, rvsdg::Region & targetRegion);
 
-  static rvsdg::Output &
-  getOperandFromTargetRegion(rvsdg::Output & output, rvsdg::Region & targetRegion);
+  static rvsdg::Input &
+  getUserFromTargetRegion(rvsdg::Input & input, rvsdg::Region & targetRegion);
 
   rvsdg::Region &
   computeTargetRegion(const rvsdg::Node & node) const;


### PR DESCRIPTION
The use of divertUsersWhere() could not only lead to impressions, but also to cycles in the graph. This fix ensures that only the respective user of the target region is modified.