### PR TITLE
LLVM: fix AndersenAgnosticModRefSummarizer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
         run: ./scripts/run-llvm-test-suite.sh --make-target llvm-run-opt
 
   llvm-test-suite-andersen-agnostic:
-    if: contains(github.event.pull_request.title, '[AndersenAgnostic]')
+    #if: contains(github.event.pull_request.title, '[AndersenAgnostic]')
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,6 @@ jobs:
         run: ./scripts/run-llvm-test-suite.sh --make-target llvm-run-opt
 
   llvm-test-suite-andersen-agnostic:
-    #if: contains(github.event.pull_request.title, '[AndersenAgnostic]')
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/jlm/llvm/opt/alias-analyses/AgnosticModRefSummarizer.cpp
+++ b/jlm/llvm/opt/alias-analyses/AgnosticModRefSummarizer.cpp
@@ -255,6 +255,15 @@ AgnosticModRefSummarizer::AnnotateSimpleNode(const rvsdg::SimpleNode & node)
         AddPointerTargetsToModRefSet(dstAddress, ModRefEffect::ModOnly, modRefSet);
         ModRefSummary_->SetSimpleNodeModRef(node, std::move(modRefSet));
       },
+      [&](const MemMoveOperation &)
+      {
+        AgnosticModRefSet modRefSet;
+        const auto & srcAddress = *MemMoveOperation::sourceInput(node).origin();
+        const auto & dstAddress = *MemMoveOperation::destinationInput(node).origin();
+        AddPointerTargetsToModRefSet(srcAddress, RefOnly, modRefSet);
+        AddPointerTargetsToModRefSet(dstAddress, ModOnly, modRefSet);
+        ModRefSummary_->SetSimpleNodeModRef(node, std::move(modRefSet));
+      },
       [&](const MemSetOperation &)
       {
         AgnosticModRefSet modRefSet;


### PR DESCRIPTION
1. Add MemMoveOperation to AndersenAgnosticModRefSummarizer
2. Let test run unconditionally.