### PR TITLE
Write alternative region predication checker with fix + theta tracing

### DIFF
--- a/jlm/llvm/opt/StoreValueForwarding.cpp
+++ b/jlm/llvm/opt/StoreValueForwarding.cpp
@@ -224,7 +224,7 @@ struct StoreValueForwarding::Context final
 
   OutputTracer outputTracer;
 
-  rvsdg::RegionPredicateTrace regionPredicateTrace;
+  rvsdg::AlternativeRegionPredicateTracer regionPredicateTracer;
 
   // The AliasAnalysis instance used for all alias queries
   aa::AliasAnalysis & aliasAnalysis;
@@ -412,11 +412,11 @@ public:
       rvsdg::SimpleNode & loadNode,
       OutputTracer & tracer,
       aa::AliasAnalysis & aliasAnalysis,
-      rvsdg::RegionPredicateTrace & regionPredicateTrace)
+      rvsdg::AlternativeRegionPredicateTracer & regionPredicateTracer)
       : loadNode(loadNode),
         tracer(tracer),
         aliasAnalysis(aliasAnalysis),
-        regionPredicateTrace(regionPredicateTrace)
+        regionPredicateTracer(regionPredicateTracer)
   {
     JLM_ASSERT(is<LoadNonVolatileOperation>(&loadNode));
     loadedAddress = &llvm::traceOutput(*LoadOperation::AddressInput(loadNode).origin());
@@ -800,13 +800,14 @@ private:
           // If region predication checks has been disabled, loopBackEdgeTaken is always true
           JLM_ASSERT(ENABLE_REGION_PREDICATE_CHECK);
 
-          auto & fromRegion = *branchResult->region();
-          if (!regionPredicateTrace.CheckPredicatesSatisfiable(fromRegion, *loadNode.region()))
+          auto & valueOriginRegion = *branchResult->region();
+          auto & targetRegion = *loadNode.region();
+          if (!regionPredicateTracer.canRegionReachRegion(valueOriginRegion, targetRegion))
           {
             // Mark the region as providing uninitialized memory, since it is never reached
             auto valueOrigin = ValueOrigin::createUninitialized();
             lastValueOriginInRegion.emplace(
-                std::make_pair(&fromRegion, loopBackEdgeTaken),
+                std::make_pair(&valueOriginRegion, loopBackEdgeTaken),
                 valueOrigin);
             addObservedValueOrigin(valueOrigin);
             continue;
@@ -926,7 +927,7 @@ private:
 
   OutputTracer & tracer;
   aa::AliasAnalysis & aliasAnalysis;
-  rvsdg::RegionPredicateTrace & regionPredicateTrace;
+  rvsdg::AlternativeRegionPredicateTracer & regionPredicateTracer;
 
   // Map containing info about each store node relevant to value forwarding.
   std::unordered_map<rvsdg::SimpleNode *, StoreNodeInfo> storeNodeInfo;
@@ -1007,7 +1008,7 @@ StoreValueForwarding::processLoadWithMemoryStates(rvsdg::SimpleNode & loadNode)
       loadNode,
       context_->outputTracer,
       context_->aliasAnalysis,
-      context_->regionPredicateTrace);
+      context_->regionPredicateTracer);
   const auto shouldForwardValueOrigins = loadTracingInfo.traceAllMemoryStateInputs();
   context_->statistics.stopTracing();
 

--- a/jlm/llvm/opt/StoreValueForwarding.cpp
+++ b/jlm/llvm/opt/StoreValueForwarding.cpp
@@ -802,7 +802,7 @@ private:
 
           auto & valueOriginRegion = *branchResult->region();
           auto & targetRegion = *loadNode.region();
-          if (!regionPredicateTracer.canRegionReachRegion(valueOriginRegion, targetRegion))
+          if (!regionPredicateTracer.isReachableFromRegion(targetRegion, valueOriginRegion))
           {
             // Mark the region as providing uninitialized memory, since it is never reached
             auto valueOrigin = ValueOrigin::createUninitialized();

--- a/jlm/rvsdg/RegionPredicateTrace.cpp
+++ b/jlm/rvsdg/RegionPredicateTrace.cpp
@@ -535,7 +535,7 @@ AlternativeRegionPredicateTracer::canRegionReachRegion(Region & originRegion, Re
   }
   // Lowest common ancestor found
   JLM_ASSERT(targetAncestor == originAncestor);
-  auto commonAncestor = targetAncestor;
+  const auto commonAncestor = targetAncestor;
 
   // Go through the ancestors of the target region and check if any of them have requirements
   // that can not be satisfied by the origin region or one of its ancestors

--- a/jlm/rvsdg/RegionPredicateTrace.cpp
+++ b/jlm/rvsdg/RegionPredicateTrace.cpp
@@ -5,11 +5,19 @@
 
 #include <jlm/rvsdg/RegionPredicateTrace.hpp>
 
+#include <jlm/rvsdg/control.hpp>
 #include <jlm/rvsdg/gamma.hpp>
 #include <jlm/rvsdg/MatchType.hpp>
+#include <jlm/rvsdg/node.hpp>
+#include <jlm/rvsdg/region.hpp>
+#include <jlm/rvsdg/simple-node.hpp>
 #include <jlm/rvsdg/theta.hpp>
+#include <jlm/rvsdg/Trace.hpp>
+#include <jlm/util/common.hpp>
 
+#include <algorithm>
 #include <unordered_map>
+#include <utility>
 
 namespace jlm::rvsdg
 {
@@ -329,6 +337,237 @@ RegionPredicateTrace::CheckPredicatesSatisfiable(Region & originRegion, Region &
   }
 
   return true;
+}
+
+AlternativeRegionPredicateTracer::AlternativeRegionPredicateTracer() = default;
+
+PredicateValueRange &
+AlternativeRegionPredicateTracer::getPossibleValues(rvsdg::Output & output)
+{
+  auto & tracedOutput = rvsdg::traceOutputIntraProcedurally(output);
+  if (auto it = predicateValueRanges_.find(&tracedOutput); it != predicateValueRanges_.end())
+  {
+    return it->second;
+  }
+
+  PredicateValueRange range = getPossibleValuesInternal(tracedOutput);
+  auto [it, inserted] = predicateValueRanges_.emplace(&tracedOutput, std::move(range));
+  JLM_ASSERT(inserted);
+  return it->second;
+}
+
+PredicateValueRange
+AlternativeRegionPredicateTracer::getPossibleValuesInternal(rvsdg::Output & output)
+{
+  auto & controlType = *util::assertedCast<const ControlType>(output.Type().get());
+
+  // Control constants provide a known value for the predicate
+  if (auto [_, ctrlOp] = TryGetSimpleNodeAndOptionalOp<ControlConstantOperation>(output); ctrlOp)
+  {
+    return PredicateValueRange::CreateSingleValue(ctrlOp->value());
+  }
+
+  // handle gamma outputs by taking the union of the possible values of each subregion
+  if (auto gamma = rvsdg::TryGetOwnerNode<rvsdg::GammaNode>(output))
+  {
+    auto exitVar = gamma->MapOutputExitVar(output);
+
+    auto range = PredicateValueRange::CreateEmpty(controlType);
+    for (auto result : exitVar.branchResult)
+    {
+      range.UpdateUnion(getPossibleValues(*result->origin()));
+    }
+
+    return range;
+  }
+
+  // This function is only called on traced outputs, so it never stops at a gamma argument
+  JLM_ASSERT(!rvsdg::TryGetRegionParentNode<rvsdg::GammaNode>(output));
+
+  // handle theta outputs by continuing from the loop var post
+  if (auto theta = rvsdg::TryGetOwnerNode<rvsdg::ThetaNode>(output))
+  {
+    auto loopVar = theta->MapOutputLoopVar(output);
+    return getPossibleValues(*loopVar.post->origin());
+  }
+
+  // Theta arguments belonging to invariant loop variables have already been traced.
+  // Other theta arguments would require following back-edges.
+
+  // Otherwise we are unable to provide a set
+  return PredicateValueRange::CreateUnknown(controlType);
+}
+
+bool
+AlternativeRegionPredicateTracer::markRequiredPredicateValue(
+    Output & output,
+    size_t value,
+    std::vector<Region *> & impossibleRegions)
+{
+  bool satisfiable = markRequiredPredicateValueInternal(output, value, impossibleRegions);
+
+  // If the output is never able to provide the required value, its region can not be an origin
+  if (!satisfiable)
+  {
+    auto originRegion = output.region();
+
+    // Multiple origins from the same region will never be considered,
+    // so we are sure we never add duplicate regions to the list
+    JLM_ASSERT(std::count(impossibleRegions.begin(), impossibleRegions.end(), originRegion) == 0);
+
+    impossibleRegions.push_back(originRegion);
+  }
+
+  return satisfiable;
+}
+
+bool
+AlternativeRegionPredicateTracer::markRequiredPredicateValueInternal(
+    rvsdg::Output & output,
+    size_t value,
+    std::vector<Region *> & impossibleRegions)
+{
+  // handle gamma outputs by recursively propagating the requirement to each subregion
+  if (auto gamma = rvsdg::TryGetOwnerNode<rvsdg::GammaNode>(output))
+  {
+    // output is the output of a gamma exit variable
+    // continue inside each of the gamma subregions
+    auto exitVar = gamma->MapOutputExitVar(output);
+
+    bool anyReachable = false;
+    for (auto result : exitVar.branchResult)
+    {
+      anyReachable |= markRequiredPredicateValue(*result->origin(), value, impossibleRegions);
+    }
+
+    // If none of the gamma subregions can provide the required value,
+    // its parent region is also not able to satisfy the requirement.
+    return anyReachable;
+  }
+
+  // handle theta outputs by making the same requirement inside the theta
+  if (auto theta = rvsdg::TryGetOwnerNode<rvsdg::ThetaNode>(output))
+  {
+    // output is the output of a theta loop variable
+    // continue from the loop variable post
+    auto loopVar = theta->MapOutputLoopVar(output);
+
+    // This call can mark certain subregions within the theta region as impossible origins.
+    // If it also returns false, it means the theta will never provide the required value,
+    // which also makes the surrounding region an impossible origin.
+    bool canLoopSatisfyValue =
+        markRequiredPredicateValue(*loopVar.post->origin(), value, impossibleRegions);
+    return canLoopSatisfyValue;
+  }
+
+  // The predicate output is not the output of a structural node.
+  // It can still be the input of a structural node, but we can not continue
+  // calling setRequiredPredicateValue out of the structural nodes.
+  // The input may for example be used in only some subregions of a gamma,
+  // or only the first iteration of a theta.
+  // We can therefore not be sure that the value is actually required.
+  // Also, RVSDG (pretty much) never routes ControlType values into structural nodes.
+
+  // Use regular tracing to see if we are able to determine a fixed value for the output.
+  auto & possibleValues = getPossibleValues(output);
+  return possibleValues.AllowsValue(value);
+}
+
+bool
+AlternativeRegionPredicateTracer::canCurrentOriginSatisfyRequirement(Output & output, size_t value)
+{
+  auto key = std::make_pair(&output, value);
+
+  // If the target region has already been processed, use the cached result
+  auto [it, inserted] = impossibleOriginRegions_.insert({ key, {} });
+
+  if (inserted)
+  {
+    // The requirement has not been processed, find regions that cannot satisfy it
+    markRequiredPredicateValue(output, value, it->second);
+  }
+
+  // Go through all regions that have been marked as unable to satisfy the requirement
+  // of the target region, and check if any of them are ancestors of the origin region
+  for (auto & impossibleOrigin : it->second)
+  {
+    if (currentOriginRegionAncestors_.Contains(impossibleOrigin))
+      return false;
+  }
+
+  return true;
+}
+
+bool
+AlternativeRegionPredicateTracer::canRegionReachRegion(Region & originRegion, Region & targetRegion)
+{
+  // find the common ancestor of the origin and target regions
+  auto targetAncestor = &targetRegion;
+  auto originAncestor = &originRegion;
+
+  // While traversing, add all ancestors of the origin region to this set
+  currentOriginRegionAncestors_.Clear();
+  currentOriginRegionAncestors_.insert(originAncestor);
+
+  while (targetAncestor != originAncestor)
+  {
+    const auto targetDepth = targetAncestor->getDepth();
+    const auto originDepth = originAncestor->getDepth();
+
+    // Move one region up along the target region ancestors
+    if (targetDepth >= originDepth)
+    {
+      targetAncestor = targetAncestor->node()->region();
+    }
+
+    // Move one region up along the origin region ancestors
+    if (originDepth >= targetDepth)
+    {
+      // If the origin ancestor region we are leaving is a theta subregion,
+      // we can add the fact that the theta predicate must be 0 in order to leave the region
+      auto node = originAncestor->node();
+      if (auto theta = dynamic_cast<rvsdg::ThetaNode *>(node))
+      {
+        if (!canCurrentOriginSatisfyRequirement(*theta->predicate()->origin(), 0))
+          return false;
+      }
+
+      // move one region up and add it to the set of origin region ancestors
+      originAncestor = node->region();
+      currentOriginRegionAncestors_.insert(originAncestor);
+    }
+  }
+  // Lowest common ancestor found
+  JLM_ASSERT(targetAncestor == originAncestor);
+  auto commonAncestor = targetAncestor;
+
+  // Go through the ancestors of the target region and check if any of them have requirements
+  // that can not be satisfied by the origin region or one of its ancestors
+  targetAncestor = &targetRegion;
+  while (targetAncestor != commonAncestor)
+  {
+    // when the target region is in a gamma subregion,
+    // the origin must be able to provide the correct gamma predicate value
+    auto node = targetAncestor->node();
+    if (auto gamma = dynamic_cast<rvsdg::GammaNode *>(node))
+    {
+      if (!canCurrentOriginSatisfyRequirement(
+              *gamma->predicate()->origin(),
+              targetAncestor->index()))
+        return false;
+    }
+    targetAncestor = node->region();
+  }
+
+  // No proof of unreachability was found
+  return true;
+}
+
+void
+AlternativeRegionPredicateTracer::clearCaches()
+{
+  predicateValueRanges_.clear();
+  impossibleOriginRegions_.clear();
 }
 
 }

--- a/jlm/rvsdg/RegionPredicateTrace.cpp
+++ b/jlm/rvsdg/RegionPredicateTrace.cpp
@@ -430,8 +430,6 @@ AlternativeRegionPredicateTracer::markRequiredPredicateValueInternal(
   // handle gamma outputs by recursively propagating the requirement to each subregion
   if (auto gamma = rvsdg::TryGetOwnerNode<rvsdg::GammaNode>(output))
   {
-    // output is the output of a gamma exit variable
-    // continue inside each of the gamma subregions
     auto exitVar = gamma->MapOutputExitVar(output);
 
     bool anyReachable = false;
@@ -448,8 +446,6 @@ AlternativeRegionPredicateTracer::markRequiredPredicateValueInternal(
   // handle theta outputs by making the same requirement inside the theta
   if (auto theta = rvsdg::TryGetOwnerNode<rvsdg::ThetaNode>(output))
   {
-    // output is the output of a theta loop variable
-    // continue from the loop variable post
     auto loopVar = theta->MapOutputLoopVar(output);
 
     // This call can mark certain subregions within the theta region as impossible origins.
@@ -478,7 +474,7 @@ AlternativeRegionPredicateTracer::canCurrentOriginSatisfyRequirement(Output & ou
 {
   auto key = std::make_pair(&output, value);
 
-  // If the target region has already been processed, use the cached result
+  // If the (output, value) pair has already been processed, use the cached result
   auto [it, inserted] = impossibleOriginRegions_.insert({ key, {} });
 
   if (inserted)
@@ -487,8 +483,8 @@ AlternativeRegionPredicateTracer::canCurrentOriginSatisfyRequirement(Output & ou
     markRequiredPredicateValue(output, value, it->second);
   }
 
-  // Go through all regions that have been marked as unable to satisfy the requirement
-  // of the target region, and check if any of them are ancestors of the origin region
+  // Go through all regions that have been marked as unable to satisfy the requirement,
+  // and check if any of them are the origin region, or one of its ancestors.
   for (auto & impossibleOrigin : it->second)
   {
     if (currentOriginRegionAncestors_.Contains(impossibleOrigin))

--- a/jlm/rvsdg/RegionPredicateTrace.cpp
+++ b/jlm/rvsdg/RegionPredicateTrace.cpp
@@ -495,7 +495,7 @@ AlternativeRegionPredicateTracer::canCurrentOriginSatisfyRequirement(Output & ou
 }
 
 bool
-AlternativeRegionPredicateTracer::canRegionReachRegion(Region & originRegion, Region & targetRegion)
+AlternativeRegionPredicateTracer::isReachableFromRegion(Region & targetRegion, Region & originRegion)
 {
   // find the common ancestor of the origin and target regions
   auto targetAncestor = &targetRegion;

--- a/jlm/rvsdg/RegionPredicateTrace.cpp
+++ b/jlm/rvsdg/RegionPredicateTrace.cpp
@@ -495,7 +495,9 @@ AlternativeRegionPredicateTracer::canCurrentOriginSatisfyRequirement(Output & ou
 }
 
 bool
-AlternativeRegionPredicateTracer::isReachableFromRegion(Region & targetRegion, Region & originRegion)
+AlternativeRegionPredicateTracer::isReachableFromRegion(
+    Region & targetRegion,
+    Region & originRegion)
 {
   // find the common ancestor of the origin and target regions
   auto targetAncestor = &targetRegion;

--- a/jlm/rvsdg/RegionPredicateTrace.hpp
+++ b/jlm/rvsdg/RegionPredicateTrace.hpp
@@ -9,6 +9,7 @@
 #include <jlm/rvsdg/control.hpp>
 #include <jlm/rvsdg/graph.hpp>
 #include <jlm/rvsdg/node.hpp>
+#include <jlm/util/HashSet.hpp>
 
 #include <unordered_map>
 
@@ -233,6 +234,101 @@ private:
 
   // Observers registered on region to inform the tracer when caches must be invalidated
   std::unordered_map<Region *, std::unique_ptr<Observer>> observers_;
+};
+
+/**
+ * \brief class providing guarantees about unreachability of regions from other regions.
+ *
+ * If any control type edges are modified, or if any regions are deleted,
+ * during the lifetime of the tracer, the tracer's caches must be cleared manually.
+ * @see clearCaches()
+ */
+class AlternativeRegionPredicateTracer final
+{
+public:
+  AlternativeRegionPredicateTracer();
+
+  /**
+   * Determines if it is possible for control flow to go from the given
+   * \p originRegion to the given \p targetRegion,
+   * without following any back-edges in any theta node that contains the \p originRegion.
+   * No assumptions are made about theta nodes surrounding the \p targetRegion,
+   * or control flow entering theta nodes between the two regions.
+   */
+  [[nodiscard]] bool
+  canRegionReachRegion(Region & originRegion, Region & targetRegion);
+
+  /**
+   * Removes all cached information from the tracer.
+   * This must be done if edges or constants of ControlType have been modified in
+   * a way that changes the static reachability guarantees between regions.
+   * Also, if regions get removed from the graph, the caches must be cleared
+   * to prevent new regions re-useing the address from causing cache collisions.
+   */
+  void
+  clearCaches();
+
+private:
+  /**
+   * Determines the set of possible values for the given \p output.
+   * @param output the output in question, must be of type ControlType.
+   * @return the possible values of the control type output.
+   */
+  [[nodiscard]] PredicateValueRange &
+  getPossibleValues(Output & output);
+
+  [[nodiscard]] PredicateValueRange
+  getPossibleValuesInternal(Output & output);
+
+  /**
+   * Processes the fact that a given output needs to have a specific value,
+   * and adds all origin regions that are unable to satisfy the requirement to a list.
+   * Assumes no back-edges are taken around the considered origin regions.
+   *
+   * @param output an output of type ControlType
+   * @param value the value the output must have in order to reach/leave the target region.
+   * @param impossibleOrigins a list to which all impossible origin regions are added.
+   * @return false if the output can never satisfy the requirement
+   */
+  bool
+  markRequiredPredicateValue(
+      Output & output,
+      size_t value,
+      std::vector<Region *> & impossibleOrigins);
+
+  bool
+  markRequiredPredicateValueInternal(
+      Output & output,
+      size_t value,
+      std::vector<Region *> & impossibleOrigins);
+
+  /**
+   * Checks if the current origin region or any of its ancestors are unable to
+   * satisfy the requirement that the given output gets the given value.
+   * If the (output, value) pair has not yet been processed,
+   * it is processed first via \ref markRequiredPredicateValue.
+   *
+   * @param output an output of type ControlType
+   * @param value the value the output must have in order to reach/leave the target region.
+   * @return false if the origin region or one of its ancestors are unable to meet the requirement
+   */
+  [[nodiscard]] bool
+  canCurrentOriginSatisfyRequirement(Output & output, size_t value);
+
+  // The possible values an output of control type may have.
+  std::unordered_map<Output *, PredicateValueRange> predicateValueRanges_;
+
+  // Map from (output, required value) to a list of origin regions that cannot provide the value,
+  // without control flow taking any back-edges around the origin region.
+  std::unordered_map<
+      std::pair<Output *, size_t>,
+      std::vector<Region *>,
+      util::Hash<std::pair<Output *, size_t>>>
+      impossibleOriginRegions_;
+
+  // The ancestors of the current origin region.
+  // Not a cache, updates for every call to \ref canRegionReachRegion.
+  util::HashSet<Region *> currentOriginRegionAncestors_;
 };
 
 }

--- a/jlm/rvsdg/RegionPredicateTrace.hpp
+++ b/jlm/rvsdg/RegionPredicateTrace.hpp
@@ -256,7 +256,7 @@ public:
    * or control flow entering theta nodes between the two regions.
    */
   [[nodiscard]] bool
-  canRegionReachRegion(Region & originRegion, Region & targetRegion);
+  isReachableFromRegion(Region & targetRegion, Region & originRegion);
 
   /**
    * Removes all cached information from the tracer.
@@ -327,7 +327,7 @@ private:
       impossibleOriginRegions_;
 
   // The ancestors of the current origin region.
-  // Not a cache, updates for every call to \ref canRegionReachRegion.
+  // Not a cache, updates for every call to \ref isReachableFromRegion.
   util::HashSet<Region *> currentOriginRegionAncestors_;
 };
 

--- a/jlm/rvsdg/RegionPredicateTraceTests.cpp
+++ b/jlm/rvsdg/RegionPredicateTraceTests.cpp
@@ -325,6 +325,12 @@ TEST(RegionPredicateTraceTests, TraceThroughGammas)
   ASSERT_TRUE(tracer.canRegionReachRegion(*gamma0.subregion(1), *gamma1.subregion(0)));
   ASSERT_TRUE(tracer.canRegionReachRegion(*gamma0.subregion(1), *gamma1.subregion(1)));
 
+  // gamma0 has no effect on the choice between region 0 or 1 in gamma2 either
+  ASSERT_TRUE(tracer.canRegionReachRegion(*gamma0.subregion(0), *gamma2.subregion(0)));
+  ASSERT_TRUE(tracer.canRegionReachRegion(*gamma0.subregion(0), *gamma2.subregion(1)));
+  ASSERT_TRUE(tracer.canRegionReachRegion(*gamma0.subregion(1), *gamma2.subregion(0)));
+  ASSERT_TRUE(tracer.canRegionReachRegion(*gamma0.subregion(1), *gamma2.subregion(1)));
+
   // From subregion 0 of gamma1 both subregions 0 and 1 can be reached in gamma2
   ASSERT_TRUE(tracer.canRegionReachRegion(*gamma1.subregion(0), *gamma2.subregion(0)));
   ASSERT_TRUE(tracer.canRegionReachRegion(*gamma1.subregion(0), *gamma2.subregion(1)));

--- a/jlm/rvsdg/RegionPredicateTraceTests.cpp
+++ b/jlm/rvsdg/RegionPredicateTraceTests.cpp
@@ -55,32 +55,33 @@ TEST(RegionPredicateTraceTests, TestTracing)
   auto s = gamma3->AddExitVar({ s0->output(0), s1->output(0) }).output;
   rvsdg::GraphExport::Create(*s, "result2");
 
-  rvsdg::RegionPredicateTrace trace;
+  rvsdg::AlternativeRegionPredicateTracer trace;
 
   // Since gamma1 dominates gamma2, not all cross-paths are possible.
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*g1_left, *g2_right));
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*g1_right, *g2_left));
-  EXPECT_FALSE(trace.CheckPredicatesSatisfiable(*g1_left, *g2_left));
-  EXPECT_FALSE(trace.CheckPredicatesSatisfiable(*g1_right, *g2_right));
+  EXPECT_TRUE(trace.canRegionReachRegion(*g1_left, *g2_right));
+  EXPECT_TRUE(trace.canRegionReachRegion(*g1_right, *g2_left));
+  EXPECT_FALSE(trace.canRegionReachRegion(*g1_left, *g2_left));
+  EXPECT_FALSE(trace.canRegionReachRegion(*g1_right, *g2_right));
 
   // Since gamma1 and gamma3 are unrelated,  all cross-paths are possible.
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*g1_left, *g3_right));
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*g1_right, *g3_left));
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*g1_left, *g3_left));
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*g1_right, *g3_right));
+  EXPECT_TRUE(trace.canRegionReachRegion(*g1_left, *g3_right));
+  EXPECT_TRUE(trace.canRegionReachRegion(*g1_right, *g3_left));
+  EXPECT_TRUE(trace.canRegionReachRegion(*g1_left, *g3_left));
+  EXPECT_TRUE(trace.canRegionReachRegion(*g1_right, *g3_right));
 
   // Now change the graph, and check again.
   gamma2->predicate()->divert_to(&pred2);
+  trace.clearCaches();
 
   // Now, everything is uncorrelated.
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*g1_left, *g2_right));
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*g1_right, *g2_left));
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*g1_left, *g2_left));
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*g1_right, *g2_right));
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*g1_left, *g3_right));
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*g1_right, *g3_left));
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*g1_left, *g3_left));
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*g1_right, *g3_right));
+  EXPECT_TRUE(trace.canRegionReachRegion(*g1_left, *g2_right));
+  EXPECT_TRUE(trace.canRegionReachRegion(*g1_right, *g2_left));
+  EXPECT_TRUE(trace.canRegionReachRegion(*g1_left, *g2_left));
+  EXPECT_TRUE(trace.canRegionReachRegion(*g1_right, *g2_right));
+  EXPECT_TRUE(trace.canRegionReachRegion(*g1_left, *g3_right));
+  EXPECT_TRUE(trace.canRegionReachRegion(*g1_right, *g3_left));
+  EXPECT_TRUE(trace.canRegionReachRegion(*g1_left, *g3_left));
+  EXPECT_TRUE(trace.canRegionReachRegion(*g1_right, *g3_right));
 }
 
 TEST(RegionPredicateTraceTests, TraceOutOfTheta)
@@ -155,40 +156,40 @@ TEST(RegionPredicateTraceTests, TraceOutOfTheta)
   rvsdg::GraphExport::Create(*loopVar0.output, "x");
 
   // Assert
-  rvsdg::RegionPredicateTrace trace;
+  rvsdg::AlternativeRegionPredicateTracer trace;
 
   // Every region can be reached from the root region
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(rvsdg.GetRootRegion(), *theta0->subregion()));
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(rvsdg.GetRootRegion(), *theta1->subregion()));
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(rvsdg.GetRootRegion(), *theta2->subregion()));
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(rvsdg.GetRootRegion(), *theta3->subregion()));
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(rvsdg.GetRootRegion(), *theta4->subregion()));
+  EXPECT_TRUE(trace.canRegionReachRegion(rvsdg.GetRootRegion(), *theta0->subregion()));
+  EXPECT_TRUE(trace.canRegionReachRegion(rvsdg.GetRootRegion(), *theta1->subregion()));
+  EXPECT_TRUE(trace.canRegionReachRegion(rvsdg.GetRootRegion(), *theta2->subregion()));
+  EXPECT_TRUE(trace.canRegionReachRegion(rvsdg.GetRootRegion(), *theta3->subregion()));
+  EXPECT_TRUE(trace.canRegionReachRegion(rvsdg.GetRootRegion(), *theta4->subregion()));
 
   // Every region can reach the root region
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta0->subregion(), rvsdg.GetRootRegion()));
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta1->subregion(), rvsdg.GetRootRegion()));
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta1->subregion(), rvsdg.GetRootRegion()));
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta1->subregion(), rvsdg.GetRootRegion()));
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta1->subregion(), rvsdg.GetRootRegion()));
+  EXPECT_TRUE(trace.canRegionReachRegion(*theta0->subregion(), rvsdg.GetRootRegion()));
+  EXPECT_TRUE(trace.canRegionReachRegion(*theta1->subregion(), rvsdg.GetRootRegion()));
+  EXPECT_TRUE(trace.canRegionReachRegion(*theta1->subregion(), rvsdg.GetRootRegion()));
+  EXPECT_TRUE(trace.canRegionReachRegion(*theta1->subregion(), rvsdg.GetRootRegion()));
+  EXPECT_TRUE(trace.canRegionReachRegion(*theta1->subregion(), rvsdg.GetRootRegion()));
 
   // theta0 can reach every region inside it
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta0->subregion(), *theta1->subregion()));
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta0->subregion(), *theta2->subregion()));
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta0->subregion(), *theta3->subregion()));
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta0->subregion(), *theta4->subregion()));
+  EXPECT_TRUE(trace.canRegionReachRegion(*theta0->subregion(), *theta1->subregion()));
+  EXPECT_TRUE(trace.canRegionReachRegion(*theta0->subregion(), *theta2->subregion()));
+  EXPECT_TRUE(trace.canRegionReachRegion(*theta0->subregion(), *theta3->subregion()));
+  EXPECT_TRUE(trace.canRegionReachRegion(*theta0->subregion(), *theta4->subregion()));
 
   // theta0 can also be reached by every region inside it
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta1->subregion(), *theta0->subregion()));
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta2->subregion(), *theta0->subregion()));
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta3->subregion(), *theta0->subregion()));
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta4->subregion(), *theta0->subregion()));
+  EXPECT_TRUE(trace.canRegionReachRegion(*theta1->subregion(), *theta0->subregion()));
+  EXPECT_TRUE(trace.canRegionReachRegion(*theta2->subregion(), *theta0->subregion()));
+  EXPECT_TRUE(trace.canRegionReachRegion(*theta3->subregion(), *theta0->subregion()));
+  EXPECT_TRUE(trace.canRegionReachRegion(*theta4->subregion(), *theta0->subregion()));
 
   // theta2 can be reached from theta1
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta1->subregion(), *theta2->subregion()));
+  EXPECT_TRUE(trace.canRegionReachRegion(*theta1->subregion(), *theta2->subregion()));
 
   // theta3 and theta4 can reach each other
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta3->subregion(), *theta4->subregion()));
-  EXPECT_TRUE(trace.CheckPredicatesSatisfiable(*theta4->subregion(), *theta3->subregion()));
+  EXPECT_TRUE(trace.canRegionReachRegion(*theta3->subregion(), *theta4->subregion()));
+  EXPECT_TRUE(trace.canRegionReachRegion(*theta4->subregion(), *theta3->subregion()));
 }
 
 TEST(RegionPredicateTraceTests, TraceIntoGamma)
@@ -244,17 +245,101 @@ TEST(RegionPredicateTraceTests, TraceIntoGamma)
   auto & gamma2 = *rvsdg::GammaNode::create(gamma0Exit.output, 2);
 
   // Assert
-  rvsdg::RegionPredicateTrace trace;
+  rvsdg::AlternativeRegionPredicateTracer trace;
 
   // targeting gamma2's left subregion
-  ASSERT_TRUE(trace.CheckPredicatesSatisfiable(*gamma1.subregion(0), *gamma2.subregion(0)));
-  ASSERT_FALSE(trace.CheckPredicatesSatisfiable(*gamma1.subregion(1), *gamma2.subregion(0)));
-  ASSERT_TRUE(trace.CheckPredicatesSatisfiable(*gamma0.subregion(0), *gamma2.subregion(0)));
-  ASSERT_FALSE(trace.CheckPredicatesSatisfiable(*gamma0.subregion(1), *gamma2.subregion(0)));
+  ASSERT_TRUE(trace.canRegionReachRegion(*gamma1.subregion(0), *gamma2.subregion(0)));
+  ASSERT_FALSE(trace.canRegionReachRegion(*gamma1.subregion(1), *gamma2.subregion(0)));
+  ASSERT_TRUE(trace.canRegionReachRegion(*gamma0.subregion(0), *gamma2.subregion(0)));
+  ASSERT_FALSE(trace.canRegionReachRegion(*gamma0.subregion(1), *gamma2.subregion(0)));
 
   // targeting gamma2's right subregion
-  ASSERT_FALSE(trace.CheckPredicatesSatisfiable(*gamma1.subregion(0), *gamma2.subregion(1)));
-  ASSERT_TRUE(trace.CheckPredicatesSatisfiable(*gamma1.subregion(1), *gamma2.subregion(1)));
-  ASSERT_TRUE(trace.CheckPredicatesSatisfiable(*gamma0.subregion(0), *gamma2.subregion(1)));
-  ASSERT_TRUE(trace.CheckPredicatesSatisfiable(*gamma0.subregion(1), *gamma2.subregion(1)));
+  ASSERT_FALSE(trace.canRegionReachRegion(*gamma1.subregion(0), *gamma2.subregion(1)));
+  ASSERT_TRUE(trace.canRegionReachRegion(*gamma1.subregion(1), *gamma2.subregion(1)));
+  ASSERT_TRUE(trace.canRegionReachRegion(*gamma0.subregion(0), *gamma2.subregion(1)));
+  ASSERT_TRUE(trace.canRegionReachRegion(*gamma0.subregion(1), *gamma2.subregion(1)));
+}
+
+TEST(RegionPredicateTraceTests, TraceThroughGammas)
+{
+  /**
+   * Creates an RVSDG that looks like
+   *
+   *  TestOp(CtrlType)
+   *    v
+   * +-gamma0-------+--------------+
+   * | Ctrl(0)      | Ctrl(1)      |
+   * |   v          |   v          |
+   * +---x----------+---x----------+
+   *               |
+   *               |
+   *  TestOp(Ctrl) |  Ctrl(1)
+   *    v          v    v
+   * +-gamma1-------+--------------+
+   * |   \          |         /    |
+   * |    \         |        /     |
+   * |     \        |       /      |
+   * |      v       |      v       |
+   * +------x-------+------x-------+
+   *     |
+   *     v
+   * +-gamma2---+---------+---------+
+   * |          |         |         |
+   * +----------+---------+---------+
+   */
+
+  using namespace jlm;
+
+  auto controlType2 = rvsdg::ControlType::Create(2);
+  auto controlType3 = rvsdg::ControlType::Create(3);
+
+  rvsdg::Graph rvsdg;
+
+  // gamma 0
+  auto & testOp0 =
+      rvsdg::CreateOpNode<rvsdg::TestNullaryOperation>(rvsdg.GetRootRegion(), controlType2);
+  auto & gamma0 = *rvsdg::GammaNode::create(testOp0.output(0), 2);
+  auto & gamma0Ctrl0 = rvsdg::ControlConstantOperation::create(*gamma0.subregion(0), { 0, 3 });
+  auto & gamma0Ctrl1 = rvsdg::ControlConstantOperation::create(*gamma0.subregion(1), { 1, 3 });
+  auto gamma0ExitVar = gamma0.AddExitVar({ &gamma0Ctrl0, &gamma0Ctrl1 });
+
+  // gamma 1
+  auto & testOp1 =
+      rvsdg::CreateOpNode<rvsdg::TestNullaryOperation>(rvsdg.GetRootRegion(), controlType2);
+  auto & gamma1 = *rvsdg::GammaNode::create(testOp1.output(0), 2);
+  auto gamma1EntryFromGamma0 = gamma1.AddEntryVar(gamma0ExitVar.output);
+  auto & gamma1Ctrl1 = rvsdg::ControlConstantOperation::create(rvsdg.GetRootRegion(), { 1, 3 });
+  auto gamma1EntryFromCtrl1 = gamma1.AddEntryVar(&gamma1Ctrl1);
+  auto gamma1ExitVar = gamma1.AddExitVar(
+      { gamma1EntryFromGamma0.branchArgument[0], gamma1EntryFromCtrl1.branchArgument[1] });
+
+  // gamma 2
+  auto & gamma2 = *rvsdg::GammaNode::create(gamma1ExitVar.output, 3);
+
+  // Assert
+  rvsdg::AlternativeRegionPredicateTracer tracer;
+
+  // gamma0 has no effect on the subregions of gamma1
+  ASSERT_TRUE(tracer.canRegionReachRegion(*gamma0.subregion(0), *gamma1.subregion(0)));
+  ASSERT_TRUE(tracer.canRegionReachRegion(*gamma0.subregion(0), *gamma1.subregion(1)));
+  ASSERT_TRUE(tracer.canRegionReachRegion(*gamma0.subregion(1), *gamma1.subregion(0)));
+  ASSERT_TRUE(tracer.canRegionReachRegion(*gamma0.subregion(1), *gamma1.subregion(1)));
+
+  // From subregion 0 of gamma1 both subregions 0 and 1 can be reached in gamma2
+  ASSERT_TRUE(tracer.canRegionReachRegion(*gamma1.subregion(0), *gamma2.subregion(0)));
+  ASSERT_TRUE(tracer.canRegionReachRegion(*gamma1.subregion(0), *gamma2.subregion(1)));
+  // From subregion 1 of gamma1, however, only subregions 1 can be reached in gamma2
+  ASSERT_FALSE(tracer.canRegionReachRegion(*gamma1.subregion(1), *gamma2.subregion(0)));
+  ASSERT_TRUE(tracer.canRegionReachRegion(*gamma1.subregion(1), *gamma2.subregion(1)));
+
+  // region 2 of gamma2 is entriely unreachable, from any region, including the root
+  ASSERT_FALSE(tracer.canRegionReachRegion(*gamma0.subregion(0), *gamma2.subregion(2)));
+  ASSERT_FALSE(tracer.canRegionReachRegion(*gamma0.subregion(1), *gamma2.subregion(2)));
+  ASSERT_FALSE(tracer.canRegionReachRegion(*gamma1.subregion(0), *gamma2.subregion(2)));
+  ASSERT_FALSE(tracer.canRegionReachRegion(*gamma1.subregion(1), *gamma2.subregion(2)));
+  ASSERT_FALSE(tracer.canRegionReachRegion(rvsdg.GetRootRegion(), *gamma2.subregion(2)));
+
+  // Using the old predicate tracer, the following assert fails
+  // rvsdg::RegionPredicateTrace oldTracer;
+  // ASSERT_TRUE(oldTracer.CheckPredicatesSatisfiable(*gamma0.subregion(0), *gamma2.subregion(1)));
 }

--- a/jlm/rvsdg/RegionPredicateTraceTests.cpp
+++ b/jlm/rvsdg/RegionPredicateTraceTests.cpp
@@ -58,30 +58,30 @@ TEST(RegionPredicateTraceTests, TestTracing)
   rvsdg::AlternativeRegionPredicateTracer trace;
 
   // Since gamma1 dominates gamma2, not all cross-paths are possible.
-  EXPECT_TRUE(trace.canRegionReachRegion(*g1_left, *g2_right));
-  EXPECT_TRUE(trace.canRegionReachRegion(*g1_right, *g2_left));
-  EXPECT_FALSE(trace.canRegionReachRegion(*g1_left, *g2_left));
-  EXPECT_FALSE(trace.canRegionReachRegion(*g1_right, *g2_right));
+  EXPECT_TRUE(trace.isReachableFromRegion(*g2_right, *g1_left));
+  EXPECT_TRUE(trace.isReachableFromRegion(*g2_left, *g1_right));
+  EXPECT_FALSE(trace.isReachableFromRegion(*g2_left, *g1_left));
+  EXPECT_FALSE(trace.isReachableFromRegion(*g2_right, *g1_right));
 
   // Since gamma1 and gamma3 are unrelated,  all cross-paths are possible.
-  EXPECT_TRUE(trace.canRegionReachRegion(*g1_left, *g3_right));
-  EXPECT_TRUE(trace.canRegionReachRegion(*g1_right, *g3_left));
-  EXPECT_TRUE(trace.canRegionReachRegion(*g1_left, *g3_left));
-  EXPECT_TRUE(trace.canRegionReachRegion(*g1_right, *g3_right));
+  EXPECT_TRUE(trace.isReachableFromRegion(*g3_right, *g1_left));
+  EXPECT_TRUE(trace.isReachableFromRegion(*g3_left, *g1_right));
+  EXPECT_TRUE(trace.isReachableFromRegion(*g3_left, *g1_left));
+  EXPECT_TRUE(trace.isReachableFromRegion(*g3_right, *g1_right));
 
   // Now change the graph, and check again.
   gamma2->predicate()->divert_to(&pred2);
   trace.clearCaches();
 
   // Now, everything is uncorrelated.
-  EXPECT_TRUE(trace.canRegionReachRegion(*g1_left, *g2_right));
-  EXPECT_TRUE(trace.canRegionReachRegion(*g1_right, *g2_left));
-  EXPECT_TRUE(trace.canRegionReachRegion(*g1_left, *g2_left));
-  EXPECT_TRUE(trace.canRegionReachRegion(*g1_right, *g2_right));
-  EXPECT_TRUE(trace.canRegionReachRegion(*g1_left, *g3_right));
-  EXPECT_TRUE(trace.canRegionReachRegion(*g1_right, *g3_left));
-  EXPECT_TRUE(trace.canRegionReachRegion(*g1_left, *g3_left));
-  EXPECT_TRUE(trace.canRegionReachRegion(*g1_right, *g3_right));
+  EXPECT_TRUE(trace.isReachableFromRegion(*g2_right, *g1_left));
+  EXPECT_TRUE(trace.isReachableFromRegion(*g2_left, *g1_right));
+  EXPECT_TRUE(trace.isReachableFromRegion(*g2_left, *g1_left));
+  EXPECT_TRUE(trace.isReachableFromRegion(*g2_right, *g1_right));
+  EXPECT_TRUE(trace.isReachableFromRegion(*g3_right, *g1_left));
+  EXPECT_TRUE(trace.isReachableFromRegion(*g3_left, *g1_right));
+  EXPECT_TRUE(trace.isReachableFromRegion(*g3_left, *g1_left));
+  EXPECT_TRUE(trace.isReachableFromRegion(*g3_right, *g1_right));
 }
 
 TEST(RegionPredicateTraceTests, TraceOutOfTheta)
@@ -159,37 +159,37 @@ TEST(RegionPredicateTraceTests, TraceOutOfTheta)
   rvsdg::AlternativeRegionPredicateTracer trace;
 
   // Every region can be reached from the root region
-  EXPECT_TRUE(trace.canRegionReachRegion(rvsdg.GetRootRegion(), *theta0->subregion()));
-  EXPECT_TRUE(trace.canRegionReachRegion(rvsdg.GetRootRegion(), *theta1->subregion()));
-  EXPECT_TRUE(trace.canRegionReachRegion(rvsdg.GetRootRegion(), *theta2->subregion()));
-  EXPECT_TRUE(trace.canRegionReachRegion(rvsdg.GetRootRegion(), *theta3->subregion()));
-  EXPECT_TRUE(trace.canRegionReachRegion(rvsdg.GetRootRegion(), *theta4->subregion()));
+  EXPECT_TRUE(trace.isReachableFromRegion(*theta0->subregion(), rvsdg.GetRootRegion()));
+  EXPECT_TRUE(trace.isReachableFromRegion(*theta1->subregion(), rvsdg.GetRootRegion()));
+  EXPECT_TRUE(trace.isReachableFromRegion(*theta2->subregion(), rvsdg.GetRootRegion()));
+  EXPECT_TRUE(trace.isReachableFromRegion(*theta3->subregion(), rvsdg.GetRootRegion()));
+  EXPECT_TRUE(trace.isReachableFromRegion(*theta4->subregion(), rvsdg.GetRootRegion()));
 
   // Every region can reach the root region
-  EXPECT_TRUE(trace.canRegionReachRegion(*theta0->subregion(), rvsdg.GetRootRegion()));
-  EXPECT_TRUE(trace.canRegionReachRegion(*theta1->subregion(), rvsdg.GetRootRegion()));
-  EXPECT_TRUE(trace.canRegionReachRegion(*theta1->subregion(), rvsdg.GetRootRegion()));
-  EXPECT_TRUE(trace.canRegionReachRegion(*theta1->subregion(), rvsdg.GetRootRegion()));
-  EXPECT_TRUE(trace.canRegionReachRegion(*theta1->subregion(), rvsdg.GetRootRegion()));
+  EXPECT_TRUE(trace.isReachableFromRegion(rvsdg.GetRootRegion(), *theta0->subregion()));
+  EXPECT_TRUE(trace.isReachableFromRegion(rvsdg.GetRootRegion(), *theta1->subregion()));
+  EXPECT_TRUE(trace.isReachableFromRegion(rvsdg.GetRootRegion(), *theta1->subregion()));
+  EXPECT_TRUE(trace.isReachableFromRegion(rvsdg.GetRootRegion(), *theta1->subregion()));
+  EXPECT_TRUE(trace.isReachableFromRegion(rvsdg.GetRootRegion(), *theta1->subregion()));
 
   // theta0 can reach every region inside it
-  EXPECT_TRUE(trace.canRegionReachRegion(*theta0->subregion(), *theta1->subregion()));
-  EXPECT_TRUE(trace.canRegionReachRegion(*theta0->subregion(), *theta2->subregion()));
-  EXPECT_TRUE(trace.canRegionReachRegion(*theta0->subregion(), *theta3->subregion()));
-  EXPECT_TRUE(trace.canRegionReachRegion(*theta0->subregion(), *theta4->subregion()));
+  EXPECT_TRUE(trace.isReachableFromRegion(*theta1->subregion(), *theta0->subregion()));
+  EXPECT_TRUE(trace.isReachableFromRegion(*theta2->subregion(), *theta0->subregion()));
+  EXPECT_TRUE(trace.isReachableFromRegion(*theta3->subregion(), *theta0->subregion()));
+  EXPECT_TRUE(trace.isReachableFromRegion(*theta4->subregion(), *theta0->subregion()));
 
   // theta0 can also be reached by every region inside it
-  EXPECT_TRUE(trace.canRegionReachRegion(*theta1->subregion(), *theta0->subregion()));
-  EXPECT_TRUE(trace.canRegionReachRegion(*theta2->subregion(), *theta0->subregion()));
-  EXPECT_TRUE(trace.canRegionReachRegion(*theta3->subregion(), *theta0->subregion()));
-  EXPECT_TRUE(trace.canRegionReachRegion(*theta4->subregion(), *theta0->subregion()));
+  EXPECT_TRUE(trace.isReachableFromRegion(*theta0->subregion(), *theta1->subregion()));
+  EXPECT_TRUE(trace.isReachableFromRegion(*theta0->subregion(), *theta2->subregion()));
+  EXPECT_TRUE(trace.isReachableFromRegion(*theta0->subregion(), *theta3->subregion()));
+  EXPECT_TRUE(trace.isReachableFromRegion(*theta0->subregion(), *theta4->subregion()));
 
   // theta2 can be reached from theta1
-  EXPECT_TRUE(trace.canRegionReachRegion(*theta1->subregion(), *theta2->subregion()));
+  EXPECT_TRUE(trace.isReachableFromRegion(*theta2->subregion(), *theta1->subregion()));
 
   // theta3 and theta4 can reach each other
-  EXPECT_TRUE(trace.canRegionReachRegion(*theta3->subregion(), *theta4->subregion()));
-  EXPECT_TRUE(trace.canRegionReachRegion(*theta4->subregion(), *theta3->subregion()));
+  EXPECT_TRUE(trace.isReachableFromRegion(*theta4->subregion(), *theta3->subregion()));
+  EXPECT_TRUE(trace.isReachableFromRegion(*theta3->subregion(), *theta4->subregion()));
 }
 
 TEST(RegionPredicateTraceTests, TraceIntoGamma)
@@ -248,16 +248,16 @@ TEST(RegionPredicateTraceTests, TraceIntoGamma)
   rvsdg::AlternativeRegionPredicateTracer trace;
 
   // targeting gamma2's left subregion
-  ASSERT_TRUE(trace.canRegionReachRegion(*gamma1.subregion(0), *gamma2.subregion(0)));
-  ASSERT_FALSE(trace.canRegionReachRegion(*gamma1.subregion(1), *gamma2.subregion(0)));
-  ASSERT_TRUE(trace.canRegionReachRegion(*gamma0.subregion(0), *gamma2.subregion(0)));
-  ASSERT_FALSE(trace.canRegionReachRegion(*gamma0.subregion(1), *gamma2.subregion(0)));
+  ASSERT_TRUE(trace.isReachableFromRegion(*gamma2.subregion(0), *gamma1.subregion(0)));
+  ASSERT_FALSE(trace.isReachableFromRegion(*gamma2.subregion(0), *gamma1.subregion(1)));
+  ASSERT_TRUE(trace.isReachableFromRegion(*gamma2.subregion(0), *gamma0.subregion(0)));
+  ASSERT_FALSE(trace.isReachableFromRegion(*gamma2.subregion(0), *gamma0.subregion(1)));
 
   // targeting gamma2's right subregion
-  ASSERT_FALSE(trace.canRegionReachRegion(*gamma1.subregion(0), *gamma2.subregion(1)));
-  ASSERT_TRUE(trace.canRegionReachRegion(*gamma1.subregion(1), *gamma2.subregion(1)));
-  ASSERT_TRUE(trace.canRegionReachRegion(*gamma0.subregion(0), *gamma2.subregion(1)));
-  ASSERT_TRUE(trace.canRegionReachRegion(*gamma0.subregion(1), *gamma2.subregion(1)));
+  ASSERT_FALSE(trace.isReachableFromRegion(*gamma2.subregion(1), *gamma1.subregion(0)));
+  ASSERT_TRUE(trace.isReachableFromRegion(*gamma2.subregion(1), *gamma1.subregion(1)));
+  ASSERT_TRUE(trace.isReachableFromRegion(*gamma2.subregion(1), *gamma0.subregion(0)));
+  ASSERT_TRUE(trace.isReachableFromRegion(*gamma2.subregion(1), *gamma0.subregion(1)));
 }
 
 TEST(RegionPredicateTraceTests, TraceThroughGammas)
@@ -320,30 +320,30 @@ TEST(RegionPredicateTraceTests, TraceThroughGammas)
   rvsdg::AlternativeRegionPredicateTracer tracer;
 
   // gamma0 has no effect on the subregions of gamma1
-  ASSERT_TRUE(tracer.canRegionReachRegion(*gamma0.subregion(0), *gamma1.subregion(0)));
-  ASSERT_TRUE(tracer.canRegionReachRegion(*gamma0.subregion(0), *gamma1.subregion(1)));
-  ASSERT_TRUE(tracer.canRegionReachRegion(*gamma0.subregion(1), *gamma1.subregion(0)));
-  ASSERT_TRUE(tracer.canRegionReachRegion(*gamma0.subregion(1), *gamma1.subregion(1)));
+  ASSERT_TRUE(tracer.isReachableFromRegion(*gamma1.subregion(0), *gamma0.subregion(0)));
+  ASSERT_TRUE(tracer.isReachableFromRegion(*gamma1.subregion(1), *gamma0.subregion(0)));
+  ASSERT_TRUE(tracer.isReachableFromRegion(*gamma1.subregion(0), *gamma0.subregion(1)));
+  ASSERT_TRUE(tracer.isReachableFromRegion(*gamma1.subregion(1), *gamma0.subregion(1)));
 
   // gamma0 has no effect on the choice between region 0 or 1 in gamma2 either
-  ASSERT_TRUE(tracer.canRegionReachRegion(*gamma0.subregion(0), *gamma2.subregion(0)));
-  ASSERT_TRUE(tracer.canRegionReachRegion(*gamma0.subregion(0), *gamma2.subregion(1)));
-  ASSERT_TRUE(tracer.canRegionReachRegion(*gamma0.subregion(1), *gamma2.subregion(0)));
-  ASSERT_TRUE(tracer.canRegionReachRegion(*gamma0.subregion(1), *gamma2.subregion(1)));
+  ASSERT_TRUE(tracer.isReachableFromRegion(*gamma2.subregion(0), *gamma0.subregion(0)));
+  ASSERT_TRUE(tracer.isReachableFromRegion(*gamma2.subregion(1), *gamma0.subregion(0)));
+  ASSERT_TRUE(tracer.isReachableFromRegion(*gamma2.subregion(0), *gamma0.subregion(1)));
+  ASSERT_TRUE(tracer.isReachableFromRegion(*gamma2.subregion(1), *gamma0.subregion(1)));
 
   // From subregion 0 of gamma1 both subregions 0 and 1 can be reached in gamma2
-  ASSERT_TRUE(tracer.canRegionReachRegion(*gamma1.subregion(0), *gamma2.subregion(0)));
-  ASSERT_TRUE(tracer.canRegionReachRegion(*gamma1.subregion(0), *gamma2.subregion(1)));
+  ASSERT_TRUE(tracer.isReachableFromRegion(*gamma2.subregion(0), *gamma1.subregion(0)));
+  ASSERT_TRUE(tracer.isReachableFromRegion(*gamma2.subregion(1), *gamma1.subregion(0)));
   // From subregion 1 of gamma1, however, only subregions 1 can be reached in gamma2
-  ASSERT_FALSE(tracer.canRegionReachRegion(*gamma1.subregion(1), *gamma2.subregion(0)));
-  ASSERT_TRUE(tracer.canRegionReachRegion(*gamma1.subregion(1), *gamma2.subregion(1)));
+  ASSERT_FALSE(tracer.isReachableFromRegion(*gamma2.subregion(0), *gamma1.subregion(1)));
+  ASSERT_TRUE(tracer.isReachableFromRegion(*gamma2.subregion(1), *gamma1.subregion(1)));
 
   // region 2 of gamma2 is entriely unreachable, from any region, including the root
-  ASSERT_FALSE(tracer.canRegionReachRegion(*gamma0.subregion(0), *gamma2.subregion(2)));
-  ASSERT_FALSE(tracer.canRegionReachRegion(*gamma0.subregion(1), *gamma2.subregion(2)));
-  ASSERT_FALSE(tracer.canRegionReachRegion(*gamma1.subregion(0), *gamma2.subregion(2)));
-  ASSERT_FALSE(tracer.canRegionReachRegion(*gamma1.subregion(1), *gamma2.subregion(2)));
-  ASSERT_FALSE(tracer.canRegionReachRegion(rvsdg.GetRootRegion(), *gamma2.subregion(2)));
+  ASSERT_FALSE(tracer.isReachableFromRegion(*gamma2.subregion(2), *gamma0.subregion(0)));
+  ASSERT_FALSE(tracer.isReachableFromRegion(*gamma2.subregion(2), *gamma0.subregion(1)));
+  ASSERT_FALSE(tracer.isReachableFromRegion(*gamma2.subregion(2), *gamma1.subregion(0)));
+  ASSERT_FALSE(tracer.isReachableFromRegion(*gamma2.subregion(2), *gamma1.subregion(1)));
+  ASSERT_FALSE(tracer.isReachableFromRegion(*gamma2.subregion(2), rvsdg.GetRootRegion()));
 
   // Using the old predicate tracer, the following assert fails
   // rvsdg::RegionPredicateTrace oldTracer;


### PR DESCRIPTION
The fix is demonstrated in the added test, where a commented out line at the bottom shows how the old predicate tracer will answer incorrectly. The issue is the same as reported in issue #1764, we were just unsure if the conditions needed to trigger the issue could ever occur in practice, until @phate's IVR improvements in PR #1859 triggered it.

The fix itself separates tracing for finding definite values from tracing for finding sets of possible values. The implementation also differs in what it caches, to support theta predicate tracing. When traversing up the region hierarchy from the origin region and leaving a theta node, we know that the theta's predicate must be 0 in order to leave. This gives more precise tracing when the target region is outside a theta.

The new tracer does not register any observers to handle automatic cache invalidation. I did this because I realized there were anyways issues with the existing observers, where they would not react to regions being deleted, which means new regions can re-use their address and pick up stale cache values. Instead of adding even more region observers, I elected to not support automatic invalidation. SVF does not affect control flow, and if some pass really needs it later, I think it in any case makes more sense to have a general `GraphObserver` instead of adding individual region observers.

With the alternative tracer used in SVF, we get 1774 fewer loads than on master, across 438 files. 18 files do worse (by 1-7 loads), which is as far as I can tell due to the fix, so the loads might not have been legal to remove in the first place.

FYI @caleridas @phate